### PR TITLE
[Validator] translate for japanese 101,102,103

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -390,6 +390,18 @@
                 <source>This value should be a valid expression.</source>
                 <target>式でなければなりません。</target>
             </trans-unit>
+            <trans-unit id="101">
+                <source>This value is not a valid CSS color.</source>
+                <target>この値は有効なCSSカラーではありません。</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>この値は有効なCIDR表記ではありません。</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>ネットマスクの値は、{{ min }}から{{ max }}の間にある必要があります。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43446 
| License       | MIT

Added missing Japanese translation units for validators.