### PR TITLE
[DI] Add `exclude` to `TaggedIterator` and `TaggedLocator`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -23,6 +23,7 @@ class TaggedIteratorArgument extends IteratorArgument
     private ?string $defaultIndexMethod;
     private ?string $defaultPriorityMethod;
     private bool $needsIndexes;
+    private array $exclude;
 
     /**
      * @param string      $tag                   The name of the tag identifying the target services
@@ -30,8 +31,9 @@ class TaggedIteratorArgument extends IteratorArgument
      * @param string|null $defaultIndexMethod    The static method that should be called to get each service's key when their tag doesn't define the previous attribute
      * @param bool        $needsIndexes          Whether indexes are required and should be generated when computing the map
      * @param string|null $defaultPriorityMethod The static method that should be called to get each service's priority when their tag doesn't define the "priority" attribute
+     * @param array       $exclude               Services to exclude from the iterator
      */
-    public function __construct(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, bool $needsIndexes = false, string $defaultPriorityMethod = null)
+    public function __construct(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, bool $needsIndexes = false, string $defaultPriorityMethod = null, array $exclude = [])
     {
         parent::__construct([]);
 
@@ -44,6 +46,7 @@ class TaggedIteratorArgument extends IteratorArgument
         $this->defaultIndexMethod = $defaultIndexMethod ?: ($indexAttribute ? 'getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute))).'Name' : null);
         $this->needsIndexes = $needsIndexes;
         $this->defaultPriorityMethod = $defaultPriorityMethod ?: ($indexAttribute ? 'getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute))).'Priority' : null);
+        $this->exclude = $exclude;
     }
 
     public function getTag()
@@ -69,5 +72,10 @@ class TaggedIteratorArgument extends IteratorArgument
     public function getDefaultPriorityMethod(): ?string
     {
         return $this->defaultPriorityMethod;
+    }
+
+    public function getExclude(): array
+    {
+        return $this->exclude;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Attribute/TaggedIterator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/TaggedIterator.php
@@ -19,6 +19,7 @@ class TaggedIterator
         public ?string $indexAttribute = null,
         public ?string $defaultIndexMethod = null,
         public ?string $defaultPriorityMethod = null,
+        public string|array $exclude = [],
     ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Attribute/TaggedLocator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/TaggedLocator.php
@@ -19,6 +19,7 @@ class TaggedLocator
         public ?string $indexAttribute = null,
         public ?string $defaultIndexMethod = null,
         public ?string $defaultPriorityMethod = null,
+        public string|array $exclude = [],
     ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add `$exclude` to `TaggedIterator` and `TaggedLocator` attributes
+ * Add `$exclude` to `tagged_iterator` and `tagged_locator` configurator
+
 6.0
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -247,13 +247,13 @@ class AutowirePass extends AbstractRecursivePass
                 foreach ($parameter->getAttributes() as $attribute) {
                     if (TaggedIterator::class === $attribute->getName()) {
                         $attribute = $attribute->newInstance();
-                        $arguments[$index] = new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, false, $attribute->defaultPriorityMethod);
+                        $arguments[$index] = new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, false, $attribute->defaultPriorityMethod, (array) $attribute->exclude);
                         break;
                     }
 
                     if (TaggedLocator::class === $attribute->getName()) {
                         $attribute = $attribute->newInstance();
-                        $arguments[$index] = new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, true, $attribute->defaultPriorityMethod));
+                        $arguments[$index] = new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, true, $attribute->defaultPriorityMethod, (array) $attribute->exclude));
                         break;
                     }
                 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -39,6 +39,7 @@ trait PriorityTaggedServiceTrait
      */
     private function findAndSortTaggedServices(string|TaggedIteratorArgument $tagName, ContainerBuilder $container): array
     {
+        $exclude = [];
         $indexAttribute = $defaultIndexMethod = $needsIndexes = $defaultPriorityMethod = null;
 
         if ($tagName instanceof TaggedIteratorArgument) {
@@ -46,6 +47,7 @@ trait PriorityTaggedServiceTrait
             $defaultIndexMethod = $tagName->getDefaultIndexMethod();
             $needsIndexes = $tagName->needsIndexes();
             $defaultPriorityMethod = $tagName->getDefaultPriorityMethod() ?? 'getDefaultPriority';
+            $exclude = $tagName->getExclude();
             $tagName = $tagName->getTag();
         }
 
@@ -53,6 +55,10 @@ trait PriorityTaggedServiceTrait
         $services = [];
 
         foreach ($container->findTaggedServiceIds($tagName, true) as $serviceId => $attributes) {
+            if (\in_array($serviceId, $exclude, true)) {
+                continue;
+            }
+
             $defaultPriority = null;
             $defaultIndex = null;
             $definition = $container->getDefinition($serviceId);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -139,17 +139,17 @@ function iterator(array $values): IteratorArgument
 /**
  * Creates a lazy iterator by tag name.
  */
-function tagged_iterator(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, string $defaultPriorityMethod = null): TaggedIteratorArgument
+function tagged_iterator(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, string $defaultPriorityMethod = null, string|array $exclude = []): TaggedIteratorArgument
 {
-    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod);
+    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude);
 }
 
 /**
  * Creates a service locator by tag name.
  */
-function tagged_locator(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, string $defaultPriorityMethod = null): ServiceLocatorArgument
+function tagged_locator(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, string $defaultPriorityMethod = null, string|array $exclude = []): ServiceLocatorArgument
 {
-    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod));
+    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod, (array) $exclude));
 }
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -205,12 +205,18 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $container->register('service3', HelloNamedService2::class)
             ->setAutoconfigured(true)
             ->addTag('my_custom_tag');
+        $container->register('service4', HelloNamedService2::class)
+            ->setAutoconfigured(true)
+            ->addTag('my_custom_tag');
+        $container->register('service5', HelloNamedService2::class)
+            ->setAutoconfigured(true)
+            ->addTag('my_custom_tag');
 
         (new ResolveInstanceofConditionalsPass())->process($container);
 
         $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
 
-        $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar');
+        $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar', exclude: ['service4', 'service5']);
         $expected = [
             'service3' => new TypedReference('service3', HelloNamedService2::class),
             'hello' => new TypedReference('service2', HelloNamedService::class),

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfiguredInterface2.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfiguredInterface2.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag]
+interface AutoconfiguredInterface2
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfiguredService1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfiguredService1.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class AutoconfiguredService1 implements AutoconfiguredInterface2
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfiguredService2.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfiguredService2.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class AutoconfiguredService2 implements AutoconfiguredInterface2
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedConsumerWithExclude.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedConsumerWithExclude.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+
+final class TaggedConsumerWithExclude implements AutoconfiguredInterface2
+{
+    public function __construct(
+        #[TaggedIterator(AutoconfiguredInterface2::class, exclude: self::class)]
+        public iterable $items,
+        #[TaggedLocator(AutoconfiguredInterface2::class, exclude: self::class)]
+        public ContainerInterface $locator,
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 
| Bug fix?      |no
| New feature?  | yes
| Deprecations? |no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

With this change, you can exclude one or more services from a tagged iterator
or locator.

It's common when working with Delegator or Chain services that call a list of services that
implement an interface, to also want to implement the interface on Delegator/Chain.

An example of this is in the Symfony HttpKernel component:

https://github.com/symfony/symfony/blob/0d6e859db236e37b8baa2b2bf4c8b7d14d151570/src/Symfony/Component/HttpKernel/CacheClearer/CacheClearerInterface.php#L19-L25
https://github.com/symfony/symfony/blob/0d6e859db236e37b8baa2b2bf4c8b7d14d151570/src/Symfony/Component/HttpKernel/CacheClearer/ChainCacheClearer.php#L21-L31

The `ChainCacheClearer` implements `CacheClearerInterface` and calls a list of `CacheClearerInterface`
clearers.

If that would have been configured with `#[AutoconfigureTag]` and `#[TaggedIterator]`, the
`ChainCacheClearer` would receive itself in the `iterable $clearers`.

With this change, it can exclude itself and rely fully on autowire/configure.

Another example:

```php
#[AutoconfigureTag]
interface ErrorTracker
{
    public function trackError(string $error): void;
}

final class SentryErrorTracker implement ErrorTracker
{
    public function trackError(string $error): void
    {
        echo "Send error to Sentry\n";
    }
}

final class NewRelicErrorTracker implement ErrorTracker
{
    public function trackError(string $error): void
    {
        echo "Send error to NewRelic\n";
    }
}

final class DelegatingErrorTracker implements ErrorTracker
{
    public function __construct(
        #[TaggedIterator(ErrorTracker::class, exclude: self::class)]
        private iterable $trackers
    ) {}

    public function trackError(string $error): void
    {
        foreach($this->trackers as $tracker) {
            $tracker->trackError($error);
        }
    }
}

// Alias ErrorTracker interface to DelegatingErrorTracker service

final class MyController
{
    public function __construct(private ErrorTracker $errorTracker) {}
    public function __invoke()
    {
        $this->errorTracker->trackError('Hello, World!');
    }
}
```

Without this change, the `DelegatingErrorTracker` would receive itself in the tagged
iterator.