### PR TITLE
[Messenger] Leverage DBAL's getNativeConnection() method

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -73,9 +73,13 @@ final class PostgreSqlConnection extends Connection
             $this->listening = true;
         }
 
-        $wrappedConnection = $this->driverConnection->getWrappedConnection();
-        if (!$wrappedConnection instanceof \PDO && $wrappedConnection instanceof DoctrinePdoConnection) {
-            $wrappedConnection = $wrappedConnection->getWrappedConnection();
+        if (method_exists($this->driverConnection, 'getNativeConnection')) {
+            $wrappedConnection = $this->driverConnection->getNativeConnection();
+        } else {
+            $wrappedConnection = $this->driverConnection->getWrappedConnection();
+            if (!$wrappedConnection instanceof \PDO && $wrappedConnection instanceof DoctrinePdoConnection) {
+                $wrappedConnection = $wrappedConnection->getWrappedConnection();
+            }
         }
 
         $notification = $wrappedConnection->pgsqlGetNotify(\PDO::FETCH_ASSOC, $this->configuration['get_notify_timeout']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Doctrine DBAL 3 introduced a new driver middleware system that makes it difficult to unwrap the native PDO connection which we need for Messenger's Postgres transport. If an application would actually make use of the middleware system, accessing the PDO connection would become impossible for us.

Because of that, I have added a method `getNativeConnection()` to DBAL with doctrine/dbal#5037. This PR leverages this new method.