### PR TITLE
[Security] Make the abstract Voter class implement CacheableVoterInterface

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * @author Roman Marintšenko <inoryy@gmail.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-abstract class Voter implements VoterInterface
+abstract class Voter implements VoterInterface, CacheableVoterInterface
 {
     /**
      * {@inheritdoc}
@@ -57,6 +57,26 @@ abstract class Voter implements VoterInterface
         }
 
         return $vote;
+    }
+
+    /**
+     * Return false if your voter doesn't support the given attribute. Symfony will cache
+     * that decision and won't call your voter again for that attribute.
+     */
+    public function supportsAttribute(string $attribute): bool
+    {
+        return true;
+    }
+
+    /**
+     * Return false if your voter doesn't support the given subject type. Symfony will cache
+     * that decision and won't call your voter again for that subject type.
+     *
+     * @param string $subjectType The type of the subject inferred by `get_class()` or `get_debug_type()`
+     */
+    public function supportsType(string $subjectType): bool
+    {
+        return true;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Related to this --> https://symfony.com/blog/new-in-symfony-5-4-faster-security-voters

The abstract `Voter` class is "a helper" to simplify the creation of custom voters. I propose to implement the new `CacheableVoterInterface`, so this nice feature is easier to discover and ready-to-use for those developers extending `Voter`.