### PR TITLE
[VarExporter] escape unicode chars involved in directionality

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -214,10 +214,10 @@ class Exporter
         if (\is_string($value)) {
             $code = sprintf("'%s'", addcslashes($value, "'\\"));
 
-            $code = preg_replace_callback('/([\0\r\n]++)(.)/', function ($m) use ($subIndent) {
+            $code = preg_replace_callback("/((?:[\\0\\r\\n]|\u{202A}|\u{202B}|\u{202D}|\u{202E}|\u{2066}|\u{2067}|\u{2068}|\u{202C}|\u{2069})++)(.)/", function ($m) use ($subIndent) {
                 $m[1] = sprintf('\'."%s".\'', str_replace(
-                    ["\0", "\r", "\n", '\n\\'],
-                    ['\0', '\r', '\n', '\n"'."\n".$subIndent.'."\\'],
+                    ["\0", "\r", "\n", "\u{202A}", "\u{202B}", "\u{202D}", "\u{202E}", "\u{2066}", "\u{2067}", "\u{2068}", "\u{202C}", "\u{2069}", '\n\\'],
+                    ['\0', '\r', '\n', '\u{202A}', '\u{202B}', '\u{202D}', '\u{202E}', '\u{2066}', '\u{2067}', '\u{2068}', '\u{202C}', '\u{2069}', '\n"'."\n".$subIndent.'."\\'],
                     $m[1]
                 ));
 

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -240,6 +240,11 @@ class VarExporterTest extends TestCase
             yield ['unit-enum', [FooUnitEnum::Bar], true];
         }
     }
+
+    public function testUnicodeDirectionality()
+    {
+        $this->assertSame('"\0\r\u{202A}\u{202B}\u{202D}\u{202E}\u{2066}\u{2067}\u{2068}\u{202C}\u{2069}\n"', VarExporter::export("\0\r\u{202A}\u{202B}\u{202D}\u{202E}\u{2066}\u{2067}\u{2068}\u{202C}\u{2069}\n"));
+    }
 }
 
 class MyWakeup


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

According to https://www.trojansource.codes/, source code should never contain directional characters.
Let's escape them.