### PR TITLE
[Console] Open CompleteCommand for custom outputs

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\CompleteCommand;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Output\BashCompletionOutput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -48,6 +49,20 @@ class CompleteCommandTest extends TestCase
     {
         $this->expectExceptionMessage('Shell completion is not supported for your shell: "unsupported" (supported: "bash").');
         $this->execute(['--shell' => 'unsupported']);
+    }
+
+    public function testAdditionalShellSupport()
+    {
+        $this->command = new CompleteCommand(['supported' => BashCompletionOutput::class]);
+        $this->command->setApplication($this->application);
+        $this->tester = new CommandTester($this->command);
+
+        $this->execute(['--shell' => 'supported', '--current' => '1', '--input' => ['bin/console']]);
+
+        // verify that the default set of shells is still supported
+        $this->execute(['--shell' => 'bash', '--current' => '1', '--input' => ['bin/console']]);
+
+        $this->assertTrue(true);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -89,7 +89,7 @@
                         "accept_value": true,
                         "is_value_required": true,
                         "is_multiple": false,
-                        "description": "The shell type (e.g. \"bash\")",
+                        "description": "The shell type (\"bash\")",
                         "default": null
                     },
                     "current": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -10,7 +10,7 @@
       <arguments/>
       <options>
         <option name="--shell" shortcut="-s" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The shell type (e.g. "bash")</description>
+          <description>The shell type ("bash")</description>
           <defaults/>
         </option>
         <option name="--input" shortcut="-i" accept_value="1" is_value_required="1" is_multiple="1">

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -93,7 +93,7 @@
                         "accept_value": true,
                         "is_value_required": true,
                         "is_multiple": false,
-                        "description": "The shell type (e.g. \"bash\")",
+                        "description": "The shell type (\"bash\")",
                         "default": null
                     },
                     "current": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -10,7 +10,7 @@
       <arguments/>
       <options>
         <option name="--shell" shortcut="-s" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The shell type (e.g. "bash")</description>
+          <description>The shell type ("bash")</description>
           <defaults/>
         </option>
         <option name="--input" shortcut="-i" accept_value="1" is_value_required="1" is_multiple="1">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -instead -->
| License       | MIT
| Doc PR        | -

Having this feature in 5.4 is especially great, as it will allow Composer 2.2 to use this feature as well.

If we in the future add fish or zsh support, it would be very cool if these can be "backported" by Composer. Keeping the `$completionOutputs` property closed would permit this, while this little change opens up adding custom output supports outside the Symfony source code.