### PR TITLE
[TwigBridge] Provide a default non-empty label on empty options to validate HTML5

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -61,7 +61,7 @@
     {%- endif -%}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
         {%- if placeholder is not none -%}
-            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ placeholder != '' ? (translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain)) }}</option>
+            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ placeholder != '' ? (translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain)) : '--' }}</option>
         {%- endif -%}
         {%- if preferred_choices|length > 0 -%}
             {% set options = preferred_choices %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

As described on https://rocketvalidator.com/html-validation/element-option-without-attribute-label-must-not-be-empty, so far this template generates empty options with no value, no content, and no label. This is not a break, but a simple "should".

Not sure how we should recommend handling this, users have the possibility to handle this themselves (https://symfony.com/doc/current/reference/forms/types/choice.html#placeholder), but if they don't we leave a non-stadanrd-compliant output.

The tailwind template is also affected from this, as it extends this one.

I proposed a double-dash default value:
- pretty affordant
- doesn't use translations as users might not use them
- doesn't suffer from language dependent doubtful meaning

I locally fix this by overriding the default templates, but I thought the default ones could get a fix.

Also, to make it quick, I proposed to change this starting 5.4. Maybe we can push this back to 4.4?
