### PR TITLE
[Translation] [LocoProvider] Use rawurlencode and separate tag setting

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -140,7 +140,7 @@ final class LocoProvider implements ProviderInterface
 
         foreach (array_keys($catalogue->all()) as $domain) {
             foreach ($this->getAssetsIds($domain) as $id) {
-                $responses[$id] = $this->client->request('DELETE', sprintf('assets/%s.json', $id));
+                $responses[$id] = $this->client->request('DELETE', sprintf('assets/%s.json', rawurlencode($id)));
             }
         }
 
@@ -202,7 +202,7 @@ final class LocoProvider implements ProviderInterface
         $responses = [];
 
         foreach ($translations as $id => $message) {
-            $responses[$id] = $this->client->request('POST', sprintf('translations/%s/%s', $id, $locale), [
+            $responses[$id] = $this->client->request('POST', sprintf('translations/%s/%s', rawurlencode($id), rawurlencode($locale)), [
                 'body' => $message,
             ]);
         }
@@ -220,12 +220,34 @@ final class LocoProvider implements ProviderInterface
             $this->createTag($tag);
         }
 
-        $response = $this->client->request('POST', sprintf('tags/%s.json', $tag), [
-            'body' => implode(',', $ids),
+        // Separate ids with and without comma.
+        $idsWithComma = $idsWithoutComma = [];
+        foreach ($ids as $id) {
+            if (false !== strpos($id, ',')) {
+                $idsWithComma[] = $id;
+            } else {
+                $idsWithoutComma[] = $id;
+            }
+        }
+
+        // Set tags for all ids without comma.
+        $response = $this->client->request('POST', sprintf('tags/%s.json', rawurlencode($tag)), [
+            'body' => implode(',', $idsWithoutComma),
         ]);
 
         if (200 !== $response->getStatusCode()) {
             $this->logger->error(sprintf('Unable to tag assets with "%s" on Loco: "%s".', $tag, $response->getContent(false)));
+        }
+
+        // Set tags for each id with comma one by one.
+        foreach ($idsWithComma as $id) {
+            $response = $this->client->request('POST', sprintf('assets/%s/tags', rawurlencode($id)), [
+                'body' => ['name' => $tag],
+            ]);
+
+            if (200 !== $response->getStatusCode()) {
+                $this->logger->error(sprintf('Unable to tag asset "%s" with "%s" on Loco: "%s".', $id, $tag, $response->getContent(false)));
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

According to [Loco documentation](https://localise.biz/api/docs/tags/tagassets#postdata) when setting tag to multiple assets, the ids must be comma separated. Because local translation ids can contain comma, I handle separately those ids and add tag one by one.

I also added `rawurlencode` for every request made to Loco. It was already used once inside the `read` method, but I added it everywhere.
