### PR TITLE
Allow autodetecting mapping type for any object

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -290,13 +290,15 @@ abstract class AbstractDoctrineExtension extends Extension
         $glob = new GlobResource($directory, '*', true);
         $container->addResource($glob);
 
+        $quotedMappingObjectName = preg_quote($this->getMappingObjectDefaultName(), '/');
+
         foreach ($glob as $file) {
             $content = file_get_contents($file);
 
-            if (preg_match('/^#\[.*Entity\b/m', $content)) {
+            if (preg_match('/^#\[.*'.$quotedMappingObjectName.'\b/m', $content)) {
                 break;
             }
-            if (preg_match('/^ \* @.*Entity\b/m', $content)) {
+            if (preg_match('/^ \* @.*'.$quotedMappingObjectName.'\b/m', $content)) {
                 $type = 'annotation';
                 break;
             }

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -49,6 +49,10 @@ class DoctrineExtensionTest extends TestCase
             ->willReturnCallback(function ($name) {
                 return 'doctrine.orm.'.$name;
             });
+
+        $this->extension
+            ->method('getMappingObjectDefaultName')
+            ->willReturn('Entity');
     }
 
     public function testFixManagersAutoMappingsWithTwoAutomappings()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

This PR would allow to auto detect the mapping type for Documents or other types