### PR TITLE
[Ldap] Add missing security-http dependency

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -41,10 +41,6 @@ class CheckLdapCredentialsListenerTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!interface_exists(AuthenticatorInterface::class)) {
-            $this->markTestSkipped('This test requires symfony/security-http:^5.1');
-        }
-
         $this->ldap = $this->createMock(LdapInterface::class);
     }
 
@@ -61,10 +57,6 @@ class CheckLdapCredentialsListenerTest extends TestCase
 
     public function provideShouldNotCheckPassport()
     {
-        if (!interface_exists(AuthenticatorInterface::class)) {
-            $this->markTestSkipped('This test requires symfony/security-http:^5.1');
-        }
-
         // no LdapBadge
         yield [new TestAuthenticator(), new Passport(new UserBadge('test'), new PasswordCredentials('s3cret'))];
 
@@ -110,10 +102,6 @@ class CheckLdapCredentialsListenerTest extends TestCase
 
     public function provideWrongPassportData()
     {
-        if (!interface_exists(AuthenticatorInterface::class)) {
-            $this->markTestSkipped('This test requires symfony/security-http:^5.1');
-        }
-
         // no password credentials
         yield [new SelfValidatingPassport(new UserBadge('test'), [new LdapBadge('app.ldap')])];
 

--- a/src/Symfony/Component/Ldap/composer.json
+++ b/src/Symfony/Component/Ldap/composer.json
@@ -22,11 +22,13 @@
         "ext-ldap": "*"
     },
     "require-dev": {
-        "symfony/security-core": "^5.3"
+        "symfony/security-core": "^5.3",
+        "symfony/security-http": "^5.2"
     },
     "conflict": {
         "symfony/options-resolver": "<4.4",
-        "symfony/security-core": "<5.3"
+        "symfony/security-core": "<5.3",
+        "symfony/security-http": "<5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Ldap\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

On the low/high deps runs, certain tests of the LDAP component are skipped because we don't install the security-http component. This PR attempts to change that.