### PR TITLE
[HttpClient] Turn negative timeout to a very long timeout

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -147,7 +147,10 @@ trait HttpClientTrait
 
         // Finalize normalization of options
         $options['http_version'] = (string) ($options['http_version'] ?? '') ?: null;
-        $options['timeout'] = (float) ($options['timeout'] ?? ini_get('default_socket_timeout'));
+        if (0 > $options['timeout'] = (float) ($options['timeout'] ?? ini_get('default_socket_timeout'))) {
+            $options['timeout'] = 172800.0; // 2 days
+        }
+
         $options['max_duration'] = isset($options['max_duration']) ? (float) $options['max_duration'] : 0;
 
         return [$url, $options];

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -179,4 +179,13 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
 
         $this->assertNotEmpty($traceInfo['debug']);
     }
+
+    public function testNegativeTimeout()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->assertSame(200, $client->request('GET', 'http://localhost:8057', [
+            'timeout' => -1,
+        ])->getStatusCode());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/44477
| License       | MIT
| Doc PR        | -

0 keeps on throwing.