### PR TITLE
[Translation] [Bridge] [Lokalise] Fix push keys to lokalise. Closes #…

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -32,6 +32,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class LokaliseProvider implements ProviderInterface
 {
+    private const LOKALISE_GET_KEYS_LIMIT = 5000;
+
     private $client;
     private $loader;
     private $logger;
@@ -75,7 +77,7 @@ final class LokaliseProvider implements ProviderInterface
                 $existingKeysByDomain[$domain] = [];
             }
 
-            $existingKeysByDomain[$domain] += $this->getKeysIds(array_keys($defaultCatalogue->all($domain)), $domain);
+            $existingKeysByDomain[$domain] += $this->getKeysIds([], $domain);
         }
 
         $keysToCreate = $createdKeysByDomain = [];
@@ -219,7 +221,7 @@ final class LokaliseProvider implements ProviderInterface
      * Translations will be created for keys without existing translations.
      * Translations will be updated for keys with existing translations.
      */
-    private function updateTranslations(array $keysByDomain, TranslatorBagInterface $translatorBag)
+    private function updateTranslations(array $keysByDomain, TranslatorBagInterface $translatorBag): void
     {
         $keysToUpdate = [];
 
@@ -250,28 +252,23 @@ final class LokaliseProvider implements ProviderInterface
             }
         }
 
-        $chunks = array_chunk($keysToUpdate, 500);
-        $responses = [];
+        $response = $this->client->request('PUT', 'keys', [
+            'json' => ['keys' => $keysToUpdate],
+        ]);
 
-        foreach ($chunks as $chunk) {
-            $responses[] = $this->client->request('PUT', 'keys', [
-                'json' => ['keys' => $chunk],
-            ]);
-        }
-
-        foreach ($responses as $response) {
-            if (200 !== $response->getStatusCode()) {
-                $this->logger->error(sprintf('Unable to create/update translations to Lokalise: "%s".', $response->getContent(false)));
-            }
+        if (200 !== $response->getStatusCode()) {
+            $this->logger->error(sprintf('Unable to create/update translations to Lokalise: "%s".', $response->getContent(false)));
         }
     }
 
-    private function getKeysIds(array $keys, string $domain): array
+    private function getKeysIds(array $keys, string $domain, int $page = 1): array
     {
         $response = $this->client->request('GET', 'keys', [
             'query' => [
                 'filter_keys' => implode(',', $keys),
                 'filter_filenames' => $this->getLokaliseFilenameFromDomain($domain),
+                'limit' => self::LOKALISE_GET_KEYS_LIMIT,
+                'page' => $page,
             ],
         ]);
 
@@ -279,14 +276,33 @@ final class LokaliseProvider implements ProviderInterface
             $this->logger->error(sprintf('Unable to get keys ids from Lokalise: "%s".', $response->getContent(false)));
         }
 
-        return array_reduce($response->toArray(false)['keys'], static function ($carry, array $keyItem) {
-            $carry[$keyItem['key_name']['web']] = $keyItem['key_id'];
+        $result = [];
+        $keysFromResponse = $response->toArray(false)['keys'] ?? [];
 
-            return $carry;
-        }, []);
+        if (\count($keysFromResponse) > 0) {
+            $result = array_reduce($keysFromResponse, static function ($carry, array $keyItem) {
+                $carry[$keyItem['key_name']['web']] = $keyItem['key_id'];
+
+                return $carry;
+            }, []);
+        }
+
+        $paginationTotalCount = $response->getHeaders(false)['x-pagination-total-count'] ?? [];
+        $keysTotalCount = (int) (reset($paginationTotalCount) ?? 0);
+
+        if (0 === $keysTotalCount) {
+            return $result;
+        }
+
+        $pages = ceil($keysTotalCount / self::LOKALISE_GET_KEYS_LIMIT);
+        if ($page < $pages) {
+            $result = array_merge($result, $this->getKeysIds($keys, $domain, ++$page));
+        }
+
+        return $result;
     }
 
-    private function ensureAllLocalesAreCreated(TranslatorBagInterface $translatorBag)
+    private function ensureAllLocalesAreCreated(TranslatorBagInterface $translatorBag): void
     {
         $providerLanguages = $this->getLanguages();
         $missingLanguages = array_reduce($translatorBag->getCatalogues(), static function ($carry, $catalogue) use ($providerLanguages) {

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -76,8 +76,10 @@ class LokaliseProviderTest extends ProviderTestCase
 
         $getKeysIdsForMessagesDomainResponse = function (string $method, string $url, array $options = []): ResponseInterface {
             $expectedQuery = [
-                'filter_keys' => 'young_dog',
+                'filter_keys' => '',
                 'filter_filenames' => 'messages.xliff',
+                'limit' => 5000,
+                'page' => 1,
             ];
 
             $this->assertSame('GET', $method);
@@ -89,8 +91,10 @@ class LokaliseProviderTest extends ProviderTestCase
 
         $getKeysIdsForValidatorsDomainResponse = function (string $method, string $url, array $options = []): ResponseInterface {
             $expectedQuery = [
-                'filter_keys' => 'post.num_comments',
+                'filter_keys' => '',
                 'filter_filenames' => 'validators.xliff',
+                'limit' => 5000,
+                'page' => 1,
             ];
 
             $this->assertSame('GET', $method);
@@ -337,6 +341,8 @@ class LokaliseProviderTest extends ProviderTestCase
             $expectedQuery = [
                 'filter_keys' => 'a',
                 'filter_filenames' => 'messages.xliff',
+                'limit' => 5000,
+                'page' => 1,
             ];
 
             $this->assertSame('GET', $method);
@@ -355,6 +361,8 @@ class LokaliseProviderTest extends ProviderTestCase
             $expectedQuery = [
                 'filter_keys' => 'post.num_comments',
                 'filter_filenames' => 'validators.xliff',
+                'limit' => 5000,
+                'page' => 1,
             ];
 
             $this->assertSame('GET', $method);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #44444 
| License       | MIT
| Doc PR        | N/A

Fixed issue in #44444 within fix some other problems e.g. 
* localise GET method "keys" return only 100 keys per request by default, max 5000. Fixed it and get all the available keys.
* localise recommend update\create only 500 keys per request but service refuse another chank with error "Your token is currently used to process another request. We do not support concurrent requests.". So I send all keys in one request and it works fine.
* add return types to some methods