### PR TITLE
[Console] add markdown feature for env-vars

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * Add support for `statusCode` default parameter when loading a template directly from route using the `Symfony\Bundle\FrameworkBundle\Controller\TemplateController` controller
  * Deprecate `translation:update` command, use `translation:extract` instead
  * Add `PhpStanExtractor` support for the PropertyInfo component
+ * Add markdown format for env vars `debug:container --env-vars --format=md`
 
 5.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Console\Descriptor;
 
-use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -285,6 +284,7 @@ class MarkdownDescriptor extends Descriptor
 
         if ([] === $envs) {
             $this->write("There are no environment variables\n");
+
             return;
         }
 
@@ -294,7 +294,7 @@ class MarkdownDescriptor extends Descriptor
         foreach ($envs as $env) {
             $this->write(
                 sprintf(
-                    '%s | %s | %s | %s'.PHP_EOL,
+                    '%s | %s | %s | %s'.\PHP_EOL,
                     $env['default_available'] ? $env['name'] : '**'.$env['name'].'**',
                     $env['processor'],
                     $env['default_available'] ? $env['default_value'] : 'n/a',

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -281,7 +281,29 @@ class MarkdownDescriptor extends Descriptor
 
     protected function describeContainerEnvVars(array $envs, array $options = [])
     {
-        throw new LogicException('Using the markdown format to debug environment variables is not supported.');
+        $this->write("# Environment Variables\n\n");
+
+        if ([] === $envs) {
+            $this->write("There are no environment variables\n");
+            return;
+        }
+
+        $this->write("NAME | PROCESSOR | DEFAULT | VALUE\n");
+        $this->write("---|---|---|---\n");
+
+        foreach ($envs as $env) {
+            $this->write(
+                sprintf(
+                    '%s | %s | %s | %s'.PHP_EOL,
+                    $env['default_available'] ? $env['name'] : '**'.$env['name'].'**',
+                    $env['processor'],
+                    $env['default_available'] ? $env['default_value'] : 'n/a',
+                    $env['runtime_available'] ? $env['runtime_value'] : 'n/a',
+                )
+            );
+        }
+
+        $this->write("\n");
     }
 
     protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = [])

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -294,7 +294,7 @@ class MarkdownDescriptor extends Descriptor
         foreach ($envs as $env) {
             $this->write(
                 sprintf(
-                    '%s | %s | %s | %s'.\PHP_EOL,
+                    "%s | %s | %s | %s\n",
                     $env['default_available'] ? $env['name'] : '**'.$env['name'].'**',
                     $env['processor'],
                     $env['default_available'] ? $env['default_value'] : 'n/a',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://twitter.com/testController/status/1456204370597515268
| License       | MIT

simple markedown table instead of an unsupported exception

no tests added