### PR TITLE
[DomCrawler] Make masterminds/html5 as a required dependency of DomCrawler

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -58,7 +58,7 @@ class Crawler implements \Countable, \IteratorAggregate
      */
     private bool $isHtml = true;
 
-    private ?HTML5 $html5Parser;
+    private HTML5 $html5Parser;
 
     /**
      * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $node A Node to use as the base for the crawling
@@ -67,7 +67,7 @@ class Crawler implements \Countable, \IteratorAggregate
     {
         $this->uri = $uri;
         $this->baseHref = $baseHref ?: $uri;
-        $this->html5Parser = class_exists(HTML5::class) ? new HTML5(['disable_html_ns' => true]) : null;
+        $this->html5Parser = new HTML5(['disable_html_ns' => true]);
         $this->cachedNamespaces = new \ArrayObject();
 
         $this->add($node);
@@ -589,7 +589,7 @@ class Crawler implements \Countable, \IteratorAggregate
         $node = $this->getNode(0);
         $owner = $node->ownerDocument;
 
-        if (null !== $this->html5Parser && '<!DOCTYPE html>' === $owner->saveXML($owner->childNodes[0])) {
+        if ('<!DOCTYPE html>' === $owner->saveXML($owner->childNodes[0])) {
             $owner = $this->html5Parser;
         }
 
@@ -610,7 +610,7 @@ class Crawler implements \Countable, \IteratorAggregate
         $node = $this->getNode(0);
         $owner = $node->ownerDocument;
 
-        if (null !== $this->html5Parser && '<!DOCTYPE html>' === $owner->saveXML($owner->childNodes[0])) {
+        if ('<!DOCTYPE html>' === $owner->saveXML($owner->childNodes[0])) {
             $owner = $this->html5Parser;
         }
 
@@ -1178,12 +1178,10 @@ class Crawler implements \Countable, \IteratorAggregate
 
     private function canParseHtml5String(string $content): bool
     {
-        if (null === $this->html5Parser) {
-            return false;
-        }
         if (false === ($pos = stripos($content, '<!doctype html>'))) {
             return false;
         }
+
         $header = substr($content, 0, $pos);
 
         return '' === $header || $this->isValidHtml5Heading($header);

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -18,14 +18,11 @@
     "require": {
         "php": ">=8.1",
         "symfony/polyfill-ctype": "~1.8",
-        "symfony/polyfill-mbstring": "~1.0"
-    },
-    "require-dev": {
-        "symfony/css-selector": "^5.4|^6.0",
+        "symfony/polyfill-mbstring": "~1.0",
         "masterminds/html5": "^2.6"
     },
-    "conflict": {
-        "masterminds/html5": "<2.6"
+    "require-dev": {
+        "symfony/css-selector": "^5.4|^6.0"
     },
     "suggest": {
         "symfony/css-selector": ""


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 (branch not created yet, targeting 6.0 for now)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/43341
| License       | MIT
| Doc PR        | -

Following the discussion on https://github.com/symfony/symfony/issues/43341 and how we will add a new HtmlSanitizer component to Symfony (https://github.com/symfony/symfony/issues/44144), it makes a lot of sense to require masterminds/html5 by default on the DomCrawler component. This PR does this and removes unnecessary checks for the library presence in the code.