### PR TITLE
[Validator] Allow Sequence constraint to be applied onto class as an attribute

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Sequentially.php
+++ b/src/Symfony/Component/Validator/Constraints/Sequentially.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Sequentially extends Composite
 {
     public $constraints = [];

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Annotation/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Annotation/Entity.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Tests\Fixtures\EntityInterfaceB;
  * @Symfony\Component\Validator\Tests\Fixtures\ConstraintA
  * @Assert\GroupSequence({"Foo", "Entity"})
  * @Assert\Callback({"Symfony\Component\Validator\Tests\Fixtures\CallbackClass", "callback"})
+ * @Assert\Sequentially({
+ *     @Assert\Expression("this.getFirstName() != null")
+ * })
  */
 class Entity extends EntityParent implements EntityInterfaceB
 {

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/Entity.php
@@ -22,6 +22,11 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
     Assert\GroupSequence(['Foo', 'Entity']),
     Assert\Callback([CallbackClass::class, 'callback']),
 ]
+/**
+ * @Assert\Sequentially({
+ *     @Assert\Expression("this.getFirstName() != null")
+ * })
+ */
 class Entity extends EntityParent implements EntityInterfaceB
 {
     /**

--- a/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php
@@ -22,6 +22,9 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
     ConstraintA,
     Assert\GroupSequence(['Foo', 'Entity']),
     Assert\Callback([CallbackClass::class, 'callback']),
+    Assert\Sequentially([
+        new Assert\Expression('this.getFirstName() != null')
+    ])
 ]
 class Entity extends EntityParent implements EntityInterfaceB
 {

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -65,6 +66,9 @@ class AnnotationLoaderTest extends TestCase
         $expected->setGroupSequence(['Foo', 'Entity']);
         $expected->addConstraint(new ConstraintA());
         $expected->addConstraint(new Callback(['Symfony\Component\Validator\Tests\Fixtures\CallbackClass', 'callback']));
+        $expected->addConstraint(new Sequentially([
+            new Expression('this.getFirstName() != null'),
+        ]));
         $expected->addConstraint(new Callback(['callback' => 'validateMe', 'payload' => 'foo']));
         $expected->addConstraint(new Callback('validateMeStatic'));
         $expected->addPropertyConstraint('firstName', new NotNull());
@@ -151,6 +155,9 @@ class AnnotationLoaderTest extends TestCase
         $expected->setGroupSequence(['Foo', 'Entity']);
         $expected->addConstraint(new ConstraintA());
         $expected->addConstraint(new Callback(['Symfony\Component\Validator\Tests\Fixtures\CallbackClass', 'callback']));
+        $expected->addConstraint(new Sequentially([
+            new Expression('this.getFirstName() != null'),
+        ]));
         $expected->addConstraint(new Callback(['callback' => 'validateMe', 'payload' => 'foo']));
         $expected->addConstraint(new Callback('validateMeStatic'));
         $expected->addPropertyConstraint('firstName', new NotNull());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/44531
| License       | MIT
| Doc PR        | N/A

This PR allows to apply `Sequentially` constraint as an attribute onto class target.

Looks like it was missed on translating annotations to attributes.

![image](https://user-images.githubusercontent.com/1302230/144623891-98bde6b2-2376-4ac0-93fc-58b43a0b0f94.png)
![image](https://user-images.githubusercontent.com/1302230/144623958-7d5fe384-771a-4711-8c28-0e9bddfc4c41.png)

