### PR TITLE
[Mailer] Change Gmail & Sendgrid to use custom ports

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
@@ -42,17 +42,17 @@ class GmailTransportFactoryTest extends TransportFactoryTestCase
     {
         yield [
             new Dsn('gmail', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, $this->getDispatcher(), $this->getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, $this->getDispatcher(), $this->getLogger()),
         ];
 
         yield [
             new Dsn('gmail+smtp', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, $this->getDispatcher(), $this->getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, $this->getDispatcher(), $this->getLogger()),
         ];
 
         yield [
             new Dsn('gmail+smtps', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, $this->getDispatcher(), $this->getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, $this->getDispatcher(), $this->getLogger()),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
@@ -42,17 +42,17 @@ class GmailTransportFactoryTest extends TransportFactoryTestCase
     {
         yield [
             new Dsn('gmail', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, true, $this->getDispatcher(), $this->getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, null, true, $this->getDispatcher(), $this->getLogger()),
         ];
 
         yield [
             new Dsn('gmail+smtp', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, true, $this->getDispatcher(), $this->getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, null, true, $this->getDispatcher(), $this->getLogger()),
         ];
 
         yield [
             new Dsn('gmail+smtps', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, true, $this->getDispatcher(), $this->getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, null, true, $this->getDispatcher(), $this->getLogger()),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
@@ -42,17 +42,17 @@ class GmailTransportFactoryTest extends TransportFactoryTestCase
     {
         yield [
             new Dsn('gmail', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, $this->getDispatcher(), $this->getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, true, $this->getDispatcher(), $this->getLogger()),
         ];
 
         yield [
             new Dsn('gmail+smtp', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, $this->getDispatcher(), $this->getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, true, $this->getDispatcher(), $this->getLogger()),
         ];
 
         yield [
             new Dsn('gmail+smtps', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, $this->getDispatcher(), $this->getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, 465, true, $this->getDispatcher(), $this->getLogger()),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
@@ -20,9 +20,9 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class GmailSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $username, string $password, int $port, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, string $password, int $port, bool $tls, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.gmail.com', $port, true, $dispatcher, $logger);
+        parent::__construct('smtp.gmail.com', $port, $tls, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
@@ -20,9 +20,9 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class GmailSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, string $password, int $port, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.gmail.com', 465, true, $dispatcher, $logger);
+        parent::__construct('smtp.gmail.com', $port, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
@@ -20,7 +20,7 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class GmailSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $username, string $password, ?int $port = null, ?bool $tls = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, string $password, int $port = 465, bool $tls = true, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('smtp.gmail.com', $port, $tls, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
@@ -20,7 +20,7 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class GmailSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $username, string $password, int $port, bool $tls, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, string $password, ?int $port = null, ?bool $tls = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('smtp.gmail.com', $port, $tls, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailTransportFactory.php
@@ -23,8 +23,11 @@ final class GmailTransportFactory extends AbstractTransportFactory
 {
     public function create(Dsn $dsn): TransportInterface
     {
+        $port = $dsn->getPort(465);
+        $secure = $dsn->getOption('verify_peer', true);
+
         if (\in_array($dsn->getScheme(), $this->getSupportedSchemes())) {
-            return new GmailSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $dsn->getPort(465), $this->dispatcher, $this->logger);
+            return new GmailSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $port, $secure, $this->dispatcher, $this->logger);
         }
 
         throw new UnsupportedSchemeException($dsn, 'gmail', $this->getSupportedSchemes());

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailTransportFactory.php
@@ -24,7 +24,7 @@ final class GmailTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         if (\in_array($dsn->getScheme(), $this->getSupportedSchemes())) {
-            return new GmailSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $this->dispatcher, $this->logger);
+            return new GmailSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $dsn->getPort(465), $this->dispatcher, $this->logger);
         }
 
         throw new UnsupportedSchemeException($dsn, 'gmail', $this->getSupportedSchemes());

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
@@ -70,17 +70,17 @@ class SendgridTransportFactoryTest extends TransportFactoryTestCase
 
         yield [
             new Dsn('sendgrid', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, 465, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('sendgrid+smtp', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, 465, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('sendgrid+smtps', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, 465, $dispatcher, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
@@ -70,17 +70,17 @@ class SendgridTransportFactoryTest extends TransportFactoryTestCase
 
         yield [
             new Dsn('sendgrid', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, 465, true, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, null, true, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('sendgrid+smtp', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, 465, true, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, null, true, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('sendgrid+smtps', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, 465, true, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, null, true, $dispatcher, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
@@ -70,17 +70,17 @@ class SendgridTransportFactoryTest extends TransportFactoryTestCase
 
         yield [
             new Dsn('sendgrid', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, 465, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, 465, true, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('sendgrid+smtp', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, 465, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, 465, true, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('sendgrid+smtps', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, 465, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, 465, true, $dispatcher, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -20,7 +20,7 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class SendgridSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $key, ?int $port = null, ?bool $tls = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $key, int $port = 465, bool $tls = true, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('smtp.sendgrid.net', $port, $tls, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -20,7 +20,7 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class SendgridSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $key, int $port, bool $tls, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $key, ?int $port = null, ?bool $tls = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('smtp.sendgrid.net', $port, $tls, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -20,9 +20,9 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class SendgridSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $key, int $port, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $key, int $port, bool $tls, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.sendgrid.net', $port, true, $dispatcher, $logger);
+        parent::__construct('smtp.sendgrid.net', $port, $tls, $dispatcher, $logger);
 
         $this->setUsername('apikey');
         $this->setPassword($key);

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -20,9 +20,9 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class SendgridSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $key, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $key, int $port, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.sendgrid.net', 465, true, $dispatcher, $logger);
+        parent::__construct('smtp.sendgrid.net', $port, true, $dispatcher, $logger);
 
         $this->setUsername('apikey');
         $this->setPassword($key);

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridTransportFactory.php
@@ -25,7 +25,8 @@ final class SendgridTransportFactory extends AbstractTransportFactory
     {
         $scheme = $dsn->getScheme();
         $key = $this->getUser($dsn);
-        $port = $dsn->getPort();
+        $port = $dsn->getPort(465);
+        $tls = (bool) $dsn->getOption('verify_peer', true);
 
         if ('sendgrid+api' === $scheme) {
             $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
@@ -34,7 +35,7 @@ final class SendgridTransportFactory extends AbstractTransportFactory
         }
 
         if ('sendgrid+smtp' === $scheme || 'sendgrid+smtps' === $scheme || 'sendgrid' === $scheme) {
-            return new SendgridSmtpTransport($key, $port, $this->dispatcher, $this->logger);
+            return new SendgridSmtpTransport($key, $port, $tls, $this->dispatcher, $this->logger);
         }
 
         throw new UnsupportedSchemeException($dsn, 'sendgrid', $this->getSupportedSchemes());

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridTransportFactory.php
@@ -25,16 +25,16 @@ final class SendgridTransportFactory extends AbstractTransportFactory
     {
         $scheme = $dsn->getScheme();
         $key = $this->getUser($dsn);
+        $port = $dsn->getPort();
 
         if ('sendgrid+api' === $scheme) {
             $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
-            $port = $dsn->getPort();
 
             return (new SendgridApiTransport($key, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
         }
 
         if ('sendgrid+smtp' === $scheme || 'sendgrid+smtps' === $scheme || 'sendgrid' === $scheme) {
-            return new SendgridSmtpTransport($key, $this->dispatcher, $this->logger);
+            return new SendgridSmtpTransport($key, $port, $this->dispatcher, $this->logger);
         }
 
         throw new UnsupportedSchemeException($dsn, 'sendgrid', $this->getSupportedSchemes());


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36224
| License       | MIT
| Doc PR        | None

No custom port was taken from the DSN when sending via smtp. I have adjusted gmail & sendgrid accordingly so that  custom ports from the DSN are also used.