### PR TITLE
[Mime] Relaxing in-reply-to header validation

### DIFF
--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -141,8 +141,8 @@ final class Headers
             'cc' => MailboxListHeader::class,
             'bcc' => MailboxListHeader::class,
             'message-id' => IdentificationHeader::class,
-            'in-reply-to' => IdentificationHeader::class,
-            'references' => IdentificationHeader::class,
+            'in-reply-to' => UnstructuredHeader::class, // `In-Reply-To` and `References` are less strict than RFC 2822 (3.6.4) to allow users entering the original email's ...
+            'references' => UnstructuredHeader::class, // ... `Message-ID`, even if that is no valid `msg-id`
             'return-path' => PathHeader::class,
         ];
 

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -243,4 +243,18 @@ class HeadersTest extends TestCase
             "Foo: =?utf-8?Q?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?=\r\n =?utf-8?Q?aaaa?=",
         ], $headers->toArray());
     }
+
+    public function testInReplyToAcceptsNonIdentifierValues()
+    {
+        $headers = new Headers();
+        $headers->addHeader('In-Reply-To', 'foobar');
+        $this->assertEquals('foobar', $headers->get('In-Reply-To')->getBody());
+    }
+
+    public function testReferencesAcceptsNonIdentifierValues()
+    {
+        $headers = new Headers();
+        $headers->addHeader('References' , 'foobar');
+        $this->assertEquals('foobar', $headers->get('References')->getBody());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | ?
| Deprecations? | no
| Tickets       | Fix #37361
| License       | MIT
| Doc PR        | not necessary

@nicolas-grekas
1. Is it OK to just use `UnstructuredHeader`?
2. Some tests at `IdentificationHeaderTest` are irrelevant now (but still pass) - should I remove them? And create some new test cases in `UnstructuredHeaderTest`? Or rely on every aspect being tested with other headers there, and don't add anything?
