### PR TITLE
[Form] Expand FormView key to include int

### DIFF
--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -16,8 +16,8 @@ use Symfony\Component\Form\Exception\BadMethodCallException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @implements \ArrayAccess<string, FormView>
- * @implements \IteratorAggregate<string, FormView>
+ * @implements \ArrayAccess<int|string, FormView>
+ * @implements \IteratorAggregate<int|string, FormView>
  */
 class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
 {
@@ -37,7 +37,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * The child views.
      *
-     * @var array<string, FormView>
+     * @var array<int|string, FormView>
      */
     public $children = [];
 
@@ -107,7 +107,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Returns a child by name (implements \ArrayAccess).
      *
-     * @param string $name The child name
+     * @param int|string $name The child name
      *
      * @return self
      */
@@ -120,7 +120,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Returns whether the given child exists (implements \ArrayAccess).
      *
-     * @param string $name The child name
+     * @param int|string $name The child name
      *
      * @return bool
      */
@@ -146,7 +146,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Removes a child (implements \ArrayAccess).
      *
-     * @param string $name The child name
+     * @param int|string $name The child name
      *
      * @return void
      */
@@ -159,7 +159,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Returns an iterator to iterate over children (implements \IteratorAggregate).
      *
-     * @return \ArrayIterator<string, FormView>
+     * @return \ArrayIterator<int|string, FormView>
      */
     #[\ReturnTypeWillChange]
     public function getIterator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Annotate FormView to also have integer keys. For example collection of forms has integers as keys.