### PR TITLE
[Finder] Restore Finder:getIterator return type PHPDoc

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -601,6 +601,8 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * This method implements the IteratorAggregate interface.
      *
+     * @return \Iterator<string, SplFileInfo>
+     *
      * @throws \LogicException if the in() method has not been called
      */
     public function getIterator(): \Iterator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44697
| License       | MIT

As discussed in the related ticket we want this annotation back. Targeting `6.0` as it is present in `5.4`, was remove during merging `5.4` up to `6.0`.