### PR TITLE
[FrameworkBundle] ResponseListener needs only 2 parameters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -70,7 +70,6 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 param('kernel.charset'),
                 abstract_arg('The "set_content_language_from_locale" config value'),
-                param('kernel.enabled_locales'),
             ])
             ->tag('kernel.event_subscriber')
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | -
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Introduced in 5.4 with : https://github.com/symfony/symfony/pull/43108
