### PR TITLE
[Translation] [Loco] Fix idempotency of LocoProvider write method

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -75,8 +75,15 @@ final class LocoProvider implements ProviderInterface
             }
 
             foreach ($catalogue->all() as $domain => $messages) {
-                $ids = $this->getAssetsIds($domain);
-                $this->translateAssets(array_combine($ids, array_values($messages)), $locale);
+                $keysIdsMap = [];
+
+                foreach ($this->getAssetsIds($domain) as $id) {
+                    $keysIdsMap[$this->retrieveKeyFromId($id, $domain)] = $id;
+                }
+
+                $ids = array_intersect_key($keysIdsMap, $messages);
+
+                $this->translateAssets(array_combine(array_values($ids), array_values($messages)), $locale);
             }
         }
     }
@@ -122,11 +129,7 @@ final class LocoProvider implements ProviderInterface
             $catalogue = new MessageCatalogue($locale);
 
             foreach ($locoCatalogue->all($domain) as $key => $message) {
-                if (str_starts_with($key, $domain.'__')) {
-                    $key = substr($key, \strlen($domain) + 2);
-                }
-
-                $catalogue->set($key, $message, $domain);
+                $catalogue->set($this->retrieveKeyFromId($key, $domain), $message, $domain);
             }
 
             $translatorBag->addCatalogue($catalogue);
@@ -288,5 +291,14 @@ final class LocoProvider implements ProviderInterface
 
             return $carry;
         }, []);
+    }
+
+    private function retrieveKeyFromId(string $id, string $domain): string
+    {
+        if (str_starts_with($id, $domain.'__')) {
+            return substr($id, \strlen($domain) + 2);
+        }
+
+        return $id;
     }
 }

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -148,7 +148,7 @@ class LocoProviderTest extends ProviderTestCase
                 $this->assertSame(['filter' => 'messages'], $options['query']);
                 $this->assertSame($expectedAuthHeader, $options['normalized_headers']['authorization'][0]);
 
-                return new MockResponse('[{"id":"messages__a"}]');
+                return new MockResponse('[{"id":"messages__foo.existing_key"},{"id":"messages__a"}]');
             },
             'translateAsset1' => function (string $method, string $url, array $options = []) use ($expectedAuthHeader): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -164,7 +164,7 @@ class LocoProviderTest extends ProviderTestCase
                 $this->assertSame(['filter' => 'validators'], $options['query']);
                 $this->assertSame($expectedAuthHeader, $options['normalized_headers']['authorization'][0]);
 
-                return new MockResponse('[{"id":"validators__post.num_comments"}]');
+                return new MockResponse('[{"id":"validators__foo.existing_key"},{"id":"validators__post.num_comments"}]');
             },
             'translateAsset2' => function (string $method, string $url, array $options = []) use ($expectedAuthHeader): ResponseInterface {
                 $this->assertSame('POST', $method);

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+namespace Symfony\Component\Translation\Tests\Command;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -18,7 +18,6 @@ use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\Reader\TranslationReader;
-use Symfony\Component\Translation\Tests\Command\TranslationProviderTestCase;
 use Symfony\Component\Translation\TranslatorBag;
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #43953 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

This PR fix the exception thrown when we push translations twice, with existing translations on Loco.

Explanation of the fix:

To translate an "asset" (a translation key in Loco vocabulary), we need its Loco `id`. But Loco does not allow us to retrieve an id from a key. So, we fetch all ids for the current domain. Then, we build a map with `key` as key, and `id` as value. After that, we can intersect the keys of this map and our messages array to get all Loco ids of the currently processed messages.

```php
foreach ($catalogue->all() as $domain => $messages) {
    $keysIdsMap = [];

    foreach ($this->getAssetsIds($domain) as $id) {
        $keysIdsMap[$this->retrieveKeyFromId($id, $domain)] = $id;
    }

    $ids = array_intersect_key($keysIdsMap, $messages);

    $this->translateAssets(array_combine(array_values($ids), array_values($messages)), $locale);
}
```

Todo:

- [x] Make some real tests to be 100% sure there is no BC
- [x] Add tests to guarantee the fix