### PR TITLE
PlantUmlDumper: use str_starts_with()

### DIFF
--- a/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
@@ -237,7 +237,7 @@ class PlantUmlDumper implements DumperInterface
     private function getTransitionColor(string $color): string
     {
         // PUML format requires that color in transition have to be prefixed with “#”.
-        if ('#' !== substr($color, 0, 1)) {
+        if (!str_starts_with($color, '#')) {
             $color = '#'.$color;
         }
 


### PR DESCRIPTION
instead of substr()

| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Use `str_starts_with()` instead of `substr()` (in a code I wrote a while ago for #29538).
