### PR TITLE
[Messenger] Store millisecond timestamps as float instead of int to prevent int overflow issues on 32 bit based systems

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -248,7 +248,7 @@ class Connection
         }
     }
 
-    public function add(string $body, array $headers, int $delayInMs = 0): void
+    public function add(string $body, array $headers, float $delayInMs = 0): void
     {
         if ($this->autoSetup) {
             $this->setup();
@@ -267,7 +267,7 @@ class Connection
                     throw new TransportException(json_last_error_msg());
                 }
 
-                $score = $this->getCurrentTimeInMilliseconds() + $delayInMs;
+                $score = $this->getCurrentTimeInMilliseconds() + (float) $delayInMs;
                 $added = $this->connection->zadd($this->queue, ['NX'], $score, $message);
             } else {
                 $message = json_encode([
@@ -316,9 +316,9 @@ class Connection
         $this->autoSetup = false;
     }
 
-    private function getCurrentTimeInMilliseconds(): int
+    private function getCurrentTimeInMilliseconds(): float
     {
-        return (int) (microtime(true) * 1000);
+        return microtime(true) * (float) 1000;
     }
 
     public function cleanup(): void

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/RedisSender.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/RedisSender.php
@@ -42,7 +42,7 @@ class RedisSender implements SenderInterface
         $delayStamp = $envelope->last(DelayStamp::class);
         $delayInMs = null !== $delayStamp ? $delayStamp->getDelay() : 0;
 
-        $this->connection->add($encodedMessage['body'], $encodedMessage['headers'] ?? [], $delayInMs);
+        $this->connection->add($encodedMessage['body'], $encodedMessage['headers'] ?? [], (float) $delayInMs);
 
         return $envelope;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43860
| License       | MIT
| Doc PR        | n/a

The Redis transport use a score variabel to calculate when a message can be handeld after an failure (retry delay).
This is based on a timestamp in milliseconds and saved in PHP as an integer. On 32 bit based systems (Raspberry Pi for example) an integer overflow will happen, due to this overflow the score calculation is faulty and the message will 'never' be retried.
Redis internaly use [double floats](https://redis.io/commands/zadd#range-of-integer-scores-that-can-be-expressed-precisely) so we can use floats to in PHP.

Demo application can be found here https://github.com/maartendekeizer/symfony-issue-43860
