### PR TITLE
[Asset][Security] Fixed leftover deprecations PHP 8.1

### DIFF
--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -62,7 +62,7 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
     private function getManifestPath(string $path): ?string
     {
         if (null === $this->manifestData) {
-            if (null !== $this->httpClient && 0 === strpos(parse_url($this->manifestPath, \PHP_URL_SCHEME), 'http')) {
+            if (null !== $this->httpClient && ($scheme = parse_url($this->manifestPath, \PHP_URL_SCHEME)) && 0 === strpos($scheme, 'http')) {
                 try {
                     $this->manifestData = $this->httpClient->request('GET', $this->manifestPath, [
                         'headers' => ['accept' => 'application/json'],

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -70,7 +70,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
 
     public function supports(Request $request): ?bool
     {
-        if (false === strpos($request->getRequestFormat(), 'json') && false === strpos($request->getContentType(), 'json')) {
+        if (false === strpos($request->getRequestFormat() ?? '', 'json') && false === strpos($request->getContentType() ?? '', 'json')) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552, leftover https://github.com/symfony/symfony/pull/41559
| License       | MIT
| Doc PR        | ~

Found during testing **PHP 8.1** and Symfony **5.4.0-BETA1**

1. src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
 ![obraz](https://user-images.githubusercontent.com/16488888/140545163-837ea4c4-907b-44e7-8f8e-7454f7d66be3.png)

Looks like https://github.com/symfony/symfony/pull/41559 didn't solve the deprecation completely.

2. src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
![obraz](https://user-images.githubusercontent.com/16488888/140545313-794c0136-cef8-4434-a8c2-21c3d77ef196.png)

`Request::getRequestFormat()` and `Request::getContentType()` may return nulls.