### PR TITLE
[Validator] Error using CssColor with doctrine annotations

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CssColor.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColor.php
@@ -72,7 +72,7 @@ class CssColor extends Constraint
         if (!$formats) {
             $options['value'] = self::$validationModes;
         } elseif (\is_array($formats) && \is_string(key($formats))) {
-            $options = array_merge($formats, $options);
+            $options = array_merge($formats, $options ?? []);
         } elseif (\is_array($formats)) {
             if ([] === array_intersect(self::$validationModes, $formats)) {
                 throw new InvalidArgumentException(sprintf('The "formats" parameter value is not valid. It must contain one or more of the following values: "%s".', $validationModesAsString));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT

When use doctrine annotations and set formats parameter throw and error 

`array_merge(): Argument #2 must be of type array, null given`

`in vendor/symfony/validator/Constraints/CssColor.php (line 75) `


