### PR TITLE
[Lock] Fix missing argument in PostgreSqlStore::putOffExpiration with DBAL connection

### DIFF
--- a/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
@@ -143,7 +143,7 @@ class PostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStore
     public function putOffExpiration(Key $key, float $ttl)
     {
         if (isset($this->dbalStore)) {
-            $this->dbalStore->putOffExpiration($key);
+            $this->dbalStore->putOffExpiration($key, $ttl);
 
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44535
| License       | MIT
| Doc PR        | -