### PR TITLE
[HttpFoundation] Correct const FORWARDED_PARAMS

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -225,7 +225,7 @@ class Request
         self::HEADER_X_FORWARDED_FOR => 'for',
         self::HEADER_X_FORWARDED_HOST => 'host',
         self::HEADER_X_FORWARDED_PROTO => 'proto',
-        self::HEADER_X_FORWARDED_PORT => 'host',
+        self::HEADER_X_FORWARDED_PORT => 'port',
     ];
 
     /**


### PR DESCRIPTION
correct a wrongly x-forwarded-port value

| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features / 4.4 or 5.3 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT


