### PR TITLE
[Processor] Fix environment string value problem

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -339,9 +339,11 @@ class Process implements \IteratorAggregate
         }
 
         $envPairs = [];
-        foreach ($env as $k => $v) {
-            if (false !== $v && 'argc' !== $k && 'argv' !== $k) {
-                $envPairs[] = $k.'='.$v;
+        if(\is_array($env)){
+            foreach ($env as $k => $v) {
+                if (false !== $v && 'argc' !== $k && 'argv' !== $k) {
+                    $envPairs[] = $k.'='.$v;
+                }
             }
         }
 


### PR DESCRIPTION
Some libs send $env argument as string

| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #44197
| License       | MIT

Sometimes environment come as string, generally from old libraries
