### PR TITLE
[ProxyManagerBridge] Remove the unused dependency on composer/package-versions-deprecated

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "composer/package-versions-deprecated": "^1.8",
         "friendsofphp/proxy-manager-lts": "^1.0.2",
         "symfony/dependency-injection": "^4.0|^5.0",
         "symfony/polyfill-php80": "^1.16"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes/no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | n/a

The ProxyManagerBridge depends on friendsofphp/proxy-manager-lts which has an optional dependency on the PackageVersions class to implement the `ProxyManager\Version::getVersion` method on composer 1 (with a fallback to a less precise version number).
However, the bridge has stopped using that API in favor of feature detection (in #39017), so the dependency is unused.

This contributes to #44726
