### PR TITLE
[Console] Fix polyfill-php73 requirement

### DIFF
--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/polyfill-php73": "^1.8",
+        "symfony/polyfill-php73": "^1.9",
         "symfony/polyfill-php80": "^1.16",
         "symfony/service-contracts": "^1.1|^2|^3",
         "symfony/string": "^5.1|^6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Fixes dependencies - https://github.com/symfony/polyfill-php73/commit/747accebb510cddb7709dfc687007ff22f8c0cd2 added array_key_last in 1.9 and https://github.com/symfony/console/commit/fb8a259b7585eb160a0e777756a560d4dab7dc8e started using it in Symfony 5.4 but it doesn't exist in 1.8 so my --prefer-lowest build is failing