### PR TITLE
[Process] Add callback for waiting process execution.

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1.0
+-----
+
+* Add the possibility to add a callback while waiting for the process to finish. This allows to add Logging or other actions.
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -398,6 +398,7 @@ class Process implements \IteratorAggregate
      * It allows to have feedback from the independent process during execution.
      *
      * @param callable|null $callback A valid PHP callback
+     * @param callable|null $waitingCallback A valid PHP callback triggered while waiting
      *
      * @return int The exitcode of the process
      *
@@ -405,7 +406,7 @@ class Process implements \IteratorAggregate
      * @throws ProcessSignaledException When process stopped after receiving signal
      * @throws LogicException           When process is not yet started
      */
-    public function wait(callable $callback = null): int
+    public function wait(callable $callback = null, callable $waitingCallback): int
     {
         $this->requireProcessIsStarted(__FUNCTION__);
 
@@ -420,6 +421,7 @@ class Process implements \IteratorAggregate
         }
 
         do {
+            $waitingCallback($this);
             $this->checkTimeout();
             $running = '\\' === \DIRECTORY_SEPARATOR ? $this->isRunning() : $this->processPipes->areOpen();
             $this->readPipes($running, '\\' !== \DIRECTORY_SEPARATOR || !$running);

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -406,7 +406,7 @@ class Process implements \IteratorAggregate
      * @throws ProcessSignaledException When process stopped after receiving signal
      * @throws LogicException           When process is not yet started
      */
-    public function wait(callable $callback = null, callable $waitingCallback): int
+    public function wait(callable $callback = null, callable $waitingCallback = null): int
     {
         $this->requireProcessIsStarted(__FUNCTION__);
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -397,7 +397,7 @@ class Process implements \IteratorAggregate
      * from the output in real-time while writing the standard input to the process.
      * It allows to have feedback from the independent process during execution.
      *
-     * @param callable|null $callback A valid PHP callback
+     * @param callable|null $callback        A valid PHP callback
      * @param callable|null $waitingCallback A valid PHP callback triggered while waiting
      *
      * @return int The exitcode of the process

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1535,6 +1535,16 @@ class ProcessTest extends TestCase
         }
     }
 
+    public function testProcessWaitingCallback()
+    {
+        $p = Process::fromShellCommandline('ls');
+        $p->wait(null,
+            function () {
+            }
+        );
+        $this->assertEquals(true, false);
+    }
+
     /**
      * @param string|array $commandline
      * @param mixed        $input

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1537,11 +1537,11 @@ class ProcessTest extends TestCase
 
     public function testProcessWaitingCallback()
     {
-        $p =  $this->getProcessForCode('usleep(3000000);');
+        $p = $this->getProcessForCode('usleep(3000000);');
         $callCounter = 0;
         $p->wait(null,
             function ($type, $buffer) use (&$callCounter) {
-                $callCounter++;
+                ++$callCounter;
             }
         );
         $this->assertSame(2, $callCounter, 'The callback should be executed while waiting');

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1545,7 +1545,7 @@ class ProcessTest extends TestCase
                 ++$callCounter;
             }
         );
-        $this->assertSame(2, $callCounter, 'The callback should be executed while waiting');
+        $this->assertGreaterThanOrEqual(2, $callCounter, 'The callback should be executed while waiting');
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1537,12 +1537,14 @@ class ProcessTest extends TestCase
 
     public function testProcessWaitingCallback()
     {
-        $p = Process::fromShellCommandline('ls');
+        $p =  $this->getProcessForCode('usleep(3000000);');
+        $callCounter = 0;
         $p->wait(null,
-            function () {
+            function ($type, $buffer) use (&$callCounter) {
+                $callCounter++;
             }
         );
-        $this->assertEquals(true, false);
+        $this->assertSame(2, $callCounter, 'The callback should be executed while waiting');
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1540,7 +1540,8 @@ class ProcessTest extends TestCase
         $p = $this->getProcessForCode('usleep(3000000);');
         $callCounter = 0;
         $p->wait(null,
-            function ($type, $buffer) use (&$callCounter) {
+            function ($process) use (&$callCounter) {
+                $this->assertInstanceOf(Process::class,$process);
                 ++$callCounter;
             }
         );


### PR DESCRIPTION
…

| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features  <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


-----

Add the possibility to add a callback while waiting for the process to finish. This allows to add Logging or other actions.

```php
<?php

class ExampleUsage
{
    private Logger $logger;

    public function runMyTask()
    {
        $process = new Symfony\Component\Process\Process('ffmpeg ...');
        $process->wait(
            null,
            function (Symfony\Component\Process\Process $process): void {
                $this->logger->notice(
                    'Ffmpeg says: ' . $process->getIncrementalErrorOutput()
                );
            }
        );
    }
}

```

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
