### PR TITLE
[Cache] Improve the performance of tag invalidation

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -116,14 +116,18 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
      */
     public function invalidateTags(array $tags)
     {
-        $ids = [];
+        $ids = $tagsToUpdate = [];
         foreach ($tags as $tag) {
             \assert('' !== CacheItem::validateKey($tag));
             unset($this->knownTagVersions[$tag]);
             $ids[] = $tag.static::TAGS_PREFIX;
         }
 
-        return !$tags || $this->tags->deleteItems($ids);
+        foreach ($this->tags->getItems($ids) as $tag => $version) {
+            $tagsToUpdate[$tag] = $version->set($newVersion ?? $newVersion = random_int(\PHP_INT_MIN, \PHP_INT_MAX));
+        }
+
+        return !$tagsToUpdate || (self::$saveTags)($this->tags, $tagsToUpdate) || $this->tags->deleteItems($ids);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR is a follow-up to #44015.

The change of tag invalidation algorithm has impact on performance because of possible mutual overwrites of tags and calculated values. The degree of impact mainly depends on the number of concurrent processes which access the same keys so the issue is greatly mitigated by `LockRegistry` in `get()` and the cache of known tag versions but in case of plain PSR-6 operations, the rate of writes may increase many times.

The main purpose of changeing the algorithm was prevention of tag invalidation losses, and it do its job flawlessly, but for the sake of performance I think we should consider the hybrid algorithm: update tag versions if possible or delete them if the pool rejects updates. It looks like a good compromise to me.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
