### PR TITLE
[DebugBundle] Add missing README

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/README.md
+++ b/src/Symfony/Bundle/DebugBundle/README.md
@@ -1,0 +1,13 @@
+DebugBundle
+===========
+
+DebugBundle provides a tight integration of the Symfony VarDumper component and
+the ServerLogCommand from MonologBridge into the Symfony full-stack framework.
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "symfony/debug-bundle",
     "type": "symfony-bundle",
-    "description": "Provides a tight integration of the Symfony Debug component into the Symfony full-stack framework",
+    "description": "Provides a tight integration of the Symfony VarDumper component and the ServerLogCommand from MonologBridge into the Symfony full-stack framework",
     "keywords": [],
     "homepage": "https://symfony.com",
     "license": "MIT",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Thanks to the "package-tests" action, I noticed that the DebugBundle is the only package that does not have a README (on 4.4). I also fixed the description. The DebugBundle doesn't use the Debug or ErrorHandler component.