### PR TITLE
[Serializer] Allow default group in serialization context

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\PropertyInfo\Extractor;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
 /**
  * Lists available properties using Symfony Serializer Component metadata.
@@ -59,7 +60,7 @@ class SerializerExtractor implements PropertyListExtractorInterface
 
     private function getAttributeGroups(AttributeMetadataInterface $serializerAttributeMetadata): array
     {
-        $groups = empty($serializerAttributeMetadata->getGroups()) ? ['_default'] : $serializerAttributeMetadata->getGroups();
+        $groups = empty($serializerAttributeMetadata->getGroups()) ? [AbstractNormalizer::DEFAULT_GROUP_FOR_ATTRIBUTE_WITHOUT_GROUPS] : $serializerAttributeMetadata->getGroups();
 
         return array_merge($groups, ['*']);
     }

--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Extractor;
 
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 
 /**
@@ -48,11 +49,18 @@ class SerializerExtractor implements PropertyListExtractorInterface
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
             $ignored = method_exists($serializerAttributeMetadata, 'isIgnored') && $serializerAttributeMetadata->isIgnored();
-            if (!$ignored && (null === $context['serializer_groups'] || array_intersect($context['serializer_groups'], $serializerAttributeMetadata->getGroups()))) {
+            if (!$ignored && (null === $context['serializer_groups'] || array_intersect($context['serializer_groups'], $this->getAttributeGroups($serializerAttributeMetadata)))) {
                 $properties[] = $serializerAttributeMetadata->getName();
             }
         }
 
         return $properties;
+    }
+
+    private function getAttributeGroups(AttributeMetadataInterface $serializerAttributeMetadata): array
+    {
+        $groups = empty($serializerAttributeMetadata->getGroups()) ? ['_default'] : $serializerAttributeMetadata->getGroups();
+
+        return array_merge($groups, ['*']);
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\SerializerExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultGroupDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IgnorePropertyDummy;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -51,5 +52,15 @@ class SerializerExtractorTest extends TestCase
     public function testGetPropertiesWithAnyGroup()
     {
         $this->assertSame(['analyses', 'feet'], $this->extractor->getProperties(AdderRemoverDummy::class, ['serializer_groups' => null]));
+    }
+
+    public function testGetPropertiesWithAllGroup()
+    {
+        $this->assertSame(['somethingWithoutGroup', 'somethingWithGroup'], $this->extractor->getProperties(DefaultGroupDummy::class, ['serializer_groups' => ['*']]));
+    }
+
+    public function testGetPropertiesWithDefaultGroup()
+    {
+        $this->assertSame(['somethingWithoutGroup'], $this->extractor->getProperties(DefaultGroupDummy::class, ['serializer_groups' => ['_default']]));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DefaultGroupDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DefaultGroupDummy.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+final class DefaultGroupDummy
+{
+
+    public $somethingWithoutGroup;
+
+    /**
+     * @Groups({"a"})
+     */
+    public $somethingWithGroup;
+}

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -29,6 +29,7 @@ CHANGELOG
  * Return empty collections as `ArrayObject` from `Serializer::normalize()` when `PRESERVE_EMPTY_OBJECTS` is set
  * Add support for collecting type errors during denormalization
  * Add missing arguments in `MissingConstructorArgumentsException`
+ * Add `_default` group serialization context that allow serializing properties without explicit group
 
 5.3
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -235,7 +235,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             // If you update this check, update accordingly the one in Symfony\Component\PropertyInfo\Extractor\SerializerExtractor::getProperties()
             if (
                 !$ignore &&
-                ([] === $groups || array_intersect(array_merge($attributeMetadata->getGroups(), ['*']), $groups)) &&
+                ([] === $groups || array_intersect($this->getAttributeGroups($attributeMetadata), $groups)) &&
                 $this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context)
             ) {
                 $allowedAttributes[] = $attributesAsString ? $name : $attributeMetadata;
@@ -255,6 +255,13 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         $groups = $context[self::GROUPS] ?? $this->defaultContext[self::GROUPS] ?? [];
 
         return is_scalar($groups) ? (array) $groups : $groups;
+    }
+
+    protected function getAttributeGroups(AttributeMetadataInterface $attributeMetadata): array
+    {
+        $groups = empty($attributeMetadata->getGroups()) ? ['_default'] : $attributeMetadata->getGroups();
+
+        return array_merge($groups, ['*']);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -113,6 +113,12 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     public const IGNORED_ATTRIBUTES = 'ignored_attributes';
 
     /**
+     * The default group can be use on the serialization context to explicitly
+     * tell the serializer to allow properties without defined groups.
+     */
+    public const DEFAULT_GROUP_FOR_ATTRIBUTE_WITHOUT_GROUPS = '_default';
+
+    /**
      * @internal
      */
     protected const CIRCULAR_REFERENCE_LIMIT_COUNTERS = 'circular_reference_limit_counters';
@@ -259,7 +265,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
     protected function getAttributeGroups(AttributeMetadataInterface $attributeMetadata): array
     {
-        $groups = empty($attributeMetadata->getGroups()) ? ['_default'] : $attributeMetadata->getGroups();
+        $groups = empty($attributeMetadata->getGroups()) ? [self::DEFAULT_GROUP_FOR_ATTRIBUTE_WITHOUT_GROUPS] : $attributeMetadata->getGroups();
 
         return array_merge($groups, ['*']);
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -87,6 +87,9 @@ class AbstractNormalizerTest extends TestCase
 
         $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*']], true);
         $this->assertEquals(['a1', 'a2', 'a3', 'a4'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['_default']], true);
+        $this->assertEquals(['a1'], $result);
     }
 
     public function testGetAllowedAttributesAsObjects()
@@ -122,6 +125,9 @@ class AbstractNormalizerTest extends TestCase
 
         $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*']], false);
         $this->assertEquals([$a1, $a2, $a3, $a4], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['_default']], false);
+        $this->assertEquals([$a1], $result);
     }
 
     public function testObjectWithStaticConstructor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #32622 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The `_default` group can be use on the serialization context to explicitly tell the serializer to allow properties without defined `@Groups`

Exemple:
```php
class User
{

    public $name;

    /**
     * @Groups({"private"})
     */
    public $age;

    /**
     * @Groups({"private", "moderator"})
     */
    public $isBan;
}
```

- With no context groups: `name`, `age`, `isBan`
- With `moderator` context group: `isBan`
- With `*` context group: `name`, `age`, `isBan`
- With `_default` context group: `name`
- With `_default` and `moderator` context groups: `name`, `isBan`

I use the `_default` keyword here but it can be easily changed for something else like I said in this issue https://github.com/symfony/symfony/issues/32622#issuecomment-967288443

> I don't know what could be the best option to reduce the BC break.
> 
> * A special char, like for the `*`. Could be `_`. (not a fan of this solution)
> * A special word, like `Default` in the JMS Serializer (high chance of BC breaks with existing project)
> * The `null` value
> * The empty string value
> 
> `null` or empty string value cannot be use in `@Groups` annotation, so we are sure there is no BC break with this solution


<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
