### PR TITLE
[String] Add conflict with symfony/translation-contracts >= 3

### DIFF
--- a/src/Symfony/Component/String/composer.json
+++ b/src/Symfony/Component/String/composer.json
@@ -29,6 +29,9 @@
         "symfony/translation-contracts": "^1.1|^2",
         "symfony/var-exporter": "^4.4|^5.0|^6.0"
     },
+    "conflict": {
+        "symfony/translation-contracts": ">=3.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\String\\": "" },
         "files": [ "Resources/functions.php" ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Got the following issue this morning in symfony 5.4-RC1 with php 8.1:
```
!!  
!!  Fatal error: Declaration of Symfony\Component\String\Slugger\AsciiSlugger::getLocale() must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::getLocale(): string in /opt/project/vendor/symfony/string/Slugger/AsciiSlugger.php on line 93
!!  Symfony\Component\ErrorHandler\Error\FatalError {#6153
!!    #message: "Compile Error: Declaration of Symfony\Component\String\Slugger\AsciiSlugger::getLocale() must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::getLocale(): string"
!!    #code: 0
!!    #file: "./vendor/symfony/string/Slugger/AsciiSlugger.php"
!!    #line: 93
!!    -error: array:4 [
!!      "type" => 64
!!      "message" => "Declaration of Symfony\Component\String\Slugger\AsciiSlugger::getLocale() must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::getLocale(): string"
!!      "file" => "/opt/project/vendor/symfony/string/Slugger/AsciiSlugger.php"
!!      "line" => 93
!!    ]
!!  }
!!  
```
This PR fixed the error on my side.
