### PR TITLE
[HttpFoundation] Add method `getString` to `ParameterBag`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add method `convertString` to `ParameterBag`
+ * Rename method `getInt` to `convertInt` in `ParameterBag`
+
 6.1
 ---
 

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -127,10 +127,32 @@ class ParameterBag implements \IteratorAggregate, \Countable
 
     /**
      * Returns the parameter value converted to integer.
+     *
+     * @deprecated since Symfony 6.2
      */
     public function getInt(string $key, int $default = 0): int
     {
+        trigger_deprecation('symfony/http-foundation', '6.2', 'Method "getInt" is deprecated because renamed to "convertInt".');
+
         return (int) $this->get($key, $default);
+    }
+
+    /**
+     * Returns the parameter value converted to integer.
+     */
+    public function convertInt(string $key, int $default = 0): int
+    {
+        return $this->filter($key, $default, \FILTER_VALIDATE_INT, ['default' => $default, 'flags' => \FILTER_VALIDATE_INT]);
+    }
+
+    /**
+     * Returns the parameter value converted to string.
+     */
+    public function convertString(string $key, string $default = ''): string
+    {
+        $output = $this->get($key, $default);
+
+        return \is_array($output) ? $default : (string) $output;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -133,12 +133,35 @@ class ParameterBagTest extends TestCase
         $this->assertEquals('', $bag->getDigits('unknown'), '->getDigits() returns empty string if a parameter is not defined');
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetInt()
     {
         $bag = new ParameterBag(['digits' => '0123']);
 
         $this->assertEquals(123, $bag->getInt('digits'), '->getInt() gets a value of parameter as integer');
         $this->assertEquals(0, $bag->getInt('unknown'), '->getInt() returns zero if a parameter is not defined');
+    }
+
+    public function testConvertInt()
+    {
+        $bag = new ParameterBag(['first' => '123', 'second' => 1.2, 'third' => [123, '0123']]);
+
+        $this->assertEquals(123, $bag->convertInt('first'), '->convertInt() gets a value of parameter as integer');
+        $this->assertEquals(0, $bag->convertInt('second'), '->convertInt() gets a value of parameter as integer');
+        $this->assertEquals(0, $bag->convertInt('third'), '->convertInt() gets a value of parameter as integer');
+        $this->assertEquals(0, $bag->convertInt('unknown'), '->convertInt() returns zero if a parameter is not defined');
+    }
+
+    public function testConvertString()
+    {
+        $bag = new ParameterBag(['first' => 'shtikov', 'second' => 123, 'third' => [123, '0123']]);
+
+        $this->assertSame('shtikov', $bag->convertString('first'), '->convertString() gets a value of parameter as string');
+        $this->assertSame('123', $bag->convertString('second'), '->convertString() gets a value of parameter as string');
+        $this->assertSame('', $bag->convertString('third'), '->convertString() gets a value of parameter as string');
+        $this->assertSame('', $bag->convertString('unknown'), '->convertString() returns empty string if a parameter is not defined');
     }
 
     public function testFilter()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Added method `getString` to `ParameterBag` for use strict type. We really need this method to make it easier to work with strong typing, because the `get` method returns several data types, and we need a specific one.