### PR TITLE
[Mailer] [Mailgun] Allow multiple TagHeaders with MailgunApiTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Allow multiple `TagHeaders` with `MailgunApiTransport`
+
 5.2
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -152,6 +152,38 @@ class MailgunApiTransportTest extends TestCase
         $this->assertSame('foobar', $message->getMessageId());
     }
 
+    public function testSendWithMultipleTagHeaders()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $content = '';
+            while ($chunk = $options['body']()) {
+                $content .= $chunk;
+            }
+
+            $this->assertStringContainsString("Content-Disposition: form-data; name=\"o:tag\"\r\n\r\npassword-reset\r\n", $content);
+            $this->assertStringContainsString("Content-Disposition: form-data; name=\"o:tag\"\r\n\r\nproduct-name\r\n", $content);
+
+            return new MockResponse(json_encode(['id' => 'foobar2']), [
+                'http_code' => 200,
+            ]);
+        });
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us-east-1', $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $mail->getHeaders()
+            ->add(new TagHeader('password-reset'))
+            ->add(new TagHeader('product-name'));
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar2', $message->getMessageId());
+    }
+
     public function testSendThrowsForErrorResponse()
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
@@ -216,6 +248,7 @@ class MailgunApiTransportTest extends TestCase
         $email->getHeaders()->addTextHeader('h:X-Mailgun-Variables', $json);
         $email->getHeaders()->addTextHeader('Custom-Header', 'value');
         $email->getHeaders()->add(new TagHeader('password-reset'));
+        $email->getHeaders()->add(new TagHeader('product-name'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
@@ -228,8 +261,10 @@ class MailgunApiTransportTest extends TestCase
         $this->assertEquals($json, $payload['h:x-mailgun-variables']);
         $this->assertArrayHasKey('h:custom-header', $payload);
         $this->assertEquals('value', $payload['h:custom-header']);
-        $this->assertArrayHasKey('o:tag', $payload);
-        $this->assertSame('password-reset', $payload['o:tag']);
+        $this->assertArrayHasKey(0, $payload);
+        $this->assertArrayHasKey(1, $payload);
+        $this->assertSame('password-reset', $payload[0]['o:tag']);
+        $this->assertSame('product-name', $payload[1]['o:tag']);
         $this->assertArrayHasKey('v:Color', $payload);
         $this->assertSame('blue', $payload['v:Color']);
         $this->assertArrayHasKey('v:Client-ID', $payload);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
@@ -122,6 +122,7 @@ class MailgunHttpTransportTest extends TestCase
         $email = new Email();
         $email->getHeaders()->addTextHeader('foo', 'bar');
         $email->getHeaders()->add(new TagHeader('password-reset'));
+        $email->getHeaders()->add(new TagHeader('product-name'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
 
@@ -130,9 +131,12 @@ class MailgunHttpTransportTest extends TestCase
         $method->setAccessible(true);
         $method->invoke($transport, $email);
 
-        $this->assertCount(3, $email->getHeaders()->toArray());
+        $this->assertCount(4, $email->getHeaders()->toArray());
         $this->assertSame('foo: bar', $email->getHeaders()->get('foo')->toString());
-        $this->assertSame('X-Mailgun-Tag: password-reset', $email->getHeaders()->get('X-Mailgun-Tag')->toString());
+        $this->assertCount(2, $email->getHeaders()->all('X-Mailgun-Tag'));
+        $tagHeaders = iterator_to_array($email->getHeaders()->all('X-Mailgun-Tag'));
+        $this->assertSame('X-Mailgun-Tag: password-reset', $tagHeaders[0]->toString());
+        $this->assertSame('X-Mailgun-Tag: product-name', $tagHeaders[1]->toString());
         $this->assertSame('X-Mailgun-Variables: '.json_encode(['Color' => 'blue', 'Client-ID' => '12345']), $email->getHeaders()->get('X-Mailgun-Variables')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -123,7 +123,7 @@ class MailgunApiTransport extends AbstractApiTransport
             }
 
             if ($header instanceof TagHeader) {
-                $payload['o:tag'] = $header->getValue();
+                $payload[] = ['o:tag' => $header->getValue()];
 
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

Mailgun allows you to set [3 tags per message](https://documentation.mailgun.com/en/latest/user_manual.html#tagging) but the current implementation in MailgunApiTransport, any consecutive TagHeader will override the previous one. Because it uses FormDataPart to build the payload, by using a integer key, it allows to set multiple parts with the same name #38323
The MailgunHttpTransport already supports multiple TagHeaders and I added a test to prove that.


