### PR TITLE
[HttpFoundation] Allow Request#request to be ParameterBag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -91,7 +91,7 @@ class Request
     /**
      * Request body parameters ($_POST).
      *
-     * @var InputBag
+     * @var InputBag|ParameterBag
      */
     public $request;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The InputBag story starts to walk circles, but I hope this is the last PR in the story.

1. It's very common in Symfony applications to put the decoded JSON request body in `$request->request`. #34363 broke this use-case
2. In https://github.com/symfony/symfony/issues/37100#issuecomment-640744573, it was decided that `$request->request` can be allowed to be `InputBag|ParameterBag` (by only using `InputBag` for form requests). Introduced by https://github.com/symfony/symfony/pull/37265
3. Later, this was reverted by https://github.com/symfony/symfony/pull/40315 as another fix for `InputBag` was merged. While this fixes `null` and other scalar types, it doesn't fix the array type (which is perfectly fine if you're doing `$request->request = new ParameterBag(json_decode(...));`)

I think, to support putting JSON decode in `$request->request`, we must make it a union of `ParameterBag|InputBag`.

_I'm not sure about the branch to target branch, feel free to change_