### PR TITLE
[Serializer] Add context builders

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.1
 ---
 
+ * Add the ability to create contexts using context builders
  * Set `Context` annotation as not final
  * Deprecate `ContextAwareNormalizerInterface`, use `NormalizerInterface` instead
  * Deprecate `ContextAwareDenormalizerInterface`, use `DenormalizerInterface` instead

--- a/src/Symfony/Component/Serializer/Context/ContextBuilderTrait.php
+++ b/src/Symfony/Component/Serializer/Context/ContextBuilderTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+trait ContextBuilderTrait
+{
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $context = [];
+
+    protected function with(string $key, mixed $value): static
+    {
+        $instance = new static();
+        $instance->context = array_merge($this->context, [$key => $value]);
+
+        return $instance;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function withContext(array $context): static
+    {
+        $instance = new static();
+        $instance->context = array_merge($this->context, $context);
+
+        return $instance;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->context;
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Encoder;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * A helper providing autocompletion for available CsvEncoder options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class CsvEncoderContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures the column delimiter character.
+     *
+     * Must be a single character.
+     *
+     * @param non-empty-string|null $delimiter
+     *
+     * @throws InvalidArgumentException
+     */
+    public function withDelimiter(?string $delimiter): static
+    {
+        if (null !== $delimiter && 1 !== \strlen($delimiter)) {
+            throw new InvalidArgumentException(sprintf('The "%s" delimiter must be a single character.', $delimiter));
+        }
+
+        return $this->with(CsvEncoder::DELIMITER_KEY, $delimiter);
+    }
+
+    /**
+     * Configures the field enclosure character.
+     *
+     * Must be a single character.
+     *
+     * @param non-empty-string|null $enclosure
+     *
+     * @throws InvalidArgumentException
+     */
+    public function withEnclosure(?string $enclosure): static
+    {
+        if (null !== $enclosure && 1 !== \strlen($enclosure)) {
+            throw new InvalidArgumentException(sprintf('The "%s" enclosure must be a single character.', $enclosure));
+        }
+
+        return $this->with(CsvEncoder::ENCLOSURE_KEY, $enclosure);
+    }
+
+    /**
+     * Configures the escape character.
+     *
+     * Must be empty or a single character.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function withEscapeChar(?string $escapeChar): static
+    {
+        if (null !== $escapeChar && \strlen($escapeChar) > 1) {
+            throw new InvalidArgumentException(sprintf('The "%s" escape character must be empty or a single character.', $escapeChar));
+        }
+
+        return $this->with(CsvEncoder::ESCAPE_CHAR_KEY, $escapeChar);
+    }
+
+    /**
+     * Configures the key separator when (un)flattening arrays.
+     */
+    public function withKeySeparator(?string $keySeparator): static
+    {
+        return $this->with(CsvEncoder::KEY_SEPARATOR_KEY, $keySeparator);
+    }
+
+    /**
+     * Configures the headers.
+     *
+     * @param list<mixed>|null $headers
+     */
+    public function withHeaders(?array $headers): static
+    {
+        return $this->with(CsvEncoder::HEADERS_KEY, $headers);
+    }
+
+    /**
+     * Configures whether formulas should be escaped.
+     */
+    public function withEscapedFormulas(?bool $escapedFormulas): static
+    {
+        return $this->with(CsvEncoder::ESCAPE_FORMULAS_KEY, $escapedFormulas);
+    }
+
+    /**
+     * Configures whether the decoded result should be considered as a collection
+     * or as a single element.
+     */
+    public function withAsCollection(?bool $asCollection): static
+    {
+        return $this->with(CsvEncoder::AS_COLLECTION_KEY, $asCollection);
+    }
+
+    /**
+     * Configures whether the input (or output) is containing (or will contain) headers.
+     */
+    public function withNoHeaders(?bool $noHeaders): static
+    {
+        return $this->with(CsvEncoder::NO_HEADERS_KEY, $noHeaders);
+    }
+
+    /**
+     * Configures the end of line characters.
+     */
+    public function withEndOfLine(?string $endOfLine): static
+    {
+        return $this->with(CsvEncoder::END_OF_LINE, $endOfLine);
+    }
+
+    /**
+     * Configures whether to add the UTF-8 Byte Order Mark (BOM)
+     * at the beginning of the encoded result or not.
+     */
+    public function withOutputUtf8Bom(?bool $outputUtf8Bom): static
+    {
+        return $this->with(CsvEncoder::OUTPUT_UTF8_BOM_KEY, $outputUtf8Bom);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Encoder/JsonEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/JsonEncoderContextBuilder.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Encoder;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncode;
+
+/**
+ * A helper providing autocompletion for available JsonEncoder options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class JsonEncoderContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures the json_encode flags bitmask.
+     *
+     * @see https://www.php.net/manual/en/json.constants.php
+     *
+     * @param positive-int|null $options
+     */
+    public function withEncodeOptions(?int $options): static
+    {
+        return $this->with(JsonEncode::OPTIONS, $options);
+    }
+
+    /**
+     * Configures the json_decode flags bitmask.
+     *
+     * @see https://www.php.net/manual/en/json.constants.php
+     *
+     * @param positive-int|null $options
+     */
+    public function withDecodeOptions(?int $options): static
+    {
+        return $this->with(JsonDecode::OPTIONS, $options);
+    }
+
+    /**
+     * Configures whether decoded objects will be given as
+     * associative arrays or as nested stdClass.
+     */
+    public function withAssociative(?bool $associative): static
+    {
+        return $this->with(JsonDecode::ASSOCIATIVE, $associative);
+    }
+
+    /**
+     * Configures the maximum recursion depth.
+     *
+     * Must be strictly positive.
+     *
+     * @param positive-int|null $recursionDepth
+     */
+    public function withRecursionDepth(?int $recursionDepth): static
+    {
+        return $this->with(JsonDecode::RECURSION_DEPTH, $recursionDepth);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Encoder;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+
+/**
+ * A helper providing autocompletion for available XmlEncoder options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class XmlEncoderContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures whether the decoded result should be considered as a collection
+     * or as a single element.
+     */
+    public function withAsCollection(?bool $asCollection): static
+    {
+        return $this->with(XmlEncoder::AS_COLLECTION, $asCollection);
+    }
+
+    /**
+     * Configures node types to ignore while decoding.
+     *
+     * @see https://www.php.net/manual/en/dom.constants.php
+     *
+     * @param list<int>|null $decoderIgnoredNodeTypes
+     */
+    public function withDecoderIgnoredNodeTypes(?array $decoderIgnoredNodeTypes): static
+    {
+        return $this->with(XmlEncoder::DECODER_IGNORED_NODE_TYPES, $decoderIgnoredNodeTypes);
+    }
+
+    /**
+     * Configures node types to ignore while encoding.
+     *
+     * @see https://www.php.net/manual/en/dom.constants.php
+     *
+     * @param list<int>|null $encoderIgnoredNodeTypes
+     */
+    public function withEncoderIgnoredNodeTypes(?array $encoderIgnoredNodeTypes): static
+    {
+        return $this->with(XmlEncoder::ENCODER_IGNORED_NODE_TYPES, $encoderIgnoredNodeTypes);
+    }
+
+    /**
+     * Configures the DOMDocument encoding.
+     *
+     * @see https://www.php.net/manual/en/class.domdocument.php#domdocument.props.encoding
+     */
+    public function withEncoding(?string $encoding): static
+    {
+        return $this->with(XmlEncoder::ENCODING, $encoding);
+    }
+
+    /**
+     * Configures whether to encode with indentation and extra space.
+     *
+     * @see https://php.net/manual/en/class.domdocument.php#domdocument.props.formatoutput
+     */
+    public function withFormatOutput(?bool $formatOutput): static
+    {
+        return $this->with(XmlEncoder::FORMAT_OUTPUT, $formatOutput);
+    }
+
+    /**
+     * Configures the DOMDocument::loadXml options bitmask.
+     *
+     * @see https://www.php.net/manual/en/libxml.constants.php
+     *
+     * @param positive-int|null $loadOptions
+     */
+    public function withLoadOptions(?int $loadOptions): static
+    {
+        return $this->with(XmlEncoder::LOAD_OPTIONS, $loadOptions);
+    }
+
+    /**
+     * Configures whether to keep empty nodes.
+     */
+    public function withRemoveEmptyTags(?bool $removeEmptyTags): static
+    {
+        return $this->with(XmlEncoder::REMOVE_EMPTY_TAGS, $removeEmptyTags);
+    }
+
+    /**
+     * Configures name of the root node.
+     */
+    public function withRootNodeName(?string $rootNodeName): static
+    {
+        return $this->with(XmlEncoder::ROOT_NODE_NAME, $rootNodeName);
+    }
+
+    /**
+     * Configures whether the document will be standalone.
+     *
+     * @see https://php.net/manual/en/class.domdocument.php#domdocument.props.xmlstandalone
+     */
+    public function withStandalone(?bool $standalone): static
+    {
+        return $this->with(XmlEncoder::STANDALONE, $standalone);
+    }
+
+    /**
+     * Configures whether casting numeric string attributes to integers or floats.
+     */
+    public function withTypeCastAttributes(?bool $typeCastAttributes): static
+    {
+        return $this->with(XmlEncoder::TYPE_CAST_ATTRIBUTES, $typeCastAttributes);
+    }
+
+    /**
+     * Configures the version number of the document.
+     *
+     * @see https://php.net/manual/en/class.domdocument.php#domdocument.props.xmlversion
+     */
+    public function withVersion(?string $version): static
+    {
+        return $this->with(XmlEncoder::VERSION, $version);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Encoder/YamlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/YamlEncoderContextBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Encoder;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
+
+/**
+ * A helper providing autocompletion for available YamlEncoder options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class YamlEncoderContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures the threshold to switch to inline YAML.
+     */
+    public function withInlineThreshold(?int $inlineThreshold): static
+    {
+        return $this->with(YamlEncoder::YAML_INLINE, $inlineThreshold);
+    }
+
+    /**
+     * Configures the indentation level.
+     *
+     * Must be positive.
+     *
+     * @param int<0, max>|null $indentLevel
+     */
+    public function withIndentLevel(?int $indentLevel): static
+    {
+        return $this->with(YamlEncoder::YAML_INDENT, $indentLevel);
+    }
+
+    /**
+     * Configures \Symfony\Component\Yaml\Dumper::dump flags bitmask.
+     *
+     * @see \Symfony\Component\Yaml\Yaml
+     */
+    public function withFlags(?int $flags): static
+    {
+        return $this->with(YamlEncoder::YAML_FLAGS, $flags);
+    }
+
+    /**
+     * Configures whether to perserve empty objects "{}" or to convert them to null.
+     */
+    public function withPreservedEmptyObjects(?bool $preserveEmptyObjects): static
+    {
+        return $this->with(YamlEncoder::PRESERVE_EMPTY_OBJECTS, $preserveEmptyObjects);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+/**
+ * A helper providing autocompletion for available AbstractNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+abstract class AbstractNormalizerContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures how many loops of circular reference to allow while normalizing.
+     *
+     * The value 1 means that when we encounter the same object a
+     * second time, we consider that a circular reference.
+     *
+     * You can raise this value for special cases, e.g. in combination with the
+     * max depth setting of the object normalizer.
+     *
+     * Must be strictly positive.
+     *
+     * @param positive-int|null $circularReferenceLimit
+     */
+    public function withCircularReferenceLimit(?int $circularReferenceLimit): static
+    {
+        return $this->with(AbstractNormalizer::CIRCULAR_REFERENCE_LIMIT, $circularReferenceLimit);
+    }
+
+    /**
+     * Configures an object to be updated instead of creating a new instance.
+     *
+     * If you have a nested structure, child objects will be overwritten with
+     * new instances unless you set AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE to true.
+     */
+    public function withObjectToPopulate(?object $objectToPopulate): static
+    {
+        return $this->with(AbstractNormalizer::OBJECT_TO_POPULATE, $objectToPopulate);
+    }
+
+    /**
+     * Configures groups containing attributes to (de)normalize.
+     *
+     * Eg: ['group1', 'group2']
+     *
+     * @param list<string>|string|null $groups
+     */
+    public function withGroups(array|string|null $groups): static
+    {
+        if (null === $groups) {
+            return $this->with(AbstractNormalizer::GROUPS, null);
+        }
+
+        return $this->with(AbstractNormalizer::GROUPS, (array) $groups);
+    }
+
+    /**
+     * Configures attributes to (de)normalize.
+     *
+     * For nested structures, this list needs to reflect the object tree.
+     *
+     * Eg: ['foo', 'bar', 'object' => ['baz']]
+     *
+     * @param array<string|array>|null $attributes
+     *
+     * @throws InvalidArgumentException
+     */
+    public function withAttributes(?array $attributes): static
+    {
+        $it = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($attributes ?? []), \RecursiveIteratorIterator::LEAVES_ONLY);
+
+        foreach ($it as $attribute) {
+            if (!\is_string($attribute)) {
+                throw new InvalidArgumentException(sprintf('Each attribute must be a string, "%s" given.', get_debug_type($attribute)));
+            }
+        }
+
+        return $this->with(AbstractNormalizer::ATTRIBUTES, $attributes);
+    }
+
+    /**
+     * If AbstractNormalizer::ATTRIBUTES are specified, and the source has fields that are not part of that list,
+     * configures whether to ignore those attributes or throw an ExtraAttributesException.
+     */
+    public function withAllowExtraAttributes(?bool $allowExtraAttributes): static
+    {
+        return $this->with(AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES, $allowExtraAttributes);
+    }
+
+    /**
+     * Configures an hashmap of classes containing hashmaps of constructor argument => default value.
+     *
+     * The names need to match the parameter names in the constructor arguments.
+     *
+     * Eg: [Foo::class => ['foo' => true, 'bar' => 0]]
+     *
+     * @param array<class-string, array<string, mixed>>|null $defaultContructorArguments
+     */
+    public function withDefaultContructorArguments(?array $defaultContructorArguments): static
+    {
+        return $this->with(AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS, $defaultContructorArguments);
+    }
+
+    /**
+     * Configures an hashmap of field name => callable to normalize this field.
+     *
+     * The callable is called if the field is encountered with the arguments:
+     *
+     * - mixed                 $attributeValue value of this field
+     * - object                $object         the whole object being normalized
+     * - string                $attributeName  name of the attribute being normalized
+     * - string                $format         the requested format
+     * - array<string, mixed>  $context        the serialization context
+     *
+     * @param array<string, callable>|null $callbacks
+     */
+    public function withCallbacks(?array $callbacks): static
+    {
+        return $this->with(AbstractNormalizer::CALLBACKS, $callbacks);
+    }
+
+    /**
+     * Configures an handler to call when a circular reference has been detected.
+     *
+     * If no handler is specified, a CircularReferenceException is thrown.
+     *
+     * The method will be called with ($object, $format, $context) and its
+     * return value is returned as the result of the normalize call.
+     */
+    public function withCircularReferenceHandler(?callable $circularReferenceHandler): static
+    {
+        return $this->with(AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER, $circularReferenceHandler);
+    }
+
+    /**
+     * Configures attributes to be skipped when normalizing an object tree.
+     *
+     * This list is applied to each element of nested structures.
+     *
+     * Eg: ['foo', 'bar']
+     *
+     * Note: The behaviour for nested structures is different from ATTRIBUTES
+     * for historical reason. Aligning the behaviour would be a BC break.
+     *
+     * @param list<string>|null $attributes
+     */
+    public function withIgnoredAttributes(?array $ignoredAttributes): static
+    {
+        return $this->with(AbstractNormalizer::IGNORED_ATTRIBUTES, $ignoredAttributes);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/AbstractObjectNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/AbstractObjectNormalizerContextBuilder.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+
+/**
+ * A helper providing autocompletion for available AbstractObjectNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+abstract class AbstractObjectNormalizerContextBuilder extends AbstractNormalizerContextBuilder
+{
+    /**
+     * Configures whether to respect the max depth metadata on fields.
+     */
+    public function withEnableMaxDepth(?bool $enableMaxDepth): static
+    {
+        return $this->with(AbstractObjectNormalizer::ENABLE_MAX_DEPTH, $enableMaxDepth);
+    }
+
+    /**
+     * Configures a pattern to keep track of the current depth.
+     *
+     * Must contain exactly two string placeholders.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function withDepthKeyPattern(?string $depthKeyPattern): static
+    {
+        if (null === $depthKeyPattern) {
+            return $this->with(AbstractObjectNormalizer::DEPTH_KEY_PATTERN, null);
+        }
+
+        // This will match every occurrences of sprintf specifiers
+        $matches = [];
+        preg_match_all('/(?<!%)(?:%{2})*%(?<specifier>[a-z])/', $depthKeyPattern, $matches);
+
+        if (2 !== \count($matches['specifier']) || 's' !== $matches['specifier'][0] || 's' !== $matches['specifier'][1]) {
+            throw new InvalidArgumentException(sprintf('The depth key pattern "%s" is not valid. You must set exactly two string placeholders.', $depthKeyPattern));
+        }
+
+        return $this->with(AbstractObjectNormalizer::DEPTH_KEY_PATTERN, $depthKeyPattern);
+    }
+
+    /**
+     * Configures whether verifying types match during denormalization.
+     */
+    public function withDisableTypeEnforcement(?bool $disableTypeEnforcement): static
+    {
+        return $this->with(AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT, $disableTypeEnforcement);
+    }
+
+    /**
+     * Configures whether fields with the value `null` should be output during normalization.
+     */
+    public function withSkipNullValues(?bool $skipNullValues): static
+    {
+        return $this->with(AbstractObjectNormalizer::SKIP_NULL_VALUES, $skipNullValues);
+    }
+
+    /**
+     * Configures whether uninitialized typed class properties should be excluded during normalization.
+     */
+    public function withSkipUninitializedValues(?bool $skipUninitializedValues): static
+    {
+        return $this->with(AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES, $skipUninitializedValues);
+    }
+
+    /**
+     * Configures a callback to allow to set a value for an attribute when the max depth has
+     * been reached.
+     *
+     * If no callback is given, the attribute is skipped. If a callable is
+     * given, its return value is used (even if null).
+     *
+     * The arguments are:
+     *
+     * - mixed                 $attributeValue value of this field
+     * - object                $object         the whole object being normalized
+     * - string                $attributeName  name of the attribute being normalized
+     * - string                $format         the requested format
+     * - array<string, mixed>  $context        the serialization context
+     */
+    public function withMaxDepthHandler(?callable $maxDepthHandler): static
+    {
+        return $this->with(AbstractObjectNormalizer::MAX_DEPTH_HANDLER, $maxDepthHandler);
+    }
+
+    /**
+     * Configures which context key are not relevant to determine which attributes
+     * of an object to (de)normalize.
+     *
+     * @param list<string>|null $excludeFromCacheKeys
+     */
+    public function withExcludeFromCacheKeys(?array $excludeFromCacheKeys): static
+    {
+        return $this->with(AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY, $excludeFromCacheKeys);
+    }
+
+    /**
+     * Configures whether to tell the denormalizer to also populate existing objects on
+     * attributes of the main object.
+     *
+     * Setting this to true is only useful if you also specify the root object
+     * in AbstractNormalizer::OBJECT_TO_POPULATE.
+     */
+    public function withDeepObjectToPopulate(?bool $deepObjectToPopulate): static
+    {
+        return $this->with(AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE, $deepObjectToPopulate);
+    }
+
+    /**
+     * Configures whether an empty object should be kept as an object (in
+     * JSON: {}) or converted to a list (in JSON: []).
+     */
+    public function withPreserveEmptyObjects(?bool $preserveEmptyObjects): static
+    {
+        return $this->with(AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS, $preserveEmptyObjects);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/ConstraintViolationListNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/ConstraintViolationListNormalizerContextBuilder.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
+
+/**
+ * A helper providing autocompletion for available ConstraintViolationList options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class ConstraintViolationListNormalizerContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configure the instance field of normalized data.
+     */
+    public function withInstance(mixed $instance): static
+    {
+        return $this->with(ConstraintViolationListNormalizer::INSTANCE, $instance);
+    }
+
+    /**
+     * Configure the status field of normalized data.
+     */
+    public function withStatus(?int $status): static
+    {
+        return $this->with(ConstraintViolationListNormalizer::STATUS, $status);
+    }
+
+    /**
+     * Configure the title field of normalized data.
+     */
+    public function withTitle(?string $title): static
+    {
+        return $this->with(ConstraintViolationListNormalizer::TITLE, $title);
+    }
+
+    /**
+     * Configure the type field of normalized data.
+     */
+    public function withType(?string $type): static
+    {
+        return $this->with(ConstraintViolationListNormalizer::TYPE, $type);
+    }
+
+    /**
+     * Configures the payload fields which will act as an allowlist
+     * for the payload field of normalized data.
+     *
+     * Eg: ['foo', 'bar']
+     *
+     * @param list<string>|null $payloadFields
+     */
+    public function withPayloadFields(?array $payloadFields): static
+    {
+        return $this->with(ConstraintViolationListNormalizer::PAYLOAD_FIELDS, $payloadFields);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/DateIntervalNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/DateIntervalNormalizerContextBuilder.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
+
+/**
+ * A helper providing autocompletion for available DateIntervalNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class DateIntervalNormalizerContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures the format of the interval.
+     *
+     * @see https://php.net/manual/en/dateinterval.format.php
+     */
+    public function withFormat(?string $format): static
+    {
+        return $this->with(DateIntervalNormalizer::FORMAT_KEY, $format);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+
+/**
+ * A helper providing autocompletion for available DateTimeNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class DateTimeNormalizerContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures the format of the date.
+     *
+     * @see https://secure.php.net/manual/en/datetime.format.php
+     */
+    public function withFormat(?string $format): static
+    {
+        return $this->with(DateTimeNormalizer::FORMAT_KEY, $format);
+    }
+
+    /**
+     * Configures the timezone of the date.
+     *
+     * It could be either a \DateTimeZone or a string
+     * that will be used to construct the \DateTimeZone
+     *
+     * @see https://secure.php.net/manual/en/class.datetimezone.php
+     *
+     * @throws InvalidArgumentException
+     */
+    public function withTimezone(\DateTimeZone|string|null $timezone): static
+    {
+        if (null === $timezone) {
+            return $this->with(DateTimeNormalizer::TIMEZONE_KEY, null);
+        }
+
+        if (\is_string($timezone)) {
+            try {
+                $timezone = new \DateTimeZone($timezone);
+            } catch (\Exception $e) {
+                throw new InvalidArgumentException(sprintf('The "%s" timezone is invalid.', $timezone), previous: $e);
+            }
+        }
+
+        return $this->with(DateTimeNormalizer::TIMEZONE_KEY, $timezone);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/FormErrorNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/FormErrorNormalizerContextBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Normalizer\FormErrorNormalizer;
+
+/**
+ * A helper providing autocompletion for available FormErrorNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class FormErrorNormalizerContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures the title of the normalized data.
+     */
+    public function withTitle(?string $title): static
+    {
+        return $this->with(FormErrorNormalizer::TITLE, $title);
+    }
+
+    /**
+     * Configures the type of the normalized data.
+     */
+    public function withType(?string $type): static
+    {
+        return $this->with(FormErrorNormalizer::TYPE, $type);
+    }
+
+    /**
+     * Configures the code of the normalized data.
+     */
+    public function withStatusCode(?int $statusCode): static
+    {
+        return $this->with(FormErrorNormalizer::CODE, $statusCode);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/GetSetMethodNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/GetSetMethodNormalizerContextBuilder.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+/**
+ * A helper providing autocompletion for available GetSetMethodNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class GetSetMethodNormalizerContextBuilder extends AbstractObjectNormalizerContextBuilder
+{
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/JsonSerializableNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/JsonSerializableNormalizerContextBuilder.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+/**
+ * A helper providing autocompletion for available JsonSerializableNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class JsonSerializableNormalizerContextBuilder extends AbstractNormalizerContextBuilder
+{
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/ObjectNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/ObjectNormalizerContextBuilder.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+/**
+ * A helper providing autocompletion for available ObjectNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class ObjectNormalizerContextBuilder extends AbstractObjectNormalizerContextBuilder
+{
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/ProblemNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/ProblemNormalizerContextBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Normalizer\ProblemNormalizer;
+
+/**
+ * A helper providing autocompletion for available ProblemNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class ProblemNormalizerContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configure the title field of normalized data.
+     */
+    public function withTitle(?string $title): static
+    {
+        return $this->with(ProblemNormalizer::TITLE, $title);
+    }
+
+    /**
+     * Configure the type field of normalized data.
+     */
+    public function withType(?string $type): static
+    {
+        return $this->with(ProblemNormalizer::TYPE, $type);
+    }
+
+    /**
+     * Configure the status field of normalized data.
+     */
+    public function withStatusCode(int|string|null $statusCode): static
+    {
+        return $this->with(ProblemNormalizer::STATUS, $statusCode);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/PropertyNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/PropertyNormalizerContextBuilder.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+/**
+ * A helper providing autocompletion for available PropertyNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class PropertyNormalizerContextBuilder extends AbstractObjectNormalizerContextBuilder
+{
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/UidNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/UidNormalizerContextBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\UidNormalizer;
+
+/**
+ * A helper providing autocompletion for available UidNormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class UidNormalizerContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures the uuid format for normalization.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function withNormalizationFormat(?string $normalizationFormat): static
+    {
+        if (null !== $normalizationFormat && !\in_array($normalizationFormat, UidNormalizer::NORMALIZATION_FORMATS, true)) {
+            throw new InvalidArgumentException(sprintf('The "%s" normalization format is not valid.', $normalizationFormat));
+        }
+
+        return $this->with(UidNormalizer::NORMALIZATION_FORMAT_KEY, $normalizationFormat);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/Normalizer/UnwrappingDenormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/UnwrappingDenormalizerContextBuilder.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException;
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
+
+/**
+ * A helper providing autocompletion for available UnwrappingDenormalizer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class UnwrappingDenormalizerContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures the path of wrapped data during denormalization.
+     *
+     * Eg: [foo].bar[bar]
+     *
+     * @see https://symfony.com/doc/current/components/property_access.html
+     *
+     * @throws InvalidArgumentException
+     */
+    public function withUnwrapPath(?string $unwrapPath): static
+    {
+        if (null === $unwrapPath) {
+            return $this->with(UnwrappingDenormalizer::UNWRAP_PATH, null);
+        }
+
+        try {
+            new PropertyPath($unwrapPath);
+        } catch (InvalidPropertyPathException $e) {
+            throw new InvalidArgumentException('The "%s" property path is not valid.', previous: $e);
+        }
+
+        return $this->with(UnwrappingDenormalizer::UNWRAP_PATH, $unwrapPath);
+    }
+}

--- a/src/Symfony/Component/Serializer/Context/SerializerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/SerializerContextBuilder.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * A helper providing autocompletion for available Serializer options.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class SerializerContextBuilder
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures whether an empty array should be transformed to an
+     * object (in JSON: {}) or to a list (in JSON: []).
+     */
+    public function withEmptyArrayAsObject(?bool $emptyArrayAsObject): static
+    {
+        return $this->with(Serializer::EMPTY_ARRAY_AS_OBJECT, $emptyArrayAsObject);
+    }
+
+    public function withCollectDenormalizationErrors(?bool $collectDenormalizationErrors): static
+    {
+        return $this->with(DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS, $collectDenormalizationErrors);
+    }
+}

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -58,7 +58,7 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
     {
         $context = array_merge($this->defaultContext, $context);
 
-        if (isset($context[self::PRESERVE_EMPTY_OBJECTS])) {
+        if ($context[self::PRESERVE_EMPTY_OBJECTS] ?? false) {
             $context[self::YAML_FLAGS] |= Yaml::DUMP_OBJECT_AS_MAP;
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -233,7 +233,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             $data = $this->updateData($data, $attribute, $this->serializer->normalize($attributeValue, $format, $childContext), $class, $format, $attributeContext);
         }
 
-        if (isset($context[self::PRESERVE_EMPTY_OBJECTS]) && !\count($data)) {
+        $preserveEmptyObjects = $context[self::PRESERVE_EMPTY_OBJECTS] ?? $this->defaultContext[self::PRESERVE_EMPTY_OBJECTS] ?? false;
+        if ($preserveEmptyObjects && !\count($data)) {
             return new \ArrayObject();
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -24,10 +24,14 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  */
 class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
+    public const TITLE = 'title';
+    public const TYPE = 'type';
+    public const STATUS = 'status';
+
     private $debug;
     private $defaultContext = [
-        'type' => 'https://tools.ietf.org/html/rfc2616#section-10',
-        'title' => 'An error occurred',
+        self::TYPE => 'https://tools.ietf.org/html/rfc2616#section-10',
+        self::TITLE => 'An error occurred',
     ];
 
     public function __construct(bool $debug = false, array $defaultContext = [])
@@ -49,9 +53,9 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
         $debug = $this->debug && ($context['debug'] ?? true);
 
         $data = [
-            'type' => $context['type'],
-            'title' => $context['title'],
-            'status' => $context['status'] ?? $object->getStatusCode(),
+            self::TYPE => $context['type'],
+            self::TITLE => $context['title'],
+            self::STATUS => $context['status'] ?? $object->getStatusCode(),
             'detail' => $debug ? $object->getMessage() : $object->getStatusText(),
         ];
         if ($debug) {

--- a/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
@@ -25,6 +25,12 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
     public const NORMALIZATION_FORMAT_BASE58 = 'base58';
     public const NORMALIZATION_FORMAT_BASE32 = 'base32';
     public const NORMALIZATION_FORMAT_RFC4122 = 'rfc4122';
+    public const NORMALIZATION_FORMATS = [
+        self::NORMALIZATION_FORMAT_CANONICAL,
+        self::NORMALIZATION_FORMAT_BASE58,
+        self::NORMALIZATION_FORMAT_BASE32,
+        self::NORMALIZATION_FORMAT_RFC4122,
+    ];
 
     private $defaultContext = [
         self::NORMALIZATION_FORMAT_KEY => self::NORMALIZATION_FORMAT_CANONICAL,

--- a/src/Symfony/Component/Serializer/Tests/Context/ContextBuilderTraitTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/ContextBuilderTraitTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class ContextBuilderTraitTest extends TestCase
+{
+    public function testWithContext()
+    {
+        $contextBuilder = new class() {
+            use ContextBuilderTrait;
+        };
+
+        $context = $contextBuilder->withContext(['foo' => 'bar'])->toArray();
+
+        $this->assertSame(['foo' => 'bar'], $context);
+    }
+
+    public function testWith()
+    {
+        $contextBuilder = new class() {
+            use ContextBuilderTrait;
+
+            public function withFoo(string $value): static
+            {
+                return $this->with('foo', $value);
+            }
+        };
+
+        $context = $contextBuilder->withFoo('bar')->toArray();
+
+        $this->assertSame(['foo' => 'bar'], $context);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Encoder;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Encoder\CsvEncoderContextBuilder;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class CsvEncoderContextBuilderTest extends TestCase
+{
+    private CsvEncoderContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new CsvEncoderContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withDelimiter($values[CsvEncoder::DELIMITER_KEY])
+            ->withEnclosure($values[CsvEncoder::ENCLOSURE_KEY])
+            ->withEscapeChar($values[CsvEncoder::ESCAPE_CHAR_KEY])
+            ->withKeySeparator($values[CsvEncoder::KEY_SEPARATOR_KEY])
+            ->withHeaders($values[CsvEncoder::HEADERS_KEY])
+            ->withEscapedFormulas($values[CsvEncoder::ESCAPE_FORMULAS_KEY])
+            ->withAsCollection($values[CsvEncoder::AS_COLLECTION_KEY])
+            ->withNoHeaders($values[CsvEncoder::NO_HEADERS_KEY])
+            ->withEndOfLine($values[CsvEncoder::END_OF_LINE])
+            ->withOutputUtf8Bom($values[CsvEncoder::OUTPUT_UTF8_BOM_KEY])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>|}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            CsvEncoder::DELIMITER_KEY => ';',
+            CsvEncoder::ENCLOSURE_KEY => '"',
+            CsvEncoder::ESCAPE_CHAR_KEY => '\\',
+            CsvEncoder::KEY_SEPARATOR_KEY => '_',
+            CsvEncoder::HEADERS_KEY => ['h1', 'h2'],
+            CsvEncoder::ESCAPE_FORMULAS_KEY => true,
+            CsvEncoder::AS_COLLECTION_KEY => true,
+            CsvEncoder::NO_HEADERS_KEY => false,
+            CsvEncoder::END_OF_LINE => 'EOL',
+            CsvEncoder::OUTPUT_UTF8_BOM_KEY => false,
+        ]];
+
+        yield 'With null values' => [[
+            CsvEncoder::DELIMITER_KEY => null,
+            CsvEncoder::ENCLOSURE_KEY => null,
+            CsvEncoder::ESCAPE_CHAR_KEY => null,
+            CsvEncoder::KEY_SEPARATOR_KEY => null,
+            CsvEncoder::HEADERS_KEY => null,
+            CsvEncoder::ESCAPE_FORMULAS_KEY => null,
+            CsvEncoder::AS_COLLECTION_KEY => null,
+            CsvEncoder::NO_HEADERS_KEY => null,
+            CsvEncoder::END_OF_LINE => null,
+            CsvEncoder::OUTPUT_UTF8_BOM_KEY => null,
+        ]];
+    }
+
+    public function testWithersWithoutValue()
+    {
+        $context = $this->contextBuilder
+            ->withDelimiter(null)
+            ->withEnclosure(null)
+            ->withEscapeChar(null)
+            ->withKeySeparator(null)
+            ->withHeaders(null)
+            ->withEscapedFormulas(null)
+            ->withAsCollection(null)
+            ->withNoHeaders(null)
+            ->withEndOfLine(null)
+            ->withOutputUtf8Bom(null)
+            ->toArray();
+
+        $this->assertSame([
+            CsvEncoder::DELIMITER_KEY => null,
+            CsvEncoder::ENCLOSURE_KEY => null,
+            CsvEncoder::ESCAPE_CHAR_KEY => null,
+            CsvEncoder::KEY_SEPARATOR_KEY => null,
+            CsvEncoder::HEADERS_KEY => null,
+            CsvEncoder::ESCAPE_FORMULAS_KEY => null,
+            CsvEncoder::AS_COLLECTION_KEY => null,
+            CsvEncoder::NO_HEADERS_KEY => null,
+            CsvEncoder::END_OF_LINE => null,
+            CsvEncoder::OUTPUT_UTF8_BOM_KEY => null,
+        ], $context);
+    }
+
+    public function testCannotSetMultipleBytesAsDelimiter()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->contextBuilder->withDelimiter('ọ');
+    }
+
+    public function testCannotSetMultipleBytesAsEnclosure()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->contextBuilder->withEnclosure('ọ');
+    }
+
+    public function testCannotSetMultipleBytesAsEscapeChar()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->contextBuilder->withEscapeChar('ọ');
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/JsonEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/JsonEncoderContextBuilderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Encoder;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Encoder\JsonEncoderContextBuilder;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncode;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class JsonEncoderContextBuilderTest extends TestCase
+{
+    private JsonEncoderContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new JsonEncoderContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withEncodeOptions($values[JsonEncode::OPTIONS])
+            ->withDecodeOptions($values[JsonDecode::OPTIONS])
+            ->withAssociative($values[JsonDecode::ASSOCIATIVE])
+            ->withRecursionDepth($values[JsonDecode::RECURSION_DEPTH])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>|}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            JsonEncode::OPTIONS => \JSON_PRETTY_PRINT,
+            JsonDecode::OPTIONS => \JSON_BIGINT_AS_STRING,
+            JsonDecode::ASSOCIATIVE => true,
+            JsonDecode::RECURSION_DEPTH => 1024,
+        ]];
+
+        yield 'With null values' => [[
+            JsonEncode::OPTIONS => null,
+            JsonDecode::OPTIONS => null,
+            JsonDecode::ASSOCIATIVE => null,
+            JsonDecode::RECURSION_DEPTH => null,
+        ]];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Encoder;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Encoder\XmlEncoderContextBuilder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class XmlEncoderContextBuilderTest extends TestCase
+{
+    private XmlEncoderContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new XmlEncoderContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withAsCollection($values[XmlEncoder::AS_COLLECTION])
+            ->withDecoderIgnoredNodeTypes($values[XmlEncoder::DECODER_IGNORED_NODE_TYPES])
+            ->withEncoderIgnoredNodeTypes($values[XmlEncoder::ENCODER_IGNORED_NODE_TYPES])
+            ->withEncoding($values[XmlEncoder::ENCODING])
+            ->withFormatOutput($values[XmlEncoder::FORMAT_OUTPUT])
+            ->withLoadOptions($values[XmlEncoder::LOAD_OPTIONS])
+            ->withRemoveEmptyTags($values[XmlEncoder::REMOVE_EMPTY_TAGS])
+            ->withRootNodeName($values[XmlEncoder::ROOT_NODE_NAME])
+            ->withStandalone($values[XmlEncoder::STANDALONE])
+            ->withTypeCastAttributes($values[XmlEncoder::TYPE_CAST_ATTRIBUTES])
+            ->withVersion($values[XmlEncoder::VERSION])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>|}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            XmlEncoder::AS_COLLECTION => true,
+            XmlEncoder::DECODER_IGNORED_NODE_TYPES => [\XML_PI_NODE, \XML_COMMENT_NODE],
+            XmlEncoder::ENCODER_IGNORED_NODE_TYPES => [\XML_TEXT_NODE],
+            XmlEncoder::ENCODING => 'UTF-8',
+            XmlEncoder::FORMAT_OUTPUT => false,
+            XmlEncoder::LOAD_OPTIONS => \LIBXML_COMPACT,
+            XmlEncoder::REMOVE_EMPTY_TAGS => true,
+            XmlEncoder::ROOT_NODE_NAME => 'root',
+            XmlEncoder::STANDALONE => false,
+            XmlEncoder::TYPE_CAST_ATTRIBUTES => true,
+            XmlEncoder::VERSION => '1.0',
+        ]];
+
+        yield 'With null values' => [[
+            XmlEncoder::AS_COLLECTION => null,
+            XmlEncoder::DECODER_IGNORED_NODE_TYPES => null,
+            XmlEncoder::ENCODER_IGNORED_NODE_TYPES => null,
+            XmlEncoder::ENCODING => null,
+            XmlEncoder::FORMAT_OUTPUT => null,
+            XmlEncoder::LOAD_OPTIONS => null,
+            XmlEncoder::REMOVE_EMPTY_TAGS => null,
+            XmlEncoder::ROOT_NODE_NAME => null,
+            XmlEncoder::STANDALONE => null,
+            XmlEncoder::TYPE_CAST_ATTRIBUTES => null,
+            XmlEncoder::VERSION => null,
+        ]];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/YamlEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/YamlEncoderContextBuilderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Encoder;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Encoder\YamlEncoderContextBuilder;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class YamlEncoderContextBuilderTest extends TestCase
+{
+    private YamlEncoderContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new YamlEncoderContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withIndentLevel($values[YamlEncoder::YAML_INDENT])
+            ->withInlineThreshold($values[YamlEncoder::YAML_INLINE])
+            ->withFlags($values[YamlEncoder::YAML_FLAGS])
+            ->withPreservedEmptyObjects($values[YamlEncoder::PRESERVE_EMPTY_OBJECTS])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>|}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            YamlEncoder::YAML_INDENT => 4,
+            YamlEncoder::YAML_INLINE => 16,
+            YamlEncoder::YAML_FLAGS => 128,
+            YamlEncoder::PRESERVE_EMPTY_OBJECTS => false,
+        ]];
+
+        yield 'With null values' => [[
+            YamlEncoder::YAML_INDENT => null,
+            YamlEncoder::YAML_INLINE => null,
+            YamlEncoder::YAML_FLAGS => null,
+            YamlEncoder::PRESERVE_EMPTY_OBJECTS => null,
+        ]];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Normalizer\AbstractNormalizerContextBuilder;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class AbstractNormalizerContextBuilderTest extends TestCase
+{
+    private AbstractNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new class() extends AbstractNormalizerContextBuilder {};
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withCircularReferenceLimit($values[AbstractNormalizer::CIRCULAR_REFERENCE_LIMIT])
+            ->withObjectToPopulate($values[AbstractNormalizer::OBJECT_TO_POPULATE])
+            ->withGroups($values[AbstractNormalizer::GROUPS])
+            ->withAttributes($values[AbstractNormalizer::ATTRIBUTES])
+            ->withAllowExtraAttributes($values[AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES])
+            ->withDefaultContructorArguments($values[AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS])
+            ->withCallbacks($values[AbstractNormalizer::CALLBACKS])
+            ->withCircularReferenceHandler($values[AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER])
+            ->withIgnoredAttributes($values[AbstractNormalizer::IGNORED_ATTRIBUTES])
+            ->toArray();
+
+        $this->assertEquals($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>|}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            AbstractNormalizer::CIRCULAR_REFERENCE_LIMIT => 12,
+            AbstractNormalizer::OBJECT_TO_POPULATE => new \stdClass(),
+            AbstractNormalizer::GROUPS => ['group'],
+            AbstractNormalizer::ATTRIBUTES => ['attribute1', 'attribute2'],
+            AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true,
+            AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS => [self::class => ['foo' => 'bar']],
+            AbstractNormalizer::CALLBACKS => [static function (): void {}],
+            AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => static function (): void {},
+            AbstractNormalizer::IGNORED_ATTRIBUTES => ['attribute3'],
+        ]];
+
+        yield 'With null values' => [[
+            AbstractNormalizer::CIRCULAR_REFERENCE_LIMIT => null,
+            AbstractNormalizer::OBJECT_TO_POPULATE => null,
+            AbstractNormalizer::GROUPS => null,
+            AbstractNormalizer::ATTRIBUTES => null,
+            AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => null,
+            AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS => null,
+            AbstractNormalizer::CALLBACKS => null,
+            AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => null,
+            AbstractNormalizer::IGNORED_ATTRIBUTES => null,
+        ]];
+    }
+
+    public function testCastSingleGroupToArray()
+    {
+        $this->assertSame([AbstractNormalizer::GROUPS => ['group']], $this->contextBuilder->withGroups('group')->toArray());
+    }
+
+    public function testCannotSetNonStringAttributes()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->contextBuilder->withAttributes(['attribute', ['nested attribute', 1]]);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractObjectNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractObjectNormalizerContextBuilderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Normalizer\AbstractObjectNormalizerContextBuilder;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class AbstractObjectNormalizerContextBuilderTest extends TestCase
+{
+    private AbstractObjectNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new class() extends AbstractObjectNormalizerContextBuilder {};
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withEnableMaxDepth($values[AbstractObjectNormalizer::ENABLE_MAX_DEPTH])
+            ->withDepthKeyPattern($values[AbstractObjectNormalizer::DEPTH_KEY_PATTERN])
+            ->withDisableTypeEnforcement($values[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT])
+            ->withSkipNullValues($values[AbstractObjectNormalizer::SKIP_NULL_VALUES])
+            ->withSkipUninitializedValues($values[AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES])
+            ->withMaxDepthHandler($values[AbstractObjectNormalizer::MAX_DEPTH_HANDLER])
+            ->withExcludeFromCacheKeys($values[AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY])
+            ->withDeepObjectToPopulate($values[AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE])
+            ->withPreserveEmptyObjects($values[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>|}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            AbstractObjectNormalizer::ENABLE_MAX_DEPTH => true,
+            AbstractObjectNormalizer::DEPTH_KEY_PATTERN => '%s_%s',
+            AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => false,
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => false,
+            AbstractObjectNormalizer::MAX_DEPTH_HANDLER => static function (): void {},
+            AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY => ['key'],
+            AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE => true,
+            AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => false,
+        ]];
+
+        yield 'With null values' => [[
+            AbstractObjectNormalizer::ENABLE_MAX_DEPTH => null,
+            AbstractObjectNormalizer::DEPTH_KEY_PATTERN => null,
+            AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => null,
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => null,
+            AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => null,
+            AbstractObjectNormalizer::MAX_DEPTH_HANDLER => null,
+            AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY => null,
+            AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE => null,
+            AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => null,
+        ]];
+    }
+
+    /**
+     * @dataProvider validateDepthKeyPatternDataProvider
+     */
+    public function testValidateDepthKeyPattern(string $pattern, bool $expectException)
+    {
+        $exception = null;
+
+        try {
+            $this->contextBuilder->withDepthKeyPattern($pattern);
+        } catch (InvalidArgumentException $e) {
+            $exception = $e;
+        }
+
+        $this->assertSame($expectException, null !== $exception);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: bool}>
+     */
+    public function validateDepthKeyPatternDataProvider(): iterable
+    {
+        yield ['depth_%s::%s', false];
+        yield ['%%%s %%s %%%%%s', false];
+        yield ['%s%%%s', false];
+        yield ['', true];
+        yield ['depth_%d::%s', true];
+        yield ['%s_%s::%s', true];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/ConstraintViolationListNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/ConstraintViolationListNormalizerContextBuilderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Context\Normalizer\ConstraintViolationListNormalizerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class ConstraintViolationListNormalizerContextBuilderTest extends TestCase
+{
+    private ConstraintViolationListNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new ConstraintViolationListNormalizerContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withInstance($values[ConstraintViolationListNormalizer::INSTANCE])
+            ->withStatus($values[ConstraintViolationListNormalizer::STATUS])
+            ->withTitle($values[ConstraintViolationListNormalizer::TITLE])
+            ->withType($values[ConstraintViolationListNormalizer::TYPE])
+            ->withPayloadFields($values[ConstraintViolationListNormalizer::PAYLOAD_FIELDS])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            ConstraintViolationListNormalizer::INSTANCE => new \stdClass(),
+            ConstraintViolationListNormalizer::STATUS => 418,
+            ConstraintViolationListNormalizer::TITLE => 'title',
+            ConstraintViolationListNormalizer::TYPE => 'type',
+            ConstraintViolationListNormalizer::PAYLOAD_FIELDS => ['field'],
+        ]];
+
+        yield 'With null values' => [[
+            ConstraintViolationListNormalizer::INSTANCE => null,
+            ConstraintViolationListNormalizer::STATUS => null,
+            ConstraintViolationListNormalizer::TITLE => null,
+            ConstraintViolationListNormalizer::TYPE => null,
+            ConstraintViolationListNormalizer::PAYLOAD_FIELDS => null,
+        ]];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateIntervalNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateIntervalNormalizerContextBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Normalizer\DateIntervalNormalizerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class DateIntervalNormalizerContextBuilderTest extends TestCase
+{
+    private DateIntervalNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new DateIntervalNormalizerContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withFormat($values[DateIntervalNormalizer::FORMAT_KEY])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            DateIntervalNormalizer::FORMAT_KEY => 'format',
+        ]];
+
+        yield 'With null values' => [[
+            DateIntervalNormalizer::FORMAT_KEY => null,
+        ]];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateTimeNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateTimeNormalizerContextBuilderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Normalizer\DateTimeNormalizerContextBuilder;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class DateTimeNormalizerContextBuilderTest extends TestCase
+{
+    private DateTimeNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new DateTimeNormalizerContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withFormat($values[DateTimeNormalizer::FORMAT_KEY])
+            ->withTimezone($values[DateTimeNormalizer::TIMEZONE_KEY])
+            ->toArray();
+
+        $this->assertEquals($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            DateTimeNormalizer::FORMAT_KEY => 'format',
+            DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('GMT'),
+        ]];
+
+        yield 'With null values' => [[
+            DateTimeNormalizer::FORMAT_KEY => null,
+            DateTimeNormalizer::TIMEZONE_KEY => null,
+        ]];
+    }
+
+    public function testCastTimezoneStringToTimezone()
+    {
+        $this->assertEquals([DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('GMT')], $this->contextBuilder->withTimezone('GMT')->toArray());
+    }
+
+    public function testCannotSetInvalidTimezone()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->contextBuilder->withTimezone('not a timezone');
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/FormErrorNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/FormErrorNormalizerContextBuilderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Normalizer\FormErrorNormalizerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\FormErrorNormalizer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class FormErrorNormalizerContextBuilderTest extends TestCase
+{
+    private FormErrorNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new FormErrorNormalizerContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withTitle($values[FormErrorNormalizer::TITLE])
+            ->withType($values[FormErrorNormalizer::TYPE])
+            ->withStatusCode($values[FormErrorNormalizer::CODE])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            FormErrorNormalizer::TITLE => 'title',
+            FormErrorNormalizer::TYPE => 'type',
+            FormErrorNormalizer::CODE => 418,
+        ]];
+
+        yield 'With null values' => [[
+            FormErrorNormalizer::TITLE => null,
+            FormErrorNormalizer::TYPE => null,
+            FormErrorNormalizer::CODE => null,
+        ]];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/ProblemNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/ProblemNormalizerContextBuilderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Normalizer\ProblemNormalizerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\ProblemNormalizer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class ProblemNormalizerContextBuilderTest extends TestCase
+{
+    private ProblemNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new ProblemNormalizerContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withTitle($values[ProblemNormalizer::TITLE])
+            ->withType($values[ProblemNormalizer::TYPE])
+            ->withStatusCode($values[ProblemNormalizer::STATUS])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            ProblemNormalizer::TITLE => 'title',
+            ProblemNormalizer::TYPE => 'type',
+            ProblemNormalizer::STATUS => 418,
+        ]];
+
+        yield 'With null values' => [[
+            ProblemNormalizer::TITLE => null,
+            ProblemNormalizer::TYPE => null,
+            ProblemNormalizer::STATUS => null,
+        ]];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/UidNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/UidNormalizerContextBuilderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Context\Normalizer\UidNormalizerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\UidNormalizer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class UidNormalizerContextBuilderTest extends TestCase
+{
+    private UidNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new UidNormalizerContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withNormalizationFormat($values[UidNormalizer::NORMALIZATION_FORMAT_KEY])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            UidNormalizer::NORMALIZATION_FORMAT_KEY => UidNormalizer::NORMALIZATION_FORMAT_BASE32,
+        ]];
+
+        yield 'With null values' => [[
+            UidNormalizer::NORMALIZATION_FORMAT_KEY => null,
+        ]];
+    }
+
+    public function testCannotSetInvalidUidNormalizationFormat()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->contextBuilder->withNormalizationFormat('invalid format');
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/UnwrappingDenormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/UnwrappingDenormalizerContextBuilderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Context\Normalizer\UnwrappingDenormalizerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class UnwrappingDenormalizerContextBuilderTest extends TestCase
+{
+    private UnwrappingDenormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new UnwrappingDenormalizerContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withUnwrapPath($values[UnwrappingDenormalizer::UNWRAP_PATH])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            UnwrappingDenormalizer::UNWRAP_PATH => 'foo'
+        ]];
+
+        yield 'With null values' => [[
+            UnwrappingDenormalizer::UNWRAP_PATH => null,
+        ]];
+    }
+
+    public function testCannotSetInvalidPropertyPath()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->contextBuilder->withUnwrapPath('invalid path...');
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/SerializerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/SerializerContextBuilderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\SerializerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class SerializerContextBuilderTest extends TestCase
+{
+    private SerializerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new SerializerContextBuilder();
+    }
+
+    /**
+     * @dataProvider withersDataProvider
+     *
+     * @param array<string, mixed> $values
+     */
+    public function testWithers(array $values)
+    {
+        $context = $this->contextBuilder
+            ->withEmptyArrayAsObject($values[Serializer::EMPTY_ARRAY_AS_OBJECT])
+            ->withCollectDenormalizationErrors($values[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS])
+            ->toArray();
+
+        $this->assertSame($values, $context);
+    }
+
+    /**
+     * @return iterable<array{0: array<string, mixed>}>
+     */
+    public function withersDataProvider(): iterable
+    {
+        yield 'With values' => [[
+            Serializer::EMPTY_ARRAY_AS_OBJECT => true,
+            DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => false,
+        ]];
+
+        yield 'With null values' => [[
+            Serializer::EMPTY_ARRAY_AS_OBJECT => null,
+            DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => null,
+        ]];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fixes partially #30818
| License       | MIT
| Doc PR        | TODO

This PR introduces ContextBuilders as discussed in #30818.

The main idea here is to introduce an abstract context builder that could be extended to create concrete context builders.
These context builders will allow serialization context construction using withers (maybe setters are better?) while providing validation, documentation, and IDE autocompletion.
Once construction is ready, `toArray` (maybe `build` is better?) can be called to generate the actual serialization context.

For example:
```php
use Symfony\Component\Serializer\Context\Encoder\CsvEncoderContextBuilder;
use Symfony\Component\Serializer\Context\Normalizer\DateTimeNormalizerContextBuilder;

$initialContext = ['custom_key' => 'custom_value']);

$contextBuilder = (new DateTimeNormalizerContextBuilder()
  ->withContext($initialContext)
  ->withFormat('Y_m_d')
  ->withTimezone('GMT');

$contextBuilder = (new CsvEncoderContextBuilder())
  ->withContext($contextBuilder->toArray())
  ->withDelimiter('-')
  ->withHeaders(['foo', 'bar']);

$this->serializer->serialize($data, 'csv', $contextBuilder->toArray());
// Serialization context will be:
// [
//   'custom_key' => 'custom_value',
//   'datetime_format' => 'Y_m_d',
//   'datetime_timezone' => DateTimeZone instance,
//   'csv_delimiter' => '-',
//   'csv_headers' => ['foo', 'bar'],
// ]
```