### PR TITLE
[Console] Handle alias in completion script

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.bash
+++ b/src/Symfony/Component/Console/Resources/completion.bash
@@ -9,6 +9,12 @@ _sf_{{ COMMAND_NAME }}() {
     # Use newline as only separator to allow space in completion values
     IFS=$'\n'
     local sf_cmd="${COMP_WORDS[0]}"
+
+    # for an alias, get the real script behind it
+    if [[ $(type -t $sf_cmd) == "alias" ]]; then
+        sf_cmd=$(alias $sf_cmd | sed -E "s/alias $sf_cmd='(.*)'/\1/")
+    fi
+
     if [ ! -f "$sf_cmd" ]; then
         return 1
     fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44461
| License       | MIT
| Doc PR        | -

Detect when completion is triggered by an alias and get the underlying command. Tip extracted from [bamarni/symfony-console-autocomplete](https://github.com/bamarni/symfony-console-autocomplete/blob/v1.4.2/resources/bash/default.php#L7-L10).

Works well with such alias:

```console
alias console=bin/console
```

Doesn't work with these aliases (command name is not the 1st part of the alias):

```console
alias console='APP_ENV=test bin/console'
```

When alias has a different name, the name in the completion script must be updated.