### PR TITLE
[Config] Add missing use statement in generated config builder classes

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -430,6 +430,8 @@ public function __construct(array $value = [])
             return;
         }
 
+        $class->addUse(ParamConfigurator::class);
+
         $class->addProperty('_extraKeys');
 
         $class->addMethod('set', '


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In certain cases a use statement for `ParamConfigurator` is not added to the generated config builder classes. This doesn't effect the code in any way, just IDEs.

![image](https://user-images.githubusercontent.com/2445045/141381240-ccbc4884-be83-45a4-bf6a-b78d5d610304.png)
