### PR TITLE
[HttpKernel] allow ignoring kernel.reset methods that don't exist

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php
@@ -30,6 +30,7 @@ return static function (ContainerConfigurator $container) {
             ])
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])
             ->tag('monolog.logger', ['channel' => 'http_client'])
+            ->tag('kernel.reset', ['method' => 'reset', 'on_invalid' => 'ignore'])
             ->tag('http_client.client')
 
         ->alias(HttpClientInterface::class, 'http_client')

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate `AbstractTestSessionListener::getSession` inject a session in the request instead
  * Deprecate the `fileLinkFormat` parameter of `DebugHandlersListener`
  * Add support for configuring log level, and status code by exception class
+ * Allow ignoring "kernel.reset" methods that don't exist with "on_invalid" attribute
 
 5.3
 ---

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ResettableServicePass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ResettableServicePass.php
@@ -57,6 +57,10 @@ class ResettableServicePass implements CompilerPassInterface
                     $methods[$id] = [];
                 }
 
+                if ('ignore' === ($attributes['on_invalid'] ?? null)) {
+                    $attributes['method'] = '?'.$attributes['method'];
+                }
+
                 $methods[$id][] = $attributes['method'];
             }
         }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
@@ -40,6 +40,10 @@ class ServicesResetter implements ResetInterface
     {
         foreach ($this->resettableServices as $id => $service) {
             foreach ((array) $this->resetMethods[$id] as $resetMethod) {
+                if ('?' === $resetMethod[0] && !method_exists($service, $resetMethod = substr($resetMethod, 1))) {
+                    continue;
+                }
+
                 $service->$resetMethod();
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ResettableServicePassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ResettableServicePassTest.php
@@ -70,6 +70,26 @@ class ResettableServicePassTest extends TestCase
         $container->compile();
     }
 
+    public function testIgnoreInvalidMethod()
+    {
+        $container = new ContainerBuilder();
+        $container->register(ResettableService::class)
+            ->setPublic(true)
+            ->addTag('kernel.reset', ['method' => 'missingMethod', 'on_invalid' => 'ignore']);
+        $container->register('services_resetter', ServicesResetter::class)
+            ->setPublic(true)
+            ->setArguments([null, []]);
+        $container->addCompilerPass(new ResettableServicePass());
+
+        $container->compile();
+
+        $this->assertSame([ResettableService::class => ['?missingMethod']], $container->getDefinition('services_resetter')->getArgument(1));
+
+        $resettable = $container->get(ResettableService::class);
+        $resetter = $container->get('services_resetter');
+        $resetter->reset();
+    }
+
     public function testCompilerPassWithoutResetters()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When a service is built by a factory, we don't always know if the resulting instance will implement `ResetInteface` or not.
One such service is `http_client`: `HttpClient::create()` might return a curl-one or a native-one, and only the former is resettable.

This PR makes it possible to make a reset conditional, aka by ignoring when the reset method doesn't exist.
This is both a new feature for HttpKernel and a bugfix for the `http_client` service.
That's why I'm targeting 5.4.