### PR TITLE
[DependencyInjection] Ignore argument type check in CheckTypeDeclarationsPass if it's a Definition with a factory

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -210,6 +210,10 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
         $class = null;
 
         if ($value instanceof Definition) {
+            if ($value->getFactory()) {
+                return;
+            }
+
             $class = $value->getClass();
 
             if ($class && isset(self::BUILTIN_TYPES[strtolower($class)])) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -999,6 +999,20 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
         $this->addToAssertionCount(1);
     }
+
+    public function testIgnoreDefinitionFactoryArgument()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', Bar::class)
+            ->setArguments([
+                (new Definition(Foo::class))
+                    ->setFactory([Foo::class, 'createStdClass']),
+            ]);
+
+        (new CheckTypeDeclarationsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
 }
 
 class CallableClass

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/Foo.php
@@ -23,4 +23,9 @@ class Foo
     {
         return [];
     }
+
+    public static function createStdClass(): \stdClass
+    {
+        return new \stdClass();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  |  no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/35599, https://github.com/symfony/symfony/issues/44515
| License       | MIT
| Doc PR        | -

When a definition uses a factory, we don't know what it returns.