### PR TITLE
[Runtime] fix defining APP_DEBUG when Dotenv is not enabled

### DIFF
--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -103,7 +103,8 @@ class SymfonyRuntime extends GenericRuntime
             $options['debug'] ?? $options['debug'] = '1' === $_SERVER['APP_DEBUG'];
             $options['disable_dotenv'] = true;
         } else {
-            $_SERVER['APP_ENV'] ?? $_SERVER['APP_ENV'] = 'dev';
+            $_SERVER['APP_ENV'] ?? $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] ?? 'dev';
+            $_SERVER['APP_DEBUG'] ?? $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] ?? !\in_array($_SERVER['APP_ENV'], (array) ($options['prod_envs'] ?? ['prod']), true);
         }
 
         $options['error_handler'] ?? $options['error_handler'] = SymfonyErrorHandler::class;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43793
| License       | MIT
| Doc PR        | -