### PR TITLE
[FrameworkBundle][Messenger] remove `FlattenExceptionNormalizer` definition if serializer not available

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1891,6 +1891,10 @@ class FrameworkExtension extends Extension
 
         $loader->load('messenger.php');
 
+        if (!interface_exists(DenormalizerInterface::class)) {
+            $container->removeDefinition('serializer.normalizer.flatten_exception');
+        }
+
         if (ContainerBuilder::willBeAvailable('symfony/amqp-messenger', AmqpTransportFactory::class, ['symfony/framework-bundle', 'symfony/messenger'])) {
             $container->getDefinition('messenger.transport.amqp.factory')->addTag('messenger.transport_factory');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44081
| License       | MIT
| Doc PR        | n/a

Autoloading a class with a non-existent trait creates an unrecoverable fatal error in PHP 8.1. @nicolas-grekas recreated the underlying issue in 7.4/8.0 but for some reason this particular definition only fails in 8.1.
