### PR TITLE
[HttpClient] Fix tracing requests made after calling withOptions()

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
@@ -218,4 +218,18 @@ class TraceableHttpClientTest extends TestCase
         $this->assertCount(1, $events['GET http://localhost:8057']->getPeriods());
         $this->assertGreaterThan(0.0, $events['GET http://localhost:8057']->getDuration());
     }
+
+    public function testWithOptions()
+    {
+        $sut = new TraceableHttpClient(new NativeHttpClient());
+
+        $sut2 = $sut->withOptions(['base_uri' => 'http://localhost:8057']);
+
+        $response = $sut2->request('GET', '/');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('http://localhost:8057/', $response->getInfo('url'));
+
+        $this->assertCount(1, $sut->getTracedRequests());
+    }
 }

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -27,13 +27,14 @@ use Symfony\Contracts\Service\ResetInterface;
 final class TraceableHttpClient implements HttpClientInterface, ResetInterface, LoggerAwareInterface
 {
     private $client;
-    private $tracedRequests = [];
     private $stopwatch;
+    private $tracedRequests;
 
     public function __construct(HttpClientInterface $client, Stopwatch $stopwatch = null)
     {
         $this->client = $client;
         $this->stopwatch = $stopwatch;
+        $this->tracedRequests = new \ArrayObject();
     }
 
     /**
@@ -84,7 +85,7 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
 
     public function getTracedRequests(): array
     {
-        return $this->tracedRequests;
+        return $this->tracedRequests->getArrayCopy();
     }
 
     public function reset()
@@ -93,7 +94,7 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
             $this->client->reset();
         }
 
-        $this->tracedRequests = [];
+        $this->tracedRequests->exchangeArray([]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44312
| License       | MIT
| Doc PR        | -