### PR TITLE
[DependencyInjection] fix auto-refresh when inline_factories is enabled

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -222,7 +222,7 @@ class PhpDumper extends Dumper
         }
 
         $code =
-            $this->startClass($options['class'], $baseClass).
+            $this->startClass($options['class'], $baseClass, $this->inlineFactories && $proxyClasses).
             $this->addServices($services).
             $this->addDeprecatedAliases().
             $this->addDefaultParametersMethod()
@@ -286,14 +286,15 @@ EOF;
 
             $code .= $this->endClass();
 
-            if ($this->inlineFactories) {
+            if ($this->inlineFactories && $proxyClasses) {
+                $files['proxy-classes.php'] = "<?php\n\n";
+
                 foreach ($proxyClasses as $c) {
-                    $code .= $c;
+                    $files['proxy-classes.php'] .= $c;
                 }
             }
 
             $files[$options['class'].'.php'] = $code;
-            $preloadedFiles[$options['class'].'.php'] = $options['class'].'.php';
             $hash = ucfirst(strtr(ContainerBuilder::hash($files), '._', 'xx'));
             $code = [];
 
@@ -313,7 +314,9 @@ EOF;
                 $autoloadFile = trim($this->export($autoloadFile), '()\\');
 
                 $preloadedFiles = array_reverse($preloadedFiles);
-                $preloadedFiles = implode("';\nrequire __DIR__.'/", $preloadedFiles);
+                if ('' !== $preloadedFiles = implode("';\nrequire __DIR__.'/", $preloadedFiles)) {
+                    $preloadedFiles = "require __DIR__.'/$preloadedFiles';\n";
+                }
 
                 $code[$options['class'].'.preload.php'] = <<<EOF
 <?php
@@ -328,8 +331,8 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require $autoloadFile;
-require __DIR__.'/$preloadedFiles';
-
+(require __DIR__.'/Container{$hash}/{$options['class']}.php')->set(\\Container{$hash}\\{$options['class']}::class, null);
+$preloadedFiles
 \$classes = [];
 
 EOF;
@@ -1179,7 +1182,7 @@ EOTXT
         return $return.sprintf('new %s(%s)', $this->dumpLiteralClass($this->dumpValue($class)), implode(', ', $arguments)).$tail;
     }
 
-    private function startClass(string $class, string $baseClass): string
+    private function startClass(string $class, string $baseClass, bool $hasProxyClasses): string
     {
         $namespaceLine = !$this->asFiles && $this->namespace ? "\nnamespace {$this->namespace};\n" : '';
 
@@ -1239,7 +1242,7 @@ EOF;
         $code .= $this->addMethodMap();
         $code .= $this->asFiles && !$this->inlineFactories ? $this->addFileMap() : '';
         $code .= $this->addAliases();
-        $code .= $this->addInlineRequires();
+        $code .= $this->addInlineRequires($hasProxyClasses);
         $code .= <<<EOF
     }
 
@@ -1451,15 +1454,12 @@ EOF;
         return $code;
     }
 
-    private function addInlineRequires(): string
+    private function addInlineRequires(bool $hasProxyClasses): string
     {
-        if (!$this->hotPathTag || !$this->inlineRequires) {
-            return '';
-        }
-
         $lineage = [];
+        $hotPathServices = $this->hotPathTag && $this->inlineRequires ? $this->container->findTaggedServiceIds($this->hotPathTag) : [];
 
-        foreach ($this->container->findTaggedServiceIds($this->hotPathTag) as $id => $tags) {
+        foreach ($hotPathServices as $id => $tags) {
             $definition = $this->container->getDefinition($id);
 
             if ($this->getProxyDumper()->isProxyCandidate($definition)) {
@@ -1482,6 +1482,10 @@ EOF;
                 $this->inlinedRequires[$file] = true;
                 $code .= sprintf("\n            include_once %s;", $file);
             }
+        }
+
+        if ($hasProxyClasses) {
+            $code .= "\n            include __DIR__.'/proxy-classes.php';";
         }
 
         return $code ? sprintf("\n        \$this->privates['service_container'] = function () {%s\n        };\n", $code) : '';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
@@ -133,7 +133,7 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
-require __DIR__.'/Container%s/ProjectServiceContainer.php';
+(require __DIR__.'/Container%s/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 require __DIR__.'/Container%s/getClosureService.php';
 
 $classes = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -907,7 +907,7 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
-require __DIR__.'/Container%s/ProjectServiceContainer.php';
+(require __DIR__.'/Container%s/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 require __DIR__.'/Container%s/getThrowingOneService.php';
 require __DIR__.'/Container%s/getTaggedIteratorService.php';
 require __DIR__.'/Container%s/getServiceFromStaticMethodService.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -562,7 +562,7 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
-require __DIR__.'/Container%s/ProjectServiceContainer.php';
+(require __DIR__.'/Container%s/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 
 $classes = [];
 $classes[] = 'Bar\FooClass';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -9,6 +9,19 @@ return [
     'Symfony\\Component\\DependencyInjection\\ContainerInterface' => true,
 ];
 
+    [Container%s/proxy-classes.php] => <?php
+
+namespace Container%s;
+
+include_once $this->targetDir.''.'/Fixtures/includes/foo.php';
+
+class FooClass_%s extends \Bar\FooClass implements \ProxyManager\Proxy\VirtualProxyInterface
+%A
+
+if (!\class_exists('FooClass_%s', false)) {
+    \class_alias(__NAMESPACE__.'\\FooClass_%s', 'FooClass_%s', false);
+}
+
     [Container%s/ProjectServiceContainer.php] => <?php
 
 namespace Container%s;
@@ -45,6 +58,10 @@ class ProjectServiceContainer extends Container
         ];
 
         $this->aliases = [];
+
+        $this->privates['service_container'] = function () {
+            include __DIR__.'/proxy-classes.php';
+        };
     }
 
     public function compile(): void
@@ -156,16 +173,6 @@ class ProjectServiceContainer extends Container
         ];
     }
 }
-include_once $this->targetDir.''.'/Fixtures/includes/foo.php';
-
-class FooClass_%s extends \Bar\FooClass implements \ProxyManager\Proxy\VirtualProxyInterface
-{
-%A
-}
-
-if (!\class_exists('FooClass_%s', false)) {
-    \class_alias(__NAMESPACE__.'\\FooClass_%s', 'FooClass_%s', false);
-}
 
     [ProjectServiceContainer.preload.php] => <?php
 
@@ -179,7 +186,7 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
-require __DIR__.'/Container%s/ProjectServiceContainer.php';
+(require __DIR__.'/Container%s/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 
 $classes = [];
 $classes[] = 'Bar\FooClass';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
@@ -144,7 +144,7 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
-require __DIR__.'/Container%s/ProjectServiceContainer.php';
+(require __DIR__.'/Container%s/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 require __DIR__.'/Container%s/proxy.php';
 require __DIR__.'/Container%s/getNonSharedFooService.php';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43956
| License       | MIT
| Doc PR        | -

This is more an improvement than a bugfix to me, thus the 5.4 target.

When `inline_factories` is set, we also inline proxy classes in the dumped container.
This breaks auto-refreshing the cache when a proxyfied class is removed (as described in the linked issue).
This PR fixes the issue by dumping proxy classes in a new `proxy-classes.php` file. This file is loaded only after the cache has been checked, when the container is initialized.