### PR TITLE
[FrameworkBundle] Fix API gateway service name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2421,7 +2421,7 @@ class FrameworkExtension extends Extension
         $container->getDefinition('notifier.channel_policy')->setArgument(0, $config['channel_policy']);
 
         $classToServices = [
-            AllMySmsTransportFactory::class => 'notifier.transport_factory.all-my-sms',
+            AllMySmsTransportFactory::class => 'notifier.transport_factory.allmysms',
             ClickatellTransportFactory::class => 'notifier.transport_factory.clickatell',
             DiscordTransportFactory::class => 'notifier.transport_factory.discord',
             EsendexTransportFactory::class => 'notifier.transport_factory.esendex',
@@ -2429,7 +2429,7 @@ class FrameworkExtension extends Extension
             FakeSmsTransportFactory::class => 'notifier.transport_factory.fakesms',
             FirebaseTransportFactory::class => 'notifier.transport_factory.firebase',
             FreeMobileTransportFactory::class => 'notifier.transport_factory.freemobile',
-            GatewayApiTransportFactory::class => 'notifier.transport_factory.gateway-api',
+            GatewayApiTransportFactory::class => 'notifier.transport_factory.gatewayapi',
             GitterTransportFactory::class => 'notifier.transport_factory.gitter',
             GoogleChatTransportFactory::class => 'notifier.transport_factory.googlechat',
             InfobipTransportFactory::class => 'notifier.transport_factory.infobip',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -85,7 +85,7 @@ return static function (ContainerConfigurator $container) {
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
 
-        ->set('notifier.transport_factory.all-my-sms', AllMySmsTransportFactory::class)
+        ->set('notifier.transport_factory.allmysms', AllMySmsTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
 
@@ -157,7 +157,7 @@ return static function (ContainerConfigurator $container) {
             ->parent('notifier.transport_factory.abstract')
             ->tag('chatter.transport_factory')
 
-        ->set('notifier.transport_factory.gateway-api', GatewayApiTransportFactory::class)
+        ->set('notifier.transport_factory.gatewayapi', GatewayApiTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 


Partially revert https://github.com/symfony/symfony/pull/44050/files to restore original names for services.

- Changing the name could be a BC break
- this is not consistent with other services
- it breaks our test suite

Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\PhpFrameworkExtensionTest::testIfNotifierTransportsAreKnownByFrameworkExtension
> Did you forget to add the "GatewayApi" TransportFactory to the $classToServices array in FrameworkExtension?
> Failed asserting that false is true.
