### PR TITLE
[DependencyInjection] fix auto-refresh when inline_factories is enabled

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -7,6 +7,13 @@ return [
     'Symfony\\Component\\DependencyInjection\\ContainerInterface' => true,
 ];
 
+    [Container%s/proxy-classes.php] => <?php
+
+include_once $this->targetDir.''.'/Fixtures/includes/foo.php';
+
+class FooClass_%s extends \Bar\FooClass implements \ProxyManager\Proxy\VirtualProxyInterface
+%A
+
     [Container%s/ProjectServiceContainer.php] => <?php
 
 namespace Container%s;
@@ -46,6 +53,10 @@ class ProjectServiceContainer extends Container
         ];
 
         $this->aliases = [];
+
+        $this->privates['service_container'] = function () {
+            include_once __DIR__.'/proxy-classes.php';
+        };
     }
 
     public function compile(): void
@@ -161,15 +172,10 @@ class ProjectServiceContainer extends Container
         ];
     }
 }
-include_once $this->targetDir.''.'/Fixtures/includes/foo.php';
-
-class FooClass_%s extends \Bar\FooClass implements \ProxyManager\Proxy\VirtualProxyInterface
-{
-%A
-}
 
     [ProjectServiceContainer.preload.php] => <?php
 %A
+(require __DIR__.'/Container%s/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 
 $classes = [];
 $classes[] = 'Bar\FooClass';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43956
| License       | MIT
| Doc PR        | -

When `inline_factories` is set, we also inline proxy classes in the dumped container.
This breaks auto-refreshing the cache when a proxyfied class is removed (as described in the linked issue).
This PR fixes the issue by dumping proxy classes in a new `proxy-classes.php` file. This file is loaded only after the cache has been checked, when the container is initialized.