### PR TITLE
[String] Slugger: Adding setSymbolsMap()

### DIFF
--- a/src/Symfony/Component/String/Slugger/AsciiSlugger.php
+++ b/src/Symfony/Component/String/Slugger/AsciiSlugger.php
@@ -95,6 +95,11 @@ class AsciiSlugger implements SluggerInterface, LocaleAwareInterface
         return $this->defaultLocale;
     }
 
+    public function setSymbolsMap($symbolsMap)
+    {
+        $this->symbolsMap = $symbolsMap;
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | None yet

Am I right that there is no way to configure the `$ymbolsMap` when using the Symfony framework integration (i.e. dependency injection)?
What about adding a public method for this?
The feature to set it in the constructor was added in https://github.com/symfony/symfony/pull/36456

Waiting for feedback before continuing.
