### PR TITLE
[PropertyInfo] Fix aliased namespace matching

### DIFF
--- a/src/Symfony/Component/PropertyInfo/PhpStan/NameScope.php
+++ b/src/Symfony/Component/PropertyInfo/PhpStan/NameScope.php
@@ -41,13 +41,14 @@ final class NameScope
         }
 
         $nameParts = explode('\\', $name);
-        if (isset($this->uses[$nameParts[0]])) {
+        $firstNamePart = $nameParts[0];
+        if (isset($this->uses[$firstNamePart])) {
             if (1 === \count($nameParts)) {
-                return $this->uses[$nameParts[0]];
+                return $this->uses[$firstNamePart];
             }
             array_shift($nameParts);
 
-            return sprintf('%s\\%s', $this->uses[$nameParts[0]], implode('\\', $nameParts));
+            return sprintf('%s\\%s', $this->uses[$firstNamePart], implode('\\', $nameParts));
         }
 
         if (null !== $this->namespace) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -370,6 +370,14 @@ class PhpStanExtractorTest extends TestCase
             ['e', [new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class, true, [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, [], [new Type(Type::BUILTIN_TYPE_STRING)])], [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, [new Type(Type::BUILTIN_TYPE_INT)], [new Type(Type::BUILTIN_TYPE_STRING, false, null, true, [], [new Type(Type::BUILTIN_TYPE_OBJECT, false, DefaultValue::class)])])]), new Type(Type::BUILTIN_TYPE_OBJECT, false, ParentDummy::class)]],
         ];
     }
+
+    public function testDummyNamespace()
+    {
+        $this->assertEquals(
+            [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')],
+            $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DummyNamespace', 'dummy')
+        );
+    }
 }
 
 class PhpStanOmittedParamTagTypeDocBlock

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyNamespace.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyNamespace.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+use Symfony\Component\PropertyInfo\Tests as TestNamespace;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class DummyNamespace
+{
+    /** @var TestNamespace\Fixtures\Dummy */
+    private $dummy;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44417
| License       | MIT
| Doc PR        | N/A

When you have an aliased namespace that you use in your code it was erroring because we didn't stored the first part of the namespace that should be replaced.