### PR TITLE
[DependencyInjection] Skip parameter attribute configurators in AttributeAutoconfigurationPass if we can't get the constructor reflector

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -976,6 +976,11 @@ PHP
             ->setPublic(true)
             ->setAutoconfigured(true);
 
+        $container->register('failing_factory', \stdClass::class);
+        $container->register('ccc', TaggedService4::class)
+            ->setFactory([new Reference('failing_factory'), 'create'])
+            ->setAutoconfigured(true);
+
         $collector = new TagCollector();
         $container->addCompilerPass($collector);
 
@@ -990,6 +995,17 @@ PHP
                 ['someAttribute' => 'on param2 in constructor', 'priority' => 0, 'parameter' => 'param2'],
                 ['method' => 'fooAction'],
                 ['someAttribute' => 'on fooAction', 'priority' => 0, 'method' => 'fooAction'],
+                ['someAttribute' => 'on param1 in fooAction', 'priority' => 0, 'parameter' => 'param1'],
+                ['method' => 'barAction'],
+                ['someAttribute' => 'on barAction', 'priority' => 0, 'method' => 'barAction'],
+                ['property' => 'name'],
+                ['someAttribute' => 'on name', 'priority' => 0, 'property' => 'name'],
+            ],
+            'ccc' => [
+                ['class' => TaggedService4::class],
+                ['method' => 'fooAction'],
+                ['someAttribute' => 'on fooAction', 'priority' => 0, 'method' => 'fooAction'],
+                ['parameter' => 'param1'],
                 ['someAttribute' => 'on param1 in fooAction', 'priority' => 0, 'parameter' => 'param1'],
                 ['method' => 'barAction'],
                 ['someAttribute' => 'on barAction', 'priority' => 0, 'method' => 'barAction'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/44342
| License       | MIT
| Doc PR        | -

`$required = false` on `getConstructor()` doesn't mean it doesn't throw. I have looked at our other usages, and we catch the exception when we want to ignore it. I'd still like to return null when the definition class is null though (on 4.4).