### PR TITLE
Release v6.0.0

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -7,6 +7,20 @@ in 6.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.0.0...v6.0.1
 
+* 6.0.0 (2021-11-29)
+
+ * bug #44309 [Messenger] Leverage DBAL's getNativeConnection() method (derrabus)
+ * bug #44300 [FrameworkBundle] Fix property-info phpstan extractor discovery (1ed)
+ * feature #44271 [Notifier] add Vonage bridge to replace the Nexmo one (nicolas-grekas)
+ * bug #44187 [Translation] [Loco] Fix idempotency of LocoProvider write method (welcoMattic)
+ * bug #43992 [Security] Do not overwrite already stored tokens for REMOTE_USER authentication (stlrnz)
+ * bug #43876 [Validator] Fix validation for single level domains (HypeMC)
+ * bug #44327 [Debug][ErrorHandler] Increased the reserved memory from 10k to 32k (sakalys)
+ * bug #44261 [Process] intersect with getenv() in case-insensitive manner to get default envs (stable-staple)
+ * bug #44295 [Serializer] fix support for lazy/unset properties (nicolas-grekas)
+ * bug #44277 [Notifier] Fix AllMySms bridge body content (afiocre)
+ * bug #44269 [DoctrineBridge] Revert " add support for the JSON type" (dunglas)
+
 * 6.0.0-RC1 (2021-11-24)
 
  * security #cve-2021-41268 [SecurityBundle] Default signature_properties to the previous behavior (wouterj)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,12 +78,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.0.0-DEV';
+    public const VERSION = '6.0.0';
     public const VERSION_ID = 60000;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 0;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2022';
     public const END_OF_LIFE = '07/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.0.0-RC1...v6.0.0)

 * bug #44309 [Messenger] Leverage DBAL's getNativeConnection() method (@derrabus)
 * bug #44300 [FrameworkBundle] Fix property-info phpstan extractor discovery (@1ed)
 * feature #44271 [Notifier] add Vonage bridge to replace the Nexmo one (@nicolas-grekas)
 * bug #44187 [Translation] [Loco] Fix idempotency of LocoProvider write method (@welcoMattic)
 * bug #43992 [Security] Do not overwrite already stored tokens for REMOTE_USER authentication (@stlrnz)
 * bug #43876 [Validator] Fix validation for single level domains (@HypeMC)
 * bug #44327 [Debug][ErrorHandler] Increased the reserved memory from 10k to 32k (@sakalys)
 * bug #44261 [Process] intersect with getenv() in case-insensitive manner to get default envs (@stable-staple)
 * bug #44295 [Serializer] fix support for lazy/unset properties (@nicolas-grekas)
 * bug #44277 [Notifier] Fix AllMySms bridge body content (@afiocre)
 * bug #44269 [DoctrineBridge] Revert " add support for the JSON type" (@dunglas)
