### PR TITLE
[Lock] Release DoctrineDbalPostgreSqlStore connection lock on failure

### DIFF
--- a/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
@@ -62,18 +62,28 @@ class DoctrineDbalPostgreSqlStore implements BlockingSharedLockStoreInterface, B
         // prevent concurrency within the same connection
         $this->getInternalStore()->save($key);
 
-        $sql = 'SELECT pg_try_advisory_lock(:key)';
-        $result = $this->conn->executeQuery($sql, [
-            'key' => $this->getHashedKey($key),
-        ]);
+        $lockAcquired = false;
 
-        // Check if lock is acquired
-        if (true === $result->fetchOne()) {
-            $key->markUnserializable();
-            // release sharedLock in case of promotion
-            $this->unlockShared($key);
+        try {
+            $sql = 'SELECT pg_try_advisory_lock(:key)';
+            $result = $this->conn->executeQuery($sql, [
+                'key' => $this->getHashedKey($key),
+            ]);
 
-            return;
+            // Check if lock is acquired
+            if (true === $result->fetchOne()) {
+                $key->markUnserializable();
+                // release sharedLock in case of promotion
+                $this->unlockShared($key);
+
+                $lockAcquired = true;
+
+                return;
+            }
+        } finally {
+            if (!$lockAcquired) {
+                $this->getInternalStore()->delete($key);
+            }
         }
 
         throw new LockConflictedException();
@@ -84,18 +94,28 @@ class DoctrineDbalPostgreSqlStore implements BlockingSharedLockStoreInterface, B
         // prevent concurrency within the same connection
         $this->getInternalStore()->saveRead($key);
 
-        $sql = 'SELECT pg_try_advisory_lock_shared(:key)';
-        $result = $this->conn->executeQuery($sql, [
-            'key' => $this->getHashedKey($key),
-        ]);
+        $lockAcquired = false;
 
-        // Check if lock is acquired
-        if (true === $result->fetchOne()) {
-            $key->markUnserializable();
-            // release lock in case of demotion
-            $this->unlock($key);
+        try {
+            $sql = 'SELECT pg_try_advisory_lock_shared(:key)';
+            $result = $this->conn->executeQuery($sql, [
+                'key' => $this->getHashedKey($key),
+            ]);
 
-            return;
+            // Check if lock is acquired
+            if (true === $result->fetchOne()) {
+                $key->markUnserializable();
+                // release lock in case of demotion
+                $this->unlock($key);
+
+                $lockAcquired = true;
+
+                return;
+            }
+        } finally {
+            if (!$lockAcquired) {
+                $this->getInternalStore()->delete($key);
+            }
         }
 
         throw new LockConflictedException();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4<!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

When using PostgreSQL advisory locks using the `DoctrineDbalPostgreSqlStore`
A first lock is acquired in memory for same connection concurrencies, this `InMemoryStore` does not rely on TTL.

When the advisory lock fails to be acquired, this first lock is not released.
 
For long running processes, this cause the lock to not be acquirable again because the `InMemoryStore` will never release its lock.

related to : https://github.com/symfony/symfony/pull/44723#issuecomment-1001919621