### PR TITLE
[DependencyInjection] Optimization of resolveEnvPlaceholders

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1413,7 +1413,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             return $result;
         }
 
-        if (!\is_string($value) || 38 > \strlen($value)) {
+        if (!\is_string($value) || 38 > \strlen($value) || !preg_match('/env[_(]/i', $value)) {
             return $value;
         }
         $envPlaceholders = $bag instanceof EnvPlaceholderParameterBag ? $bag->getEnvPlaceholders() : $this->envPlaceholders;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT


When you have to much env variables and many services in your container, container compilаtion can take much time due to the function stripos which is called much time.
Look at the bottom of picture https://i2.piccy.info/i9/cdc413af9aecce8f7ed5ca0fe69b6c7c/1640950765/149173/1453384/6833Screenshot_from_2021_12_31_13_38_20.png

It happens because function resolveEnvPlaceholders try to find env placeholders in any value, even when there is no possible env in string.

So i offer to check value on strings env_ or env( and if they are present than look for placeholders.

In my project it helps me to save 10 seconds in container building.

