### PR TITLE
[FrameworkBundle] alias `cache.app.taggable` to `cache.app` if using `cache.adapter.redis_tag_aware`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2153,7 +2153,9 @@ class FrameworkExtension extends Extension
                 $pool['reset'] = 'reset';
             }
 
-            if ($isRedisTagAware) {
+            if ($isRedisTagAware && 'cache.app' === $name) {
+                $container->setAlias('cache.app.taggable', $name);
+            } elseif ($isRedisTagAware) {
                 $tagAwareId = $name;
                 $container->setAlias('.'.$name.'.inner', $name);
             } elseif ($pool['tags']) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware.php
@@ -1,0 +1,7 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'cache' => [
+        'app' => 'cache.adapter.redis_tag_aware',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware_pool.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_app_redis_tag_aware_pool.php
@@ -1,0 +1,15 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'cache' => [
+        'app' => 'cache.redis_tag_aware.bar',
+        'pools' => [
+            'cache.redis_tag_aware.foo' => [
+                'adapter' => 'cache.adapter.redis_tag_aware',
+            ],
+            'cache.redis_tag_aware.bar' => [
+                'adapter' => 'cache.redis_tag_aware.foo',
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:cache>
+            <framework:app>cache.adapter.redis_tag_aware</framework:app>
+        </framework:cache>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware_pool.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_app_redis_tag_aware_pool.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:cache>
+            <framework:app>cache.redis_tag_aware.bar</framework:app>
+            <framework:pool name="cache.redis_tag_aware.foo" adapter="cache.adapter.redis_tag_aware" />
+            <framework:pool name="cache.redis_tag_aware.bar" adapter="cache.redis_tag_aware.foo" />
+        </framework:cache>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware.yml
@@ -1,0 +1,3 @@
+framework:
+    cache:
+        app: cache.adapter.redis_tag_aware

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware_pool.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_app_redis_tag_aware_pool.yml
@@ -1,0 +1,8 @@
+framework:
+    cache:
+        app: cache.redis_tag_aware.bar
+        pools:
+            cache.redis_tag_aware.foo:
+                adapter: cache.adapter.redis_tag_aware
+            cache.redis_tag_aware.bar:
+                adapter: cache.redis_tag_aware.foo

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1587,6 +1587,32 @@ abstract class FrameworkExtensionTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider testAppRedisTagAwareConfigProvider
+     */
+    public function testAppRedisTagAwareAdapter()
+    {
+        $container = $this->createContainerFromFile('cache_app_redis_tag_aware');
+
+        foreach ([TagAwareCacheInterface::class, CacheInterface::class, CacheItemPoolInterface::class] as $alias) {
+            $def = $container->findDefinition($alias);
+
+            while ($def instanceof ChildDefinition) {
+                $def = $container->getDefinition($def->getParent());
+            }
+
+            $this->assertSame(RedisTagAwareAdapter::class, $def->getClass());
+        }
+    }
+
+    public function testAppRedisTagAwareConfigProvider(): array
+    {
+        return [
+            ['cache_app_redis_tag_aware'],
+            ['cache_app_redis_tag_aware_pool'],
+        ];
+    }
+
     public function testRemovesResourceCheckerConfigCacheFactoryArgumentOnlyIfNoDebug()
     {
         $container = $this->createContainer(['kernel.debug' => true]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

When using `cache.adapter.redis_tag_aware` for your `cache.app`, `cache.app.taggable` is unnecessarily decorated with `TagAwareAdapter`. This sets `cache.app.taggable` as an alias to `cache.app` in this case.

Alternative to #44673.