### PR TITLE
[HttpKernel] Generic templates for `ControllerArgumentsEvent`,`ControllerEvent` and `ExceptionEvent`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
+ * @template TController of object
+ *
  * Allows filtering of controller arguments.
  *
  * You can call getController() to retrieve the controller and getArguments
@@ -28,9 +30,15 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 final class ControllerArgumentsEvent extends KernelEvent
 {
+    /**
+     * @var TController
+     */
     private $controller;
     private array $arguments;
 
+    /**
+     * @param TController $controller
+     */
     public function __construct(HttpKernelInterface $kernel, callable $controller, array $arguments, Request $request, ?int $requestType)
     {
         parent::__construct($kernel, $request, $requestType);
@@ -39,11 +47,17 @@ final class ControllerArgumentsEvent extends KernelEvent
         $this->arguments = $arguments;
     }
 
+    /**
+     * @return TController
+     */
     public function getController(): callable
     {
         return $this->controller;
     }
 
+    /**
+     * @param TController $controller
+     */
     public function setController(callable $controller)
     {
         $this->controller = $controller;

--- a/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
+ * @template TController of object
+ *
  * Allows filtering of a controller callable.
  *
  * You can call getController() to retrieve the current controller. With
@@ -27,8 +29,14 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 final class ControllerEvent extends KernelEvent
 {
+    /**
+     * @var TController
+     */
     private string|array|object $controller;
 
+    /**
+     * @param TController $controller
+     */
     public function __construct(HttpKernelInterface $kernel, callable $controller, Request $request, ?int $requestType)
     {
         parent::__construct($kernel, $request, $requestType);
@@ -36,11 +44,17 @@ final class ControllerEvent extends KernelEvent
         $this->setController($controller);
     }
 
+    /**
+     * @return TController
+     */
     public function getController(): callable
     {
         return $this->controller;
     }
 
+    /**
+     * @param TController $controller
+     */
     public function setController(callable $controller): void
     {
         $this->controller = $controller;

--- a/src/Symfony/Component/HttpKernel/Event/ExceptionEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ExceptionEvent.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
+ * @template TException of \Throwable
+ *
  * Allows to create a response for a thrown exception.
  *
  * Call setResponse() to set the response that will be returned for the
@@ -29,9 +31,15 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 final class ExceptionEvent extends RequestEvent
 {
+    /**
+     * @var TException
+     */
     private \Throwable $throwable;
     private bool $allowCustomResponseCode = false;
 
+    /**
+     * @param TException $e
+     */
     public function __construct(HttpKernelInterface $kernel, Request $request, int $requestType, \Throwable $e)
     {
         parent::__construct($kernel, $request, $requestType);
@@ -39,12 +47,17 @@ final class ExceptionEvent extends RequestEvent
         $this->setThrowable($e);
     }
 
+    /**
+     * @return TException
+     */
     public function getThrowable(): \Throwable
     {
         return $this->throwable;
     }
 
     /**
+     * @param TException $exception
+     *
      * Replaces the thrown exception.
      *
      * This exception will be thrown if no response is set in the event.


### PR DESCRIPTION
Added generic templates in `ControllerArgumentsEvent`,`ControllerEvent` and `ExceptionEvent`.

| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

[HttpKernel] Added generic templates in `ControllerArgumentsEvent`,`ControllerEvent` and `ExceptionEvent` for IDE IntelliSense support.
