### PR TITLE
[Serializer] fix support for unset properties on PHP < 7.4

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -103,23 +103,17 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             }
         }
 
-        $checkPropertyInitialization = \PHP_VERSION_ID >= 70400;
-
         // properties
+        $propertyValues = (array) $object;
         foreach ($reflClass->getProperties() as $reflProperty) {
-            $isPublic = $reflProperty->isPublic();
-
-            if ($checkPropertyInitialization) {
-                if (!$isPublic) {
-                    $reflProperty->setAccessible(true);
-                }
-                if (!$reflProperty->isInitialized($object)) {
+            if (!\array_key_exists($reflProperty->name, $propertyValues)) {
+                if ($reflProperty->isPublic()
+                    || ($reflProperty->isProtected() && !\array_key_exists("\0*\0{$reflProperty->name}", $propertyValues))
+                    || ($reflProperty->isPrivate() && !\array_key_exists("\0{$reflProperty->class}\0{$reflProperty->name}", $propertyValues))
+                ) {
                     unset($attributes[$reflProperty->name]);
-                    continue;
                 }
-            }
 
-            if (!$isPublic) {
                 continue;
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -101,21 +101,15 @@ class PropertyNormalizer extends AbstractObjectNormalizer
     {
         $reflectionObject = new \ReflectionObject($object);
         $attributes = [];
-        $checkPropertyInitialization = \PHP_VERSION_ID >= 70400;
+        $propertyValues = (array) $object;
 
         do {
             foreach ($reflectionObject->getProperties() as $property) {
-                if ($checkPropertyInitialization) {
-                    if (!$property->isPublic()) {
-                        $property->setAccessible(true);
-                    }
-
-                    if (!$property->isInitialized($object)) {
-                        continue;
-                    }
-                }
-
-                if (!$this->isAllowedAttribute($reflectionObject->getName(), $property->name, $format, $context)) {
+                if (($property->isPublic() && !\array_key_exists($property->name, $propertyValues))
+                    || ($property->isProtected() && !\array_key_exists("\0*\0{$property->name}", $propertyValues))
+                    || ($property->isPrivate() && !\array_key_exists("\0{$property->class}\0{$property->name}", $propertyValues))
+                    || !$this->isAllowedAttribute($reflectionObject->getName(), $property->name, $format, $context)
+                ) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -132,6 +132,16 @@ class ObjectNormalizerTest extends TestCase
         );
     }
 
+    public function testNormalizeObjectWithUnsetProperties()
+    {
+        $obj = new ObjectInner();
+        unset($obj->foo);
+        $this->assertEquals(
+            ['bar' => null],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
     /**
      * @requires PHP 7.4
      */

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -101,6 +101,16 @@ class PropertyNormalizerTest extends TestCase
         );
     }
 
+    public function testNormalizeObjectWithUnsetProperties()
+    {
+        $obj = new PropertyDummy();
+        unset($obj->foo);
+        $this->assertEquals(
+            ['bar' => null, 'camelCase' => null],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
     public function testDenormalize()
     {
         $obj = $this->normalizer->denormalize(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This bug is why the CI fails on 5.3 currently.