### PR TITLE
[HttpClient] Implement ResetInterface for all http clients

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\HttpClientKernel;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Adds caching on top of an HTTP client.
@@ -30,7 +31,7 @@ use Symfony\Contracts\HttpClient\ResponseStreamInterface;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class CachingHttpClient implements HttpClientInterface
+class CachingHttpClient implements HttpClientInterface, ResetInterface
 {
     use HttpClientTrait;
 
@@ -140,5 +141,12 @@ class CachingHttpClient implements HttpClientInterface
             yield from MockResponse::stream($mockResponses, $timeout);
             yield $this->client->stream($clientResponses, $timeout);
         })());
+    }
+
+    public function reset()
+    {
+        if ($this->client instanceof ResetInterface) {
+            $this->client->reset();
+        }
     }
 }

--- a/src/Symfony/Component/HttpClient/DecoratorTrait.php
+++ b/src/Symfony/Component/HttpClient/DecoratorTrait.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Eases with writing decorators.
@@ -54,5 +55,12 @@ trait DecoratorTrait
         $clone->client = $this->client->withOptions($options);
 
         return $clone;
+    }
+
+    public function reset()
+    {
+        if ($this->client instanceof ResetInterface) {
+            $this->client->reset();
+        }
     }
 }

--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -19,12 +19,13 @@ use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Antoine Bluchet <soyuka@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class EventSourceHttpClient implements HttpClientInterface
+final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
 {
     use AsyncDecoratorTrait, HttpClientTrait {
         AsyncDecoratorTrait::withOptions insteadof HttpClientTrait;

--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -39,6 +39,7 @@ use Symfony\Component\HttpClient\Response\HttplugPromise;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 if (!interface_exists(HttplugInterface::class)) {
     throw new \LogicException('You cannot use "Symfony\Component\HttpClient\HttplugClient" as the "php-http/httplug" package is not installed. Try running "composer require php-http/httplug".');
@@ -56,7 +57,7 @@ if (!interface_exists(RequestFactory::class)) {
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestFactory, StreamFactory, UriFactory
+final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestFactory, StreamFactory, UriFactory, ResetInterface
 {
     private $client;
     private $responseFactory;
@@ -236,6 +237,13 @@ final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestF
     public function __destruct()
     {
         $this->wait();
+    }
+
+    public function reset()
+    {
+        if ($this->client instanceof ResetInterface) {
+            $this->client->reset();
+        }
     }
 
     private function sendPsr7Request(RequestInterface $request, bool $buffer = null): ResponseInterface

--- a/src/Symfony/Component/HttpClient/Internal/NativeClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/NativeClientState.php
@@ -37,4 +37,11 @@ final class NativeClientState extends ClientState
     {
         $this->id = random_int(\PHP_INT_MIN, \PHP_INT_MAX);
     }
+
+    public function reset()
+    {
+        $this->responseCount = 0;
+        $this->dnsCache = [];
+        $this->hosts = [];
+    }
 }

--- a/src/Symfony/Component/HttpClient/MockHttpClient.php
+++ b/src/Symfony/Component/HttpClient/MockHttpClient.php
@@ -17,13 +17,14 @@ use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * A test-friendly HttpClient that doesn't make actual HTTP requests.
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class MockHttpClient implements HttpClientInterface
+class MockHttpClient implements HttpClientInterface, ResetInterface
 {
     use HttpClientTrait;
 
@@ -114,5 +115,10 @@ class MockHttpClient implements HttpClientInterface
         $clone->defaultOptions = self::mergeDefaultOptions($options, $this->defaultOptions, true);
 
         return $clone;
+    }
+
+    public function reset()
+    {
+        $this->requestsCount = 0;
     }
 }

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * A portable implementation of the HttpClientInterface contracts based on PHP stream wrappers.
@@ -30,7 +31,7 @@ use Symfony\Contracts\HttpClient\ResponseStreamInterface;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterface
+final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
 {
     use HttpClientTrait;
     use LoggerAwareTrait;
@@ -259,6 +260,11 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
         }
 
         return new ResponseStream(NativeResponse::stream($responses, $timeout));
+    }
+
+    public function reset()
+    {
+        $this->multi->reset();
     }
 
     private static function getBodyAsString($body): string

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -19,13 +19,14 @@ use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Decorator that blocks requests to private networks by default.
  *
  * @author Hallison Boaventura <hallisonboaventura@gmail.com>
  */
-final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwareInterface
+final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
 {
     use HttpClientTrait;
 
@@ -120,5 +121,12 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
         $clone->client = $this->client->withOptions($options);
 
         return $clone;
+    }
+
+    public function reset()
+    {
+        if ($this->client instanceof ResetInterface) {
+            $this->client->reset();
+        }
     }
 }

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpClient\Response\StreamableInterface;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 if (!interface_exists(RequestFactoryInterface::class)) {
     throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\Psr18Client" as the "psr/http-factory" package is not installed. Try running "composer require nyholm/psr7".');
@@ -49,7 +50,7 @@ if (!interface_exists(ClientInterface::class)) {
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class Psr18Client implements ClientInterface, RequestFactoryInterface, StreamFactoryInterface, UriFactoryInterface
+final class Psr18Client implements ClientInterface, RequestFactoryInterface, StreamFactoryInterface, UriFactoryInterface, ResetInterface
 {
     private $client;
     private $responseFactory;
@@ -189,6 +190,13 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
         }
 
         throw new \LogicException(sprintf('You cannot use "%s()" as the "nyholm/psr7" package is not installed. Try running "composer require nyholm/psr7".', __METHOD__));
+    }
+
+    public function reset()
+    {
+        if ($this->client instanceof ResetInterface) {
+            $this->client->reset();
+        }
     }
 }
 

--- a/src/Symfony/Component/HttpClient/RetryableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/RetryableHttpClient.php
@@ -21,13 +21,14 @@ use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Automatically retries failing HTTP requests.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class RetryableHttpClient implements HttpClientInterface
+class RetryableHttpClient implements HttpClientInterface, ResetInterface
 {
     use AsyncDecoratorTrait;
 

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -418,4 +418,16 @@ class MockHttpClientTest extends HttpClientTestCase
 
         $this->assertSame('foo=bar', $response->getRequestOptions()['body']);
     }
+
+    public function testResetsRequestCount()
+    {
+        $client = new MockHttpClient([new MockResponse()]);
+        $this->assertSame(0, $client->getRequestsCount());
+
+        $client->request('POST', '/url', ['body' => 'payload']);
+
+        $this->assertSame(1, $client->getRequestsCount());
+        $client->reset();
+        $this->assertSame(0, $client->getRequestsCount());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Result of discussion at https://github.com/symfony/symfony/pull/43972

Targeting 5.4 branch as I think its kind of a new feature without BC break
