### PR TITLE
[SecurityBundle] Default access_decision_manager.strategy option with merge

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -47,24 +47,6 @@ class MainConfiguration implements ConfigurationInterface
         $rootNode = $tb->getRootNode();
 
         $rootNode
-            ->beforeNormalization()
-                ->ifTrue(function ($v) {
-                    if (!isset($v['access_decision_manager'])) {
-                        return true;
-                    }
-
-                    if (!isset($v['access_decision_manager']['strategy']) && !isset($v['access_decision_manager']['service'])) {
-                        return true;
-                    }
-
-                    return false;
-                })
-                ->then(function ($v) {
-                    $v['access_decision_manager']['strategy'] = AccessDecisionManager::STRATEGY_AFFIRMATIVE;
-
-                    return $v;
-                })
-            ->end()
             ->children()
                 ->scalarNode('access_denied_url')->defaultNull()->example('/foo/error403')->end()
                 ->enumNode('session_fixation_strategy')

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
@@ -130,7 +131,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         } else {
             $container
                 ->getDefinition('security.access.decision_manager')
-                ->addArgument($config['access_decision_manager']['strategy'])
+                ->addArgument($config['access_decision_manager']['strategy'] ?? AccessDecisionManager::STRATEGY_AFFIRMATIVE)
                 ->addArgument($config['access_decision_manager']['allow_if_all_abstain'])
                 ->addArgument($config['access_decision_manager']['allow_if_equal_granted_denied']);
         }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\MainConfiguration;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 
 class MainConfigurationTest extends TestCase
 {
@@ -112,5 +113,23 @@ class MainConfigurationTest extends TestCase
         $processedConfig = $processor->processConfiguration($configuration, [$config]);
 
         $this->assertEquals('app.henk_checker', $processedConfig['firewalls']['stub']['user_checker']);
+    }
+
+    public function testConfigMergeWithAccessDecisionManager()
+    {
+        $config = [
+            'access_decision_manager' => [
+                'strategy' => AccessDecisionManager::STRATEGY_UNANIMOUS,
+            ],
+        ];
+        $config = array_merge(static::$minimalConfig, $config);
+
+        $config2 = [];
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration([], []);
+        $processedConfig = $processor->processConfiguration($configuration, [$config, $config2]);
+
+        $this->assertSame(AccessDecisionManager::STRATEGY_UNANIMOUS, $processedConfig['access_decision_manager']['strategy']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #25609
| License       | MIT

Security bundle should set default `access_decision_manager.strategy` in extension instead of configuration.
Otherwise merging configurations will override first set option if the next configurations do not have the option set.