### PR TITLE
[FrameworkBundle] Allow PHP configuration in config/packages by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Environment variable `SYMFONY_IDE` is read by default when `framework.ide` config is not set.
+ * Load PHP configuration files by default in the `MicroKernelTrait`
 
 6.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -50,8 +50,8 @@ trait MicroKernelTrait
     {
         $configDir = $this->getConfigDir();
 
-        $container->import($configDir.'/{packages}/*.yaml');
-        $container->import($configDir.'/{packages}/'.$this->environment.'/*.yaml');
+        $container->import($configDir.'/{packages}/*.{php,yaml}');
+        $container->import($configDir.'/{packages}/'.$this->environment.'/*.{php,yaml}');
 
         if (is_file($configDir.'/services.yaml')) {
             $container->import($configDir.'/services.yaml');
@@ -74,8 +74,8 @@ trait MicroKernelTrait
     {
         $configDir = $this->getConfigDir();
 
-        $routes->import($configDir.'/{routes}/'.$this->environment.'/*.yaml');
-        $routes->import($configDir.'/{routes}/*.yaml');
+        $routes->import($configDir.'/{routes}/'.$this->environment.'/*.{php,yaml}');
+        $routes->import($configDir.'/{routes}/*.{php,yaml}');
 
         if (is_file($configDir.'/routes.yaml')) {
             $routes->import($configDir.'/routes.yaml');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | -

Since the introduction of ConfigBuilders in 5.3, it is way more common for developers to use PHP configuration files in config/packages, yet these config files are still not loaded by default. Having this small change would drastically improve the developer experience for those who prefer working with PHP configuration.

I have a doc PR ready but wanted to check first if this is something the maintainers could agree on.