### PR TITLE
[PropertyInfo] Bump phpstan/phpdoc-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,7 @@
         "paragonie/sodium_compat": "^1.8",
         "pda/pheanstalk": "^4.0",
         "php-http/httplug": "^1.0|^2.0",
-        "phpstan/phpdoc-parser": "^0.4",
+        "phpstan/phpdoc-parser": "^1.0",
         "predis/predis": "~1.1",
         "psr/http-client": "^1.0",
         "psr/simple-cache": "^1.0|^2.0",

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -33,7 +33,7 @@
         "symfony/cache": "^4.4|^5.0|^6.0",
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-        "phpstan/phpdoc-parser": "^0.4",
+        "phpstan/phpdoc-parser": "^1.0",
         "doctrine/annotations": "^1.10.4"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

We are currently running our tests against an old beta version of PHPStan's phpdoc parser. Let's test with the 1.x branch instead.