### PR TITLE
Make use of the nullsafe operator

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
+++ b/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
@@ -37,9 +37,7 @@ class DbalLogger implements SQLLogger
      */
     public function startQuery($sql, array $params = null, array $types = null): void
     {
-        if (null !== $this->stopwatch) {
-            $this->stopwatch->start('doctrine', 'doctrine');
-        }
+        $this->stopwatch?->start('doctrine', 'doctrine');
 
         if (null !== $this->logger) {
             $this->log($sql, null === $params ? [] : $this->normalizeParams($params));
@@ -51,9 +49,7 @@ class DbalLogger implements SQLLogger
      */
     public function stopQuery(): void
     {
-        if (null !== $this->stopwatch) {
-            $this->stopwatch->stop('doctrine');
-        }
+        $this->stopwatch?->stop('doctrine');
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Validator/DoctrineInitializer.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/DoctrineInitializer.php
@@ -30,9 +30,6 @@ class DoctrineInitializer implements ObjectInitializerInterface
 
     public function initialize(object $object)
     {
-        $manager = $this->registry->getManagerForClass(\get_class($object));
-        if (null !== $manager) {
-            $manager->initializeObject($object);
-        }
+        $this->registry->getManagerForClass(\get_class($object))?->initializeObject($object);
     }
 }

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -230,9 +230,7 @@ EOF
     {
         $line = $exception->getTemplateLine();
 
-        if ($githubReporter) {
-            $githubReporter->error($exception->getRawMessage(), $file, $line <= 0 ? null : $line);
-        }
+        $githubReporter?->error($exception->getRawMessage(), $file, $line <= 0 ? null : $line);
 
         if ($file) {
             $output->text(sprintf('<error> ERROR </error> in %s (line %s)', $file, $line));

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
@@ -55,9 +55,7 @@ class ConfigBuilderCacheWarmer implements CacheWarmerInterface
             try {
                 $this->dumpExtension($extension, $generator);
             } catch (\Exception $e) {
-                if ($this->logger) {
-                    $this->logger->warning('Failed to generate ConfigBuilder for extension {extensionClass}.', ['exception' => $e, 'extensionClass' => \get_class($extension)]);
-                }
+                $this->logger?->warning('Failed to generate ConfigBuilder for extension {extensionClass}.', ['exception' => $e, 'extensionClass' => \get_class($extension)]);
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
@@ -70,7 +70,7 @@ EOF
         }
 
         $secrets = $this->vault->list($reveal);
-        $localSecrets = null !== $this->localVault ? $this->localVault->list($reveal) : null;
+        $localSecrets = $this->localVault?->list($reveal);
 
         $rows = [];
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/Configuration.php
@@ -27,9 +27,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('test');
 
-        if ($this->customConfig) {
-            $this->customConfig->addConfiguration($treeBuilder->getRootNode());
-        }
+        $this->customConfig?->addConfiguration($treeBuilder->getRootNode());
 
         return $treeBuilder;
     }

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -110,9 +110,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
             $logoutUrl = null;
             try {
-                if (null !== $this->logoutUrlGenerator) {
-                    $logoutUrl = $this->logoutUrlGenerator->getLogoutPath();
-                }
+                $logoutUrl = $this->logoutUrlGenerator?->getLogoutPath();
             } catch (\Exception $e) {
                 // fail silently when the logout URL cannot be generated
             }

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -71,9 +71,7 @@ class ProfilerController
     {
         $this->denyAccessIfProfilerDisabled();
 
-        if (null !== $this->cspHandler) {
-            $this->cspHandler->disableCsp();
-        }
+        $this->cspHandler?->disableCsp();
 
         $panel = $request->query->get('panel');
         $page = $request->query->get('page', 'home');
@@ -172,9 +170,7 @@ class ProfilerController
     {
         $this->denyAccessIfProfilerDisabled();
 
-        if (null !== $this->cspHandler) {
-            $this->cspHandler->disableCsp();
-        }
+        $this->cspHandler?->disableCsp();
 
         if (!$request->hasSession()) {
             $ip =
@@ -224,9 +220,7 @@ class ProfilerController
     {
         $this->denyAccessIfProfilerDisabled();
 
-        if (null !== $this->cspHandler) {
-            $this->cspHandler->disableCsp();
-        }
+        $this->cspHandler?->disableCsp();
 
         $profile = $this->profiler->loadProfile($token);
 
@@ -312,9 +306,7 @@ class ProfilerController
     {
         $this->denyAccessIfProfilerDisabled();
 
-        if (null !== $this->cspHandler) {
-            $this->cspHandler->disableCsp();
-        }
+        $this->cspHandler?->disableCsp();
 
         ob_start();
         phpinfo();
@@ -336,9 +328,7 @@ class ProfilerController
             throw new NotFoundHttpException('Xdebug must be installed in version 3.');
         }
 
-        if (null !== $this->cspHandler) {
-            $this->cspHandler->disableCsp();
-        }
+        $this->cspHandler?->disableCsp();
 
         ob_start();
         xdebug_info();
@@ -358,9 +348,7 @@ class ProfilerController
             throw new NotFoundHttpException('The base dir should be set.');
         }
 
-        if ($this->profiler) {
-            $this->profiler->disable();
-        }
+        $this->profiler?->disable();
 
         $file = $request->query->get('file');
         $line = $request->query->get('line');

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -421,9 +421,7 @@ class Command
     public function addArgument(string $name, int $mode = null, string $description = '', mixed $default = null): static
     {
         $this->definition->addArgument(new InputArgument($name, $mode, $description, $default));
-        if (null !== $this->fullDefinition) {
-            $this->fullDefinition->addArgument(new InputArgument($name, $mode, $description, $default));
-        }
+        $this->fullDefinition?->addArgument(new InputArgument($name, $mode, $description, $default));
 
         return $this;
     }
@@ -442,9 +440,7 @@ class Command
     public function addOption(string $name, string|array $shortcut = null, int $mode = null, string $description = '', mixed $default = null): static
     {
         $this->definition->addOption(new InputOption($name, $shortcut, $mode, $description, $default));
-        if (null !== $this->fullDefinition) {
-            $this->fullDefinition->addOption(new InputOption($name, $shortcut, $mode, $description, $default));
-        }
+        $this->fullDefinition?->addOption(new InputOption($name, $shortcut, $mode, $description, $default));
 
         return $this;
     }

--- a/src/Symfony/Component/Console/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/Console/EventListener/ErrorListener.php
@@ -79,7 +79,7 @@ class ErrorListener implements EventSubscriberInterface
 
     private static function getInputString(ConsoleEvent $event): ?string
     {
-        $commandName = $event->getCommand() ? $event->getCommand()->getName() : null;
+        $commandName = $event->getCommand()?->getName();
         $input = $event->getInput();
 
         if ($input instanceof \Stringable) {

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -189,9 +189,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         try {
             $allListeners = $this->getListeners();
         } catch (\Exception $e) {
-            if (null !== $this->logger) {
-                $this->logger->info('An exception was thrown while getting the uncalled listeners.', ['exception' => $e]);
-            }
+            $this->logger?->info('An exception was thrown while getting the uncalled listeners.', ['exception' => $e]);
 
             // unable to retrieve the uncalled listeners
             return [];
@@ -308,9 +306,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
             }
 
             if ($listener->wasCalled()) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('Notified event "{event}" to listener "{listener}".', $context);
-                }
+                $this->logger?->debug('Notified event "{event}" to listener "{listener}".', $context);
             } else {
                 $this->callStack->detach($listener);
             }
@@ -320,9 +316,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
             }
 
             if ($listener->stoppedPropagation()) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('Listener "{listener}" stopped propagation of the event "{event}".', $context);
-                }
+                $this->logger?->debug('Listener "{listener}" stopped propagation of the event "{event}".', $context);
 
                 $skipped = true;
             }

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -93,7 +93,7 @@ final class WrappedListener
 
         return [
             'event' => $eventName,
-            'priority' => null !== $this->priority ? $this->priority : (null !== $this->dispatcher ? $this->dispatcher->getListenerPriority($eventName, $this->listener) : null),
+            'priority' => $this->priority ?? $this->dispatcher?->getListenerPriority($eventName, $this->listener),
             'pretty' => $this->pretty,
             'stub' => $this->stub,
         ];

--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -91,8 +91,8 @@ class FormFactory implements FormFactoryInterface
 
         $type = $typeGuess ? $typeGuess->getType() : TextType::class;
 
-        $maxLength = $maxLengthGuess ? $maxLengthGuess->getValue() : null;
-        $pattern = $patternGuess ? $patternGuess->getValue() : null;
+        $maxLength = $maxLengthGuess?->getValue();
+        $pattern = $patternGuess?->getValue();
 
         if (null !== $pattern) {
             $options = array_replace_recursive(['attr' => ['pattern' => $pattern]], $options);

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -115,9 +115,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (null !== $this->parent) {
-            $this->parent->buildForm($builder, $options);
-        }
+        $this->parent?->buildForm($builder, $options);
 
         $this->innerType->buildForm($builder, $options);
 
@@ -131,9 +129,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if (null !== $this->parent) {
-            $this->parent->buildView($view, $form, $options);
-        }
+        $this->parent?->buildView($view, $form, $options);
 
         $this->innerType->buildView($view, $form, $options);
 
@@ -147,9 +143,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
-        if (null !== $this->parent) {
-            $this->parent->finishView($view, $form, $options);
-        }
+        $this->parent?->finishView($view, $form, $options);
 
         $this->innerType->finishView($view, $form, $options);
 

--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -160,9 +160,7 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
             foreach ($pushedResponses as [$pushedUrl, $pushDeferred]) {
                 $pushDeferred->fail(new CancelledException());
 
-                if ($this->logger) {
-                    $this->logger->debug(sprintf('Unused pushed response: "%s"', $pushedUrl));
-                }
+                $this->logger?->debug(sprintf('Unused pushed response: "%s"', $pushedUrl));
             }
         }
 

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -268,21 +268,21 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             unset($this->multi->pushedResponses[$url]);
 
             if (self::acceptPushForRequest($method, $options, $pushedResponse)) {
-                $this->logger && $this->logger->debug(sprintf('Accepting pushed response: "%s %s"', $method, $url));
+                $this->logger?->debug(sprintf('Accepting pushed response: "%s %s"', $method, $url));
 
                 // Reinitialize the pushed response with request's options
                 $ch = $pushedResponse->handle;
                 $pushedResponse = $pushedResponse->response;
                 $pushedResponse->__construct($this->multi, $url, $options, $this->logger);
             } else {
-                $this->logger && $this->logger->debug(sprintf('Rejecting pushed response: "%s"', $url));
+                $this->logger?->debug(sprintf('Rejecting pushed response: "%s"', $url));
                 $pushedResponse = null;
             }
         }
 
         if (!$pushedResponse) {
             $ch = curl_init();
-            $this->logger && $this->logger->info(sprintf('Request: "%s %s"', $method, $url));
+            $this->logger?->info(sprintf('Request: "%s %s"', $method, $url));
         }
 
         foreach ($curlopts as $opt => $value) {

--- a/src/Symfony/Component/HttpClient/Internal/AmpClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpClientState.php
@@ -200,11 +200,11 @@ final class AmpClientState extends ClientState
         if ($this->maxPendingPushes <= \count($this->pushedResponses[$authority] ?? [])) {
             $fifoUrl = key($this->pushedResponses[$authority]);
             unset($this->pushedResponses[$authority][$fifoUrl]);
-            $this->logger && $this->logger->debug(sprintf('Evicting oldest pushed response: "%s"', $fifoUrl));
+            $this->logger?->debug(sprintf('Evicting oldest pushed response: "%s"', $fifoUrl));
         }
 
         $url = (string) $request->getUri();
-        $this->logger && $this->logger->debug(sprintf('Queueing pushed response: "%s"', $url));
+        $this->logger?->debug(sprintf('Queueing pushed response: "%s"', $url));
         $this->pushedResponses[$authority][] = [$url, $deferred, $request, $response, [
             'proxy' => $options['proxy'],
             'bindto' => $options['bindto'],

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -115,7 +115,7 @@ final class CurlClientState extends ClientState
         }
 
         if (!isset($headers[':method']) || !isset($headers[':scheme']) || !isset($headers[':authority']) || !isset($headers[':path'])) {
-            $this->logger && $this->logger->debug(sprintf('Rejecting pushed response from "%s": pushed headers are invalid', $origin));
+            $this->logger?->debug(sprintf('Rejecting pushed response from "%s": pushed headers are invalid', $origin));
 
             return \CURL_PUSH_DENY;
         }
@@ -126,7 +126,7 @@ final class CurlClientState extends ClientState
         // but this is a MUST in the HTTP/2 RFC; let's restrict pushes to the original host,
         // ignoring domains mentioned as alt-name in the certificate for now (same as curl).
         if (!str_starts_with($origin, $url.'/')) {
-            $this->logger && $this->logger->debug(sprintf('Rejecting pushed response from "%s": server is not authoritative for "%s"', $origin, $url));
+            $this->logger?->debug(sprintf('Rejecting pushed response from "%s": server is not authoritative for "%s"', $origin, $url));
 
             return \CURL_PUSH_DENY;
         }
@@ -134,11 +134,11 @@ final class CurlClientState extends ClientState
         if ($maxPendingPushes <= \count($this->pushedResponses)) {
             $fifoUrl = key($this->pushedResponses);
             unset($this->pushedResponses[$fifoUrl]);
-            $this->logger && $this->logger->debug(sprintf('Evicting oldest pushed response: "%s"', $fifoUrl));
+            $this->logger?->debug(sprintf('Evicting oldest pushed response: "%s"', $fifoUrl));
         }
 
         $url .= $headers[':path'][0];
-        $this->logger && $this->logger->debug(sprintf('Queueing pushed response: "%s"', $url));
+        $this->logger?->debug(sprintf('Queueing pushed response: "%s"', $url));
 
         $this->pushedResponses[$url] = new PushedResponse(new CurlResponse($this, $pushed), $headers, $this->openHandles[(int) $parent][1] ?? [], $pushed);
 

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -176,7 +176,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
             $this->multi->dnsCache = $options['resolve'] + $this->multi->dnsCache;
         }
 
-        $this->logger && $this->logger->info(sprintf('Request: "%s %s"', $method, implode('', $url)));
+        $this->logger?->info(sprintf('Request: "%s %s"', $method, implode('', $url)));
 
         if (!isset($options['normalized_headers']['user-agent'])) {
             $options['headers'][] = 'User-Agent: Symfony HttpClient/Native';

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -126,7 +126,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
                 throw new TransportException($msg);
             }
 
-            $this->logger && $this->logger->info(sprintf('%s for "%s".', $msg, $url ?? $this->url));
+            $this->logger?->info(sprintf('%s for "%s".', $msg, $url ?? $this->url));
         });
 
         try {
@@ -162,7 +162,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
                     break;
                 }
 
-                $this->logger && $this->logger->info(sprintf('Redirecting: "%s %s"', $this->info['http_code'], $url ?? $this->url));
+                $this->logger?->info(sprintf('Redirecting: "%s %s"', $this->info['http_code'], $url ?? $this->url));
             }
         } catch (\Throwable $e) {
             $this->close();

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -65,7 +65,7 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
             }
         };
 
-        return new TraceableResponse($this->client, $this->client->request($method, $url, $options), $content, null === $this->stopwatch ? null : $this->stopwatch->start("$method $url", 'http_client'));
+        return new TraceableResponse($this->client, $this->client->request($method, $url, $options), $content, $this->stopwatch?->start("$method $url", 'http_client'));
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -36,9 +36,7 @@ class ControllerResolver implements ControllerResolverInterface
     public function getController(Request $request): callable|false
     {
         if (!$controller = $request->attributes->get('_controller')) {
-            if (null !== $this->logger) {
-                $this->logger->warning('Unable to look for the controller as the "_controller" parameter is missing.');
-            }
+            $this->logger?->warning('Unable to look for the controller as the "_controller" parameter is missing.');
 
             return false;
         }

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -69,9 +69,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
     public function dump(Data $data)
     {
-        if ($this->stopwatch) {
-            $this->stopwatch->start('dump');
-        }
+        $this->stopwatch?->start('dump');
 
         ['name' => $name, 'file' => $file, 'line' => $line, 'file_excerpt' => $fileExcerpt] = $this->sourceContextProvider->getContext();
 
@@ -91,9 +89,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
         $this->data[] = compact('data', 'name', 'file', 'line', 'fileExcerpt');
         ++$this->dataCount;
 
-        if ($this->stopwatch) {
-            $this->stopwatch->stop('dump');
-        }
+        $this->stopwatch?->stop('dump');
     }
 
     public function collect(Request $request, Response $response, \Throwable $exception = null)
@@ -133,9 +129,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
     public function reset()
     {
-        if ($this->stopwatch) {
-            $this->stopwatch->reset();
-        }
+        $this->stopwatch?->reset();
         $this->data = [];
         $this->dataCount = 0;
         $this->isCollected = true;

--- a/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
@@ -59,9 +59,7 @@ class TimeDataCollector extends DataCollector implements LateDataCollectorInterf
     {
         $this->data = [];
 
-        if (null !== $this->stopwatch) {
-            $this->stopwatch->reset();
-        }
+        $this->stopwatch?->reset();
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -76,9 +76,7 @@ class LocaleListener implements EventSubscriberInterface
 
     private function setRouterContext(Request $request)
     {
-        if (null !== $this->router) {
-            $this->router->getContext()->setParameter('_locale', $request->getLocale());
-        }
+        $this->router?->getContext()->setParameter('_locale', $request->getLocale());
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -108,14 +108,12 @@ class RouterListener implements EventSubscriberInterface
                 $parameters = $this->matcher->match($request->getPathInfo());
             }
 
-            if (null !== $this->logger) {
-                $this->logger->info('Matched route "{route}".', [
-                    'route' => $parameters['_route'] ?? 'n/a',
-                    'route_parameters' => $parameters,
-                    'request_uri' => $request->getUri(),
-                    'method' => $request->getMethod(),
-                ]);
-            }
+            $this->logger?->info('Matched route "{route}".', [
+                'route' => $parameters['_route'] ?? 'n/a',
+                'route_parameters' => $parameters,
+                'request_uri' => $request->getUri(),
+                'method' => $request->getMethod(),
+            ]);
 
             $request->attributes->add($parameters);
             unset($parameters['_route'], $parameters['_controller']);

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -449,9 +449,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      */
     protected function forward(Request $request, bool $catch = false, Response $entry = null)
     {
-        if ($this->surrogate) {
-            $this->surrogate->addSurrogateCapability($request);
-        }
+        $this->surrogate?->addSurrogateCapability($request);
 
         // always a "master" request (as the real master request can be in cache)
         $response = SubRequestHandler::handle($this->kernel, $request, HttpKernelInterface::MAIN_REQUEST, $catch);

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -78,7 +78,7 @@ class Profile
      */
     public function getParentToken(): ?string
     {
-        return $this->parent ? $this->parent->getToken() : null;
+        return $this->parent?->getToken();
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -55,9 +55,7 @@ class HttpCacheTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        if ($this->cache) {
-            $this->cache->getStore()->cleanup();
-        }
+        $this->cache?->getStore()->cleanup();
         $this->kernel = null;
         $this->cache = null;
         $this->caches = null;

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsSender.php
@@ -56,9 +56,7 @@ class AmazonSqsSender implements SenderInterface
 
         /** @var AmazonSqsXrayTraceHeaderStamp|null $amazonSqsXrayTraceHeaderStamp */
         $amazonSqsXrayTraceHeaderStamp = $envelope->last(AmazonSqsXrayTraceHeaderStamp::class);
-        if (null !== $amazonSqsXrayTraceHeaderStamp) {
-            $xrayTraceId = $amazonSqsXrayTraceHeaderStamp->getTraceId();
-        }
+        $xrayTraceId = $amazonSqsXrayTraceHeaderStamp?->getTraceId();
 
         try {
             $this->connection->send(

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -556,7 +556,7 @@ class Connection
 
     private function getRoutingKeyForMessage(?AmqpStamp $amqpStamp): ?string
     {
-        return (null !== $amqpStamp ? $amqpStamp->getRoutingKey() : null) ?? $this->getDefaultPublishRoutingKey();
+        return $amqpStamp?->getRoutingKey() ?? $this->getDefaultPublishRoutingKey();
     }
 }
 

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -65,7 +65,7 @@ abstract class AbstractFailedMessagesCommand extends Command
         /** @var TransportMessageIdStamp $stamp */
         $stamp = $envelope->last(TransportMessageIdStamp::class);
 
-        return null !== $stamp ? $stamp->getId() : null;
+        return $stamp?->getId();
     }
 
     protected function displaySingleMessage(Envelope $envelope, SymfonyStyle $io)
@@ -129,10 +129,7 @@ abstract class AbstractFailedMessagesCommand extends Command
             $dump = new Dumper($io, null, $this->createCloner());
             $io->writeln($dump($envelope->getMessage()));
             $io->title('Exception:');
-            $flattenException = null;
-            if (null !== $lastErrorDetailsStamp) {
-                $flattenException = $lastErrorDetailsStamp->getFlattenException();
-            }
+            $flattenException = $lastErrorDetailsStamp?->getFlattenException();
             $io->writeln(null === $flattenException ? '(no data)' : $dump($flattenException));
         } else {
             $io->writeln(' Re-run command with <info>-vv</info> to see more message & error details.');

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -69,9 +69,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
             $delay = $retryStrategy->getWaitingTime($envelope, $throwable);
 
-            if (null !== $this->logger) {
-                $this->logger->warning('Error thrown while handling message {class}. Sending for retry #{retryCount} using {delay} ms delay. Error: "{error}"', $context + ['retryCount' => $retryCount, 'delay' => $delay, 'error' => $throwable->getMessage(), 'exception' => $throwable]);
-            }
+            $this->logger?->warning('Error thrown while handling message {class}. Sending for retry #{retryCount} using {delay} ms delay. Error: "{error}"', $context + ['retryCount' => $retryCount, 'delay' => $delay, 'error' => $throwable->getMessage(), 'exception' => $throwable]);
 
             // add the delay and retry stamp info
             $retryEnvelope = $this->withLimitedHistory($envelope, new DelayStamp($delay), new RedeliveryStamp($retryCount));
@@ -79,13 +77,9 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
             // re-send the message for retry
             $this->getSenderForTransport($event->getReceiverName())->send($retryEnvelope);
 
-            if (null !== $this->eventDispatcher) {
-                $this->eventDispatcher->dispatch(new WorkerMessageRetriedEvent($retryEnvelope, $event->getReceiverName()));
-            }
+            $this->eventDispatcher?->dispatch(new WorkerMessageRetriedEvent($retryEnvelope, $event->getReceiverName()));
         } else {
-            if (null !== $this->logger) {
-                $this->logger->critical('Error thrown while handling message {class}. Removing from transport after {retryCount} retries. Error: "{error}"', $context + ['retryCount' => $retryCount, 'error' => $throwable->getMessage(), 'exception' => $throwable]);
-            }
+            $this->logger?->critical('Error thrown while handling message {class}. Removing from transport after {retryCount} retries. Error: "{error}"', $context + ['retryCount' => $retryCount, 'error' => $throwable->getMessage(), 'exception' => $throwable]);
         }
     }
 

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -59,12 +59,10 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
             new RedeliveryStamp(0)
         );
 
-        if (null !== $this->logger) {
-            $this->logger->info('Rejected message {class} will be sent to the failure transport {transport}.', [
-                'class' => \get_class($envelope->getMessage()),
-                'transport' => \get_class($failureSender),
-            ]);
-        }
+        $this->logger?->info('Rejected message {class} will be sent to the failure transport {transport}.', [
+            'class' => \get_class($envelope->getMessage()),
+            'transport' => \get_class($failureSender),
+        ]);
 
         $failureSender->send($envelope);
     }

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnFailureLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnFailureLimitListener.php
@@ -47,9 +47,7 @@ class StopWorkerOnFailureLimitListener implements EventSubscriberInterface
             $this->failedMessages = 0;
             $event->getWorker()->stop();
 
-            if (null !== $this->logger) {
-                $this->logger->info('Worker stopped due to limit of {count} failed message(s) is reached', ['count' => $this->maximumNumberOfFailures]);
-            }
+            $this->logger?->info('Worker stopped due to limit of {count} failed message(s) is reached', ['count' => $this->maximumNumberOfFailures]);
         }
     }
 

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnMemoryLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnMemoryLimitListener.php
@@ -39,9 +39,7 @@ class StopWorkerOnMemoryLimitListener implements EventSubscriberInterface
         $usedMemory = $memoryResolver();
         if ($usedMemory > $this->memoryLimit) {
             $event->getWorker()->stop();
-            if (null !== $this->logger) {
-                $this->logger->info('Worker stopped due to memory limit of {limit} bytes exceeded ({memory} bytes used)', ['limit' => $this->memoryLimit, 'memory' => $usedMemory]);
-            }
+            $this->logger?->info('Worker stopped due to memory limit of {limit} bytes exceeded ({memory} bytes used)', ['limit' => $this->memoryLimit, 'memory' => $usedMemory]);
         }
     }
 

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnMessageLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnMessageLimitListener.php
@@ -42,9 +42,7 @@ class StopWorkerOnMessageLimitListener implements EventSubscriberInterface
             $this->receivedMessages = 0;
             $event->getWorker()->stop();
 
-            if (null !== $this->logger) {
-                $this->logger->info('Worker stopped due to maximum count of {count} messages processed', ['count' => $this->maximumNumberOfMessages]);
-            }
+            $this->logger?->info('Worker stopped due to maximum count of {count} messages processed', ['count' => $this->maximumNumberOfMessages]);
         }
     }
 

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
@@ -43,9 +43,7 @@ class StopWorkerOnRestartSignalListener implements EventSubscriberInterface
     {
         if ($this->shouldRestart()) {
             $event->getWorker()->stop();
-            if (null !== $this->logger) {
-                $this->logger->info('Worker stopped because a restart was requested.');
-            }
+            $this->logger?->info('Worker stopped because a restart was requested.');
         }
     }
 

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
@@ -30,9 +30,7 @@ class StopWorkerOnSigtermSignalListener implements EventSubscriberInterface
     public function onWorkerStarted(WorkerStartedEvent $event): void
     {
         pcntl_signal(\SIGTERM, function () use ($event) {
-            if (null !== $this->logger) {
-                $this->logger->info('Received SIGTERM signal.', ['transport_names' => $event->getWorker()->getMetadata()->getTransportNames()]);
-            }
+            $this->logger?->info('Received SIGTERM signal.', ['transport_names' => $event->getWorker()->getMetadata()->getTransportNames()]);
 
             $event->getWorker()->stop();
         });

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnTimeLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnTimeLimitListener.php
@@ -42,9 +42,7 @@ class StopWorkerOnTimeLimitListener implements EventSubscriberInterface
     {
         if ($this->endTime < microtime(true)) {
             $event->getWorker()->stop();
-            if (null !== $this->logger) {
-                $this->logger->info('Worker stopped due to time limit of {timeLimit}s exceeded', ['timeLimit' => $this->timeLimitInSeconds]);
-            }
+            $this->logger?->info('Worker stopped due to time limit of {timeLimit}s exceeded', ['timeLimit' => $this->timeLimitInSeconds]);
         }
     }
 

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -244,9 +244,7 @@ class Worker
 
     public function stop(): void
     {
-        if (null !== $this->logger) {
-            $this->logger->info('Stopping worker.', ['transport_names' => $this->metadata->getTransportNames()]);
-        }
+        $this->logger?->info('Stopping worker.', ['transport_names' => $this->metadata->getTransportNames()]);
 
         $this->shouldStop = true;
     }

--- a/src/Symfony/Component/Notifier/Chatter.php
+++ b/src/Symfony/Component/Notifier/Chatter.php
@@ -50,9 +50,7 @@ final class Chatter implements ChatterInterface
             return $this->transport->send($message);
         }
 
-        if (null !== $this->dispatcher) {
-            $this->dispatcher->dispatch(new MessageEvent($message, true));
-        }
+        $this->dispatcher?->dispatch(new MessageEvent($message, true));
 
         $this->bus->dispatch($message);
 

--- a/src/Symfony/Component/Notifier/Message/ChatMessage.php
+++ b/src/Symfony/Component/Notifier/Message/ChatMessage.php
@@ -54,7 +54,7 @@ final class ChatMessage implements MessageInterface
 
     public function getRecipientId(): ?string
     {
-        return $this->options ? $this->options->getRecipientId() : null;
+        return $this->options?->getRecipientId();
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Message/PushMessage.php
+++ b/src/Symfony/Component/Notifier/Message/PushMessage.php
@@ -41,7 +41,7 @@ final class PushMessage implements MessageInterface
 
     public function getRecipientId(): ?string
     {
-        return $this->options ? $this->options->getRecipientId() : null;
+        return $this->options?->getRecipientId();
     }
 
     public function subject(string $subject): self

--- a/src/Symfony/Component/Notifier/Texter.php
+++ b/src/Symfony/Component/Notifier/Texter.php
@@ -50,9 +50,7 @@ final class Texter implements TexterInterface
             return $this->transport->send($message);
         }
 
-        if (null !== $this->dispatcher) {
-            $this->dispatcher->dispatch(new MessageEvent($message, true));
-        }
+        $this->dispatcher?->dispatch(new MessageEvent($message, true));
 
         $this->bus->dispatch($message);
 

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1546,9 +1546,7 @@ class ProcessTest extends TestCase
             $process = new Process($commandline, $cwd, $env, $input, $timeout);
         }
 
-        if (self::$process) {
-            self::$process->stop(0);
-        }
+        self::$process?->stop(0);
 
         return self::$process = $process;
     }

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -192,9 +192,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                             throw new InvalidParameterException(strtr($message, ['{parameter}' => $varName, '{route}' => $name, '{expected}' => $token[2], '{given}' => $mergedParams[$varName]]));
                         }
 
-                        if ($this->logger) {
-                            $this->logger->error($message, ['parameter' => $varName, 'route' => $name, 'expected' => $token[2], 'given' => $mergedParams[$varName]]);
-                        }
+                        $this->logger?->error($message, ['parameter' => $varName, 'route' => $name, 'expected' => $token[2], 'given' => $mergedParams[$varName]]);
 
                         return '';
                     }
@@ -247,9 +245,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                             throw new InvalidParameterException(strtr($message, ['{parameter}' => $token[3], '{route}' => $name, '{expected}' => $token[2], '{given}' => $mergedParams[$token[3]]]));
                         }
 
-                        if ($this->logger) {
-                            $this->logger->error($message, ['parameter' => $token[3], 'route' => $name, 'expected' => $token[2], 'given' => $mergedParams[$token[3]]]);
-                        }
+                        $this->logger?->error($message, ['parameter' => $token[3], 'route' => $name, 'expected' => $token[2], 'given' => $mergedParams[$token[3]]]);
 
                         return '';
                     }

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -158,7 +158,7 @@ class TraceableUrlMatcher extends UrlMatcher
             'log' => $log,
             'name' => $name,
             'level' => $level,
-            'path' => null !== $route ? $route->getPath() : null,
+            'path' => $route?->getPath(),
         ];
     }
 }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -101,17 +101,13 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         $skippedAuthenticators = [];
         $lazy = true;
         foreach ($this->authenticators as $authenticator) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Checking support on authenticator.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
-            }
+            $this->logger?->debug('Checking support on authenticator.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
 
             if (false !== $supports = $authenticator->supports($request)) {
                 $authenticators[] = $authenticator;
                 $lazy = $lazy && null === $supports;
             } else {
-                if (null !== $this->logger) {
-                    $this->logger->debug('Authenticator does not support the request.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
-                }
+                $this->logger?->debug('Authenticator does not support the request.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
                 $skippedAuthenticators[] = $authenticator;
             }
         }
@@ -149,18 +145,14 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             // eagerly (before token storage is initialized), whereas authenticate() is called
             // lazily (after initialization).
             if (false === $authenticator->supports($request)) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('Skipping the "{authenticator}" authenticator as it did not support the request.', ['authenticator' => \get_class($authenticator)]);
-                }
+                $this->logger?->debug('Skipping the "{authenticator}" authenticator as it did not support the request.', ['authenticator' => \get_class($authenticator)]);
 
                 continue;
             }
 
             $response = $this->executeAuthenticator($authenticator, $request);
             if (null !== $response) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('The "{authenticator}" authenticator set the response. Any later authenticator will not be called', ['authenticator' => \get_class($authenticator)]);
-                }
+                $this->logger?->debug('The "{authenticator}" authenticator set the response. Any later authenticator will not be called', ['authenticator' => \get_class($authenticator)]);
 
                 return $response;
             }
@@ -208,9 +200,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
 
             $this->eventDispatcher->dispatch(new AuthenticationSuccessEvent($authenticatedToken), AuthenticationEvents::AUTHENTICATION_SUCCESS);
 
-            if (null !== $this->logger) {
-                $this->logger->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => \get_class($authenticator)]);
-            }
+            $this->logger?->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => \get_class($authenticator)]);
         } catch (AuthenticationException $e) {
             // oh no! Authentication failed!
             $response = $this->handleAuthenticationFailure($e, $request, $authenticator, $passport);
@@ -227,9 +217,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             return $response;
         }
 
-        if (null !== $this->logger) {
-            $this->logger->debug('Authenticator set no success response: request continues.', ['authenticator' => \get_class($authenticator)]);
-        }
+        $this->logger?->debug('Authenticator set no success response: request continues.', ['authenticator' => \get_class($authenticator)]);
 
         return null;
     }
@@ -254,9 +242,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
      */
     private function handleAuthenticationFailure(AuthenticationException $authenticationException, Request $request, AuthenticatorInterface $authenticator, ?Passport $passport): ?Response
     {
-        if (null !== $this->logger) {
-            $this->logger->info('Authenticator failed.', ['exception' => $authenticationException, 'authenticator' => \get_class($authenticator)]);
-        }
+        $this->logger?->info('Authenticator failed.', ['exception' => $authenticationException, 'authenticator' => \get_class($authenticator)]);
 
         // Avoid leaking error details in case of invalid user (e.g. user not found or invalid account status)
         // to prevent user enumeration via response content comparison

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -78,9 +78,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
         }
 
         if ($this->options['failure_forward']) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Authentication failure, forward triggered.', ['failure_path' => $this->options['failure_path']]);
-            }
+            $this->logger?->debug('Authentication failure, forward triggered.', ['failure_path' => $this->options['failure_path']]);
 
             $subRequest = $this->httpUtils->createRequest($request, $this->options['failure_path']);
             $subRequest->attributes->set(Security::AUTHENTICATION_ERROR, $exception);
@@ -88,9 +86,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
             return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
         }
 
-        if (null !== $this->logger) {
-            $this->logger->debug('Authentication failure, redirect triggered.', ['failure_path' => $this->options['failure_path']]);
-        }
+        $this->logger?->debug('Authentication failure, redirect triggered.', ['failure_path' => $this->options['failure_path']]);
 
         $request->getSession()->set(Security::AUTHENTICATION_ERROR, $exception);
 

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
@@ -64,17 +64,13 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
         } catch (BadCredentialsException $e) {
             $this->clearToken($e);
 
-            if (null !== $this->logger) {
-                $this->logger->debug('Skipping pre-authenticated authenticator as a BadCredentialsException is thrown.', ['exception' => $e, 'authenticator' => static::class]);
-            }
+            $this->logger?->debug('Skipping pre-authenticated authenticator as a BadCredentialsException is thrown.', ['exception' => $e, 'authenticator' => static::class]);
 
             return false;
         }
 
         if (null === $username) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Skipping pre-authenticated authenticator no username could be extracted.', ['authenticator' => static::class]);
-            }
+            $this->logger?->debug('Skipping pre-authenticated authenticator no username could be extracted.', ['authenticator' => static::class]);
 
             return false;
         }
@@ -83,9 +79,7 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
         $token = $this->tokenStorage->getToken();
 
         if ($token instanceof PreAuthenticatedToken && $this->firewallName === $token->getFirewallName() && $token->getUserIdentifier() === $username) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Skipping pre-authenticated authenticator as the user already has an existing session.', ['authenticator' => static::class]);
-            }
+            $this->logger?->debug('Skipping pre-authenticated authenticator as the user already has an existing session.', ['authenticator' => static::class]);
 
             return false;
         }
@@ -131,9 +125,7 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
         if ($token instanceof PreAuthenticatedToken && $this->firewallName === $token->getFirewallName()) {
             $this->tokenStorage->setToken(null);
 
-            if (null !== $this->logger) {
-                $this->logger->info('Cleared pre-authenticated token due to an exception.', ['exception' => $exception]);
-            }
+            $this->logger?->info('Cleared pre-authenticated token due to an exception.', ['exception' => $exception]);
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
@@ -86,9 +86,7 @@ class HttpBasicAuthenticator implements AuthenticatorInterface, AuthenticationEn
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
-        if (null !== $this->logger) {
-            $this->logger->info('Basic authentication failed for user.', ['username' => $request->headers->get('PHP_AUTH_USER'), 'exception' => $exception]);
-        }
+        $this->logger?->info('Basic authentication failed for user.', ['username' => $request->headers->get('PHP_AUTH_USER'), 'exception' => $exception]);
 
         return $this->start($request, $exception);
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -73,9 +73,7 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
             return false;
         }
 
-        if (null !== $this->logger) {
-            $this->logger->debug('Remember-me cookie detected.');
-        }
+        $this->logger?->debug('Remember-me cookie detected.');
 
         // the `null` return value indicates that this authenticator supports lazy firewalls
         return null;

--- a/src/Symfony/Component/Security/Http/EventListener/CheckRememberMeConditionsListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CheckRememberMeConditionsListener.php
@@ -56,9 +56,7 @@ class CheckRememberMeConditionsListener implements EventSubscriberInterface
         if (!$this->options['always_remember_me']) {
             $parameter = ParameterBagUtils::getRequestParameterValue($event->getRequest(), $this->options['remember_me_parameter']);
             if (!('true' === $parameter || 'on' === $parameter || '1' === $parameter || 'yes' === $parameter || true === $parameter)) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('Remember me disabled; request does not contain remember me parameter ("{parameter}").', ['parameter' => $this->options['remember_me_parameter']]);
-                }
+                $this->logger?->debug('Remember me disabled; request does not contain remember me parameter ("{parameter}").', ['parameter' => $this->options['remember_me_parameter']]);
 
                 return;
             }

--- a/src/Symfony/Component/Security/Http/EventListener/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/RememberMeListener.php
@@ -47,9 +47,7 @@ class RememberMeListener implements EventSubscriberInterface
     {
         $passport = $event->getPassport();
         if (!$passport->hasBadge(RememberMeBadge::class)) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Remember me skipped: your authenticator does not support it.', ['authenticator' => \get_class($event->getAuthenticator())]);
-            }
+            $this->logger?->debug('Remember me skipped: your authenticator does not support it.', ['authenticator' => \get_class($event->getAuthenticator())]);
 
             return;
         }
@@ -60,16 +58,12 @@ class RememberMeListener implements EventSubscriberInterface
         /** @var RememberMeBadge $badge */
         $badge = $passport->getBadge(RememberMeBadge::class);
         if (!$badge->isEnabled()) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Remember me skipped: the RememberMeBadge is not enabled.');
-            }
+            $this->logger?->debug('Remember me skipped: the RememberMeBadge is not enabled.');
 
             return;
         }
 
-        if (null !== $this->logger) {
-            $this->logger->debug('Remember-me was requested; setting cookie.');
-        }
+        $this->logger?->debug('Remember-me was requested; setting cookie.');
 
         $this->rememberMeHandler->createRememberMeCookie($event->getUser());
     }

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -62,9 +62,7 @@ class ChannelListener extends AbstractListener
         }
 
         if ('http' === $channel && $request->isSecure()) {
-            if (null !== $this->logger) {
-                $this->logger->info('Redirecting to HTTP.');
-            }
+            $this->logger?->info('Redirecting to HTTP.');
 
             return true;
         }

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -120,30 +120,22 @@ class ContextListener extends AbstractListener
 
         $token = $this->safelyUnserialize($token);
 
-        if (null !== $this->logger) {
-            $this->logger->debug('Read existing security token from the session.', [
-                'key' => $this->sessionKey,
-                'token_class' => \is_object($token) ? \get_class($token) : null,
-            ]);
-        }
+        $this->logger?->debug('Read existing security token from the session.', [
+            'key' => $this->sessionKey,
+            'token_class' => \is_object($token) ? \get_class($token) : null,
+        ]);
 
         if ($token instanceof TokenInterface) {
             $originalToken = $token;
             $token = $this->refreshUser($token);
 
             if (!$token) {
-                if ($this->logger) {
-                    $this->logger->debug('Token was deauthenticated after trying to refresh it.');
-                }
+                $this->logger?->debug('Token was deauthenticated after trying to refresh it.');
 
-                if ($this->dispatcher) {
-                    $this->dispatcher->dispatch(new TokenDeauthenticatedEvent($originalToken, $request));
-                }
+                $this->dispatcher?->dispatch(new TokenDeauthenticatedEvent($originalToken, $request));
             }
         } elseif (null !== $token) {
-            if (null !== $this->logger) {
-                $this->logger->warning('Expected a security token from the session, got something else.', ['key' => $this->sessionKey, 'received' => $token]);
-            }
+            $this->logger?->warning('Expected a security token from the session, got something else.', ['key' => $this->sessionKey, 'received' => $token]);
 
             $token = null;
         }
@@ -170,9 +162,7 @@ class ContextListener extends AbstractListener
             return;
         }
 
-        if ($this->dispatcher) {
-            $this->dispatcher->removeListener(KernelEvents::RESPONSE, [$this, 'onKernelResponse']);
-        }
+        $this->dispatcher?->removeListener(KernelEvents::RESPONSE, [$this, 'onKernelResponse']);
         $this->registered = false;
         $session = $request->getSession();
         $sessionId = $session->getId();
@@ -186,9 +176,7 @@ class ContextListener extends AbstractListener
         } else {
             $session->set($this->sessionKey, serialize($token));
 
-            if (null !== $this->logger) {
-                $this->logger->debug('Stored the security token in the session.', ['key' => $this->sessionKey]);
-            }
+            $this->logger?->debug('Stored the security token in the session.', ['key' => $this->sessionKey]);
         }
 
         if ($this->sessionTrackerEnabler && $session->getId() === $sessionId) {
@@ -227,9 +215,7 @@ class ContextListener extends AbstractListener
                 if ($token instanceof AbstractToken && $this->hasUserChanged($user, $newToken)) {
                     $userDeauthenticated = true;
 
-                    if (null !== $this->logger) {
-                        $this->logger->debug('Cannot refresh token because user has changed.', ['username' => $refreshedUser->getUserIdentifier(), 'provider' => \get_class($provider)]);
-                    }
+                    $this->logger?->debug('Cannot refresh token because user has changed.', ['username' => $refreshedUser->getUserIdentifier(), 'provider' => \get_class($provider)]);
 
                     continue;
                 }
@@ -251,9 +237,7 @@ class ContextListener extends AbstractListener
             } catch (UnsupportedUserException $e) {
                 // let's try the next user provider
             } catch (UserNotFoundException $e) {
-                if (null !== $this->logger) {
-                    $this->logger->warning('Username could not be found in the selected user provider.', ['username' => $e->getUserIdentifier(), 'provider' => \get_class($provider)]);
-                }
+                $this->logger?->warning('Username could not be found in the selected user provider.', ['username' => $e->getUserIdentifier(), 'provider' => \get_class($provider)]);
 
                 $userNotFoundByProvider = true;
             }
@@ -288,9 +272,7 @@ class ContextListener extends AbstractListener
             if (0x37313BC !== $e->getCode()) {
                 throw $e;
             }
-            if ($this->logger) {
-                $this->logger->warning('Failed to unserialize the security token from the session.', ['key' => $this->sessionKey, 'received' => $serializedToken, 'exception' => $e]);
-            }
+            $this->logger?->warning('Failed to unserialize the security token from the session.', ['key' => $this->sessionKey, 'received' => $serializedToken, 'exception' => $e]);
         } finally {
             restore_error_handler();
             ini_set('unserialize_callback_func', $prevUnserializeHandler);

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -121,9 +121,7 @@ class ExceptionListener
 
     private function handleAuthenticationException(ExceptionEvent $event, AuthenticationException $exception): void
     {
-        if (null !== $this->logger) {
-            $this->logger->info('An AuthenticationException was thrown; redirecting to authentication entry point.', ['exception' => $exception]);
-        }
+        $this->logger?->info('An AuthenticationException was thrown; redirecting to authentication entry point.', ['exception' => $exception]);
 
         try {
             $event->setResponse($this->startAuthentication($event->getRequest(), $exception));
@@ -139,9 +137,7 @@ class ExceptionListener
 
         $token = $this->tokenStorage->getToken();
         if (!$this->authenticationTrustResolver->isFullFledged($token)) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Access denied, the user is not fully authenticated; redirecting to authentication entry point.', ['exception' => $exception]);
-            }
+            $this->logger?->debug('Access denied, the user is not fully authenticated; redirecting to authentication entry point.', ['exception' => $exception]);
 
             try {
                 $insufficientAuthenticationException = new InsufficientAuthenticationException('Full authentication is required to access this resource.', 0, $exception);
@@ -157,9 +153,7 @@ class ExceptionListener
             return;
         }
 
-        if (null !== $this->logger) {
-            $this->logger->debug('Access denied, the user is neither anonymous, nor remember-me.', ['exception' => $exception]);
-        }
+        $this->logger?->debug('Access denied, the user is neither anonymous, nor remember-me.', ['exception' => $exception]);
 
         try {
             if (null !== $this->accessDeniedHandler) {
@@ -176,9 +170,7 @@ class ExceptionListener
                 $event->allowCustomResponseCode();
             }
         } catch (\Exception $e) {
-            if (null !== $this->logger) {
-                $this->logger->error('An exception was thrown when handling an AccessDeniedException.', ['exception' => $e]);
-            }
+            $this->logger?->error('An exception was thrown when handling an AccessDeniedException.', ['exception' => $e]);
 
             $event->setThrowable(new \RuntimeException('Exception thrown when handling an exception.', 0, $e));
         }
@@ -188,9 +180,7 @@ class ExceptionListener
     {
         $event->setThrowable(new AccessDeniedHttpException($exception->getMessage(), $exception));
 
-        if (null !== $this->logger) {
-            $this->logger->info('A LogoutException was thrown; wrapping with AccessDeniedHttpException', ['exception' => $exception]);
-        }
+        $this->logger?->info('A LogoutException was thrown; wrapping with AccessDeniedHttpException', ['exception' => $exception]);
     }
 
     private function startAuthentication(Request $request, AuthenticationException $authException): Response
@@ -199,9 +189,7 @@ class ExceptionListener
             $this->throwUnauthorizedException($authException);
         }
 
-        if (null !== $this->logger) {
-            $this->logger->debug('Calling Authentication entry point.');
-        }
+        $this->logger?->debug('Calling Authentication entry point.');
 
         if (!$this->stateless) {
             $this->setTargetPath($request);
@@ -211,9 +199,7 @@ class ExceptionListener
             // remove the security token to prevent infinite redirect loops
             $this->tokenStorage->setToken(null);
 
-            if (null !== $this->logger) {
-                $this->logger->info('The security token was removed due to an AccountStatusException.', ['exception' => $authException]);
-            }
+            $this->logger?->info('The security token was removed due to an AccountStatusException.', ['exception' => $authException]);
         }
 
         try {
@@ -241,9 +227,7 @@ class ExceptionListener
 
     private function throwUnauthorizedException(AuthenticationException $authException)
     {
-        if (null !== $this->logger) {
-            $this->logger->notice(sprintf('No Authentication entry point configured, returning a %s HTTP response. Configure "entry_point" on the firewall "%s" if you want to modify the response.', Response::HTTP_UNAUTHORIZED, $this->firewallName));
-        }
+        $this->logger?->notice(sprintf('No Authentication entry point configured, returning a %s HTTP response. Configure "entry_point" on the firewall "%s" if you want to modify the response.', Response::HTTP_UNAUTHORIZED, $this->firewallName));
 
         throw new HttpException(Response::HTTP_UNAUTHORIZED, $authException->getMessage(), $authException, [], $authException->getCode());
     }

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -173,9 +173,7 @@ class SwitchUserListener extends AbstractListener
             throw $exception;
         }
 
-        if (null !== $this->logger) {
-            $this->logger->info('Attempting to switch to user.', ['username' => $username]);
-        }
+        $this->logger?->info('Attempting to switch to user.', ['username' => $username]);
 
         $this->userChecker->checkPostAuth($user);
 

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeHandler.php
@@ -74,9 +74,7 @@ abstract class AbstractRememberMeHandler implements RememberMeHandlerInterface
 
         $this->processRememberMe($rememberMeDetails, $user);
 
-        if (null !== $this->logger) {
-            $this->logger->info('Remember-me cookie accepted.');
-        }
+        $this->logger?->info('Remember-me cookie accepted.');
 
         return $user;
     }
@@ -86,9 +84,7 @@ abstract class AbstractRememberMeHandler implements RememberMeHandlerInterface
      */
     public function clearRememberMeCookie(): void
     {
-        if (null !== $this->logger) {
-            $this->logger->debug('Clearing remember-me cookie.', ['name' => $this->options['name']]);
-        }
+        $this->logger?->debug('Clearing remember-me cookie.', ['name' => $this->options['name']]);
 
         $this->createCookie(null);
     }
@@ -108,8 +104,8 @@ abstract class AbstractRememberMeHandler implements RememberMeHandlerInterface
         // the ResponseListener configures the cookie saved in this attribute on the final response object
         $request->attributes->set(ResponseListener::COOKIE_ATTR_NAME, new Cookie(
             $this->options['name'],
-            $rememberMeDetails ? $rememberMeDetails->toString() : null,
-            $rememberMeDetails ? $rememberMeDetails->getExpires() : 1,
+            $rememberMeDetails?->toString(),
+            $rememberMeDetails?->getExpires() ?? 1,
             $this->options['path'],
             $this->options['domain'],
             $this->options['secure'] ?? $request->isSecure(),

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -91,9 +91,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         if ($persistentToken->getLastUsed()->getTimestamp() + 60 < time()) {
             $tokenValue = $this->generateHash(base64_encode(random_bytes(64)));
             $tokenLastUsed = new \DateTime();
-            if ($this->tokenVerifier) {
-                $this->tokenVerifier->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
-            }
+            $this->tokenVerifier?->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
             $this->tokenProvider->updateToken($series, $tokenValue, $tokenLastUsed);
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -169,7 +169,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $stack = [];
         $attributes = $this->getAttributes($object, $format, $context);
         $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
-        $attributesMetadata = $this->classMetadataFactory ? $this->classMetadataFactory->getMetadataFor($class)->getAttributesMetadata() : null;
+        $attributesMetadata = $this->classMetadataFactory?->getMetadataFor($class)->getAttributesMetadata();
         if (isset($context[self::MAX_DEPTH_HANDLER])) {
             $maxDepthHandler = $context[self::MAX_DEPTH_HANDLER];
             if (!\is_callable($maxDepthHandler)) {

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -133,7 +133,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             $this->discriminatorCache[$cacheKey] = null;
             if (null !== $this->classDiscriminatorResolver) {
                 $mapping = $this->classDiscriminatorResolver->getMappingForMappedObject($object);
-                $this->discriminatorCache[$cacheKey] = null === $mapping ? null : $mapping->getTypeProperty();
+                $this->discriminatorCache[$cacheKey] = $mapping?->getTypeProperty();
             }
         }
 

--- a/src/Symfony/Component/Templating/Loader/CacheLoader.php
+++ b/src/Symfony/Component/Templating/Loader/CacheLoader.php
@@ -49,9 +49,7 @@ class CacheLoader extends Loader
         $path = $dir.\DIRECTORY_SEPARATOR.$file;
 
         if (is_file($path)) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Fetching template from cache.', ['name' => $template->get('name')]);
-            }
+            $this->logger?->debug('Fetching template from cache.', ['name' => $template->get('name')]);
 
             return new FileStorage($path);
         }
@@ -68,9 +66,7 @@ class CacheLoader extends Loader
 
         file_put_contents($path, $content);
 
-        if (null !== $this->logger) {
-            $this->logger->debug('Storing template in cache.', ['name' => $template->get('name')]);
-        }
+        $this->logger?->debug('Storing template in cache.', ['name' => $template->get('name')]);
 
         return new FileStorage($path);
     }

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -51,9 +51,7 @@ class FilesystemLoader extends Loader
         $fileFailures = [];
         foreach ($this->templatePathPatterns as $templatePathPattern) {
             if (is_file($file = strtr($templatePathPattern, $replacements)) && is_readable($file)) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('Loaded template file.', ['file' => $file]);
-                }
+                $this->logger?->debug('Loaded template file.', ['file' => $file]);
 
                 return new FileStorage($file);
             }
@@ -65,9 +63,7 @@ class FilesystemLoader extends Loader
 
         // only log failures if no template could be loaded at all
         foreach ($fileFailures as $file) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Failed loading template file.', ['file' => $file]);
-            }
+            $this->logger?->debug('Failed loading template file.', ['file' => $file]);
         }
 
         return false;

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -184,9 +184,7 @@ EOF
                     // general document errors have a '-1' line number
                     $line = -1 === $error['line'] ? null : $error['line'];
 
-                    if ($githubReporter) {
-                        $githubReporter->error($error['message'], $info['file'], $line, null !== $line ? $error['column'] : null);
-                    }
+                    $githubReporter?->error($error['message'], $info['file'], $line, null !== $line ? $error['column'] : null);
 
                     return null === $line ? $error['message'] : sprintf('Line %d, Column %d: %s', $line, $error['column'], $error['message']);
                 }, $info['messages']));

--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -86,7 +86,7 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
             throw new NoSuchMetadataException(sprintf('The class or interface "%s" does not exist.', $class));
         }
 
-        $cacheItem = null === $this->cache ? null : $this->cache->getItem($this->escapeClassName($class));
+        $cacheItem = $this->cache?->getItem($this->escapeClassName($class));
         if ($cacheItem && $cacheItem->isHit()) {
             $metadata = $cacheItem->get();
 
@@ -98,9 +98,7 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
 
         $metadata = new ClassMetadata($class);
 
-        if (null !== $this->loader) {
-            $this->loader->loadClassMetadata($metadata);
-        }
+        $this->loader?->loadClassMetadata($metadata);
 
         if (null !== $cacheItem) {
             $this->cache->save($cacheItem->set($metadata));

--- a/src/Symfony/Component/VarDumper/Server/DumpServer.php
+++ b/src/Symfony/Component/VarDumper/Server/DumpServer.php
@@ -56,25 +56,19 @@ class DumpServer
         }
 
         foreach ($this->getMessages() as $clientId => $message) {
-            if ($this->logger) {
-                $this->logger->info('Received a payload from client {clientId}', ['clientId' => $clientId]);
-            }
+            $this->logger?->info('Received a payload from client {clientId}', ['clientId' => $clientId]);
 
             $payload = @unserialize(base64_decode($message), ['allowed_classes' => [Data::class, Stub::class]]);
 
             // Impossible to decode the message, give up.
             if (false === $payload) {
-                if ($this->logger) {
-                    $this->logger->warning('Unable to decode a message from {clientId} client.', ['clientId' => $clientId]);
-                }
+                $this->logger?->warning('Unable to decode a message from {clientId} client.', ['clientId' => $clientId]);
 
                 continue;
             }
 
             if (!\is_array($payload) || \count($payload) < 2 || !$payload[0] instanceof Data || !\is_array($payload[1])) {
-                if ($this->logger) {
-                    $this->logger->warning('Invalid payload from {clientId} client. Expected an array of two elements (Data $data, array $context)', ['clientId' => $clientId]);
-                }
+                $this->logger?->warning('Invalid payload from {clientId} client. Expected an array of two elements (Data $data, array $context)', ['clientId' => $clientId]);
 
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

PHP 8 introduced a nullsafe operator which allows us to simplify some of our code.

I have used a PhpStorm inspection to automate the change. I did some minor adjustments afterwards where the fixer left unnecessary paranthesis or local variables.