### PR TITLE
[Config] Fix return type of `ExprBuilder::ifEmpty()`

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -91,7 +91,7 @@ class ExprBuilder
     /**
      * Tests if the value is empty.
      *
-     * @return ExprBuilder
+     * @return $this
      */
     public function ifEmpty()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | N/A

phpstan probably moans otherwise: Call to an undefined method Symfony\Component\Config\Definition\Builder\NodeParentInterface::scalarNode().

The following code part does not cause any errors:
```php
->ifTrue(function ($v) {return empty($v);})
```
