### PR TITLE
[Filesystem] Added method `Filesystem::appendStreamToFile()`

### DIFF
--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * added method `Filesystem::appendStreamToFile()` to append contents from one file to another using stream_copy_to_stream()
+
 5.4
 ---
 

--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 6.1
 ---
 
- * added method `Filesystem::appendStreamToFile()` to append contents from one file to another using stream_copy_to_stream()
+ * Add method `Filesystem::appendStreamToFile()` to append contents from one file to another using stream_copy_to_stream()
 
 5.4
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | symfony/symfony-docs#16340

I am exporting millions of rows to multiple files, which have to be concatenated one-by-one. In order to reduce the memory footprint I have written a new method that uses stream_copy_to_stream() instead of fetching the contents and appending them using `Filesystem::appendToFile()`.