### PR TITLE
[Validator] Add Swedish translation for issue #43737

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
@@ -394,7 +394,14 @@
                 <source>This value is not a valid CSS color.</source>
                 <target>Det här värdet är inte en giltig CSS-färg.</target>
             </trans-unit>
-
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Det här värdet är inte en giltig CIDR-notation.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>Värdet på nätmasken bör vara mellan {{ min }} och {{ max }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #43737 
| License       | MIT

Added missing Swedish translation for the Validator component.
