### PR TITLE
[Messenger][Serializer] Deprecate "context aware" interfaces

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -1,0 +1,10 @@
+UPGRADE FROM 6.0 to 6.1
+=======================
+
+Serializer
+----------
+
+ * Deprecate `ContextAwareNormalizerInterface`, use `NormalizerInterface` instead
+ * Deprecate `ContextAwareDenormalizerInterface`, use `DenormalizerInterface` instead
+ * Deprecate `ContextAwareEncoderInterface`, use `EncoderInterface` instead
+ * Deprecate `ContextAwareDecoderInterface`, use `DecoderInterface` instead

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Deprecate `ContextAwareNormalizerInterface`, use `NormalizerInterface` instead
+ * Deprecate `ContextAwareDenormalizerInterface`, use `DenormalizerInterface` instead
+ * Deprecate `ContextAwareEncoderInterface`, use `EncoderInterface` instead
+ * Deprecate `ContextAwareDecoderInterface`, use `DecoderInterface` instead
+
 6.0
 ---
 

--- a/src/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Serializer\Encoder;
  * Adds the support of an extra $context parameter for the supportsDecoding method.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated since symfony/serializer 6.1, use DecoderInterface instead
  */
 interface ContextAwareDecoderInterface extends DecoderInterface
 {

--- a/src/Symfony/Component/Serializer/Encoder/ContextAwareEncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/ContextAwareEncoderInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Serializer\Encoder;
  * Adds the support of an extra $context parameter for the supportsEncoding method.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated since symfony/serializer 6.1, use EncoderInterface instead
  */
 interface ContextAwareEncoderInterface extends EncoderInterface
 {

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -123,8 +123,10 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsEncoding(string $format): bool
+    public function supportsEncoding(string $format /*, array $context = [] */): bool
     {
         return self::FORMAT === $format;
     }
@@ -209,8 +211,10 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDecoding(string $format): bool
+    public function supportsDecoding(string $format /*, array $context = [] */): bool
     {
         return self::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
@@ -40,8 +40,9 @@ interface DecoderInterface
      * Checks whether the deserializer can decode from given format.
      *
      * @param string $format Format name
+     * @param array  $context Options that decoders have access to
      *
      * @return bool
      */
-    public function supportsDecoding(string $format);
+    public function supportsDecoding(string $format /*, array $context = [] */);
 }

--- a/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
@@ -32,7 +32,8 @@ interface EncoderInterface
     /**
      * Checks whether the serializer can encode to given format.
      *
-     * @param string $format Format name
+     * @param string $format  Format name
+     * @param array  $context Options that normalizers/encoders have access to
      */
-    public function supportsEncoding(string $format): bool;
+    public function supportsEncoding(string $format /*, array $context = [] */): bool;
 }

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -95,8 +95,10 @@ class JsonDecode implements DecoderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDecoding(string $format): bool
+    public function supportsDecoding(string $format /*, array $context = [] */): bool
     {
         return JsonEncoder::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -57,8 +57,10 @@ class JsonEncode implements EncoderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsEncoding(string $format): bool
+    public function supportsEncoding(string $format /*, array $context = [] */): bool
     {
         return JsonEncoder::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
@@ -47,16 +47,20 @@ class JsonEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsEncoding(string $format): bool
+    public function supportsEncoding(string $format /*, array $context = [] */): bool
     {
         return self::FORMAT === $format;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDecoding(string $format): bool
+    public function supportsDecoding(string $format /*, array $context = [] */): bool
     {
         return self::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -174,16 +174,20 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsEncoding(string $format): bool
+    public function supportsEncoding(string $format /*, array $context = [] */): bool
     {
         return self::FORMAT === $format;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDecoding(string $format): bool
+    public function supportsDecoding(string $format /*, array $context = [] */): bool
     {
         return self::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -67,8 +67,10 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsEncoding(string $format): bool
+    public function supportsEncoding(string $format /*, array $context = [] */): bool
     {
         return self::FORMAT === $format || self::ALTERNATIVE_FORMAT === $format;
     }
@@ -85,8 +87,10 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDecoding(string $format): bool
+    public function supportsDecoding(string $format /*, array $context = [] */): bool
     {
         return self::FORMAT === $format || self::ALTERNATIVE_FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -134,8 +134,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null)
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */)
     {
         return \is_object($data) && !$data instanceof \Traversable;
     }
@@ -349,8 +351,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null)
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */)
     {
         return class_exists($type) || (interface_exists($type, false) && $this->classDiscriminatorResolver && null !== $this->classDiscriminatorResolver->getMappingForClass($type));
     }

--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -37,7 +37,7 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null): bool
+    public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return $data instanceof \BackedEnum;
     }
@@ -67,7 +67,7 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null): bool
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         return is_subclass_of($type, \BackedEnum::class);
     }

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -106,8 +106,10 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return $data instanceof ConstraintViolationListInterface;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/ContextAwareDenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ContextAwareDenormalizerInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Serializer\Normalizer;
  * Adds the support of an extra $context parameter for the supportsDenormalization method.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated since symfony/serializer 6.1, use DenormalizerInterface instead
  */
 interface ContextAwareDenormalizerInterface extends DenormalizerInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/ContextAwareNormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ContextAwareNormalizerInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Serializer\Normalizer;
  * Adds the support of an extra $context parameter for the supportsNormalization method.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated since symfony/serializer 6.1, use NormalizerInterface instead
  */
 interface ContextAwareNormalizerInterface extends NormalizerInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -44,10 +44,11 @@ class CustomNormalizer implements NormalizerInterface, DenormalizerInterface, Se
     /**
      * Checks if the given class implements the NormalizableInterface.
      *
-     * @param mixed  $data   Data to normalize
-     * @param string $format The format being (de-)serialized from or into
+     * @param mixed  $data    Data to normalize
+     * @param string $format  The format being (de-)serialized from or into
+     * @param array  $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return $data instanceof NormalizableInterface;
     }
@@ -55,11 +56,12 @@ class CustomNormalizer implements NormalizerInterface, DenormalizerInterface, Se
     /**
      * Checks if the given class implements the DenormalizableInterface.
      *
-     * @param mixed  $data   Data to denormalize from
-     * @param string $type   The class to which the data should be denormalized
-     * @param string $format The format being deserialized from
+     * @param mixed  $data    Data to denormalize from
+     * @param string $type    The class to which the data should be denormalized
+     * @param string $format  The format being deserialized from
+     * @param array  $context
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */): bool
     {
         return is_subclass_of($type, DenormalizableInterface::class);
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -73,8 +73,10 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return $data instanceof \SplFileInfo;
     }
@@ -117,8 +119,10 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */): bool
     {
         return isset(self::SUPPORTED_TYPES[$type]);
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -49,8 +49,10 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return $data instanceof \DateInterval;
     }
@@ -117,8 +119,10 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */): bool
     {
         return \DateInterval::class === $type;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -71,8 +71,10 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return $data instanceof \DateTimeInterface;
     }
@@ -112,8 +114,10 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */): bool
     {
         return isset(self::SUPPORTED_TYPES[$type]);
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
@@ -38,8 +38,10 @@ class DateTimeZoneNormalizer implements NormalizerInterface, DenormalizerInterfa
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return $data instanceof \DateTimeZone;
     }
@@ -64,8 +66,10 @@ class DateTimeZoneNormalizer implements NormalizerInterface, DenormalizerInterfa
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */): bool
     {
         return \DateTimeZone::class === $type;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -49,11 +49,12 @@ interface DenormalizerInterface
     /**
      * Checks whether the given class is supported for denormalization by this normalizer.
      *
-     * @param mixed  $data   Data to denormalize from
-     * @param string $type   The class to which the data should be denormalized
-     * @param string $format The format being deserialized from
+     * @param mixed  $data    Data to denormalize from
+     * @param string $type    The class to which the data should be denormalized
+     * @param string $format  The format being deserialized from
+     * @param array  $context Options available to the denormalizer
      *
      * @return bool
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null);
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */);
 }

--- a/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
@@ -44,7 +44,7 @@ final class FormErrorNormalizer implements NormalizerInterface, CacheableSupport
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof FormInterface && $data->isSubmitted() && !$data->isValid();
     }

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -38,16 +38,20 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return parent::supportsNormalization($data, $format) && $this->supports(\get_class($data));
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */): bool
     {
         return parent::supportsDenormalization($data, $type, $format) && $this->supports($type);
     }

--- a/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
@@ -43,16 +43,20 @@ class JsonSerializableNormalizer extends AbstractNormalizer
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return $data instanceof \JsonSerializable;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */): bool
     {
         return false;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -100,7 +100,7 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof Message || $data instanceof Headers || $data instanceof HeaderInterface || $data instanceof Address || $data instanceof AbstractPart;
     }
@@ -108,7 +108,7 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return is_a($type, Message::class, true) || Headers::class === $type || AbstractPart::class === $type;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -41,10 +41,11 @@ interface NormalizerInterface
     /**
      * Checks whether the given class is supported for normalization by this normalizer.
      *
-     * @param mixed  $data   Data to normalize
-     * @param string $format The format being (de-)serialized from or into
+     * @param mixed  $data    Data to normalize
+     * @param string $format  The format being (de-)serialized from or into
+     * @param array  $context Context options for the normalizer
      *
      * @return bool
      */
-    public function supportsNormalization(mixed $data, string $format = null);
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */);
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -64,8 +64,10 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return $data instanceof FlattenException;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -34,16 +34,20 @@ class PropertyNormalizer extends AbstractObjectNormalizer
 {
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */): bool
     {
         return parent::supportsNormalization($data, $format) && $this->supports(\get_class($data));
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $context
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null /*, array $context = [] */): bool
     {
         return parent::supportsDenormalization($data, $type, $format) && $this->supports($type);
     }

--- a/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
@@ -59,7 +59,7 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof AbstractUid;
     }
@@ -85,7 +85,7 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return is_a($type, AbstractUid::class, true);
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -90,7 +90,7 @@ class ChainEncoderTest extends TestCase
 
 class NormalizationAwareEncoder implements EncoderInterface, NormalizationAwareInterface
 {
-    public function supportsEncoding(string $format): bool
+    public function supportsEncoding(string $format, array $context = []): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
@@ -38,7 +38,7 @@ class AbstractNormalizerDummy extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return true;
     }
@@ -53,7 +53,7 @@ class AbstractNormalizerDummy extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -535,7 +535,7 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
         return null;
     }
 
-    public function supportsDenormalization($data, string $type, string $format = null): bool
+    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
@@ -30,7 +30,7 @@ class TestDenormalizer implements DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null): bool
+    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
@@ -31,7 +31,7 @@ class TestNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null): bool
+    public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return true;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        | TODO

In `supports*` methods, we are really often relying on serialization context.
Previously (~2017), in order to have the context in these methods (and be BC compatible), new interfaces were introduced:
- `ContextAwareNormalizerInterface`
- `ContextAwareDenormalizerInterface` 
- `ContextAwareEncoderInterface`
- `ContextAwareDecoderInterface`

But right now, thanks to the `DebugClassLoader`, we're able to have an upgrade path where the regular interfaces:
- `NormalizerInterface`
- `DenormalizerInterface` 
- `EncoderInterface`
- `DecoderInterface`
can be updated to rely on the serialization context.

Therefore, the "context aware" interfaces could be deprecated in favor of "regular" ones (and then save 4 interfaces in 7.0).