### PR TITLE
[Debug][ErrorHandler] Increased the reserved memory from 10k to 32k

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -119,7 +119,7 @@ class ErrorHandler
     public static function register(self $handler = null, $replace = true)
     {
         if (null === self::$reservedMemory) {
-            self::$reservedMemory = str_repeat('x', 10240);
+            self::$reservedMemory = str_repeat('x', 32768);
             register_shutdown_function(__CLASS__.'::handleFatalError');
         }
 

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -111,7 +111,7 @@ class ErrorHandler
     public static function register(self $handler = null, bool $replace = true): self
     {
         if (null === self::$reservedMemory) {
-            self::$reservedMemory = str_repeat('x', 10240);
+            self::$reservedMemory = str_repeat('x', 32768);
             register_shutdown_function(__CLASS__.'::handleFatalError');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40824 
| License       | MIT
| Doc PR        | n/a

The ErrorHandler's job includes handling out of memory (OOM) exceptions,
therefore it is important that that feature works. In the current state,
when handling OOM exceptions, the error handler produces an OOM error
itself, because the old 10kB reserve is apparently not enough anymore.
To mitigate that, the reserved memory gets bumped to 32k (which is enough).

*Note* I'm not familiar with the whole open source submitting process, so any feedback and instructions on how to improve this PR are welcome.
I am not sure on how to write a unit test to test something like that (talking about the issue here https://github.com/symfony/symfony/issues/40824).