### PR TITLE
Suppress psalm error for UndefinedDocblockClass for PHP 8.1 classes

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -27,5 +27,13 @@
                 <referencedClass name="UnitEnum"/>
             </errorLevel>
         </UndefinedClass>
+        <UndefinedDocblockClass>
+            <errorLevel type="suppress">
+                <!-- These classes have been added in PHP 8.1 -->
+                <referencedClass name="BackedEnum"/>
+                <referencedClass name="ReflectionIntersectionType"/>
+                <referencedClass name="UnitEnum"/>
+            </errorLevel>
+        </UndefinedDocblockClass>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | https://github.com/symfony/symfony/pull/44831#discussion_r776204831 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

Same as https://github.com/symfony/symfony/pull/43050 for inlined docblock comments (mainly `class-string<FQCN>`)