### PR TITLE
[Lock] Release PostgreSqlStore connection lock on failure

### DIFF
--- a/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
@@ -94,18 +94,28 @@ class PostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStore
         // prevent concurrency within the same connection
         $this->getInternalStore()->save($key);
 
-        $sql = 'SELECT pg_try_advisory_lock(:key)';
-        $stmt = $this->getConnection()->prepare($sql);
-        $stmt->bindValue(':key', $this->getHashedKey($key));
-        $result = $stmt->execute();
+        $lockAcquired = false;
 
-        // Check if lock is acquired
-        if (true === $stmt->fetchColumn()) {
-            $key->markUnserializable();
-            // release sharedLock in case of promotion
-            $this->unlockShared($key);
+        try {
+            $sql = 'SELECT pg_try_advisory_lock(:key)';
+            $stmt = $this->getConnection()->prepare($sql);
+            $stmt->bindValue(':key', $this->getHashedKey($key));
+            $result = $stmt->execute();
 
-            return;
+            // Check if lock is acquired
+            if (true === $stmt->fetchColumn()) {
+                $key->markUnserializable();
+                // release sharedLock in case of promotion
+                $this->unlockShared($key);
+
+                $lockAcquired = true;
+
+                return;
+            }
+        } finally {
+            if (!$lockAcquired) {
+                $this->getInternalStore()->delete($key);
+            }
         }
 
         throw new LockConflictedException();
@@ -122,19 +132,29 @@ class PostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStore
         // prevent concurrency within the same connection
         $this->getInternalStore()->saveRead($key);
 
-        $sql = 'SELECT pg_try_advisory_lock_shared(:key)';
-        $stmt = $this->getConnection()->prepare($sql);
+        $lockAcquired = false;
 
-        $stmt->bindValue(':key', $this->getHashedKey($key));
-        $result = $stmt->execute();
+        try {
+            $sql = 'SELECT pg_try_advisory_lock_shared(:key)';
+            $stmt = $this->getConnection()->prepare($sql);
 
-        // Check if lock is acquired
-        if (true === $stmt->fetchColumn()) {
-            $key->markUnserializable();
-            // release lock in case of demotion
-            $this->unlock($key);
+            $stmt->bindValue(':key', $this->getHashedKey($key));
+            $result = $stmt->execute();
 
-            return;
+            // Check if lock is acquired
+            if (true === $stmt->fetchColumn()) {
+                $key->markUnserializable();
+                // release lock in case of demotion
+                $this->unlock($key);
+
+                $lockAcquired = true;
+
+                return;
+            }
+        } finally {
+            if (!$lockAcquired) {
+                $this->getInternalStore()->delete($key);
+            }
         }
 
         throw new LockConflictedException();

--- a/src/Symfony/Component/Lock/Tests/Store/PostgreSqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PostgreSqlStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\PostgreSqlStore;
@@ -49,5 +50,32 @@ class PostgreSqlStoreTest extends AbstractStoreTest
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The adapter "Symfony\Component\Lock\Store\PostgreSqlStore" does not support');
         $store->exists(new Key('foo'));
+    }
+
+    public function testSaveAfterConflict()
+    {
+        $store1 = $this->getStore();
+        $store2 = $this->getStore();
+
+        $key = new Key(uniqid(__METHOD__, true));
+
+        $store1->save($key);
+        $this->assertTrue($store1->exists($key));
+
+        $lockConflicted = false;
+
+        try {
+            $store2->save($key);
+        } catch (LockConflictedException $lockConflictedException) {
+            $lockConflicted = true;
+        }
+
+        $this->assertTrue($lockConflicted);
+        $this->assertFalse($store2->exists($key));
+
+        $store1->delete($key);
+
+        $store2->save($key);
+        $this->assertTrue($store2->exists($key));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3<!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

When using PostgreSQL advisory locks using the `PostgreSqlStore`
A first lock is acquired in memory for same connection concurrencies, this `InMemoryStore` does not rely on TTL.

When the advisory lock fails to be acquired, this first lock is not released.
 
For long running processes, this cause the lock to not be acquirable again because the `InMemoryStore` will never release its lock.