### PR TITLE
[SecurityBundle] Remove Guard

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -27,7 +27,6 @@
         "symfony/password-hasher": "^5.4|^6.0",
         "symfony/security-core": "^5.4|^6.0",
         "symfony/security-csrf": "^5.4|^6.0",
-        "symfony/security-guard": "^5.4|^6.0",
         "symfony/security-http": "^5.4|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follow-up to #44174. The Guard component is gone in 6.0, so SecurityBundle must not depend on it.