### PR TITLE
Use symfony-*-bridge instead of symfony-bridge for component bridges

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/amazon-mailer",
-    "type": "symfony-bridge",
+    "type": "symfony-mailer-bridge",
     "description": "Symfony Amazon Mailer Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Mailer/Bridge/Google/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Google/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/google-mailer",
-    "type": "symfony-bridge",
+    "type": "symfony-mailer-bridge",
     "description": "Symfony Google Mailer Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/mailchimp-mailer",
-    "type": "symfony-bridge",
+    "type": "symfony-mailer-bridge",
     "description": "Symfony Mailchimp Mailer Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/mailgun-mailer",
-    "type": "symfony-bridge",
+    "type": "symfony-mailer-bridge",
     "description": "Symfony Mailgun Mailer Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/mailjet-mailer",
-    "type": "symfony-bridge",
+    "type": "symfony-mailer-bridge",
     "description": "Symfony Mailjet Mailer Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Mailer/Bridge/OhMySmtp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/OhMySmtp/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/oh-my-smtp-mailer",
-    "type": "symfony-bridge",
+    "type": "symfony-mailer-bridge",
     "description": "Symfony OhMySMTP Mailer Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/postmark-mailer",
-    "type": "symfony-bridge",
+    "type": "symfony-mailer-bridge",
     "description": "Symfony Postmark Mailer Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/sendgrid-mailer",
-    "type": "symfony-bridge",
+    "type": "symfony-mailer-bridge",
     "description": "Symfony Sendgrid Mailer Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/sendinblue-mailer",
-    "type": "symfony-bridge",
+    "type": "symfony-mailer-bridge",
     "description": "Symfony Sendinblue Mailer Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/amazon-sqs-messenger",
-    "type": "symfony-bridge",
+    "type": "symfony-messenger-bridge",
     "description": "Symfony Amazon SQS extension Messenger Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/amqp-messenger",
-    "type": "symfony-bridge",
+    "type": "symfony-messenger-bridge",
     "description": "Symfony AMQP extension Messenger Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/beanstalkd-messenger",
-    "type": "symfony-bridge",
+    "type": "symfony-messenger-bridge",
     "description": "Symfony Beanstalkd Messenger Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/doctrine-messenger",
-    "type": "symfony-bridge",
+    "type": "symfony-messenger-bridge",
     "description": "Symfony Doctrine Messenger Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/redis-messenger",
-    "type": "symfony-bridge",
+    "type": "symfony-messenger-bridge",
     "description": "Symfony Redis extension Messenger Bridge",
     "keywords": [],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/allmysms-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony AllMySms Notifier Bridge",
     "keywords": ["sms", "allMySms", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/amazon-sns-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Provides Amazon SNS integration for Symfony Notifier.",
     "keywords": ["amazon", "sns", "notifier", "chat", "sms"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/clickatell-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Clickatell Notifier Bridge",
     "keywords": ["sms", "clickatell", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/discord-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Discord Notifier Bridge",
     "keywords": ["discord", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/esendex-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Esendex Notifier Bridge",
     "keywords": ["sms", "esendex", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/expo-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Expo Notifier Bridge",
     "keywords": ["expo", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/fake-chat-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Fake Chat (as email or log during development) Notifier Bridge.",
     "keywords": ["chat", "development", "email", "notifier", "symfony"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/fake-sms-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Fake SMS (as email or log during development) Notifier Bridge.",
     "keywords": ["sms", "development", "email", "notifier", "symfony"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/firebase-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Firebase Notifier Bridge",
     "keywords": ["firebase", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/free-mobile-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Free Mobile Notifier Bridge",
     "keywords": ["sms", "FreeMobile", "notifier", "alerting"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/gatewayapi-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony GatewayApi Notifier Bridge",
     "keywords": ["sms", "gatewayapi", "notifier"],
     "homepage": "https://gatewayapi.com",

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/gitter-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Gitter Notifier Bridge",
     "keywords": ["chat", "gitter", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/google-chat-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Google Chat Notifier Bridge",
     "keywords": ["google", "chat", "google chat", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/infobip-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Infobip Notifier Bridge",
     "keywords": ["sms", "infobip", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/iqsms-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Iqsms Notifier Bridge",
     "keywords": ["sms", "iqsms", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/light-sms-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony LightSms Notifier Bridge",
     "keywords": ["sms", "light-sms", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/linked-in-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony LinkedIn Notifier Bridge",
     "keywords": ["linkedin", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/mailjet-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Mailjet Notifier Bridge",
     "keywords": ["sms", "mailjet", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/mattermost-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Mattermost Notifier Bridge",
     "keywords": ["mattermost", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/mercure-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Mercure Notifier Bridge",
     "keywords": ["mercure", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/message-bird-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony MessageBird Notifier Bridge",
     "keywords": ["sms", "message-bird", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "symfony/message-media-notifier",
-  "type": "symfony-bridge",
+  "type": "symfony-notifier-bridge",
   "description": "Symfony MessageMedia Notifier Bridge",
   "keywords": ["sms", "messagemedia", "notifier"],
   "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/microsoft-teams-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Microsoft Teams Notifier Bridge",
     "keywords": ["chat", "microsoft-teams", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/mobyt-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Mobyt Notifier Bridge",
     "keywords": ["sms", "mobyt", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/nexmo-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Nexmo Notifier Bridge",
     "keywords": ["sms", "nexmo", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/octopush-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Octopush Notifier Bridge",
     "keywords": ["sms", "octopush", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/one-signal-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony OneSignal Notifier Bridge",
     "keywords": ["onesignal", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/ovh-cloud-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony OvhCloud Notifier Bridge",
     "keywords": ["sms", "OvhCloud", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/rocket-chat-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony RocketChat Notifier Bridge",
     "keywords": ["rocketchat", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/sendinblue-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Sendinblue Notifier Bridge",
     "keywords": ["sms", "sendinblue", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/sinch-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Sinch Notifier Bridge",
     "keywords": ["sms", "sinch", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/slack-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Slack Notifier Bridge",
     "keywords": ["slack", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/sms77-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony sms77 Notifier Bridge",
     "keywords": ["sms", "sms77", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/sms-biuras-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony SmsBiuras Notifier Bridge",
     "keywords": ["sms", "smsbiuras", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/smsapi-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Smsapi Notifier Bridge",
     "keywords": ["sms", "smsapi", "notifier"],
     "homepage": "https://mvpdoers.com",

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/smsc-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony SMSC Notifier Bridge",
     "keywords": ["sms", "smsc", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/spot-hit-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Spot-Hit Notifier Bridge",
     "keywords": ["sms", "spot-hit", "notifier", "symfony"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/telegram-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Telegram Notifier Bridge",
     "keywords": ["telegram", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/telnyx-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Telnyx Notifier Bridge",
     "keywords": ["sms", "telnyx", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/turbosms-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony TurboSms Notifier Bridge",
     "keywords": ["sms", "TurboSms", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/twilio-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Twilio Notifier Bridge",
     "keywords": ["sms", "twilio", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/yunpian-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Yunpian Notifier Bridge",
     "keywords": ["sms", "yunpian", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/zulip-notifier",
-    "type": "symfony-bridge",
+    "type": "symfony-notifier-bridge",
     "description": "Symfony Zulip Notifier Bridge",
     "keywords": ["zulip", "notifier"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/crowdin-translation-provider",
-    "type": "symfony-bridge",
+    "type": "symfony-translation-bridge",
     "description": "Symfony Crowdin Translation Provider Bridge",
     "keywords": ["crowdin", "translation", "provider"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Translation/Bridge/Loco/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Loco/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/loco-translation-provider",
-    "type": "symfony-bridge",
+    "type": "symfony-translation-bridge",
     "description": "Symfony Loco Translation Provider Bridge",
     "keywords": ["loco", "translation", "provider"],
     "homepage": "https://symfony.com",

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/lokalise-translation-provider",
-    "type": "symfony-bridge",
+    "type": "symfony-translation-bridge",
     "description": "Symfony Lokalise Translation Provider Bridge",
     "keywords": ["lokalise", "translation", "provider"],
     "homepage": "https://symfony.com",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Might help discovering bridges for each component.