### PR TITLE
[Messenger] Added generic template for `Envelope::last()` method

### DIFF
--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -94,6 +94,13 @@ final class Envelope
         return $cloned;
     }
 
+    /**
+     * @template TStamp of StampInterface
+     *
+     * @param class-string<TStamp> $stampFqcn
+     *
+     * @return TStamp|null
+     */
     public function last(string $stampFqcn): ?StampInterface
     {
         return isset($this->stamps[$stampFqcn = $this->resolveAlias($stampFqcn)]) ? end($this->stamps[$stampFqcn]) : null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Added possibility to PHPStorm generic support for Envelope::last method, no need more `/** @var SomeStampClass */`

