### PR TITLE
[FrameworkBundle] Fix typo in ContainerLintCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -74,7 +74,7 @@ final class ContainerLintCommand extends Command
             return 1;
         }
 
-        $io->success('The container was lint successfully: all services are injected with values that are compatible with their type declarations.');
+        $io->success('The container was linted successfully: all services are injected with values that are compatible with their type declarations.');
 
         return 0;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This pull request

- [x] fixes the wording of a success message

💁‍♂️ For reference, see https://en.wiktionary.org/wiki/lint#Verb.