### PR TITLE
Fix param annotation in HttpKernelBrowser

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
@@ -192,7 +192,7 @@ EOF;
     /**
      * {@inheritdoc}
      *
-     * @param Request $request
+     * @param Response $response
      *
      * @return DomResponse A DomResponse instance
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | 

The deprecation
```
2021-12-27T08:36:11+00:00 [info] User Deprecated: The "Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser::filterResponse()" method will require a new "Request $request" argument in the next major version of its parent class "Symfony\Component\HttpKernel\HttpKernelBrowser", not defining it is deprecated.
```
Makes no sense. I guess the param typehint should not be there