### PR TITLE
[HttpFoundation] Fix notice when HTTP_PHP_AUTH_USER passed without pass

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -89,7 +89,7 @@ class ServerBag extends ParameterBag
 
         // PHP_AUTH_USER/PHP_AUTH_PW
         if (isset($headers['PHP_AUTH_USER'])) {
-            $headers['AUTHORIZATION'] = 'Basic '.base64_encode($headers['PHP_AUTH_USER'].':'.$headers['PHP_AUTH_PW']);
+            $headers['AUTHORIZATION'] = 'Basic '.base64_encode($headers['PHP_AUTH_USER'].':'.($headers['PHP_AUTH_PW'] ?? ''));
         } elseif (isset($headers['PHP_AUTH_DIGEST'])) {
             $headers['AUTHORIZATION'] = $headers['PHP_AUTH_DIGEST'];
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
@@ -57,6 +57,16 @@ class ServerBagTest extends TestCase
         ], $bag->getHeaders());
     }
 
+    public function testHttpPasswordIsOptionalWhenPassedWithHttpPrefix()
+    {
+        $bag = new ServerBag(['HTTP_PHP_AUTH_USER' => 'foo']);
+
+        $this->assertEquals([
+            'AUTHORIZATION' => 'Basic '.base64_encode('foo:'),
+            'PHP_AUTH_USER' => 'foo',
+        ], $bag->getHeaders());
+    }
+
     public function testHttpBasicAuthWithPhpCgi()
     {
         $bag = new ServerBag(['HTTP_AUTHORIZATION' => 'Basic '.base64_encode('foo:bar')]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.4
| Bug fix?      | yes
| New feature?  | No
| Deprecations? | No
| License       | MIT

There is a way to pass HTTP_XXX vars. If someone will pass HTTP_PHP_AUTH_USER var without HTTP_PHP_AUTH_PW notice will appear since there is no second isset check against $headers, there is isset only for $this->params

