### PR TITLE
[Serializer] Improve UidNormalizer denormalize error message

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
@@ -71,10 +71,8 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
     {
         try {
             return AbstractUid::class !== $type ? $type::fromString($data) : Uuid::fromString($data);
-        } catch (\InvalidArgumentException $exception) {
-            throw NotNormalizableValueException::createForUnexpectedDataType('The data is not a valid UUID string representation.', $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
-        } catch (\TypeError $exception) {
-            throw NotNormalizableValueException::createForUnexpectedDataType('The data is not a valid UUID string representation.', $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
+        } catch (\InvalidArgumentException|\TypeError $exception) {
+            throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('The data is not a valid "%s" string representation.', $type), $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
         } catch (\Error $e) {
             if (str_starts_with($e->getMessage(), 'Cannot instantiate abstract class')) {
                 return $this->denormalize($data, AbstractUid::class, $format, $context);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -884,7 +884,7 @@ class SerializerTest extends TestCase
                 ],
                 'path' => 'uuid',
                 'useMessageForUser' => true,
-                'message' => 'The data is not a valid UUID string representation.',
+                'message' => 'The data is not a valid "Symfony\Component\Uid\Uuid" string representation.',
             ],
             [
                 'currentType' => 'null',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

The two catch blocks can be merged. Also we should use ULID when the type is an ULID, and UID when we don't know.