### PR TITLE
[HttpKernel] fix how configuring log-level and status-code by exception works

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -46,11 +47,24 @@ class ErrorListener implements EventSubscriberInterface
     {
         $throwable = $event->getThrowable();
         $logLevel = null;
+
         foreach ($this->exceptionsMapping as $class => $config) {
             if ($throwable instanceof $class && $config['log_level']) {
                 $logLevel = $config['log_level'];
                 break;
             }
+        }
+
+        foreach ($this->exceptionsMapping as $class => $config) {
+            if (!$throwable instanceof $class || !$config['status_code']) {
+                continue;
+            }
+            if (!$throwable instanceof HttpExceptionInterface || $throwable->getStatusCode() !== $config['status_code']) {
+                $headers = $throwable instanceof HttpExceptionInterface ? $throwable->getHeaders() : [];
+                $throwable = new HttpException($config['status_code'], $throwable->getMessage(), $throwable, $headers);
+                $event->setThrowable($throwable);
+            }
+            break;
         }
 
         $e = FlattenException::createFromThrowable($throwable);
@@ -86,13 +100,6 @@ class ErrorListener implements EventSubscriberInterface
             $prev->setValue($wrapper, $throwable);
 
             throw $e;
-        }
-
-        foreach ($this->exceptionsMapping as $exception => $config) {
-            if ($throwable instanceof $exception && $config['status_code']) {
-                $response->setStatusCode($config['status_code']);
-                break;
-            }
         }
 
         $event->setResponse($response);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
@@ -231,6 +232,11 @@ class TestKernel implements HttpKernelInterface
 {
     public function handle(Request $request, $type = self::MAIN_REQUEST, $catch = true): Response
     {
+        $e = $request->attributes->get('exception');
+        if ($e instanceof HttpExceptionInterface) {
+            return new Response('foo', $e->getStatusCode(), $e->getHeaders());
+        }
+
         return new Response('foo');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44433
| License       | MIT
| Doc PR        | -

This PR replaces #44456, and essentially fixes the way configuring log-level/status-code by exception works: instead of hacking them in the listener, the original exception should be wrapped in an `HttpExceptionInterface`, so that the rest of the code can seamlessly know about the configuration.
