### PR TITLE
[CI] If package is not bridge, it should be in replace section

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -82,7 +82,7 @@ jobs:
                 echo "Verifying new package"
                 _correct_license_file $DIR/LICENSE || localExit=1
 
-                if [ $TYPE == 'component_bridge' ]; then
+                if [ $TYPE != 'component_bridge' ]; then
                   if [ ! $(cat composer.json | jq -e ".replace.\"$NAME\"|test(\"self.version\")") ]; then
                     echo "Composer.json's replace section needs to contain $NAME"
                     localExit=1


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Related to #44511. Ping @fancyweb 

We should only add packages in the root composer's replace section for bundles, packages and contracts. Ie everything but bridges. 
