### PR TITLE
Add a tool that can help users quickly try this app?

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Installation
 * Symfony follows the [semantic versioning][5] strictly, publishes "Long Term
   Support" (LTS) versions and has a [release process][6] that is predictable and
   business-friendly.
+* Or Run without installation [![TeamCode try-it-now](https://static01.teamcode.com/badge/teamcode-badge-run-in-cloud-en.svg)](https://www.teamcode.com/tin/clone?applicationId=275260578471518208)
 
 Sponsor
 -------


### PR DESCRIPTION
Hello, we are TeamCode. We have created a Tin application for this app, which help users to quickly run and try the app without installing and configuring the environment. Users don't need to pay for this service. Hope it can help you better promote the app!

[![TeamCode try-it-now](https://static01.teamcode.com/badge/teamcode-badge-run-in-cloud-en.svg)](https://www.teamcode.com/tin/clone?applicationId=275260578471518208)
Guidance: https://www.teamcode.com/docs/en-US/tin/clone-tin

This is the entire usage process：

Users click the badge Run in Cloud.
Sign up first if they have not logged in.
After that, they will be directed to the Clone page and start to build & run this app.