### PR TITLE
[FrameworkBundle] Skip auto-validation for empty auto_mapping

### DIFF
--- a/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
@@ -27,11 +27,11 @@ class AddAutoMappingConfigurationPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasParameter('validator.auto_mapping') || !$container->hasDefinition('validator.builder')) {
+        $config = $container->getParameter('validator.auto_mapping');
+
+        if (!$config || !$container->hasDefinition('validator.builder')) {
             return;
         }
-
-        $config = $container->getParameter('validator.auto_mapping');
 
         $globalNamespaces = [];
         $servicesToNamespaces = [];

--- a/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
@@ -30,6 +30,8 @@ class AddAutoMappingConfigurationPass implements CompilerPassInterface
         $config = $container->hasParameter('validator.auto_mapping') ? $container->getParameter('validator.auto_mapping') : null;
 
         if (!$config || !$container->hasDefinition('validator.builder')) {
+            $container->getParameterBag()->remove('validator.auto_mapping');
+            
             return;
         }
 

--- a/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
@@ -27,7 +27,7 @@ class AddAutoMappingConfigurationPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $config = $container->getParameter('validator.auto_mapping');
+        $config = $container->hasParameter('validator.auto_mapping') ? $container->getParameter('validator.auto_mapping') : null;
 
         if (!$config || !$container->hasDefinition('validator.builder')) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | Fix #44693
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I can confirm this fixes the issue on our side at 4.4.

I created this PR mostly to see what tests do on your side. :crossed_fingers: I'm not planning to digest this feature any further :)

I let you decide as of which branch to disable auto-validation ;)