### PR TITLE
[Config] Use better typehint in PHP Configuration

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Config\Builder;
 use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\BooleanNode;
+use Symfony\Component\Config\Definition\Builder\ExprBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\EnumNode;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -141,8 +142,9 @@ public function NAME(): string
             $node->getName(),
             $this->getType($childClass->getFqcn(), $hasNormalizationClosures)
         );
+        $nodeTypes = $this->getParameterTypes($node);
         $body = $hasNormalizationClosures ? '
-COMMENTpublic function NAME(mixed $value = []): CLASS|static
+COMMENTpublic function NAME(PARAM_TYPE $value = []): CLASS|static
 {
     if (!\is_array($value)) {
         $this->_usedProperties[\'PROPERTY\'] = true;
@@ -172,7 +174,12 @@ COMMENTpublic function NAME(array $value = []): CLASS
     return $this->PROPERTY;
 }';
         $class->addUse(InvalidConfigurationException::class);
-        $class->addMethod($node->getName(), $body, ['COMMENT' => $comment, 'PROPERTY' => $property->getName(), 'CLASS' => $childClass->getFqcn()]);
+        $class->addMethod($node->getName(), $body, [
+            'COMMENT' => $comment,
+            'PROPERTY' => $property->getName(),
+            'CLASS' => $childClass->getFqcn(),
+            'PARAM_TYPE' => \in_array('mixed', $nodeTypes, true) ? 'mixed' : implode('|', $nodeTypes),
+        ]);
 
         $this->buildNode($node, $childClass, $this->getSubNamespace($childClass));
     }
@@ -209,19 +216,21 @@ public function NAME(mixed $valueDEFAULT): static
         $methodName = $name;
         $hasNormalizationClosures = $this->hasNormalizationClosures($node) || $this->hasNormalizationClosures($prototype);
 
-        $parameterType = $this->getParameterType($prototype);
-        if (null !== $parameterType || $prototype instanceof ScalarNode) {
+        $nodeParameterTypes = $this->getParameterTypes($node);
+        $prototypeParameterTypes = $this->getParameterTypes($prototype);
+        if (!$prototype instanceof ArrayNode || ($prototype instanceof PrototypedArrayNode && $prototype->getPrototype() instanceof ScalarNode)) {
             $class->addUse(ParamConfigurator::class);
             $property = $class->addProperty($node->getName());
             if (null === $key = $node->getKeyAttribute()) {
                 // This is an array of values; don't use singular name
+                $nodeTypesWithoutArray = array_filter($nodeParameterTypes, static fn ($type) => 'array' !== $type);
                 $body = '
 /**
- * @param PHPDOC_TYPE $value
+ * @param ParamConfigurator|list<ParamConfigurator|PROTOTYPE_TYPE>EXTRA_TYPE $value
  *
  * @return $this
  */
-public function NAME(TYPE $value): static
+public function NAME(PARAM_TYPE $value): static
 {
     $this->_usedProperties[\'PROPERTY\'] = true;
     $this->PROPERTY = $value;
@@ -231,8 +240,9 @@ public function NAME(TYPE $value): static
 
                 $class->addMethod($node->getName(), $body, [
                     'PROPERTY' => $property->getName(),
-                    'TYPE' => $hasNormalizationClosures ? 'mixed' : 'ParamConfigurator|array',
-                    'PHPDOC_TYPE' => $hasNormalizationClosures ? 'mixed' : sprintf('ParamConfigurator|list<ParamConfigurator|%s>', '' === $parameterType ? 'mixed' : $parameterType),
+                    'PROTOTYPE_TYPE' => implode('|', $prototypeParameterTypes),
+                    'EXTRA_TYPE' => $nodeTypesWithoutArray ? '|'.implode('|', $nodeTypesWithoutArray) : '',
+                    'PARAM_TYPE' => \in_array('mixed', $nodeParameterTypes, true) ? 'mixed' : 'ParamConfigurator|'.implode('|', $nodeParameterTypes),
                 ]);
             } else {
                 $body = '
@@ -249,7 +259,7 @@ public function NAME(string $VAR, TYPE $VALUE): static
 
                 $class->addMethod($methodName, $body, [
                     'PROPERTY' => $property->getName(),
-                    'TYPE' => $hasNormalizationClosures || '' === $parameterType ? 'mixed' : 'ParamConfigurator|'.$parameterType,
+                    'TYPE' => \in_array('mixed', $prototypeParameterTypes, true) ? 'mixed' : 'ParamConfigurator|'.implode('|', $prototypeParameterTypes),
                     'VAR' => '' === $key ? 'key' : $key,
                     'VALUE' => 'value' === $key ? 'data' : 'value',
                 ]);
@@ -282,7 +292,7 @@ public function NAME(string $VAR, TYPE $VALUE): static
 
         if (null === $key = $node->getKeyAttribute()) {
             $body = $hasNormalizationClosures ? '
-COMMENTpublic function NAME(mixed $value = []): CLASS|static
+COMMENTpublic function NAME(PARAM_TYPE $value = []): CLASS|static
 {
     $this->_usedProperties[\'PROPERTY\'] = true;
     if (!\is_array($value)) {
@@ -299,10 +309,15 @@ COMMENTpublic function NAME(array $value = []): CLASS
 
     return $this->PROPERTY[] = new CLASS($value);
 }';
-            $class->addMethod($methodName, $body, ['COMMENT' => $comment, 'PROPERTY' => $property->getName(), 'CLASS' => $childClass->getFqcn()]);
+            $class->addMethod($methodName, $body, [
+                'COMMENT' => $comment,
+                'PROPERTY' => $property->getName(),
+                'CLASS' => $childClass->getFqcn(),
+                'PARAM_TYPE' => \in_array('mixed', $nodeParameterTypes, true) ? 'mixed' : implode('|', $nodeParameterTypes),
+            ]);
         } else {
             $body = $hasNormalizationClosures ? '
-COMMENTpublic function NAME(string $VAR, mixed $VALUE = []): CLASS|static
+COMMENTpublic function NAME(string $VAR, PARAM_TYPE $VALUE = []): CLASS|static
 {
     if (!\is_array($VALUE)) {
         $this->_usedProperties[\'PROPERTY\'] = true;
@@ -337,6 +352,7 @@ COMMENTpublic function NAME(string $VAR, array $VALUE = []): CLASS
                 'CLASS' => $childClass->getFqcn(),
                 'VAR' => '' === $key ? 'key' : $key,
                 'VALUE' => 'value' === $key ? 'data' : 'value',
+                'PARAM_TYPE' => \in_array('mixed', $prototypeParameterTypes, true) ? 'mixed' : implode('|', $prototypeParameterTypes),
             ]);
         }
 
@@ -364,35 +380,33 @@ public function NAME($value): static
         $class->addMethod($node->getName(), $body, ['PROPERTY' => $property->getName(), 'COMMENT' => $comment]);
     }
 
-    private function getParameterType(NodeInterface $node): ?string
+    private function getParameterTypes(NodeInterface $node): array
     {
+        $paramTypes = [];
+        if ($node instanceof BaseNode) {
+            $types = $node->getNormalizedTypes();
+            if (\in_array(ExprBuilder::TYPE_ANY, $types, true)) {
+                $paramTypes[] = 'mixed';
+            }
+            if (\in_array(ExprBuilder::TYPE_STRING, $types, true)) {
+                $paramTypes[] = 'string';
+            }
+        }
         if ($node instanceof BooleanNode) {
-            return 'bool';
+            $paramTypes[] = 'bool';
+        } elseif ($node instanceof IntegerNode) {
+            $paramTypes[] = 'int';
+        } elseif ($node instanceof FloatNode) {
+            $paramTypes[] = 'float';
+        } elseif ($node instanceof EnumNode) {
+            $paramTypes[] = 'mixed';
+        } elseif ($node instanceof ArrayNode) {
+            $paramTypes[] = 'array';
+        } elseif ($node instanceof VariableNode) {
+            $paramTypes[] = 'mixed';
         }
 
-        if ($node instanceof IntegerNode) {
-            return 'int';
-        }
-
-        if ($node instanceof FloatNode) {
-            return 'float';
-        }
-
-        if ($node instanceof EnumNode) {
-            return '';
-        }
-
-        if ($node instanceof PrototypedArrayNode && $node->getPrototype() instanceof ScalarNode) {
-            // This is just an array of variables
-            return 'array';
-        }
-
-        if ($node instanceof VariableNode) {
-            // mixed
-            return '';
-        }
-
-        return null;
+        return array_unique($paramTypes);
     }
 
     private function getComment(BaseNode $node): string
@@ -416,11 +430,8 @@ public function NAME($value): static
                     return var_export($a, true);
                 }, $node->getValues())))."\n";
             } else {
-                $parameterType = $this->getParameterType($node);
-                if (null === $parameterType || '' === $parameterType) {
-                    $parameterType = 'mixed';
-                }
-                $comment .= ' * @param ParamConfigurator|'.$parameterType.' $value'."\n";
+                $parameterTypes = $this->getParameterTypes($node);
+                $comment .= ' * @param ParamConfigurator|'.implode('|', $parameterTypes).' $value'."\n";
             }
         } else {
             foreach ((array) ($node->getExample() ?? []) as $example) {

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate calling `NodeBuilder::setParent()` without any arguments
+ * Add a more accurate typehint in generated PHP config
 
 6.1
 ---

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -32,6 +32,7 @@ abstract class BaseNode implements NodeInterface
     protected $name;
     protected $parent;
     protected $normalizationClosures = [];
+    protected $normalizedTypes = [];
     protected $finalValidationClosures = [];
     protected $allowOverwrite = true;
     protected $required = false;
@@ -210,6 +211,26 @@ abstract class BaseNode implements NodeInterface
     public function setNormalizationClosures(array $closures)
     {
         $this->normalizationClosures = $closures;
+    }
+
+    /**
+     * Sets the list of types supported by normalization.
+     *
+     * see ExprBuilder::TYPE_* constants.
+     */
+    public function setNormalizedTypes(array $types)
+    {
+        $this->normalizedTypes = $types;
+    }
+
+    /**
+     * Gets the list of types supported by normalization.
+     *
+     * see ExprBuilder::TYPE_* constants.
+     */
+    public function getNormalizedTypes(): array
+    {
+        return $this->normalizedTypes;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -405,6 +405,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
 
         if (null !== $this->normalization) {
             $node->setNormalizationClosures($this->normalization->before);
+            $node->setNormalizedTypes($this->normalization->declaredTypes);
             $node->setXmlRemappings($this->normalization->remappings);
         }
 

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -106,7 +106,13 @@ abstract class NodeDefinition implements NodeParentInterface
         }
 
         if (null !== $this->normalization) {
+            $allowedTypes = [];
+            foreach ($this->normalization->before as $expr) {
+                $allowedTypes[] = $expr->allowedTypes;
+            }
+            $allowedTypes = array_unique($allowedTypes);
             $this->normalization->before = ExprBuilder::buildExpressions($this->normalization->before);
+            $this->normalization->declaredTypes = $allowedTypes;
         }
 
         if (null !== $this->validation) {

--- a/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
@@ -20,6 +20,7 @@ class NormalizationBuilder
 {
     protected $node;
     public $before = [];
+    public $declaredTypes = [];
     public $remappings = [];
 
     public function __construct(NodeDefinition $node)

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
@@ -24,11 +24,11 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     private $_usedProperties = [];
 
     /**
-     * @param mixed $value
+     * @param ParamConfigurator|list<ParamConfigurator|mixed>|string $value
      *
      * @return $this
      */
-    public function simpleArray(mixed $value): static
+    public function simpleArray(ParamConfigurator|string|array $value): static
     {
         $this->_usedProperties['simpleArray'] = true;
         $this->simpleArray = $value;
@@ -39,7 +39,7 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     /**
      * @return $this
      */
-    public function keyedArray(string $name, mixed $value): static
+    public function keyedArray(string $name, ParamConfigurator|string|array $value): static
     {
         $this->_usedProperties['keyedArray'] = true;
         $this->keyedArray[$name] = $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR now followup #46328 to replace the generic `mixed` type-hint by type inferred from normalizations (ie, if a config use `ifString`, when now that the normalization works only for string, these `mixed` can safely be replaced by `string`)