### PR TITLE
[Translation] [LocoProvider] Fix use of asset ids

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -79,9 +79,14 @@ final class LocoProvider implements ProviderInterface
                     $keysIdsMap[$this->retrieveKeyFromId($id, $domain)] = $id;
                 }
 
-                $ids = array_intersect_key($keysIdsMap, $messages);
+                $assets = [];
+                foreach ($keysIdsMap as $key => $id) {
+                    if (isset($messages[$key])) {
+                        $assets[$id] = $messages[$key];
+                    }
+                }
 
-                $this->translateAssets(array_combine(array_values($ids), array_values($messages)), $locale);
+                $this->translateAssets($assets, $locale);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When using asset ids, because the ids were retrieved from localize, they could be in another order than the ones from local catalogue. Because of this, when used the array_combine, the messages would end mixed up.

I manually check and build the assets, so the ids will match.