### PR TITLE
Make sure hostnames without a TLD can use hyphens and underscores

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -25,7 +25,7 @@ class UrlValidator extends ConstraintValidator
             (%s)://                                 # protocol
             (((?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+:)?((?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+)@)?  # basic auth
             (
-                ([\pL\pN\pS\-\_]+\.)*(([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
+                ([\pL\pN\pS\-\_]+\.?)*(([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
                     |                                                 # or
                 \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}                    # an IP address
                     |                                                 # or

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -122,6 +122,8 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             ['http://www.symfony.com/doc/current/book/validation.html#supported-constraints'],
             ['http://very.long.domain.name.com/'],
             ['http://localhost/'],
+            ['http://example-hostname/'],
+            ['http://example_hostname/'],
             ['http://myhost123/'],
             ['http://127.0.0.1/'],
             ['http://127.0.0.1:80/'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #... 
| License       | MIT

This PR ensures hostnames without a TLD that contain hyphens and/or underscores are considered valid by the UrlValidator Constraint. 

