### PR TITLE
[HttpKernel] Fix wrong usage of SessionUtils::popSessionCookie

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -146,7 +146,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
             $sessionCookieHttpOnly = $this->sessionOptions['cookie_httponly'] ?? true;
             $sessionCookieSameSite = $this->sessionOptions['cookie_samesite'] ?? Cookie::SAMESITE_LAX;
 
-            SessionUtils::popSessionCookie($sessionName, $sessionCookiePath);
+            SessionUtils::popSessionCookie($sessionName, $sessionId);
 
             $request = $event->getRequest();
             $requestSessionCookieId = $request->cookies->get($sessionName);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -312,6 +312,7 @@ class SessionListenerTest extends TestCase
     public function testSessionIsSavedWhenUnexpectedSessionExceptionThrown()
     {
         $session = $this->createMock(Session::class);
+        $session->expects($this->exactly(1))->method('getId')->willReturn('123456');
         $session->expects($this->exactly(1))->method('getName')->willReturn('PHPSESSID');
         $session->method('isStarted')->willReturn(true);
         $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44434
| License       | MIT

The function onKernelResponse() removes possible Set-Cookie headers from headers_list by using SessionUtils::popSessionCookie($sessionName, $sessionCookiePath);
https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php#L149

2nd expected parameter of SessionUtils::popSessionCookie function is the sessionId, not the $sessionCookiePath
https://github.com/symfony/symfony/blob/v5.4.0/src/Symfony/Component/HttpFoundation/Session/SessionUtils.php#L28
