### PR TITLE
[Cache] Revert "feature #41989  make `LockRegistry` use semaphores when possible"

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -4,7 +4,6 @@ CHANGELOG
 5.4
 ---
 
- * Make `LockRegistry` use semaphores when possible
  * Deprecate `DoctrineProvider` and `DoctrineAdapter` because these classes have been added to the `doctrine/cache` package
  * Add `DoctrineDbalAdapter` identical to `PdoAdapter` for `Doctrine\DBAL\Connection` or DBAL URL
  * Deprecate usage of `PdoAdapter` with `Doctrine\DBAL\Connection` or DBAL URL

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\Cache\ItemInterface;
 final class LockRegistry
 {
     private static $openedFiles = [];
-    private static $lockedKeys;
+    private static $lockedFiles;
 
     /**
      * The number of items in this list controls the max number of concurrent processes.
@@ -77,25 +77,21 @@ final class LockRegistry
                 fclose($file);
             }
         }
-        self::$openedFiles = self::$lockedKeys = [];
+        self::$openedFiles = self::$lockedFiles = [];
 
         return $previousFiles;
     }
 
     public static function compute(callable $callback, ItemInterface $item, bool &$save, CacheInterface $pool, \Closure $setMetadata = null, LoggerInterface $logger = null)
     {
-        if ('\\' === \DIRECTORY_SEPARATOR && null === self::$lockedKeys) {
+        if ('\\' === \DIRECTORY_SEPARATOR && null === self::$lockedFiles) {
             // disable locking on Windows by default
-            self::$files = self::$lockedKeys = [];
+            self::$files = self::$lockedFiles = [];
         }
 
-        $key = unpack('i', md5($item->getKey(), true))[1];
+        $key = self::$files ? abs(crc32($item->getKey())) % \count(self::$files) : -1;
 
-        if (!\function_exists('sem_get')) {
-            $key = self::$files ? abs($key) % \count(self::$files) : null;
-        }
-
-        if (null === $key || (self::$lockedKeys[$key] ?? false) || !$lock = self::open($key)) {
+        if ($key < 0 || (self::$lockedFiles[$key] ?? false) || !$lock = self::open($key)) {
             return $callback($item, $save);
         }
 
@@ -103,15 +99,11 @@ final class LockRegistry
             try {
                 $locked = false;
                 // race to get the lock in non-blocking mode
-                if ($wouldBlock = \function_exists('sem_get')) {
-                    $locked = @sem_acquire($lock, true);
-                } else {
-                    $locked = flock($lock, \LOCK_EX | \LOCK_NB, $wouldBlock);
-                }
+                $locked = flock($lock, \LOCK_EX | \LOCK_NB, $wouldBlock);
 
                 if ($locked || !$wouldBlock) {
                     $logger && $logger->info(sprintf('Lock %s, now computing item "{key}"', $locked ? 'acquired' : 'not supported'), ['key' => $item->getKey()]);
-                    self::$lockedKeys[$key] = true;
+                    self::$lockedFiles[$key] = true;
 
                     $value = $callback($item, $save);
 
@@ -126,25 +118,12 @@ final class LockRegistry
 
                     return $value;
                 }
-
                 // if we failed the race, retry locking in blocking mode to wait for the winner
                 $logger && $logger->info('Item "{key}" is locked, waiting for it to be released', ['key' => $item->getKey()]);
-
-                if (\function_exists('sem_get')) {
-                    $lock = sem_get($key);
-                    @sem_acquire($lock);
-                } else {
-                    flock($lock, \LOCK_SH);
-                }
+                flock($lock, \LOCK_SH);
             } finally {
-                if ($locked) {
-                    if (\function_exists('sem_get')) {
-                        sem_remove($lock);
-                    } else {
-                        flock($lock, \LOCK_UN);
-                    }
-                }
-                unset(self::$lockedKeys[$key]);
+                flock($lock, \LOCK_UN);
+                unset(self::$lockedFiles[$key]);
             }
             static $signalingException, $signalingCallback;
             $signalingException = $signalingException ?? unserialize("O:9:\"Exception\":1:{s:16:\"\0Exception\0trace\";a:0:{}}");
@@ -169,10 +148,6 @@ final class LockRegistry
 
     private static function open(int $key)
     {
-        if (\function_exists('sem_get')) {
-            return sem_get($key);
-        }
-
         if (null !== $h = self::$openedFiles[$key] ?? null) {
             return $h;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44536
| License       | MIT
| Doc PR        | -

This reverts commit 479919d4d5cbc17710d16a04ff9728d1519afb8e, reversing
changes made to 356c9533cc520b5aab5d92d0b06a408beb22a157.

I'd like to revert this PR because using semaphores is creating problems that don't have any easy solution.