### PR TITLE
[FrameworkBundle] Remove assets:install command definition when config disabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -387,6 +387,8 @@ class FrameworkExtension extends Extension
             }
 
             $this->registerAssetsConfiguration($config['assets'], $container, $loader);
+        } else {
+            $container->removeDefinition('console.command.assets_install');
         }
 
         if ($this->messengerConfigEnabled = $this->isConfigEnabled($container, $config['messenger'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -721,6 +721,12 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('assets.custom_version_strategy', (string) $defaultPackage->getArgument(1));
     }
 
+    public function testAssetsServicesRemovedWhenDisabled()
+    {
+        $container = $this->createContainerFromFile('assets_disabled');
+        $this->assertFalse($container->hasDefinition('console.command.assets_install'));
+    }
+
     public function testWebLink()
     {
         $container = $this->createContainerFromFile('web_link');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | 

When disabling assets using `framework.assets.enabled: false` configuration node the `assets:install` command definition stays in the container builder since it's loaded by `console.php` configuration file which is loaded around 150 lines before near to `if (class_exists(Application::class))` condition.
What it means is that without these two lines there is no way to effectively disable all assets definitions from the container.
