### PR TITLE
[SecurityBundle] There is no Guard 6

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/polyfill-php80": "^1.16",
         "symfony/security-core": "^5.4|^6.0",
         "symfony/security-csrf": "^4.4|^5.0|^6.0",
-        "symfony/security-guard": "^5.3|^6.0",
+        "symfony/security-guard": "^5.3",
         "symfony/security-http": "^5.4|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

We won't release a version 6 of the Guard component, so let's remove it from the bundle's composer.json.