### PR TITLE
[HttpClient] Fix handling error info in MockResponse

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -260,6 +260,10 @@ class MockResponse implements ResponseInterface
             'http_code' => $response->info['http_code'],
         ] + $info + $response->info;
 
+        if (null !== $response->info['error']) {
+            throw new TransportException($response->info['error']);
+        }
+
         if (!isset($response->info['total_time'])) {
             $response->info['total_time'] = microtime(true) - $response->info['start_time'];
         }

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class MockHttpClientTest extends HttpClientTestCase
 {
@@ -141,16 +140,8 @@ class MockHttpClientTest extends HttpClientTestCase
                 break;
 
             case 'testDnsError':
-                $mock = $this->createMock(ResponseInterface::class);
-                $mock->expects($this->any())
-                    ->method('getStatusCode')
-                    ->willThrowException(new TransportException('DSN error'));
-                $mock->expects($this->any())
-                    ->method('getInfo')
-                    ->willReturn([]);
-
-                $responses[] = $mock;
-                $responses[] = $mock;
+                $responses[] = $mockResponse = new MockResponse('', ['error' => 'DNS error']);
+                $responses[] = $mockResponse;
                 break;
 
             case 'testToStream':
@@ -164,12 +155,7 @@ class MockHttpClientTest extends HttpClientTestCase
                 break;
 
             case 'testTimeoutOnAccess':
-                $mock = $this->createMock(ResponseInterface::class);
-                $mock->expects($this->any())
-                    ->method('getHeaders')
-                    ->willThrowException(new TransportException('Timeout'));
-
-                $responses[] = $mock;
+                $responses[] = new MockResponse('', ['error' => 'Timeout']);
                 break;
 
             case 'testAcceptHeader':
@@ -231,16 +217,7 @@ class MockHttpClientTest extends HttpClientTestCase
                 break;
 
             case 'testMaxDuration':
-                $mock = $this->createMock(ResponseInterface::class);
-                $mock->expects($this->any())
-                    ->method('getContent')
-                    ->willReturnCallback(static function (): void {
-                        usleep(100000);
-
-                        throw new TransportException('Max duration was reached.');
-                    });
-
-                $responses[] = $mock;
+                $responses[] = new MockResponse('', ['error' => 'Max duration was reached.']);
                 break;
         }
 

--- a/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
@@ -4,6 +4,7 @@ namespace Symfony\Component\HttpClient\Tests\Response;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\Exception\JsonException;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
 /**
@@ -82,5 +83,15 @@ class MockResponseTest extends TestCase
             'responseHeaders' => [],
             'message' => 'JSON content was expected to decode to an array, "integer" returned for "https://example.com/file.json".',
         ];
+    }
+
+    public function testErrorIsTakenIntoAccountInInitialization()
+    {
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('ccc error');
+
+        MockResponse::fromRequest('GET', 'https://symfony.com', [], new MockResponse('', [
+            'error' => 'ccc error',
+        ]))->getStatusCode();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Using `new MockResponse('', ['error' => 'foobar'])` with the `MockHttpClient`, I expect a `TransportException` to be thrown if I call `getStatusCode()`, `getHeaders()`, `getContent()` or `toArray()`.

Currently, it does not work for `getStatusCode()` and `getHeaders()` because `MockResponse` only "converts" the passed error to an exception after the full response workflow has been simulated. `getStatusCode()` and `getHeaders()` stops at the first chunk so it cannot work. I propose to throw at the beginning of the simulated response reading.