### PR TITLE
[Workflow] Allow use of UnitEnum and BackedEnum in workflow places

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -396,7 +396,24 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                     ->arrayNode('initial_marking')
                                         ->beforeNormalization()->castToArray()->end()
-                                        ->defaultValue([])
+                                        ->beforeNormalization()
+                                            ->ifTrue(function ($v) {
+                                                foreach ($v as $value) {
+                                                    if (!is_scalar($value) && !$value instanceof \UnitEnum) {
+                                                        return true;
+                                                    }
+                                                }
+
+                                                return false;
+                                            })
+                                            ->thenInvalid('Initial marking must either be a scalar or an UnitEnum.')
+                                        ->end()
+                                        ->beforeNormalization()
+                                            ->always()
+                                            ->then(function ($places) {
+                                                return array_map(static fn ($element) => $element instanceof \UnitEnum ? \get_class($element).'::'.$element->name : $element, $places);
+                                            })
+                                        ->end()
                                         ->prototype('scalar')->end()
                                     ->end()
                                     ->variableNode('events_to_dispatch')
@@ -431,9 +448,9 @@ class Configuration implements ConfigurationInterface
                                             ->always()
                                             ->then(function ($places) {
                                                 // It's an indexed array of shape  ['place1', 'place2']
-                                                if (isset($places[0]) && \is_string($places[0])) {
-                                                    return array_map(function (string $place) {
-                                                        return ['name' => $place];
+                                                if (isset($places[0]) && (\is_string($places[0]) || $places[0] instanceof \UnitEnum)) {
+                                                    return array_map(function (string|\UnitEnum $place) {
+                                                        return ['name' => $place instanceof \UnitEnum ? \get_class($place).'::'.$place->name : $place];
                                                     }, $places);
                                                 }
 
@@ -505,9 +522,24 @@ class Configuration implements ConfigurationInterface
                                                     ->example('is_fully_authenticated() and is_granted(\'ROLE_JOURNALIST\') and subject.getTitle() == \'My first article\'')
                                                 ->end()
                                                 ->arrayNode('from')
+                                                    ->beforeNormalization()->castToArray()->end()
                                                     ->beforeNormalization()
-                                                        ->ifString()
-                                                        ->then(function ($v) { return [$v]; })
+                                                        ->ifTrue(function ($v) {
+                                                            foreach ($v as $value) {
+                                                                if (!is_scalar($value) && !$value instanceof \UnitEnum) {
+                                                                    return true;
+                                                                }
+                                                            }
+
+                                                            return false;
+                                                        })
+                                                        ->thenInvalid('"From" places must either be scalars or UnitEnum.')
+                                                    ->end()
+                                                    ->beforeNormalization()
+                                                        ->always()
+                                                        ->then(function ($places) {
+                                                            return array_map(static fn ($element) => $element instanceof \UnitEnum ? \get_class($element).'::'.$element->name : $element, $places);
+                                                        })
                                                     ->end()
                                                     ->requiresAtLeastOneElement()
                                                     ->prototype('scalar')
@@ -515,9 +547,24 @@ class Configuration implements ConfigurationInterface
                                                     ->end()
                                                 ->end()
                                                 ->arrayNode('to')
+                                                    ->beforeNormalization()->castToArray()->end()
                                                     ->beforeNormalization()
-                                                        ->ifString()
-                                                        ->then(function ($v) { return [$v]; })
+                                                        ->ifTrue(function ($v) {
+                                                            foreach ($v as $value) {
+                                                                if (!is_scalar($value) && !$value instanceof \UnitEnum) {
+                                                                    return true;
+                                                                }
+                                                            }
+
+                                                            return false;
+                                                        })
+                                                        ->thenInvalid('"To" places must either be scalars or UnitEnum.')
+                                                    ->end()
+                                                    ->beforeNormalization()
+                                                        ->always()
+                                                        ->then(function ($places) {
+                                                            return array_map(static fn ($element) => $element instanceof \UnitEnum ? \get_class($element).'::'.$element->name : $element, $places);
+                                                        })
                                                     ->end()
                                                     ->requiresAtLeastOneElement()
                                                     ->prototype('scalar')

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Allow use of UnitEnum and BackedEnum in workflow places
+
 6.0
 ---
 

--- a/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
+++ b/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Workflow\EventListener;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\Event;
+use Symfony\Component\Workflow\Utils\PlaceEnumerationUtils;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
@@ -30,7 +31,7 @@ class AuditTrailListener implements EventSubscriberInterface
     public function onLeave(Event $event)
     {
         foreach ($event->getTransition()->getFroms() as $place) {
-            $this->logger->info(sprintf('Leaving "%s" for subject of class "%s" in workflow "%s".', $place, \get_class($event->getSubject()), $event->getWorkflowName()));
+            $this->logger->info(sprintf('Leaving "%s" for subject of class "%s" in workflow "%s".', PlaceEnumerationUtils::getPlaceKey($place), \get_class($event->getSubject()), $event->getWorkflowName()));
         }
     }
 
@@ -42,7 +43,7 @@ class AuditTrailListener implements EventSubscriberInterface
     public function onEnter(Event $event)
     {
         foreach ($event->getTransition()->getTos() as $place) {
-            $this->logger->info(sprintf('Entering "%s" for subject of class "%s" in workflow "%s".', $place, \get_class($event->getSubject()), $event->getWorkflowName()));
+            $this->logger->info(sprintf('Entering "%s" for subject of class "%s" in workflow "%s".', PlaceEnumerationUtils::getPlaceKey($place), \get_class($event->getSubject()), $event->getWorkflowName()));
         }
     }
 

--- a/src/Symfony/Component/Workflow/Marking.php
+++ b/src/Symfony/Component/Workflow/Marking.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Workflow;
 
+use Symfony\Component\Workflow\Utils\PlaceEnumerationUtils;
+
 /**
  * Marking contains the place of every tokens.
  *
@@ -22,33 +24,44 @@ class Marking
     private ?array $context = null;
 
     /**
-     * @param int[] $representation Keys are the place name and values should be 1
+     * @param int[]|\UnitEnum[] $representation Keys are the place name and values should be 1, unless UnitEnums
+     *                                          are used as workflow places
      */
     public function __construct(array $representation = [])
     {
-        foreach ($representation as $place => $nbToken) {
-            $this->mark($place);
+        foreach ($representation as $place => $token) {
+            $this->mark($token instanceof \UnitEnum ? $token : $place);
         }
     }
 
-    public function mark(string $place)
+    public function mark(string|\UnitEnum $place)
     {
-        $this->places[$place] = 1;
+        $this->places[PlaceEnumerationUtils::getPlaceKey($place)] = 1;
     }
 
-    public function unmark(string $place)
+    public function unmark(string|\UnitEnum $place)
     {
-        unset($this->places[$place]);
+        unset($this->places[PlaceEnumerationUtils::getPlaceKey($place)]);
     }
 
-    public function has(string $place)
+    public function has(string|\UnitEnum $place)
     {
-        return isset($this->places[$place]);
+        return isset($this->places[PlaceEnumerationUtils::getPlaceKey($place)]);
     }
 
     public function getPlaces()
     {
-        return $this->places;
+        $places = [];
+        foreach ($this->places as $key => $value) {
+            $typedKey = PlaceEnumerationUtils::getTypedValue($key);
+            if ($typedKey instanceof \UnitEnum) {
+                $places[$key] = $typedKey;
+            } else {
+                $places[$typedKey] = 1;
+            }
+        }
+
+        return $places;
     }
 
     /**

--- a/src/Symfony/Component/Workflow/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DefinitionTest.php
@@ -5,11 +5,12 @@ namespace Symfony\Component\Workflow\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Exception\LogicException;
+use Symfony\Component\Workflow\Tests\fixtures\FooEnum;
 use Symfony\Component\Workflow\Transition;
 
 class DefinitionTest extends TestCase
 {
-    public function testAddPlaces()
+    public function testAddPlacesAsString()
     {
         $places = range('a', 'e');
         $definition = new Definition($places, []);
@@ -19,7 +20,20 @@ class DefinitionTest extends TestCase
         $this->assertEquals(['a'], $definition->getInitialPlaces());
     }
 
-    public function testSetInitialPlace()
+    /**
+     * @requires PHP 8.1
+     */
+    public function testAddPlacesAsEnum()
+    {
+        $places = FooEnum::cases();
+        $definition = new Definition($places, []);
+
+        $this->assertCount(\count(FooEnum::cases()), $definition->getPlaces());
+
+        $this->assertEquals([FooEnum::Bar], $definition->getInitialPlaces());
+    }
+
+    public function testSetInitialPlaceAsString()
     {
         $places = range('a', 'e');
         $definition = new Definition($places, [], $places[3]);
@@ -27,7 +41,18 @@ class DefinitionTest extends TestCase
         $this->assertEquals([$places[3]], $definition->getInitialPlaces());
     }
 
-    public function testSetInitialPlaces()
+    /**
+     * @requires PHP 8.1
+     */
+    public function testSetInitialPlaceAsEnum()
+    {
+        $places = FooEnum::cases();
+        $definition = new Definition($places, [], FooEnum::Baz);
+
+        $this->assertEquals([FooEnum::Baz], $definition->getInitialPlaces());
+    }
+
+    public function testSetInitialPlacesAsString()
     {
         $places = range('a', 'e');
         $definition = new Definition($places, [], ['a', 'e']);
@@ -35,14 +60,35 @@ class DefinitionTest extends TestCase
         $this->assertEquals(['a', 'e'], $definition->getInitialPlaces());
     }
 
-    public function testSetInitialPlaceAndPlaceIsNotDefined()
+    /**
+     * @requires PHP 8.1
+     */
+    public function testSetInitialPlacesAsEnum()
+    {
+        $places = FooEnum::cases();
+        $definition = new Definition($places, [], [FooEnum::Bar, FooEnum::Qux]);
+
+        $this->assertEquals([FooEnum::Bar, FooEnum::Qux], $definition->getInitialPlaces());
+    }
+
+    public function testSetInitialPlaceAsStringAndPlaceIsNotDefined()
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Place "d" cannot be the initial place as it does not exist.');
         new Definition([], [], 'd');
     }
 
-    public function testAddTransition()
+    /**
+     * @requires PHP 8.1
+     */
+    public function testSetInitialPlaceAsEnumAndPlaceIsNotDefined()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Place "Symfony\Component\Workflow\Tests\fixtures\FooEnum::Bar" cannot be the initial place as it does not exist.');
+        new Definition([], [], FooEnum::Bar);
+    }
+
+    public function testAddTransitionWithStringPlaces()
     {
         $places = range('a', 'b');
 
@@ -53,7 +99,21 @@ class DefinitionTest extends TestCase
         $this->assertSame($transition, $definition->getTransitions()[0]);
     }
 
-    public function testAddTransitionAndFromPlaceIsNotDefined()
+    /**
+     * @requires PHP 8.1
+     */
+    public function testAddTransitionWithEnumPlaces()
+    {
+        $places = FooEnum::cases();
+
+        $transition = new Transition('name', $places[0], $places[1]);
+        $definition = new Definition($places, [$transition]);
+
+        $this->assertCount(1, $definition->getTransitions());
+        $this->assertSame($transition, $definition->getTransitions()[0]);
+    }
+
+    public function testAddTransitionAndFromPlaceAsStringIsNotDefined()
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Place "c" referenced in transition "name" does not exist.');
@@ -62,12 +122,36 @@ class DefinitionTest extends TestCase
         new Definition($places, [new Transition('name', 'c', $places[1])]);
     }
 
-    public function testAddTransitionAndToPlaceIsNotDefined()
+    /**
+     * @requires PHP 8.1
+     */
+    public function testAddTransitionAndFromPlaceAsEnumIsNotDefined()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Place "Symfony\Component\Workflow\Tests\fixtures\FooEnum::Qux" referenced in transition "name" does not exist.');
+        $places = [FooEnum::Bar, FooEnum::Baz];
+
+        new Definition($places, [new Transition('name', FooEnum::Qux, $places[1])]);
+    }
+
+    public function testAddTransitionAndToPlaceAsStringIsNotDefined()
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Place "c" referenced in transition "name" does not exist.');
         $places = range('a', 'b');
 
         new Definition($places, [new Transition('name', $places[0], 'c')]);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testAddTransitionAndToPlaceAsEnumIsNotDefined()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Place "Symfony\Component\Workflow\Tests\fixtures\FooEnum::Qux" referenced in transition "name" does not exist.');
+        $places = [FooEnum::Bar, FooEnum::Baz];
+
+        new Definition($places, [new Transition('name', $places[0], FooEnum::Qux)]);
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/EventListener/AuditTrailListenerTest.php
+++ b/src/Symfony/Component/Workflow/Tests/EventListener/AuditTrailListenerTest.php
@@ -15,7 +15,7 @@ class AuditTrailListenerTest extends TestCase
 {
     use WorkflowBuilderTrait;
 
-    public function testItWorks()
+    public function testItWorksWithStrings()
     {
         $definition = $this->createSimpleWorkflowDefinition();
 
@@ -34,6 +34,33 @@ class AuditTrailListenerTest extends TestCase
             'Leaving "a" for subject of class "Symfony\Component\Workflow\Tests\Subject" in workflow "unnamed".',
             'Transition "t1" for subject of class "Symfony\Component\Workflow\Tests\Subject" in workflow "unnamed".',
             'Entering "b" for subject of class "Symfony\Component\Workflow\Tests\Subject" in workflow "unnamed".',
+        ];
+
+        $this->assertSame($expected, $logger->logs);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testItWorksWithEnumerations()
+    {
+        $definition = $this->createSimpleWorkflowDefinition(true);
+
+        $object = new Subject();
+
+        $logger = new Logger();
+
+        $ed = new EventDispatcher();
+        $ed->addSubscriber(new AuditTrailListener($logger));
+
+        $workflow = new Workflow($definition, new MethodMarkingStore(), $ed);
+
+        $workflow->apply($object, 't1');
+
+        $expected = [
+            'Leaving "Symfony\Component\Workflow\Tests\fixtures\AlphabeticalEnum::A" for subject of class "Symfony\Component\Workflow\Tests\Subject" in workflow "unnamed".',
+            'Transition "t1" for subject of class "Symfony\Component\Workflow\Tests\Subject" in workflow "unnamed".',
+            'Entering "Symfony\Component\Workflow\Tests\fixtures\AlphabeticalEnum::B" for subject of class "Symfony\Component\Workflow\Tests\Subject" in workflow "unnamed".',
         ];
 
         $this->assertSame($expected, $logger->logs);

--- a/src/Symfony/Component/Workflow/Tests/MarkingTest.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingTest.php
@@ -4,10 +4,11 @@ namespace Symfony\Component\Workflow\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Tests\fixtures\FooEnum;
 
 class MarkingTest extends TestCase
 {
-    public function testMarking()
+    public function testMarkingWithPlacesAsString()
     {
         $marking = new Marking(['a' => 1]);
 
@@ -31,6 +32,36 @@ class MarkingTest extends TestCase
 
         $this->assertFalse($marking->has('a'));
         $this->assertFalse($marking->has('b'));
+        $this->assertSame([], $marking->getPlaces());
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testMarkingWithPlacesAsEnumerations()
+    {
+        $marking = new Marking([FooEnum::Bar]);
+
+        $this->assertTrue($marking->has(FooEnum::Bar));
+        $this->assertFalse($marking->has(FooEnum::Baz));
+        $this->assertSame(['Symfony\Component\Workflow\Tests\fixtures\FooEnum::Bar' => FooEnum::Bar], $marking->getPlaces());
+
+        $marking->mark(FooEnum::Baz);
+
+        $this->assertTrue($marking->has(FooEnum::Bar));
+        $this->assertTrue($marking->has(FooEnum::Baz));
+        $this->assertSame(['Symfony\Component\Workflow\Tests\fixtures\FooEnum::Bar' => FooEnum::Bar, 'Symfony\Component\Workflow\Tests\fixtures\FooEnum::Baz' => FooEnum::Baz], $marking->getPlaces());
+
+        $marking->unmark(FooEnum::Bar);
+
+        $this->assertFalse($marking->has(FooEnum::Bar));
+        $this->assertTrue($marking->has(FooEnum::Baz));
+        $this->assertSame(['Symfony\Component\Workflow\Tests\fixtures\FooEnum::Baz' => FooEnum::Baz], $marking->getPlaces());
+
+        $marking->unmark(FooEnum::Baz);
+
+        $this->assertFalse($marking->has(FooEnum::Bar));
+        $this->assertFalse($marking->has(FooEnum::Baz));
         $this->assertSame([], $marking->getPlaces());
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/TransitionTest.php
+++ b/src/Symfony/Component/Workflow/Tests/TransitionTest.php
@@ -3,16 +3,29 @@
 namespace Symfony\Component\Workflow\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Tests\fixtures\FooEnum;
 use Symfony\Component\Workflow\Transition;
 
 class TransitionTest extends TestCase
 {
-    public function testConstructor()
+    public function testConstructorWithStrings()
     {
         $transition = new Transition('name', 'a', 'b');
 
         $this->assertSame('name', $transition->getName());
         $this->assertSame(['a'], $transition->getFroms());
         $this->assertSame(['b'], $transition->getTos());
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testConstructorWithEnumerations()
+    {
+        $transition = new Transition('name', FooEnum::Bar, FooEnum::Baz);
+
+        $this->assertSame('name', $transition->getName());
+        $this->assertSame([FooEnum::Bar], $transition->getFroms());
+        $this->assertSame([FooEnum::Baz], $transition->getTos());
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/Utils/PlaceEnumerationUtilsTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Utils/PlaceEnumerationUtilsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Component\Workflow\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Tests\Fixtures\FooEnum;
+use Symfony\Component\Workflow\Utils\PlaceEnumerationUtils;
+
+class PlaceEnumerationUtilsTest extends TestCase
+{
+    public function testPlaceKey()
+    {
+        $this->assertSame('my_place', PlaceEnumerationUtils::getPlaceKey('my_place'));
+
+        if (\PHP_VERSION_ID >= 80100) {
+            $this->assertSame('Symfony\Component\Workflow\Tests\fixtures\FooEnum::Bar', PlaceEnumerationUtils::getPlaceKey(FooEnum::Bar));
+        }
+    }
+
+    public function testTypedValue()
+    {
+        $this->assertSame('my_place', PlaceEnumerationUtils::getTypedValue('my_place'));
+
+        if (\PHP_VERSION_ID >= 80100) {
+            $this->assertSame(FooEnum::Bar, PlaceEnumerationUtils::getTypedValue('Symfony\Component\Workflow\Tests\fixtures\FooEnum::Bar'));
+        }
+    }
+}

--- a/src/Symfony/Component/Workflow/Tests/fixtures/AlphabeticalEnum.php
+++ b/src/Symfony/Component/Workflow/Tests/fixtures/AlphabeticalEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Workflow\Tests\fixtures;
+
+enum AlphabeticalEnum: string
+{
+    case A = 'a';
+    case B = 'b';
+    case C = 'c';
+    case D = 'd';
+    case E = 'e';
+    case F = 'f';
+    case G = 'g';
+}

--- a/src/Symfony/Component/Workflow/Tests/fixtures/FooEnum.php
+++ b/src/Symfony/Component/Workflow/Tests/fixtures/FooEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Workflow\Tests\fixtures;
+
+enum FooEnum
+{
+    case Bar;
+    case Baz;
+    case Qux;
+}

--- a/src/Symfony/Component/Workflow/Transition.php
+++ b/src/Symfony/Component/Workflow/Transition.php
@@ -25,11 +25,11 @@ class Transition
      * @param string|string[] $froms
      * @param string|string[] $tos
      */
-    public function __construct(string $name, string|array $froms, string|array $tos)
+    public function __construct(string $name, string|\UnitEnum|array $froms, string|\UnitEnum|array $tos)
     {
         $this->name = $name;
-        $this->froms = (array) $froms;
-        $this->tos = (array) $tos;
+        $this->froms = \is_array($froms) ? $froms : [$froms];
+        $this->tos = \is_array($tos) ? $tos : [$tos];
     }
 
     public function getName(): string

--- a/src/Symfony/Component/Workflow/Utils/PlaceEnumerationUtils.php
+++ b/src/Symfony/Component/Workflow/Utils/PlaceEnumerationUtils.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Utils;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+final class PlaceEnumerationUtils
+{
+    public static function getPlaceKey(string|\UnitEnum $place): string
+    {
+        if ($place instanceof \UnitEnum) {
+            return \get_class($place).'::'.$place->name;
+        }
+
+        return $place;
+    }
+
+    public static function getTypedValue(string $place): string|\UnitEnum
+    {
+        try {
+            $value = \constant($place);
+            if ($value instanceof \UnitEnum) {
+                // Assure we actually retrieved an enumeration case and not a constant with a name
+                // that looks like an enumeration.
+                return $value;
+            }
+
+            return $place;
+        } catch (\Throwable) {
+            return $place;
+        }
+    }
+}

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -24,6 +24,7 @@ use Symfony\Component\Workflow\Exception\UndefinedTransitionException;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
 use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
+use Symfony\Component\Workflow\Utils\PlaceEnumerationUtils;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -367,7 +368,7 @@ class Workflow implements WorkflowInterface
             $this->dispatcher->dispatch($event, sprintf('workflow.%s.leave', $this->name));
 
             foreach ($places as $place) {
-                $this->dispatcher->dispatch($event, sprintf('workflow.%s.leave.%s', $this->name, $place));
+                $this->dispatcher->dispatch($event, sprintf('workflow.%s.leave.%s', $this->name, PlaceEnumerationUtils::getPlaceKey($place)));
             }
         }
 
@@ -402,7 +403,7 @@ class Workflow implements WorkflowInterface
             $this->dispatcher->dispatch($event, sprintf('workflow.%s.enter', $this->name));
 
             foreach ($places as $place) {
-                $this->dispatcher->dispatch($event, sprintf('workflow.%s.enter.%s', $this->name, $place));
+                $this->dispatcher->dispatch($event, sprintf('workflow.%s.enter.%s', $this->name, PlaceEnumerationUtils::getPlaceKey($place)));
             }
         }
 
@@ -423,7 +424,7 @@ class Workflow implements WorkflowInterface
         $this->dispatcher->dispatch($event, sprintf('workflow.%s.entered', $this->name));
 
         foreach ($marking->getPlaces() as $placeName => $nbToken) {
-            $this->dispatcher->dispatch($event, sprintf('workflow.%s.entered.%s', $this->name, $placeName));
+            $this->dispatcher->dispatch($event, sprintf('workflow.%s.entered.%s', $this->name, PlaceEnumerationUtils::getPlaceKey($placeName)));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #44203 
| License       | MIT
| Doc PR        | To be done

:information_source: **Meant to be merged on 6.1, waiting for the branch to open.**

One thing should be noted here. Currently, subject marking is done with the following form: `['place_a' => 1, 'place_b' => 1]`, which is **not** possible to reproduce with enumerations. Indeed, you're not allowed to use enumeration cases as array keys.
That's why, when using enumerations, subject marking is stored using a simple list of cases, like `[FooEnum::Bar, FooEnum::Baz]`.
I think this solution is ok, as it seems `$nbToken` (the 1 affected to places in marking) seems to not be used anywhere at this time.