### PR TITLE
[WebProfilerBundle] fix Email HTML preview

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -141,42 +141,48 @@
                                             </div>
                                             {% if message.htmlBody is defined %}
                                                 {# Email instance #}
-                                                <div class="tab">
-                                                    <h3 class="tab-title">HTML preview</h3>
-                                                    <div class="tab-content">
-                                                        <pre class="prewrap" style="max-height: 600px">
-                                                            <iframe
-                                                                src="data:text/html;base64;charset=utf-8,{{ collector.base64Encode(message.htmlBody()) }}"
-                                                                style="height: 80vh;width: 100%;"
-                                                            >
-                                                            </iframe>
-                                                        </pre>
+                                                {% set htmlBody = message.htmlBody() %}
+                                                {% if htmlBody is not null %}
+                                                    <div class="tab">
+                                                        <h3 class="tab-title">HTML Preview</h3>
+                                                        <div class="tab-content">
+                                                            <pre class="prewrap" style="max-height: 600px">
+                                                                <iframe
+                                                                    src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}"
+                                                                    style="height: 80vh;width: 100%;"
+                                                                >
+                                                                </iframe>
+                                                            </pre>
+                                                        </div>
                                                     </div>
-                                                </div>
-                                                <div class="tab">
-                                                    <h3 class="tab-title">HTML Content</h3>
-                                                    <div class="tab-content">
-                                                        <pre class="prewrap" style="max-height: 600px">
-                                                            {%- if message.htmlCharset() %}
-                                                                {{- message.htmlBody()|convert_encoding('UTF-8', message.htmlCharset()) }}
-                                                            {%- else %}
-                                                                {{- message.htmlBody() }}
-                                                            {%- endif -%}
-                                                        </pre>
+                                                    <div class="tab">
+                                                        <h3 class="tab-title">HTML Content</h3>
+                                                        <div class="tab-content">
+                                                            <pre class="prewrap" style="max-height: 600px">
+                                                                {%- if message.htmlCharset() %}
+                                                                    {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
+                                                                {%- else %}
+                                                                    {{- htmlBody }}
+                                                                {%- endif -%}
+                                                            </pre>
+                                                        </div>
                                                     </div>
-                                                </div>
-                                                <div class="tab">
-                                                    <h3 class="tab-title">Text Content</h3>
-                                                    <div class="tab-content">
-                                                        <pre class="prewrap" style="max-height: 600px">
-                                                            {%- if message.textCharset() %}
-                                                                {{- message.textBody()|convert_encoding('UTF-8', message.textCharset()) }}
-                                                            {%- else %}
-                                                                {{- message.textBody() }}
-                                                            {%- endif -%}
-                                                        </pre>
+                                                {% endif %}
+                                                {% set textBody = message.textBody() %}
+                                                {% if textBody is not null %}
+                                                    <div class="tab">
+                                                        <h3 class="tab-title">Text Content</h3>
+                                                        <div class="tab-content">
+                                                            <pre class="prewrap" style="max-height: 600px">
+                                                                {%- if message.textCharset() %}
+                                                                    {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
+                                                                {%- else %}
+                                                                    {{- textBody }}
+                                                                {%- endif -%}
+                                                            </pre>
+                                                        </div>
                                                     </div>
-                                                </div>
+                                                {% endif %}
                                                 {% for attachment in message.attachments %}
                                                     <div class="tab">
                                                         <h3 class="tab-title">Attachment #{{ loop.index }}</h3>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/44696 Fix https://github.com/symfony/symfony/issues/44703
| License       | MIT

## First issue:

When swapping the order of `base64` & `charset=utf-8` it works well
Friendly ping @lyrixx as PR author

## Second issue:

Friendly ping @Art4 as issue author

As the `Mime\Email` is:

```php
    /**
     * @return resource|string|null
     */
    public function getHtmlBody()
    {
        return $this->html;
    }
```

