### PR TITLE
[Process] intersect with getenv() to populate default envs

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1671,13 +1671,8 @@ class Process implements \IteratorAggregate
 
     private function getDefaultEnv(): array
     {
-        $env = [];
-
-        foreach ($_SERVER as $k => $v) {
-            if (\is_string($v) && false !== $v = getenv($k)) {
-                $env[$k] = $v;
-            }
-        }
+        $env = getenv();
+        $env = array_intersect_key($env, $_SERVER) ?: $env;
 
         foreach ($_ENV as $k => $v) {
             if (\is_string($v)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44066
| License       | MIT
| Doc PR        | -