### PR TITLE
[Form] Allow `int` in `Form::add`

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -803,7 +803,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
     /**
      * {@inheritdoc}
      */
-    public function add(FormInterface|string $child, string $type = null, array $options = []): static
+    public function add(FormInterface|string|int $child, string $type = null, array $options = []): static
     {
         if ($this->submitted) {
             throw new AlreadySubmittedException('You cannot add children to a submitted form.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

Here in the same function, there is this check:

https://github.com/symfony/symfony/blob/c7d7c357432033faa981259978307fcd0bb8c985/src/Symfony/Component/Form/Form.php#L816-L819

The problem is that using strict types and `CollectionType` it throws a `TypeError` because it adds the data as array with integer keys and then the `FormResizerListener` re-add them for ordering:

https://github.com/symfony/symfony/blob/c7d7c357432033faa981259978307fcd0bb8c985/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php#L72-L77

here `$name` is an int.

Or the `FormResizerListener` should cast the `$name` to `string`.