### PR TITLE
[Mailer] Make Transports and Mailer private properties read-only.

### DIFF
--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -34,6 +34,11 @@ final class Mailer implements MailerInterface
         $this->dispatcher = $dispatcher;
     }
 
+    public function getTransport(): TransportInterface
+    {
+        return $this->transport;
+    }
+
     public function send(RawMessage $message, Envelope $envelope = null): void
     {
         if (null === $this->bus) {

--- a/src/Symfony/Component/Mailer/Transport/Transports.php
+++ b/src/Symfony/Component/Mailer/Transport/Transports.php
@@ -44,6 +44,14 @@ final class Transports implements TransportInterface
         }
     }
 
+    /**
+     * @return TransportInterface[]
+     */
+    public function getTransports(): array
+    {
+        return $this->transports;
+    }
+
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         /** @var Message $message */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        |

"In order to be able to read mailer transports configuration/details from the user space, allow the read of it."

Basically, I'm working on a project where developers could easily set-up a real SMTP configuration on their development environments. Therefore I wanted to add a second protection, hard-coded in our PHP logic relative to the sending of mails which prevents sending an email to any non-local domain. But it seems like their is no way to retrieve the Symfony Mailer Transports configuration from inside my services, other than a really heavy use of reflection.

It occurred to me that making those properties read-only wouldn't hurt the initial intention of having them impossible to change at runtime by the user, but still make it possible to check their value.