### PR TITLE
[HttpKernel] Make sure that decorated service works with kernel.reset tag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -89,8 +89,9 @@ class DecoratorServicePass implements CompilerPassInterface
                 $decoratingTags = $decoratingDefinition->getTags();
                 $resetTags = [];
 
-                // container.service_locator and container.service_subscriber have special logic and they must not be transferred out to decorators
-                foreach (['container.service_locator', 'container.service_subscriber'] as $containerTag) {
+                // container.service_locator, container.service_subscriber and kernel.reset
+                // have special logic and they must not be transferred out to decorators
+                foreach (['container.service_locator', 'container.service_subscriber', 'kernel.reset'] as $containerTag) {
                     if (isset($decoratingTags[$containerTag])) {
                         $resetTags[$containerTag] = $decoratingTags[$containerTag];
                         unset($decoratingTags[$containerTag]);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -263,6 +263,25 @@ class DecoratorServicePassTest extends TestCase
         $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
     }
 
+    public function testProcessLeavesKernelResetTagOnOriginalDefinition()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setTags(['kernel.reset' => [], 'bar' => ['attr' => 'baz']])
+        ;
+        $container
+            ->register('baz')
+            ->setTags(['foobar' => ['attr' => 'bar']])
+            ->setDecoratedService('foo')
+        ;
+
+        $this->process($container);
+
+        $this->assertEquals(['kernel.reset' => []], $container->getDefinition('baz.inner')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+    }
+
     public function testCannotDecorateSyntheticService()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ResettableServicePassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ResettableServicePassTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -10,7 +11,9 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\ResettableServicePass;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Symfony\Component\HttpKernel\Tests\Fixtures\ClearableInterface;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ClearableService;
+use Symfony\Component\HttpKernel\Tests\Fixtures\ClearableServiceDecorator;
 use Symfony\Component\HttpKernel\Tests\Fixtures\MultiResettableService;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ResettableService;
 
@@ -80,5 +83,103 @@ class ResettableServicePassTest extends TestCase
         $container->compile();
 
         $this->assertFalse($container->has('services_resetter'));
+    }
+
+    public function testDecoratedLastResettableService()
+    {
+        $container = new ContainerBuilder();
+        $container->register('services_resetter', ServicesResetter::class)
+            ->setPublic(true)
+            ->setArguments([null, []]);
+        $container->addCompilerPass(new ResettableServicePass());
+
+        $container->register('clearable_service', ClearableService::class)
+            ->setFactory([ClearableService::class, 'create'])
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $container->setAlias(ClearableInterface::class, new Alias('clearable_service', true));
+
+        $container->register('clearable_service_decorator', ClearableServiceDecorator::class)
+            ->setDecoratedService(ClearableInterface::class)
+            ->setArgument(0, new Reference('.inner'));
+
+        $container->register('clearable_service_decorator_2', ClearableServiceDecorator::class)
+            ->setDecoratedService(ClearableInterface::class)
+            ->setArgument(0, new Reference('.inner'));
+
+        $container->compile();
+
+        $container->get(ClearableInterface::class)->clear();
+
+        self::assertSame(1, ClearableService::$counter);
+        self::assertSame(2, ClearableServiceDecorator::$counter);
+
+        $container->get('services_resetter')->reset();
+        self::assertSame(0, ClearableService::$counter);
+        self::assertSame(2, ClearableServiceDecorator::$counter);
+    }
+
+    public function testDecoratedMiddleResettableService()
+    {
+        $container = new ContainerBuilder();
+        $container->register('services_resetter', ServicesResetter::class)
+            ->setPublic(true)
+            ->setArguments([null, []]);
+        $container->addCompilerPass(new ResettableServicePass());
+
+        $container->register('clearable_service', ClearableService::class)
+            ->setFactory([ClearableService::class, 'create']);
+
+        $container->setAlias(ClearableInterface::class, new Alias('clearable_service', true));
+
+        $container->register('clearable_service_decorator', ClearableServiceDecorator::class)
+            ->setDecoratedService(ClearableInterface::class)
+            ->setArgument(0, new Reference('.inner'))
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $container->register('clearable_service_decorator_2', ClearableServiceDecorator::class)
+            ->setDecoratedService(ClearableInterface::class)
+            ->setArgument(0, new Reference('.inner'));
+
+        $container->compile();
+
+        $container->get(ClearableInterface::class)->clear();
+
+        self::assertSame(1, ClearableService::$counter);
+        self::assertSame(2, ClearableServiceDecorator::$counter);
+
+        $container->get('services_resetter')->reset();
+        self::assertSame(1, ClearableService::$counter);
+        self::assertSame(0, ClearableServiceDecorator::$counter);
+    }
+
+    public function testDecoratedFirstResettableService()
+    {
+        $container = new ContainerBuilder();
+        $container->register('services_resetter', ServicesResetter::class)
+            ->setPublic(true)
+            ->setArguments([null, []]);
+        $container->addCompilerPass(new ResettableServicePass());
+
+        $container->register('clearable_service', ClearableService::class)
+            ->setFactory([ClearableService::class, 'create']);
+
+        $container->setAlias(ClearableInterface::class, new Alias('clearable_service', true));
+
+        $container->register('clearable_service_decorator', ClearableServiceDecorator::class)
+            ->setDecoratedService(ClearableInterface::class)
+            ->setArgument(0, new Reference('.inner'))
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $container->compile();
+
+        $container->get(ClearableInterface::class)->clear();
+
+        self::assertSame(1, ClearableService::$counter);
+        self::assertSame(1, ClearableServiceDecorator::$counter);
+
+        $container->get('services_resetter')->reset();
+        self::assertSame(1, ClearableService::$counter);
+        self::assertSame(0, ClearableServiceDecorator::$counter);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/ClearableInterface.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/ClearableInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+interface ClearableInterface
+{
+    public function clear();
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/ClearableService.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/ClearableService.php
@@ -2,12 +2,24 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Fixtures;
 
-class ClearableService
+use Symfony\Contracts\Service\ResetInterface;
+
+class ClearableService implements ClearableInterface, ResetInterface
 {
     public static $counter = 0;
 
     public function clear()
     {
         ++self::$counter;
+    }
+
+    public static function create()
+    {
+        return new self();
+    }
+
+    public function reset()
+    {
+        self::$counter = 0;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/ClearableServiceDecorator.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/ClearableServiceDecorator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Contracts\Service\ResetInterface;
+
+class ClearableServiceDecorator implements ClearableInterface, ResetInterface
+{
+    public static $counter = 0;
+
+    private $clearableService;
+
+    public function __construct(ClearableInterface $clearableService)
+    {
+        $this->clearableService = $clearableService;
+    }
+
+    public function clear()
+    {
+        ++self::$counter;
+
+        $this->clearableService->clear();
+    }
+
+    public function reset()
+    {
+        self::$counter = 0;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Do not transfer `kernel.reset` tag to decorators and added some tests to make sure that ServicesResetter has a decorated service
