### PR TITLE
[Workflow] Remove redundant type check

### DIFF
--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -83,10 +83,6 @@ class Workflow implements WorkflowInterface
     {
         $marking = $this->markingStore->getMarking($subject);
 
-        if (!$marking instanceof Marking) {
-            throw new LogicException(sprintf('The value returned by the MarkingStore is not an instance of "%s" for workflow "%s".', Marking::class, $this->name));
-        }
-
         // check if the subject is already in the workflow
         if (!$marking->getPlaces()) {
             if (!$this->definition->getInitialPlaces()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`MarkingStoreInterface::getMarking()` has a native return type `Marking`. The type check I've removed here is thus 100% redundant and can be removed.