### PR TITLE
[Routing] Allow route paths and prefixes to be lists

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -187,6 +187,12 @@ abstract class AnnotationClassLoader implements LoaderInterface
                 foreach ($path as $locale => $localePath) {
                     $paths[$locale] = $prefix.$localePath;
                 }
+            } elseif (array_is_list($path) && array_is_list($prefix)) {
+                foreach ($prefix as $subPrefix) {
+                    foreach ($path as $subPath) {
+                        $paths[] = $subPrefix.$subPath;
+                    }
+                }
             } elseif ($missing = array_diff_key($prefix, $path)) {
                 throw new \LogicException(sprintf('Route to "%s" is missing paths for locale(s) "%s".', $class->name.'::'.$method->name, implode('", "', array_keys($missing))));
             } else {

--- a/src/Symfony/Component/Routing/Tests/Annotation/RouteAliasTest.php
+++ b/src/Symfony/Component/Routing/Tests/Annotation/RouteAliasTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Annotation;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\RouteAliasController;
+
+class RouteAliasTest extends TestCase
+{
+    public function testAlias(): void
+    {
+        $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
+        $collection = $loader->load(RouteAliasController::class);
+
+        $this->assertSame(
+            [
+                '/MainRoute1/SubPath',
+                '/MainRoute1/SubAlias',
+                '/RouteAlias1/SubPath',
+                '/RouteAlias1/SubAlias',
+            ],
+            array_map(
+                static fn (Route $route) => $route->getPath(),
+                array_values(iterator_to_array($collection)),
+            ),
+        );
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/RouteAliasController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/RouteAliasController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(['/MainRoute1', '/RouteAlias1'])]
+class RouteAliasController
+{
+    #[Route(['/SubPath', '/SubAlias'])]
+    public function withAlias()
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no (likely)
| New feature?  | yes (likely)
| Deprecations? | no
| Tickets       | Fix #44840
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Allow "intuitive" usage of `Route` to define multiple route paths where each has multiple possible prefixes:
```php
#[Route(['/attr1', '/attr2'])]
class AttributeController
{
    #[Route(['/route1', '/route2'])]
    public function ok(): Response
    {
        return new Response('OK');
    }
}
```