### PR TITLE
[HttpClient] fix closing curl multi handle when destructing client

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -336,33 +336,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
     public function reset()
     {
-        if ($this->logger) {
-            foreach ($this->multi->pushedResponses as $url => $response) {
-                $this->logger->debug(sprintf('Unused pushed response: "%s"', $url));
-            }
-        }
-
-        $this->multi->pushedResponses = [];
-        $this->multi->dnsCache->evictions = $this->multi->dnsCache->evictions ?: $this->multi->dnsCache->removals;
-        $this->multi->dnsCache->removals = $this->multi->dnsCache->hostnames = [];
-
-        if (\is_resource($this->multi->handle) || $this->multi->handle instanceof \CurlMultiHandle) {
-            if (\defined('CURLMOPT_PUSHFUNCTION')) {
-                curl_multi_setopt($this->multi->handle, \CURLMOPT_PUSHFUNCTION, null);
-            }
-
-            $active = 0;
-            while (\CURLM_CALL_MULTI_PERFORM === curl_multi_exec($this->multi->handle, $active));
-        }
-
-        foreach ($this->multi->openHandles as [$ch]) {
-            if (\is_resource($ch) || $ch instanceof \CurlHandle) {
-                curl_setopt($ch, \CURLOPT_VERBOSE, false);
-            }
-        }
-
-        curl_multi_close($this->multi->handle);
-        $this->multi->handle = curl_multi_init();
+        $this->multi->logger = $this->logger;
+        $this->multi->reset();
     }
 
     /**
@@ -380,7 +355,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
     public function __destruct()
     {
-        $this->reset();
+        $this->multi->logger = $this->logger;
     }
 
     private function handlePush($parent, $pushed, array $requestHeaders, int $maxPendingPushes): int

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpClient\Internal;
 
+use Psr\Log\LoggerInterface;
+
 /**
  * Internal representation of the cURL client's state.
  *
@@ -26,10 +28,58 @@ final class CurlClientState extends ClientState
     public $pushedResponses = [];
     /** @var DnsCache */
     public $dnsCache;
+    /** @var LoggerInterface|null */
+    public $logger;
 
     public function __construct()
     {
         $this->handle = curl_multi_init();
         $this->dnsCache = new DnsCache();
+    }
+
+    public function reset()
+    {
+        if ($this->logger) {
+            foreach ($this->pushedResponses as $url => $response) {
+                $this->logger->debug(sprintf('Unused pushed response: "%s"', $url));
+            }
+        }
+
+        $this->pushedResponses = [];
+        $this->dnsCache->evictions = $this->dnsCache->evictions ?: $this->dnsCache->removals;
+        $this->dnsCache->removals = $this->dnsCache->hostnames = [];
+
+        if (\is_resource($this->handle) || $this->handle instanceof \CurlMultiHandle) {
+            if (\defined('CURLMOPT_PUSHFUNCTION')) {
+                curl_multi_setopt($this->handle, \CURLMOPT_PUSHFUNCTION, null);
+            }
+
+            $active = 0;
+            while (\CURLM_CALL_MULTI_PERFORM === curl_multi_exec($this->handle, $active));
+        }
+
+        foreach ($this->openHandles as [$ch]) {
+            if (\is_resource($ch) || $ch instanceof \CurlHandle) {
+                curl_setopt($ch, \CURLOPT_VERBOSE, false);
+            }
+        }
+
+        curl_multi_close($this->handle);
+        $this->handle = curl_multi_init();
+    }
+
+    public function __sleep(): array
+    {
+        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+    }
+
+    public function __wakeup()
+    {
+        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+    }
+
+    public function __destruct()
+    {
+        $this->reset();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44198
| License       | MIT
| Doc PR        | -

Only 4.4 is affected, this borrows from 5.3.