### PR TITLE
LDAP authentication should return a meaningful error when the LDAP server is unavailable

### DIFF
--- a/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
+++ b/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Ldap\Security;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Ldap\Exception\ConnectionException;
+use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
 use Symfony\Component\Ldap\LdapInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\LogicException;
@@ -99,7 +99,7 @@ class CheckLdapCredentialsListener implements EventSubscriberInterface
             }
 
             $ldap->bind($dn, $presentedPassword);
-        } catch (ConnectionException $e) {
+        } catch (InvalidCredentialsException $e) {
             throw new BadCredentialsException('The presented password is invalid.');
         }
 

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Ldap\Security;
 
 use Symfony\Component\Ldap\Entry;
-use Symfony\Component\Ldap\Exception\ConnectionException;
 use Symfony\Component\Ldap\Exception\ExceptionInterface;
 use Symfony\Component\Ldap\LdapInterface;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
@@ -74,17 +73,10 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
 
     public function loadUserByIdentifier(string $identifier): UserInterface
     {
-        try {
-            $this->ldap->bind($this->searchDn, $this->searchPassword);
-            $identifier = $this->ldap->escape($identifier, '', LdapInterface::ESCAPE_FILTER);
-            $query = str_replace(['{username}', '{user_identifier}'], $identifier, $this->defaultSearch);
-            $search = $this->ldap->query($this->baseDn, $query);
-        } catch (ConnectionException $e) {
-            $e = new UserNotFoundException(sprintf('User "%s" not found.', $identifier), 0, $e);
-            $e->setUserIdentifier($identifier);
-
-            throw $e;
-        }
+        $this->ldap->bind($this->searchDn, $this->searchPassword);
+        $identifier = $this->ldap->escape($identifier, '', LdapInterface::ESCAPE_FILTER);
+        $query = str_replace(['{username}', '{user_identifier}'], $identifier, $this->defaultSearch);
+        $search = $this->ldap->query($this->baseDn, $query);
 
         $entries = $search->execute();
         $count = \count($entries);

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Ldap\Adapter\CollectionInterface;
 use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Entry;
-use Symfony\Component\Ldap\Exception\ConnectionException;
+use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
 use Symfony\Component\Ldap\LdapInterface;
 use Symfony\Component\Ldap\Security\CheckLdapCredentialsListener;
 use Symfony\Component\Ldap\Security\LdapBadge;
@@ -139,7 +139,7 @@ class CheckLdapCredentialsListenerTest extends TestCase
         $this->expectExceptionMessage('The presented password is invalid.');
 
         $this->ldap->method('escape')->willReturnArgument(0);
-        $this->ldap->expects($this->any())->method('bind')->willThrowException(new ConnectionException());
+        $this->ldap->expects($this->any())->method('bind')->willThrowException(new InvalidCredentialsException());
 
         $listener = $this->createListener();
         $listener->onCheckPassport($this->createEvent());

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
@@ -29,7 +29,7 @@ class LdapUserProviderTest extends TestCase
 {
     public function testLoadUserByUsernameFailsIfCantConnectToLdap()
     {
-        $this->expectException(UserNotFoundException::class);
+        $this->expectException(ConnectionException::class);
 
         $ldap = $this->createMock(LdapInterface::class);
         $ldap


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 (?)
| Bug fix?      | no (?)
| New feature?  | no (?)
| Deprecations? | no
| Tickets       | Fix #44089
| License       | MIT

Return a 500 ISE if the LDAP server is unreachable.

Not sure if this is seen as a "bug fix" or a "new feature", or neither. It's not a bug per se, but it feels like wrong behavior to state that credentials are invalid if the LDAP server is unreachable.

I have tested the following scenarios:

<details>
<summary>LDAP server unreachable</summary>

`Adapter/ExtLdap/Connection.php` throws a `ConnectionException` which is not caught, and this results in a 500 ISE shown to the user. In development mode, you see a relevant trace and the correct error hinting to an unreachable LDAP server, and in production mode this wouldn't be shown to the user, and would be logged.
</details>

<details>
<summary>LDAP server reachable, with invalid search bind credentials</summary>

The `LdapUserProvider` tries to search the LDAP directory for the provided user. To search, it tries to authenticate using the (invalid) bind credentials, resulting in `Adapter/ExtLdap/Connection.php` throwing an `InvalidCredentialsException` which is not caught. As this is indicative of a misconfiguration within the application (ie. the app's search bind credentials are wrong, and searching for any user will always fail) I believe a 500 ISE is appropriate.

We could opt to catch the `InvalidCredentialsException` inside the `LdapUserProvider` and throw something more specific, to indicate it is the applications search bind credentials that are invalid, as opposed to the credentials the user provided during authentication.
</details>

<details>
<summary>LDAP server reachable, with valid search bind credentials, authenticating as an unknown user</summary>

As the search bind credentials are valid, the `LdapUserProvider` searches the LDAP directory, finds no entries, and throws a `UserNotFoundException` which results in the authenticator returning `{"code":401,"message":"Invalid credentials."}`. I believe this is good / expected behavior.
</details>

<details>
<summary>LDAP server reachable, with valid search bind credentials, using known user with invalid password</summary>

The `ldap/Adapter/ExtLdap/Connection.php` throws an `InvalidCredentialsException`. The `ldap/Security/CheckLdapCredentialsListener.php` now catches the `InvalidCredentialsException` (instead of the `ConnectionException`) and throws a `BadCredentialsException` such that the authenticator returns `{"code":401,"message":"Invalid credentials."}` 
</details>

<details>
<summary>LDAP server reachable, with valid search bind credentials, using known user with valid password</summary>

The credentials are validated and the user is logged in, everything works as expected
</details>