### PR TITLE
[Process] fixed uppercase ARGC and ARGV should also be skipped

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -340,7 +340,7 @@ class Process implements \IteratorAggregate
 
         $envPairs = [];
         foreach ($env as $k => $v) {
-            if (false !== $v && 'argc' !== $k && 'argv' !== $k) {
+            if (false !== $v && false === \in_array($k, ['argc', 'argv', 'ARGC', 'ARGV'], true)) {
                 $envPairs[] = $k.'='.$v;
             }
         }
@@ -973,8 +973,6 @@ class Process implements \IteratorAggregate
 
     /**
      * Gets the last output time in seconds.
-     *
-     * @return float|null The last output time in seconds or null if it isn't started
      */
     public function getLastOutputTime(): ?float
     {
@@ -1502,8 +1500,6 @@ class Process implements \IteratorAggregate
      *
      * @param int  $signal         A valid POSIX signal (see https://php.net/pcntl.constants)
      * @param bool $throwException Whether to throw exception in case signal failed
-     *
-     * @return bool True if the signal was sent successfully, false otherwise
      *
      * @throws LogicException   In case the process is not running
      * @throws RuntimeException In case --enable-sigchild is activated and the process can't be killed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44534
| License       | MIT
| Doc PR        | no

uppercase env ARGC and ARGV were showing a warning:
```
[09-Dec-2021 17:17:05 Europe/Amsterdam] PHP Warning:  Array to string conversion in /var/www/app/vendor/symfony/process/Process.php on line 344
```

This PR fixes that by adding upon the existing functionality blocking argv and argc env vars to become part of the eventual env vars.