### PR TITLE
[Validator] throw when Constraint::_construct() has not been called

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -226,6 +226,10 @@ abstract class Constraint
      */
     public function addImplicitGroupName($group)
     {
+        if (null === $this->groups && \array_key_exists('groups', (array) $this)) {
+            throw new \LogicException(sprintf('"%s::$groups" is set to null. Did you forget to call "%s::__construct()"?', static::class, self::class));
+        }
+
         if (\in_array(self::DEFAULT_GROUP, $this->groups) && !\in_array($group, $this->groups)) {
             $this->groups[] = $group;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44846
| License       | MIT
| Doc PR        | -

Instead of #44847 