### PR TITLE
[HttpClient][WebProfilerBundle] Add button to copy a request as a cURL command

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
@@ -94,6 +94,11 @@
                                                 Profile
                                             </th>
                                         {% endif %}
+                                        {% if trace.curlCommand is not null %}
+                                            <th>
+                                                <button class="btn btn-sm hidden label" title="Copy as cURL command" data-clipboard-text="{{ trace.curlCommand }}">cURL</button>
+                                            </th>
+                                        {% endif %}
                                     </tr>
                                     </thead>
                                     <tbody>
@@ -110,7 +115,7 @@
                                                 {{ trace.http_code }}
                                             </span>
                                         </th>
-                                        <td>
+                                        <td{% if trace.curlCommand %} colspan="2"{% endif %}>
                                             {{ profiler_dump(trace.info, maxDepth=1) }}
                                         </td>
                                         {% if profiler_token and profiler_link %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -39,11 +39,29 @@ if (typeof Sfjs === 'undefined' || typeof Sfjs.loadToolbar === 'undefined') {
         }
 
         if (navigator.clipboard) {
-            document.querySelectorAll('[data-clipboard-text]').forEach(function(element) {
-                removeClass(element, 'hidden');
-                element.addEventListener('click', function() {
-                    navigator.clipboard.writeText(element.getAttribute('data-clipboard-text'));
-                })
+            document.addEventListener('readystatechange', () => {
+                if (document.readyState !== 'complete') {
+                    return;
+                }
+
+                document.querySelectorAll('[data-clipboard-text]').forEach(function (element) {
+                    removeClass(element, 'hidden');
+                    element.addEventListener('click', function () {
+                        navigator.clipboard.writeText(element.getAttribute('data-clipboard-text'));
+
+                        if (element.classList.contains("label")) {
+                            let oldContent = element.textContent;
+
+                            element.textContent = "✅ Copied!";
+                            element.classList.add("status-success");
+
+                            setTimeout(() => {
+                                element.textContent = oldContent;
+                                element.classList.remove("status-success");
+                            }, 7000);
+                        }
+                    });
+                });
             });
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | #33311 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

Adding a button to each request in the HttpClient section to copy it as a `curl` command that can be then pasted either in the terminal (on Linux and Mac) or in an application that can parse it (like Insomnia).

Work in progress:
- [x] Make a first PoC of the feature
- [x] Generate the `curl` command
- [x] Added some UX considerations to the button
- [x] Update the tests

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
