### PR TITLE
[HttpFoundation] Makes RedisSessionHandler options protected and initialize ttl with session.gc_maxlifetime

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -28,12 +28,12 @@ class RedisSessionHandler extends AbstractSessionHandler
     /**
      * Key prefix for shared environments.
      */
-    private string $prefix;
+    protected string $prefix;
 
     /**
      * Time to live in seconds.
      */
-    private ?int $ttl;
+    protected int $ttl;
 
     /**
      * List of available options:
@@ -50,7 +50,7 @@ class RedisSessionHandler extends AbstractSessionHandler
 
         $this->redis = $redis;
         $this->prefix = $options['prefix'] ?? 'sf_s';
-        $this->ttl = $options['ttl'] ?? null;
+        $this->ttl = (int) ($options['ttl'] ?? ini_get('session.gc_maxlifetime'));
     }
 
     /**
@@ -66,7 +66,7 @@ class RedisSessionHandler extends AbstractSessionHandler
      */
     protected function doWrite(string $sessionId, string $data): bool
     {
-        $result = $this->redis->setEx($this->prefix.$sessionId, (int) ($this->ttl ?? ini_get('session.gc_maxlifetime')), $data);
+        $result = $this->redis->setEx($this->prefix.$sessionId, $this->ttl, $data);
 
         return $result && !$result instanceof ErrorInterface;
     }
@@ -108,6 +108,6 @@ class RedisSessionHandler extends AbstractSessionHandler
 
     public function updateTimestamp(string $sessionId, string $data): bool
     {
-        return $this->redis->expire($this->prefix.$sessionId, (int) ($this->ttl ?? ini_get('session.gc_maxlifetime')));
+        return $this->redis->expire($this->prefix.$sessionId, $this->ttl);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

This PR makes able to use handler options (like `prefix` and `ttl`) in inherited classes and sets `session.gc_maxlifetime` value as `$ttl` if other wasn't specified in config.

Today we cannot implement our own inherited handler with overridden `doWrite` method correctly, because we don't know redis key name (or should duplicate constructor code with hardcode of `'sf_s'` default value for `$prefix`).