### PR TITLE
[Workflow] fixed $context not available on GuardEvent

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -245,3 +245,4 @@ Workflow
 --------
 
  * Deprecate `InvalidTokenConfigurationException`
+ * Deprecate `WorkflowInterface::getMarking()`, use `WorkflowInterface::getWorkflowMarking()` instead

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -400,6 +400,7 @@ Workflow
 --------
 
  * Remove `InvalidTokenConfigurationException`
+ * Remove `WorkflowInterface::getMarking()` in favor of `WorkflowInterface::getWorkflowMarking()`
 
 Yaml
 ----

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -51,9 +51,9 @@ final class WorkflowExtension extends AbstractExtension
     /**
      * Returns true if the transition is enabled.
      */
-    public function canTransition(object $subject, string $transitionName, string $name = null): bool
+    public function canTransition(object $subject, string $transitionName, string $name = null, array $context = []): bool
     {
-        return $this->workflowRegistry->get($subject, $name)->can($subject, $transitionName);
+        return $this->workflowRegistry->get($subject, $name)->can($subject, $transitionName, $context);
     }
 
     /**
@@ -61,22 +61,22 @@ final class WorkflowExtension extends AbstractExtension
      *
      * @return Transition[] All enabled transitions
      */
-    public function getEnabledTransitions(object $subject, string $name = null): array
+    public function getEnabledTransitions(object $subject, string $name = null, array $context = []): array
     {
-        return $this->workflowRegistry->get($subject, $name)->getEnabledTransitions($subject);
+        return $this->workflowRegistry->get($subject, $name)->getEnabledTransitions($subject, $context);
     }
 
-    public function getEnabledTransition(object $subject, string $transition, string $name = null): ?Transition
+    public function getEnabledTransition(object $subject, string $transition, string $name = null, array $context = []): ?Transition
     {
-        return $this->workflowRegistry->get($subject, $name)->getEnabledTransition($subject, $transition);
+        return $this->workflowRegistry->get($subject, $name)->getEnabledTransition($subject, $transition, $context);
     }
 
     /**
      * Returns true if the place is marked.
      */
-    public function hasMarkedPlace(object $subject, string $placeName, string $name = null): bool
+    public function hasMarkedPlace(object $subject, string $placeName, string $name = null, array $context = []): bool
     {
-        return $this->workflowRegistry->get($subject, $name)->getMarking($subject)->has($placeName);
+        return $this->workflowRegistry->get($subject, $name)->getMarking($subject, $context)->has($placeName);
     }
 
     /**
@@ -84,9 +84,9 @@ final class WorkflowExtension extends AbstractExtension
      *
      * @return string[]|int[]
      */
-    public function getMarkedPlaces(object $subject, bool $placesNameOnly = true, string $name = null): array
+    public function getMarkedPlaces(object $subject, bool $placesNameOnly = true, string $name = null, array $context = []): array
     {
-        $places = $this->workflowRegistry->get($subject, $name)->getMarking($subject)->getPlaces();
+        $places = $this->workflowRegistry->get($subject, $name)->getMarking($subject, $context)->getPlaces();
 
         if ($placesNameOnly) {
             return array_keys($places);
@@ -112,10 +112,10 @@ final class WorkflowExtension extends AbstractExtension
         ;
     }
 
-    public function buildTransitionBlockerList(object $subject, string $transitionName, string $name = null): TransitionBlockerList
+    public function buildTransitionBlockerList(object $subject, string $transitionName, string $name = null, array $context = []): TransitionBlockerList
     {
         $workflow = $this->workflowRegistry->get($subject, $name);
 
-        return $workflow->buildTransitionBlockerList($subject, $transitionName);
+        return $workflow->buildTransitionBlockerList($subject, $transitionName, $context);
     }
 }

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -76,7 +76,7 @@ final class WorkflowExtension extends AbstractExtension
      */
     public function hasMarkedPlace(object $subject, string $placeName, string $name = null, array $context = []): bool
     {
-        return $this->workflowRegistry->get($subject, $name)->getMarking($subject, $context)->has($placeName);
+        return $this->workflowRegistry->get($subject, $name)->getWorkflowMarking($subject, $context)->has($placeName);
     }
 
     /**
@@ -86,7 +86,7 @@ final class WorkflowExtension extends AbstractExtension
      */
     public function getMarkedPlaces(object $subject, bool $placesNameOnly = true, string $name = null, array $context = []): array
     {
-        $places = $this->workflowRegistry->get($subject, $name)->getMarking($subject, $context)->getPlaces();
+        $places = $this->workflowRegistry->get($subject, $name)->getWorkflowMarking($subject, $context)->getPlaces();
 
         if ($placesNameOnly) {
             return array_keys($places);

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -3,9 +3,10 @@ CHANGELOG
 
 5.3
 ---
-
+ * Deprecate `WorkflowInterface::getMarking()` method use `WorkflowInterface::getWorkflowMarking()` instead
  * Deprecate `InvalidTokenConfigurationException`
  * Added `MermaidDumper` to dump Workflow graphs in the Mermaid.js flowchart format
+ * Added `$context` to GuardEvent constructor
 
 5.2.0
 -----

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -28,9 +28,9 @@ final class GuardEvent extends Event
     /**
      * {@inheritdoc}
      */
-    public function __construct(object $subject, Marking $marking, Transition $transition, WorkflowInterface $workflow = null)
+    public function __construct(object $subject, Marking $marking, Transition $transition, WorkflowInterface $workflow = null, array $context = [])
     {
-        parent::__construct($subject, $marking, $transition, $workflow);
+        parent::__construct($subject, $marking, $transition, $workflow, $context);
 
         $this->transitionBlockerList = new TransitionBlockerList();
     }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -30,7 +30,7 @@ class WorkflowTest extends TestCase
         $subject = new Subject();
         $workflow = new Workflow(new Definition([], []), $this->createMock(MarkingStoreInterface::class));
 
-        $workflow->getMarking($subject);
+        $workflow->getWorkflowMarking($subject);
     }
 
     public function testGetMarkingWithEmptyDefinition()
@@ -40,7 +40,7 @@ class WorkflowTest extends TestCase
         $subject = new Subject();
         $workflow = new Workflow(new Definition([], []), new MethodMarkingStore());
 
-        $workflow->getMarking($subject);
+        $workflow->getWorkflowMarking($subject);
     }
 
     public function testGetMarkingWithImpossiblePlace()
@@ -51,7 +51,7 @@ class WorkflowTest extends TestCase
         $subject->setMarking(['nope' => 1]);
         $workflow = new Workflow(new Definition([], []), new MethodMarkingStore());
 
-        $workflow->getMarking($subject);
+        $workflow->getWorkflowMarking($subject);
     }
 
     public function testGetMarkingWithEmptyInitialMarking()
@@ -60,7 +60,7 @@ class WorkflowTest extends TestCase
         $subject = new Subject();
         $workflow = new Workflow($definition, new MethodMarkingStore());
 
-        $marking = $workflow->getMarking($subject);
+        $marking = $workflow->getWorkflowMarking($subject);
 
         $this->assertInstanceOf(Marking::class, $marking);
         $this->assertTrue($marking->has('a'));
@@ -74,7 +74,7 @@ class WorkflowTest extends TestCase
         $subject->setMarking(['b' => 1, 'c' => 1]);
         $workflow = new Workflow($definition, new MethodMarkingStore());
 
-        $marking = $workflow->getMarking($subject);
+        $marking = $workflow->getWorkflowMarking($subject);
 
         $this->assertInstanceOf(Marking::class, $marking);
         $this->assertTrue($marking->has('b'));

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -31,6 +31,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Carlos Pereira De Amorim <carlos@shauri.fr>
+ * @author Maikel Ortega Hernandez <maikeloh@gmail.com>
  */
 class Workflow implements WorkflowInterface
 {
@@ -99,7 +100,7 @@ class Workflow implements WorkflowInterface
             // update the subject with the new marking
             $this->markingStore->setMarking($subject, $marking);
 
-            if (!$context) {
+            if (empty($context)) {
                 $context = self::DEFAULT_INITIAL_CONTEXT;
             }
 
@@ -125,17 +126,17 @@ class Workflow implements WorkflowInterface
     /**
      * {@inheritdoc}
      */
-    public function can(object $subject, string $transitionName)
+    public function can(object $subject, string $transitionName, array $context = [])
     {
         $transitions = $this->definition->getTransitions();
-        $marking = $this->getMarking($subject);
+        $marking = $this->getMarking($subject, $context);
 
         foreach ($transitions as $transition) {
             if ($transition->getName() !== $transitionName) {
                 continue;
             }
 
-            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition);
+            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition, $context);
 
             if ($transitionBlockerList->isEmpty()) {
                 return true;
@@ -148,10 +149,10 @@ class Workflow implements WorkflowInterface
     /**
      * {@inheritdoc}
      */
-    public function buildTransitionBlockerList(object $subject, string $transitionName): TransitionBlockerList
+    public function buildTransitionBlockerList(object $subject, string $transitionName, array $context = []): TransitionBlockerList
     {
         $transitions = $this->definition->getTransitions();
-        $marking = $this->getMarking($subject);
+        $marking = $this->getMarking($subject, $context);
         $transitionBlockerList = null;
 
         foreach ($transitions as $transition) {
@@ -159,7 +160,7 @@ class Workflow implements WorkflowInterface
                 continue;
             }
 
-            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition);
+            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition, $context);
 
             if ($transitionBlockerList->isEmpty()) {
                 return $transitionBlockerList;
@@ -199,7 +200,7 @@ class Workflow implements WorkflowInterface
 
             $transitionExist = true;
 
-            $tmpTransitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition);
+            $tmpTransitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition, $context);
 
             if ($tmpTransitionBlockerList->isEmpty()) {
                 $approvedTransitions[] = $transition;
@@ -250,13 +251,13 @@ class Workflow implements WorkflowInterface
     /**
      * {@inheritdoc}
      */
-    public function getEnabledTransitions(object $subject)
+    public function getEnabledTransitions(object $subject, array $context = [])
     {
         $enabledTransitions = [];
-        $marking = $this->getMarking($subject);
+        $marking = $this->getMarking($subject, $context);
 
         foreach ($this->definition->getTransitions() as $transition) {
-            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition);
+            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition, $context);
             if ($transitionBlockerList->isEmpty()) {
                 $enabledTransitions[] = $transition;
             }
@@ -265,15 +266,15 @@ class Workflow implements WorkflowInterface
         return $enabledTransitions;
     }
 
-    public function getEnabledTransition(object $subject, string $name): ?Transition
+    public function getEnabledTransition(object $subject, string $name, array $context = []): ?Transition
     {
-        $marking = $this->getMarking($subject);
+        $marking = $this->getMarking($subject, $context);
 
         foreach ($this->definition->getTransitions() as $transition) {
             if ($transition->getName() !== $name) {
                 continue;
             }
-            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition);
+            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition, $context);
             if (!$transitionBlockerList->isEmpty()) {
                 continue;
             }
@@ -316,7 +317,7 @@ class Workflow implements WorkflowInterface
         return $this->definition->getMetadataStore();
     }
 
-    private function buildTransitionBlockerListForTransition(object $subject, Marking $marking, Transition $transition): TransitionBlockerList
+    private function buildTransitionBlockerListForTransition(object $subject, Marking $marking, Transition $transition, array $context = []): TransitionBlockerList
     {
         foreach ($transition->getFroms() as $place) {
             if (!$marking->has($place)) {
@@ -330,7 +331,7 @@ class Workflow implements WorkflowInterface
             return new TransitionBlockerList();
         }
 
-        $event = $this->guardTransition($subject, $marking, $transition);
+        $event = $this->guardTransition($subject, $marking, $transition, $context);
 
         if ($event->isBlocked()) {
             return $event->getTransitionBlockerList();
@@ -339,13 +340,13 @@ class Workflow implements WorkflowInterface
         return new TransitionBlockerList();
     }
 
-    private function guardTransition(object $subject, Marking $marking, Transition $transition): ?GuardEvent
+    private function guardTransition(object $subject, Marking $marking, Transition $transition, array $context = []): ?GuardEvent
     {
         if (null === $this->dispatcher) {
             return null;
         }
 
-        $event = new GuardEvent($subject, $marking, $transition, $this);
+        $event = new GuardEvent($subject, $marking, $transition, $this, $context);
 
         $this->dispatcher->dispatch($event, WorkflowEvents::GUARD);
         $this->dispatcher->dispatch($event, sprintf('workflow.%s.guard', $this->name));
@@ -449,7 +450,7 @@ class Workflow implements WorkflowInterface
         $this->dispatcher->dispatch($event, WorkflowEvents::ANNOUNCE);
         $this->dispatcher->dispatch($event, sprintf('workflow.%s.announce', $this->name));
 
-        foreach ($this->getEnabledTransitions($subject) as $transition) {
+        foreach ($this->getEnabledTransitions($subject, $context) as $transition) {
             $this->dispatcher->dispatch($event, sprintf('workflow.%s.announce.%s', $this->name, $transition->getName()));
         }
     }

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -80,7 +80,17 @@ class Workflow implements WorkflowInterface
     /**
      * {@inheritdoc}
      */
-    public function getMarking(object $subject, array $context = [])
+    public function getMarking(object $subject)
+    {
+        trigger_deprecation('symfony/workflow', '5.3', 'The method "%s"  is deprecated.You should stop using it, as it will be removed in the future. Use "%s::getWorkflowMarking" instead.', __METHOD__, WorkflowInterface::class);
+        return $this->getWorkflowMarking($subject);
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWorkflowMarking(object $subject, array $context = [])
     {
         $marking = $this->markingStore->getMarking($subject);
 
@@ -129,7 +139,7 @@ class Workflow implements WorkflowInterface
     public function can(object $subject, string $transitionName, array $context = [])
     {
         $transitions = $this->definition->getTransitions();
-        $marking = $this->getMarking($subject, $context);
+        $marking = $this->getWorkflowMarking($subject, $context);
 
         foreach ($transitions as $transition) {
             if ($transition->getName() !== $transitionName) {
@@ -152,7 +162,7 @@ class Workflow implements WorkflowInterface
     public function buildTransitionBlockerList(object $subject, string $transitionName, array $context = []): TransitionBlockerList
     {
         $transitions = $this->definition->getTransitions();
-        $marking = $this->getMarking($subject, $context);
+        $marking = $this->getWorkflowMarking($subject, $context);
         $transitionBlockerList = null;
 
         foreach ($transitions as $transition) {
@@ -187,7 +197,7 @@ class Workflow implements WorkflowInterface
      */
     public function apply(object $subject, string $transitionName, array $context = [])
     {
-        $marking = $this->getMarking($subject, $context);
+        $marking = $this->getWorkflowMarking($subject, $context);
 
         $transitionExist = false;
         $approvedTransitions = [];
@@ -254,7 +264,7 @@ class Workflow implements WorkflowInterface
     public function getEnabledTransitions(object $subject, array $context = [])
     {
         $enabledTransitions = [];
-        $marking = $this->getMarking($subject, $context);
+        $marking = $this->getWorkflowMarking($subject, $context);
 
         foreach ($this->definition->getTransitions() as $transition) {
             $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition, $context);
@@ -268,7 +278,7 @@ class Workflow implements WorkflowInterface
 
     public function getEnabledTransition(object $subject, string $name, array $context = []): ?Transition
     {
-        $marking = $this->getMarking($subject, $context);
+        $marking = $this->getWorkflowMarking($subject, $context);
 
         foreach ($this->definition->getTransitions() as $transition) {
             if ($transition->getName() !== $name) {

--- a/src/Symfony/Component/Workflow/WorkflowInterface.php
+++ b/src/Symfony/Component/Workflow/WorkflowInterface.php
@@ -27,19 +27,19 @@ interface WorkflowInterface
      *
      * @throws LogicException
      */
-    public function getMarking(object $subject);
+    public function getMarking(object $subject, array $context = []);
 
     /**
      * Returns true if the transition is enabled.
      *
      * @return bool true if the transition is enabled
      */
-    public function can(object $subject, string $transitionName);
+    public function can(object $subject, string $transitionName, array $context = []);
 
     /**
      * Builds a TransitionBlockerList to know why a transition is blocked.
      */
-    public function buildTransitionBlockerList(object $subject, string $transitionName): TransitionBlockerList;
+    public function buildTransitionBlockerList(object $subject, string $transitionName, array $context = []): TransitionBlockerList;
 
     /**
      * Fire a transition.
@@ -55,7 +55,7 @@ interface WorkflowInterface
      *
      * @return Transition[] All enabled transitions
      */
-    public function getEnabledTransitions(object $subject);
+    public function getEnabledTransitions(object $subject, array $context = []);
 
     /**
      * @return string

--- a/src/Symfony/Component/Workflow/WorkflowInterface.php
+++ b/src/Symfony/Component/Workflow/WorkflowInterface.php
@@ -26,8 +26,19 @@ interface WorkflowInterface
      * @return Marking The Marking
      *
      * @throws LogicException
+     *
+     * @deprecated since Symfony 5.3 use getWorkflowMarking instead.
      */
-    public function getMarking(object $subject, array $context = []);
+    public function getMarking(object $subject);
+
+    /**
+     * Returns the object's Marking.
+     *
+     * @return Marking The Marking
+     *
+     * @throws LogicException
+     */
+    public function getWorkflowMarking(object $subject, array $context = []);
 
     /**
      * Returns true if the transition is enabled.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | 
| License       | MIT

For Workflow component, the $context should be available for all events as described on official doc, but GuardEvent don't receive the $context when is instantiated, the context is useful in many ways,  so grant access to it on GuardEvent allow developers to get custom payload on workflow guard event listeners

