### PR TITLE
[HttpKernel] Do not attempt to register enum arguments in controller service locator

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -127,6 +127,11 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                     $type = ltrim($target = (string) ProxyHelper::getTypeHint($r, $p), '\\');
                     $invalidBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
 
+                    if (is_subclass_of($type, \UnitEnum::class, true)) {
+                        // do not attempt to register enum typed arguments
+                        continue;
+                    }
+
                     if (isset($arguments[$r->name][$p->name])) {
                         $target = $arguments[$r->name][$p->name];
                         if ('?' !== $target[0]) {

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Component\HttpKernel\DependencyInjection\RegisterControllerArgumentLocatorsPass;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Suit;
 
 class RegisterControllerArgumentLocatorsPassTest extends TestCase
 {
@@ -369,6 +370,25 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $this->assertInstanceOf(Reference::class, $locatorArgument);
     }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testEnumArgumentIsIgnored()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service')->addArgument([]);
+
+        $container->register('foo', NonNullableEnumArgumentWithDefaultController::class)
+            ->addTag('controller.service_arguments')
+        ;
+
+        $pass = new RegisterControllerArgumentLocatorsPass();
+        $pass->process($container);
+
+        $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
+        $this->assertEmpty(array_keys($locator), 'enum typed argument is ignored');
+    }
 }
 
 class RegisterTestController
@@ -427,6 +447,13 @@ class NonExistentClassOptionalController
 class ArgumentWithoutTypeController
 {
     public function fooAction(string $someArg)
+    {
+    }
+}
+
+class NonNullableEnumArgumentWithDefaultController
+{
+    public function fooAction(Suit $suit = Suit::Spades)
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Suit.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Suit.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

Given:

```php
namespace App\Model;

enum Suit: string 
{
    case Hearts = 'H';
    case Diamonds = 'D';
    case Clubs = 'C';
    case Spades = 'S';
}
```

and the controller:

```php
class FooController extends AbstractController
{
    #[Route('/foo')]
    public function foo(Suit $suit = Suit::Hearts): Response
    {
        dd($suit);
    }
}
```

you get:

```php
Cannot autowire argument $suit of "App\Controller\FooController::foo()": it references class "App\Model\Suit" but no such service exists.
in vendor/symfony/dependency-injection/Container.php (line 416)
in vendor/symfony/dependency-injection/Argument/ServiceLocator.php -> getService (line 42)
in vendor/symfony/http-kernel/Controller/ArgumentResolver/ServiceValueResolver.php -> get (line 84)
```

which would be annoying in case you have a resolver registered to resolve this argument, but won't support this specific request, hence expect to let the `DefaultValueResolver` use the default value (or another resolver to try).
Currently, the `DefaultValueResolver` wouldn't be reached since the `ServiceValueResolver` would throw the above exception.