### PR TITLE
[Process] Run `open_basedir` tests in separate processes

### DIFF
--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -96,6 +96,9 @@ class ExecutableFinderTest extends TestCase
         $this->assertSamePath(\PHP_BINARY, $result);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testFindWithOpenBaseDir()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
@@ -114,6 +117,9 @@ class ExecutableFinderTest extends TestCase
         $this->assertSamePath(\PHP_BINARY, $result);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testFindProcessInOpenBasedir()
     {
         if (ini_get('open_basedir')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While working on #43239, I noticed that when a test sets `open_basedir`, the setting is not reset to its initial value after the test, which can have an impact on subsequent tests. I could not find the reason why the setting cannot be reset. I assume this is for security reasons, so the solution is to always run such test in a separate process.

This only concerns two tests for now. Before running those in separate process, the first one prevented subsequent tests in the same class from being run because they are skipped when `open_basedir` is set, which was always true.