### PR TITLE
[SecurityBundle] Allow to specify a RequestMatcher directly in an ACL definition

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+6.1
+---
+* The `security.access_control` now accepts a `RequestMatcherInterface` under the `request_matcher` option as scope configuration
+
 6.0
 ---
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -134,6 +134,7 @@ class MainConfiguration implements ConfigurationInterface
                         ->fixXmlConfig('ip')
                         ->fixXmlConfig('method')
                         ->children()
+                            ->scalarNode('request_matcher')->defaultNull()->end()
                             ->scalarNode('requires_channel')->defaultNull()->end()
                             ->scalarNode('path')
                                 ->defaultNull()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -195,14 +195,24 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
     private function createAuthorization(array $config, ContainerBuilder $container)
     {
         foreach ($config['access_control'] as $access) {
-            $matcher = $this->createRequestMatcher(
-                $container,
-                $access['path'],
-                $access['host'],
-                $access['port'],
-                $access['methods'],
-                $access['ips']
-            );
+            if (isset($access['request_matcher'])) {
+                if (
+                    isset($access['path']) || isset($access['host']) || isset($access['port'])
+                    || [] !== $access['ips'] || [] !== $access['methods']
+                ) {
+                    throw new InvalidConfigurationException('The "request_matcher" option should not be specified alongside other options. Consider integrating your constraints inside your RequestMatcher directly.');
+                }
+                $matcher = new Reference($access['request_matcher']);
+            } else {
+                $matcher = $this->createRequestMatcher(
+                    $container,
+                    $access['path'],
+                    $access['host'],
+                    $access['port'],
+                    $access['methods'],
+                    $access['ips']
+                );
+            }
 
             $attributes = $access['roles'];
             if ($access['allow_if']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/44103
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16296

This PR allows users to directly specify a service reference in the definition of an access control rule. The given service MUST implement the `RequestMatcherInterface`.

The goal is to be able to pass custom request matchers, with more complex rules than the standard path, host, ips, ... options to have the same flexibility as the user has in defining his/her firewalls.
