### PR TITLE
[Console] Fix autocompletion of argument with default value

### DIFF
--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -109,12 +109,12 @@ final class CompletionInput extends ArgvInput
         // complete argument value
         $this->completionType = self::TYPE_ARGUMENT_VALUE;
 
-        $arguments = $this->getArguments();
-        foreach ($arguments as $argumentName => $argumentValue) {
-            if (null === $argumentValue) {
+        foreach ($this->definition->getArguments() as $argumentName => $argument) {
+            if (!isset($this->arguments[$argumentName])) {
                 break;
             }
 
+            $argumentValue = $this->arguments[$argumentName];
             $this->completionName = $argumentName;
             if (\is_array($argumentValue)) {
                 $this->completionValue = $argumentValue ? $argumentValue[array_key_last($argumentValue)] : null;
@@ -124,7 +124,7 @@ final class CompletionInput extends ArgvInput
         }
 
         if ($this->currentIndex >= \count($this->tokens)) {
-            if (null === $arguments[$argumentName] || $this->definition->getArgument($argumentName)->isArray()) {
+            if (!isset($this->arguments[$argumentName]) || $this->definition->getArgument($argumentName)->isArray()) {
                 $this->completionName = $argumentName;
                 $this->completionValue = '';
             } else {

--- a/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
@@ -92,7 +92,7 @@ class HelpCommandTest extends TestCase
 
         yield 'nothing' => [
             [''],
-            [],
+            ['completion', 'help', 'list', 'foo:bar'],
         ];
 
         yield 'command_name' => [

--- a/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
@@ -97,6 +97,20 @@ class CompletionInputTest extends TestCase
         yield [CompletionInput::fromTokens(['bin/console', 'symfony', 'sen'], 2), 'sen'];
     }
 
+    public function testBindArgumentWithDefault()
+    {
+        $definition = new InputDefinition([
+            new InputArgument('arg-with-default', InputArgument::OPTIONAL, '', 'default'),
+        ]);
+
+        $input = CompletionInput::fromTokens(['bin/console'], 1);
+        $input->bind($definition);
+
+        $this->assertEquals(CompletionInput::TYPE_ARGUMENT_VALUE, $input->getCompletionType(), 'Unexpected type');
+        $this->assertEquals('arg-with-default', $input->getCompletionName(), 'Unexpected name');
+        $this->assertEquals('', $input->getCompletionValue(), 'Unexpected value');
+    }
+
     /**
      * @dataProvider provideFromStringData
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44505
| License       | MIT
| Doc PR        | -

Also fix completion for the `help` command when the command name have not been started.

The `Input::getArguments` method merges input arguments with default values; which is not desired for completion. This fix uses the raw `Input::$arguments` property instead.

https://github.com/symfony/symfony/blob/94eb8a9c657257360b65a6ec4a6a64fb0551fe6a/src/Symfony/Component/Console/Input/Input.php#L99-L102