### PR TITLE
Allow package-versions-deprecated plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -152,6 +152,11 @@
         "ocramius/proxy-manager": "<2.1",
         "phpunit/phpunit": "<5.4.3"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
+    },
     "autoload": {
         "psr-4": {
             "Symfony\\Bridge\\Doctrine\\": "src/Symfony/Bridge/Doctrine/",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Since composer 2.2, plugins explicitly need to be enabled. Otherwise, Composer keeps asking about them.

This change should make contributing to Symfony a little less annoying.