### PR TITLE
[VarExporter] fix exporting declared but unset properties when __sleep() is implemented

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -90,13 +90,12 @@ class Exporter
 
             $properties = [];
             $sleep = null;
-            $arrayValue = (array) $value;
             $proto = Registry::$prototypes[$class];
 
             if (($value instanceof \ArrayIterator || $value instanceof \ArrayObject) && null !== $proto) {
                 // ArrayIterator and ArrayObject need special care because their "flags"
                 // option changes the behavior of the (array) casting operator.
-                $properties = self::getArrayObjectProperties($value, $arrayValue, $proto);
+                [$arrayValue, $properties] = self::getArrayObjectProperties($value, $proto);
 
                 // populates Registry::$prototypes[$class] with a new instance
                 Registry::getClassReflector($class, Registry::$instantiableWithoutConstructor[$class], Registry::$cloneable[$class]);
@@ -108,25 +107,23 @@ class Exporter
                     $properties[] = $value[$v];
                 }
                 $properties = ['SplObjectStorage' => ["\0" => $properties]];
+                $arrayValue = (array) $value;
             } elseif ($value instanceof \Serializable || $value instanceof \__PHP_Incomplete_Class) {
                 ++$objectsCount;
                 $objectsPool[$value] = [$id = \count($objectsPool), serialize($value), [], 0];
                 $value = new Reference($id);
                 goto handle_value;
-            }
-
-            if (method_exists($class, '__sleep')) {
-                if (!\is_array($sleep = $value->__sleep())) {
-                    trigger_error('serialize(): __sleep should return an array only containing the names of instance-variables to serialize', \E_USER_NOTICE);
-                    $value = null;
-                    goto handle_value;
-                }
-                foreach ($sleep as $name) {
-                    if (property_exists($value, $name) && !$reflector->hasProperty($name)) {
-                        $arrayValue[$name] = $value->$name;
+            } else {
+                if (method_exists($class, '__sleep')) {
+                    if (!\is_array($sleep = $value->__sleep())) {
+                        trigger_error('serialize(): __sleep should return an array only containing the names of instance-variables to serialize', \E_USER_NOTICE);
+                        $value = null;
+                        goto handle_value;
                     }
+                    $sleep = array_flip($sleep);
                 }
-                $sleep = array_flip($sleep);
+
+                $arrayValue = (array) $value;
             }
 
             $proto = (array) $proto;
@@ -370,13 +367,13 @@ class Exporter
      * @param \ArrayIterator|\ArrayObject $value
      * @param \ArrayIterator|\ArrayObject $proto
      */
-    private static function getArrayObjectProperties($value, array &$arrayValue, $proto): array
+    private static function getArrayObjectProperties($value, $proto): array
     {
         $reflector = $value instanceof \ArrayIterator ? 'ArrayIterator' : 'ArrayObject';
         $reflector = Registry::$reflectors[$reflector] ?? Registry::getClassReflector($reflector);
 
         $properties = [
-            $arrayValue,
+            $arrayValue = (array) $value,
             $reflector->getMethod('getFlags')->invoke($value),
             $value instanceof \ArrayObject ? $reflector->getMethod('getIteratorClass')->invoke($value) : 'ArrayIterator',
         ];
@@ -402,6 +399,6 @@ class Exporter
             $properties = [$reflector->class => ["\0" => $properties]];
         }
 
-        return $properties;
+        return [$arrayValue, $properties];
     }
 }

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -332,6 +332,13 @@ class MyArrayObject extends \ArrayObject
 
 class GoodNight
 {
+    public $good;
+
+    public function __construct()
+    {
+        unset($this->good);
+    }
+
     public function __sleep(): array
     {
         $this->good = 'night';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44138 Fix #44182
| License       | MIT
| Doc PR        | -

Best reviewed [ignoring whitespaces](https://github.com/symfony/symfony/pull/44188/files?w=1).