### PR TITLE
[Form] Fix `ChoiceType` with `choice_filter` and `expanded` options

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/Loader/FilterChoiceLoaderDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/FilterChoiceLoaderDecorator.php
@@ -50,7 +50,7 @@ class FilterChoiceLoaderDecorator extends AbstractChoiceLoader
      */
     public function loadChoicesForValues(array $values, callable $value = null): array
     {
-        return array_filter($this->decoratedLoader->loadChoicesForValues($values, $value), $this->filter);
+        return array_filter(parent::loadChoicesForValues($values, $value), $this->filter);
     }
 
     /**
@@ -58,6 +58,6 @@ class FilterChoiceLoaderDecorator extends AbstractChoiceLoader
      */
     public function loadValuesForChoices(array $choices, callable $value = null): array
     {
-        return $this->decoratedLoader->loadValuesForChoices(array_filter($choices, $this->filter), $value);
+        return parent::loadValuesForChoices(array_filter($choices, $this->filter), $value);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1321,6 +1321,31 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->assertNull($form[4]->getViewData());
     }
 
+    public function testSubmitSingleExpandedFilteredObjectChoices()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'multiple' => false,
+            'expanded' => true,
+            'choices' => $this->objectChoices,
+            'choice_label' => 'name',
+            'choice_value' => 'id',
+            'choice_filter' => function ($choice) { return null === $choice || $choice->id < 4; },
+        ]);
+
+        $form->submit('2');
+
+        $this->assertSame($this->objectChoices[1], $form->getData());
+        $this->assertTrue($form->isSynchronized());
+
+        $this->assertFalse($form[0]->getData());
+        $this->assertTrue($form[1]->getData());
+        $this->assertFalse($form[2]->getData());
+        $this->assertFalse(isset($form[3]));
+        $this->assertNull($form[0]->getViewData());
+        $this->assertSame('2', $form[1]->getViewData());
+        $this->assertNull($form[2]->getViewData());
+    }
+
     public function testSubmitSingleExpandedClearMissingFalse()
     {
         $form = $this->factory->create(self::TESTED_TYPE, 'foo', [
@@ -1508,6 +1533,31 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->assertNull($form[2]->getViewData());
         $this->assertNull($form[3]->getViewData());
         $this->assertNull($form[4]->getViewData());
+    }
+
+    public function testSubmitMultipleExpandedFilteredObjectChoices()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'multiple' => true,
+            'expanded' => true,
+            'choices' => $this->objectChoices,
+            'choice_label' => 'name',
+            'choice_value' => 'id',
+            'choice_filter' => function ($choice) { return null === $choice || $choice->id < 4; },
+        ]);
+
+        $form->submit(['1', '2']);
+
+        $this->assertSame([$this->objectChoices[0], $this->objectChoices[1]], $form->getData());
+        $this->assertTrue($form->isSynchronized());
+
+        $this->assertTrue($form[0]->getData());
+        $this->assertTrue($form[1]->getData());
+        $this->assertFalse($form[2]->getData());
+        $this->assertFalse(isset($form[3]));
+        $this->assertSame('1', $form[0]->getViewData());
+        $this->assertSame('2', $form[1]->getViewData());
+        $this->assertNull($form[2]->getViewData());
     }
 
     public function testSubmitMultipleChoicesInts()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #44655 (doesn't entirely fix)
| License       | MIT
| Doc PR        | N/A

This fixes `FilterChoiceLoaderDecorator` so that it works when used by `ChoiceType` with the `expanded` option set to true. It doesn't fix the design issues with `AbstractChoiceLoader` breaking the `ChoiceLoaderInterface` contract.