### PR TITLE
[Yaml] revert using functions provided by polyfill packages

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -211,7 +211,19 @@ class Inline
      */
     public static function isHash($value): bool
     {
-        return !\is_array($value) || !array_is_list($value);
+        if ($value instanceof \stdClass || $value instanceof \ArrayObject) {
+            return true;
+        }
+
+        $expectedKey = 0;
+
+        foreach ($value as $key => $val) {
+            if ($key !== $expectedKey++) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -18,9 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1",
-        "symfony/polyfill-ctype": "^1.8",
-        "symfony/polyfill-php80": "^1.16",
-        "symfony/polyfill-php81": "^1.22"
+        "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {
         "symfony/console": "^5.3|^6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43943
| License       | MIT
| Doc PR        | 

This reverts #41431 for the same reason for which we merged #42296 (see #42280 and composer/composer#10024 for more information).