### PR TITLE
[PropertyInfo] PhpStan extractor nested object fix

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\RootDummy\RootDummyItem;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type;
@@ -116,6 +117,8 @@ class PhpStanExtractorTest extends TestCase
             ['arrayOfMixed', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_STRING), null)]],
             ['listOfStrings', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING))]],
             ['self', [new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)]],
+            ['rootDummyItems', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, RootDummyItem::class))]],
+            ['rootDummyItem', [new Type(Type::BUILTIN_TYPE_OBJECT, false, RootDummyItem::class)]],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -78,6 +78,8 @@ class ReflectionExtractorTest extends TestCase
                 'files',
                 'propertyTypeStatic',
                 'parentAnnotationNoParent',
+                'rootDummyItems',
+                'rootDummyItem',
                 'a',
                 'DOB',
                 'Id',
@@ -138,6 +140,8 @@ class ReflectionExtractorTest extends TestCase
                 'files',
                 'propertyTypeStatic',
                 'parentAnnotationNoParent',
+                'rootDummyItems',
+                'rootDummyItem',
                 'date',
                 'c',
                 'ct',
@@ -187,6 +191,8 @@ class ReflectionExtractorTest extends TestCase
                 'files',
                 'propertyTypeStatic',
                 'parentAnnotationNoParent',
+                'rootDummyItems',
+                'rootDummyItem',
             ],
             $noPrefixExtractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')
         );

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ParentDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ParentDummy.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
 
+use Symfony\Component\PropertyInfo\Tests\Fixtures\RootDummy\RootDummyItem;
+
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
@@ -57,6 +59,16 @@ class ParentDummy
      * @var parent
      */
     public $parentAnnotationNoParent;
+
+    /**
+     * @var RootDummyItem[]
+     */
+    public $rootDummyItems;
+
+    /**
+     * @var \Symfony\Component\PropertyInfo\Tests\Fixtures\RootDummy\RootDummyItem
+     */
+    public $rootDummyItem;
 
     /**
      * @return bool|null

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/RootDummy/RootDummyItem.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/RootDummy/RootDummyItem.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\RootDummy;
+
+class RootDummyItem
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets | -
| License | MIT
| Doc PR | -

PhpStanExtractor wrongly extracts object type when it is in a different namespace