### PR TITLE
[Assets] Accept empty `base_url`, in order to simplify local dev configuration.

### DIFF
--- a/src/Symfony/Component/Asset/CHANGELOG.md
+++ b/src/Symfony/Component/Asset/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+* `UrlPackage` accepts empty strings as `base_url`, in order to simplify local dev configuration.
+
 6.0
 ---
 

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -85,6 +85,7 @@ class UrlPackageTest extends TestCase
 
             [true, ['http://example.com'], '', 'foo', 'http://example.com/foo?v1'],
             [true, ['http://example.com', 'https://example.com'], '', 'foo', 'https://example.com/foo?v1'],
+            [true, ['', 'https://example.com'], '', 'foo', '/foo?v1'],
         ];
     }
 

--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -117,7 +117,7 @@ class UrlPackage extends Package
     {
         $sslUrls = [];
         foreach ($urls as $url) {
-            if (str_starts_with($url, 'https://') || str_starts_with($url, '//')) {
+            if (str_starts_with($url, 'https://') || str_starts_with($url, '//') || '' === $url) {
                 $sslUrls[] = $url;
             } elseif (null === parse_url($url, \PHP_URL_SCHEME)) {
                 throw new InvalidArgumentException(sprintf('"%s" is not a valid URL.', $url));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #28391
| License       | MIT
| Doc PR        | -