### PR TITLE
Zsh shell autocompletions

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -364,7 +364,7 @@ class Application implements ResetInterface
             && 'command' === $input->getCompletionName()
         ) {
             $suggestions->suggestValues(array_filter(array_map(function (Command $command) use ($input) {
-                return $command->isHidden() ? null : $command->getName() . ($input->isShell('zsh') ? "\t".$command->getDescription() : '');
+                return $command->isHidden() ? null : $command->getName().($input->isShell('zsh') ? "\t".$command->getDescription() : '');
             }, $this->all())));
 
             return;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -363,8 +363,8 @@ class Application implements ResetInterface
             CompletionInput::TYPE_ARGUMENT_VALUE === $input->getCompletionType()
             && 'command' === $input->getCompletionName()
         ) {
-            $suggestions->suggestValues(array_filter(array_map(function (Command $command) {
-                return $command->isHidden() ? null : $command->getName();
+            $suggestions->suggestValues(array_filter(array_map(function (Command $command) use ($input) {
+                return $command->isHidden() ? null : $command->getName() . ($input->isShell('zsh') ? "\t".$command->getDescription() : '');
             }, $this->all())));
 
             return;

--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Completion\Output\BashCompletionOutput;
 use Symfony\Component\Console\Completion\Output\CompletionOutputInterface;
+use Symfony\Component\Console\Completion\Output\ZshCompletionOutput;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,6 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Responsible for providing the values to the shell completion.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
+ * @author Jitendra A <adhocore@gmail.com>
  */
 final class CompleteCommand extends Command
 {
@@ -41,7 +43,10 @@ final class CompleteCommand extends Command
     public function __construct(array $completionOutputs = [])
     {
         // must be set before the parent constructor, as the property value is used in configure()
-        $this->completionOutputs = $completionOutputs + ['bash' => BashCompletionOutput::class];
+        $this->completionOutputs = $completionOutputs + [
+            'bash' => BashCompletionOutput::class,
+            'zsh' => ZshCompletionOutput::class,
+        ];
 
         parent::__construct();
     }
@@ -168,6 +173,7 @@ final class CompleteCommand extends Command
         }
 
         $completionInput = CompletionInput::fromTokens($input->getOption('input'), (int) $currentIndex);
+        $completionInput->setShell($input->getOption('shell'));
 
         try {
             $completionInput->bind($this->getApplication()->getDefinition());

--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -181,11 +181,9 @@ final class CompletionInput extends ArgvInput
         return self::TYPE_ARGUMENT_VALUE === $this->getCompletionType() && $argumentName === $this->getCompletionName();
     }
 
-    public function setShell(string $shell): string
+    public function setShell(string $shell): void
     {
-        [$this->shell, $old] = [$shell, $this->shell];
-
-        return $old;
+        $this->shell = $shell;
     }
 
     public function isShell(string $shell): bool

--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Input\InputOption;
  * completion is expected.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
+ * @author Jitendra A <adhocore@gmail.com>
  */
 final class CompletionInput extends ArgvInput
 {
@@ -32,6 +33,7 @@ final class CompletionInput extends ArgvInput
     public const TYPE_NONE = 'none';
 
     private $tokens;
+    private $shell = '';
     private $currentIndex;
     private $completionType;
     private $completionName = null;
@@ -177,6 +179,18 @@ final class CompletionInput extends ArgvInput
     public function mustSuggestArgumentValuesFor(string $argumentName): bool
     {
         return self::TYPE_ARGUMENT_VALUE === $this->getCompletionType() && $argumentName === $this->getCompletionName();
+    }
+
+    public function setShell(string $shell): string
+    {
+        [$this->shell, $old] = [$shell, $this->shell];
+
+        return $old;
+    }
+
+    public function isShell(string $shell): bool
+    {
+        return $this->shell === $shell;
     }
 
     protected function parseToken(string $token, bool $parseOptions): bool

--- a/src/Symfony/Component/Console/Completion/Output/ZshCompletionOutput.php
+++ b/src/Symfony/Component/Console/Completion/Output/ZshCompletionOutput.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Completion\Output;
+
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Jitendra A <adhocore@gmail.com>
+ */
+class ZshCompletionOutput implements CompletionOutputInterface
+{
+    public function write(CompletionSuggestions $suggestions, OutputInterface $output): void
+    {
+        $options = $suggestions->getValueSuggestions();
+        foreach ($suggestions->getOptionSuggestions() as $option) {
+            $options[] = '--'.$option->getName()."\t".$option->getDescription();
+        }
+        $output->writeln(implode("\n", $options));
+    }
+}

--- a/src/Symfony/Component/Console/Resources/completion.zsh
+++ b/src/Symfony/Component/Console/Resources/completion.zsh
@@ -1,0 +1,80 @@
+# This file is part of the Symfony package.
+#
+# (c) Fabien Potencier <fabien@symfony.com>
+#
+# For the full copyright and license information, please view
+# https://symfony.com/doc/current/contributing/code/license.html
+
+#
+# zsh completions for {{ COMMAND_NAME }}
+#
+# References:
+#   - https://github.com/spf13/cobra/blob/master/zsh_completions.go
+#   - https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Console/Resources/completion.bash
+#
+_sf_{{ COMMAND_NAME }}() {
+    local lastParam flagPrefix requestComp out comp
+    local -a completions
+
+    # The user could have moved the cursor backwards on the command-line.
+    # We need to trigger completion from the $CURRENT location, so we need
+    # to truncate the command-line ($words) up to the $CURRENT location.
+    # (We cannot use $CURSOR as its value does not work when a command is an alias.)
+    words=("${=words[1,CURRENT]}") lastParam=${words[-1]}
+
+    # For zsh, when completing a flag with an = (e.g., {{ COMMAND_NAME }} -n=<TAB>)
+    # completions must be prefixed with the flag
+    setopt local_options BASH_REMATCH
+    if [[ "${lastParam}" =~ '-.*=' ]]; then
+        # We are dealing with a flag with an =
+        flagPrefix="-P ${BASH_REMATCH}"
+    fi
+
+    # Prepare the command to obtain completions
+    requestComp="${words[0]} ${words[1]} _complete -szsh -S{{ VERSION }} -c$((CURRENT-1))" i=""
+    for w in ${words[@]}; do
+        w=$(printf -- '%b' "$w")
+        # remove quotes from typed values
+        quote="${w:0:1}"
+        if [ "$quote" = \' ]; then
+            w="${w%\'}"
+            w="${w#\'}"
+        elif [ "$quote" = \" ]; then
+            w="${w%\"}"
+            w="${w#\"}"
+        fi
+        # empty values are ignored
+        if [ ! -z "$w" ]; then
+            i="${i}-i${w} "
+        fi
+    done
+
+    # Ensure atleast 1 input
+    if [ "${i}" = "" ]; then
+        requestComp="${requestComp} -i\" \""
+    else
+        requestComp="${requestComp} ${i}"
+    fi
+
+    # Use eval to handle any environment variables and such
+    out=$(eval ${requestComp} 2>/dev/null)
+
+    while IFS='\n' read -r comp; do
+        if [ -n "$comp" ]; then
+            # If requested, completions are returned with a description.
+            # The description is preceded by a TAB character.
+            # For zsh's _describe, we need to use a : instead of a TAB.
+            # We first need to escape any : as part of the completion itself.
+            comp=${comp//:/\\:}
+            local tab=$(printf '\t')
+            comp=${comp//$tab/:}
+            completions+=${comp}
+        fi
+    done < <(printf "%s\n" "${out[@]}")
+
+    # Let inbuilt _describe handle completions
+    eval _describe "completions" completions $flagPrefix
+    return $?
+}
+
+compdef _sf_{{ COMMAND_NAME }} {{ COMMAND_NAME }}

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -47,7 +47,7 @@ class CompleteCommandTest extends TestCase
 
     public function testUnsupportedShellOption()
     {
-        $this->expectExceptionMessage('Shell completion is not supported for your shell: "unsupported" (supported: "bash").');
+        $this->expectExceptionMessage('Shell completion is not supported for your shell: "unsupported" (supported: "bash", "zsh").');
         $this->execute(['--shell' => 'unsupported']);
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -122,6 +122,54 @@ class CompleteCommandTest extends TestCase
         yield 'custom' => [['bin/console', 'hello'], ['Fabien', 'Robin', 'Wouter']];
     }
 
+    /**
+     * @dataProvider provideZshCompleteCommandNameInputs
+     */
+    public function testZshCompleteCommandName(array $input, array $suggestions)
+    {
+        $this->execute(['--current' => '1', '--input' => $input, '--shell' => 'zsh']);
+        $this->assertEquals(implode("\n", $suggestions).\PHP_EOL, $this->tester->getDisplay());
+    }
+
+    public function provideZshCompleteCommandNameInputs()
+    {
+        yield 'empty' => [['bin/console'], [
+            'help'."\t".'Display help for a command',
+            'list'."\t".'List commands',
+            'completion'."\t".'Dump the shell completion script',
+            'hello'."\t".'Hello test command',
+        ]];
+        yield 'partial' => [['bin/console', 'he'], [
+            'help'."\t".'Display help for a command',
+            'list'."\t".'List commands',
+            'completion'."\t".'Dump the shell completion script',
+            'hello'."\t".'Hello test command',
+        ]];
+        yield 'complete-shortcut-name' => [['bin/console', 'hell'], ['hello']];
+    }
+
+    /**
+     * @dataProvider provideZshCompleteCommandInputDefinitionInputs
+     */
+    public function testZshCompleteCommandInputDefinition(array $input, array $suggestions)
+    {
+        $this->execute(['--current' => '2', '--input' => $input, '--shell' => 'zsh']);
+        $this->assertEquals(implode("\n", $suggestions).\PHP_EOL, $this->tester->getDisplay());
+    }
+
+    public function provideZshCompleteCommandInputDefinitionInputs()
+    {
+        yield 'definition' => [['bin/console', 'hello', '-'], [
+            '--help'."\t".'Display help for the given command. When no command is given display help for the list command',
+            '--quiet'."\t".'Do not output any message',
+            '--verbose'."\t".'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug',
+            '--version'."\t".'Display this application version',
+            '--ansi'."\t".'Force (or disable --no-ansi) ANSI output',
+            '--no-interaction'."\t".'Do not ask any interactive question',
+        ]];
+        yield 'custom' => [['bin/console', 'hello'], ['Fabien', 'Robin', 'Wouter']];
+    }
+
     private function execute(array $input)
     {
         // run in verbose mode to assert exceptions
@@ -134,6 +182,7 @@ class CompleteCommandTest_HelloCommand extends Command
     public function configure(): void
     {
         $this->setName('hello')
+             ->setDescription('Hello test command')
              ->addArgument('name', InputArgument::REQUIRED)
          ;
     }

--- a/src/Symfony/Component/Console/Tests/Command/DumpCompletionCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/DumpCompletionCommandTest.php
@@ -23,7 +23,7 @@ class DumpCompletionCommandTest extends TestCase
     {
         yield 'shell' => [
             [''],
-            ['bash'],
+            ['bash', 'zsh'],
         ];
     }
 }

--- a/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
@@ -119,4 +119,12 @@ class CompletionInputTest extends TestCase
         yield ['bin/console cache:clear "multi word string"', ['bin/console', 'cache:clear', '"multi word string"']];
         yield ['bin/console cache:clear \'multi word string\'', ['bin/console', 'cache:clear', '\'multi word string\'']];
     }
+
+    public function testShell()
+    {
+        $input = CompletionInput::fromString('bin/console cache:clear \'multi word string\'', 1);
+        $input->setShell('zsh');
+
+        $this->assertTrue($input->isShell('zsh'));
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -89,7 +89,7 @@
                         "accept_value": true,
                         "is_value_required": true,
                         "is_multiple": false,
-                        "description": "The shell type (\"bash\")",
+                        "description": "The shell type (\"bash\", \"zsh\")",
                         "default": null
                     },
                     "current": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -10,7 +10,7 @@
       <arguments/>
       <options>
         <option name="--shell" shortcut="-s" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The shell type ("bash")</description>
+          <description>The shell type ("bash", "zsh")</description>
           <defaults/>
         </option>
         <option name="--input" shortcut="-i" accept_value="1" is_value_required="1" is_multiple="1">

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -93,7 +93,7 @@
                         "accept_value": true,
                         "is_value_required": true,
                         "is_multiple": false,
-                        "description": "The shell type (\"bash\")",
+                        "description": "The shell type (\"bash\", \"zsh\")",
                         "default": null
                     },
                     "current": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -10,7 +10,7 @@
       <arguments/>
       <options>
         <option name="--shell" shortcut="-s" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The shell type ("bash")</description>
+          <description>The shell type ("bash", "zsh")</description>
           <defaults/>
         </option>
         <option name="--input" shortcut="-i" accept_value="1" is_value_required="1" is_multiple="1">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #43592 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

### Usage
#### Setup/Install
In `zsh` terminal run:
```zsh
bin/console completion zsh > "$fpath[1]/console"
```
which will add dumped zsh completion helper in first fpath (zsh's functions autoload path).
Then reload shell or just do `source "$fpath[1]/console"`.

---

Here's a simple script `sfzsh` that I'm using while adding the **zsh** autocompletion support as a testbed:

<details><summary>Toggle code</summary>
<p>

```php
#!/bin/env php
<?php

use Symfony\Component\Console\Application;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Completion\CompletionInput;
use Symfony\Component\Console\Completion\CompletionSuggestions;
use Symfony\Component\Console\Descriptor\ApplicationDescription;
use Symfony\Component\Console\Helper\DescriptorHelper;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputOption;
use Symfony\Component\Console\Output\OutputInterface;

putenv('SYMFONY_COMPLETION_DEBUG=1');

$app = new Application('sfzsh', '0.0.1');

// test1
$app->add(new class() extends Command {
    protected static $defaultName = 'test1';
    protected static $defaultDescription = 'Test one cmd';

    protected function configure(): void
    {
        $this
            ->addOption('t1o1', '1', InputOption::VALUE_REQUIRED, 't1o1 str val')
            ->addOption('t1o2', '2', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 't1o2 array val')
            ->addArgument('php', InputArgument::REQUIRED, 'PHP file in current dir')
        ;
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        return 0;
    }

    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
    {
        if ($input->mustSuggestOptionValuesFor('t1o1')) {
            $suggestions->suggestValues(['t1o1.v1', 't1o1.v2']);

            return;
        }

        if ($input->mustSuggestOptionValuesFor('t1o2')) {
            $suggestions->suggestValues(['t1o2.v1', 't1o2.v2']);

            return;
        }

        if ($input->mustSuggestArgumentValuesFor('php')) {
            $suggestions->suggestValues([system('ls -1 *.php')]);

            return;
        }
    }
});

// test2
$app->add(new class() extends Command {
    protected static $defaultName = 'test2';
    protected static $defaultDescription = 'Test two cmd';

    protected function configure(): void
    {
        $this
            ->addOption('t2o1', '1', InputOption::VALUE_REQUIRED, 't2o1 str val')
            ->addOption('t2o2', '2', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 't2o2 array val')
            ->addArgument('dir', InputArgument::REQUIRED, 'subdir in current dir')
        ;
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        return 0;
    }

    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
    {
        if ($input->mustSuggestOptionValuesFor('t2o1')) {
            $suggestions->suggestValues(['t2o1.v1', 't2o1.v2']);

            return;
        }

        if ($input->mustSuggestOptionValuesFor('t2o2')) {
            $suggestions->suggestValues(['t2o2.v1', 't2o2.v2']);

            return;
        }

        if ($input->mustSuggestArgumentValuesFor('dir')) {
            $suggestions->suggestValues([system('ls -1d */')]);

            return;
        }
    }
});

$app->run();
```
</p>
</details>

```zsh
sfzsh completion zsh > "${fpath[1]}/sfzsh"
. "${fpath[1]}/sfzsh"
```
#### Autocomplete commands
```zsh
sfzsh [TAB]
```
![image](https://user-images.githubusercontent.com/2908547/140903159-718e27bd-226a-4e15-b976-88fc34b74d3b.png)

> Shortlisting works too: `sfzsh te[TAB]` autocompletes for `test1` and `test2`

> Fuzzy match works too: `sfzsh t1[TAB]` autocompletes `test1`
  
#### Autocomplete options
```zsh
 sfzsh test1 --[TAB]
```
![image](https://user-images.githubusercontent.com/2908547/140903736-bdbd4c1b-5a39-4e68-83f5-e8580bcf53e3.png)

#### Autocomplete option values
```zsh
sfzsh test1 --t1o1 [TAB]
```
![image](https://user-images.githubusercontent.com/2908547/140904073-4445f053-7abe-4e94-9582-9df185aadf57.png)

> `=` separator works too: `sfzsh test1 --t1o1=[TAB]`

#### Autocomplete args
```zsh
sfzsh test1 [TAB]
```
> |_ (autocompletes *.php files in current dir)

```zsh
sfzsh test2 [TAB]
```
> |_ (autocompletes subdirs in current dir)
