### PR TITLE
[RateLimiter] Make RateLimiter resilient to timeShifting

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -66,7 +66,7 @@ final class FixedWindowLimiter implements LimiterInterface
             $now = microtime(true);
             $availableTokens = $window->getAvailableTokens($now);
             if ($availableTokens >= $tokens) {
-                $window->add($tokens);
+                $window->add($tokens, $now);
 
                 $reservation = new Reservation($now, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now)), true, $this->limit));
             } else {
@@ -77,7 +77,7 @@ final class FixedWindowLimiter implements LimiterInterface
                     throw new MaxWaitDurationExceededException(sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
                 }
 
-                $window->add($tokens);
+                $window->add($tokens, $now);
 
                 $reservation = new Reservation($now + $waitDuration, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
             }

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
@@ -82,7 +82,7 @@ final class TokenBucket implements LimiterStateInterface
 
     public function getAvailableTokens(float $now): int
     {
-        $elapsed = $now - $this->timer;
+        $elapsed = max(0, $now - $this->timer);
 
         return min($this->burstSize, $this->tokens + $this->rate->calculateNewTokensDuringInterval($elapsed));
     }

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -88,10 +88,10 @@ final class TokenBucketLimiter implements LimiterInterface
 
                 // at $now + $waitDuration all tokens will be reserved for this process,
                 // so no tokens are left for other processes.
-                $bucket->setTokens(0);
-                $bucket->setTimer($now + $waitDuration);
+                $bucket->setTokens($availableTokens - $tokens);
+                $bucket->setTimer($now);
 
-                $reservation = new Reservation($bucket->getTimer(), new RateLimit(0, \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->maxBurst));
+                $reservation = new Reservation($now + $waitDuration, new RateLimit(0, \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->maxBurst));
             }
 
             $this->storage->save($bucket);

--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -68,11 +68,6 @@ final class Window implements LimiterStateInterface
 
     public function getAvailableTokens(float $now)
     {
-        // if timer is in future, there are no tokens available anymore
-        if ($this->timer > $now) {
-            return 0;
-        }
-
         // if now is more than the window interval in the past, all tokens are available
         if (($now - $this->timer) > $this->intervalInSeconds) {
             return $this->maxSize;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When 2 servers use the FixedWindowLimiter and do not have the exact same clock (with microsecond precision) the `Window` might return 0 available tokens.