### PR TITLE
[Console] Fix PHP 7 syntax error

### DIFF
--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -21,7 +21,7 @@ class AsCommand
         public string $name,
         public ?string $description = null,
         array $aliases = [],
-        bool $hidden = false,
+        bool $hidden = false
     ) {
         if (!$hidden && !$aliases) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3, 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        |

I realize this file shouldn't be included on PHP 7, but as I'm linting every file that is part of the composer.phar for safety this breaks the linting step which runs on PHP 7.

IMO it's generally nicer if the files are valid PHP 7.2 syntax in the versions of the package which do support PHP 7.2+.