### PR TITLE
[DependencyInjection] Allow enumerated keys as result of defaultIndexMethod

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -158,6 +158,10 @@ class PriorityTaggedServiceUtil
             return $default;
         }
 
+        if (\PHP_VERSION_ID >= 80100 && $default instanceof \BackedEnum) {
+            $default = $default->value;
+        }
+
         if (\is_int($default)) {
             $default = (string) $default;
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooEnumeratedTagClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomAnyAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomAutoconfiguration;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomMethodAttribute;
@@ -621,6 +622,32 @@ class IntegrationTest extends TestCase
         self::assertSame(['foo_tag_class', 'bar_tag_class'], array_keys($factories->getValue($locator)));
         self::assertSame($container->get(BarTagClass::class), $locator->get('bar_tag_class'));
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo_tag_class'));
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testTaggedLocatorWithDefaultIndexMethodAndWithDefaultPriorityMethodConfiguredViaAttributeAndEnumeratedKeys()
+    {
+        $container = new ContainerBuilder();
+        $container->register(FooEnumeratedTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar')
+        ;
+
+        $container->register(LocatorConsumerWithDefaultIndexMethod::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        /** @var LocatorConsumerWithDefaultIndexMethod $s */
+        $s = $container->get(LocatorConsumerWithDefaultIndexMethod::class);
+
+        $locator = $s->getLocator();
+
+        self::assertSame($container->get(FooEnumeratedTagClass::class), $locator->get('bar'));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooBackedEnum.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooBackedEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+enum FooBackedEnum: string
+{
+    case BAR = 'bar';
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooEnumeratedTagClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooEnumeratedTagClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooEnumeratedTagClass
+{
+    public static function getDefaultFooName()
+    {
+        return FooBackedEnum::BAR;
+    }
+}


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #44556
| License       | MIT
| Doc PR        | 

Allows using PHP8.1 enums as a result of `getDefaultIndexMethod`, as described in #44556.  
