### PR TITLE
Don't access uninitialized typed property ChromePhpHandler::$response

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
@@ -59,7 +59,7 @@ class ChromePhpHandler extends BaseChromePhpHandler
             return;
         }
 
-        if ($this->response) {
+        if (isset($this->response)) {
             $this->response->headers->set($header, $content);
         } else {
             $this->headers[$header] = $content;


### PR DESCRIPTION
Fixes #44513

| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| Tickets       | Fix #44513
| License       | MIT