### PR TITLE
[DependencyInjection] Fix support for unions/intersections together with `ServiceSubscriberInterface`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -103,7 +103,7 @@ class AutowirePass extends AbstractRecursivePass
     private function doProcessValue($value, bool $isRoot = false)
     {
         if ($value instanceof TypedReference) {
-            if ($ref = $this->getAutowiredReference($value)) {
+            if ($ref = $this->getAutowiredReference($value, true)) {
                 return $ref;
             }
             if (ContainerBuilder::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE === $value->getInvalidBehavior()) {
@@ -294,7 +294,7 @@ class AutowirePass extends AbstractRecursivePass
             }
 
             $getValue = function () use ($type, $parameter, $class, $method) {
-                if (!$value = $this->getAutowiredReference($ref = new TypedReference($type, $type, ContainerBuilder::EXCEPTION_ON_INVALID_REFERENCE, Target::parseName($parameter)))) {
+                if (!$value = $this->getAutowiredReference($ref = new TypedReference($type, $type, ContainerBuilder::EXCEPTION_ON_INVALID_REFERENCE, Target::parseName($parameter)), true)) {
                     $failureMessage = $this->createTypeNotFoundMessageCallback($ref, sprintf('argument "$%s" of method "%s()"', $parameter->name, $class !== $this->currentId ? $class.'::'.$method : $method));
 
                     if ($parameter->isDefaultValueAvailable()) {
@@ -349,13 +349,21 @@ class AutowirePass extends AbstractRecursivePass
     /**
      * Returns a reference to the service matching the given type, if any.
      */
-    private function getAutowiredReference(TypedReference $reference): ?TypedReference
+    private function getAutowiredReference(TypedReference $reference, bool $filterType): ?TypedReference
     {
         $this->lastFailure = null;
         $type = $reference->getType();
 
         if ($type !== (string) $reference) {
             return $reference;
+        }
+
+        if ($filterType && false !== $m = strpbrk($type, '&|')) {
+            $types = array_diff(explode($m[0], $type), ['int', 'string', 'array', 'bool', 'float', 'iterable', 'object', 'callable', 'null']);
+
+            sort($types);
+
+            $type = implode($m[0], $types);
         }
 
         if (null !== $name = $reference->getName()) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
@@ -72,7 +72,7 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
         $subscriberMap = [];
 
         foreach ($class::getSubscribedServices() as $key => $type) {
-            if (!\is_string($type) || !preg_match('/^\??[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+$/', $type)) {
+            if (!\is_string($type) || !preg_match('/(?(DEFINE)(?<cn>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+))(?(DEFINE)(?<fqcn>(?&cn)(?:\\\\(?&cn))*+))^\??(?&fqcn)(?:(?:\|(?&fqcn))*+|(?:&(?&fqcn))*+)$/', $type)) {
                 throw new InvalidArgumentException(sprintf('"%s::getSubscribedServices()" must return valid PHP types for service "%s" key "%s", "%s" returned.', $class, $this->currentId, $key, \is_string($type) ? $type : get_debug_type($type)));
             }
             if ($optionalBehavior = '?' === $type[0]) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1754,7 +1754,7 @@ EOF;
 
                     $returnedType = '';
                     if ($value instanceof TypedReference) {
-                        $returnedType = sprintf(': %s\%s', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $value->getInvalidBehavior() ? '' : '?', $value->getType());
+                        $returnedType = sprintf(': %s\%s', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $value->getInvalidBehavior() ? '' : '?', str_replace(['|', '&'], ['|\\', '&\\'], $value->getType()));
                     }
 
                     $code = sprintf('return %s;', $code);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberIntersection.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberIntersection.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+class TestServiceSubscriberIntersection implements ServiceSubscriberInterface
+{
+    public function __construct($container)
+    {
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            TestDefinition1::class.'&'.TestDefinition2::class,
+            'bar' => TestDefinition1::class.'&'.TestDefinition2::class,
+            'baz' => '?'.TestDefinition1::class.'&'.TestDefinition2::class,
+        ];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberIntersectionWithTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberIntersectionWithTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\Contracts\Service\ServiceSubscriberTrait;
+
+class TestServiceSubscriberIntersectionWithTrait implements ServiceSubscriberInterface
+{
+    use ServiceSubscriberTrait;
+
+    #[SubscribedService]
+    private function method1(): TestDefinition1&TestDefinition2
+    {
+        return $this->container->get(__METHOD__);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberUnion.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberUnion.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+class TestServiceSubscriberUnion implements ServiceSubscriberInterface
+{
+    public function __construct($container)
+    {
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            'string|'.TestDefinition2::class.'|'.TestDefinition1::class,
+            'bar' => TestDefinition1::class.'|'.TestDefinition2::class,
+            'baz' => '?'.TestDefinition1::class.'|'.TestDefinition2::class,
+        ];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberUnionWithTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberUnionWithTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\Contracts\Service\ServiceSubscriberTrait;
+
+class TestServiceSubscriberUnionWithTrait implements ServiceSubscriberInterface
+{
+    use ServiceSubscriberTrait;
+
+    #[SubscribedService]
+    private function method1(): TestDefinition1|TestDefinition2|null
+    {
+        return $this->container->get(__METHOD__);
+    }
+
+    #[SubscribedService]
+    private function method2(): TestDefinition1|TestDefinition2
+    {
+        return $this->container->get(__METHOD__);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Continuation of #43479 per [discussion](https://github.com/symfony/symfony/issues/43913#issuecomment-959718034) with @nicolas-grekas.

Todo:
- [x] intersection type support/tests
- [x] `ServiceSubscriberTrait` support
