### PR TITLE
[Serializer] Remove some type hints for API Platform compatibility

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -875,3 +875,145 @@ index 024da1884e..943790e875 100644
 +    public function getOption(string $name): mixed;
  
      /**
+diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+index b0a1f32..893fe59 100644
+--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
++++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+@@ -222,7 +222,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
+      *
+      * @return string[]|AttributeMetadataInterface[]|bool
+      */
+-    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false)
++    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false): array|bool
+     {
+         $allowExtraAttributes = $context[self::ALLOW_EXTRA_ATTRIBUTES] ?? $this->defaultContext[self::ALLOW_EXTRA_ATTRIBUTES];
+         if (!$this->classMetadataFactory) {
+@@ -272,7 +272,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
+      *
+      * @return bool
+      */
+-    protected function isAllowedAttribute(object|string $classOrObject, string $attribute, string $format = null, array $context = [])
++    protected function isAllowedAttribute(object|string $classOrObject, string $attribute, string $format = null, array $context = []): bool
+     {
+         $ignoredAttributes = $context[self::IGNORED_ATTRIBUTES] ?? $this->defaultContext[self::IGNORED_ATTRIBUTES];
+         if (\in_array($attribute, $ignoredAttributes)) {
+@@ -323,7 +323,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
+      * @throws RuntimeException
+      * @throws MissingConstructorArgumentsException
+      */
+-    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null)
++    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null): object
+     {
+         if (null !== $object = $this->extractObjectToPopulate($class, $context, self::OBJECT_TO_POPULATE)) {
+             unset($context[self::OBJECT_TO_POPULATE]);
+diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+index a241215..c6bcc63 100644
+--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
++++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+@@ -143,7 +143,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+     /**
+      * {@inheritdoc}
+      */
+-    public function normalize(mixed $object, string $format = null, array $context = [])
++    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+     {
+         if (!isset($context['cache_key'])) {
+             $context['cache_key'] = $this->getCacheKey($format, $context);
+@@ -276,7 +276,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+     /**
+      * {@inheritdoc}
+      */
+-    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null)
++    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null): object
+     {
+         if ($this->classDiscriminatorResolver && $mapping = $this->classDiscriminatorResolver->getMappingForClass($class)) {
+             if (!isset($data[$mapping->getTypeProperty()])) {
+@@ -338,19 +338,19 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+      *
+      * @return string[]
+      */
+-    abstract protected function extractAttributes(object $object, string $format = null, array $context = []);
++    abstract protected function extractAttributes(object $object, string $format = null, array $context = []): array;
+ 
+     /**
+      * Gets the attribute value.
+      *
+      * @return mixed
+      */
+-    abstract protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = []);
++    abstract protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = []): mixed;
+ 
+     /**
+      * {@inheritdoc}
+      */
+-    public function supportsDenormalization(mixed $data, string $type, string $format = null)
++    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+     {
+         return class_exists($type) || (interface_exists($type, false) && $this->classDiscriminatorResolver && null !== $this->classDiscriminatorResolver->getMappingForClass($type));
+     }
+@@ -358,7 +358,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+     /**
+      * {@inheritdoc}
+      */
+-    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
++    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+     {
+         if (!isset($context['cache_key'])) {
+             $context['cache_key'] = $this->getCacheKey($format, $context);
+diff --git a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+index 5e94400..726d89c 100644
+--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
++++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+@@ -44,7 +44,7 @@ interface DenormalizerInterface
+      * @throws RuntimeException         Occurs if the class cannot be instantiated
+      * @throws ExceptionInterface       Occurs for all the other cases of errors
+      */
+-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []);
++    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed;
+ 
+     /**
+      * Checks whether the given class is supported for denormalization by this normalizer.
+@@ -55,5 +55,5 @@ interface DenormalizerInterface
+      *
+      * @return bool
+      */
+-    public function supportsDenormalization(mixed $data, string $type, string $format = null);
++    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool;
+ }
+diff --git a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+index fb4bee4..00e8ad0 100644
+--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
++++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+@@ -36,7 +36,7 @@ interface NormalizerInterface
+      * @throws LogicException             Occurs when the normalizer is not called in an expected context
+      * @throws ExceptionInterface         Occurs for all the other cases of errors
+      */
+-    public function normalize(mixed $object, string $format = null, array $context = []);
++    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null;
+ 
+     /**
+      * Checks whether the given class is supported for normalization by this normalizer.
+diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+index c6bcc63..2ed1af7 100644
+--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
++++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+@@ -135,7 +135,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+     /**
+      * {@inheritdoc}
+      */
+-    public function supportsNormalization(mixed $data, string $format = null)
++    public function supportsNormalization(mixed $data, string $format = null): bool
+     {
+         return \is_object($data) && !$data instanceof \Traversable;
+     }
+diff --git a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+index d9f8df9..a7a60ad 100644
+--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
++++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+@@ -46,5 +46,5 @@ interface NormalizerInterface
+      *
+      * @return bool
+      */
+-    public function supportsNormalization(mixed $data, string $format = null);
++    public function supportsNormalization(mixed $data, string $format = null): bool;
+ }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -222,7 +222,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      *
      * @return string[]|AttributeMetadataInterface[]|bool
      */
-    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false): array|bool
+    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false)
     {
         $allowExtraAttributes = $context[self::ALLOW_EXTRA_ATTRIBUTES] ?? $this->defaultContext[self::ALLOW_EXTRA_ATTRIBUTES];
         if (!$this->classMetadataFactory) {
@@ -269,8 +269,10 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
     /**
      * Is this attribute allowed?
+     *
+     * @return bool
      */
-    protected function isAllowedAttribute(object|string $classOrObject, string $attribute, string $format = null, array $context = []): bool
+    protected function isAllowedAttribute(object|string $classOrObject, string $attribute, string $format = null, array $context = [])
     {
         $ignoredAttributes = $context[self::IGNORED_ATTRIBUTES] ?? $this->defaultContext[self::IGNORED_ATTRIBUTES];
         if (\in_array($attribute, $ignoredAttributes)) {
@@ -316,10 +318,12 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      * is removed from the context before being returned to avoid side effects
      * when recursively normalizing an object graph.
      *
+     * @return object
+     *
      * @throws RuntimeException
      * @throws MissingConstructorArgumentsException
      */
-    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null): object
+    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null)
     {
         if (null !== $object = $this->extractObjectToPopulate($class, $context, self::OBJECT_TO_POPULATE)) {
             unset($context[self::OBJECT_TO_POPULATE]);

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -135,7 +135,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null)
     {
         return \is_object($data) && !$data instanceof \Traversable;
     }
@@ -143,7 +143,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $object, string $format = null, array $context = [])
     {
         if (!isset($context['cache_key'])) {
             $context['cache_key'] = $this->getCacheKey($format, $context);
@@ -276,7 +276,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null): object
+    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null)
     {
         if ($this->classDiscriminatorResolver && $mapping = $this->classDiscriminatorResolver->getMappingForClass($class)) {
             if (!isset($data[$mapping->getTypeProperty()])) {
@@ -338,17 +338,19 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      *
      * @return string[]
      */
-    abstract protected function extractAttributes(object $object, string $format = null, array $context = []): array;
+    abstract protected function extractAttributes(object $object, string $format = null, array $context = []);
 
     /**
      * Gets the attribute value.
+     *
+     * @return mixed
      */
-    abstract protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = []): mixed;
+    abstract protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = []);
 
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null)
     {
         return class_exists($type) || (interface_exists($type, false) && $this->classDiscriminatorResolver && null !== $this->classDiscriminatorResolver->getMappingForClass($type));
     }
@@ -356,7 +358,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
     {
         if (!isset($context['cache_key'])) {
             $context['cache_key'] = $this->getCacheKey($format, $context);

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -34,6 +34,8 @@ interface DenormalizerInterface
      * @param string $format  Format the given data was extracted from
      * @param array  $context Options available to the denormalizer
      *
+     * @return mixed
+     *
      * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
      * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported
      * @throws UnexpectedValueException Occurs when the item cannot be hydrated with the given data
@@ -42,7 +44,7 @@ interface DenormalizerInterface
      * @throws RuntimeException         Occurs if the class cannot be instantiated
      * @throws ExceptionInterface       Occurs for all the other cases of errors
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed;
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []);
 
     /**
      * Checks whether the given class is supported for denormalization by this normalizer.
@@ -50,6 +52,8 @@ interface DenormalizerInterface
      * @param mixed  $data   Data to denormalize from
      * @param string $type   The class to which the data should be denormalized
      * @param string $format The format being deserialized from
+     *
+     * @return bool
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool;
+    public function supportsDenormalization(mixed $data, string $type, string $format = null);
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -36,13 +36,15 @@ interface NormalizerInterface
      * @throws LogicException             Occurs when the normalizer is not called in an expected context
      * @throws ExceptionInterface         Occurs for all the other cases of errors
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null;
+    public function normalize(mixed $object, string $format = null, array $context = []);
 
     /**
      * Checks whether the given class is supported for normalization by this normalizer.
      *
      * @param mixed  $data   Data to normalize
      * @param string $format The format being (de-)serialized from or into
+     *
+     * @return bool
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool;
+    public function supportsNormalization(mixed $data, string $format = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43021, https://github.com/api-platform/core/issues/4495
| License       | MIT


Since Symfony 6.0 and the addition of type hinting, API Platform's tests fails. After a talk with @dunglas , we decide to remove some type hinting in the serializer component in order for api-platform to work correctly.
