### PR TITLE
[Security] Remove outdated `createAuthenticatedToken()` leftover

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -65,12 +65,7 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
 
     public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
-        return method_exists($this->authenticator, 'createToken') ? $this->authenticator->createToken($passport, $firewallName) : $this->authenticator->createAuthenticatedToken($passport, $firewallName);
-    }
-
-    public function createAuthenticatedToken(Passport $passport, string $firewallName): TokenInterface
-    {
-        return $this->authenticator->createAuthenticatedToken($passport, $firewallName);
+        return $this->authenticator->createToken($passport, $firewallName);
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -
