### PR TITLE
[Serializer] Fix AbstractObjectNormalizer TypeError on denormalization

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -296,7 +296,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      * Normalizes the given data to an array. It's particularly useful during
      * the denormalization process.
      */
-    protected function prepareForDenormalization(object|array|null $data): array
+    protected function prepareForDenormalization(mixed $data): array
     {
         return (array) $data;
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -5,6 +5,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
@@ -216,5 +217,16 @@ class AbstractNormalizerTest extends TestCase
         $normalizer = new PropertyNormalizer($this->classMetadata);
 
         $this->assertSame([], $normalizer->normalize($dummy));
+    }
+
+    public function testDenormalizeRecursiveWithObjectAttributeWithStringValue()
+    {
+        $extractor = new ReflectionExtractor();
+        $normalizer = new ObjectNormalizer(null, null, null, $extractor);
+        $serializer = new Serializer([$normalizer]);
+
+        $obj = $serializer->denormalize(['inner' => 'foo'], ObjectOuter::class);
+
+        $this->assertInstanceOf(ObjectInner::class, $obj->getInner());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -713,9 +713,9 @@ class ObjectNormalizerTest extends TestCase
         $normalizer = new ObjectNormalizer(null, null, null, $extractor);
         $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
 
-        $this->expectException(UnexpectedValueException::class);
+        $obj = $serializer->denormalize(['inner' => 'foo'], ObjectOuter::class);
 
-        $serializer->denormalize(['inner' => 'foo'], ObjectOuter::class);
+        self::assertInstanceOf(ObjectInner::class, $obj->getInner());
     }
 
     public function testAcceptJsonNumber()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -707,6 +707,17 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame(2, $obj->getInners()[1]->foo);
     }
 
+    public function testDenomalizeRecursiveWithObjectAttributeWithStringValue()
+    {
+        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+        $normalizer = new ObjectNormalizer(null, null, null, $extractor);
+        $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
+
+        $this->expectException(UnexpectedValueException::class);
+
+        $serializer->denormalize(['inner' => 'foo'], ObjectOuter::class);
+    }
+
     public function testAcceptJsonNumber()
     {
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -707,17 +707,6 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame(2, $obj->getInners()[1]->foo);
     }
 
-    public function testDenomalizeRecursiveWithObjectAttributeWithStringValue()
-    {
-        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
-        $normalizer = new ObjectNormalizer(null, null, null, $extractor);
-        $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
-
-        $obj = $serializer->denormalize(['inner' => 'foo'], ObjectOuter::class);
-
-        self::assertInstanceOf(ObjectInner::class, $obj->getInner());
-    }
-
     public function testAcceptJsonNumber()
     {
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44872
| License       | MIT
| Doc PR        | 

When using dependency injection to get the serializer (instead of manually instantiating it) the object normalizer that is injected into that serializer throws a value exception when doing denormalizing the following:

```php
class Outer {
  public Inner $inner;
}

class Inner {
  public $foo;
}

#[Route('/bug')]
public function test(DenormalizerInterface $denormalizer) {
    $blog = $denormalizer->denormalize([
        'inner' => 'test string',
    ], Outer ::class);
}
```

This throws
```php
TypeError:
Symfony\Component\Serializer\Normalizer\AbstractNormalizer::prepareForDenormalization(): Argument #1 ($data) must be of type object|array|null, string given, called in /var/www/symfony/vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php on line 368

  at vendor/symfony/serializer/Normalizer/AbstractNormalizer.php:299
  at Symfony\Component\Serializer\Normalizer\AbstractNormalizer->prepareForDenormalization('test string')
     (vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php:368)
  at Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer->denormalize('test string', 'App\\Entity\\User', null, array('cache_key' => 'c93a6d4efa206ea58a62cc6b7fab8dfb', 'deserialization_path' => 'author'))
     (vendor/symfony/serializer/Serializer.php:238)
  at Symfony\Component\Serializer\Serializer->denormalize('test string', 'App\\Entity\\User', null, array('cache_key' => 'c93a6d4efa206ea58a62cc6b7fab8dfb', 'deserialization_path' => 'author'))
     (vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php:559)
  at Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer->validateAndDenormalize(array(object(Type)), 'App\\Entity\\Blog', 'author', 'test string', null, array('cache_key' => '44db5a926a1544b1a8585af40107ca3a', 'deserialization_path' => 'author'))
     (vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php:401)
  at Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer->denormalize(array('author' => 'test string'), 'App\\Entity\\Blog', null, array('cache_key' => '44db5a926a1544b1a8585af40107ca3a'))
     (vendor/symfony/serializer/Serializer.php:238)
  at Symfony\Component\Serializer\Serializer->denormalize(array('author' => 'test string'), 'App\\Entity\\Blog')
     (src/Controller/BugReproductionController.php:18)
  at App\Controller\BugReproductionController->test(object(Serializer))
     (vendor/symfony/http-kernel/HttpKernel.php:152)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php:35)
  at Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
     (vendor/autoload_runtime.php:29)
  at require_once('/var/www/symfony/vendor/autoload_runtime.php')
     (public/index.php:5)
```

I have been going through the code for 8 hours but I have yet to find an optimal solution for this, I did however add a unit test that indicates the bug. Any suggestions on how to solve this are welcome