### PR TITLE
[WebProfilerBundle] Tweak the colors of the security panel

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -4,15 +4,7 @@
 
 {% block toolbar %}
     {% if collector.firewall %}
-        {% if collector.token %}
-            {% set is_authenticated = collector.enabled and collector.authenticated  %}
-            {% set color_code = not is_authenticated ? 'yellow' %}
-        {% elseif collector.enabled %}
-            {% set color_code = collector.authenticatorManagerEnabled ? 'yellow' : 'red' %}
-        {% else %}
-            {% set color_code = '' %}
-        {% endif %}
-
+        {% set color_code = collector.enabled and not collector.authenticatorManagerEnabled ? 'yellow' %}
         {% set icon %}
             {{ include('@Security/Collector/icon.svg') }}
             <span class="sf-toolbar-value">{{ collector.user|default('n/a') }}</span>
@@ -38,7 +30,7 @@
 
                         <div class="sf-toolbar-info-piece">
                             <b>Authenticated</b>
-                            <span class="sf-toolbar-status sf-toolbar-status-{{ is_authenticated ? 'green' : 'yellow' }}">{{ is_authenticated ? 'Yes' : 'No' }}</span>
+                            <span class="sf-toolbar-status sf-toolbar-status-{{ collector.authenticated ? 'green' : 'yellow' }}">{{ collector.authenticated ? 'Yes' : 'No' }}</span>
                         </div>
 
                         <div class="sf-toolbar-info-piece">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | -
| New feature?  | -
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

In 5.4, by default the Security panel in the toolbar displays a yellow background when there's no security:

<img width="1108" alt="toolbar-before" src="https://user-images.githubusercontent.com/73419/142232598-5ed36f89-ed2c-4355-83a3-6f8adfb3b14e.png">

I think this shouldn't be the case because a yellow background means: *"Hey, look here because there's something you probably need to fix"* But, it's OK if certain pages don't have any security, so there's no issue to fix.

After this PR, this is how it looks:

<img width="1109" alt="toolbar-after" src="https://user-images.githubusercontent.com/73419/142232793-d1c71ef8-728d-4ec9-9023-8fcb716f8a1a.png">
