### PR TITLE
[HttpFoundation] Allow changing the redis session TTL at runtime

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -110,9 +110,9 @@ class RedisSessionHandler extends AbstractSessionHandler
     {
         return $this->redis->expire($this->prefix.$sessionId, (int) ($this->ttl ?? ini_get('session.gc_maxlifetime')));
     }
-    
+
     public function setTtl(?int $ttl): void
     {
-        $this->ttl = $ttl;   
+        $this->ttl = $ttl;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -50,7 +50,7 @@ class RedisSessionHandler extends AbstractSessionHandler
 
         $this->redis = $redis;
         $this->prefix = $options['prefix'] ?? 'sf_s';
-        $this->ttl = $options['ttl'] ?? null;
+        $this->setTtl($options['ttl'] ?? null);
     }
 
     /**
@@ -109,5 +109,10 @@ class RedisSessionHandler extends AbstractSessionHandler
     public function updateTimestamp(string $sessionId, string $data): bool
     {
         return $this->redis->expire($this->prefix.$sessionId, (int) ($this->ttl ?? ini_get('session.gc_maxlifetime')));
+    }
+    
+    public function setTtl(?int $ttl): void
+    {
+        $this->ttl = $ttl;   
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

A tiny setter addition, because I do have a use case where I need to change the session TTL at runtime only for some users, and right now I need ReflectionProperty which isn't great.