### PR TITLE
Run high-deps tests on PHP 8

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - php: '7.2'
           - php: '8.1'
-          - php: '7.4'
+          - php: '8.0'
             mode: high-deps
           - php: '8.0'
             mode: low-deps


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Currently, our high deps tests run on PHP 7.4. That means that even if a component indicates compatibility with Symfony 6 components, we'd still get the Symfony 5.4 versions. This is a bit unfortunate because we don't get proper feedback about incompatible dependencies that way. For instance, the test suite of the Security Guard component is deep red if we run it on high deps on PHP 8, but our CI did not catch that.