### PR TITLE
[Console] Make CompletionSuggestions final

### DIFF
--- a/src/Symfony/Component/Console/Completion/CompletionSuggestions.php
+++ b/src/Symfony/Component/Console/Completion/CompletionSuggestions.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputOption;
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-class CompletionSuggestions
+final class CompletionSuggestions
 {
     private $valueSuggestions = [];
     private $optionSuggestions = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

A very late call, but I suddenly realized we have to do something with the `CompletionSuggestions` class to not cut ourselves in the fingers for 6.1.

**The problem**: `suggestValues()` currently only allows `string` values. ZSH and FISH shells can have much more advanced completion support - also allowing descriptions for instance. Instead of making the completion integration shell specific, it is better to allow a `DecoratedSuggestion` or something like that, like [suggested by @GromNaN in the ZSH PR](https://github.com/symfony/symfony/pull/43970/files#r746660919)

We won't add zsh/fish support in Symfony <6.1, so we must allow ourselves to widen the argument type in Symfony 6.1.

Another option is to add the basic `DecoratedSuggestion` and widen this argument type in Symfony 5.4 already, without immediately using its power.