### PR TITLE
[SecurityBundle]  Fix invalid reference with `always_authenticate_before_granting`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -122,7 +122,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             if ($config['always_authenticate_before_granting']) {
                 $authorizationChecker = $container->getDefinition('security.authorization_checker');
                 $authorizationCheckerArgs = $authorizationChecker->getArguments();
-                array_splice($authorizationCheckerArgs, 1, 0, [new Reference('security.authentication_manager')]);
+                array_splice($authorizationCheckerArgs, 1, 0, [new Reference('security.authentication.manager')]);
                 $authorizationChecker->setArguments($authorizationCheckerArgs);
             }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -834,7 +834,7 @@ class SecurityExtensionTest extends TestCase
 
         $args = $container->getDefinition('security.authorization_checker')->getArguments();
         $this->assertEquals('security.token_storage', (string) $args[0]);
-        $this->assertEquals('security.authentication_manager', (string) $args[1]);
+        $this->assertEquals('security.authentication.manager', (string) $args[1]);
         $this->assertEquals('security.access.decision_manager', (string) $args[2]);
         $this->assertEquals('%security.access.always_authenticate_before_granting%', (string) $args[3]);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./legacy_base_config.yml }
 
 security:
+    always_authenticate_before_granting: true
     firewalls:
         default:
             anonymous: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes https://github.com/symfony/symfony/issues/44337
| License       | MIT
| Doc PR        | -