### PR TITLE
[Security] AccountStatusException::$user should be nullable

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -27,7 +27,7 @@ abstract class AccountStatusException extends AuthenticationException
     /**
      * Get the user.
      *
-     * @return UserInterface
+     * @return UserInterface|null
      */
     public function getUser()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      |  yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR fix error when throw an excepion extending `AccountStatusException` (`CustomUserMessageAccountStatusException` for example)

```php
Error: Typed property Symfony\Component\Security\Core\Exception\AccountStatusException::$user must not be accessed before initialization
```
