### PR TITLE
[Mailer] Render the message before setting the headers

### DIFF
--- a/src/Symfony/Component/Mailer/EventListener/MessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageListener.php
@@ -40,8 +40,11 @@ class MessageListener implements EventSubscriberInterface
             return;
         }
 
-        $this->setHeaders($message);
+        // the renderer might modify the message and add new headers
+        // so we have to render it before setting the headers
+        // @see \Symfony\Bridge\Twig\Mime\WrappedTemplatedEmail
         $this->renderMessage($message);
+        $this->setHeaders($message);
     }
 
     private function setHeaders(Message $message): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

My use case would be setting the subject of an email from a template by calling

```twig
{% do email.setSubject('email.subject'|trans) %}
<h1>{{ email.subject }}</h1>
```

Maybe it's not the best idea for a template to have side effects, but
WrappedTemplatedEmail has setters, so it should be possible and it's
convenient to set the subject in the template like this.