### PR TITLE
[Routing] Allow using services in the route condition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate the `reset_on_message` config option. It can be set to `true` only and does nothing now
  * Add `trust_x_sendfile_type_header` option
  * Add support for first-class callable route controller in `MicroKernelTrait`
+ * Add tag `routing.condition_service` to autoconfigure routing condition services.
 
 6.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -75,6 +75,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'routing.expression_language_provider',
         'routing.loader',
         'routing.route_loader',
+        'routing.condition_service',
         'security.authenticator.login_linker',
         'security.expression_language_provider',
         'security.remember_me_aware',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -27,6 +27,7 @@ use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
+use Symfony\Bundle\FrameworkBundle\Routing\Attribute\AsRoutingConditionService;
 use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Bundle\FullStack;
 use Symfony\Bundle\MercureBundle\MercureBundle;
@@ -666,6 +667,10 @@ class FrameworkExtension extends Extension
             'kernel.locale_aware',
             'kernel.reset',
         ]);
+
+        $container->registerAttributeForAutoconfiguration(AsRoutingConditionService::class, static function (ChildDefinition $definition, AsRoutingConditionService $attribute): void {
+            $definition->addTag('routing.condition_service', (array) $attribute);
+        });
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -200,6 +200,14 @@ return static function (ContainerConfigurator $container) {
             ])
             ->tag('routing.expression_language_function', ['function' => 'env'])
 
+        ->set('container.get_routing_condition_service', \Closure::class)
+            ->public()
+            ->factory([\Closure::class, 'fromCallable'])
+            ->args([
+                [tagged_locator('routing.condition_service', 'alias'), 'get'],
+            ])
+            ->tag('routing.expression_language_function', ['function' => 'service'])
+
         // inherit from this service to lazily access env vars
         ->set('container.env', LazyString::class)
             ->abstract()

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Attribute/AsRoutingConditionService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Attribute/AsRoutingConditionService.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Routing\Attribute;
+
+/**
+ * Service tag to autoconfigure routing condition services.
+ *
+ * You can tag a service:
+ *
+ *     #[AsRoutingConditionService('foo')]
+ *     class SomeFooService
+ *     {
+ *         public function bar(): bool
+ *         {
+ *             // ...
+ *         }
+ *     }
+ *
+ * Then you can use the tagged service in the routing condition:
+ *
+ *     class PageController
+ *     {
+ *         #[Route('/page', condition: "service('foo').bar()")]
+ *         public function page(): Response
+ *         {
+ *             // ...
+ *         }
+ *     }
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsRoutingConditionService
+{
+    public function __construct(
+        public ?string $alias = null,
+        public int $priority = 0,
+    ) {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Controller/DefaultController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Controller/DefaultController.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DefaultController
+{
+    #[Route(
+        path: '/allowed/manually-tagged',
+        condition: 'service("manually_tagged").giveMeTrue()',
+    )]
+    public function allowedByManuallyTagged(): Response
+    {
+        return new Response();
+    }
+
+    #[Route(
+        path: '/allowed/auto-configured',
+        condition: 'service("auto_configured").flip(false)',
+    )]
+    public function allowedByAutoConfigured(): Response
+    {
+        return new Response();
+    }
+
+    #[Route(
+        path: '/allowed/auto-configured-non-aliased',
+        condition: 'service("auto_configured_non_aliased").alwaysTrue()',
+    )]
+    public function allowedByAutoConfiguredNonAliased(): Response
+    {
+        return new Response();
+    }
+
+    #[Route(
+        path: '/denied/manually-tagged',
+        condition: 'service("manually_tagged").giveMeFalse()',
+    )]
+    public function deniedByManuallyTagged(): Response
+    {
+        return new Response();
+    }
+
+    #[Route(
+        path: '/denied/auto-configured',
+        condition: 'service("auto_configured").flip(true)',
+    )]
+    public function deniedByAutoConfigured(): Response
+    {
+        return new Response();
+    }
+
+    #[Route(
+        path: '/denied/auto-configured-non-aliased',
+        condition: 'service("auto_configured_non_aliased").alwaysFalse()',
+    )]
+    public function deniedByAutoConfiguredNonAliased(): Response
+    {
+        return new Response();
+    }
+
+    #[Route(
+        path: '/denied/overridden',
+        condition: 'service("foo").isAllowed()',
+    )]
+    public function deniedByOverriddenAlias(): Response
+    {
+        return new Response();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/RoutingConditionServiceBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/RoutingConditionServiceBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class RoutingConditionServiceBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/AutoConfiguredNonAliasedService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/AutoConfiguredNonAliasedService.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service;
+
+use Symfony\Bundle\FrameworkBundle\Routing\Attribute\AsRoutingConditionService;
+
+#[AsRoutingConditionService]
+class AutoConfiguredNonAliasedService
+{
+    public function alwaysFalse(): bool
+    {
+        return false;
+    }
+
+    public function alwaysTrue(): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/AutoConfiguredService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/AutoConfiguredService.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service;
+
+use Symfony\Bundle\FrameworkBundle\Routing\Attribute\AsRoutingConditionService;
+
+#[AsRoutingConditionService('auto_configured')]
+class AutoConfiguredService
+{
+    public function flip(bool $value): bool
+    {
+        return !$value;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/FooOriginalService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/FooOriginalService.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service;
+
+use Symfony\Bundle\FrameworkBundle\Routing\Attribute\AsRoutingConditionService;
+
+#[AsRoutingConditionService('foo')]
+class FooOriginalService
+{
+    public function isAllowed(): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/FooReplacementService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/FooReplacementService.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service;
+
+use Symfony\Bundle\FrameworkBundle\Routing\Attribute\AsRoutingConditionService;
+
+#[AsRoutingConditionService(alias: 'foo', priority: -1)]
+class FooReplacementService
+{
+    public function isAllowed(): bool
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/ManuallyTaggedService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/RoutingConditionServiceBundle/Service/ManuallyTaggedService.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service;
+
+class ManuallyTaggedService
+{
+    public function giveMeTrue(): bool
+    {
+        return true;
+    }
+
+    public function giveMeFalse(): bool
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RoutingConditionServiceTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RoutingConditionServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+class RoutingConditionServiceTest extends AbstractWebTestCase
+{
+    /**
+     * @dataProvider provideRoutes
+     */
+    public function testCondition(int $code, string $path)
+    {
+        $client = static::createClient(['test_case' => 'RoutingConditionService']);
+
+        $client->request('GET', $path);
+        $this->assertSame($code, $client->getResponse()->getStatusCode());
+    }
+
+    public function provideRoutes(): iterable
+    {
+        yield 'allowed by an autoconfigured service' => [
+            200,
+            '/allowed/manually-tagged',
+        ];
+
+        yield 'allowed by a manually tagged service' => [
+            200,
+            '/allowed/auto-configured',
+        ];
+
+        yield 'allowed by a manually tagged non aliased service' => [
+            200,
+            '/allowed/auto-configured-non-aliased',
+        ];
+
+        yield 'denied by an autoconfigured service' => [
+            404,
+            '/denied/manually-tagged',
+        ];
+
+        yield 'denied by a manually tagged service' => [
+            404,
+            '/denied/auto-configured',
+        ];
+
+        yield 'denied by a manually tagged non aliased service' => [
+            404,
+            '/denied/auto-configured-non-aliased',
+        ];
+
+        yield 'denied by an overridden service' => [
+            404,
+            '/denied/overridden',
+        ];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\RoutingConditionServiceBundle;
+
+return [
+    new FrameworkBundle(),
+    new RoutingConditionServiceBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/config.yml
@@ -1,0 +1,4 @@
+imports:
+  - { resource: ../config/default.yml }
+  - { resource: services_auto_configured.yml }
+  - { resource: services_manually_configured.yml }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/routing.yml
@@ -1,0 +1,4 @@
+_routingconditionservice_bundle:
+    prefix:   /
+    resource: "@RoutingConditionServiceBundle/Controller"
+    type:     annotation

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/services_auto_configured.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/services_auto_configured.yml
@@ -1,0 +1,13 @@
+services:
+
+  _defaults:
+    autoconfigure: true
+
+  Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service\AutoConfiguredService:
+
+  auto_configured_non_aliased:
+    class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service\AutoConfiguredNonAliasedService
+
+  Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service\FooOriginalService:
+
+  Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service\FooReplacementService:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/services_manually_configured.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RoutingConditionService/services_manually_configured.yml
@@ -1,0 +1,8 @@
+services:
+
+  _defaults:
+    autoconfigure: false
+
+  Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\RoutingConditionServiceBundle\Service\ManuallyTaggedService:
+    tags:
+      - { name: 'routing.condition_service', alias: 'manually_tagged' }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

```php
#[AsRoutingConditionService(alias: 'foo')]
class SomeFooService
{
    public function bar(): bool { ... }
}
```

```php
class DefaultController
{
    #[Route('/page', condition: "service('foo').bar()")]
    public function page(): Response { ... }
} 
```
