### PR TITLE
[Routing] Allow multiple prefixes on controller class

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Annotation/MultipleRoutesTest.php
+++ b/src/Symfony/Component/Routing/Tests/Annotation/MultipleRoutesTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Annotation;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\MultipleRoutesController;
+
+class MultipleRoutesTest extends TestCase
+{
+    public function testAlias(): void
+    {
+        $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
+        $collection = $loader->load(MultipleRoutesController::class);
+
+        $this->assertSame(
+            [
+                '/MainRoute2/SubPath',
+                '/RouteAlias2/SubPath',
+                '/MainRoute2/SubAlias',
+                '/RouteAlias2/SubAlias',
+            ],
+            array_map(
+                static fn (Route $route) => $route->getPath(),
+                array_values(iterator_to_array($collection)),
+            ),
+        );
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/MultipleRoutesController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/MultipleRoutesController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/MainRoute2')]
+#[Route('/RouteAlias2')]
+class MultipleRoutesController
+{
+    #[Route('/SubPath')]
+    #[Route('/SubAlias')]
+    public function withAlias()
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no (likely)
| New feature?  | yes (likely)
| Deprecations? | no
| Tickets       | Fix #44840
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Allow repetition of `Route` at class level to define multiple route paths where each has multiple possible prefixes:
```php
#[Route('/attr1')]
#[Route('/attr2')]
class AttributeController
{
    #[Route('/route1')]
    #[Route('/route2')]
    public function ok(): Response
    {
        return new Response('OK');
    }
}
```

It sounds to me, `Route` should be repeatable for class as it is for methods and as the `\Attribute::IS_REPEATABLE` suggests.