### PR TITLE
[Security] Guard is incompatible with Symfony 6

### DIFF
--- a/src/Symfony/Component/Security/Guard/composer.json
+++ b/src/Symfony/Component/Security/Guard/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "symfony/security-core": "^5.0|^6.0",
-        "symfony/security-http": "^5.3|^6.0",
+        "symfony/security-core": "^5.0",
+        "symfony/security-http": "^5.3",
         "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The Guard component is designed to work with the old authenticator system that has been removed in Symfony 6. I see no way we can make it work with Security Core 6 or Security HTTP 6.