### PR TITLE
[Serializer] fix support for lazy/unset properties

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -385,6 +385,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         $result = self::RESULT_PROTO;
         $object = $zval[self::VALUE];
+        $class = \get_class($object);
         $access = $this->getReadAccessInfo(\get_class($object), $property);
 
         try {
@@ -406,6 +407,11 @@ class PropertyAccessor implements PropertyAccessorInterface
                     throw $e;
                 }
             } elseif (self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]) {
+                $name = $access[self::ACCESS_NAME];
+                if (!method_exists($object, '__get') && !isset($object->$name) && !\array_key_exists($name, (array) $object) && (\PHP_VERSION_ID < 70400 || !(new \ReflectionProperty($class, $name))->hasType())) {
+                    throw new AccessException(sprintf('The property "%s::$%s" is not initialized.', $class, $name));
+                }
+
                 $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]};
 
                 if ($access[self::ACCESS_REF] && isset($zval[self::REF])) {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -181,7 +182,23 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 continue;
             }
 
-            $attributeValue = $this->getAttributeValue($object, $attribute, $format, $context);
+            try {
+                $attributeValue = $this->getAttributeValue($object, $attribute, $format, $context);
+            } catch (AccessException $e) {
+                if (sprintf('The property "%s::$%s" is not initialized.', \get_class($object), $attribute) === $e->getMessage()) {
+                    continue;
+                }
+                if (($p = $e->getPrevious()) && 'Error' === \get_class($p) && $this->isUninitializedValueError($p)) {
+                    continue;
+                }
+                throw $e;
+            } catch (\Error $e) {
+                if ($this->isUninitializedValueError($e)) {
+                    continue;
+                }
+                throw $e;
+            }
+
             if ($maxDepthReached) {
                 $attributeValue = $maxDepthHandler($attributeValue, $object, $attribute, $format, $context);
             }
@@ -636,5 +653,16 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             // The context cannot be serialized, skip the cache
             return false;
         }
+    }
+
+    /**
+     * This error may occur when specific object normalizer implementation gets attribute value
+     * by accessing a public uninitialized property or by calling a method accessing such property.
+     */
+    private function isUninitializedValueError(\Error $e): bool
+    {
+        return \PHP_VERSION_ID >= 70400
+            && str_starts_with($e->getMessage(), 'Typed property')
+            && str_ends_with($e->getMessage(), 'must not be accessed before initialization');
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -104,16 +104,8 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         }
 
         // properties
-        $propertyValues = !method_exists($object, '__get') ? (array) $object : null;
         foreach ($reflClass->getProperties() as $reflProperty) {
-            if (null !== $propertyValues && !\array_key_exists($reflProperty->name, $propertyValues)) {
-                if ($reflProperty->isPublic()
-                    || ($reflProperty->isProtected() && !\array_key_exists("\0*\0{$reflProperty->name}", $propertyValues))
-                    || ($reflProperty->isPrivate() && !\array_key_exists("\0{$reflProperty->class}\0{$reflProperty->name}", $propertyValues))
-                ) {
-                    unset($attributes[$reflProperty->name]);
-                }
-
+            if (!$reflProperty->isPublic()) {
                 continue;
             }
 

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -29,7 +29,7 @@
         "symfony/error-handler": "^4.4|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
         "symfony/mime": "^4.4|^5.0",
-        "symfony/property-access": "^3.4.41|^4.4.9|^5.0.9",
+        "symfony/property-access": "^4.4.36|^5.3.13",
         "symfony/property-info": "^3.4.13|~4.0|^5.0",
         "symfony/validator": "^3.4|^4.0|^5.0",
         "symfony/yaml": "^3.4|^4.0|^5.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44273 #44283
| License       | MIT
| Doc PR        | -

This basically backports #43469 into 4.4, which is the way to go to fix #44273.
The code that exists to handle uninitialized properties is broken anyway (it was before the recent changes.)