### PR TITLE
[HttpKernel] [HttpCache] Don't throw on 304 Not Modified

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -95,7 +95,7 @@ abstract class AbstractSurrogate implements SurrogateInterface
         try {
             $response = $cache->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
 
-            if (!$response->isSuccessful()) {
+            if (!$response->isSuccessful() && Response::HTTP_NOT_MODIFIED !== $response->getStatusCode()) {
                 throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %d).', $subRequest->getUri(), $response->getStatusCode()));
             }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -221,6 +221,15 @@ class EsiTest extends TestCase
         $this->assertEquals('bar', $esi->handle($cache, '/', '/alt', false));
     }
 
+    public function testHandleWhenResponseIsNotModified()
+    {
+        $esi = new Esi();
+        $response = new Response('');
+        $response->setStatusCode(304);
+        $cache = $this->getCache(Request::create('/'), $response);
+        $this->assertEquals('', $esi->handle($cache, '/', '/alt', true));
+    }
+
     protected function getCache($request, $response)
     {
         $cache = $this->getMockBuilder(HttpCache::class)->setMethods(['getRequest', 'handle'])->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes  #43997
| License       | MIT
| Doc PR        | ~

If the response cache keeps a `Last-Modified` header clients will request with `If-Modified-Since`.
The surrogate will not handle a `304 Not Modified` correctly, resulting in a 500 and a failed request.

This fixes that request / response cycle, as observed in testing PR #42355.