### PR TITLE
[DoctrineBridge][Form] Fix `EntityType` memory leak

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -43,6 +43,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
+use Symfony\Component\Form\ChoiceList\Factory\Cache\AbstractStaticOption;
 use Symfony\Component\Form\DependencyInjection\FormPass;
 use Symfony\Component\HttpClient\DependencyInjection\HttpClientPass;
 use Symfony\Component\HttpFoundation\Request;
@@ -94,6 +95,15 @@ class FrameworkBundle extends Bundle
 
         if ($this->container->getParameter('kernel.http_method_override')) {
             Request::enableHttpMethodParameterOverride();
+        }
+    }
+
+    public function shutdown()
+    {
+        parent::shutdown();
+
+        if (class_exists(AbstractStaticOption::class)) {
+            AbstractStaticOption::reset();
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40965
| License       | MIT
| Doc PR        | n/a

Symfony 5.1 (#30994) introduced a memory leak (at least for functional tests) when using the EntityType. See https://github.com/symfony/symfony/issues/40965#issuecomment-988079028 for more details.