### PR TITLE
[Console][Process] Free process resources

### DIFF
--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -20,11 +20,12 @@ final class Cursor
 {
     private $output;
     private $input;
+    private $inputResource = null;
 
     public function __construct(OutputInterface $output, $input = null)
     {
         $this->output = $output;
-        $this->input = $input ?? (\defined('STDIN') ? \STDIN : fopen('php://input', 'r+'));
+        $this->input = $input ?? (\defined('STDIN') ? \STDIN : $this->inputResource = fopen('php://input', 'r+'));
     }
 
     public function moveUp(int $lines = 1): self
@@ -171,5 +172,12 @@ final class Cursor
         sscanf($code, "\033[%d;%dR", $row, $col);
 
         return [$col, $row];
+    }
+
+    public function __destruct()
+    {
+        if (null !== $this->inputResource) {
+            fclose($this->inputResource);
+        }
     }
 }

--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -145,7 +145,14 @@ final class Cursor
         static $isTtySupported;
 
         if (null === $isTtySupported && \function_exists('proc_open')) {
-            $isTtySupported = (bool) @proc_open('echo 1 >/dev/null', [['file', '/dev/tty', 'r'], ['file', '/dev/tty', 'w'], ['file', '/dev/tty', 'w']], $pipes);
+            $handle = @proc_open('echo 1 >/dev/null', [['file', '/dev/tty', 'r'], ['file', '/dev/tty', 'w'], ['file', '/dev/tty', 'w']], $pipes);
+            $isTtySupported = (bool) $handle;
+            if (false !== $handle) {
+                fclose($pipes[0]);
+                fclose($pipes[1]);
+                fclose($pipes[2]);
+                proc_close($handle);
+            }
         }
 
         if (!$isTtySupported) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

I am experiencing `Failed to open stream: Too many open files` error when running tests. Since `lsof` shows new `/dev/pts/1` being added every second, I tried closing the open processes and also https://github.com/squizlabs/PHP_CodeSniffer/pull/3523 but to no avail. But it is a good practice nonetheless.
