### PR TITLE
[HttpClient] Remove deprecated usage of `GuzzleHttp\Promise\queue`

### DIFF
--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient;
 
 use GuzzleHttp\Promise\Promise as GuzzlePromise;
 use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Promise\Utils;
 use Http\Client\Exception\NetworkException;
 use Http\Client\Exception\RequestException;
 use Http\Client\HttpAsyncClient;
@@ -69,7 +70,7 @@ final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestF
         $this->client = $client ?? HttpClient::create();
         $this->responseFactory = $responseFactory;
         $this->streamFactory = $streamFactory ?? ($responseFactory instanceof StreamFactoryInterface ? $responseFactory : null);
-        $this->promisePool = \function_exists('GuzzleHttp\Promise\queue') ? new \SplObjectStorage() : null;
+        $this->promisePool = class_exists(Utils::class) ? new \SplObjectStorage() : null;
 
         if (null === $this->responseFactory || null === $this->streamFactory) {
             if (!class_exists(Psr17Factory::class) && !class_exists(Psr17FactoryDiscovery::class)) {

--- a/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
+++ b/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
@@ -47,7 +47,7 @@ final class HttplugWaitLoop
             return 0;
         }
 
-        $guzzleQueue = \GuzzleHttp\Promise\queue();
+        $guzzleQueue = \GuzzleHttp\Promise\Utils::queue();
 
         if (0.0 === $remainingDuration = $maxDuration) {
             $idleTimeout = 0.0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`GuzzleHttp\Promise\queue` was deprecated in `1.4.0` in favour of `GuzzleHttp\Promise\Utils::queue`, to enable PSR-4 compliance and eliminate issues with multiple installs globally and locally. Since the minimum version of this package in Symfony's composer.json is `1.4.0` (`^1.4`), then this change should be safe to make.

---

cc @Nyholm