### PR TITLE
Document session issue when upgrading from Symfony 4.x

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -424,7 +424,8 @@ Security
    ```
  * The `LdapUserProvider` class has been removed, use `Symfony\Component\Ldap\Security\LdapUserProvider` instead.
  * Implementations of `PasswordEncoderInterface` and `UserPasswordEncoderInterface` must have a new `needsRehash()` method
- * The `Role` and `SwitchUserRole` classes have been removed.
+ * The `Role` and `SwitchUserRole` classes have been removed. This change will terminate all active sessions when upgrading from Symfony 4.x.
+   To avoid this issue, require the `ajgl/sf4-to-sf5-role-unserialization` component in you composer.json.
  * The `getReachableRoles()` method of the `RoleHierarchy` class has been removed. It has been replaced by the new
    `getReachableRoleNames()` method.
  * The `getRoles()` method has been removed from the `TokenInterface`. It has been replaced by the new


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Document #44676
| License       | MIT

Document the workaround to avoid issue #44676: Upgrading from Symfony 4.x to Symfony 5.x logouts all users 