### PR TITLE
[Translation] Make http requests synchronous when reading the Loco API

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -92,47 +92,37 @@ final class LocoProvider implements ProviderInterface
     {
         $domains = $domains ?: ['*'];
         $translatorBag = new TranslatorBag();
-        $responses = [];
 
         foreach ($locales as $locale) {
             foreach ($domains as $domain) {
-                $responses[] = [
-                    'response' => $this->client->request('GET', sprintf('export/locale/%s.xlf', rawurlencode($locale)), [
-                        'query' => [
-                            'filter' => $domain,
-                            'status' => 'translated',
-                        ],
-                    ]),
-                    'locale' => $locale,
-                    'domain' => $domain,
-                ];
+                // Loco forbids concurrent requests, so the requests must be synchronous in order to prevent "429 Too Many Requests" errors.
+                $response = $this->client->request('GET', sprintf('export/locale/%s.xlf', rawurlencode($locale)), [
+                    'query' => [
+                        'filter' => $domain,
+                        'status' => 'translated',
+                    ],
+                ]);
+
+                if (404 === $response->getStatusCode()) {
+                    $this->logger->warning(sprintf('Locale "%s" for domain "%s" does not exist in Loco.', $locale, $domain));
+                    continue;
+                }
+
+                $responseContent = $response->getContent(false);
+
+                if (200 !== $response->getStatusCode()) {
+                    throw new ProviderException('Unable to read the Loco response: '.$responseContent, $response);
+                }
+
+                $locoCatalogue = $this->loader->load($responseContent, $locale, $domain);
+                $catalogue = new MessageCatalogue($locale);
+
+                foreach ($locoCatalogue->all($domain) as $key => $message) {
+                    $catalogue->set($this->retrieveKeyFromId($key, $domain), $message, $domain);
+                }
+
+                $translatorBag->addCatalogue($catalogue);
             }
-        }
-
-        foreach ($responses as $response) {
-            $locale = $response['locale'];
-            $domain = $response['domain'];
-            $response = $response['response'];
-
-            if (404 === $response->getStatusCode()) {
-                $this->logger->warning(sprintf('Locale "%s" for domain "%s" does not exist in Loco.', $locale, $domain));
-                continue;
-            }
-
-            $responseContent = $response->getContent(false);
-
-            if (200 !== $response->getStatusCode()) {
-                throw new ProviderException('Unable to read the Loco response: '.$responseContent, $response);
-            }
-
-            $locoCatalogue = $this->loader->load($responseContent, $locale, $domain);
-            $catalogue = new MessageCatalogue($locale);
-
-            foreach ($locoCatalogue->all($domain) as $key => $message) {
-                $catalogue->set($this->retrieveKeyFromId($key, $domain), $message, $domain);
-            }
-
-            $translatorBag->addCatalogue($catalogue);
         }
 
         return $translatorBag;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Hi!

Since we migrated from the [PHP Translation's Loco Adapter](https://github.com/php-translation/loco-adapter) to the [Symfony's Loco Translation Provider](https://github.com/symfony/loco-translation-provider), we started to have 429 errors from the Loco API when running our CI or deploying our code on review apps/staging/production environments:

<details>
<summary>Some screenshots</summary>

![image](https://user-images.githubusercontent.com/2103975/144423896-4ee1a4f5-7705-475b-83dc-efd34adeeeab.png)

![image](https://user-images.githubusercontent.com/2103975/144423987-fa739f3a-da16-41f7-9284-ce145009b84d.png)


</details>

We have asked to the Loco support and this is their response:
> Hello.
> 
> You will never get a 429 if you make single threaded requests. i.e. waiting for a response before dispatching another requests. As noted in the API usage limits: parallel requests burst the response speed limit. This is currently the only thing that would invoke a 429. I can provide more detail on the implementation if you would like.
>
> This measure is in lieu of quota based rate limiting which will one day be added, but currently no other limits are in place in terms of number of requests.

Which makes sense. AFAIK, the PHP Translation's Loco Adapter makes synchronous requests to get translations from Loco.

Some Blackfire traces, it does not impact performances:
- before: https://blackfire.io/profiles/315f0748-76f8-4817-b59d-54ea482e1558/graph
- after: https://blackfire.io/profiles/a6779b3e-b2ae-4870-b67f-667fe2016c0b/graph
- delta: https://blackfire.io/profiles/compare/406d1f86-d9d8-45f1-9f8b-5c371d0973a3/graph

I consider this PR as a bug-fix and not a feature, that's why I've targeted 5.3.

WDYT?

ping @welcoMattic 