### PR TITLE
[SecurityBundle] Fix listing listeners in profiler when authenticator manager is disabled

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -194,8 +194,14 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                     'access_denied_handler' => $firewallConfig->getAccessDeniedHandler(),
                     'access_denied_url' => $firewallConfig->getAccessDeniedUrl(),
                     'user_checker' => $firewallConfig->getUserChecker(),
-                    'authenticators' => $firewallConfig->getAuthenticators(),
                 ];
+
+                // in 6.0, always fill `$this->data['authenticators'] only
+                if ($this->authenticatorManagerEnabled) {
+                    $this->data['authenticators'] = $firewallConfig->getAuthenticators();
+                } else {
+                    $this->data['listeners'] = $firewallConfig->getAuthenticators();
+                }
 
                 // generate exit impersonation path from current request
                 if ($this->data['impersonated'] && null !== $switchUserConfig = $firewallConfig->getSwitchUser()) {

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -113,7 +113,7 @@ final class FirewallConfig
     }
 
     /**
-     * @deprecated since Symfony 5.4, use {@see getListeners()} instead
+     * @deprecated since Symfony 5.4, use {@see getAuthenticators()} instead
      */
     public function getListeners(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix profiler v5.4.0.beta1
| License       | MIT

I am trying to upgrade an app from v4.4 to v5.4 beta1
when going to the profiler > security panel, I got this error:
`Neither the property "listeners" nor one of the methods "listeners()", "getlisteners()"/"islisteners()"/"haslisteners()" or "__call()" exist and have public access in class "Symfony\Component\VarDumper\Cloner\Data".`

This PR tries to fix this in Twig, I do not know the collector logic to fix differently