### PR TITLE
[Serializer] Add trait support for mapping

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassResolverTrait.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassResolverTrait.php
@@ -32,8 +32,8 @@ trait ClassResolverTrait
     private function getClass($value): string
     {
         if (\is_string($value)) {
-            if (!class_exists($value) && !interface_exists($value, false)) {
-                throw new InvalidArgumentException(sprintf('The class or interface "%s" does not exist.', $value));
+            if (!class_exists($value) && !interface_exists($value, false) && !trait_exists($value, false)) {
+                throw new InvalidArgumentException(sprintf('The class, interface or trait "%s" does not exist.', $value));
             }
 
             return ltrim($value, '\\');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (and up)
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT
| Doc PR        | none

Hi,

Let say I have a class `FooBar` that uses a trait `DummyTrait` defined as follow

```php
//src/FooBar.php
<?php

declare(strict_types=1);

use Symfony\Component\Serializer\Annotation\Groups;

namespace App;

class FooBar
{
    use DummyTrait;

    #[Groups(groups: ['read', 'write'])]
    public string $foo;
}
```


```php
//src/DummyTrait.php
<?php

declare(strict_types=1);

use Symfony\Component\Serializer\Annotation\Groups;

namespace App;

class DummyTrait
{
    #[Groups(groups: ['read'])]
    public string $bar;
}
```

Nothing wrong with the attributes (or annotations for earlier PHP versions), but when using an XML file to describe the groups.

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
        https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
>
    <class name="App\FooBar">
        <attribute name="foo">
            <group>read</group>
            <group>write</group>
        </attribute>
    </class>
</serializer>
```

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
        https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
>
    <class name="App\DummyTrait">
        <attribute name="bar">
            <group>read</group>
        </attribute>
    </class>
</serializer>
```

The following error is thrown:

> The class or interface "App\DummyTrait" does not exist.

This PR aims at allowing traits to be considered for the mapping when using XML (and potentially YAML as well).
I am not sure how to test that behaviour. I will be very happy to add some use cases here. Just let me know how to proceed and I will update this PR.

Many thanks.
Regards.