### PR TITLE
[Security] fix unserializing session payloads from v4

### DIFF
--- a/src/Symfony/Component/Security/Core/Role/Role.php
+++ b/src/Symfony/Component/Security/Core/Role/Role.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Role;
+
+/**
+ * Allows migrating session payloads from v4.
+ *
+ * @internal
+ */
+class Role
+{
+    private $role;
+
+    private function __construct()
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->role;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Role/SwitchUserRole.php
+++ b/src/Symfony/Component/Security/Core/Role/SwitchUserRole.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Role;
+
+/**
+ * Allows migrating session payloads from v4.
+ *
+ * @internal
+ */
+class SwitchUserRole extends Role
+{
+    private $deprecationTriggered;
+    private $source;
+}

--- a/src/Symfony/Component/Security/Core/Tests/Role/LegacyRoleTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/LegacyRoleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Role;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class LegacyRoleTest extends TestCase
+{
+    public function testPayloadFromV4CanBeUnserialized()
+    {
+        $serialized = 'C:74:"Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken":236:{a:3:{i:0;N;i:1;s:4:"main";i:2;a:5:{i:0;s:2:"sf";i:1;b:1;i:2;a:1:{i:0;O:41:"Symfony\Component\Security\Core\Role\Role":1:{s:47:"Symfony\Component\Security\Core\Role\Role'."\0".'role'."\0".'";s:9:"ROLE_USER";}}i:3;a:0:{}i:4;a:1:{i:0;s:9:"ROLE_USER";}}}}';
+
+        $token = unserialize($serialized);
+
+        $this->assertInstanceOf(UsernamePasswordToken::class, $token);
+        $this->assertSame(['ROLE_USER'], $token->getRoleNames());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44676
| License       | MIT
| Doc PR        | -

Replaces #44801

I propose to reintroduce these classes to ease transitioning to v5, ~then removing them in v6.~