### PR TITLE
[Messenger] Add consumer strategy for poll mechanism of receivers

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -80,7 +80,7 @@ class ConsumeMessagesCommand extends Command
                 new InputOption('bus', 'b', InputOption::VALUE_REQUIRED, 'Name of the bus to which received messages should be dispatched (if not passed, bus is determined automatically)'),
                 new InputOption('queues', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Limit receivers to only consume from the specified queues'),
                 new InputOption('no-reset', null, InputOption::VALUE_NONE, 'Do not reset container services after each message'),
-                new InputOption('strategy', null, InputOption::VALUE_REQUIRED, 'The strategy to use to consume from the different receivers: "priority", "ordered", "random"', 'priority'),
+                new InputOption('strategy', null, InputOption::VALUE_REQUIRED, 'The strategy to use to consume from the different receivers: "priority", "ordered" or "random"', 'priority'),
             ])
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command consumes messages and dispatches them to the message bus.

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -215,7 +215,7 @@ EOF
 
         $bus = $input->getOption('bus') ? $this->routableBus->getMessageBus($input->getOption('bus')) : $this->routableBus;
         $strategies = ['priority', 'ordered', 'random'];
-        if (! in_array($input->getOption('strategy'), $strategies, true)) {
+        if (!\in_array($input->getOption('strategy'), $strategies, true)) {
             throw new InvalidArgumentException(sprintf('The "%s" strategy does not exist. Available strategies are: "%s".', $input->getOption('strategy'), implode('", "', $strategies)));
         }
 

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -98,7 +98,7 @@ class Worker
             $envelopeHandled = false;
             $envelopeHandledStart = microtime(true);
             $receivers = $this->receivers;
-            $receivers = $options['strategy'] === self::STRATEGY_RANDOM ? shuffle($receivers) : $receivers;
+            $receivers = self::STRATEGY_RANDOM === $options['strategy'] ? shuffle($receivers) : $receivers;
             foreach ($this->receivers as $transportName => $receiver) {
                 if ($queueNames) {
                     $envelopes = $receiver->getFromQueues($queueNames);
@@ -120,7 +120,7 @@ class Worker
                 // after handling a single receiver, quit and start the loop again
                 // this should prevent multiple lower priority receivers from
                 // blocking too long before the higher priority are checked
-                if ($envelopeHandled && $options['strategy'] === self::STRATEGY_PRIORITY) {
+                if ($envelopeHandled && self::STRATEGY_PRIORITY === $options['strategy']) {
                     break;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets | no
| License | MIT
| Doc PR | not yet

When using Symfony messenger to consume messages, the default behaviour is to poll each receiver in order. If a receiver has returned messages that were handled, the loop starts to poll the first receiver again. With a comment at the logic stating:

> after handling a single receiver, quit and start the loop again
> this should prevent multiple lower priority receivers from
> blocking too long before the higher priority are checked

Which makes sense, if you have high and low priority receivers. But I've often found the need for equal polling of receivers, when they don't have different priorities. In that case it is not desired to keep receiving from the first receiver as long as it is returning messages. But to poll each receiver in order. 

A random order could also be beneficial for load-balancing. E.g. If you have 2 consumers polling the same receivers in order, and they'd start at the same time, the receivers that are last to be polled will have a handling delay. Until the consumers happen to diverge. But if the order of receivers is randomized, each receiver would likely have less delays between polling. 

A `--strategy=priority|ordered|random` command option (and worker option) could expose this as a feature.  I'm curious about the thoughts on this.

I have not yet added a changelog line (or tests) as I'd first like to get input on this idea as a concept. 
