### PR TITLE
[Validator] Add PHP 8.1 backed enums as Assert\Choice

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -35,7 +35,7 @@ class ChoiceValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Choice::class);
         }
 
-        if (!\is_array($constraint->choices) && !$constraint->callback && !is_a($constraint->choices, \BackedEnum::class, true)) {
+        if (!\is_array($constraint->choices) && !$constraint->callback && !\is_a($constraint->choices, \BackedEnum::class, true)) {
             throw new ConstraintDefinitionException('Either "choices", "callback" or "BackedEnum" must be specified on constraint Choice.');
         }
 
@@ -47,7 +47,7 @@ class ChoiceValidator extends ConstraintValidator
             throw new UnexpectedValueException($value, 'array');
         }
 
-        if (is_a($constraint->choices, \BackedEnum::class, true)) {
+        if (\is_a($constraint->choices, \BackedEnum::class, true)) {
             $constraint->choices = array_map(static fn (\BackedEnum $enum) => $enum->value, $constraint->choices::cases());
         }
 
@@ -61,10 +61,6 @@ class ChoiceValidator extends ConstraintValidator
             $choices = $choices();
         } else {
             $choices = $constraint->choices;
-        }
-
-        if ($value instanceof \BackedEnum) {
-            $value = $value->value;
         }
 
         if (true !== $constraint->strict) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Feature #44564
| License       | MIT
| Doc PR        | [16225](https://github.com/symfony/symfony-docs/pull/16225)

The feature allows using PHP 8.1 BackedEnum as a choices option for Assert\Choice Validator Constraint. 

### Example
*Enum*:
```php
enum StatusEnum: string
{
    case DRAFT = 'draft';
    case PUBLISHED = 'published';
    case ARCHIVED = 'archived';
}
```
*DTO*:
```php
final class ProductDto {
    #[Assert\Choice(choices: StatusEnum::class)]
    public string $status;
}
```
or 
```php
final class ProductDto {
    #[Assert\Choice(choices: StatusEnum::class)]
    public StatusEnum $status;
}
```