### PR TITLE
Remove non-autoloadable classes from preload

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
@@ -131,14 +131,17 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+if (\PHP_VERSION_ID >= 80100) {
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 require __DIR__.'/Container%s/getClosureService.php';
+}
 
 $classes = [];
+$preloaded = [];
 $classes[] = 'FooClass';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-$preloaded = Preloader::preload($classes);
+$preloaded = Preloader::preload($classes, $preloaded);
 
     [ProjectServiceContainer.php] => <?php
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -897,6 +897,7 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+if (\PHP_VERSION_ID >= 80100) {
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 require __DIR__.'/Container%s/getThrowingOneService.php';
 require __DIR__.'/Container%s/getTaggedIteratorService.php';
@@ -922,8 +923,10 @@ require __DIR__.'/Container%s/getBazService.php';
 require __DIR__.'/Container%s/getBar23Service.php';
 require __DIR__.'/Container%s/getBAR22Service.php';
 require __DIR__.'/Container%s/getBAR2Service.php';
+}
 
 $classes = [];
+$preloaded = [];
 $classes[] = 'Bar\FooClass';
 $classes[] = 'Baz';
 $classes[] = 'ConfClass';
@@ -938,7 +941,7 @@ $classes[] = 'Some\Sidekick2';
 $classes[] = 'Request';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-$preloaded = Preloader::preload($classes);
+$preloaded = Preloader::preload($classes, $preloaded);
 
     [ProjectServiceContainer.php] => <?php
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -552,9 +552,12 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+if (\PHP_VERSION_ID >= 80100) {
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
+}
 
 $classes = [];
+$preloaded = [];
 $classes[] = 'Bar\FooClass';
 $classes[] = 'Baz';
 $classes[] = 'ConfClass';
@@ -569,7 +572,7 @@ $classes[] = 'Some\Sidekick2';
 $classes[] = 'Request';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-$preloaded = Preloader::preload($classes);
+$preloaded = Preloader::preload($classes, $preloaded);
 
     [ProjectServiceContainer.php] => <?php
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -169,14 +169,17 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+if (\PHP_VERSION_ID >= 80100) {
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
+}
 
 $classes = [];
+$preloaded = [];
 $classes[] = 'Bar\FooClass';
 $classes[] = 'Bar\FooLazyClass';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-$preloaded = Preloader::preload($classes);
+$preloaded = Preloader::preload($classes, $preloaded);
 
     [ProjectServiceContainer.php] => <?php
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
@@ -130,15 +130,18 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+if (\PHP_VERSION_ID >= 80100) {
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 require __DIR__.'/Container%s/proxy.php';
 require __DIR__.'/Container%s/getNonSharedFooService.php';
+}
 
 $classes = [];
+$preloaded = [];
 $classes[] = 'Bar\FooLazyClass';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-$preloaded = Preloader::preload($classes);
+$preloaded = Preloader::preload($classes, $preloaded);
 
     [ProjectServiceContainer.php] => <?php
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | mp
| Tickets       | Fix #44364
| License       | MIT
| Doc PR        | 


When a class is required in a preloaded file, all the type hinted properties have to be auto-loadable. (sees discussion in linked issue)

This could be an issue for classes like `BodyRenderer` that have a property typehinted with an optional dependency.

https://github.com/symfony/symfony/blob/02b40c032865dee88e8f428c08b671896b6fb02c/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php#L27-L39

Sometime, the relation is tricky. For instance `RedisAdapter` uses `RedisTrait` that have a property `$redis` typehinted `RedisClusterProxy` that have a property typehinted `Predis\ClientInterface` => but `Predis` is an optional dependency

When dumping the Preload classMap, this PR now check if all the properties are auto-loadable.