### PR TITLE
[Translation] Handle the blank-translation in Loco Adapter

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -99,7 +99,7 @@ final class LocoProvider implements ProviderInterface
                 $response = $this->client->request('GET', sprintf('export/locale/%s.xlf', rawurlencode($locale)), [
                     'query' => [
                         'filter' => $domain,
-                        'status' => 'translated',
+                        'status' => 'translated,blank-translation',
                     ],
                 ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3, 5.4, 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44595
| License       | MIT

This PR aim to be able to pull the "blank-translation" in addition to "translated" status translations. See the ticket to know more about. I don't think we can add a unit test here as the calls to loco are fully mocked. 
