### PR TITLE
[Messenger] Allow StopWorkerOnTimeLimitListener to be extended

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnTimeLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnTimeLimitListener.php
@@ -22,9 +22,9 @@ use Symfony\Component\Messenger\Event\WorkerStartedEvent;
  */
 class StopWorkerOnTimeLimitListener implements EventSubscriberInterface
 {
-    private int $timeLimitInSeconds;
-    private ?LoggerInterface $logger;
-    private float $endTime = 0;
+    protected int $timeLimitInSeconds;
+    protected ?LoggerInterface $logger;
+    protected float $endTime = 0;
 
     public function __construct(int $timeLimitInSeconds, LoggerInterface $logger = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Would allow to extend `StopWorkerOnTimeLimitListener` to create custom time based listeners, like for example:
```php
class StopWorkerOnInactivityLimitListener extends StopWorkerOnTimeLimitListener
{
    public function onWorkerRunning(WorkerRunningEvent $event): void
    {
        if (!$event->isWorkerIdle()) {
            $this->endTime += $this->timeLimitInSeconds;
        }

        parent::onWorkerRunning($event);
    }
}
```