### PR TITLE
JS: use startsWith()

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -351,7 +351,7 @@ if (typeof Sfjs === 'undefined' || typeof Sfjs.loadToolbar === 'undefined') {
 
                     /* prevent logging AJAX calls to static and inline files, like templates */
                     var path = url;
-                    if (url.substr(0, 1) === '/') {
+                    if (url.startsWith('/')) {
                         if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
                             path = url.substr({{ request.basePath|length }});
                         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Similar to  #44499, but with JSFix
| License       | MIT
| Doc PR        | -

It's standart: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith