### PR TITLE
Use str_ends_with() and str_starts_with()

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Csp/ContentSecurityPolicyHandler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Csp/ContentSecurityPolicyHandler.php
@@ -224,7 +224,7 @@ class ContentSecurityPolicyHandler
             if (!str_ends_with($directive, '\'')) {
                 continue;
             }
-            if ('\'nonce-' === substr($directive, 0, 7)) {
+            if (str_starts_with($directive, '\'nonce-')) {
                 return true;
             }
             if (\in_array(substr($directive, 0, 8), ['\'sha256-', '\'sha384-', '\'sha512-'], true)) {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -254,7 +254,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
         $text = $prefix.preg_replace('~([^\\n]{'.$width.'})\\ *~', "\$1\n", $text);
         $text = rtrim($text, "\n").($matches[1] ?? '');
 
-        if (!$currentLineLength && '' !== $current && "\n" !== substr($current, -1)) {
+        if (!$currentLineLength && '' !== $current && !str_ends_with($current, "\n")) {
             $text = "\n".$text;
         }
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/AddAnnotatedClassesToCachePass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/AddAnnotatedClassesToCachePass.php
@@ -117,7 +117,7 @@ class AddAnnotatedClassesToCachePass implements CompilerPassInterface
             $regex = strtr($regex, ['\\*\\*' => '.*?', '\\*' => '[^\\\\]*?']);
 
             // If this class does not end by a slash, anchor the end
-            if ('\\' !== substr($regex, -1)) {
+            if (!str_ends_with($regex, '\\')) {
                 $regex .= '$';
             }
 

--- a/src/Symfony/Component/Mime/Tests/Encoder/Rfc2231EncoderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Encoder/Rfc2231EncoderTest.php
@@ -102,7 +102,7 @@ class Rfc2231EncoderTest extends TestCase
         $dir = realpath(__DIR__.'/../Fixtures/samples/charsets');
         $sampleFp = opendir($dir);
         while (false !== $encoding = readdir($sampleFp)) {
-            if ('.' == substr($encoding, 0, 1)) {
+            if (str_starts_with($encoding, '.')) {
                 continue;
             }
 
@@ -110,7 +110,7 @@ class Rfc2231EncoderTest extends TestCase
             if (is_dir($dir.'/'.$encoding)) {
                 $fileFp = opendir($dir.'/'.$encoding);
                 while (false !== $sampleFile = readdir($fileFp)) {
-                    if ('.' == substr($sampleFile, 0, 1)) {
+                    if (str_starts_with($sampleFile, '.')) {
                         continue;
                     }
 

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -37,7 +37,7 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
             new \RecursiveCallbackFilterIterator(
                 new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS),
                 function (\SplFileInfo $current) {
-                    return '.' !== substr($current->getBasename(), 0, 1);
+                    return !str_starts_with($current->getBasename(), '.');
                 }
             ),
             \RecursiveIteratorIterator::LEAVES_ONLY

--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -45,7 +45,7 @@ class CsvFileLoader extends FileLoader
                 continue;
             }
 
-            if ('#' !== substr($data[0], 0, 1) && isset($data[1]) && 2 === \count($data)) {
+            if (!str_starts_with($data[0], '#') && isset($data[1]) && 2 === \count($data)) {
                 $messages[$data[0]] = $data[1];
             }
         }

--- a/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
@@ -237,7 +237,7 @@ class PlantUmlDumper implements DumperInterface
     private function getTransitionColor(string $color): string
     {
         // PUML format requires that color in transition have to be prefixed with “#”.
-        if ('#' !== substr($color, 0, 1)) {
+        if (!str_starts_with($color, '#')) {
             $color = '#'.$color;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Use `str_ends_with()` and `str_starts_with()` instead of `substr()`.

(replaces #44482 and #44476 :smiling_face_with_tear:)

