### PR TITLE
[Messenger] fix Redis support on 32b arch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,8 @@ install:
     - cd ext
     - appveyor DownloadFile https://github.com/symfony/binary-utils/releases/download/v0.1/php_apcu-5.1.18-7.1-ts-vc14-x86.zip
     - 7z x php_apcu-5.1.18-7.1-ts-vc14-x86.zip -y >nul
+    - appveyor DownloadFile https://github.com/symfony/binary-utils/releases/download/v0.1/php_redis-5.1.1-7.1-ts-vc14-x86.zip
+    - 7z x php_redis-5.1.1-7.1-ts-vc14-x86.zip -y >nul
     - cd ..
     - copy /Y php.ini-development php.ini-min
     - echo memory_limit=-1 >> php.ini-min
@@ -36,6 +38,7 @@ install:
     - echo opcache.enable_cli=1 >> php.ini-max
     - echo extension=php_openssl.dll >> php.ini-max
     - echo extension=php_apcu.dll >> php.ini-max
+    - echo extension=php_redis.dll >> php.ini-max
     - echo apc.enable_cli=1 >> php.ini-max
     - echo extension=php_intl.dll >> php.ini-max
     - echo extension=php_mbstring.dll >> php.ini-max
@@ -54,6 +57,7 @@ install:
     - SET COMPOSER_ROOT_VERSION=%SYMFONY_VERSION%.x-dev
     - php composer.phar update --no-progress --ansi
     - php phpunit install
+    - choco install memurai-developer
 
 test_script:
     - SET X=0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -99,15 +99,11 @@ jobs:
       - name: Run tests
         run: ./phpunit --group integration -v
         env:
-          REDIS_HOST: localhost
           REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
           REDIS_SENTINEL_HOSTS: 'localhost:26379'
           REDIS_SENTINEL_SERVICE: redis_sentinel
           MESSENGER_REDIS_DSN: redis://127.0.0.1:7006/messages
           MESSENGER_AMQP_DSN: amqp://localhost/%2f/messages
-          MEMCACHED_HOST: localhost
-          LDAP_HOST: localhost
-          LDAP_PORT: 3389
 
       #- name: Run HTTP push tests
       #  if: matrix.php == '8.0'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
         <env name="LDAP_HOST" value="localhost" />
         <env name="LDAP_PORT" value="3389" />
         <env name="REDIS_HOST" value="localhost" />
+        <env name="MESSENGER_REDIS_DSN" value="redis://localhost/messages" />
         <env name="MEMCACHED_HOST" value="localhost" />
         <env name="MONGODB_HOST" value="localhost" />
         <env name="ZOOKEEPER_HOST" value="localhost" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43860
| License       | MIT
| Doc PR        | -

It took me a while to fix it, but PR is now ready. We have to use `rawCommand()` to work around phpredis casting scores to floats and ignoring any overflow/loss of precision in the process. Passing the score as a string is required here (note that Redis always stores numbers as 64b floats, even when running on x86)