### PR TITLE
[Validator] Add Some and None collection constraints

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate constraint `ExpressionLanguageSyntax`, use `ExpressionSyntax` instead
  * Add method `__toString()` to `ConstraintViolationInterface` & `ConstraintViolationListInterface`
  * Allow creating constraints with required arguments
+ * Add `Some` and `None` collection constraints
 
 6.0
 ---

--- a/src/Symfony/Component/Validator/Constraints/None.php
+++ b/src/Symfony/Component/Validator/Constraints/None.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class None extends Composite
+{
+    public array $constraints = [];
+    public string $message = 'None of values should satisfy one of the following constraints:';
+    public bool $includeInternalMessages = true;
+
+    public function __construct(mixed $constraints = null, array $groups = null, mixed $payload = null, string $message = null, bool $includeInternalMessages = null)
+    {
+        parent::__construct($constraints ?? [], $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+        $this->includeInternalMessages = $includeInternalMessages ?? $this->includeInternalMessages;
+    }
+
+    public function getDefaultOption(): ?string
+    {
+        return 'constraints';
+    }
+
+    public function getRequiredOptions(): array
+    {
+        return ['constraints'];
+    }
+
+    protected function getCompositeOption(): string
+    {
+        return 'constraints';
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/NoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NoneValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+class NoneValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(mixed $value, Constraint $constraint)
+    {
+        if (!$constraint instanceof None) {
+            throw new UnexpectedTypeException($constraint, None::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!is_iterable($value)) {
+            throw new UnexpectedValueException($value, 'iterable');
+        }
+
+        $this->context
+            ->getValidator()
+            ->inContext($this->context)
+            ->validate($value, new Some([
+                'constraints' => $constraint->constraints,
+                'exactly' => 0,
+                'exactMessage' => $constraint->message,
+                'includeInternalMessages' => $constraint->includeInternalMessages,
+            ]), $this->context->getGroup());
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/Some.php
+++ b/src/Symfony/Component/Validator/Constraints/Some.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Some extends Composite
+{
+    public const SOME_TOO_FEW_ERROR = 'a7ea059b-f8e6-4e85-a48a-bc5eddc0103b';
+    public const SOME_TOO_MANY_ERROR = '63d385ab-9101-4195-bc32-7283e13a5283';
+    public const SOME_EXACTLY_ERROR = '6466f661-8b8e-495d-ac96-408aa2e7ee33';
+
+    protected static $errorNames = [
+        self::SOME_TOO_FEW_ERROR => 'SOME_TOO_FEW_ERROR',
+        self::SOME_TOO_MANY_ERROR => 'SOME_TOO_MANY_ERROR',
+        self::SOME_EXACTLY_ERROR => 'SOME_EXACTLY_ERROR',
+    ];
+
+    public array $constraints = [];
+    public int $min = 1;
+    public ?int $max = null;
+    public string $minMessage = 'At least {{ limit }} value should satisfy one of the following constraints:|At least {{ limit }} values should satisfy one of the following constraints:';
+    public string $maxMessage = 'At most {{ limit }} value should satisfy one of the following constraints:|At most {{ limit }} values should satisfy one of the following constraints:';
+    public string $exactMessage = 'Exactly {{ limit }} value should satisfy one of the following constraints:|Exactly {{ limit }} values should satisfy one of the following constraints:';
+    public bool $includeInternalMessages = true;
+
+    public function __construct(array $options = null, mixed $constraints = null, int $exactly = null, int $min = null, int $max = null, array $groups = null, mixed $payload = null, string $minMessage = null, string $maxMessage = null, string $exactMessage = null, bool $includeInternalMessages = null)
+    {
+        $exactly ??= $options['exactly'] ?? null;
+
+        if (null !== $exactly && null === $min && null === $max) {
+            $min = $max = $exactly;
+        }
+
+        if (\is_array($constraints)) {
+            $options['constraints'] = $constraints;
+        }
+
+        unset($options['exactly']);
+
+        parent::__construct($options, $groups, $payload);
+
+        $this->min = $min ?? $this->min;
+        $this->max = $max ?? $this->max;
+        $this->minMessage = $minMessage ?? $this->minMessage;
+        $this->maxMessage = $maxMessage ?? $this->maxMessage;
+        $this->exactMessage = $exactMessage ?? $this->exactMessage;
+        $this->includeInternalMessages = $includeInternalMessages ?? $this->includeInternalMessages;
+
+        if ($this->min < 0) {
+            throw new ConstraintDefinitionException('The "min" option must be greater than 0.');
+        }
+    }
+
+    public function getDefaultOption(): ?string
+    {
+        return 'constraints';
+    }
+
+    public function getRequiredOptions(): array
+    {
+        return ['constraints'];
+    }
+
+    protected function getCompositeOption(): string
+    {
+        return 'constraints';
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/SomeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/SomeValidator.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+class SomeValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(mixed $value, Constraint $constraint)
+    {
+        if (!$constraint instanceof Some) {
+            throw new UnexpectedTypeException($constraint, Some::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!is_iterable($value)) {
+            throw new UnexpectedValueException($value, 'iterable');
+        }
+
+        $validator = $this->context->getValidator();
+        $atLeastOneOf = new AtLeastOneOf([
+            'constraints' => $constraint->constraints,
+            'message' => '',
+            'includeInternalMessages' => $constraint->includeInternalMessages,
+        ]);
+        $validValues = 0;
+        $violationMessages = [];
+
+        foreach ($value as $element) {
+            $executionContext = clone $this->context;
+            $executionContext->setNode($element, $this->context->getObject(), $this->context->getMetadata(), $this->context->getPropertyPath());
+            $violations = $validator->inContext($executionContext)->validate($element, $atLeastOneOf, $this->context->getGroup())->getViolations();
+
+            if (0 === \count($violations)) {
+                ++$validValues;
+            } elseif (0 === \count($violationMessages)) {
+                foreach ($violations as $violation) {
+                    $violationMessages[] = $violation->getMessage();
+                }
+            }
+        }
+
+        if ($constraint->min === $constraint->max && $validValues !== $constraint->min) {
+            $this->context->buildViolation($this->buildMessage($constraint->exactMessage, $violationMessages))
+                ->setParameter('{{ count }}', $this->formatValue($validValues))
+                ->setParameter('{{ limit }}', $this->formatValue($constraint->min))
+                ->setPlural($constraint->min)
+                ->setInvalidValue($value)
+                ->setCode(Some::SOME_EXACTLY_ERROR)
+                ->addViolation();
+        } elseif (null !== $constraint->max && $validValues > $constraint->max) {
+            $this->context->buildViolation($this->buildMessage($constraint->maxMessage, $violationMessages))
+                ->setParameter('{{ count }}', $this->formatValue($validValues))
+                ->setParameter('{{ limit }}', $this->formatValue($constraint->max))
+                ->setPlural($constraint->max)
+                ->setInvalidValue($value)
+                ->setCode(Some::SOME_TOO_MANY_ERROR)
+                ->addViolation();
+        } elseif ($validValues < $constraint->min) {
+            $this->context->buildViolation($this->buildMessage($constraint->minMessage, $violationMessages))
+                ->setParameter('{{ count }}', $this->formatValue($validValues))
+                ->setParameter('{{ limit }}', $this->formatValue($constraint->min))
+                ->setPlural($constraint->min)
+                ->setInvalidValue($value)
+                ->setCode(Some::SOME_TOO_FEW_ERROR)
+                ->addViolation();
+        }
+    }
+
+    private function buildMessage(string $message, array $violationMessages): string
+    {
+        if (!str_contains($message, '|')) {
+            return implode('', [$message, ...$violationMessages]);
+        }
+
+        $messageParts = explode('|', $message);
+        $messageParts = array_map(static fn (string $part) => implode('', [$part, ...$violationMessages]), $messageParts);
+
+        return implode('|', $messageParts);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NoneTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NoneTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\None;
+use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+class NoneTest extends TestCase
+{
+    public function testRejectNonConstraints()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+
+        new None(['foo']);
+    }
+
+    public function testRejectValidConstraint()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+
+        new None([new Valid()]);
+    }
+
+    public function testCustomMessage()
+    {
+        $constraint = new None(['constraints' => [], 'message' => 'No values should:']);
+
+        self::assertSame('No values should:', $constraint->message);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NoneValidatorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\EqualTo;
+use Symfony\Component\Validator\Constraints\IsFalse;
+use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\None;
+use Symfony\Component\Validator\Constraints\NoneValidator;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+class NoneValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): NoneValidator
+    {
+        return new NoneValidator();
+    }
+
+    /**
+     * @dataProvider getValidValueCases
+     */
+    public function testValidValue($value, $constraints)
+    {
+        $this->assertCount(0, Validation::createValidator()->validate($value, new None(['constraints' => $constraints])));
+    }
+
+    /**
+     * @dataProvider getInvalidValueCases
+     */
+    public function testInvalidValue($value, $constraints)
+    {
+        $this->assertCount(1, Validation::createValidator()->validate($value, new None(['constraints' => $constraints])));
+    }
+
+    public function testGroupsArePropagatedToNestedConstraints()
+    {
+        $validator = Validation::createValidator();
+
+        $violations = $validator->validate(['d'], new None([
+            'constraints' => [
+                new EqualTo([
+                    'groups' => 'non_default_group',
+                    'value' => 'd',
+                ]),
+            ],
+            'groups' => 'non_default_group',
+        ]), 'non_default_group');
+
+        $this->assertCount(1, $violations);
+    }
+
+    public function getValidValueCases(): iterable
+    {
+        yield [
+            [null, null, null],
+            [new NotNull()],
+        ];
+
+        yield [
+            [false, true, false],
+            [new Type('string')],
+        ];
+
+        yield [
+            [false, false, false],
+            [new IsTrue()],
+        ];
+
+        yield [
+            [true, true, true],
+            [new IsFalse()],
+        ];
+
+        yield [
+            ['', 'test', 'Symfony'],
+            [
+                new Length(['min' => 10]),
+                new EqualTo(['value' => 'symfony']),
+            ],
+        ];
+
+        yield [
+            [1, 5, 19],
+            [new EqualTo(20)],
+        ];
+
+        yield [
+            ['a', 'b', 'c'],
+            [new Regex('/B/')],
+        ];
+    }
+
+    public function getInvalidValueCases(): iterable
+    {
+        yield [
+            [null, true, null],
+            [new NotNull()],
+        ];
+
+        yield [
+            [false, true, false],
+            [new IsTrue()],
+        ];
+
+        yield [
+            [true, false, true],
+            [new IsFalse()],
+        ];
+
+        yield [
+            ['', 'test', 'Symfony'],
+            [
+                new Length(['min' => 10]),
+                new EqualTo(['value' => 'Symfony']),
+            ],
+        ];
+
+        yield [
+            ['a', 'B', 'c'],
+            [new Regex('/B/')],
+        ];
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/SomeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/SomeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Some;
+use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+class SomeTest extends TestCase
+{
+    public function testRejectNonConstraints()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+
+        new Some(['foo']);
+    }
+
+    public function testRejectValidConstraint()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+
+        new Some([new Valid()]);
+    }
+
+    public function testThrowsWithMinLessThanZero()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The "min" option must be greater than 0.');
+
+        new Some(['min' => -1, 'constraints' => []]);
+    }
+
+    public function testCustomMinMessage()
+    {
+        $constraint = new Some(['constraints' => [], 'minMessage' => 'One value should:']);
+
+        self::assertSame('One value should:', $constraint->minMessage);
+    }
+
+    public function testCustomMaxMessage()
+    {
+        $constraint = new Some(['constraints' => [], 'maxMessage' => 'Two values should:']);
+
+        self::assertSame('Two values should:', $constraint->maxMessage);
+    }
+
+    public function testCustomExactlyMessage()
+    {
+        $constraint = new Some(['constraints' => [], 'exactMessage' => 'Exactly 3 values should:']);
+
+        self::assertSame('Exactly 3 values should:', $constraint->exactMessage);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/SomeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/SomeValidatorTest.php
@@ -1,0 +1,310 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\EqualTo;
+use Symfony\Component\Validator\Constraints\IsFalse;
+use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Some;
+use Symfony\Component\Validator\Constraints\SomeValidator;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+class SomeValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): SomeValidator
+    {
+        return new SomeValidator();
+    }
+
+    /**
+     * @dataProvider getValidValueCases
+     */
+    public function testValidValue($value, $constraints)
+    {
+        $this->assertCount(0, Validation::createValidator()->validate($value, new Some(['constraints' => $constraints])));
+    }
+
+    /**
+     * @dataProvider getInvalidValueCases
+     */
+    public function testInvalidValue($value, $constraints)
+    {
+        $this->assertCount(1, Validation::createValidator()->validate($value, new Some(['constraints' => $constraints])));
+    }
+
+    /**
+     * @dataProvider getInvalidValueExactLimitCases
+     */
+    public function testExactLimit(int $exactly, int $expectedCount, array $value, array $constraints, string $expectedMessage)
+    {
+        $violations = Validation::createValidator()->validate($value, new Some(['exactly' => $exactly, 'constraints' => $constraints, 'includeInternalMessages' => false]));
+
+        $this->assertCount(1, $violations);
+
+        $this->assertSame($value, $violations[0]->getInvalidValue());
+        $this->assertSame($expectedMessage, $violations[0]->getMessage());
+        $this->assertSame('6466f661-8b8e-495d-ac96-408aa2e7ee33', $violations[0]->getCode());
+        $this->assertSame(['{{ count }}' => "$expectedCount", '{{ limit }}' => "$exactly"], $violations[0]->getParameters());
+        $this->assertInstanceOf(Some::class, $violations[0]->getConstraint());
+        $this->assertSame($exactly, $violations[0]->getConstraint()->min);
+        $this->assertSame($exactly, $violations[0]->getConstraint()->max);
+    }
+
+    /**
+     * @dataProvider provideMinLimitCases
+     */
+    public function testMinLimit(int $min, int $expectedCount, array $value, array $constraints, string $expectedMessage)
+    {
+        $violations = Validation::createValidator()->validate($value, new Some(['min' => $min, 'constraints' => $constraints, 'includeInternalMessages' => false]));
+
+        $this->assertCount(1, $violations);
+
+        $this->assertSame($value, $violations[0]->getInvalidValue());
+        $this->assertSame($expectedMessage, $violations[0]->getMessage());
+        $this->assertSame('a7ea059b-f8e6-4e85-a48a-bc5eddc0103b', $violations[0]->getCode());
+        $this->assertSame(['{{ count }}' => "$expectedCount", '{{ limit }}' => "$min"], $violations[0]->getParameters());
+        $this->assertInstanceOf(Some::class, $violations[0]->getConstraint());
+        $this->assertSame($min, $violations[0]->getConstraint()->min);
+        $this->assertNull($violations[0]->getConstraint()->max);
+    }
+
+    /**
+     * @dataProvider provideMaxLimitCases
+     */
+    public function testMaxLimit(int $max, int $expectedCount, array $value, array $constraints, string $expectedMessage)
+    {
+        $violations = Validation::createValidator()->validate($value, new Some(['max' => $max, 'constraints' => $constraints, 'includeInternalMessages' => false]));
+
+        $this->assertCount(1, $violations);
+
+        $this->assertSame($value, $violations[0]->getInvalidValue());
+        $this->assertSame($expectedMessage, $violations[0]->getMessage());
+        $this->assertSame('63d385ab-9101-4195-bc32-7283e13a5283', $violations[0]->getCode());
+        $this->assertSame(['{{ count }}' => "$expectedCount", '{{ limit }}' => "$max"], $violations[0]->getParameters());
+        $this->assertInstanceOf(Some::class, $violations[0]->getConstraint());
+        $this->assertSame($max, $violations[0]->getConstraint()->max);
+        $this->assertSame(1, $violations[0]->getConstraint()->min);
+    }
+
+    public function testWithIncludedInternalMessages()
+    {
+        $violations = Validation::createValidator()->validate([true, 1, false], new Some([
+            'constraints' => [
+                new Type('string'),
+                new Length(['min' => 10]),
+            ],
+        ]));
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('At least 1 value should satisfy one of the following constraints: [1] This value should be of type string. [2] This value is too short. It should have 10 characters or more.', $violations[0]->getMessage());
+        $this->assertSame('At least {{ limit }} value should satisfy one of the following constraints: [1] This value should be of type string. [2] This value is too short. It should have 10 characters or more.|At least {{ limit }} values should satisfy one of the following constraints: [1] This value should be of type string. [2] This value is too short. It should have 10 characters or more.', $violations[0]->getMessageTemplate());
+    }
+
+    public function testGroupsArePropagatedToNestedConstraints()
+    {
+        $validator = Validation::createValidator();
+
+        $violations = $validator->validate(['a'], new Some([
+            'constraints' => [
+                new EqualTo([
+                    'groups' => 'non_default_group',
+                    'value' => 'd',
+                ]),
+            ],
+            'groups' => 'non_default_group',
+        ]), 'non_default_group');
+
+        $this->assertCount(1, $violations);
+    }
+
+    public function getValidValueCases(): iterable
+    {
+        yield [
+            [null, true, null],
+            [new NotNull()],
+        ];
+
+        yield [
+            [null, 'null', null],
+            [new Type('string')],
+        ];
+
+        yield [
+            [false, true, false],
+            [new IsTrue()],
+        ];
+
+        yield [
+            [true, false, true],
+            [new IsFalse()],
+        ];
+
+        yield [
+            ['', 'test', 'symfony', null],
+            [
+                new Length(['min' => 10]),
+                new EqualTo(['value' => 'symfony']),
+            ],
+        ];
+
+        yield [
+            [1, 5, 20],
+            [new EqualTo(20)],
+        ];
+
+        yield [
+            ['a', 'B', 'c'],
+            [new Regex('/B/')],
+        ];
+    }
+
+    public function getInvalidValueCases(): iterable
+    {
+        yield [
+            [null, null, null],
+            [new NotNull()],
+        ];
+
+        yield [
+            [false, false, false],
+            [new IsTrue()],
+        ];
+
+        yield [
+            [true, true, true],
+            [new IsFalse()],
+        ];
+
+        yield [
+            ['', 'test', 'symfony'],
+            [
+                new Length(['min' => 10]),
+                new EqualTo(['value' => 'Symfony']),
+            ],
+        ];
+
+        yield [
+            ['a', 'b', 'c'],
+            [new Regex('/B/')],
+        ];
+    }
+
+    public function getInvalidValueExactLimitCases(): iterable
+    {
+        // too low
+        yield [
+            1, 0,
+            ['a', 'b', 'c'],
+            [new EqualTo('d')],
+            'Exactly 1 value should satisfy one of the following constraints:',
+        ];
+
+        yield [
+            2, 1,
+            ['a', 'b', 'c', 'd'],
+            [new EqualTo('d')],
+            'Exactly 2 values should satisfy one of the following constraints:',
+        ];
+
+        yield [
+            3, 2,
+            ['a', 'b', 'c', 'd', 'd'],
+            [new EqualTo('d')],
+            'Exactly 3 values should satisfy one of the following constraints:',
+        ];
+
+        // too many
+        yield [
+            0, 1,
+            ['a', 'b', 'c', 'd'],
+            [new EqualTo('d')],
+            'Exactly 0 values should satisfy one of the following constraints:',
+        ];
+
+        yield [
+            1, 2,
+            ['a', 'b', 'c', 'd', 'd'],
+            [new EqualTo('d')],
+            'Exactly 1 value should satisfy one of the following constraints:',
+        ];
+
+        yield [
+            2, 3,
+            ['a', 'b', 'c', 'd', 'd', 'd'],
+            [new EqualTo('d')],
+            'Exactly 2 values should satisfy one of the following constraints:',
+        ];
+
+        yield [
+            3, 4,
+            ['a', 'b', 'c', 'd', 'd', 'd', 'd'],
+            [new EqualTo('d')],
+            'Exactly 3 values should satisfy one of the following constraints:',
+        ];
+    }
+
+    public function provideMinLimitCases(): iterable
+    {
+        yield [
+            1, 0,
+            ['a', 'b', 'c'],
+            [new EqualTo('d')],
+            'At least 1 value should satisfy one of the following constraints:',
+        ];
+
+        yield [
+            2, 1,
+            ['a', 'b', 'c', 'd'],
+            [new EqualTo('d')],
+            'At least 2 values should satisfy one of the following constraints:',
+        ];
+
+        yield [
+            3, 2,
+            ['a', 'b', 'c', 'd', 'd'],
+            [new EqualTo('d')],
+            'At least 3 values should satisfy one of the following constraints:',
+        ];
+    }
+
+    public function provideMaxLimitCases(): iterable
+    {
+        yield [
+            2, 3,
+            ['a', 'b', 'c', 'd', 'd', 'd'],
+            [new EqualTo('d')],
+            'At most 2 values should satisfy one of the following constraints:',
+        ];
+
+        yield [
+            3, 4,
+            ['a', 'b', 'c', 'd', 'd', 'd', 'd'],
+            [new EqualTo('d')],
+            'At most 3 values should satisfy one of the following constraints:',
+        ];
+
+        yield [
+            4, 5,
+            ['a', 'b', 'c', 'd', 'd', 'd', 'd', 'd'],
+            [new EqualTo('d')],
+            'At most 4 values should satisfy one of the following constraints:',
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #9888
| License       | MIT
| Doc PR        | -

This adds Some and None collection constraints which are built on top of `AtLeastOneOf` constraint which validates that value must at least satisfy one constraint, so we will now be able to validate that the required numbers of elements should match the provided constraints:

`Some(min=1, constraints: [..])` <- at least 1 value should be satified (default)
`Some(min=2, constraints: [..])` <- at least 2 values should be satisfied
`Some(max=2, constraints: [..])` <- at most 2 values should be satisfied
`Some(exactly=3, constraints: [..])` <- exactly 3 values should be satisfied
`None(constraints: [])` <- alias of `Some(min=0)`
