### PR TITLE
[HttpClient] fix monitoring responses issued before reset()

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -306,9 +306,9 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             throw new \TypeError(sprintf('"%s()" expects parameter 1 to be an iterable of CurlResponse objects, "%s" given.', __METHOD__, \is_object($responses) ? \get_class($responses) : \gettype($responses)));
         }
 
-        if (\is_resource($this->multi->handle) || $this->multi->handle instanceof \CurlMultiHandle) {
+        if (\is_resource($mh = $this->multi->handles[0] ?? null) || $mh instanceof \CurlMultiHandle) {
             $active = 0;
-            while (\CURLM_CALL_MULTI_PERFORM === curl_multi_exec($this->multi->handle, $active)) {
+            while (\CURLM_CALL_MULTI_PERFORM === curl_multi_exec($mh, $active)) {
             }
         }
 

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -23,8 +23,8 @@ use Symfony\Component\HttpClient\Response\CurlResponse;
  */
 final class CurlClientState extends ClientState
 {
-    /** @var \CurlMultiHandle|resource */
-    public $handle;
+    /** @var array<\CurlMultiHandle|resource> */
+    public $handles = [];
     /** @var PushedResponse[] */
     public $pushedResponses = [];
     /** @var DnsCache */
@@ -41,20 +41,20 @@ final class CurlClientState extends ClientState
     {
         self::$curlVersion = self::$curlVersion ?? curl_version();
 
-        $this->handle = curl_multi_init();
+        array_unshift($this->handles, $mh = curl_multi_init());
         $this->dnsCache = new DnsCache();
         $this->maxHostConnections = $maxHostConnections;
         $this->maxPendingPushes = $maxPendingPushes;
 
         // Don't enable HTTP/1.1 pipelining: it forces responses to be sent in order
         if (\defined('CURLPIPE_MULTIPLEX')) {
-            curl_multi_setopt($this->handle, \CURLMOPT_PIPELINING, \CURLPIPE_MULTIPLEX);
+            curl_multi_setopt($mh, \CURLMOPT_PIPELINING, \CURLPIPE_MULTIPLEX);
         }
         if (\defined('CURLMOPT_MAX_HOST_CONNECTIONS')) {
-            $maxHostConnections = curl_multi_setopt($this->handle, \CURLMOPT_MAX_HOST_CONNECTIONS, 0 < $maxHostConnections ? $maxHostConnections : \PHP_INT_MAX) ? 0 : $maxHostConnections;
+            $maxHostConnections = curl_multi_setopt($mh, \CURLMOPT_MAX_HOST_CONNECTIONS, 0 < $maxHostConnections ? $maxHostConnections : \PHP_INT_MAX) ? 0 : $maxHostConnections;
         }
         if (\defined('CURLMOPT_MAXCONNECTS') && 0 < $maxHostConnections) {
-            curl_multi_setopt($this->handle, \CURLMOPT_MAXCONNECTS, $maxHostConnections);
+            curl_multi_setopt($mh, \CURLMOPT_MAXCONNECTS, $maxHostConnections);
         }
 
         // Skip configuring HTTP/2 push when it's unsupported or buggy, see https://bugs.php.net/77535
@@ -67,45 +67,40 @@ final class CurlClientState extends ClientState
             return;
         }
 
-        curl_multi_setopt($this->handle, \CURLMOPT_PUSHFUNCTION, function ($parent, $pushed, array $requestHeaders) use ($maxPendingPushes) {
-            return $this->handlePush($parent, $pushed, $requestHeaders, $maxPendingPushes);
+        // Clone to prevent a circular reference
+        $multi = clone $this;
+        $multi->handles = [$mh];
+        $multi->pushedResponses = &$this->pushedResponses;
+        $multi->logger = &$this->logger;
+        $multi->handlesActivity = &$this->handlesActivity;
+        $multi->openHandles = &$this->openHandles;
+        $multi->lastTimeout = &$this->lastTimeout;
+
+        curl_multi_setopt($mh, \CURLMOPT_PUSHFUNCTION, static function ($parent, $pushed, array $requestHeaders) use ($multi, $maxPendingPushes) {
+            return $multi->handlePush($parent, $pushed, $requestHeaders, $maxPendingPushes);
         });
     }
 
     public function reset()
     {
-        if ($this->logger) {
-            foreach ($this->pushedResponses as $url => $response) {
-                $this->logger->debug(sprintf('Unused pushed response: "%s"', $url));
+        foreach ($this->pushedResponses as $url => $response) {
+            $this->logger && $this->logger->debug(sprintf('Unused pushed response: "%s"', $url));
+
+            foreach ($this->handles as $mh) {
+                curl_multi_remove_handle($mh, $response->handle);
             }
+            curl_close($response->handle);
         }
 
         $this->pushedResponses = [];
         $this->dnsCache->evictions = $this->dnsCache->evictions ?: $this->dnsCache->removals;
         $this->dnsCache->removals = $this->dnsCache->hostnames = [];
 
-        if (\is_resource($this->handle) || $this->handle instanceof \CurlMultiHandle) {
-            if (\defined('CURLMOPT_PUSHFUNCTION')) {
-                curl_multi_setopt($this->handle, \CURLMOPT_PUSHFUNCTION, null);
-            }
-
-            curl_multi_close($this->handle);
-            $this->__construct($this->maxHostConnections, $this->maxPendingPushes);
+        if (\defined('CURLMOPT_PUSHFUNCTION')) {
+            curl_multi_setopt($this->handles[0], \CURLMOPT_PUSHFUNCTION, null);
         }
-    }
 
-    public function __wakeup()
-    {
-        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
-    }
-
-    public function __destruct()
-    {
-        foreach ($this->openHandles as [$ch]) {
-            if (\is_resource($ch) || $ch instanceof \CurlHandle) {
-                curl_setopt($ch, \CURLOPT_VERBOSE, false);
-            }
-        }
+        $this->__construct($this->maxHostConnections, $this->maxPendingPushes);
     }
 
     private function handlePush($parent, $pushed, array $requestHeaders, int $maxPendingPushes): int

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -150,7 +150,7 @@ final class CurlResponse implements ResponseInterface
         // Schedule the request in a non-blocking way
         $multi->lastTimeout = null;
         $multi->openHandles[$id] = [$ch, $options];
-        curl_multi_add_handle($multi->handle, $ch);
+        curl_multi_add_handle($multi->handles[0], $ch);
 
         $this->canary = new Canary(static function () use ($ch, $multi, $id) {
             unset($multi->openHandles[$id], $multi->handlesActivity[$id]);
@@ -160,7 +160,9 @@ final class CurlResponse implements ResponseInterface
                 return;
             }
 
-            curl_multi_remove_handle($multi->handle, $ch);
+            foreach ($multi->handles as $mh) {
+                curl_multi_remove_handle($mh, $ch);
+            }
             curl_setopt_array($ch, [
                 \CURLOPT_NOPROGRESS => true,
                 \CURLOPT_PROGRESSFUNCTION => null,
@@ -242,7 +244,7 @@ final class CurlResponse implements ResponseInterface
      */
     private static function schedule(self $response, array &$runningResponses): void
     {
-        if (isset($runningResponses[$i = (int) $response->multi->handle])) {
+        if (isset($runningResponses[$i = (int) $response->multi->handles[0]])) {
             $runningResponses[$i][1][$response->id] = $response;
         } else {
             $runningResponses[$i] = [$response->multi, [$response->id => $response]];
@@ -274,39 +276,47 @@ final class CurlResponse implements ResponseInterface
 
         try {
             self::$performing = true;
-            $active = 0;
-            while (\CURLM_CALL_MULTI_PERFORM === ($err = curl_multi_exec($multi->handle, $active))) {
-            }
 
-            if (\CURLM_OK !== $err) {
-                throw new TransportException(curl_multi_strerror($err));
-            }
-
-            while ($info = curl_multi_info_read($multi->handle)) {
-                if (\CURLMSG_DONE !== $info['msg']) {
-                    continue;
+            foreach ($multi->handles as $i => $mh) {
+                $active = 0;
+                while (\CURLM_CALL_MULTI_PERFORM === ($err = curl_multi_exec($mh, $active))) {
                 }
-                $result = $info['result'];
-                $id = (int) $ch = $info['handle'];
-                $waitFor = @curl_getinfo($ch, \CURLINFO_PRIVATE) ?: '_0';
 
-                if (\in_array($result, [\CURLE_SEND_ERROR, \CURLE_RECV_ERROR, /*CURLE_HTTP2*/ 16, /*CURLE_HTTP2_STREAM*/ 92], true) && $waitFor[1] && 'C' !== $waitFor[0]) {
-                    curl_multi_remove_handle($multi->handle, $ch);
-                    $waitFor[1] = (string) ((int) $waitFor[1] - 1); // decrement the retry counter
-                    curl_setopt($ch, \CURLOPT_PRIVATE, $waitFor);
-                    curl_setopt($ch, \CURLOPT_FORBID_REUSE, true);
+                if (\CURLM_OK !== $err) {
+                    throw new TransportException(curl_multi_strerror($err));
+                }
 
-                    if (0 === curl_multi_add_handle($multi->handle, $ch)) {
+                while ($info = curl_multi_info_read($mh)) {
+                    if (\CURLMSG_DONE !== $info['msg']) {
                         continue;
                     }
+                    $result = $info['result'];
+                    $id = (int) $ch = $info['handle'];
+                    $waitFor = @curl_getinfo($ch, \CURLINFO_PRIVATE) ?: '_0';
+
+                    if (\in_array($result, [\CURLE_SEND_ERROR, \CURLE_RECV_ERROR, /*CURLE_HTTP2*/ 16, /*CURLE_HTTP2_STREAM*/ 92], true) && $waitFor[1] && 'C' !== $waitFor[0]) {
+                        curl_multi_remove_handle($mh, $ch);
+                        $waitFor[1] = (string) ((int) $waitFor[1] - 1); // decrement the retry counter
+                        curl_setopt($ch, \CURLOPT_PRIVATE, $waitFor);
+                        curl_setopt($ch, \CURLOPT_FORBID_REUSE, true);
+
+                        if (0 === curl_multi_add_handle($mh, $ch)) {
+                            continue;
+                        }
+                    }
+
+                    if (\CURLE_RECV_ERROR === $result && 'H' === $waitFor[0] && 400 <= ($responses[(int) $ch]->info['http_code'] ?? 0)) {
+                        $multi->handlesActivity[$id][] = new FirstChunk();
+                    }
+
+                    $multi->handlesActivity[$id][] = null;
+                    $multi->handlesActivity[$id][] = \in_array($result, [\CURLE_OK, \CURLE_TOO_MANY_REDIRECTS], true) || '_0' === $waitFor || curl_getinfo($ch, \CURLINFO_SIZE_DOWNLOAD) === curl_getinfo($ch, \CURLINFO_CONTENT_LENGTH_DOWNLOAD) ? null : new TransportException(sprintf('%s for "%s".', curl_strerror($result), curl_getinfo($ch, \CURLINFO_EFFECTIVE_URL)));
                 }
 
-                if (\CURLE_RECV_ERROR === $result && 'H' === $waitFor[0] && 400 <= ($responses[(int) $ch]->info['http_code'] ?? 0)) {
-                    $multi->handlesActivity[$id][] = new FirstChunk();
+                if (!$active && 0 < $i) {
+                    curl_multi_close($mh);
+                    unset($multi->handles[$i]);
                 }
-
-                $multi->handlesActivity[$id][] = null;
-                $multi->handlesActivity[$id][] = \in_array($result, [\CURLE_OK, \CURLE_TOO_MANY_REDIRECTS], true) || '_0' === $waitFor || curl_getinfo($ch, \CURLINFO_SIZE_DOWNLOAD) === curl_getinfo($ch, \CURLINFO_CONTENT_LENGTH_DOWNLOAD) ? null : new TransportException(sprintf('%s for "%s".', curl_strerror($result), curl_getinfo($ch, \CURLINFO_EFFECTIVE_URL)));
             }
         } finally {
             self::$performing = false;
@@ -325,7 +335,7 @@ final class CurlResponse implements ResponseInterface
             $timeout = min($timeout, 0.01);
         }
 
-        return curl_multi_select($multi->handle, $timeout);
+        return curl_multi_select($multi->handles[array_key_last($multi->handles)], $timeout);
     }
 
     /**

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -143,9 +143,20 @@ class CurlHttpClientTest extends HttpClientTestCase
         $r = new \ReflectionProperty($httpClient, 'multi');
         $r->setAccessible(true);
         $clientState = $r->getValue($httpClient);
-        $initialHandleId = (int) $clientState->handle;
+        $initialHandleId = (int) $clientState->handles[0];
         $httpClient->reset();
-        self::assertNotSame($initialHandleId, (int) $clientState->handle);
+        self::assertNotSame($initialHandleId, (int) $clientState->handles[0]);
+    }
+
+    public function testProcessAfterReset()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $response = $client->request('GET', 'http://127.0.0.1:8057/json');
+
+        $client->reset();
+
+        $this->assertSame(['application/json'], $response->getHeaders()['content-type']);
     }
 
     private function getVulcainClient(): CurlHttpClient


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follow up of #44601

In order to reset the DNS cache, we have to create a new curl-multi handle. But since there might still be responses attached to the previous handle, we need to keep it around to monitor it.

Best reviewed [ignoring whitespaces](https://github.com/symfony/symfony/pull/44625/files?w=1).