### PR TITLE
[ExpressionLanguage] Support lexing numbers with underscores and decimals with no leading zero

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.1
+-----
+
+ * Support lexing numbers with the numeric literal separator `_`
+ * Support lexing decimals with no leading zero
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -38,13 +38,13 @@ class Lexer
                 continue;
             }
 
-            if (preg_match('/[0-9]+(?:\.[0-9]+)?([Ee][\+\-][0-9]+)?/A', $expression, $match, 0, $cursor)) {
+            if (preg_match('/
+                (?(DEFINE)(?P<LNUM>[0-9]+(_[0-9]+)*))
+                (?:\.(?&LNUM)|(?&LNUM)(?:\.(?!\.)(?&LNUM)?)?)(?:[eE][+-]?(?&LNUM))?/Ax',
+                $expression, $match, 0, $cursor)
+            ) {
                 // numbers
-                $number = (float) $match[0];  // floats
-                if (preg_match('/^[0-9]+$/', $match[0]) && $number <= \PHP_INT_MAX) {
-                    $number = (int) $match[0]; // integers lower than the maximum
-                }
-                $tokens[] = new Token(Token::NUMBER_TYPE, $number, $cursor + 1);
+                $tokens[] = new Token(Token::NUMBER_TYPE, 0 + str_replace('_', '', $match[0]), $cursor + 1);
                 $cursor += \strlen($match[0]);
             } elseif (str_contains('([{', $expression[$cursor])) {
                 // opening bracket

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -135,6 +135,25 @@ class LexerTest extends TestCase
                 ],
                 'foo.not in [bar]',
             ],
+            [
+                [new Token('number', 0.787, 1)],
+                '0.787',
+            ],
+            [
+                [new Token('number', 0.1234, 1)],
+                '.1234',
+            ],
+            [
+                [new Token('number', 188165.1178, 1)],
+                '188_165.1_178',
+            ],
+            [
+                [
+                    new Token('operator', '-', 1),
+                    new Token('number', 7189000000.0, 2),
+                ],
+                '-.7_189e+10',
+            ],
         ];
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -189,6 +189,10 @@ class ParserTest extends TestCase
                 new Node\BinaryNode('..', new Node\ConstantNode(0), new Node\ConstantNode(3)),
                 '0..3',
             ],
+            [
+                new Node\BinaryNode('+', new Node\ConstantNode(0), new Node\ConstantNode(0.1)),
+                '0+.1',
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/44014
| License       | MIT
| Doc PR        | -

I understand that the supported Expression Language syntax is, and can be different than the PHP syntax, however, like @epixian, I would have expected `.123` to work since it's a common notation.
Supporting the numeric literal separator `_` looks good to me for the readability (the expression language is still code IMO). As most of us are PHP devs, we know this syntax.
Supporting those new syntaxes doesn't really bring more complexity in the code and it allows us to realign with the PHP behavior (thus having a guide) which is not something mandatory but something a random user would expect I think, that's why it improves the DX IMHO.
We could make the change in Twig too for the same reasons.
We could also support the hexadecimal, binary and octal syntaxes but let's wait for someone that actually needs it :smiley: