### PR TITLE
[DependencyInjection] PSR Container dependency version fix for 5.3 & 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/persistence": "^2",
         "twig/twig": "^2.13|^3.0.4",
         "psr/cache": "^1.0|^2.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.1.1",
         "psr/event-dispatcher": "^1.0",
         "psr/link": "^1.0",
         "psr/log": "^1|^2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 / 5.4
| Bug fix?      | somehow
| New feature?  | no
| Deprecations? | no
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This problem is already solved on Sf 6.0 branch and also on the component itself but for 5.4 and 5.3 if you install with `--prefer-lowest` for `symfony/symfony` package, it will install a wrong version of psr container.

Updated from https://github.com/symfony/symfony/pull/44561 with @fabpot feedbacks.

@derrabus see the correct version here: https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/DependencyInjection/composer.json#L20