### PR TITLE
[Security] Allow RememberMeHandler to use a custom RememberMeDetails class

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -5,3 +5,9 @@ Validator
 ---------
 
  * Deprecate the "loose" e-mail validation mode, use "html5" instead
+
+Security
+--------
+
+ * Deprecate `RememberMeHandler` not implementing `getUserIdentifierForCookie()`; `AbstractRememberMeHandler` has a default implementation
+ * Deprecate `RememberMeHandler` not implementing `getRememberMeDetails()`; `AbstractRememberMeHandler` has a default implementation

--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -1,0 +1,8 @@
+UPGRADE FROM 6.4 to 7.0
+=======================
+
+Security
+--------
+
+ * Add `getRememberMeDetails()` to `RememberMeHandlerInterface`.
+ * Add `getUserIdentifierForCookie()` to `RememberMeHandlerInterface`.

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add the `Security` helper class
+ * Add the `getUserIdentifierForCookie()` method to the `Symfony\Bundle\SecurityBundle\RememberMe\DecoratedRememberMeHandler`
+   and `Symfony\Bundle\SecurityBundle\RememberMe\FirewallAwareRememberMeHandler` classes
 
 6.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/RememberMe/DecoratedRememberMeHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/RememberMe/DecoratedRememberMeHandler.php
@@ -50,6 +50,14 @@ final class DecoratedRememberMeHandler implements RememberMeHandlerInterface
     /**
      * {@inheritDoc}
      */
+    public function getUserIdentifierForCookie(RememberMeDetails $rememberMeDetails): string
+    {
+        return $this->handler->getUserIdentifierForCookie($rememberMeDetails);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function clearRememberMeCookie(): void
     {
         $this->handler->clearRememberMeCookie();

--- a/src/Symfony/Bundle/SecurityBundle/RememberMe/FirewallAwareRememberMeHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/RememberMe/FirewallAwareRememberMeHandler.php
@@ -51,4 +51,9 @@ final class FirewallAwareRememberMeHandler implements RememberMeHandlerInterface
     {
         $this->getForFirewall()->clearRememberMeCookie();
     }
+
+    public function getUserIdentifierForCookie(RememberMeDetails $rememberMeDetails): string
+    {
+        return $this->getForFirewall()->getUserIdentifierForCookie($rememberMeDetails);
+    }
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -87,14 +87,14 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
             throw new \LogicException('No remember-me cookie is found.');
         }
 
-        if (!is_callable([$this->rememberMeHandler, 'getRememberMeDetails'])) {
+        if (!\is_callable([$this->rememberMeHandler, 'getRememberMeDetails'])) {
             trigger_deprecation('symfony/security-http', '6.1', 'RememberMeHandlers should implement method "getRememberMeDetails()".');
             $rememberMeCookie = RememberMeDetails::fromRawCookie($rawCookie);
         } else {
             $rememberMeCookie = $this->rememberMeHandler->getRememberMeDetails($rawCookie);
         }
 
-        if (!is_callable([$this->rememberMeHandler, 'getUserIdentifierForCookie'])) {
+        if (!\is_callable([$this->rememberMeHandler, 'getUserIdentifierForCookie'])) {
             trigger_deprecation('symfony/security-http', '6.1', 'RememberMeHandlers should implement method "getUserIdentifierForCookie()".');
             $userIdentifier = $rememberMeCookie->getUserIdentifier();
         } else {

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -88,14 +88,12 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
         }
 
         if (!\is_callable([$this->rememberMeHandler, 'getRememberMeDetails'])) {
-            trigger_deprecation('symfony/security-http', '6.1', 'RememberMeHandlers should implement method "getRememberMeDetails()".');
             $rememberMeCookie = RememberMeDetails::fromRawCookie($rawCookie);
         } else {
             $rememberMeCookie = $this->rememberMeHandler->getRememberMeDetails($rawCookie);
         }
 
         if (!\is_callable([$this->rememberMeHandler, 'getUserIdentifierForCookie'])) {
-            trigger_deprecation('symfony/security-http', '6.1', 'RememberMeHandlers should implement method "getUserIdentifierForCookie()".');
             $userIdentifier = $rememberMeCookie->getUserIdentifier();
         } else {
             $userIdentifier = $this->rememberMeHandler->getUserIdentifierForCookie($rememberMeCookie);

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Deprecate `RememberMeHandler` not implementing `getUserIdentifierForCookie()`; `AbstractRememberMeHandler` has a default implementation
+ * Deprecate `RememberMeHandler` not implementing `getRememberMeDetails()`; `AbstractRememberMeHandler` has a default implementation
+ * Add `getRememberMeDetails()` method to `Symfony\Component\Security\Http\RememberMe\AbstractRememberMeHandler`
+ * Add `getUserIdentifierForCookie()` method to `Symfony\Component\Security\Http\RememberMe\AbstractRememberMeHandler`
+
 6.0
 ---
 

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeHandler.php
@@ -20,13 +20,14 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
+ * @author Patrick Elshof <tyrelcher@protonmail.com>
  */
 abstract class AbstractRememberMeHandler implements RememberMeHandlerInterface
 {
     private UserProviderInterface $userProvider;
-    protected $requestStack;
-    protected $options;
-    protected $logger;
+    protected RequestStack $requestStack;
+    protected array $options;
+    protected ?LoggerInterface $logger;
 
     public function __construct(UserProviderInterface $userProvider, RequestStack $requestStack, array $options = [], LoggerInterface $logger = null)
     {
@@ -87,6 +88,29 @@ abstract class AbstractRememberMeHandler implements RememberMeHandlerInterface
         $this->logger?->debug('Clearing remember-me cookie.', ['name' => $this->options['name']]);
 
         $this->createCookie(null);
+    }
+
+    /**
+     * Retrieves the User Identifier for the RememberMe cookie.
+     *
+     * If the cookie is required to contain the User Identifier {@see UserInterface::getUserIdentifier()}
+     * then it can simply be retrieved from the provided cookie details; if not, then it could be retrieved
+     * from elsewhere based on some other information provided (e.g. in a database).
+     */
+    public function getUserIdentifierForCookie(RememberMeDetails $rememberMeDetails): string
+    {
+        return $rememberMeDetails->getUserIdentifier();
+    }
+
+    /**
+     * Retrieves the RememberMeDetails using the raw cookie.
+     *
+     * This method allows the authenticator to retrieve the cookie details without needing
+     * to care about the implementation details used by the RememberMeHandler.
+     */
+    public function getRememberMeDetails(string $rawCookie): RememberMeDetails
+    {
+        return RememberMeDetails::fromRawCookie($rawCookie);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeHandlerInterface.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @author Patrick Elshof <tyrelcher@protonmail.com>
  *
  * @method string            getUserIdentifierForCookie(RememberMeDetails $rememberMeDetails) Retrieves the User Identifier for the RememberMe cookie.
- * @method RememberMeDetails getRememberMeDetails(string $rawCookie) Retrieves the RememberMeDetails using the raw cookie.
+ * @method RememberMeDetails getRememberMeDetails(string $rawCookie)                          Retrieves the RememberMeDetails using the raw cookie.
  */
 interface RememberMeHandlerInterface
 {

--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeHandlerInterface.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * {@see AbstractRememberMeHandler} instead.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
+ * @author Patrick Elshof <tyrelcher@protonmail.com>
  */
 interface RememberMeHandlerInterface
 {
@@ -51,4 +52,25 @@ interface RememberMeHandlerInterface
      * This should set a cookie with a `null` value on the request attribute.
      */
     public function clearRememberMeCookie(): void;
+
+    /**
+     * Retrieves the User Identifier for the RememberMe cookie.
+     *
+     * If the cookie is required to contain the User Identifier {@see UserInterface::getUserIdentifier()}
+     * then it can simply be retrieved from the provided cookie details; if not, then it could be retrieved
+     * from elsewhere based on some other information provided (e.g. in a database).
+     *
+     * Cannot be added to 6.1 because of backwards compatibility.
+     */
+    //public function getUserIdentifierForCookie(RememberMeDetails $rememberMeDetails): string;
+
+    /**
+     * Retrieves the RememberMeDetails using the raw cookie.
+     *
+     * This method allows the authenticator to retrieve the cookie details without needing
+     * to care about the implementation details of the RememberMeDetails used by the RememberMeHandler.
+     *
+     * Cannot be added to 6.1 because of backwards compatibility.
+     */
+    //public function getRememberMeDetails(string $rawCookie): RememberMeDetails;
 }

--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeHandlerInterface.php
@@ -22,6 +22,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  * @author Patrick Elshof <tyrelcher@protonmail.com>
+ *
+ * @method string            getUserIdentifierForCookie(RememberMeDetails $rememberMeDetails) Retrieves the User Identifier for the RememberMe cookie.
+ * @method RememberMeDetails getRememberMeDetails(string $rawCookie) Retrieves the RememberMeDetails using the raw cookie.
  */
 interface RememberMeHandlerInterface
 {
@@ -52,25 +55,4 @@ interface RememberMeHandlerInterface
      * This should set a cookie with a `null` value on the request attribute.
      */
     public function clearRememberMeCookie(): void;
-
-    /**
-     * Retrieves the User Identifier for the RememberMe cookie.
-     *
-     * If the cookie is required to contain the User Identifier {@see UserInterface::getUserIdentifier()}
-     * then it can simply be retrieved from the provided cookie details; if not, then it could be retrieved
-     * from elsewhere based on some other information provided (e.g. in a database).
-     *
-     * Cannot be added to 6.1 because of backwards compatibility.
-     */
-    //public function getUserIdentifierForCookie(RememberMeDetails $rememberMeDetails): string;
-
-    /**
-     * Retrieves the RememberMeDetails using the raw cookie.
-     *
-     * This method allows the authenticator to retrieve the cookie details without needing
-     * to care about the implementation details of the RememberMeDetails used by the RememberMeHandler.
-     *
-     * Cannot be added to 6.1 because of backwards compatibility.
-     */
-    //public function getRememberMeDetails(string $rawCookie): RememberMeDetails;
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -31,7 +31,11 @@ class RememberMeAuthenticatorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->rememberMeHandler = $this->createMock(RememberMeHandlerInterface::class);
+        $this->rememberMeHandler = $this->getMockBuilder(RememberMeHandlerInterface::class)
+            ->onlyMethods(get_class_methods(RememberMeHandlerInterface::class))
+            ->addMethods(['getRememberMeDetails', 'getUserIdentifierForCookie'])
+            ->getMock();
+
         $this->tokenStorage = new TokenStorage();
         $this->authenticator = new RememberMeAuthenticator($this->rememberMeHandler, 's3cr3t', $this->tokenStorage, '_remember_me_cookie');
     }
@@ -67,6 +71,15 @@ class RememberMeAuthenticatorTest extends TestCase
     {
         $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 1, 'secret');
         $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => $rememberMeDetails->toString()]);
+
+        $this->rememberMeHandler->expects($this->once())->method('getRememberMeDetails')
+            ->with($rememberMeDetails->toString())
+            ->willReturn($rememberMeDetails);
+
+        $this->rememberMeHandler->expects($this->once())->method('getUserIdentifierForCookie')
+            ->with($rememberMeDetails)
+            ->willReturn('wouter');
+
         $passport = $this->authenticator->authenticate($request);
 
         $this->rememberMeHandler->expects($this->once())->method('consumeRememberMeCookie')->with($this->callback(function ($arg) use ($rememberMeDetails) {
@@ -86,7 +99,40 @@ class RememberMeAuthenticatorTest extends TestCase
     {
         $this->expectException(AuthenticationException::class);
 
-        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => base64_encode('foo:bar')]);
+        $encodedData = base64_encode('foo:bar');
+        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => $encodedData]);
+
+        $this->rememberMeHandler->expects($this->once())->method('getRememberMeDetails')->with($encodedData)->willThrowException(new AuthenticationException());
         $this->authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateDeprecatedCodePath()
+    {
+        $mock = $this->getMockBuilder(RememberMeHandlerInterface::class)
+            ->getMock();
+
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 1, 'secret');
+        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => $rememberMeDetails->toString()]);
+
+        $authenticator = new RememberMeAuthenticator($mock, 's3cr3t', $this->tokenStorage, '_remember_me_cookie');
+        $passport = $authenticator->authenticate($request);
+
+        $mock->expects($this->once())->method('consumeRememberMeCookie')->with($this->callback(function ($arg) use ($rememberMeDetails) {
+            return $rememberMeDetails == $arg;
+        }));
+        $passport->getUser(); // trigger the user loader
+    }
+
+    public function testAuthenticateWithoutOldTokenDeprecatedCodePath()
+    {
+        $mock = $this->getMockBuilder(RememberMeHandlerInterface::class)
+            ->getMock();
+
+        $this->expectException(AuthenticationException::class);
+
+        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => base64_encode('foo:bar')]);
+
+        $authenticator = new RememberMeAuthenticator($mock, 's3cr3t', $this->tokenStorage, '_remember_me_cookie');
+        $authenticator->authenticate($request);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -106,6 +106,9 @@ class RememberMeAuthenticatorTest extends TestCase
         $this->authenticator->authenticate($request);
     }
 
+    /**
+     * @group legacy
+     */
     public function testAuthenticateDeprecatedCodePath()
     {
         $mock = $this->getMockBuilder(RememberMeHandlerInterface::class)
@@ -123,6 +126,9 @@ class RememberMeAuthenticatorTest extends TestCase
         $passport->getUser(); // trigger the user loader
     }
 
+    /**
+     * @group legacy
+     */
     public function testAuthenticateWithoutOldTokenDeprecatedCodePath()
     {
         $mock = $this->getMockBuilder(RememberMeHandlerInterface::class)

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -130,4 +130,16 @@ class PersistentRememberMeHandlerTest extends TestCase
 
         $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
     }
+
+    public function testGetUserIdentifierForCookie()
+    {
+        $this->assertEquals('wouter', $this->handler->getUserIdentifierForCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'signature')));
+    }
+
+    public function testGetRememberMeDetails()
+    {
+        $details = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'signature');
+
+        $this->assertEquals($details, $this->handler->getRememberMeDetails($details->toString()));
+    }
 }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/SignatureRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/SignatureRememberMeHandlerTest.php
@@ -122,4 +122,16 @@ class SignatureRememberMeHandlerTest extends TestCase
 
         $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'signature'));
     }
+
+    public function testGetUserIdentifierForCookie()
+    {
+        $this->assertEquals('wouter', $this->handler->getUserIdentifierForCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'signature')));
+    }
+
+    public function testGetRememberMeDetails()
+    {
+        $details = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'signature');
+
+        $this->assertEquals($details, $this->handler->getRememberMeDetails($details->toString()));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #44168
| License       | MIT
| Doc PR        | -

When writing a custom `RememberMeHandler` it is not possible to change anything about what is stored in the cookie or how. Not every implementation would for example need to include the user class or identifier in the cookie or may not even want to. Maybe you might want to add some other value to it, in which case concatenating it to the `$value` parameter would seem like more of a dirty workaround.

This PR adds support for the `RememberMeAuthenticator` and `RememberMeHandler` to use a different `RememberMeDetails` class when needed.

Currently I have not yet added an interface for `RememberMeDetails` to implement so it would be necessary to extend the class directly. This is because I'm thinking of making an RFC first for changing the `RememberMeDetails` implementation for the different available strategies.