### PR TITLE
[Messenger] Add completion to command messenger:consume

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -151,6 +151,7 @@ return static function (ContainerConfigurator $container) {
                 service('logger')->nullOnInvalid(),
                 [], // Receiver names
                 service('messenger.listener.reset_services')->nullOnInvalid(),
+                [], // Bus names
             ])
             ->tag('console.command')
             ->tag('monolog.logger', ['channel' => 'messenger'])

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
@@ -309,6 +310,11 @@ class MessengerPass implements CompilerPassInterface
             }
 
             $consumeCommandDefinition->replaceArgument(4, array_values($receiverNames));
+            try {
+                $consumeCommandDefinition->replaceArgument(6, $busIds);
+            } catch (OutOfBoundsException $e) {
+                // ignore to preserve compatibility with symfony/framework-bundle < 5.4
+            }
         }
 
         if ($container->hasDefinition('console.command.messenger_setup_transports')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #43594
| License       | MIT
| Doc PR        | -

Command `messenger:consume` takes a list of `receivers` that should be unique. The values for option `--bus` where easy to inject into the command.

I skipped the option `--queue` whose values are defined deep in the transport options.