### PR TITLE
curl_multi_exec errors should not be ignored?

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -274,7 +274,11 @@ final class CurlResponse implements ResponseInterface
         try {
             self::$performing = true;
             $active = 0;
-            while (\CURLM_CALL_MULTI_PERFORM === curl_multi_exec($multi->handle, $active));
+            while (\CURLM_CALL_MULTI_PERFORM === ($err = curl_multi_exec($multi->handle, $active)));
+
+            if (\CURLM_OK !== $err) {
+                throw new TransportException(curl_multi_strerror($err));
+            }
 
             while ($info = curl_multi_info_read($multi->handle)) {
                 $result = $info['result'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

curl_multi_exec errors should not be ignored, but i'm not exactly sure how they should be handled either, so i just throw a RuntimeException, any suggestions?

in any case, these errors should be exceedingly rare, the `CURLM_BAD_EASY_HANDLE` / `CURLM_BAD_HANDLE` should only be caused by internal Symfony bugs, and `CURLM_INTERNAL_ERROR` should only be caused by internal libcurl bugs, which leaves CURLM_OUT_OF_MEMORY