### PR TITLE
[Lock] Create tables in transaction only if supported by driver

### DIFF
--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -92,8 +92,21 @@ class DoctrineDbalStore implements PersistingStoreInterface
                 ParameterType::STRING,
             ]);
         } catch (TableNotFoundException $e) {
-            $this->createTable();
-            $this->save($key);
+            if (!$this->conn->isTransactionActive() || $this->platformSupportsTableCreationInTransaction()) {
+                $this->createTable();
+            }
+
+            try {
+                $this->conn->executeStatement($sql, [
+                    $this->getHashedKey($key),
+                    $this->getUniqueToken($key),
+                ], [
+                    ParameterType::STRING,
+                    ParameterType::STRING,
+                ]);
+            } catch (DBALException $e) {
+                $this->putOffExpiration($key, $this->initialTtl);
+            }
         } catch (DBALException $e) {
             // the lock is already acquired. It could be us. Let's try to put off.
             $this->putOffExpiration($key, $this->initialTtl);
@@ -233,6 +246,25 @@ class DoctrineDbalStore implements PersistingStoreInterface
 
             default:
                 return (string) time();
+        }
+    }
+
+    /**
+     * Checks wether current platform supports table creation within transaction.
+     */
+    private function platformSupportsTableCreationInTransaction(): bool
+    {
+        $platform = $this->conn->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform:
+            case $platform instanceof \Doctrine\DBAL\Platforms\PostgreSQL94Platform:
+            case $platform instanceof \Doctrine\DBAL\Platforms\SqlitePlatform:
+            case $platform instanceof \Doctrine\DBAL\Platforms\SQLServerPlatform:
+            case $platform instanceof \Doctrine\DBAL\Platforms\SQLServer2012Platform:
+                return true;
+            default:
+                return false;
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Fixed `DoctrineDbalStore` to allow the creation of a lock table within a transaction only if it is supported by the driver.
