### PR TITLE
[FrameworkBundle] add `cache.adapter.filesystem_tag_aware` pre-configured adapter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Environment variable `SYMFONY_IDE` is read by default when `framework.ide` config is not set.
+ * Add `cache.adapter.filesystem_tag_aware` pre-configured adapter
 
 6.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -18,6 +18,7 @@ use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemTagAwareAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
@@ -105,6 +106,18 @@ return static function (ContainerConfigurator $container) {
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])
             ->tag('cache.pool', ['clearer' => 'cache.default_clearer', 'reset' => 'reset'])
             ->tag('monolog.logger', ['channel' => 'cache'])
+
+        ->set('cache.adapter.filesystem_tag_aware', FilesystemTagAwareAdapter::class)
+        ->abstract()
+        ->args([
+            '', // namespace
+            0, // default lifetime
+            sprintf('%s/pools/app', param('kernel.cache_dir')),
+            service('cache.default_marshaller')->ignoreOnInvalid(),
+        ])
+        ->call('setLogger', [service('logger')->ignoreOnInvalid()])
+        ->tag('cache.pool', ['clearer' => 'cache.default_clearer', 'reset' => 'reset'])
+        ->tag('monolog.logger', ['channel' => 'cache'])
 
         ->set('cache.adapter.psr6', ProxyAdapter::class)
             ->abstract()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo
