### PR TITLE
[Messenger][AmazonSqs] Add test for default queue_name when not set in DSN path or options

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -100,6 +100,15 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testQueueNameDefault()
+    {
+        $httpClient = new MockHttpClient();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'messages'], new SqsClient(['region' => 'us-east-2', 'accessKeyId' => 'key_dsn', 'accessKeySecret' => 'secret_dsn'], null, $httpClient)),
+            Connection::fromDsn('sqs://key_dsn:secret_dsn@default/?region=us-east-2', ['region' => 'eu-west-3', 'access_key' => 'key_option', 'secret_key' => 'secret_option'], $httpClient)
+        );
+    }
+
     public function testFromDsnWithRegion()
     {
         $httpClient = new MockHttpClient();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44254 
| License       | MIT

Suggesting to change the precedence of `queue_name` option to `config -> DSN -> default ("messages")` instead of current `DSN -> config -> default ("messages")`