### PR TITLE
[Console] Default ansi option to null

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1040,7 +1040,7 @@ class Application implements ResetInterface
             new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
             new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
-            new InputOption('--ansi', '', InputOption::VALUE_NEGATABLE, 'Force (or disable --no-ansi) ANSI output', false),
+            new InputOption('--ansi', '', InputOption::VALUE_NEGATABLE, 'Force (or disable --no-ansi) ANSI output', null),
             new InputOption('--no-interaction', '-n', InputOption::VALUE_NONE, 'Do not ask any interactive question'),
         ]);
     }

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add support for bright colors
  * Add `#[AsCommand]` attribute for declaring commands on PHP 8
  * Add `Helper::width()` and `Helper::length()`
+ * The `--ansi` and `--no-ansi` options now default to `null`.
 
 5.2.0
 -----

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
@@ -103,7 +103,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 
@@ -230,7 +230,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -116,7 +116,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 
@@ -243,7 +243,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 
@@ -318,7 +318,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 
@@ -409,7 +409,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 
@@ -481,7 +481,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
@@ -107,7 +107,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 
@@ -234,7 +234,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 
@@ -325,7 +325,7 @@ Force (or disable --no-ansi) ANSI output
 * Is value required: no
 * Is multiple: no
 * Is negatable: yes
-* Default: `false`
+* Default: `NULL`
 
 #### `--no-interaction|-n`
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


This PR is an alternative to #41794 (see comment for the reasoning of this PR) to fixes laravel/tinker#127

It defaults the negatable option `--ansi` to null

For the recall, having default null is interpreted like this:

| flag passed | getOption(??) return |
| --- | --- |
| `--ansi` | `ansi = true`<br>`no-ansi = false` |
| `--no-ansi` | `ansi = false`<br>`no-ansi = true` |
| nothing | `ansi = null`<br>`no-ansi = null` |

This could be a BC break for people that use strict comparison `getOption('ansi') === false`
But: 
- Provide a compatible code for people that cast to bool or use weak comparison
- It fixes the issue by letting know if the option has been defined by the user or is the default value (null)

Here is a summary of the changes

| call | 5.2 | 5.3 | this PR |
| -- | --- | --- | --- |
getOption('ansi') | false | false | null |
getOption('no-ansi') | false | true | null |
