### PR TITLE
Update security.lb.xlf file metadata

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.lb.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.lb.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" target-language="lb" datatype="plaintext" original="security.en.xlf">
+    <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no (more metadata)
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix spotted while working on https://github.com/symfony/demo/pull/1298#issuecomment-1000419645
| License       | MIT

It seems that this translation file is the only one using this metadata