### PR TITLE
[Messenger] add SerializedMessageStamp

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
@@ -213,6 +213,7 @@ class AmqpExtIntegrationTest extends TestCase
         $this->assertSame($expectedOutput.<<<'TXT'
 Get envelope with message: Symfony\Component\Messenger\Bridge\Amqp\Tests\Fixtures\DummyMessage
 with stamps: [
+    "Symfony\\Component\\Messenger\\Stamp\\SerializedMessageStamp",
     "Symfony\\Component\\Messenger\\Bridge\\Amqp\\Transport\\AmqpReceivedStamp",
     "Symfony\\Component\\Messenger\\Stamp\\ReceivedStamp",
     "Symfony\\Component\\Messenger\\Stamp\\ConsumedByWorkerStamp",

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add `SerializedMessageStamp` to avoid serializing a message when a retry occurs.
+
 6.0
 ---
 

--- a/src/Symfony/Component/Messenger/Stamp/SerializedMessageStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/SerializedMessageStamp.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+final class SerializedMessageStamp implements NonSendableStampInterface
+{
+    public function __construct(private string $serializedMessage)
+    {
+    }
+
+    public function getSerializedMessage(): string
+    {
+        return $this->serializedMessage;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\SerializedMessageStamp;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
 use Symfony\Component\Messenger\Stamp\ValidationStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
@@ -29,9 +30,10 @@ class SerializerTest extends TestCase
     {
         $serializer = new Serializer();
 
-        $envelope = new Envelope(new DummyMessage('Hello'));
+        $decodedEnvelope = $serializer->decode($serializer->encode(new Envelope(new DummyMessage('Hello'))));
 
-        $this->assertEquals($envelope, $serializer->decode($serializer->encode($envelope)));
+        $this->assertEquals(new DummyMessage('Hello'), $decodedEnvelope->getMessage());
+        $this->assertEquals(new SerializedMessageStamp('{"message":"Hello"}'), $decodedEnvelope->last(SerializedMessageStamp::class));
     }
 
     public function testEncodedWithStampsIsDecodable()
@@ -41,9 +43,21 @@ class SerializerTest extends TestCase
         $envelope = (new Envelope(new DummyMessage('Hello')))
             ->with(new SerializerStamp([ObjectNormalizer::GROUPS => ['foo']]))
             ->with(new ValidationStamp(['foo', 'bar']))
+            ->with(new SerializedMessageStamp('{"message":"Hello"}'))
         ;
 
         $this->assertEquals($envelope, $serializer->decode($serializer->encode($envelope)));
+    }
+
+    public function testSerializedMessageStampIsUsedForEncoding()
+    {
+        $serializer = new Serializer();
+
+        $encoded = $serializer->encode(
+            new Envelope(new DummyMessage(''), [new SerializedMessageStamp('{"message":"Hello"}')])
+        );
+
+        $this->assertSame('{"message":"Hello"}', $encoded['body'] ?? null);
     }
 
     public function testEncodedIsHavingTheBodyAndTypeHeader()

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -15,6 +15,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\SerializedMessageStamp;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -71,6 +72,8 @@ class Serializer implements SerializerInterface
         }
 
         $stamps = $this->decodeStamps($encodedEnvelope);
+        $stamps[] = new SerializedMessageStamp($encodedEnvelope['body']);
+
         $serializerStamp = $this->findFirstSerializerStamp($stamps);
 
         $context = $this->context;
@@ -98,12 +101,17 @@ class Serializer implements SerializerInterface
             $context = $serializerStamp->getContext() + $context;
         }
 
+        /** @var SerializedMessageStamp|null $serializedMessageStamp */
+        $serializedMessageStamp = $envelope->last(SerializedMessageStamp::class);
+
         $envelope = $envelope->withoutStampsOfType(NonSendableStampInterface::class);
 
         $headers = ['type' => \get_class($envelope->getMessage())] + $this->encodeStamps($envelope) + $this->getContentTypeHeader();
 
         return [
-            'body' => $this->serializer->serialize($envelope->getMessage(), $this->format, $context),
+            'body' => $serializedMessageStamp
+                ? $serializedMessageStamp->getSerializedMessage()
+                : $this->serializer->serialize($envelope->getMessage(), $this->format, $context),
             'headers' => $headers,
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #43496
| License       | MIT
| Doc PR        | (will be added if PR is accepted)

This PR fixes #43496

When a message is sent for retry, we currently serialize it from the message POPO object whereas we already had the serialized representation of the message before deserializing it.

This solution proposes to store the serialized message in a "not serializable" stamp when we receive the message. Then the serialized message will be used in `\Symfony\Component\Messenger\Transport\Serialization\Serializer::encode()`, if the message is retried, which prevents to serialize the message again.

This has several advantages, mainly when we're dealing with big payloads:
- it prevents the performance impact of serializing potential big objects
- it prevents the need of a dedicated normalizer if the message comes from another system.


