### PR TITLE
[Routing] Support the "attribute" type (alias of "annotation") in annotation loaders

### DIFF
--- a/src/Symfony/Component/Config/Tests/Exception/LoaderLoadExceptionTest.php
+++ b/src/Symfony/Component/Config/Tests/Exception/LoaderLoadExceptionTest.php
@@ -34,6 +34,12 @@ class LoaderLoadExceptionTest extends TestCase
         $this->assertEquals('Cannot load resource "resource". Make sure there is a loader supporting the "annotation" type.', $exception->getMessage());
     }
 
+    public function testMessageCannotLoadResourceWithAttributeType()
+    {
+        $exception = new LoaderLoadException('resource', null, 0, null, 'attribute');
+        $this->assertEquals('Cannot load resource "resource". Make sure there is a loader supporting the "attribute" type.', $exception->getMessage());
+    }
+
     public function testMessageCannotImportResourceFromSource()
     {
         $exception = new LoaderLoadException('resource', 'sourceResource');

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `getMissingParameters` and `getRouteName` methods on `MissingMandatoryParametersException`
  * Allow using UTF-8 parameter names
+ * Support the `attribute` type (alias of `annotation`) in annotation loaders
 
 5.3
 ---

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -237,7 +237,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
      */
     public function supports(mixed $resource, string $type = null): bool
     {
-        return \is_string($resource) && preg_match('/^(?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+$/', $resource) && (!$type || 'annotation' === $type);
+        return \is_string($resource) && preg_match('/^(?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+$/', $resource) && (!$type || \in_array($type, ['annotation', 'attribute'], true));
     }
 
     /**

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -69,7 +69,7 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
      */
     public function supports(mixed $resource, string $type = null): bool
     {
-        if ('annotation' === $type) {
+        if (\in_array($type, ['annotation', 'attribute'], true)) {
             return true;
         }
 

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -67,7 +67,7 @@ class AnnotationFileLoader extends FileLoader
      */
     public function supports(mixed $resource, string $type = null): bool
     {
-        return \is_string($resource) && 'php' === pathinfo($resource, \PATHINFO_EXTENSION) && (!$type || 'annotation' === $type);
+        return \is_string($resource) && 'php' === pathinfo($resource, \PATHINFO_EXTENSION) && (!$type || \in_array($type, ['annotation', 'attribute'], true));
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -46,6 +46,7 @@ abstract class AnnotationClassLoaderTest extends TestCase
     public function testSupportsChecksTypeIfSpecified()
     {
         $this->assertTrue($this->loader->supports('class', 'annotation'), '->supports() checks the resource type if specified');
+        $this->assertTrue($this->loader->supports('class', 'attribute'), '->supports() checks the resource type if specified');
         $this->assertFalse($this->loader->supports('class', 'foo'), '->supports() checks the resource type if specified');
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -78,6 +78,7 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
         $this->assertFalse($this->loader->supports('foo.foo'), '->supports() returns true if the resource is loadable');
 
         $this->assertTrue($this->loader->supports($fixturesDir, 'annotation'), '->supports() checks the resource type if specified');
+        $this->assertTrue($this->loader->supports($fixturesDir, 'attribute'), '->supports() checks the resource type if specified');
         $this->assertFalse($this->loader->supports($fixturesDir, 'foo'), '->supports() checks the resource type if specified');
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -83,6 +83,7 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
         $this->assertFalse($this->loader->supports('foo.foo'), '->supports() returns true if the resource is loadable');
 
         $this->assertTrue($this->loader->supports($fixture, 'annotation'), '->supports() checks the resource type if specified');
+        $this->assertTrue($this->loader->supports($fixture, 'attribute'), '->supports() checks the resource type if specified');
         $this->assertFalse($this->loader->supports($fixture, 'foo'), '->supports() checks the resource type if specified');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Minor DX feature. I migrated several projects to PHP 8 and they now use the `Route` class as an attribute. They don't require `doctrine/annotations` anymore. There is no PHPDoc annotations left in the code. For example, I declare the routes like this:
```php
<?php

declare(strict_types=1);

use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;

return static function (RoutingConfigurator $routes): void {
    $routes
        ->import('../../src/Controller', 'annotation')
        ->namePrefix('app_');
};
```

I'd like to use `attribute` as the type instead of `annotation` now because it makes more sense. Also, it's easier to explain it to newcomers.