### PR TITLE
[Messenger] [WIP]  Remove ability to delete message in retry command

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -1,0 +1,8 @@
+UPGRADE FROM 6.0 to 6.1
+=======================
+
+Messenger
+---------
+
+ * Removed the ability to delete a failed message when running `messenger:failed:retry` command, use the `messenger:failed:remove` command instead
+ 

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -177,14 +177,14 @@ EOF
 
             $this->displaySingleMessage($envelope, $io);
 
-            $shouldHandle = $shouldForce || $io->confirm('Do you want to retry (yes) or delete this message (no)?');
+            $shouldHandle = $shouldForce || $io->confirm('Do you want to retry this message?');
 
             if ($shouldHandle) {
                 return;
             }
 
-            $messageReceivedEvent->shouldHandle(false);
-            $receiver->reject($envelope);
+            //$messageReceivedEvent->shouldHandle(false);
+            //$receiver->reject($envelope);
         };
         $this->eventDispatcher->addListener(WorkerMessageReceivedEvent::class, $listener);
 

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -141,7 +141,7 @@ EOF
         $io->writeln([
             '',
             sprintf(' Run <comment>messenger:failed:retry %s --transport=%s</comment> to retry this message.', $id, $failedTransportName),
-            sprintf(' Run <comment>messenger:failed:remove %s --transport=%s</comment> to delete it.', $id, $failedTransportName),
+            sprintf(' Run <comment>messenger:failed:remove %s --transport=%s</comment> to remove it.', $id, $failedTransportName),
         ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no (even if removing a production message due to the question can be considered as a bug)
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/42353
| License       | MIT
| Doc PR        | .

Try to improve the related issue: use `retry` for retry only, and lets use `remove` for removal

---

**WIP** 

I need to boot a bare symfony app and configure messenger with retry feature to test things
While also understanding messenger internals with the `shouldHandle` and `reject`

Edit: after playing/trying a bit, I relate on https://github.com/symfony/symfony/issues/42353#issuecomment-934212735 as well, I am unable to avoid the removal of the message if no retry is wanted
If someone with knowledge on this component could help/guide, It would be appreciated :)