### PR TITLE
[HttpKernel] Fix SessionListener without session in request

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -68,7 +68,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event)
     {
-        if (!$event->isMainRequest()) {
+        if (!$event->isMainRequest() || (!$this->container->has('initialized_session') && !$event->getRequest()->hasSession())) {
             return;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -142,6 +142,24 @@ class SessionListenerTest extends TestCase
         $this->assertFalse($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
     }
 
+    public function testUninitializedSessionWithoutInitializedSession()
+    {
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $response = new Response();
+        $response->setSharedMaxAge(60);
+        $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 'true');
+
+        $container = new ServiceLocator([]);
+
+        $listener = new SessionListener($container);
+        $listener->onKernelResponse(new ResponseEvent($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST, $response));
+        $this->assertFalse($response->headers->has('Expires'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('public'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('private'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('must-revalidate'));
+        $this->assertSame('60', $response->headers->getCacheControlDirective('s-maxage'));
+    }
+
     public function testSurrogateMainRequestIsPublic()
     {
         $session = $this->createMock(Session::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

We have in our project a Listener for `kernel.request` which sets a Response object if it's a `OPTIONS` call. A `setResponse` in the event does stopping all other listeners also the session listener. As the session listener is not triggered in the kernel.request the followup kernel.response event will let the session listener crash.

https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php#L80

This line tries to get the session from the container, if its missing it calls `getSession` this throws then a error Session is not set.


It looks like this issue has been fixed already in Symfony 6.  See https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php#L99-L101
