### PR TITLE
[HttpClient] Fix MockResponse processing the whole body when simulating an idle timeout

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -279,6 +279,8 @@ class MockResponse implements ResponseInterface
                 if ('' === $chunk = (string) $chunk) {
                     // simulate an idle timeout
                     $response->body[] = new ErrorChunk($offset, sprintf('Idle timeout reached for "%s".', $response->info['url']));
+
+                    break;
                 } else {
                     $response->body[] = $chunk;
                     $offset += \strlen($chunk);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

If an idle timeout is simulated, the remaining "body" chunks shouldn't be processed isn't it?