### PR TITLE
[Console] Fix parameter types for `ProcessHelper::mustRun()`

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -95,10 +95,10 @@ class ProcessHelper extends Helper
      * This is identical to run() except that an exception is thrown if the process
      * exits with a non-zero exit code.
      *
-     * @param string|Process $cmd      An instance of Process or a command to run
-     * @param string|null    $error    An error message that must be displayed if something went wrong
-     * @param callable|null  $callback A PHP callback to run whenever there is some
-     *                                 output available on STDOUT or STDERR
+     * @param array|Process $cmd      An instance of Process or a command to run
+     * @param string|null   $error    An error message that must be displayed if something went wrong
+     * @param callable|null $callback A PHP callback to run whenever there is some
+     *                                output available on STDOUT or STDERR
      *
      * @return Process The process that ran
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The `mustRun()` method wraps the `run()` method and therefor must accepts the same parameter types. However, `mustRun()` claims to accept a string as `$cmd` while `run()` requires it to be an array.

This PR fixes the incorrect doc block.