### PR TITLE
[DoctrineBridge] Revert " add support for the JSON type"

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -189,7 +189,6 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                         case self::$useDeprecatedConstants ? DBALType::TARRAY : Types::ARRAY:
                         // no break
                         case 'json_array':
-                        case 'json':
                             return [new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true)];
 
                         case self::$useDeprecatedConstants ? DBALType::SIMPLE_ARRAY : Types::SIMPLE_ARRAY:
@@ -317,7 +316,6 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
             case self::$useDeprecatedConstants ? DBALType::SIMPLE_ARRAY : Types::SIMPLE_ARRAY:
             // no break
             case 'json_array':
-            case 'json':
                 return Type::BUILTIN_TYPE_ARRAY;
         }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -254,11 +254,11 @@ class DoctrineExtractorTest extends TestCase
                 new Type(Type::BUILTIN_TYPE_INT),
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, DoctrineRelation::class)
             )]],
-            ['json', [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)]],
+            ['json', null],
         ];
 
         if (class_exists(Types::class)) {
-            $provider[] = ['json', [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)]];
+            $provider[] = ['json', null];
         }
 
         return $provider;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This reverts commit 1e218c5a6aa684ea2ebd15b7b6635de5d8af58b9 (#43988).

As pointed out by @stof and @fancyweb on Slack, my patch is not in sync with Doctrine's code. Contrary to what is stated in the docs, Doctrine allows (almost) any PHP type to be stored as JSON. I also fixed the documentation of Doctrine: https://github.com/doctrine/dbal/pull/5022