### PR TITLE
[DependencyInjection][HttpKernel] Fix enum typed bindings

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -133,6 +133,11 @@ class ResolveBindingsPass extends AbstractRecursivePass
                 continue;
             }
 
+            if (is_subclass_of($m[1], \UnitEnum::class)) {
+                $bindingNames[substr($key, \strlen($m[0]))] = $binding;
+                continue;
+            }
+
             if (null !== $bindingValue && !$bindingValue instanceof Reference && !$bindingValue instanceof Definition && !$bindingValue instanceof TaggedIteratorArgument && !$bindingValue instanceof ServiceLocatorArgument) {
                 throw new InvalidArgumentException(sprintf('Invalid value for binding key "%s" for service "%s": expected "%s", "%s", "%s", "%s" or null, "%s" given.', $key, $this->currentId, Reference::class, Definition::class, TaggedIteratorArgument::class, ServiceLocatorArgument::class, \gettype($bindingValue)));
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -24,7 +24,9 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedEnumArgumentDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists;
 use Symfony\Component\DependencyInjection\TypedReference;
 
@@ -61,6 +63,27 @@ class ResolveBindingsPassTest extends TestCase
         ];
         $this->assertEquals($expected, $definition->getArguments());
         $this->assertEquals([['setSensitiveClass', [new Reference('foo')]]], $definition->getMethodCalls());
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testProcessEnum()
+    {
+        $container = new ContainerBuilder();
+
+        $bindings = [
+            FooUnitEnum::class.' $bar' => new BoundArgument(FooUnitEnum::BAR),
+        ];
+
+        $definition = $container->register(NamedEnumArgumentDummy::class, NamedEnumArgumentDummy::class);
+        $definition->setBindings($bindings);
+
+        $pass = new ResolveBindingsPass();
+        $pass->process($container);
+
+        $expected = [FooUnitEnum::BAR];
+        $this->assertEquals($expected, $definition->getArguments());
     }
 
     public function testUnusedBinding()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedEnumArgumentDummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedEnumArgumentDummy.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class NamedEnumArgumentDummy
+{
+    public function __construct(FooUnitEnum $bar)
+    {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -127,11 +127,6 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                     $type = ltrim($target = (string) ProxyHelper::getTypeHint($r, $p), '\\');
                     $invalidBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
 
-                    if (is_subclass_of($type, \UnitEnum::class)) {
-                        // do not attempt to register enum typed arguments
-                        continue;
-                    }
-
                     if (isset($arguments[$r->name][$p->name])) {
                         $target = $arguments[$r->name][$p->name];
                         if ('?' !== $target[0]) {
@@ -156,6 +151,9 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                             $args[$p->name] = $bindingValue;
                         }
 
+                        continue;
+                    } elseif (is_subclass_of($type, \UnitEnum::class)) {
+                        // do not attempt to register enum typed arguments if not already present in bindings
                         continue;
                     } elseif (!$type || !$autowire || '\\' !== $target[0]) {
                         continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Relates to https://github.com/symfony/symfony/issues/44834

While:

```yml
# services.yaml
services:
    _defaults:
        autowire: true     
        autoconfigure: true
        bind:
            $myParam: !php/const App\Status::Deleted
```

is working for me, the following isn't:

```diff
# services.yaml
services:
    _defaults:
        autowire: true     
        autoconfigure: true
        bind:
-            $myParam: !php/const App\Status::Deleted
+            App\Status $myParam: !php/const App\Status::Deleted
```

-> 

> Invalid value for binding key "App\Status $myParam" for service […]: expected "Symfony\Component\DependencyInjection\Reference", "Symfony\Component\DependencyInjection\Definition", "Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument", "Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument" or null, "App\Status" given.

This attempts to fix it by accounting for `\UnitEnum` in the `ResolveBindingPass`, 
as well as re-allowing enum types already present in bindings after #44826.