### PR TITLE
Fix CI by removing ext-mongodb

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: Ubuntu-20.04
 
     env:
-      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,mongodb,redis-5.3.4
+      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,redis-5.3.4
 
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 2
 
       - name: Configure for PHP >= 8.2
-        if: "${{ matrix.php >= '8.2' }}"
+        if: "matrix.php >= '8.2'"
         run: |
           composer config platform.php 8.1.99
 
@@ -135,7 +135,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Patch return types
-        if: "${{ matrix.php == '8.1' && ! matrix.mode }}"
+        if: "matrix.php == '8.1' && ! matrix.mode"
         run: |
           sed -i 's/"\*\*\/Tests\/"//' composer.json
           composer install -q --optimize-autoloader
@@ -209,7 +209,7 @@ jobs:
           [[ ! $X ]] || (exit 1)
 
       - name: Run tests with SIGCHLD enabled PHP
-        if: "${{ matrix.php == '7.2' && ! matrix.mode }}"
+        if: "matrix.php == '7.2' && ! matrix.mode"
         run: |
           mkdir build
           cd build


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

ext-mongodb [is broken](https://github.com/symfony/symfony/runs/4198337700) on PHP 8.1, and makes installing PHP extra slow anyway.

![image](https://user-images.githubusercontent.com/243674/141646298-7d06f54e-e516-4055-9a15-7eddc3c4cd20.png)
