### PR TITLE
Fix #44434

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -123,7 +123,10 @@ class KernelBrowser extends HttpKernelBrowser
         }
 
         $token = new TestBrowserToken($user->getRoles(), $user, $firewallContext);
-        $token->setAuthenticated(true);
+        // @deprecated since Symfony 5.4
+        if (method_exists($token, 'setAuthenticated')) {
+            $token->setAuthenticated(true);
+        }
 
         $container = $this->getContainer();
         $container->get('security.untracked_token_storage')->setToken($token);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -138,7 +138,12 @@ class AbstractControllerTest extends TestCase
     public function testGetUser()
     {
         $user = new InMemoryUser('user', 'pass');
-        $token = new UsernamePasswordToken($user, 'pass', 'default', ['ROLE_USER']);
+        if (method_exists(UsernamePasswordToken::class, 'setAuthenticated')) {
+            // @deprecated since Symfony 5.4
+            $token = new UsernamePasswordToken($user, 'pass', 'default', ['ROLE_USER']);
+        } else {
+            $token = new UsernamePasswordToken($user, 'default', ['ROLE_USER']);
+        }
 
         $controller = $this->createController();
         $controller->setContainer($this->getContainerWithTokenStorage($token));
@@ -148,6 +153,11 @@ class AbstractControllerTest extends TestCase
 
     public function testGetUserAnonymousUserConvertedToNull()
     {
+        // @deprecated since Symfony 5.4
+        if (!class_exists(AnonymousToken::class)) {
+            $this->markTestSkipped('This test requires "symfony/security-core" <6.0.');
+        }
+
         $token = new AnonymousToken('default', 'anon.');
 
         $controller = $this->createController();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -138,12 +138,7 @@ class AbstractControllerTest extends TestCase
     public function testGetUser()
     {
         $user = new InMemoryUser('user', 'pass');
-        if (method_exists(UsernamePasswordToken::class, 'setAuthenticated')) {
-            // @deprecated since Symfony 5.4
-            $token = new UsernamePasswordToken($user, 'pass', 'default', ['ROLE_USER']);
-        } else {
-            $token = new UsernamePasswordToken($user, 'default', ['ROLE_USER']);
-        }
+        $token = new UsernamePasswordToken($user, 'default', ['ROLE_USER']);
 
         $controller = $this->createController();
         $controller->setContainer($this->getContainerWithTokenStorage($token));
@@ -156,11 +151,6 @@ class AbstractControllerTest extends TestCase
      */
     public function testGetUserAnonymousUserConvertedToNull()
     {
-        // @deprecated since Symfony 5.4
-        if (!class_exists(AnonymousToken::class)) {
-            $this->markTestSkipped('This test requires "symfony/security-core" <6.0.');
-        }
-
         $token = new AnonymousToken('default', 'anon.');
 
         $controller = $this->createController();

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -146,7 +146,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
             $sessionCookieHttpOnly = $this->sessionOptions['cookie_httponly'] ?? true;
             $sessionCookieSameSite = $this->sessionOptions['cookie_samesite'] ?? Cookie::SAMESITE_LAX;
 
-            SessionUtils::popSessionCookie($sessionName, $sessionCookiePath);
+            SessionUtils::popSessionCookie($sessionName, $sessionId);
 
             $request = $event->getRequest();
             $requestSessionCookieId = $request->cookies->get($sessionName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44434
| License       | MIT

The function onKernelResponse() removes possible Set-Cookie headers from headers_list by using SessionUtils::popSessionCookie($sessionName, $sessionCookiePath);
https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php#L149

2nd expected parameter of SessionUtils::popSessionCookie function is the sessionId, not the $sessionCookiePath
https://github.com/symfony/symfony/blob/v5.4.0/src/Symfony/Component/HttpFoundation/Session/SessionUtils.php#L28
