### PR TITLE
[Security] Do not overwrite already stored tokens for REMOTE_USER authentication

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
@@ -79,6 +79,17 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
             return false;
         }
 
+        // do not overwrite already stored tokens from the same user (i.e. from the session)
+        $token = $this->tokenStorage->getToken();
+
+        if ($token instanceof PreAuthenticatedToken && $this->firewallName === $token->getFirewallName() && $token->getUserIdentifier() === $username) {
+            if (null !== $this->logger) {
+                $this->logger->debug('Skipping pre-authenticated authenticator as the user already has an existing session.', ['authenticator' => static::class]);
+            }
+
+            return false;
+        }
+
         $request->attributes->set('_pre_authenticated_username', $username);
 
         return true;

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RemoteUserAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RemoteUserAuthenticatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Tests\Authenticator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
@@ -35,6 +36,17 @@ class RemoteUserAuthenticatorTest extends TestCase
         $authenticator = new RemoteUserAuthenticator(new InMemoryUserProvider(), new TokenStorage(), 'main');
 
         $this->assertFalse($authenticator->supports($this->createRequest([])));
+    }
+
+    public function testSupportTokenStorageWithToken()
+    {
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new PreAuthenticatedToken('username', 'credentials', 'main'));
+
+        $authenticator = new RemoteUserAuthenticator(new InMemoryUserProvider(), $tokenStorage, 'main');
+
+        $this->assertFalse($authenticator->supports($this->createRequest(['REMOTE_USER' => 'username'])));
+        $this->assertTrue($authenticator->supports($this->createRequest(['REMOTE_USER' => 'another_username'])));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43648
| License       | MIT

As described in #43648 the user is currently loaded on every request for REMOTE_USER authentication.
Thanks to @wouterj for confirming me on Slack that this seems weird. So, I looked deeper into this.

I found out that other Authenticators tell the AuthenticatorManager only under special conditions (like matching route etc.) that they support the current request. However, the `AbstractPreAuthenticatedAuthenticator` is not so picky. In consequence, the user is authenticated again on every request.

Inspired by `RememberMeAuthenticator`, this PR adds an addition check to `AbstractPreAuthenticatedAuthenticator` to solve this issue.
https://github.com/symfony/symfony/blob/07a891f6c57d9da513d75402f2aa2da73d897044/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php#L63