### PR TITLE
[Workflow] Fix eventsToDispatch parameter setup for StateMachine

### DIFF
--- a/src/Symfony/Component/Workflow/StateMachine.php
+++ b/src/Symfony/Component/Workflow/StateMachine.php
@@ -20,8 +20,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class StateMachine extends Workflow
 {
-    public function __construct(Definition $definition, MarkingStoreInterface $markingStore = null, EventDispatcherInterface $dispatcher = null, string $name = 'unnamed')
+    public function __construct(Definition $definition, MarkingStoreInterface $markingStore = null, EventDispatcherInterface $dispatcher = null, string $name = 'unnamed', array $eventsToDispatch = null)
     {
-        parent::__construct($definition, $markingStore ?? new MethodMarkingStore(true), $dispatcher, $name);
+        parent::__construct($definition, $markingStore ?? new MethodMarkingStore(true), $dispatcher, $name, $eventsToDispatch);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | see description
| License       | MIT
| Doc PR        | N/A

Using `state_machine` type of the workflow in the project have mentioned that workflow events still propagated with `events_to_dispatch: []` parameter. But this bug does not appear for `workflow` type. 

Current pull request fixes that bug by adding $eventsToDispatch parameter initialization for StateMachine class.

Before fixing (`state_machine` with `events_to_dispatch: []`):
![Screenshot from 2021-12-08 10-55-51](https://user-images.githubusercontent.com/13361839/145183068-e419b48e-129d-424a-89d4-5c2ed77b0695.png)

After fixing (`state_machine` with `events_to_dispatch: []`);
![Screenshot from 2021-12-08 10-54-58](https://user-images.githubusercontent.com/13361839/145183132-f227d927-f385-4ede-b60d-87d1f8fa2bf4.png)

