### PR TITLE
[HttpKernel] Make sure FileLinkFormatter can be serialized

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -94,7 +94,7 @@ class FileLinkFormatter
         }
     }
 
-    private function getFileLinkFormat()
+    private function getFileLinkFormat(): array|false
     {
         if ($this->fileLinkFormat) {
             return $this->fileLinkFormat;
@@ -111,6 +111,6 @@ class FileLinkFormatter
             }
         }
 
-        return null;
+        return false;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
@@ -60,4 +60,9 @@ class FileLinkFormatterTest extends TestCase
 
         $this->assertSame("atom://core/open/file?filename=$file&line=3", $sut->format($file, 3));
     }
+
+    public function testSerialize()
+    {
+        $this->assertInstanceOf(FileLinkFormatter::class, unserialize(serialize(new FileLinkFormatter())));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

We currently get a `TypeError` when serializing a `FileLinkFormatter`. This PR should help.