### PR TITLE
[DependencyInjection] only allow `ReflectionNamedType` for `ServiceSubscriberTrait`

### DIFF
--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -42,9 +42,19 @@ trait ServiceSubscriberTrait
                 continue;
             }
 
-            if (self::class === $method->getDeclaringClass()->name && ($returnType = $method->getReturnType()) && !$returnType->isBuiltin()) {
-                $services[self::class.'::'.$method->name] = '?'.($returnType instanceof \ReflectionNamedType ? $returnType->getName() : $returnType);
+            if (self::class !== $method->getDeclaringClass()->name) {
+                continue;
             }
+
+            if (!($returnType = $method->getReturnType()) instanceof \ReflectionNamedType) {
+                continue;
+            }
+
+            if ($returnType->isBuiltin()) {
+                continue;
+            }
+
+            $services[self::class.'::'.$method->name] = '?'.$returnType->getName();
         }
 
         return $services;

--- a/src/Symfony/Contracts/Tests/Fixtures/TestServiceSubscriberUnion.php
+++ b/src/Symfony/Contracts/Tests/Fixtures/TestServiceSubscriberUnion.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Contracts\Tests\Fixtures;
+
+use Symfony\Contracts\Service\ServiceSubscriberTrait;
+
+class TestServiceSubscriberUnion
+{
+    use ServiceSubscriberTrait;
+
+    private function method1(): Service1
+    {
+        return $this->container->get(__METHOD__);
+    }
+
+    private function method2(): Service1|Service2
+    {
+        return $this->container->get(__METHOD__);
+    }
+
+    private function method3(): Service1|Service2|null
+    {
+        return $this->container->get(__METHOD__);
+    }
+}

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -16,6 +16,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Service\ServiceSubscriberTrait;
+use Symfony\Contracts\Tests\Fixtures\TestServiceSubscriberUnion;
 
 class ServiceSubscriberTraitTest extends TestCase
 {
@@ -33,6 +34,16 @@ class ServiceSubscriberTraitTest extends TestCase
         };
 
         $this->assertSame($container, (new TestService())->setContainer($container));
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testMethodsWithUnionReturnTypesAreIgnored()
+    {
+        $expected = [TestServiceSubscriberUnion::class.'::method1' => '?Symfony\Contracts\Tests\Fixtures\Service1'];
+
+        $this->assertEquals($expected, TestServiceSubscriberUnion::getSubscribedServices());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43913
| License       | MIT
| Doc PR        | n/a

I'll follow this up with a PR on 5.4 to allow union/intersections when using the `SubscribedService` attribute (once `ServiceSubscriberInterface` [supports this](https://github.com/symfony/symfony/issues/43913#issuecomment-959718034)).