### PR TITLE
[Notifier] Use correct factory for the msteams transport

### DIFF
--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -24,7 +24,7 @@ use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransportFactory;
 use Symfony\Component\Notifier\Bridge\LightSms\LightSmsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\MessageBird\MessageBirdTransportFactory;
-use Symfony\Component\Notifier\Bridge\MicrosoftTeams\MicrosoftTeamsTransport;
+use Symfony\Component\Notifier\Bridge\MicrosoftTeams\MicrosoftTeamsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
 use Symfony\Component\Notifier\Bridge\Octopush\OctopushTransportFactory;
@@ -68,7 +68,7 @@ class Transport
         LightSmsTransportFactory::class,
         MattermostTransportFactory::class,
         MessageBirdTransportFactory::class,
-        MicrosoftTeamsTransport::class,
+        MicrosoftTeamsTransportFactory::class,
         MobytTransportFactory::class,
         NexmoTransportFactory::class,
         OctopushTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Creating a microsoft teams transport through the `Notifier` `Transport::fromDsn()` class results in an exception:

```
PHP Fatal error:  Uncaught TypeError: Symfony\Component\Notifier\Bridge\MicrosoftTeams\MicrosoftTeamsTransport::__construct(): Argument #1 ($path) must be of type string, null given, called in /vendor/symfony/notifier/Transport.php on line 186 and defined in /vendor/symfony/microsoft-teams-notifier/MicrosoftTeamsTransport.php:35
Stack trace:

* snap *
```


This PR uses the correct ms teams transport factory instead.
It is pointed at the `5.3` branch, in which this specific transport was introduced.
The error is also there in all versions upwards. See https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Notifier/Transport.php#L84
