### PR TITLE
[PropertyInfo] Add support for phpDocumentor and PHPStan pseudo-types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -157,7 +157,7 @@
         "egulias/email-validator": "~3.0.0",
         "masterminds/html5": "<2.6",
         "phpdocumentor/reflection-docblock": "<5.2",
-        "phpdocumentor/type-resolver": "<1.4.0",
+        "phpdocumentor/type-resolver": "<1.5.1",
         "ocramius/proxy-manager": "<2.1",
         "phpunit/phpunit": "<5.4.3"
     },

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add support for phpDocumentor and PHPStan pseudo-types
+
 6.0
 ---
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -406,6 +406,29 @@ class PhpDocExtractorTest extends TestCase
             ['ddd', null],
         ];
     }
+
+    /**
+     * @dataProvider pseudoTypesProvider
+     */
+    public function testPseudoTypes($property, array $type)
+    {
+        $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\PseudoTypesDummy', $property));
+    }
+
+    public function pseudoTypesProvider(): array
+    {
+        return [
+            ['classString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['classStringGeneric', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['htmlEscapedString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['lowercaseString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['nonEmptyLowercaseString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['nonEmptyString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['numericString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['traitString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['positiveInt', [new Type(Type::BUILTIN_TYPE_INT, false, null)]],
+        ];
+    }
 }
 
 class EmptyDocBlock

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -371,6 +371,39 @@ class PhpStanExtractorTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider pseudoTypesProvider
+     */
+    public function testPseudoTypes($property, array $type)
+    {
+        $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\PhpStanPseudoTypesDummy', $property));
+    }
+
+    public function pseudoTypesProvider(): array
+    {
+        return [
+            ['classString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['classStringGeneric', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['htmlEscapedString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['lowercaseString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['nonEmptyLowercaseString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['nonEmptyString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['numericString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['traitString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['interfaceString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['literalString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
+            ['positiveInt', [new Type(Type::BUILTIN_TYPE_INT, false, null)]],
+            ['negativeInt', [new Type(Type::BUILTIN_TYPE_INT, false, null)]],
+            ['nonEmptyArray', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true)]],
+            ['nonEmptyList', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT))]],
+            ['scalar', [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_FLOAT), new Type(Type::BUILTIN_TYPE_STRING), new Type(Type::BUILTIN_TYPE_BOOL)]],
+            ['number', [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_FLOAT)]],
+            ['numeric', [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_FLOAT), new Type(Type::BUILTIN_TYPE_STRING)]],
+            ['arrayKey', [new Type(Type::BUILTIN_TYPE_STRING), new Type(Type::BUILTIN_TYPE_INT)]],
+            ['double', [new Type(Type::BUILTIN_TYPE_FLOAT)]],
+        ];
+    }
+
     public function testDummyNamespace()
     {
         $this->assertEquals(

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PhpStanPseudoTypesDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PhpStanPseudoTypesDummy.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * @author Emil Masiakowski <emil.masiakowski@gmail.com>
+ */
+class PhpStanPseudoTypesDummy extends PseudoTypesDummy
+{
+    /** @var negative-int */
+    public $negativeInt;
+
+    /** @var non-empty-array */
+    public $nonEmptyArray;
+
+    /** @var non-empty-list */
+    public $nonEmptyList;
+
+    /** @var interface-string */
+    public $interfaceString;
+
+    /** @var scalar */
+    public $scalar;
+
+    /** @var array-key */
+    public $arrayKey;
+
+    /** @var number */
+    public $number;
+
+    /** @var numeric */
+    public $numeric;
+
+    /** @var double */
+    public $double;
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypesDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypesDummy.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * @author Emil Masiakowski <emil.masiakowski@gmail.com>
+ */
+class PseudoTypesDummy
+{
+    /** @var class-string */
+    public $classString;
+
+    /** @var class-string<\stdClass> */
+    public $classStringGeneric;
+
+    /** @var html-escaped-string */
+    public $htmlEscapedString;
+
+    /** @var lowercase-string */
+    public $lowercaseString;
+
+    /** @var non-empty-lowercase-string */
+    public $nonEmptyLowercaseString;
+
+    /** @var non-empty-string */
+    public $nonEmptyString;
+
+    /** @var numeric-string */
+    public $numericString;
+
+    /** @var trait-string */
+    public $traitString;
+
+    /** @var positive-int */
+    public $positiveInt;
+
+    /** @var literal-string */
+    public $literalString;
+}

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -11,13 +11,16 @@
 
 namespace Symfony\Component\PropertyInfo\Util;
 
+use phpDocumentor\Reflection\PseudoType;
 use phpDocumentor\Reflection\PseudoTypes\List_;
 use phpDocumentor\Reflection\Type as DocType;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Collection;
 use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\Null_;
 use phpDocumentor\Reflection\Types\Nullable;
+use phpDocumentor\Reflection\Types\String_;
 use Symfony\Component\PropertyInfo\Type;
 
 // Workaround for phpdocumentor/type-resolver < 1.6
@@ -141,6 +144,14 @@ final class PhpDocTypeHelper
             }
 
             return new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true, $collectionKeyType, $collectionValueType);
+        }
+
+        if ($type instanceof PseudoType) {
+            if ($type->underlyingType() instanceof Integer) {
+                return new Type(Type::BUILTIN_TYPE_INT, $nullable, null);
+            } elseif ($type->underlyingType() instanceof String_) {
+                return new Type(Type::BUILTIN_TYPE_STRING, $nullable, null);
+            }
         }
 
         $docType = $this->normalizeType($docType);

--- a/src/Symfony/Component/PropertyInfo/Util/PhpStanTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpStanTypeHelper.php
@@ -110,6 +110,10 @@ final class PhpStanTypeHelper
             return $this->compressNullableType($types);
         }
         if ($node instanceof GenericTypeNode) {
+            if ('class-string' === $node->type->name) {
+                return [new Type(Type::BUILTIN_TYPE_STRING)];
+            }
+
             [$mainType] = $this->extractTypes($node->type, $nameScope);
 
             $collectionKeyTypes = $mainType->getCollectionKeyTypes();
@@ -158,9 +162,16 @@ final class PhpStanTypeHelper
 
             switch ($node->name) {
                 case 'integer':
+                case 'positive-int':
+                case 'negative-int':
                     return [new Type(Type::BUILTIN_TYPE_INT)];
+                case 'double':
+                    return [new Type(Type::BUILTIN_TYPE_FLOAT)];
                 case 'list':
+                case 'non-empty-list':
                     return [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT))];
+                case 'non-empty-array':
+                    return [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true)];
                 case 'mixed':
                     return []; // mixed seems to be ignored in all other extractors
                 case 'parent':
@@ -168,8 +179,26 @@ final class PhpStanTypeHelper
                 case 'static':
                 case 'self':
                     return [new Type(Type::BUILTIN_TYPE_OBJECT, false, $nameScope->resolveRootClass())];
+                case 'class-string':
+                case 'html-escaped-string':
+                case 'lowercase-string':
+                case 'non-empty-lowercase-string':
+                case 'non-empty-string':
+                case 'numeric-string':
+                case 'trait-string':
+                case 'interface-string':
+                case 'literal-string':
+                    return [new Type(Type::BUILTIN_TYPE_STRING)];
                 case 'void':
                     return [new Type(Type::BUILTIN_TYPE_NULL)];
+                case 'scalar':
+                    return [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_FLOAT), new Type(Type::BUILTIN_TYPE_STRING), new Type(Type::BUILTIN_TYPE_BOOL)];
+                case 'number':
+                    return [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_FLOAT)];
+                case 'numeric':
+                    return [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_FLOAT), new Type(Type::BUILTIN_TYPE_STRING)];
+                case 'array-key':
+                    return [new Type(Type::BUILTIN_TYPE_STRING), new Type(Type::BUILTIN_TYPE_INT)];
             }
 
             return [new Type(Type::BUILTIN_TYPE_OBJECT, false, $nameScope->resolveStringName($node->name))];

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -36,7 +36,7 @@
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<5.2",
-        "phpdocumentor/type-resolver": "<1.4.0",
+        "phpdocumentor/type-resolver": "<1.5.1",
         "symfony/dependency-injection": "<5.4"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

More and more apps are using pseudo-types like `non-empty-string`, `positive-int` which are understood by static analysis tools but are not a part of the language. This PR adds support for these types to `PhpDocExtractor` and `PhpStanExtractor`. Pseudo-type is mapped to built-in type(s) (e.g. `non-empty-string` => `string`, `positive-int` => `int`, `number` => `int|float`).

This PR adds support for all pseudo-types defined by the [phpDocumentor](https://github.com/phpDocumentor/TypeResolver/tree/f8ec4ab631de5a97769e66b13418c3b8b24e81f4/src/PseudoTypes) (some of them like `list` or `true`, `false` are already supported) and [PHPStan's](https://phpstan.org/writing-php-code/phpdoc-types) basic types.