### PR TITLE
[Validator] Restore default locale in ConstraintValidatorTestCase

### DIFF
--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -58,6 +58,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
     protected $propertyPath;
     protected $constraint;
     protected $defaultTimezone;
+    private $defaultLocale;
 
     private function doSetUp()
     {
@@ -76,6 +77,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $this->validator = $this->createValidator();
         $this->validator->initialize($this->context);
 
+        $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
 
         $this->setDefaultTimezone('UTC');
@@ -84,6 +86,8 @@ abstract class ConstraintValidatorTestCase extends TestCase
     private function doTearDown()
     {
         $this->restoreDefaultTimezone();
+
+        \Locale::setDefault($this->defaultLocale);
     }
 
     protected function setDefaultTimezone($defaultTimezone)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Previously this code was not resetting the locale after changing it to `en` - which affected other tests which relied on this value being the configured value (however it was configured).

This mirrors the pattern used for the timezone, storing it to be reset on tearDown.

I've based this on 6.1. If it's valid, I'm unsure if it's classed a bug, or needs UPGRADE notes?