### PR TITLE
[SecurityBundle] Make enable_authenticator_manager true as there is no other way in Symfony 6

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -65,7 +65,7 @@ class MainConfiguration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('hide_user_not_found')->defaultTrue()->end()
                 ->booleanNode('erase_credentials')->defaultTrue()->end()
-                ->booleanNode('enable_authenticator_manager')->defaultFalse()->info('Enables the new Symfony Security system based on Authenticators, all used authenticators must support this before enabling this.')->end()
+                ->booleanNode('enable_authenticator_manager')->defaultTrue()->end()
                 ->arrayNode('access_decision_manager')
                     ->addDefaultsIfNotSet()
                     ->children()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0 for features / 4.4, 5.3, 5.4 or 6.0 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | /no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Did read the new docs and I was confused about:

```
security:
    enable_authenticator_manager: true
```

as I thought thats the default now and there is no other way. And that seems to case as if you set it to false it will error in: https://github.com/symfony/symfony/blob/6ab662b0a8d5deabe03920a6dc0c7cbdc50a8d21/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php#L93-L95

So I would remove the `enable_authenticator_manager` also from the 6.0 docs and make this just the default to avod confusion here.
