### PR TITLE
[Cache] Flag component as incompatible with DBAL 4

### DIFF
--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -43,7 +43,7 @@
         "symfony/var-dumper": "^4.4|^5.0"
     },
     "conflict": {
-        "doctrine/dbal": "<2.7",
+        "doctrine/dbal": "<2.7|>=4",
         "symfony/dependency-injection": "<3.4",
         "symfony/http-kernel": "<4.4|>=5.0",
         "symfony/var-dumper": "<4.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

If DBAL 4 would be released in its current state, we can pretty much tell that it would break the cache component. The reason is that we access the driver connection directly to retrieve the database server version.

I think, users of our old LTS can live with the limitation of not being able to work with bleeding edge DBAL branches. 🙂 