### PR TITLE
[Workflow] Fix Event constructor requirements

### DIFF
--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -29,7 +29,7 @@ class Event extends BaseEvent
     private $transition;
     private $workflow;
 
-    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
+    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow, array $context = [])
     {
         $this->subject = $subject;
         $this->marking = $marking;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

This has already been deprecied in 4.x
But while cleaning the 5.x branch, I forgot to apply this patch

See
https://github.com/symfony/symfony/pull/31824/files#diff-5f386ffb0109cc731bd98e63eea021b32faadd98791bd6ba65926d09c5e2ec40L37

More over, `Event::getWorkflow()` has the correct return type.