### PR TITLE
[Process] exclude argv/argc from possible default env vars

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1673,6 +1673,7 @@ class Process implements \IteratorAggregate
     {
         $env = getenv();
         $env = array_intersect_key($env, $_SERVER) ?: $env;
+        unset($env['argc'], $env['argv']);
 
         foreach ($_ENV as $k => $v) {
             if (\is_string($v)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44197
| License       | MIT
| Doc PR        | -

For some reason `getenv()` can contain these special keys.
Looks a lot like #7196