### PR TITLE
[FrameworkBundle] alias `cache.app.taggable` to `cache.app` if using `cache.adapter.redis_tag_aware`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Environment variable `SYMFONY_IDE` is read by default when `framework.ide` config is not set.
+ * When `cache.app` is `cache.adapter.redis_tag_aware`, set `cache.app.taggable` as an alias.
 
 6.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2103,6 +2103,15 @@ class FrameworkExtension extends Extension
                 'tags' => false,
             ];
         }
+
+        if ('cache.adapter.redis_tag_aware' === $config['app']) {
+            $container->setAlias('cache.app.taggable', 'cache.app');
+        } else {
+            $container->register('cache.app.taggable', TagAwareAdapter::class)
+                ->addArgument(new Reference('cache.app'))
+            ;
+        }
+
         foreach ($config['pools'] as $name => $pool) {
             $pool['adapters'] = $pool['adapters'] ?: ['cache.app'];
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -23,7 +23,6 @@ use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
-use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
 use Symfony\Component\Cache\Messenger\EarlyExpirationHandler;
 use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
@@ -36,9 +35,6 @@ return static function (ContainerConfigurator $container) {
             ->parent('cache.adapter.filesystem')
             ->public()
             ->tag('cache.pool', ['clearer' => 'cache.app_clearer'])
-
-        ->set('cache.app.taggable', TagAwareAdapter::class)
-            ->args([service('cache.app')])
 
         ->set('cache.system')
             ->parent('cache.adapter.system')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

When using `cache.adapter.redis_tag_aware` for your `cache.app`, `cache.app.taggable` is unnecessarily decorated.
