### PR TITLE
[Mime] Fix encoding filenames in multipart/form-data

### DIFF
--- a/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
+++ b/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
@@ -123,6 +123,22 @@ final class ParameterizedHeader extends UnstructuredHeader
                 $maxValueLength = $this->getMaxLineLength() - \strlen($name.'*N*="";') - 1;
                 $firstLineOffset = \strlen($this->getCharset()."'".$this->getLanguage()."'");
             }
+
+            if (\in_array($name, ['name', 'filename'], true) && 'form-data' === $this->getValue() && 'content-disposition' === strtolower($this->getName()) && preg_match('//u', $value)) {
+                // WHATWG HTML living standard 4.10.21.8 2 specifies:
+                // For field names and filenames for file fields, the result of the
+                // encoding in the previous bullet point must be escaped by replacing
+                // any 0x0A (LF) bytes with the byte sequence `%0A`, 0x0D (CR) with `%0D`
+                // and 0x22 (") with `%22`.
+                // The user agent must not perform any other escapes.
+                $value = str_replace(['"', "\r", "\n"], ['%22', '%0D', '%0A'], $value);
+
+                if (\strlen($value) <= $maxValueLength) {
+                    return $name.'="'.$value.'"';
+                }
+
+                $value = $origValue;
+            }
         }
 
         // Encode if we need to
@@ -158,7 +174,7 @@ final class ParameterizedHeader extends UnstructuredHeader
      */
     private function getEndOfParameterValue(string $value, bool $encoded = false, bool $firstLine = false): string
     {
-        $forceHttpQuoting = 'content-disposition' === strtolower($this->getName()) && 'form-data' === $this->getValue();
+        $forceHttpQuoting = 'form-data' === $this->getValue() && 'content-disposition' === strtolower($this->getName());
         if ($forceHttpQuoting || !preg_match('/^'.self::TOKEN_REGEX.'$/D', $value)) {
             $value = '"'.$value.'"';
         }

--- a/src/Symfony/Component/Mime/Tests/Header/ParameterizedHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/ParameterizedHeaderTest.php
@@ -58,6 +58,20 @@ class ParameterizedHeaderTest extends TestCase
         $this->assertEquals('attachment; filename="my file.txt"', $header->getBodyAsString());
     }
 
+    public function testFormDataResultsInQuotedString()
+    {
+        $header = new ParameterizedHeader('Content-Disposition', 'form-data');
+        $header->setParameters(['filename' => 'file.txt']);
+        $this->assertEquals('form-data; filename="file.txt"', $header->getBodyAsString());
+    }
+
+    public function testFormDataUtf8()
+    {
+        $header = new ParameterizedHeader('Content-Disposition', 'form-data');
+        $header->setParameters(['filename' => "déjà%\"\n\r.txt"]);
+        $this->assertEquals('form-data; filename="déjà%%22%0A%0D.txt"', $header->getBodyAsString());
+    }
+
     public function testLongParamsAreBrokenIntoMultipleAttributeStrings()
     {
         /* -- RFC 2231, 3.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41249
| License       | MIT
| Doc PR        | -

File uploads that use forms have stick to browsers' behavior. This is captured by the WHATWG in their living standard:
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data

curl did the same a few weeks ago:
https://github.com/curl/curl/pull/7805