### PR TITLE
[HttpKernel] fix sending Vary: Accept-Language when appropriate

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -70,6 +70,7 @@ class LocaleListener implements EventSubscriberInterface
             $request->setLocale($locale);
         } elseif ($this->useAcceptLanguageHeader && $this->enabledLocales && ($preferredLanguage = $request->getPreferredLanguage($this->enabledLocales))) {
             $request->setLocale($preferredLanguage);
+            $request->attributes->set('_vary_by_language', true);
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
@@ -50,6 +50,9 @@ class ResponseListener implements EventSubscriberInterface
 
         if ($this->addContentLanguageHeader && !$response->isInformational() && !$response->isEmpty() && !$response->headers->has('Content-Language')) {
             $response->headers->set('Content-Language', $event->getRequest()->getLocale());
+        }
+
+        if ($event->getRequest()->attributes->get('_vary_by_language')) {
             $response->setVary('Accept-Language', false);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

That's something I figured our while reviewing #44386 and that we missed in #43108:
the `Vary` header should be sent when we use `Accept-Language`, not when we send `Content-Language`.
/cc @chalasr 