### PR TITLE
Fix description that does not work well

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.yaml
@@ -1,5 +1,5 @@
 name: 🐛 Bug Report
-description: ⚠️ See below for security reports
+description: ⚠️ NEVER report security issues, read https://symfony.com/security instead
 labels: Bug
 
 body:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a

Currently, the description for reporting a bug read: "See below for security reports", which works well on the page where you choose the kind of issue you want to create, but it does not work well on the bug report page.

I propose to change it to make it more explicit so that it works everywhere.
