### PR TITLE
Release v6.0.1

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -7,6 +7,33 @@ in 6.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.0.0...v6.0.1
 
+* 6.0.1 (2021-12-09)
+
+ * bug #44494 Remove FQCN type hints on properties (fabpot)
+ * bug #44490 [DependencyInjection][Messenger] Add auto-registration for BatchHandlerInterface (GaryPEGEOT)
+ * bug #44523 [Console] Fix polyfill-php73 requirement (Seldaek)
+ * bug #44514 Don't access uninitialized typed property ChromePhpHandler::$response (Philipp91)
+ * bug #44502 [HttpFoundation] do not call preg_match() on null (xabbuh)
+ * bug #44475 [Console] Handle alias in completion script (GromNaN)
+ * bug #44481 [FrameworkBundle] Fix loginUser() causing deprecation (wouterj)
+ * bug #44416 [Translation] Make http requests synchronous when reading the Loco API (Kocal)
+ * bug #44437 [HttpKernel] Fix wrong usage of SessionUtils::popSessionCookie (simonchrz)
+ * bug #44350 [Translation] Fix TranslationTrait (Tomasz Kusy)
+ * bug #44460 [SecurityBundle] Fix ambiguous deprecation message on missing provider (chalasr)
+ * bug #44467 [Console] Fix parameter types for `ProcessHelper::mustRun()` (derrabus)
+ * bug #44427 [FrameworkBundle] Fix compatibility with symfony/security-core 6.x (deps=high tests) (wouterj)
+ * bug #44424 [SecurityBundle] Don't rely on deprecated strategy constants (derrabus)
+ * bug #44399 Prevent infinite nesting of lazy `ObjectManager` instances when `ObjectManager` is reset (Ocramius)
+ * bug #44402 [HttpKernel] Fix using FileLinkFormatter after serialization (derrabus)
+ * bug #44395 [HttpKernel] fix sending Vary: Accept-Language when appropriate (nicolas-grekas)
+ * bug #44385 [DependencyInjection] Skip parameter attribute configurators in AttributeAutoconfigurationPass if we can't get the constructor reflector (fancyweb)
+ * bug #44359 Avoid duplicated session listener registration in tests (alexander-schranz)
+ * bug #44375 [DoctrineBridge] fix calling get_class on non-object (kbond)
+ * bug #44378 [HttpFoundation] fix SessionHandlerFactory using connections (dmaicher)
+ * bug #44365 [SecurityBundle]  Fix invalid reference with `always_authenticate_before_granting` (chalasr)
+ * bug #44361 [HttpClient] Fix handling error info in MockResponse (fancyweb)
+ * bug #44370 [Lock] create lock table if it does not exist (martinssipenko)
+
 * 6.0.0 (2021-11-29)
 
  * bug #44309 [Messenger] Leverage DBAL's getNativeConnection() method (derrabus)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,12 +78,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.0.1-DEV';
+    public const VERSION = '6.0.1';
     public const VERSION_ID = 60001;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 1;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2022';
     public const END_OF_LIFE = '07/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.0.0...v6.0.1)

 * bug #44494 Remove FQCN type hints on properties (@fabpot)
 * bug #44490 [DependencyInjection][Messenger] Add auto-registration for BatchHandlerInterface (@GaryPEGEOT)
 * bug #44523 [Console] Fix polyfill-php73 requirement (@Seldaek)
 * bug #44514 Don't access uninitialized typed property ChromePhpHandler::$response (@Philipp91)
 * bug #44502 [HttpFoundation] do not call preg_match() on null (@xabbuh)
 * bug #44475 [Console] Handle alias in completion script (@GromNaN)
 * bug #44481 [FrameworkBundle] Fix loginUser() causing deprecation (@wouterj)
 * bug #44416 [Translation] Make http requests synchronous when reading the Loco API (@Kocal)
 * bug #44437 [HttpKernel] Fix wrong usage of SessionUtils::popSessionCookie (@simonchrz)
 * bug #44350 [Translation] Fix TranslationTrait (@Tomasz Kusy)
 * bug #44460 [SecurityBundle] Fix ambiguous deprecation message on missing provider (@chalasr)
 * bug #44467 [Console] Fix parameter types for `ProcessHelper::mustRun()` (@derrabus)
 * bug #44427 [FrameworkBundle] Fix compatibility with symfony/security-core 6.x (deps=high tests) (@wouterj)
 * bug #44424 [SecurityBundle] Don't rely on deprecated strategy constants (@derrabus)
 * bug #44399 Prevent infinite nesting of lazy `ObjectManager` instances when `ObjectManager` is reset (@Ocramius)
 * bug #44402 [HttpKernel] Fix using FileLinkFormatter after serialization (@derrabus)
 * bug #44395 [HttpKernel] fix sending Vary: Accept-Language when appropriate (@nicolas-grekas)
 * bug #44385 [DependencyInjection] Skip parameter attribute configurators in AttributeAutoconfigurationPass if we can't get the constructor reflector (@fancyweb)
 * bug #44359 Avoid duplicated session listener registration in tests (@alexander-schranz)
 * bug #44375 [DoctrineBridge] fix calling get_class on non-object (@kbond)
 * bug #44378 [HttpFoundation] fix SessionHandlerFactory using connections (@dmaicher)
 * bug #44365 [SecurityBundle]  Fix invalid reference with `always_authenticate_before_granting` (@chalasr)
 * bug #44361 [HttpClient] Fix handling error info in MockResponse (@fancyweb)
 * bug #44370 [Lock] create lock table if it does not exist (@martinssipenko)
