### PR TITLE
[HttpFoundation] Fix `SessionHandlerFactory::createHandler()` with object as connection

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
@@ -30,7 +30,7 @@ class SessionHandlerFactory
             throw new \TypeError(sprintf('Argument 1 passed to "%s()" must be a string or a connection object, "%s" given.', __METHOD__, get_debug_type($connection)));
         }
 
-        if ($options = parse_url($connection)) {
+        if (\is_string($connection) && $options = parse_url($connection)) {
             parse_str($options['query'] ?? '', $options);
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionHandlerFactoryTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionHandlerFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\SessionHandlerFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\StrictSessionHandler;
 
@@ -34,6 +35,16 @@ class SessionHandlerFactoryTest extends TestCase
 
         $this->assertInstanceOf($expectedHandlerType, $handler);
         $this->assertEquals($expectedPath, ini_get('session.save_path'));
+    }
+
+    /**
+     * @dataProvider provideConnectionDSN
+     */
+    public function testCreateHandlerWithConnectionObject()
+    {
+        $handler = SessionHandlerFactory::createHandler($this->createMock(\Redis::class));
+
+        $this->assertInstanceOf(RedisSessionHandler::class, $handler);
     }
 
     public function provideConnectionDSN(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes https://github.com/symfony/symfony/issues/44372
| License       | MIT
| Doc PR        | -
