### PR TITLE
[SecurityBundle] Remove unused "encoder" complex type

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -69,23 +69,6 @@
         </xsd:restriction>
     </xsd:simpleType>
 
-    <xsd:complexType name="encoder">
-        <xsd:sequence>
-            <xsd:element name="migrate-from" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
-        </xsd:sequence>
-        <xsd:attribute name="class" type="xsd:string" use="required" />
-        <xsd:attribute name="algorithm" type="xsd:string" />
-        <xsd:attribute name="hash-algorithm" type="xsd:string" />
-        <xsd:attribute name="key-length" type="xsd:string" />
-        <xsd:attribute name="ignore-case" type="xsd:boolean" />
-        <xsd:attribute name="encode-as-base64" type="xsd:boolean" />
-        <xsd:attribute name="iterations" type="xsd:string" />
-        <xsd:attribute name="cost" type="xsd:integer" />
-        <xsd:attribute name="memory-cost" type="xsd:string" />
-        <xsd:attribute name="time-cost" type="xsd:string" />
-        <xsd:attribute name="id" type="xsd:string" />
-    </xsd:complexType>
-
     <xsd:complexType name="password_hasher">
         <xsd:sequence>
             <xsd:element name="migrate-from" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

It looks like it's a leftover from https://github.com/symfony/symfony/pull/41960