### PR TITLE
Remove < PHP 8 unused code

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
@@ -44,7 +44,7 @@ class DefaultMarshallerTest extends TestCase
     public function testIgbinaryUnserialize()
     {
         if (version_compare('3.1.6', phpversion('igbinary'), '>')) {
-            $this->markTestSkipped('igbinary is not compatible with PHP 7.4.');
+            $this->markTestSkipped('igbinary needs to be v3.1.6 or higher.');
         }
 
         $marshaller = new DefaultMarshaller();
@@ -68,7 +68,7 @@ class DefaultMarshallerTest extends TestCase
     public function testIgbinaryUnserializeNotFoundClass()
     {
         if (version_compare('3.1.6', phpversion('igbinary'), '>')) {
-            $this->markTestSkipped('igbinary is not compatible with PHP 7.4.');
+            $this->markTestSkipped('igbinary needs to be v3.1.6 or higher.');
         }
 
         $this->expectException(\DomainException::class);
@@ -96,7 +96,7 @@ class DefaultMarshallerTest extends TestCase
     public function testIgbinaryUnserializeInvalid()
     {
         if (version_compare('3.1.6', phpversion('igbinary'), '>')) {
-            $this->markTestSkipped('igbinary is not compatible with PHP 7.4.');
+            $this->markTestSkipped('igbinary needs to be v3.1.6 or higher.');
         }
 
         $this->expectException(\DomainException::class);

--- a/src/Symfony/Component/Config/Exception/LoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/LoaderLoadException.php
@@ -62,12 +62,7 @@ class LoaderLoadException extends \Exception
             $message .= sprintf(' Make sure the "%s" bundle is correctly registered and loaded in the application kernel class.', $bundle);
             $message .= sprintf(' If the bundle is registered, make sure the bundle path "%s" is not empty.', $resource);
         } elseif (null !== $type) {
-            // maybe there is no loader for this specific type
-            if ('annotation' === $type) {
-                $message .= ' Make sure to use PHP 8+ or that annotations are installed and enabled.';
-            } else {
-                $message .= sprintf(' Make sure there is a loader supporting the "%s" type.', $type);
-            }
+            $message .= sprintf(' Make sure there is a loader supporting the "%s" type.', $type);
         }
 
         parent::__construct($message, $code, $previous);

--- a/src/Symfony/Component/Config/Tests/Exception/LoaderLoadExceptionTest.php
+++ b/src/Symfony/Component/Config/Tests/Exception/LoaderLoadExceptionTest.php
@@ -31,7 +31,7 @@ class LoaderLoadExceptionTest extends TestCase
     public function testMessageCannotLoadResourceWithAnnotationType()
     {
         $exception = new LoaderLoadException('resource', null, 0, null, 'annotation');
-        $this->assertEquals('Cannot load resource "resource". Make sure to use PHP 8+ or that annotations are installed and enabled.', $exception->getMessage());
+        $this->assertEquals('Cannot load resource "resource". Make sure there is a loader supporting the "annotation" type.', $exception->getMessage());
     }
 
     public function testMessageCannotImportResourceFromSource()

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -24,8 +24,7 @@ use Symfony\Component\Ldap\Exception\NotBoundException;
  */
 class Query extends AbstractQuery
 {
-    // As of PHP 7.2, we can use LDAP_CONTROL_PAGEDRESULTS instead of this
-    public const PAGINATION_OID = '1.2.840.113556.1.4.319';
+    public const PAGINATION_OID = \LDAP_CONTROL_PAGEDRESULTS;
 
     /** @var Connection */
     protected $connection;

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -149,8 +149,7 @@ class AdapterTest extends LdapTestCase
             $this->assertEquals(\count($paged_query->getResources()), 5);
 
             // This last query is to ensure that we haven't botched the state of our connection
-            // by not resetting pagination properly. extldap <= PHP 7.1 do not implement the necessary
-            // bits to work around an implementation flaw, so we simply can't guarantee this to work there.
+            // by not resetting pagination properly.
             $final_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
                 'scope' => Query::SCOPE_ONE,
             ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Targetting 6.0 because we require PHP 8 everywhere and all the modified code is theoretically unreachable (once my potential mistakes have been fixed :sweat_smile:).