### PR TITLE
Release v6.0.0-BETA3

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -7,6 +7,27 @@ in 6.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.0.0...v6.0.1
 
+* 6.0.0-BETA3 (2021-11-18)
+
+ * feature #44125 Add a setter on DateTimeNormalizer to change the default context at runtime (Seldaek)
+ * bug #44110 [FrameworkBundle] Fix default PHP attributes support in validation and serializer configuration when doctrine/annotations is not installed with PHP 8 (fancyweb)
+ * bug #44115 [WebProfilerBundle] Tweak the colors of the security panel (javiereguiluz)
+ * bug #44121 [Serializer] fix support for lazy properties (nicolas-grekas)
+ * bug #44108 [FrameworkBundle][Messenger] remove `FlattenExceptionNormalizer` definition if serializer not available (kbond)
+ * bug #44111 [Serializer] fix support for unset properties on PHP < 7.4 (nicolas-grekas)
+ * bug #44098 [DependencyInjection] fix preloading (nicolas-grekas)
+ * bug #44065 [FrameworkBundle] Add framework config for DBAL cache adapter (GromNaN)
+ * bug #44096 Make ExpressionVoter Cacheable (jderusse)
+ * bug #44070 [Process] intersect with getenv() to populate default envs (nicolas-grekas)
+ * feature #43181 Allow AbstractDoctrineExtension implementations to support the newer bundle structure (mbabker)
+ * bug #44060 [Cache] Fix calculate ttl in couchbase sdk 3.0 (ajcerezo)
+ * bug #43990 [Translation] [Loco] Generate id parameter instead of letting Loco do it (welcoMattic)
+ * bug #44043 [Cache] fix dbindex Redis (a1812)
+ * feature #44015 [Cache] Decrease the probability of invalidation loss on tag eviction (nicolas-grekas)
+ * bug #44064 [Cache] fix releasing not acquired locks (nicolas-grekas)
+ * bug #44063 [DependencyInjection] fix creating 2nd container instances (nicolas-grekas)
+ * bug #44056 [DependencyInjection] Fix YamlFileLoader return type (1ed)
+
 * 6.0.0-BETA2 (2021-11-14)
 
  * bug #44051 [Notifier] Fix package name (fabpot)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,12 +78,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.0.0-DEV';
+    public const VERSION = '6.0.0-BETA3';
     public const VERSION_ID = 60000;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 0;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = 'BETA3';
 
     public const END_OF_MAINTENANCE = '07/2022';
     public const END_OF_LIFE = '07/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.0.0-BETA2...v6.0.0-BETA3)

 * feature #44125 Add a setter on DateTimeNormalizer to change the default context at runtime (@Seldaek)
 * bug #44110 [FrameworkBundle] Fix default PHP attributes support in validation and serializer configuration when doctrine/annotations is not installed with PHP 8 (@fancyweb)
 * bug #44115 [WebProfilerBundle] Tweak the colors of the security panel (@javiereguiluz)
 * bug #44121 [Serializer] fix support for lazy properties (@nicolas-grekas)
 * bug #44108 [FrameworkBundle][Messenger] remove `FlattenExceptionNormalizer` definition if serializer not available (@kbond)
 * bug #44111 [Serializer] fix support for unset properties on PHP < 7.4 (@nicolas-grekas)
 * bug #44098 [DependencyInjection] fix preloading (@nicolas-grekas)
 * bug #44065 [FrameworkBundle] Add framework config for DBAL cache adapter (@GromNaN)
 * bug #44096 Make ExpressionVoter Cacheable (@jderusse)
 * bug #44070 [Process] intersect with getenv() to populate default envs (@nicolas-grekas)
 * feature #43181 Allow AbstractDoctrineExtension implementations to support the newer bundle structure (@mbabker)
 * bug #44060 [Cache] Fix calculate ttl in couchbase sdk 3.0 (@ajcerezo)
 * bug #43990 [Translation] [Loco] Generate id parameter instead of letting Loco do it (@welcoMattic)
 * bug #44043 [Cache] fix dbindex Redis (@a1812)
 * feature #44015 [Cache] Decrease the probability of invalidation loss on tag eviction (@nicolas-grekas)
 * bug #44064 [Cache] fix releasing not acquired locks (@nicolas-grekas)
 * bug #44063 [DependencyInjection] fix creating 2nd container instances (@nicolas-grekas)
 * bug #44056 [DependencyInjection] Fix YamlFileLoader return type (@1ed)
