### PR TITLE
[HttpClient] Double check if handle is complete

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -277,6 +277,9 @@ final class CurlResponse implements ResponseInterface
             while (\CURLM_CALL_MULTI_PERFORM === curl_multi_exec($multi->handle, $active));
 
             while ($info = curl_multi_info_read($multi->handle)) {
+                if (\CURLMSG_DONE !== $info['msg']) {
+                    continue;
+                }
                 $result = $info['result'];
                 $id = (int) $ch = $info['handle'];
                 $waitFor = @curl_getinfo($ch, \CURLINFO_PRIVATE) ?: '_0';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This is a forward compatibility fix. We did the same in Guzzle after a comment from bagder. 

https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216

Basically, if libcurl decides to add an other value for `msg`, then our code will break without this PR. The only value for `msg` with current latest version of curl is `CURLMSG_DONE` which means that this is not a bugfix yet.. but it make sure that we respect the libcurl API.
