### PR TITLE
[DoctrineBridge] add support for the JSON type

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -189,6 +189,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                         case self::$useDeprecatedConstants ? DBALType::TARRAY : Types::ARRAY:
                         // no break
                         case 'json_array':
+                        case 'json':
                             return [new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true)];
 
                         case self::$useDeprecatedConstants ? DBALType::SIMPLE_ARRAY : Types::SIMPLE_ARRAY:
@@ -316,6 +317,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
             case self::$useDeprecatedConstants ? DBALType::SIMPLE_ARRAY : Types::SIMPLE_ARRAY:
             // no break
             case 'json_array':
+            case 'json':
                 return Type::BUILTIN_TYPE_ARRAY;
         }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -254,11 +254,11 @@ class DoctrineExtractorTest extends TestCase
                 new Type(Type::BUILTIN_TYPE_INT),
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, DoctrineRelation::class)
             )]],
-            ['json', null],
+            ['json', [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)]],
         ];
 
         if (class_exists(Types::class)) {
-            $provider[] = ['json', null];
+            $provider[] = ['json', [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)]];
         }
 
         return $provider;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/api-platform/core/issues/4547, https://github.com/api-platform/core/pull/4553
| License       | MIT
| Doc PR        | n/a

The `json_array` Doctrine type is deprecated since DBAL 2.6 (we require version 2.7) and has been removed in DBAL 3.0 This PR adds back support for this new type.