### PR TITLE
[DependencyInjection] Resolve ChildDefinition in AbstractRecursivePass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -131,25 +132,35 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
 
         if ($factory) {
             [$class, $method] = $factory;
+
+            if ('__construct' === $method) {
+                throw new RuntimeException(sprintf('Invalid service "%s": "__construct()" cannot be used as a factory method.', $this->currentId));
+            }
+
             if ($class instanceof Reference) {
-                $class = $this->container->findDefinition((string) $class)->getClass();
+                $factoryDefinition = $this->container->findDefinition((string) $class);
+                while ((null === $class = $factoryDefinition->getClass()) && $factoryDefinition instanceof ChildDefinition) {
+                    $factoryDefinition = $this->container->findDefinition($factoryDefinition->getParent());
+                }
             } elseif ($class instanceof Definition) {
                 $class = $class->getClass();
             } elseif (null === $class) {
                 $class = $definition->getClass();
             }
 
-            if ('__construct' === $method) {
-                throw new RuntimeException(sprintf('Invalid service "%s": "__construct()" cannot be used as a factory method.', $this->currentId));
-            }
-
             return $this->getReflectionMethod(new Definition($class), $method);
         }
 
-        $class = $definition->getClass();
+        while ((null === $class = $definition->getClass()) && $definition instanceof ChildDefinition) {
+            $definition = $this->container->findDefinition($definition->getParent());
+        }
 
         try {
             if (!$r = $this->container->getReflectionClass($class)) {
+                if (null === $class) {
+                    throw new RuntimeException(sprintf('Invalid service "%s": the class is not set.', $this->currentId));
+                }
+
                 throw new RuntimeException(sprintf('Invalid service "%s": class "%s" does not exist.', $this->currentId, $class));
             }
         } catch (\ReflectionException $e) {
@@ -179,7 +190,11 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
             return $this->getConstructor($definition, true);
         }
 
-        if (!$class = $definition->getClass()) {
+        while ((null === $class = $definition->getClass()) && $definition instanceof ChildDefinition) {
+            $definition = $this->container->findDefinition($definition->getParent());
+        }
+
+        if (null === $class) {
             throw new RuntimeException(sprintf('Invalid service "%s": the class is not set.', $this->currentId));
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AbstractRecursivePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AbstractRecursivePassTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummy;
+
+class AbstractRecursivePassTest extends TestCase
+{
+    public function testGetConstructorResolvesFactoryChildDefinitionsClass()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('factory_dummy_class', FactoryDummy::class);
+        $container
+            ->register('parent', '%factory_dummy_class%')
+            ->setAbstract(true);
+        $container->setDefinition('child', new ChildDefinition('parent'));
+        $container
+            ->register('foo', \stdClass::class)
+            ->setFactory([new Reference('child'), 'createFactory']);
+
+        $pass = new class() extends AbstractRecursivePass {
+            public $actual;
+
+            protected function processValue($value, $isRoot = false)
+            {
+                if ($value instanceof Definition && 'foo' === $this->currentId) {
+                    $this->actual = $this->getConstructor($value, true);
+                }
+
+                return parent::processValue($value, $isRoot);
+            }
+        };
+        $pass->process($container);
+
+        $this->assertInstanceOf(\ReflectionMethod::class, $pass->actual);
+        $this->assertSame(FactoryDummy::class, $pass->actual->class);
+    }
+
+    public function testGetConstructorResolvesChildDefinitionsClass()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('parent', Bar::class)
+            ->setAbstract(true);
+        $container->setDefinition('foo', new ChildDefinition('parent'));
+
+        $pass = new class() extends AbstractRecursivePass {
+            public $actual;
+
+            protected function processValue($value, $isRoot = false)
+            {
+                if ($value instanceof Definition && 'foo' === $this->currentId) {
+                    $this->actual = $this->getConstructor($value, true);
+                }
+
+                return parent::processValue($value, $isRoot);
+            }
+        };
+        $pass->process($container);
+
+        $this->assertInstanceOf(\ReflectionMethod::class, $pass->actual);
+        $this->assertSame(Bar::class, $pass->actual->class);
+    }
+
+    public function testGetReflectionMethodResolvesChildDefinitionsClass()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('parent', Bar::class)
+            ->setAbstract(true);
+        $container->setDefinition('foo', new ChildDefinition('parent'));
+
+        $pass = new class() extends AbstractRecursivePass {
+            public $actual;
+
+            protected function processValue($value, $isRoot = false)
+            {
+                if ($value instanceof Definition && 'foo' === $this->currentId) {
+                    $this->actual = $this->getReflectionMethod($value, 'create');
+                }
+
+                return parent::processValue($value, $isRoot);
+            }
+        };
+        $pass->process($container);
+
+        $this->assertInstanceOf(\ReflectionMethod::class, $pass->actual);
+        $this->assertSame(Bar::class, $pass->actual->class);
+    }
+
+    public function testGetConstructorDefinitionNoClass()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid service "foo": the class is not set.');
+
+        $container = new ContainerBuilder();
+        $container->register('foo');
+
+        (new class() extends AbstractRecursivePass {
+            protected function processValue($value, $isRoot = false)
+            {
+                if ($value instanceof Definition && 'foo' === $this->currentId) {
+                    $this->getConstructor($value, true);
+                }
+
+                return parent::processValue($value, $isRoot);
+            }
+        })->process($container);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/44342
| License       | MIT
| Doc PR        | -

At least `AttributeAutoconfigurationPass` (5.4 new pass) relies on `AbstractRecursivePass` and is executed before `ResolveChildDefinitionsPass` so child definitions are not necessary resolved in `AbstractRecursivePass`. Doing it on 4.4 to have the same behavior on all maintained branches.

It fixes https://github.com/symfony/symfony/issues/44342 in a better way because the final class of the factory can be resolved.