### PR TITLE
[TwigBundle] Remove php 8.0 polyfill

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -23,7 +23,6 @@
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/polyfill-ctype": "~1.8",
-        "symfony/polyfill-php80": "^1.16",
         "twig/twig": "^2.13|^3.0.4"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

We require PHP 8.0, so we shouldn't need the polyfill.