### PR TITLE
[BrowserKit][DomCrawler] Relax return types needed for Symfony Panther

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -17,31 +17,38 @@ index 0ad5f625a7..f614f93465 100644
          ]
      },
 diff --git a/src/Symfony/Component/BrowserKit/AbstractBrowser.php b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
-index 152050159b..e2ec1aeea2 100644
+index ac92a0f85e..93780da419 100644
 --- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
 +++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
-@@ -408,5 +408,5 @@ abstract class AbstractBrowser
+@@ -136,5 +136,5 @@ abstract class AbstractBrowser
+      * @return mixed
+      */
+-    public function getServerParameter(string $key, mixed $default = '')
++    public function getServerParameter(string $key, mixed $default = ''): mixed
+     {
+         return $this->server[$key] ?? $default;
+@@ -410,5 +410,5 @@ abstract class AbstractBrowser
       * @throws \RuntimeException When processing returns exit code
       */
 -    protected function doRequestInProcess(object $request)
 +    protected function doRequestInProcess(object $request): object
      {
          $deprecationsFile = tempnam(sys_get_temp_dir(), 'deprec');
-@@ -441,5 +441,5 @@ abstract class AbstractBrowser
+@@ -443,5 +443,5 @@ abstract class AbstractBrowser
       * @return object
       */
 -    abstract protected function doRequest(object $request);
 +    abstract protected function doRequest(object $request): object;
  
      /**
-@@ -460,5 +460,5 @@ abstract class AbstractBrowser
+@@ -462,5 +462,5 @@ abstract class AbstractBrowser
       * @return object
       */
 -    protected function filterRequest(Request $request)
 +    protected function filterRequest(Request $request): object
      {
          return $request;
-@@ -470,5 +470,5 @@ abstract class AbstractBrowser
+@@ -472,5 +472,5 @@ abstract class AbstractBrowser
       * @return Response
       */
 -    protected function filterResponse(object $response)
@@ -327,6 +334,162 @@ index a9d78115dd..8b3b420a9c 100644
 -    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator);
 +    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator): object;
  }
+diff --git a/src/Symfony/Component/DomCrawler/Crawler.php b/src/Symfony/Component/DomCrawler/Crawler.php
+index 6f101f2108..c1db1aff24 100644
+--- a/src/Symfony/Component/DomCrawler/Crawler.php
++++ b/src/Symfony/Component/DomCrawler/Crawler.php
+@@ -306,5 +306,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @return static
+      */
+-    public function eq(int $position)
++    public function eq(int $position): static
+     {
+         if (isset($this->nodes[$position])) {
+@@ -346,5 +346,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @return static
+      */
+-    public function slice(int $offset = 0, int $length = null)
++    public function slice(int $offset = 0, int $length = null): static
+     {
+         return $this->createSubCrawler(\array_slice($this->nodes, $offset, $length));
+@@ -360,5 +360,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @return static
+      */
+-    public function reduce(\Closure $closure)
++    public function reduce(\Closure $closure): static
+     {
+         $nodes = [];
+@@ -377,5 +377,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @return static
+      */
+-    public function first()
++    public function first(): static
+     {
+         return $this->eq(0);
+@@ -387,5 +387,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @return static
+      */
+-    public function last()
++    public function last(): static
+     {
+         return $this->eq(\count($this->nodes) - 1);
+@@ -399,5 +399,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @throws \InvalidArgumentException When current node is empty
+      */
+-    public function siblings()
++    public function siblings(): static
+     {
+         if (!$this->nodes) {
+@@ -454,5 +454,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @throws \InvalidArgumentException When current node is empty
+      */
+-    public function nextAll()
++    public function nextAll(): static
+     {
+         if (!$this->nodes) {
+@@ -470,5 +470,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @throws \InvalidArgumentException
+      */
+-    public function previousAll()
++    public function previousAll(): static
+     {
+         if (!$this->nodes) {
+@@ -486,5 +486,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @throws \InvalidArgumentException When the current node is empty
+      */
+-    public function ancestors()
++    public function ancestors(): static
+     {
+         if (!$this->nodes) {
+@@ -512,5 +512,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @throws \RuntimeException         If the CssSelector Component is not available and $selector is provided
+      */
+-    public function children(string $selector = null)
++    public function children(string $selector = null): static
+     {
+         if (!$this->nodes) {
+@@ -715,5 +715,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @return static
+      */
+-    public function filterXPath(string $xpath)
++    public function filterXPath(string $xpath): static
+     {
+         $xpath = $this->relativize($xpath);
+@@ -736,5 +736,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @throws \RuntimeException if the CssSelector Component is not available
+      */
+-    public function filter(string $selector)
++    public function filter(string $selector): static
+     {
+         $converter = $this->createCssSelectorConverter();
+@@ -749,5 +749,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @return static
+      */
+-    public function selectLink(string $value)
++    public function selectLink(string $value): static
+     {
+         return $this->filterRelativeXPath(
+@@ -761,5 +761,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @return static
+      */
+-    public function selectImage(string $value)
++    public function selectImage(string $value): static
+     {
+         $xpath = sprintf('descendant-or-self::img[contains(normalize-space(string(@alt)), %s)]', static::xpathLiteral($value));
+@@ -773,5 +773,5 @@ class Crawler implements \Countable, \IteratorAggregate
+      * @return static
+      */
+-    public function selectButton(string $value)
++    public function selectButton(string $value): static
+     {
+         return $this->filterRelativeXPath(
+diff --git a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+index d72af82d29..122cfc9335 100644
+--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
++++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+@@ -287,5 +287,5 @@ class ChoiceFormField extends FormField
+      * @return static
+      */
+-    public function disableValidation()
++    public function disableValidation(): static
+     {
+         $this->validationDisabled = true;
+diff --git a/src/Symfony/Component/DomCrawler/Field/FormField.php b/src/Symfony/Component/DomCrawler/Field/FormField.php
+index bd316e60d2..e952bc4ef4 100644
+--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
++++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
+@@ -88,5 +88,5 @@ abstract class FormField
+      * @return string|array|null
+      */
+-    public function getValue()
++    public function getValue(): string|array|null
+     {
+         return $this->value;
+diff --git a/src/Symfony/Component/DomCrawler/Form.php b/src/Symfony/Component/DomCrawler/Form.php
+index adfbefb73c..98f4d823c6 100644
+--- a/src/Symfony/Component/DomCrawler/Form.php
++++ b/src/Symfony/Component/DomCrawler/Form.php
+@@ -57,5 +57,5 @@ class Form extends Link implements \ArrayAccess
+      * @return static
+      */
+-    public function setValues(array $values)
++    public function setValues(array $values): static
+     {
+         foreach ($values as $name => $value) {
+@@ -259,5 +259,5 @@ class Form extends Link implements \ArrayAccess
+      * @throws \InvalidArgumentException When field is not present in this form
+      */
+-    public function get(string $name)
++    public function get(string $name): FormField|array
+     {
+         return $this->fields->get($name);
+@@ -301,5 +301,5 @@ class Form extends Link implements \ArrayAccess
+      * @throws \InvalidArgumentException if the field does not exist
+      */
+-    public function offsetGet(mixed $name)
++    public function offsetGet(mixed $name): mixed
+     {
+         return $this->fields->get($name);
 diff --git a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
 index 2085e428e9..ca0d6964e5 100644
 --- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -132,8 +132,10 @@ abstract class AbstractBrowser
 
     /**
      * Gets single server parameter for specified key.
+     *
+     * @return mixed
      */
-    public function getServerParameter(string $key, mixed $default = ''): mixed
+    public function getServerParameter(string $key, mixed $default = '')
     {
         return $this->server[$key] ?? $default;
     }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -302,8 +302,10 @@ class Crawler implements \Countable, \IteratorAggregate
 
     /**
      * Returns a node given its position in the node list.
+     *
+     * @return static
      */
-    public function eq(int $position): static
+    public function eq(int $position)
     {
         if (isset($this->nodes[$position])) {
             return $this->createSubCrawler($this->nodes[$position]);
@@ -340,8 +342,10 @@ class Crawler implements \Countable, \IteratorAggregate
 
     /**
      * Slices the list of nodes by $offset and $length.
+     *
+     * @return static
      */
-    public function slice(int $offset = 0, int $length = null): static
+    public function slice(int $offset = 0, int $length = null)
     {
         return $this->createSubCrawler(\array_slice($this->nodes, $offset, $length));
     }
@@ -352,8 +356,10 @@ class Crawler implements \Countable, \IteratorAggregate
      * To remove a node from the list, the anonymous function must return false.
      *
      * @param \Closure $closure An anonymous function
+     *
+     * @return static
      */
-    public function reduce(\Closure $closure): static
+    public function reduce(\Closure $closure)
     {
         $nodes = [];
         foreach ($this->nodes as $i => $node) {
@@ -367,16 +373,20 @@ class Crawler implements \Countable, \IteratorAggregate
 
     /**
      * Returns the first node of the current selection.
+     *
+     * @return static
      */
-    public function first(): static
+    public function first()
     {
         return $this->eq(0);
     }
 
     /**
      * Returns the last node of the current selection.
+     *
+     * @return static
      */
-    public function last(): static
+    public function last()
     {
         return $this->eq(\count($this->nodes) - 1);
     }
@@ -384,9 +394,11 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the siblings nodes of the current selection.
      *
+     * @return static
+     *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function siblings(): static
+    public function siblings()
     {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
@@ -437,9 +449,11 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the next siblings nodes of the current selection.
      *
+     * @return static
+     *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function nextAll(): static
+    public function nextAll()
     {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
@@ -451,9 +465,11 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the previous sibling nodes of the current selection.
      *
+     * @return static
+     *
      * @throws \InvalidArgumentException
      */
-    public function previousAll(): static
+    public function previousAll()
     {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
@@ -465,9 +481,11 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the ancestors of the current selection.
      *
+     * @return static
+     *
      * @throws \InvalidArgumentException When the current node is empty
      */
-    public function ancestors(): static
+    public function ancestors()
     {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
@@ -488,10 +506,12 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the children nodes of the current selection.
      *
+     * @return static
+     *
      * @throws \InvalidArgumentException When current node is empty
      * @throws \RuntimeException         If the CssSelector Component is not available and $selector is provided
      */
-    public function children(string $selector = null): static
+    public function children(string $selector = null)
     {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
@@ -691,8 +711,10 @@ class Crawler implements \Countable, \IteratorAggregate
      * is considered as a fake parent of the elements inside it.
      * This means that a child selector "div" or "./div" will match only
      * the div elements of the current crawler, not their children.
+     *
+     * @return static
      */
-    public function filterXPath(string $xpath): static
+    public function filterXPath(string $xpath)
     {
         $xpath = $this->relativize($xpath);
 
@@ -709,9 +731,11 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * This method only works if you have installed the CssSelector Symfony Component.
      *
+     * @return static
+     *
      * @throws \RuntimeException if the CssSelector Component is not available
      */
-    public function filter(string $selector): static
+    public function filter(string $selector)
     {
         $converter = $this->createCssSelectorConverter();
 
@@ -721,8 +745,10 @@ class Crawler implements \Countable, \IteratorAggregate
 
     /**
      * Selects links by name or alt value for clickable images.
+     *
+     * @return static
      */
-    public function selectLink(string $value): static
+    public function selectLink(string $value)
     {
         return $this->filterRelativeXPath(
             sprintf('descendant-or-self::a[contains(concat(\' \', normalize-space(string(.)), \' \'), %1$s) or ./img[contains(concat(\' \', normalize-space(string(@alt)), \' \'), %1$s)]]', static::xpathLiteral(' '.$value.' '))
@@ -731,8 +757,10 @@ class Crawler implements \Countable, \IteratorAggregate
 
     /**
      * Selects images by alt value.
+     *
+     * @return static
      */
-    public function selectImage(string $value): static
+    public function selectImage(string $value)
     {
         $xpath = sprintf('descendant-or-self::img[contains(normalize-space(string(@alt)), %s)]', static::xpathLiteral($value));
 
@@ -741,8 +769,10 @@ class Crawler implements \Countable, \IteratorAggregate
 
     /**
      * Selects a button by name or alt value for images.
+     *
+     * @return static
      */
-    public function selectButton(string $value): static
+    public function selectButton(string $value)
     {
         return $this->filterRelativeXPath(
             sprintf('descendant-or-self::input[((contains(%1$s, "submit") or contains(%1$s, "button")) and contains(concat(\' \', normalize-space(string(@value)), \' \'), %2$s)) or (contains(%1$s, "image") and contains(concat(\' \', normalize-space(string(@alt)), \' \'), %2$s)) or @id=%3$s or @name=%3$s] | descendant-or-self::button[contains(concat(\' \', normalize-space(string(.)), \' \'), %2$s) or @id=%3$s or @name=%3$s]', 'translate(@type, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")', static::xpathLiteral(' '.$value.' '), static::xpathLiteral($value))

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -284,9 +284,9 @@ class ChoiceFormField extends FormField
      *
      * @internal
      *
-     * @return $this
+     * @return static
      */
-    public function disableValidation(): static
+    public function disableValidation()
     {
         $this->validationDisabled = true;
 

--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -84,8 +84,10 @@ abstract class FormField
 
     /**
      * Gets the value of the field.
+     *
+     * @return string|array|null
      */
-    public function getValue(): string|array|null
+    public function getValue()
     {
         return $this->value;
     }

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -54,9 +54,9 @@ class Form extends Link implements \ArrayAccess
      *
      * @param array $values An array of field values
      *
-     * @return $this
+     * @return static
      */
-    public function setValues(array $values): static
+    public function setValues(array $values)
     {
         foreach ($values as $name => $value) {
             $this->fields->set($name, $value);
@@ -258,7 +258,7 @@ class Form extends Link implements \ArrayAccess
      *
      * @throws \InvalidArgumentException When field is not present in this form
      */
-    public function get(string $name): FormField|array
+    public function get(string $name)
     {
         return $this->fields->get($name);
     }
@@ -300,7 +300,7 @@ class Form extends Link implements \ArrayAccess
      *
      * @throws \InvalidArgumentException if the field does not exist
      */
-    public function offsetGet(mixed $name): FormField|array
+    public function offsetGet(mixed $name)
     {
         return $this->fields->get($name);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Part of #43021, https://github.com/symfony/panther/pull/509 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

To make Symfony Panther compatible with Symfony 6 those types need to be
removed. Symfony Panther overrides those classes and it is compatible
with PHP 7.

Previous conversations:

https://github.com/symfony/panther/pull/509 (in this PR I am showing those changes applied as patches on composer directly)
https://github.com/symfony/symfony/issues/43021#issuecomment-955764741
