### PR TITLE
[Console] Add method `__toString()` to `InputInterface`

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add method `__toString()` to `InputInterface`
+
 6.0
 ---
 

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -18,6 +18,9 @@ use Symfony\Component\Console\Exception\RuntimeException;
  * InputInterface is the interface implemented by all input classes.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method string __toString() Returns a stringified representation of the args passed to the command.
+ *                             InputArguments MUST be escaped as well as the InputOption values passed to the command.
  */
 interface InputInterface
 {

--- a/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
@@ -143,4 +143,9 @@ class NonStringInput extends Input
     public function parse()
     {
     }
+
+    public function __toString(): string
+    {
+        return '';
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42042
| License       | MIT
| Doc PR        | -

Continues #42056. No test added because adding one for the deprecation feels like testing DebugClassLoader, which is not the point here.