### PR TITLE
Fix typo in sponsor name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
 Sponsor
 -------
 
-Symfony 6.1 is [backed][27] by [Basecom][28].
+Symfony 6.1 is [backed][27] by [basecom][28].
 
 As a professional software service provider, basecom implements customized
 solutions in the areas of e-commerce, PIM solutions and web portals. With our


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

This fixes a typo in the name of basecom (sponsor for 6.1).
