### PR TITLE
[DependencyInjection] fix inlining when non-shared services are involved

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -190,7 +190,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
                 $srcId = $edge->getSourceNode()->getId();
                 $this->connectedIds[$srcId] = true;
                 if ($edge->isWeak() || $edge->isLazy()) {
-                    return false;
+                    return !$this->connectedIds[$id] = true;
                 }
             }
 
@@ -212,9 +212,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
 
         $srcIds = [];
         $srcCount = 0;
-        $isReferencedByConstructor = false;
         foreach ($this->graph->getNode($id)->getInEdges() as $edge) {
-            $isReferencedByConstructor = $isReferencedByConstructor || $edge->isReferencedByConstructor();
             $srcId = $edge->getSourceNode()->getId();
             $this->connectedIds[$srcId] = true;
             if ($edge->isWeak() || $edge->isLazy()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43980
| License       | MIT
| Doc PR        | -

I'm unable to write a service graph that hits the bug, but this is still fixing the referenced issue appropriately.
As a reminder, since #27528, we don't inline non-shared service as soon as they're referenced by a service locator.
But when doing so, we need to ensure that the shared services referenced by such non-inlined-non-shared services are not themselves inlined, since that'd break the non-inlined-non-shared services.
This patch does it :)