### PR TITLE
[Security] Add getting started example to README

### DIFF
--- a/src/Symfony/Component/Security/Core/README.md
+++ b/src/Symfony/Component/Security/Core/README.md
@@ -3,8 +3,40 @@ Security Component - Core
 
 Security provides an infrastructure for sophisticated authorization systems,
 which makes it possible to easily separate the actual authorization logic from
-so called user providers that hold the users credentials. It is inspired by
-the Java Spring framework.
+so called user providers that hold the users credentials.
+
+Getting Started
+---------------
+
+```
+$ composer require symfony/security-core
+```
+
+```php
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Core\Authorization\Voter\RoleVoter;
+use Symfony\Component\Security\Core\Authorization\Voter\RoleHierarchyVoter;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Role\RoleHierarchy;
+
+$accessDecisionManager = new AccessDecisionManager([
+    new AuthenticatedVoter(new AuthenticationTrustResolver()),
+    new RoleVoter(),
+    new RoleHierarchyVoter(new RoleHierarchy([
+        'ROLE_ADMIN' => ['ROLE_USER'],
+    ]))
+]);
+
+$user = new \App\Entity\User(...);
+$token = new UsernamePasswordToken($user, 'main', $user->getRoles());
+
+if (!$accessDecisionManager->decide($token, ['ROLE_ADMIN'])) {
+    throw new AccessDeniedException();
+}
+```
 
 Resources
 ---------

--- a/src/Symfony/Component/Security/Http/README.md
+++ b/src/Symfony/Component/Security/Http/README.md
@@ -1,10 +1,16 @@
 Security Component - HTTP Integration
 =====================================
 
-Security provides an infrastructure for sophisticated authorization systems,
-which makes it possible to easily separate the actual authorization logic from
-so called user providers that hold the users credentials. It is inspired by
-the Java Spring framework.
+The Security HTTP component provides an HTTP integration of the Security Core
+component. It allows securing (parts of) your application using firewalls and
+provides authenticators to authenticate visitors.
+
+Getting Started
+---------------
+
+```
+$ composer require symfony/security-http
+```
 
 Resources
 ---------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

We're about to remove the Security component docs from symfony.com. I tried creating a minimal example for Security HTTP - but that one is quite coupled with the HttpKernel component. So let's not document things there. If you're using it standalone, you're on your own (and already such an advanced user that you probably will be able to find out things on your own).

Targeting 5.3 to not have to document the deprecated APIs. This is also in sync with the doc removal (we'll keep documenting the legacy stuff in <5.3)