### PR TITLE
Remove return void PHPDoc in test

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
@@ -95,7 +95,6 @@ class ManagerRegistryTest extends TestCase
         self::assertNotInstanceOf(ValueHolderInterface::class, $wrappedValue);
     }
 
-    /** @return void */
     private function dumpLazyServiceProjectAsFilesServiceContainer()
     {
         if (class_exists(\LazyServiceProjectAsFilesServiceContainer::class, false)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

AFAIK we don't add them in tests and that's why the CI is not green on 6.0 and 6.1 (see https://github.com/symfony/symfony/runs/4405273301?check_suite_focus=true for example).