### PR TITLE
[Messenger] Allow fine-grained control in log severity of failures

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
@@ -64,4 +64,36 @@ class HandlerFailedException extends RuntimeException
             )
         );
     }
+
+    /**
+     * Determine if failure was unrecoverable.
+     *
+     * If ALL nested Exceptions are an instance of UnrecoverableExceptionInterface the failure is unrecoverable
+     */
+    public function isUnrecoverable(): bool
+    {
+        foreach ($this->exceptions as $nestedException) {
+            if (!$nestedException instanceof UnrecoverableExceptionInterface) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if failure was recoverable.
+     *
+     * If one or more nested Exceptions is an instance of RecoverableExceptionInterface the failure is recoverable
+     */
+    public function isRecoverable(): bool
+    {
+        foreach ($this->exceptions as $nestedException) {
+            if ($nestedException instanceof RecoverableExceptionInterface) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
+++ b/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
@@ -32,6 +32,8 @@ use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
  */
 class MultiplierRetryStrategy implements RetryStrategyInterface
 {
+    use RetryRecoveryBehaviorTrait;
+
     private int $maxRetries;
     private int $delayMilliseconds;
     private float $multiplier;
@@ -61,16 +63,6 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
             throw new InvalidArgumentException(sprintf('Max delay must be greater than or equal to zero: "%s" given.', $maxDelayMilliseconds));
         }
         $this->maxDelayMilliseconds = $maxDelayMilliseconds;
-    }
-
-    /**
-     * @param \Throwable|null $throwable The cause of the failed handling
-     */
-    public function isRetryable(Envelope $message, \Throwable $throwable = null): bool
-    {
-        $retries = RedeliveryStamp::getRetryCountFromEnvelope($message);
-
-        return $retries < $this->maxRetries;
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Retry/RetryRecoveryBehaviorTrait.php
+++ b/src/Symfony/Component/Messenger/Retry/RetryRecoveryBehaviorTrait.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Retry;
+
+use Psr\Log\LogLevel;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\RecoverableExceptionInterface;
+use Symfony\Component\Messenger\Exception\UnrecoverableExceptionInterface;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+
+/**
+ * Trait for retry strategies containing default log severity rules.
+ */
+trait RetryRecoveryBehaviorTrait
+{
+    /**
+     * @param \Throwable|null $throwable The cause of the failed handling
+     */
+    public function isRetryable(Envelope $message, \Throwable $throwable = null): bool
+    {
+        if (null !== $throwable) {
+            // A failure is either unrecoverable, recoverable or neutral
+            if ($this->isUnrecoverable($throwable)) {
+                return false;
+            }
+
+            if ($this->isRecoverable($throwable)) {
+                return true;
+            }
+        }
+
+        $retries = RedeliveryStamp::getRetryCountFromEnvelope($message);
+
+        return $retries < $this->maxRetries;
+    }
+
+    /**
+     * @return string The \Psr\Log\LogLevel log severity
+     */
+    public function getLogSeverity(Envelope $message, \Throwable $throwable = null): string
+    {
+        return $this->isRetryable($message, $throwable)
+            ? LogLevel::WARNING
+            : LogLevel::CRITICAL;
+    }
+
+    /**
+     * Determine if exception was unrecoverable.
+     *
+     * Unrecoverable exceptions should never be retried
+     */
+    private function isUnrecoverable(\Throwable $throwable): bool
+    {
+        return ($throwable instanceof HandlerFailedException)
+            ? $throwable->isUnrecoverable()
+            : $throwable instanceof UnrecoverableExceptionInterface;
+    }
+
+    /**
+     * Determine if exception was recoverable.
+     *
+     * Recoverable exceptions should always be retried
+     */
+    private function isRecoverable(\Throwable $throwable): bool
+    {
+        return ($throwable instanceof HandlerFailedException)
+            ? $throwable->isRecoverable()
+            : $throwable instanceof RecoverableExceptionInterface;
+    }
+}

--- a/src/Symfony/Component/Messenger/Retry/RetryStrategyInterface.php
+++ b/src/Symfony/Component/Messenger/Retry/RetryStrategyInterface.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\Envelope;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @author Joris Steyn <symfony@j0r1s.nl>
  */
 interface RetryStrategyInterface
 {
@@ -31,4 +32,9 @@ interface RetryStrategyInterface
      * @return int The time to delay/wait in milliseconds
      */
     public function getWaitingTime(Envelope $message, \Throwable $throwable = null): int;
+
+    /**
+     * @return string The \Psr\Log\LogLevel log severity
+     */
+    public function getLogSeverity(Envelope $message, \Throwable $throwable = null): string;
 }


### PR DESCRIPTION
This PR adds a new interface method on the `RetryStrategyInterface` allowing custom retry strategies to control the log severity of failed and retried messages. 

This is a spin-off from https://github.com/symfony/symfony/pull/43160

| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| BC break? | yes - custom retry strategies require including the new trait or implementing the new method
| New feature?  | yes - changelog not yet updated
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | not yet, collecting feedback first

The default logic for determining the log severity for failed messages has been (since https://github.com/symfony/symfony/pull/43492):

 - recoverable exceptions are logged as warning
 - unrecoverable exceptions are logged as critical
 - neutral exceptions are logged as warning after a non-final attempt
 - neutral exceptions are logged as critical after a final attempt

This PR implements the exact same behaviour but in a way that allows users to augment or override the default behaviour with their own specific needs. For example, having specific exceptions logged as `EMERGENCY` or to log them as `NOTICE` until or including the last attempt.

The refactoring done to make this possible is:

 - move the logic determining if an exception is recoverable/unrecoverable/neutral to the `HandlerFailedException` so it can be used by retry strategy objects

 - add a new interface method on the `RetryStrategyInterface` (BC break!)

 - implement the existing behaviour using the new mechanism in a trait, this way, custom retry strategies can easily re-use the
   default behaviour
