### PR TITLE
[ErrorHandler] Fix FlattenException::setPrevious argument typing

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -276,7 +276,7 @@ class FlattenException extends LegacyFlattenException
     /**
      * @return $this
      */
-    final public function setPrevious(LegacyFlattenException $previous): self
+    final public function setPrevious(?LegacyFlattenException $previous): self
     {
         $this->previous = $previous;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/issues/44024 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

The setter didn't accept `null` value, while the getter can return `null`. It can be a fix for the linked issue, but I'm not 100% sure about the cause of the issue (I'll try to make a reproducer soon).

In the meantime, this typing bug seems to fix at least the case explained in the issue.