### PR TITLE
[Config] Add tests to compare generated code

### DIFF
--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Symfony\Config\AddToList\Messenger;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class ReceivingConfig 
+{
+    private $priority;
+    private $color;
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|int $value
+     * @return $this
+     */
+    public function priority($value): self
+    {
+        $this->priority = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function color($value): self
+    {
+        $this->color = $value;
+    
+        return $this;
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['priority'])) {
+            $this->priority = $value['priority'];
+            unset($value['priority']);
+        }
+    
+        if (isset($value['color'])) {
+            $this->color = $value['color'];
+            unset($value['color']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->priority) {
+            $output['priority'] = $this->priority;
+        }
+        if (null !== $this->color) {
+            $output['color'] = $this->color;
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Symfony\Config\AddToList\Messenger;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class RoutingConfig 
+{
+    private $senders;
+    
+    /**
+     * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
+     * @return $this
+     */
+    public function senders($value): self
+    {
+        $this->senders = $value;
+    
+        return $this;
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['senders'])) {
+            $this->senders = $value['senders'];
+            unset($value['senders']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->senders) {
+            $output['senders'] = $this->senders;
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Symfony\Config\AddToList;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'Messenger'.\DIRECTORY_SEPARATOR.'RoutingConfig.php';
+require_once __DIR__.\DIRECTORY_SEPARATOR.'Messenger'.\DIRECTORY_SEPARATOR.'ReceivingConfig.php';
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class MessengerConfig 
+{
+    private $routing;
+    private $receiving;
+    
+    public function routing(string $message_class, array $value = []): \Symfony\Config\AddToList\Messenger\RoutingConfig
+    {
+        if (!isset($this->routing[$message_class])) {
+            return $this->routing[$message_class] = new \Symfony\Config\AddToList\Messenger\RoutingConfig($value);
+        }
+        if ([] === $value) {
+            return $this->routing[$message_class];
+        }
+    
+        throw new InvalidConfigurationException('The node created by "routing()" has already been initialized. You cannot pass values the second time you call routing().');
+    }
+    
+    public function receiving(array $value = []): \Symfony\Config\AddToList\Messenger\ReceivingConfig
+    {
+        return $this->receiving[] = new \Symfony\Config\AddToList\Messenger\ReceivingConfig($value);
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['routing'])) {
+            $this->routing = array_map(function ($v) { return new \Symfony\Config\AddToList\Messenger\RoutingConfig($v); }, $value['routing']);
+            unset($value['routing']);
+        }
+    
+        if (isset($value['receiving'])) {
+            $this->receiving = array_map(function ($v) { return new \Symfony\Config\AddToList\Messenger\ReceivingConfig($v); }, $value['receiving']);
+            unset($value['receiving']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->routing) {
+            $output['routing'] = array_map(function ($v) { return $v->toArray(); }, $this->routing);
+        }
+        if (null !== $this->receiving) {
+            $output['receiving'] = array_map(function ($v) { return $v->toArray(); }, $this->receiving);
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Symfony\Config\AddToList;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class TranslatorConfig 
+{
+    private $fallbacks;
+    private $sources;
+    
+    /**
+     * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
+     * @return $this
+     */
+    public function fallbacks($value): self
+    {
+        $this->fallbacks = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function source(string $source_class, $value): self
+    {
+        $this->sources[$source_class] = $value;
+    
+        return $this;
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['fallbacks'])) {
+            $this->fallbacks = $value['fallbacks'];
+            unset($value['fallbacks']);
+        }
+    
+        if (isset($value['sources'])) {
+            $this->sources = $value['sources'];
+            unset($value['sources']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->fallbacks) {
+            $output['fallbacks'] = $this->fallbacks;
+        }
+        if (null !== $this->sources) {
+            $output['sources'] = $this->sources;
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Symfony\Config;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'AddToList'.\DIRECTORY_SEPARATOR.'TranslatorConfig.php';
+require_once __DIR__.\DIRECTORY_SEPARATOR.'AddToList'.\DIRECTORY_SEPARATOR.'MessengerConfig.php';
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+{
+    private $translator;
+    private $messenger;
+    
+    public function translator(array $value = []): \Symfony\Config\AddToList\TranslatorConfig
+    {
+        if (null === $this->translator) {
+            $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value);
+        } elseif ([] !== $value) {
+            throw new InvalidConfigurationException('The node created by "translator()" has already been initialized. You cannot pass values the second time you call translator().');
+        }
+    
+        return $this->translator;
+    }
+    
+    public function messenger(array $value = []): \Symfony\Config\AddToList\MessengerConfig
+    {
+        if (null === $this->messenger) {
+            $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value);
+        } elseif ([] !== $value) {
+            throw new InvalidConfigurationException('The node created by "messenger()" has already been initialized. You cannot pass values the second time you call messenger().');
+        }
+    
+        return $this->messenger;
+    }
+    
+    public function getExtensionAlias(): string
+    {
+        return 'add_to_list';
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['translator'])) {
+            $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value['translator']);
+            unset($value['translator']);
+        }
+    
+        if (isset($value['messenger'])) {
+            $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value['messenger']);
+            unset($value['messenger']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->translator) {
+            $output['translator'] = $this->translator->toArray();
+        }
+        if (null !== $this->messenger) {
+            $output['messenger'] = $this->messenger->toArray();
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Symfony\Config\ArrayExtraKeys;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class BarConfig 
+{
+    private $corge;
+    private $grault;
+    private $_extraKeys;
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function corge($value): self
+    {
+        $this->corge = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function grault($value): self
+    {
+        $this->grault = $value;
+    
+        return $this;
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['corge'])) {
+            $this->corge = $value['corge'];
+            unset($value['corge']);
+        }
+    
+        if (isset($value['grault'])) {
+            $this->grault = $value['grault'];
+            unset($value['grault']);
+        }
+    
+        $this->_extraKeys = $value;
+    
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->corge) {
+            $output['corge'] = $this->corge;
+        }
+        if (null !== $this->grault) {
+            $output['grault'] = $this->grault;
+        }
+    
+        return $output + $this->_extraKeys;
+    }
+    
+    /**
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function set(string $key, $value): self
+    {
+        if (null === $value) {
+            unset($this->_extraKeys[$key]);
+        } else {
+            $this->_extraKeys[$key] = $value;
+        }
+    
+        return $this;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Symfony\Config\ArrayExtraKeys;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class FooConfig 
+{
+    private $baz;
+    private $qux;
+    private $_extraKeys;
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function baz($value): self
+    {
+        $this->baz = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function qux($value): self
+    {
+        $this->qux = $value;
+    
+        return $this;
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['baz'])) {
+            $this->baz = $value['baz'];
+            unset($value['baz']);
+        }
+    
+        if (isset($value['qux'])) {
+            $this->qux = $value['qux'];
+            unset($value['qux']);
+        }
+    
+        $this->_extraKeys = $value;
+    
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->baz) {
+            $output['baz'] = $this->baz;
+        }
+        if (null !== $this->qux) {
+            $output['qux'] = $this->qux;
+        }
+    
+        return $output + $this->_extraKeys;
+    }
+    
+    /**
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function set(string $key, $value): self
+    {
+        if (null === $value) {
+            unset($this->_extraKeys[$key]);
+        } else {
+            $this->_extraKeys[$key] = $value;
+        }
+    
+        return $this;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Symfony\Config;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'ArrayExtraKeys'.\DIRECTORY_SEPARATOR.'FooConfig.php';
+require_once __DIR__.\DIRECTORY_SEPARATOR.'ArrayExtraKeys'.\DIRECTORY_SEPARATOR.'BarConfig.php';
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+{
+    private $foo;
+    private $bar;
+    
+    public function foo(array $value = []): \Symfony\Config\ArrayExtraKeys\FooConfig
+    {
+        if (null === $this->foo) {
+            $this->foo = new \Symfony\Config\ArrayExtraKeys\FooConfig($value);
+        } elseif ([] !== $value) {
+            throw new InvalidConfigurationException('The node created by "foo()" has already been initialized. You cannot pass values the second time you call foo().');
+        }
+    
+        return $this->foo;
+    }
+    
+    public function bar(array $value = []): \Symfony\Config\ArrayExtraKeys\BarConfig
+    {
+        return $this->bar[] = new \Symfony\Config\ArrayExtraKeys\BarConfig($value);
+    }
+    
+    public function getExtensionAlias(): string
+    {
+        return 'array_extra_keys';
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['foo'])) {
+            $this->foo = new \Symfony\Config\ArrayExtraKeys\FooConfig($value['foo']);
+            unset($value['foo']);
+        }
+    
+        if (isset($value['bar'])) {
+            $this->bar = array_map(function ($v) { return new \Symfony\Config\ArrayExtraKeys\BarConfig($v); }, $value['bar']);
+            unset($value['bar']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->foo) {
+            $output['foo'] = $this->foo->toArray();
+        }
+        if (null !== $this->bar) {
+            $output['bar'] = array_map(function ($v) { return $v->toArray(); }, $this->bar);
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Symfony\Config\NodeInitialValues\Messenger;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class TransportsConfig 
+{
+    private $dsn;
+    private $serializer;
+    private $options;
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function dsn($value): self
+    {
+        $this->dsn = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function serializer($value): self
+    {
+        $this->serializer = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
+     * @return $this
+     */
+    public function options($value): self
+    {
+        $this->options = $value;
+    
+        return $this;
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['dsn'])) {
+            $this->dsn = $value['dsn'];
+            unset($value['dsn']);
+        }
+    
+        if (isset($value['serializer'])) {
+            $this->serializer = $value['serializer'];
+            unset($value['serializer']);
+        }
+    
+        if (isset($value['options'])) {
+            $this->options = $value['options'];
+            unset($value['options']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->dsn) {
+            $output['dsn'] = $this->dsn;
+        }
+        if (null !== $this->serializer) {
+            $output['serializer'] = $this->serializer;
+        }
+        if (null !== $this->options) {
+            $output['options'] = $this->options;
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Config\NodeInitialValues;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'Messenger'.\DIRECTORY_SEPARATOR.'TransportsConfig.php';
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class MessengerConfig 
+{
+    private $transports;
+    
+    public function transports(string $name, array $value = []): \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig
+    {
+        if (!isset($this->transports[$name])) {
+            return $this->transports[$name] = new \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig($value);
+        }
+        if ([] === $value) {
+            return $this->transports[$name];
+        }
+    
+        throw new InvalidConfigurationException('The node created by "transports()" has already been initialized. You cannot pass values the second time you call transports().');
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['transports'])) {
+            $this->transports = array_map(function ($v) { return new \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig($v); }, $value['transports']);
+            unset($value['transports']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->transports) {
+            $output['transports'] = array_map(function ($v) { return $v->toArray(); }, $this->transports);
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Symfony\Config\NodeInitialValues;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class SomeCleverNameConfig 
+{
+    private $first;
+    private $second;
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function first($value): self
+    {
+        $this->first = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function second($value): self
+    {
+        $this->second = $value;
+    
+        return $this;
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['first'])) {
+            $this->first = $value['first'];
+            unset($value['first']);
+        }
+    
+        if (isset($value['second'])) {
+            $this->second = $value['second'];
+            unset($value['second']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->first) {
+            $output['first'] = $this->first;
+        }
+        if (null !== $this->second) {
+            $output['second'] = $this->second;
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Symfony\Config;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'NodeInitialValues'.\DIRECTORY_SEPARATOR.'SomeCleverNameConfig.php';
+require_once __DIR__.\DIRECTORY_SEPARATOR.'NodeInitialValues'.\DIRECTORY_SEPARATOR.'MessengerConfig.php';
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+{
+    private $someCleverName;
+    private $messenger;
+    
+    public function someCleverName(array $value = []): \Symfony\Config\NodeInitialValues\SomeCleverNameConfig
+    {
+        if (null === $this->someCleverName) {
+            $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value);
+        } elseif ([] !== $value) {
+            throw new InvalidConfigurationException('The node created by "someCleverName()" has already been initialized. You cannot pass values the second time you call someCleverName().');
+        }
+    
+        return $this->someCleverName;
+    }
+    
+    public function messenger(array $value = []): \Symfony\Config\NodeInitialValues\MessengerConfig
+    {
+        if (null === $this->messenger) {
+            $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value);
+        } elseif ([] !== $value) {
+            throw new InvalidConfigurationException('The node created by "messenger()" has already been initialized. You cannot pass values the second time you call messenger().');
+        }
+    
+        return $this->messenger;
+    }
+    
+    public function getExtensionAlias(): string
+    {
+        return 'node_initial_values';
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['some_clever_name'])) {
+            $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value['some_clever_name']);
+            unset($value['some_clever_name']);
+        }
+    
+        if (isset($value['messenger'])) {
+            $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value['messenger']);
+            unset($value['messenger']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->someCleverName) {
+            $output['some_clever_name'] = $this->someCleverName->toArray();
+        }
+        if (null !== $this->messenger) {
+            $output['messenger'] = $this->messenger->toArray();
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Symfony\Config;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+{
+    private $enabled;
+    private $favoriteFloat;
+    private $goodIntegers;
+    
+    /**
+     * @default false
+     * @param ParamConfigurator|bool $value
+     * @return $this
+     */
+    public function enabled($value): self
+    {
+        $this->enabled = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|float $value
+     * @return $this
+     */
+    public function favoriteFloat($value): self
+    {
+        $this->favoriteFloat = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @param ParamConfigurator|list<int|ParamConfigurator> $value
+     * @return $this
+     */
+    public function goodIntegers($value): self
+    {
+        $this->goodIntegers = $value;
+    
+        return $this;
+    }
+    
+    public function getExtensionAlias(): string
+    {
+        return 'placeholders';
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['enabled'])) {
+            $this->enabled = $value['enabled'];
+            unset($value['enabled']);
+        }
+    
+        if (isset($value['favorite_float'])) {
+            $this->favoriteFloat = $value['favorite_float'];
+            unset($value['favorite_float']);
+        }
+    
+        if (isset($value['good_integers'])) {
+            $this->goodIntegers = $value['good_integers'];
+            unset($value['good_integers']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->enabled) {
+            $output['enabled'] = $this->enabled;
+        }
+        if (null !== $this->favoriteFloat) {
+            $output['favorite_float'] = $this->favoriteFloat;
+        }
+        if (null !== $this->goodIntegers) {
+            $output['good_integers'] = $this->goodIntegers;
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Symfony\Config;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+{
+    private $booleanNode;
+    private $enumNode;
+    private $floatNode;
+    private $integerNode;
+    private $scalarNode;
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|bool $value
+     * @return $this
+     */
+    public function booleanNode($value): self
+    {
+        $this->booleanNode = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|'foo'|'bar'|'baz' $value
+     * @return $this
+     */
+    public function enumNode($value): self
+    {
+        $this->enumNode = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|float $value
+     * @return $this
+     */
+    public function floatNode($value): self
+    {
+        $this->floatNode = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|int $value
+     * @return $this
+     */
+    public function integerNode($value): self
+    {
+        $this->integerNode = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function scalarNode($value): self
+    {
+        $this->scalarNode = $value;
+    
+        return $this;
+    }
+    
+    public function getExtensionAlias(): string
+    {
+        return 'primitive_types';
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['boolean_node'])) {
+            $this->booleanNode = $value['boolean_node'];
+            unset($value['boolean_node']);
+        }
+    
+        if (isset($value['enum_node'])) {
+            $this->enumNode = $value['enum_node'];
+            unset($value['enum_node']);
+        }
+    
+        if (isset($value['float_node'])) {
+            $this->floatNode = $value['float_node'];
+            unset($value['float_node']);
+        }
+    
+        if (isset($value['integer_node'])) {
+            $this->integerNode = $value['integer_node'];
+            unset($value['integer_node']);
+        }
+    
+        if (isset($value['scalar_node'])) {
+            $this->scalarNode = $value['scalar_node'];
+            unset($value['scalar_node']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->booleanNode) {
+            $output['boolean_node'] = $this->booleanNode;
+        }
+        if (null !== $this->enumNode) {
+            $output['enum_node'] = $this->enumNode;
+        }
+        if (null !== $this->floatNode) {
+            $output['float_node'] = $this->floatNode;
+        }
+        if (null !== $this->integerNode) {
+            $output['integer_node'] = $this->integerNode;
+        }
+        if (null !== $this->scalarNode) {
+            $output['scalar_node'] = $this->scalarNode;
+        }
+    
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Symfony\Config;
+
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+
+/**
+ * This class is automatically generated to help creating config.
+ */
+class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+{
+    private $anyValue;
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function anyValue($value): self
+    {
+        $this->anyValue = $value;
+    
+        return $this;
+    }
+    
+    public function getExtensionAlias(): string
+    {
+        return 'variable_type';
+    }
+    
+    public function __construct(array $value = [])
+    {
+    
+        if (isset($value['any_value'])) {
+            $this->anyValue = $value['any_value'];
+            unset($value['any_value']);
+        }
+    
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+    
+    public function toArray(): array
+    {
+        $output = [];
+        if (null !== $this->anyValue) {
+            $output['any_value'] = $this->anyValue;
+        }
+    
+        return $output;
+    }
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Adding tests that compare the generated code has several benefits
- assert that the PR does not break the generated code (that should be part of our BC promises)
- easier to review the PR that touch the CodeGenerator

This PR adds nothing but initializing the Fixtures without output generated by the current implementation.

The single file changed is src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php