### PR TITLE
[SecurityBundle] Display the inherited roles of the logged-in user in the WDT

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -3,7 +3,9 @@ CHANGELOG
 
 6.1
 ---
-* The `security.access_control` now accepts a `RequestMatcherInterface` under the `request_matcher` option as scope configuration
+
+ * The `security.access_control` now accepts a `RequestMatcherInterface` under the `request_matcher` option as scope configuration
+ * Display the inherited roles of the logged-in user in the Web Debug Toolbar
 
 6.0
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -46,6 +46,26 @@
                             </span>
                         </div>
 
+                        {% if collector.supportsRoleHierarchy %}
+                            <div class="sf-toolbar-info-piece">
+                                <b>Inherited Roles</b>
+                                <span>
+                                    {% if collector.inheritedRoles is empty %}
+                                        none
+                                    {% else %}
+                                        {% set remainingRoles = collector.inheritedRoles|slice(1) %}
+                                        {{ collector.inheritedRoles|first }}
+                                        {% if remainingRoles is not empty %}
+                                            +
+                                            <abbr title="{{ remainingRoles|join(', ') }}">
+                                                {{ remainingRoles|length }} more
+                                            </abbr>
+                                        {% endif %}
+                                    {% endif %}
+                                </span>
+                            </div>
+                        {% endif %}
+
                         <div class="sf-toolbar-info-piece">
                             <b>Token class</b>
                             <span>{{ collector.tokenClass|abbr_class }}</span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Hi,

As suggested on Slack by Javier it would be interesting to see inherited roles in the WDT to debug quickly.

[Edit] Aaaand the screenshot :)

![screenshot-wdt](https://user-images.githubusercontent.com/3929498/143581726-c400191d-734a-486d-aed1-03749dc12347.png)