### PR TITLE
[FrameworkBundle] Use correct cookie domain in loginUser()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -142,8 +142,13 @@ class KernelBrowser extends HttpKernelBrowser
         $session->set('_security_'.$firewallContext, serialize($token));
         $session->save();
 
-        $cookie = new Cookie($session->getName(), $session->getId());
-        $this->getCookieJar()->set($cookie);
+        $domains = array_unique(array_map(function (Cookie $cookie) use ($session) {
+            return $cookie->getName() === $session->getName() ? $cookie->getDomain() : '';
+        }, $this->getCookieJar()->all())) ?: [''];
+        foreach ($domains as $domain) {
+            $cookie = new Cookie($session->getName(), $session->getId(), null, null, $domain);
+            $this->getCookieJar()->set($cookie);
+        }
 
         return $this;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
@@ -70,4 +70,20 @@ class SecurityTest extends AbstractWebTestCase
         $client->request('GET', '/main/user_profile');
         $this->assertEquals('Welcome the-username!', $client->getResponse()->getContent());
     }
+
+    public function testLoginUserMultipleTimes()
+    {
+        $userFoo = new InMemoryUser('the-username', 'the-password', ['ROLE_FOO']);
+        $userBar = new InMemoryUser('no-role-username', 'the-password');
+        $client = $this->createClient(['test_case' => 'Security', 'root_config' => 'config.yml']);
+        $client->loginUser($userFoo);
+
+        $client->request('GET', '/main/user_profile');
+        $this->assertEquals('Welcome the-username!', $client->getResponse()->getContent());
+
+        $client->loginUser($userBar);
+
+        $client->request('GET', '/main/user_profile');
+        $this->assertEquals('Welcome no-role-username!', $client->getResponse()->getContent());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43266 
| License       | MIT
| Doc PR        | 

Upon each request, we parse the cookie header from the response. This means that after a first request in the test, the session cookie has a domain (localhost), instead of `''`. This breaks calling `loginUser()` with another user for a subsequent test.

This PR fixes this by discovering if there are already session cookies set for a specific domain, and then overriding that session.