### PR TITLE
[HtmlSanitizer] Some minor changes in the config API

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
@@ -105,7 +105,7 @@ class HtmlSanitizerConfig
      * All scripts will be removed but the output may still contain other dangerous
      * behaviors like CSS injection (click-jacking), CSS expressions, ...
      */
-    public function allowAllStaticElements(): static
+    public function allowStaticElements(): static
     {
         $elements = array_merge(
             array_keys(W3CReference::HEAD_ELEMENTS),

--- a/src/Symfony/Component/HtmlSanitizer/README.md
+++ b/src/Symfony/Component/HtmlSanitizer/README.md
@@ -22,7 +22,7 @@ $config = (new HtmlSanitizerConfig())
     // standard. All scripts will be removed but the output may still contain
     // other dangerous behaviors like CSS injection (click-jacking), CSS
     // expressions, ...
-    ->allowAllStaticElements()
+    ->allowStaticElements()
 
     // Allow the "div" element and no attribute can be on it
     ->allowElement('div')

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -21,7 +21,7 @@ class HtmlSanitizerAllTest extends TestCase
     {
         return new HtmlSanitizer(
             (new HtmlSanitizerConfig())
-                ->allowAllStaticElements()
+                ->allowStaticElements()
                 ->allowLinkHosts(['trusted.com', 'external.com'])
                 ->allowMediaHosts(['trusted.com', 'external.com'])
                 ->allowRelativeLinks()

--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/StringSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/StringSanitizer.php
@@ -26,7 +26,7 @@ final class StringSanitizer
             // "&#34;" is shorter than "&quot;"
             '&quot;',
 
-            // Fix several potential issues in how browsers intepret attributes values
+            // Fix several potential issues in how browsers interpret attributes values
             '+',
             '=',
             '@',

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
@@ -47,7 +47,7 @@ final class DomVisitor
     private array $elementsConfig;
 
     /**
-     * Registry of attributes to forcefuly set on nodes, index by element and attribute.
+     * Registry of attributes to forcefully set on nodes, index by element and attribute.
      *
      * @var array<string, array<string, string>>
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

First of all, thanks to @tgalopin for this superb contribution 🙇 

This PR makes 3 little changes:

(1) Fix two minor typos

(2) Rename `allowAllStaticElements()` as `allowStaticElements()` to be consistent with the rest of methods, which don't include the `All` word.

(3) A proposal to change this default value:

```diff
-public function allowElement(string $element, array|string $allowedAttributes = []): static
+public function allowElement(string $element, array|string $allowedAttributes = '*'): static
```

In my opinion, when you want to allow some element, most of the times you want to allow the standard attributes on them too. So, the following should allow `<div>` and their standard attributes:

```php
->allowElement('div')
```

Forcing to write it as `->allowElement('div', '*')` seems cumbersome. The previous behavior (forbid all attributes) would now be like this:

```php
->allowElement('div', [])
```

