### PR TITLE
[Serializer][Translation] Add TranslatableNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/TranslatableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/TranslatableNormalizer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TranslatableNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
+{
+    public const LOCALE_KEY = 'locale';
+
+    private $defaultContext = [
+        self::LOCALE_KEY => null,
+    ];
+
+    private $translator;
+
+    public function __construct(array $defaultContext = [], TranslatorInterface $translator = null)
+    {
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
+        $this->translator = $translator;
+    }
+
+    public function normalize($object, $format = null, array $context = []): string
+    {
+        return $object->trans($this->translator, $context[self::LOCALE_KEY] ?? $this->defaultContext[self::LOCALE_KEY]);
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data instanceof TranslatableInterface &&
+            $this->translator instanceof TranslatorInterface;
+    }
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return __CLASS__ === static::class;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TranslatableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TranslatableNormalizerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\TranslatableNormalizer;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Component\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TranslatableNormalizerTest extends TestCase
+{
+    public function testNormalize(): void
+    {
+        $enResource = [
+            'foo' => 'Hello rambo',
+            'bar' => 'Hello rambo: %masterpiece%',
+        ];
+
+        $cnResource = [
+            'foo' => '你好兰博',
+            'bar' => '你好兰博：%masterpiece%',
+        ];
+
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', $enResource, 'en');
+        $translator->addResource('array', $cnResource, 'zh_CN');
+
+        $enNormalizer = new TranslatableNormalizer([], $translator);
+        static::assertSame('Hello rambo', $enNormalizer->normalize(new TranslatableMessage('foo')));
+        static::assertSame('Hello rambo', $enNormalizer->normalize(new TestTranslatableMessage('foo')));
+        static::assertSame('Hello rambo: First Blood', $enNormalizer->normalize(new TranslatableMessage('bar', ['%masterpiece%' => 'First Blood'])));
+        static::assertSame('Hello rambo: First Blood', $enNormalizer->normalize(new TestTranslatableMessage('bar', ['%masterpiece%' => 'First Blood'])));
+
+        $cnNormalizer = new TranslatableNormalizer([TranslatableNormalizer::LOCALE_KEY => 'zh_CN'], $translator);
+        static::assertSame('你好兰博', $cnNormalizer->normalize(new TranslatableMessage('foo')));
+        static::assertSame('你好兰博', $cnNormalizer->normalize(new TestTranslatableMessage('foo')));
+        static::assertSame('你好兰博：第一滴血', $cnNormalizer->normalize(new TranslatableMessage('bar', ['%masterpiece%' => '第一滴血'])));
+        static::assertSame('你好兰博：第一滴血', $cnNormalizer->normalize(new TestTranslatableMessage('bar', ['%masterpiece%' => '第一滴血'])));
+    }
+
+    public function testSupportsNormalization(): void
+    {
+        $normalizer = new TranslatableNormalizer([], new Translator('en'));
+
+        static::assertTrue($normalizer->supportsNormalization(new TranslatableMessage('foo')));
+        static::assertTrue($normalizer->supportsNormalization(new TestTranslatableMessage('foo')));
+    }
+
+    public function testSupportsNormalizationWithoutTranslator(): void
+    {
+        $normalizer = new TranslatableNormalizer();
+
+        static::assertFalse($normalizer->supportsNormalization(null));
+        static::assertFalse($normalizer->supportsNormalization(new \stdClass()));
+        static::assertFalse($normalizer->supportsNormalization(new TranslatableMessage('foo')));
+        static::assertFalse($normalizer->supportsNormalization(new TestTranslatableMessage('foo')));
+    }
+}
+
+class TestTranslatableMessage implements TranslatableInterface
+{
+    private $message;
+    private $parameters;
+    private $domain;
+
+    public function __construct(string $message, array $parameters = [], string $domain = null)
+    {
+        $this->message = $message;
+        $this->parameters = $parameters;
+        $this->domain = $domain;
+    }
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        return $translator->trans($this->message, $this->parameters, $this->domain, $locale);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TranslatableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TranslatableNormalizerTest.php
@@ -12,7 +12,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class TranslatableNormalizerTest extends TestCase
 {
-    public function testNormalize(): void
+    public function testNormalize()
     {
         $enResource = [
             'foo' => 'Hello rambo',
@@ -42,7 +42,7 @@ class TranslatableNormalizerTest extends TestCase
         static::assertSame('你好兰博：第一滴血', $cnNormalizer->normalize(new TestTranslatableMessage('bar', ['%masterpiece%' => '第一滴血'])));
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $normalizer = new TranslatableNormalizer([], new Translator('en'));
 
@@ -50,7 +50,7 @@ class TranslatableNormalizerTest extends TestCase
         static::assertTrue($normalizer->supportsNormalization(new TestTranslatableMessage('foo')));
     }
 
-    public function testSupportsNormalizationWithoutTranslator(): void
+    public function testSupportsNormalizationWithoutTranslator()
     {
         $normalizer = new TranslatableNormalizer();
 

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -36,6 +36,7 @@
         "symfony/property-access": "^5.1|^6.0",
         "symfony/property-info": "^5.3|^6.0",
         "symfony/uid": "^5.1|^6.0",
+        "symfony/translation": "^5.2|^6.0",
         "symfony/validator": "^4.4|^5.0|^6.0",
         "symfony/var-dumper": "^4.4|^5.0|^6.0",
         "symfony/var-exporter": "^4.4|^5.0|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Add an TranslatableMessage for Serializer Normalizer.

For example:

```php
// ../src/Model/BlogPost.php

use Symfony\Component\Translation\TranslatableMessage;
use Symfony\Contracts\Translation\TranslatableInterface;

class BlogPost
{
    // ...

    public const STATUS_PENDING = 'pending';
    public const STATUS_APPROVED = 'approved';
    public const STATUS_UNAPPROVED = 'unapproved';

    private $status;

    public function getStatus(): string
    {
        return $this->status;
    }

    public function getStatusLabel(): TranslatableInterface
    {
        return new TranslatableMessage(sprintf('blog_post.status.%s', $this.status));
    }

    // ...
}
```

```yaml
# ../translations/messages.zh_CN.yaml

blog_post.status.pending: '审核中'
blog_post.status.approved: '已通过'
blog_post.status.unapproved: '未通过审核'
```

Result:

```php
$blogPost = new BlogPost();
$blogPost->setStatus(BlogPost::STATUS_PENDING);

$data = $this->serializer->serialize($blogPost, 'json');

// {"status": "pending", "status_label": "审核中"}
```
