### PR TITLE
[Loco] Fix Loco Provider ID and pull & push local messages reading

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -171,6 +171,7 @@ final class LocoProvider implements ProviderInterface
         foreach ($keys as $key) {
             $responses[$key] = $this->client->request('POST', 'assets', [
                 'body' => [
+                    'id' => $key,
                     'text' => $key,
                     'type' => 'text',
                     'default' => 'untranslated',

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -63,6 +63,7 @@ class LocoProviderTest extends ProviderTestCase
         $responses = [
             'createAsset1' => function (string $method, string $url, array $options = []) use ($expectedAuthHeader): ResponseInterface {
                 $expectedBody = http_build_query([
+                    'id' => 'a',
                     'text' => 'a',
                     'type' => 'text',
                     'default' => 'untranslated',
@@ -99,6 +100,7 @@ class LocoProviderTest extends ProviderTestCase
             },
             'createAsset2' => function (string $method, string $url, array $options = []) use ($expectedAuthHeader): ResponseInterface {
                 $expectedBody = http_build_query([
+                    'id' => 'post.num_comments',
                     'text' => 'post.num_comments',
                     'type' => 'text',
                     'default' => 'untranslated',

--- a/src/Symfony/Component/Translation/Command/TranslationTrait.php
+++ b/src/Symfony/Component/Translation/Command/TranslationTrait.php
@@ -32,8 +32,7 @@ trait TranslationTrait
 
             if ($domains) {
                 foreach ($domains as $domain) {
-                    $catalogue = $this->filterCatalogue($catalogue, $domain);
-                    $bag->addCatalogue($catalogue);
+                    $bag->addCatalogue($this->filterCatalogue($catalogue, $domain));
                 }
             } else {
                 $bag->addCatalogue($catalogue);

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -90,22 +90,32 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
     public function testPushForceMessages()
     {
         $xliffLoader = new XliffFileLoader();
-        $filenameEn = $this->createFile([
+        $filenameMessagesEn = $this->createFile([
             'note' => 'NOTE UPDATED',
             'new.foo' => 'newFoo',
-        ]);
-        $filenameFr = $this->createFile([
+        ], 'en');
+        $filenameMessagesFr = $this->createFile([
             'note' => 'NOTE MISE À JOUR',
             'new.foo' => 'nouveauFoo',
         ], 'fr');
+        $filenameValidatorsEn = $this->createFile([
+            'foo.error' => 'Wrong value',
+            'bar.success' => 'Form valid!',
+        ], 'en', 'validators.%locale%.xlf');
+        $filenameValidatorsFr = $this->createFile([
+            'foo.error' => 'Valeur erronée',
+            'bar.success' => 'Formulaire valide !',
+        ], 'fr', 'validators.%locale%.xlf');
         $locales = ['en', 'fr'];
-        $domains = ['messages'];
+        $domains = ['messages', 'validators'];
 
         $provider = $this->createMock(ProviderInterface::class);
 
         $localTranslatorBag = new TranslatorBag();
-        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameEn, 'en'));
-        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameFr, 'fr'));
+        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameMessagesEn, 'en', 'messages'));
+        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameMessagesFr, 'fr', 'messages'));
+        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameValidatorsEn, 'en', 'validators'));
+        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameValidatorsFr, 'fr', 'validators'));
 
         $provider->expects($this->once())
             ->method('write')
@@ -117,9 +127,9 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
 
         $tester = $this->createCommandTester($provider, $locales, $domains);
 
-        $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages'], '--force' => true]);
+        $tester->execute(['--locales' => $locales, '--domains' => $domains, '--force' => true]);
 
-        $this->assertStringContainsString('[OK] All local translations has been sent to "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] All local translations has been sent to "null" (for "en, fr" locale(s), and "messages, validators" domain(s)).', trim($tester->getDisplay()));
     }
 
     public function testDeleteMissingMessages()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/issues/42395 & https://github.com/symfony/symfony/issues/43954
| License       | MIT
| Doc PR        | 

It fixes Loco push new messages and avoiding Loco auto-generation of ID for each new messages (which use dash notation instead of dot notation IIRC).

And it fixes also the Translation push & pull commands when they read local messages for multiple domains.