### PR TITLE
[Translation] Translatable parameters

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Parameters implementing `TranslatableInterface` are processed
+
 5.4
 ---
 

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Translation\Exception\NotFoundResourceException;
 use Symfony\Component\Translation\Exception\RuntimeException;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Component\Translation\Translator;
 
 class TranslatorTest extends TestCase
@@ -467,11 +468,14 @@ class TranslatorTest extends TestCase
         ];
     }
 
-    public function getTransTests()
+    public function getTransTests(): iterable
     {
+        $param = new TranslatableMessage('Symfony is %what%!', ['%what%' => 'awesome'], '');
+
         return [
             ['Symfony est super !', 'Symfony is great!', 'Symfony est super !', [], 'fr', ''],
             ['Symfony est awesome !', 'Symfony is %what%!', 'Symfony est %what% !', ['%what%' => 'awesome'], 'fr', ''],
+            ['Symfony est Symfony est awesome ! !', 'Symfony is %what%!', 'Symfony est %what% !', ['%what%' => $param], 'fr', ''],
             ['Symfony est super !', new StringClass('Symfony is great!'), 'Symfony est super !', [], 'fr', ''],
             ['', null, '', [], 'fr', ''],
         ];

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -22,6 +22,7 @@ use Symfony\Component\Translation\Formatter\MessageFormatter;
 use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
+use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 // Help opcache.preload discover always-needed symbols
@@ -193,6 +194,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
                 break;
             }
         }
+
+        $parameters = array_map(function ($parameter) use ($locale) {
+            return $parameter instanceof TranslatableInterface ? $parameter->trans($this, $locale) : $parameter;
+        }, $parameters);
 
         $len = \strlen(MessageCatalogue::INTL_DOMAIN_SUFFIX);
         if ($this->hasIntlFormatter


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TBD

✅  The TwigExtension now supports messages implementing `TranslatableInterface` (https://symfony.com/blog/new-in-symfony-5-2-translatable-objects).
✅ Thanks to #41858, `TranslatableMessage` now supports recursive `TranslatableInterface` as params.

❌ But using `TranslatableInterface` as params with regular messages is not supported yet.

💡 This PR addresses this issue and makes it possible to create dedicated `TranslatableInterface` implementations like the one from https://github.com/symfony/symfony/pull/41136

_Note: I would like also to add `TranslatableInterface` to the `trans(?string $id)` signature method like with the one from the [TwigExtension](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php#L111) but I don't know how to do it without breaking BC. Any advice is welcome!_