### PR TITLE
Make ExpressionVoter Cacheable

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ExpressionVoter implements VoterInterface
+class ExpressionVoter implements CacheableVoterInterface
 {
     private $expressionLanguage;
     private $trustResolver;
@@ -37,6 +37,16 @@ class ExpressionVoter implements VoterInterface
         $this->trustResolver = $trustResolver;
         $this->authChecker = $authChecker;
         $this->roleHierarchy = $roleHierarchy;
+    }
+
+    public function supportsAttribute(string $attribute): bool
+    {
+        return false;
+    }
+
+    public function supportsType(string $subjectType): bool
+    {
+        return true;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When making voters cacheable, I forgot to update the `ExpressionVoter`.

The ExpressionVoter only supports attributes that are an instance of Expression. So, the Expression does not support any attribute of type string.

FYI: When an attribute is not a string, the AccessDessision manager considers that all voters support it.

