### PR TITLE
[Validator] Add missing type-hint on RecursiveValidator

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -65,7 +65,7 @@ class MainConfiguration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('hide_user_not_found')->defaultTrue()->end()
                 ->booleanNode('erase_credentials')->defaultTrue()->end()
-                ->booleanNode('enable_authenticator_manager')->defaultFalse()->info('Enables the new Symfony Security system based on Authenticators, all used authenticators must support this before enabling this.')->end()
+                ->booleanNode('enable_authenticator_manager')->defaultTrue()->end()
                 ->arrayNode('access_decision_manager')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -65,7 +65,7 @@ class MainConfiguration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('hide_user_not_found')->defaultTrue()->end()
                 ->booleanNode('erase_credentials')->defaultTrue()->end()
-                ->booleanNode('enable_authenticator_manager')->defaultTrue()->end()
+                ->booleanNode('enable_authenticator_manager')->defaultFalse()->info('Enables the new Symfony Security system based on Authenticators, all used authenticators must support this before enabling this.')->end()
                 ->arrayNode('access_decision_manager')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
@@ -28,10 +28,10 @@ use Symfony\Component\Validator\ObjectInitializerInterface;
  */
 class RecursiveValidator implements ValidatorInterface
 {
-    protected $contextFactory;
-    protected $metadataFactory;
-    protected $validatorFactory;
-    protected $objectInitializers;
+    protected ExecutionContextFactoryInterface $contextFactory;
+    protected MetadataFactoryInterface $metadataFactory;
+    protected ConstraintValidatorFactoryInterface $validatorFactory;
+    protected array $objectInitializers;
 
     /**
      * Creates a new validator.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Was walking around through the Validator code, some type-hint seemed to be missing.
Saw this commit https://github.com/symfony/symfony/commit/52aaa561497c371e5b544fc8c9d334d5fa0202df and the related PR talking about reverting type-hints in 6.1. Type-hints in this file seem missing from 6.1 as it didn't appear in the commit removing them.