### PR TITLE
[Framework] Read env var SYMFONY_IDE by default for framework.ide

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Environment variable `SYMFONY_IDE` is read by default when `framework.ide` config is not set.
+
 6.0
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -80,7 +80,7 @@ class Configuration implements ConfigurationInterface
                     ->info("Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. Note: When using the HttpCache, you need to call the method in your front controller instead")
                     ->defaultTrue()
                 ->end()
-                ->scalarNode('ide')->defaultNull()->end()
+                ->scalarNode('ide')->defaultValue('%env(default::SYMFONY_IDE)%')->end()
                 ->booleanNode('test')->end()
                 ->scalarNode('default_locale')->defaultValue('en')->end()
                 ->booleanNode('set_locale_from_accept_language')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -368,7 +368,7 @@ class ConfigurationTest extends TestCase
     {
         return [
             'http_method_override' => true,
-            'ide' => null,
+            'ide' => '%env(default::SYMFONY_IDE)%',
             'default_locale' => 'en',
             'enabled_locales' => [],
             'set_locale_from_accept_language' => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Choosing an IDE is a personal preference, it should not be a project configuration ([doc](https://symfony.com/doc/current/reference/configuration/framework.html#ide)). In a team, each developer can use a different IDE, and a developer generally uses the same IDE on all their projects.

To setup a system-wide config, it is possible to update `xdebug.file_link_format` in php.ini. But that have to be done on every php version installed or any docker image; and we miss the shortcuts provided by Symfony.

My proposition it to read an environment variable that can be set by the developers in their user profile or in `.env.local`. The name `SYMFONY_IDE` can be discussed.

I currently uses the following config:
```yaml
framework:
    ide: "%env(string:default::SYMFONY_IDE)%"
```