### PR TITLE
[Cache][FrameworkBundle] add `cache:pool:invalidate-tags` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Environment variable `SYMFONY_IDE` is read by default when `framework.ide` config is not set.
  * Load PHP configuration files by default in the `MicroKernelTrait`
+ * Add `cache:pool:invalidate-tags` command
 
 6.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolInvalidateTagsCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolInvalidateTagsCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsCommand(name: 'cache:pool:invalidate-tags', description: 'Invalidate cache tags for all or a specific pool')]
+final class CachePoolInvalidateTagsCommand extends Command
+{
+    private ServiceProviderInterface $pools;
+    private array $poolNames;
+
+    public function __construct(ServiceProviderInterface $pools)
+    {
+        parent::__construct();
+
+        $this->pools = $pools;
+        $this->poolNames = array_keys($pools->getProvidedServices());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('tags', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The tags to invalidate')
+            ->addOption('pool', 'p', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'The pools to invalidate on')
+            ->setHelp(<<<'EOF'
+                The <info>%command.name%</info> command invalidates tags from taggable pools. By default, all pools
+                have the passed tags invalidated. Pass <info>--pool=my_pool</info> to invalidate tags on a specific pool.
+
+                  php %command.full_name% tag1 tag2
+                  php %command.full_name% tag1 tag2 --pool=cache2 --pool=cache1
+                EOF)
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $pools = $input->getOption('pool') ?: $this->poolNames;
+        $tags = $input->getArgument('tags');
+        $tagList = implode(', ', $tags);
+        $errors = false;
+
+        foreach ($pools as $name) {
+            $io->comment(sprintf('Invalidating tag(s): <info>%s</info> from pool <comment>%s</comment>.', $tagList, $name));
+
+            try {
+                $pool = $this->pools->get($name);
+            } catch (ServiceNotFoundException) {
+                $io->error(sprintf('Pool "%s" not found.', $name));
+                $errors = true;
+
+                continue;
+            }
+
+            if (!$pool instanceof TagAwareCacheInterface) {
+                $io->error(sprintf('Pool "%s" is not taggable.', $name));
+                $errors = true;
+
+                continue;
+            }
+
+            if (!$pool->invalidateTags($tags)) {
+                $io->error(sprintf('Cache tag(s) "%s" could not be invalidated for pool "%s".', $tagList, $name));
+                $errors = true;
+            }
+        }
+
+        if ($errors) {
+            $io->error('Done but with errors.');
+
+            return self::FAILURE;
+        }
+
+        $io->success('Successfully invalidated cache tags.');
+
+        return self::SUCCESS;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestOptionValuesFor('pool')) {
+            $suggestions->suggestValues($this->poolNames);
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -27,6 +27,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'auto_alias',
         'cache.pool',
         'cache.pool.clearer',
+        'cache.taggable',
         'chatter.transport_factory',
         'config_cache.resource_checker',
         'console.command',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2145,9 +2145,11 @@ class FrameworkExtension extends Extension
 
             if ($isRedisTagAware && 'cache.app' === $name) {
                 $container->setAlias('cache.app.taggable', $name);
+                $definition->addTag('cache.taggable', ['pool' => $name]);
             } elseif ($isRedisTagAware) {
                 $tagAwareId = $name;
                 $container->setAlias('.'.$name.'.inner', $name);
+                $definition->addTag('cache.taggable', ['pool' => $name]);
             } elseif ($pool['tags']) {
                 if (true !== $pool['tags'] && ($config['pools'][$pool['tags']]['tags'] ?? false)) {
                     $pool['tags'] = '.'.$pool['tags'].'.inner';
@@ -2156,6 +2158,7 @@ class FrameworkExtension extends Extension
                     ->addArgument(new Reference('.'.$name.'.inner'))
                     ->addArgument(true !== $pool['tags'] ? new Reference($pool['tags']) : null)
                     ->setPublic($pool['public'])
+                    ->addTag('cache.taggable', ['pool' => $name])
                 ;
 
                 if (method_exists(TagAwareAdapter::class, 'setLogger')) {
@@ -2172,6 +2175,7 @@ class FrameworkExtension extends Extension
                 $tagAwareId = '.'.$name.'.taggable';
                 $container->register($tagAwareId, TagAwareAdapter::class)
                     ->addArgument(new Reference($name))
+                    ->addTag('cache.taggable', ['pool' => $name])
                 ;
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -39,6 +39,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('cache.app.taggable', TagAwareAdapter::class)
             ->args([service('cache.app')])
+            ->tag('cache.taggable', ['pool' => 'cache.app'])
 
         ->set('cache.system')
             ->parent('cache.adapter.system')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Command\AssetsInstallCommand;
 use Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolDeleteCommand;
+use Symfony\Bundle\FrameworkBundle\Command\CachePoolInvalidateTagsCommand;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolListCommand;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolPruneCommand;
 use Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand;
@@ -90,6 +91,12 @@ return static function (ContainerConfigurator $container) {
         ->set('console.command.cache_pool_prune', CachePoolPruneCommand::class)
             ->args([
                 [],
+            ])
+            ->tag('console.command')
+
+        ->set('console.command.cache_pool_invalidate_tags', CachePoolInvalidateTagsCommand::class)
+            ->args([
+                tagged_locator('cache.taggable', 'pool'),
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolInvalidateTagsCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolInvalidateTagsCommandTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\CachePoolInvalidateTagsCommand;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+class CachePoolInvalidateTagsCommandTest extends TestCase
+{
+    public function testComplete()
+    {
+        $tester = new CommandCompletionTester($this->createCommand(['foo' => null, 'bar' => null]));
+
+        $suggestions = $tester->complete(['--pool=']);
+
+        $this->assertSame(['foo', 'bar'], $suggestions);
+    }
+
+    public function testInvalidatesTagsForAllPoolsByDefault()
+    {
+        $tagsToInvalidate = ['tag1', 'tag2'];
+
+        $foo = $this->createMock(TagAwareCacheInterface::class);
+        $foo->expects($this->once())->method('invalidateTags')->with($tagsToInvalidate)->willReturn(true);
+
+        $bar = $this->createMock(TagAwareCacheInterface::class);
+        $bar->expects($this->once())->method('invalidateTags')->with($tagsToInvalidate)->willReturn(true);
+
+        $tester = new CommandTester($this->createCommand([
+            'foo' => $foo,
+            'bar' => $bar,
+        ]));
+
+        $ret = $tester->execute(['tags' => $tagsToInvalidate]);
+
+        $this->assertSame(Command::SUCCESS, $ret);
+    }
+
+    public function testCanInvalidateSpecificPools()
+    {
+        $tagsToInvalidate = ['tag1', 'tag2'];
+
+        $foo = $this->createMock(TagAwareCacheInterface::class);
+        $foo->expects($this->once())->method('invalidateTags')->with($tagsToInvalidate)->willReturn(true);
+
+        $bar = $this->createMock(TagAwareCacheInterface::class);
+        $bar->expects($this->never())->method('invalidateTags');
+
+        $tester = new CommandTester($this->createCommand([
+            'foo' => $foo,
+            'bar' => $bar,
+        ]));
+
+        $ret = $tester->execute(['tags' => $tagsToInvalidate, '--pool' => ['foo']]);
+
+        $this->assertSame(Command::SUCCESS, $ret);
+    }
+
+    public function testCommandFailsIfPoolNotFound()
+    {
+        $tagsToInvalidate = ['tag1', 'tag2'];
+
+        $foo = $this->createMock(TagAwareCacheInterface::class);
+        $foo->expects($this->once())->method('invalidateTags')->with($tagsToInvalidate)->willReturn(true);
+
+        $bar = $this->createMock(TagAwareCacheInterface::class);
+        $bar->expects($this->never())->method('invalidateTags');
+
+        $tester = new CommandTester($this->createCommand([
+            'foo' => $foo,
+            'bar' => $bar,
+        ]));
+
+        $ret = $tester->execute(['tags' => $tagsToInvalidate, '--pool' => ['invalid', 'foo']]);
+
+        $this->assertSame(Command::FAILURE, $ret);
+    }
+
+    public function testCommandFailsIfPoolNotTaggable()
+    {
+        $tagsToInvalidate = ['tag1', 'tag2'];
+
+        $foo = new \stdClass();
+
+        $bar = $this->createMock(TagAwareCacheInterface::class);
+        $bar->expects($this->once())->method('invalidateTags')->with($tagsToInvalidate)->willReturn(true);
+
+        $tester = new CommandTester($this->createCommand([
+            'foo' => $foo,
+            'bar' => $bar,
+        ]));
+
+        $ret = $tester->execute(['tags' => $tagsToInvalidate]);
+
+        $this->assertSame(Command::FAILURE, $ret);
+    }
+
+    public function testCommandFailsIfInvalidatingTagsFails()
+    {
+        $tagsToInvalidate = ['tag1', 'tag2'];
+
+        $foo = $this->createMock(TagAwareCacheInterface::class);
+        $foo->expects($this->once())->method('invalidateTags')->with($tagsToInvalidate)->willReturn(false);
+
+        $bar = $this->createMock(TagAwareCacheInterface::class);
+        $bar->expects($this->once())->method('invalidateTags')->with($tagsToInvalidate)->willReturn(true);
+
+        $tester = new CommandTester($this->createCommand([
+            'foo' => $foo,
+            'bar' => $bar,
+        ]));
+
+        $ret = $tester->execute(['tags' => $tagsToInvalidate]);
+
+        $this->assertSame(Command::FAILURE, $ret);
+    }
+
+    private function createCommand(array $services): CachePoolInvalidateTagsCommand
+    {
+        return new CachePoolInvalidateTagsCommand(
+            new ServiceLocator(array_map(fn ($service) => fn () => $service, $services))
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40218
| License       | MIT
| Doc PR        | symfony/symfony-docs#16328

Adds a `cache:pool:invalidate-tags` command. 

## Usage

```bash
bin/console cache:pool:invalidate-tags tag1 # invalidates tag1 from all taggable pools
bin/console cache:pool:invalidate-tags tag1 tag2 # invalidates tag1 & tag2 from all taggable pools
bin/console cache:pool:invalidate-tags tag1 tag2 --pool=cache.app # invalidates tag1 & tag2 from cache.app pool
bin/console cache:pool:invalidate-tags tag1 tag2 -p cache1 -p cache2 # invalidates tag1 & tag2 from cache1 & cache2 pools
```

## TODO

- [x] tests
- [x] account for #44682 (once merged up to 6.1)