### PR TITLE
[DependencyInjection] Add Parameter attribute to bind container parameters to services.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Parameter.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Parameter.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class Parameter
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\Parameter;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
 use Symfony\Component\DependencyInjection\Attribute\Target;
@@ -254,6 +255,12 @@ class AutowirePass extends AbstractRecursivePass
                     if (TaggedLocator::class === $attribute->getName()) {
                         $attribute = $attribute->newInstance();
                         $arguments[$index] = new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, true, $attribute->defaultPriorityMethod));
+                        break;
+                    }
+
+                    if (Parameter::class === $attribute->getName()) {
+                        $attribute = $attribute->newInstance();
+                        $arguments[$index] = $this->container->getParameter($attribute->name);
                         break;
                     }
                 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -38,6 +38,27 @@ require_once __DIR__.'/../Fixtures/includes/autowiring_classes.php';
  */
 class AutowirePassTest extends TestCase
 {
+    /**
+     * @requires PHP 8.0
+     */
+    public function testParameterBindingsSuccess()
+    {
+        $container = new ContainerBuilder();
+
+        $testDefinition = $container->register(AutowiredParameterTest::class);
+        $testDefinition->setAutowired(true);
+
+        $container->setParameter('parameter.test', 'hello world');
+
+        (new ResolveClassPass())->process($container);
+        (new AutowirePass())->process($container);
+        $definition = $container->getDefinition(AutowiredParameterTest::class);
+
+        $this->assertCount(1, $definition->getArguments());
+        $this->assertEquals('hello world', $definition->getArgument(0));
+        $this->assertEquals('hello world', $container->get(AutowiredParameterTest::class)->testParam);
+    }
+
     public function testProcess()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
+use Symfony\Component\DependencyInjection\Attribute\Parameter;
 use Symfony\Contracts\Service\Attribute\Required;
 
 class AutowireSetter
@@ -25,4 +26,11 @@ class AutowireProperty
 {
     #[Required]
     public Foo $foo;
+}
+
+class AutowiredParameterTest
+{
+    public function __construct(#[Parameter("parameter.test")] public string $testParam)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | not yet created. Will update if PR looks to be merged <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Hi all.

This PR proposes the addition of a new Attribute to bind container parameters to services.

**Motivation**:
Seeing as Symfony has been adopting the usage of attributes to configure services, this would add the possibility to bind parameters and have services be self-contained instead of having their configuration split into multiple files.

In the application we develop most services which require parameters have their values declared in a Yaml file via the following syntax.

```
Acme\Service\DummyService:
    arguments:
        $isDebugEnv: "%kernel.debug%"
```

Downsides

* Configuration remains in a separate file which also grows in size with the number of services. 
* Duplication of class,namespace and arguments
* Error-prone refactoring: namespace, class name, arguments in the yaml file are not updated by any IDE or plugin when they change.

Recently I also became aware of the `#[Autoconfigure(bind:['$isDebugEnv' => '%kernel.debug%'])]` syntax. This addresses the separation of the declaration into multiple files and follows the class when moved around. If this PR won't pass then this would be our preferred method once the application I help develop is upgraded to PHP 8.

* The argument name is passed as a string to `bind` and is also not refactored and is also duplicated.
* Can only be applied to a class rather than the constructor, having argument names and the constructor be visually "far" from each-other.

**Proposal**:

The `Parameter` (or `BindParameter`, name tbd) attribute which is applied to parameters and properties (to account for promoted properties) and has the parameter name bound via a compiler pass. Currently only parameters are supported so the following is not a valid syntax `#[Parameter("%kernel.logs_dir%/subdir")]` (also tbd).

This would address the concerns from both previous approaches and in my opinion has a main advantage: It does not rely on strings for the argument name. The php community has been moving away for quite some time now from hard-coded strings to reference things. Classes now have the `::class` syntax, and references to functions, properties and methods went from strings and arrays to having first-class support with the new `(...)` syntax.

The downside of this new attribute would be that it is yet another way to do something that is already possible. On the other hand, Symfony has always had multiple options to do configuration (annotations and now attributes, yaml, xml, php).

**Example**:

```php
class DummyService
{
    public function __construct(#[Parameter("kernel.debug")] public bool $isDebugEnv)
    {
    }
}
```


Looking forward to your thoughts. Related issue: #40327