### PR TITLE
[ErrorHandler] Render template with status code assigned to the exception

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -452,6 +452,7 @@ class FrameworkExtension extends Extension
         $this->registerSecretsConfiguration($config['secrets'], $container, $loader);
 
         $container->getDefinition('exception_listener')->replaceArgument(3, $config['exceptions']);
+        $container->getDefinition('error_handler.error_renderer.html')->replaceArgument(6, $config['exceptions']);
 
         if ($this->isConfigEnabled($container, $config['serializer'])) {
             if (!class_exists(\Symfony\Component\Serializer\Serializer::class)) {
@@ -459,6 +460,8 @@ class FrameworkExtension extends Extension
             }
 
             $this->registerSerializerConfiguration($config['serializer'], $container, $loader);
+
+            $container->getDefinition('error_handler.error_renderer.serializer')->replaceArgument(4, $config['exceptions']);
         }
 
         if ($propertyInfoEnabled) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.php
@@ -30,6 +30,7 @@ return static function (ContainerConfigurator $container) {
                     ->factory([HtmlErrorRenderer::class, 'getAndCleanOutputBuffer'])
                     ->args([service('request_stack')]),
                 service('logger')->nullOnInvalid(),
+                abstract_arg('Configuration per exception class'),
             ])
 
         ->alias('error_renderer.html', 'error_handler.error_renderer.html')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -208,6 +208,7 @@ return static function (ContainerConfigurator $container) {
                 inline_service()
                     ->factory([HtmlErrorRenderer::class, 'isDebug'])
                     ->args([service('request_stack'), param('kernel.debug')]),
+                abstract_arg('Configuration per exception class'),
             ])
     ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -106,7 +106,7 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.error_controller'),
                 service('logger')->nullOnInvalid(),
                 param('kernel.debug'),
-                abstract_arg('an exceptions to log & status code mapping'),
+                abstract_arg('Configuration per exception class'),
             ])
             ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'request'])

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/dependency-injection": "^5.3|^6.0",
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/event-dispatcher": "^5.1|^6.0",
-        "symfony/error-handler": "^4.4.1|^5.0.1|^6.0",
+        "symfony/error-handler": "^5.4.2|^6.0.2",
         "symfony/http-foundation": "^5.3|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/polyfill-mbstring": "~1.0",

--- a/src/Symfony/Component/Serializer/Tests/ErrorRenderer/SerializerErrorRendererTest.php
+++ b/src/Symfony/Component/Serializer/Tests/ErrorRenderer/SerializerErrorRendererTest.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\ErrorRenderer;
+
+use function json_decode;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ErrorHandler\ErrorRenderer\SerializerErrorRenderer;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * @author Alexey Deriyenko <alexey.deriyenko@gmail.com>
+ */
+class SerializerErrorRendererTest extends TestCase
+{
+    /**
+     * @dataProvider getRenderData
+     */
+    public function testRenderReturnsJson(\Throwable $exception, SerializerErrorRenderer $serializerErrorRenderer)
+    {
+        $this->assertJson($serializerErrorRenderer->render($exception)->getAsString());
+    }
+
+    /**
+     * @dataProvider getRenderData
+     */
+    public function testRenderReturnsJsonWithCorrectStatusCode(\Throwable $exception, SerializerErrorRenderer $serializerErrorRenderer, int $expectedStatusCode)
+    {
+        $statusCodeFromJson = json_decode($serializerErrorRenderer->render($exception)->getAsString())->statusCode;
+        $this->assertEquals($expectedStatusCode, $statusCodeFromJson);
+    }
+
+    /**
+     * @dataProvider getRenderData
+     */
+    public function testRenderReturnsJsonWithCorrectStatusText(\Throwable $exception, SerializerErrorRenderer $serializerErrorRenderer, int $expectedStatusCode, string $expectedStatusText)
+    {
+        $statusTextFromJson = json_decode($serializerErrorRenderer->render($exception)->getAsString())->statusText;
+        $this->assertEquals($expectedStatusText, $statusTextFromJson);
+    }
+
+    public function getRenderData(): iterable
+    {
+        yield '->render() returns the JSON content without exception mapping config' => [
+            new \RuntimeException('Foo'),
+            new SerializerErrorRenderer(new Serializer([new ObjectNormalizer()], [new JsonEncoder()]), 'json'),
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            Response::$statusTexts[Response::HTTP_INTERNAL_SERVER_ERROR],
+        ];
+
+        yield '->render() returns the JSON content with exception mapping config' => [
+            new \RuntimeException('Foo'),
+            new SerializerErrorRenderer(new Serializer([new ObjectNormalizer()], [new JsonEncoder()]), 'json', null, false, [
+                \RuntimeException::class => [
+                    'status_code' => Response::HTTP_I_AM_A_TEAPOT,
+                    'log_level' => null,
+                ],
+            ]),
+            Response::HTTP_I_AM_A_TEAPOT,
+            Response::$statusTexts[Response::HTTP_I_AM_A_TEAPOT],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44433 
| License       | MIT
| Doc PR        | N/A


* Injecting `framework.exceptions` config into `Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer`
* Passing the status code from the config into `FlattenException::createFromThrowable()`
* Tests
