### PR TITLE
Fix Psr16Cache not being compatible with non-Symfony cache pools

### DIFF
--- a/src/Symfony/Component/Cache/Psr16Cache.php
+++ b/src/Symfony/Component/Cache/Psr16Cache.php
@@ -30,7 +30,7 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
 
     private const METADATA_EXPIRY_OFFSET = 1527506807;
 
-    private \Closure $createCacheItem;
+    private ?\Closure $createCacheItem = null;
     private $cacheItemPrototype = null;
 
     public function __construct(CacheItemPoolInterface $pool)

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheWithExternalAdapter.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheWithExternalAdapter.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Psr16Cache;
+use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
+
+/**
+ * @group time-sensitive
+ */
+class Psr16CacheWithExternalAdapter extends SimpleCacheTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skippedTests['testSetTtl'] =
+        $this->skippedTests['testSetMultipleTtl'] = 'The ExternalAdapter test class does not support TTLs.';
+    }
+
+    public function createSimpleCache(): CacheInterface
+    {
+        return new Psr16Cache(new ExternalAdapter());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44736
| License       | MIT
| Doc PR        | n/a

Resolves #44736 by making the Closure nullable so that checks for `null` don't fail when the property is not initialized.