### PR TITLE
MailerInterface: failed exception contract when enabling messenger

### DIFF
--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -13,8 +13,10 @@ namespace Symfony\Component\Mailer;
 
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Messenger\SendEmailMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Mime\RawMessage;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -50,6 +52,15 @@ final class Mailer implements MailerInterface
             $this->dispatcher->dispatch($event);
         }
 
-        $this->bus->dispatch(new SendEmailMessage($message, $envelope));
+        try {
+            $this->bus->dispatch(new SendEmailMessage($message, $envelope));
+        } catch (HandlerFailedException $e) {
+            foreach ($e->getNestedExceptions() as $nested) {
+                if ($nested instanceof TransportExceptionInterface) {
+                    throw $nested;
+                }
+            }
+            throw $e;
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | likely not required...

The interface for MailerInterface::send states that exception for
transport failures are sent as TransportExceptionInterface, which
make perfectly sense and allows to create solid UI.

If at later stage the Messenger component is enabled, the mail will
be rewired into a dispatched message, which by default is synchronous.
This cause all exception to be wrapped into HandlerFailedException
which doesn't the interface contract.

In the end the UI is broken, and the exception HandlerFailedException,
even if caught, is totally unrelated to the usage context as it is only
related to configuration details.

This patch will unwrap the underlying MailTransportInterface exception
if available for the handler exception.

PS: don't know if make sense to add a phpunit test for this cross-component scenario, if so I'll try. Also, this will restore compatibility with interface, but I don't if it's to be considered a BC (strictly speaking, it may be)
