### PR TITLE
[Cache] disable lock on CLI

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -14,12 +14,10 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
-use Symfony\Component\Cache\LockRegistry;
 use Symfony\Component\Cache\Tests\Fixtures\PrunableAdapter;
 
 /**
@@ -196,24 +194,6 @@ class TagAwareAdapterTest extends AdapterTestCase
 
         $item = $anotherPool->getItem($itemKey);
         $this->assertFalse($item->isHit());
-    }
-
-    public function testLog()
-    {
-        $lockFiles = LockRegistry::setFiles([__FILE__]);
-
-        $logger = $this->createMock(LoggerInterface::class);
-        $logger
-            ->expects($this->atLeastOnce())
-            ->method($this->anything());
-
-        $cache = new TagAwareAdapter(new ArrayAdapter());
-        $cache->setLogger($logger);
-
-        // Computing will produce at least one log
-        $cache->get('foo', static function (): string { return 'ccc'; });
-
-        LockRegistry::setFiles($lockFiles);
     }
 
     /**

--- a/src/Symfony/Component/Cache/Traits/ContractsTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ContractsTrait.php
@@ -31,7 +31,7 @@ trait ContractsTrait
         doGet as private contractsGet;
     }
 
-    private $callbackWrapper = [LockRegistry::class, 'compute'];
+    private $callbackWrapper;
     private $computing = [];
 
     /**
@@ -41,8 +41,16 @@ trait ContractsTrait
      */
     public function setCallbackWrapper(?callable $callbackWrapper): callable
     {
+        if (!isset($this->callbackWrapper)) {
+            $this->callbackWrapper = \Closure::fromCallable([LockRegistry::class, 'compute']);
+
+            if (\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
+                $this->setCallbackWrapper(null);
+            }
+        }
+
         $previousWrapper = $this->callbackWrapper;
-        $this->callbackWrapper = $callbackWrapper ?? function (callable $callback, ItemInterface $item, bool &$save, CacheInterface $pool, \Closure $setMetadata, ?LoggerInterface $logger) {
+        $this->callbackWrapper = $callbackWrapper ?? static function (callable $callback, ItemInterface $item, bool &$save, CacheInterface $pool, \Closure $setMetadata, ?LoggerInterface $logger) {
             return $callback($item, $save);
         };
 
@@ -81,6 +89,10 @@ trait ContractsTrait
 
             $this->computing[$key] = $key;
             $startTime = microtime(true);
+
+            if (!isset($this->callbackWrapper)) {
+                $this->setCallbackWrapper($this->setCallbackWrapper(null));
+            }
 
             try {
                 $value = ($this->callbackWrapper)($callback, $item, $save, $pool, function (CacheItem $item) use ($setMetadata, $startTime, &$metadata) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | 
| Tickets       | Fix #41130
| License       | MIT
| Doc PR        | -

I thought using semaphores would fix the linked issue but I'm proposing to revert them in #44667

Instead, I think we should disable the lock on CLI processes.

The purpose of having locks enabled by default is to prevent cache stamped at deploy time. Disabling the lock on CLI still provides this protection on eg FPM.

For ppl that really want a lock between eg crons and FPM, the lock component should be used instead.