### PR TITLE
[HttpKernel] Set session cookie only when not empty

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -151,7 +151,8 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
             $request = $event->getRequest();
             $requestSessionCookieId = $request->cookies->get($sessionName);
 
-            if ($requestSessionCookieId && $session->isEmpty()) {
+            $isSessionEmpty = $session->isEmpty();
+            if ($requestSessionCookieId && $isSessionEmpty) {
                 $response->headers->clearCookie(
                     $sessionName,
                     $sessionCookiePath,
@@ -160,7 +161,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
                     $sessionCookieHttpOnly,
                     $sessionCookieSameSite
                 );
-            } elseif ($sessionId !== $requestSessionCookieId) {
+            } elseif ($sessionId !== $requestSessionCookieId && !$isSessionEmpty) {
                 $expire = 0;
                 $lifetime = $this->sessionOptions['cookie_lifetime'] ?? null;
                 if ($lifetime) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/issues/44616
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

A session is normally not written when empty so we need to check for empty before set the session cookie.

TODO:

 - [ ] Test