### PR TITLE
[PropertyInfo] Drop support for old PHPDoc parser versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
         "symfony/phpunit-bridge": "^5.4|^6.0",
         "symfony/runtime": "self.version",
         "symfony/security-acl": "~2.8|~3.0",
-        "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+        "phpdocumentor/reflection-docblock": "^5.2",
         "twig/cssinliner-extra": "^2.12|^3",
         "twig/inky-extra": "^2.12|^3",
         "twig/markdown-extra": "^2.12|^3"
@@ -156,7 +156,7 @@
         "doctrine/dbal": "<2.13.1",
         "egulias/email-validator": "~3.0.0",
         "masterminds/html5": "<2.6",
-        "phpdocumentor/reflection-docblock": "<3.2.2",
+        "phpdocumentor/reflection-docblock": "<5.2",
         "phpdocumentor/type-resolver": "<1.4.0",
         "ocramius/proxy-manager": "<2.1",
         "phpunit/phpunit": "<5.4.3"

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
-use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
-use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\Types\Collection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
@@ -57,8 +55,8 @@ class PhpDocExtractorTest extends TestCase
         return [
             'pub' => ['pub', null, null],
             'stat' => ['stat', null, null],
-            'foo' => ['foo', $this->isPhpDocumentorV5() ? 'Foo.' : null, null],
-            'bar' => ['bar', $this->isPhpDocumentorV5() ? 'Bar.' : null, null],
+            'foo' => ['foo', 'Foo.', null],
+            'bar' => ['bar', 'Bar.', null],
         ];
     }
 
@@ -124,23 +122,9 @@ class PhpDocExtractorTest extends TestCase
             ['donotexist', null, null, null],
             ['staticGetter', null, null, null],
             ['staticSetter', null, null, null],
-            ['emptyVar', null, $this->isPhpDocumentorV5() ? 'This should not be removed.' : null, null],
-            [
-                'arrayWithKeys',
-                $this->isPhpDocumentorV5() ? [
-                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_STRING), new Type(Type::BUILTIN_TYPE_STRING)),
-                ] : null,
-                null,
-                null,
-            ],
-            [
-                'arrayOfMixed',
-                $this->isPhpDocumentorV5() ? [
-                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_STRING), null),
-                ] : null,
-                null,
-                null,
-            ],
+            ['emptyVar', null, 'This should not be removed.', null],
+            ['arrayWithKeys', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_STRING), new Type(Type::BUILTIN_TYPE_STRING))], null, null],
+            ['arrayOfMixed', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_STRING), null)], null, null],
             ['self', [new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)], null, null],
         ];
     }
@@ -401,16 +385,6 @@ class PhpDocExtractorTest extends TestCase
             [ParentDummy::class, 'parentAnnotationNoParent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'parent')]],
             [Dummy::class, 'parentAnnotation', [new Type(Type::BUILTIN_TYPE_OBJECT, false, ParentDummy::class)]],
         ];
-    }
-
-    protected function isPhpDocumentorV5()
-    {
-        if (class_exists(InvalidTag::class)) {
-            return true;
-        }
-
-        return (new \ReflectionMethod(StandardTagFactory::class, 'create'))
-            ->hasReturnType();
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -30,12 +30,12 @@
         "symfony/serializer": "^5.4|^6.0",
         "symfony/cache": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
-        "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+        "phpdocumentor/reflection-docblock": "^5.2",
         "phpstan/phpdoc-parser": "^0.4",
         "doctrine/annotations": "^1.10.4"
     },
     "conflict": {
-        "phpdocumentor/reflection-docblock": "<3.2.2",
+        "phpdocumentor/reflection-docblock": "<5.2",
         "phpdocumentor/type-resolver": "<1.4.0",
         "symfony/dependency-injection": "<5.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

On PHP 8, Composer won't let us install versions of phpDocumentor's parser older than 5.2. I think it's fair to drop support for those releases on the 6.0 branch.