### PR TITLE
[Workflow] Added generic template in Event and his inheritors

### DIFF
--- a/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
+++ b/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @template TSubject of object
+ * @extends Event<TSubject>
+ */
 final class AnnounceEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/CompletedEvent.php
+++ b/src/Symfony/Component/Workflow/Event/CompletedEvent.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @template TSubject of object
+ * @extends Event<TSubject>
+ */
 final class CompletedEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/EnterEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnterEvent.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @template TSubject of object
+ * @extends Event<TSubject>
+ */
 final class EnterEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/EnteredEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnteredEvent.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @template TSubject of object
+ * @extends Event<TSubject>
+ */
 final class EnteredEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -17,6 +17,8 @@ use Symfony\Component\Workflow\WorkflowInterface;
 use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
 
 /**
+ * @template TSubject of object
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Carlos Pereira De Amorim <carlos@shauri.fr>
@@ -24,11 +26,17 @@ use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
 class Event extends BaseEvent
 {
     protected $context;
+    /**
+     * @var TSubject
+     */
     private object $subject;
     private Marking $marking;
     private ?Transition $transition;
     private ?WorkflowInterface $workflow;
 
+    /**
+     * @param TSubject $subject
+     */
     public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
     {
         $this->subject = $subject;
@@ -47,7 +55,7 @@ class Event extends BaseEvent
     }
 
     /**
-     * @return object
+     * @return TSubject
      */
     public function getSubject()
     {

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -18,6 +18,9 @@ use Symfony\Component\Workflow\TransitionBlockerList;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
+ * @template TSubject of object
+ * @extends Event<TSubject>
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
@@ -27,6 +30,8 @@ final class GuardEvent extends Event
 
     /**
      * {@inheritdoc}
+     *
+     * @param TSubject $subject
      */
     public function __construct(object $subject, Marking $marking, Transition $transition, WorkflowInterface $workflow = null)
     {

--- a/src/Symfony/Component/Workflow/Event/LeaveEvent.php
+++ b/src/Symfony/Component/Workflow/Event/LeaveEvent.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @template TSubject of object
+ * @extends Event<TSubject>
+ */
 final class LeaveEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/TransitionEvent.php
+++ b/src/Symfony/Component/Workflow/Event/TransitionEvent.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @template TSubject of object
+ * @extends Event<TSubject>
+ */
 final class TransitionEvent extends Event
 {
     public function setContext(array $context): void


### PR DESCRIPTION
Added generic template for `Event` in Workflow Component

| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Added generic template for `Event`, `Event::$subject` and `Event::getSubject()` for PHPStorm support.
