### PR TITLE
[Ldap] LDAP authentication should return a meaningful error when the LDAP server is unavailable

### DIFF
--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Return a 500 Internal Server Error if LDAP server in unavailable during user enumeration / authentication
+ * Introduce `InvalidSearchCredentialsException` to differentiate between cases where user-provided credentials are invalid and cases where the configured search credentials are invalid
+
 6.0
 ---
 

--- a/src/Symfony/Component/Ldap/Exception/InvalidSearchCredentialsException.php
+++ b/src/Symfony/Component/Ldap/Exception/InvalidSearchCredentialsException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Exception;
+
+/**
+ * InvalidSearchCredentialsException is thrown if binding to ldap fails when
+ * using the configured search_dn and search_password.
+ *
+ * @author Jeroen de Boer <info@jayfrown.nl>
+ */
+class InvalidSearchCredentialsException extends InvalidCredentialsException
+{
+}

--- a/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
+++ b/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
@@ -13,7 +13,8 @@ namespace Symfony\Component\Ldap\Security;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Ldap\Exception\ConnectionException;
+use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
+use Symfony\Component\Ldap\Exception\InvalidSearchCredentialsException;
 use Symfony\Component\Ldap\LdapInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\LogicException;
@@ -74,7 +75,11 @@ class CheckLdapCredentialsListener implements EventSubscriberInterface
         try {
             if ($ldapBadge->getQueryString()) {
                 if ('' !== $ldapBadge->getSearchDn() && '' !== $ldapBadge->getSearchPassword()) {
-                    $ldap->bind($ldapBadge->getSearchDn(), $ldapBadge->getSearchPassword());
+                    try {
+                        $ldap->bind($ldapBadge->getSearchDn(), $ldapBadge->getSearchPassword());
+                    } catch (InvalidCredentialsException $e) {
+                        throw new InvalidSearchCredentialsException();
+                    }
                 } else {
                     throw new LogicException('Using the "query_string" config without using a "search_dn" and a "search_password" is not supported.');
                 }
@@ -92,7 +97,7 @@ class CheckLdapCredentialsListener implements EventSubscriberInterface
             }
 
             $ldap->bind($dn, $presentedPassword);
-        } catch (ConnectionException $e) {
+        } catch (InvalidCredentialsException $e) {
             throw new BadCredentialsException('The presented password is invalid.');
         }
 

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -12,8 +12,9 @@
 namespace Symfony\Component\Ldap\Security;
 
 use Symfony\Component\Ldap\Entry;
-use Symfony\Component\Ldap\Exception\ConnectionException;
 use Symfony\Component\Ldap\Exception\ExceptionInterface;
+use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
+use Symfony\Component\Ldap\Exception\InvalidSearchCredentialsException;
 use Symfony\Component\Ldap\LdapInterface;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -75,15 +76,13 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
     {
         try {
             $this->ldap->bind($this->searchDn, $this->searchPassword);
-            $identifier = $this->ldap->escape($identifier, '', LdapInterface::ESCAPE_FILTER);
-            $query = str_replace(['{username}', '{user_identifier}'], $identifier, $this->defaultSearch);
-            $search = $this->ldap->query($this->baseDn, $query, ['filter' => 0 == \count($this->extraFields) ? '*' : $this->extraFields]);
-        } catch (ConnectionException $e) {
-            $e = new UserNotFoundException(sprintf('User "%s" not found.', $identifier), 0, $e);
-            $e->setUserIdentifier($identifier);
-
-            throw $e;
+        } catch (InvalidCredentialsException $e) {
+            throw new InvalidSearchCredentialsException();
         }
+
+        $identifier = $this->ldap->escape($identifier, '', LdapInterface::ESCAPE_FILTER);
+        $query = str_replace(['{username}', '{user_identifier}'], $identifier, $this->defaultSearch);
+        $search = $this->ldap->query($this->baseDn, $query, ['filter' => 0 == \count($this->extraFields) ? '*' : $this->extraFields]);
 
         $entries = $search->execute();
         $count = \count($entries);

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Ldap\Adapter\CollectionInterface;
 use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Entry;
-use Symfony\Component\Ldap\Exception\ConnectionException;
+use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
 use Symfony\Component\Ldap\LdapInterface;
 use Symfony\Component\Ldap\Security\CheckLdapCredentialsListener;
 use Symfony\Component\Ldap\Security\LdapBadge;
@@ -133,7 +133,7 @@ class CheckLdapCredentialsListenerTest extends TestCase
         $this->expectExceptionMessage('The presented password is invalid.');
 
         $this->ldap->method('escape')->willReturnArgument(0);
-        $this->ldap->expects($this->any())->method('bind')->willThrowException(new ConnectionException());
+        $this->ldap->expects($this->any())->method('bind')->willThrowException(new InvalidCredentialsException());
 
         $listener = $this->createListener();
         $listener->onCheckPassport($this->createEvent());

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
@@ -29,7 +29,7 @@ class LdapUserProviderTest extends TestCase
 {
     public function testLoadUserByUsernameFailsIfCantConnectToLdap()
     {
-        $this->expectException(UserNotFoundException::class);
+        $this->expectException(ConnectionException::class);
 
         $ldap = $this->createMock(LdapInterface::class);
         $ldap


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #44089
| License       | MIT

Return a 500 ISE if the LDAP server is unreachable.

I have tested the following scenarios:

<details>
<summary>LDAP server unreachable</summary>

`Adapter/ExtLdap/Connection.php` throws a `ConnectionException` which is not caught, and this results in a 500 ISE shown to the user. In development mode, you see a relevant trace and the correct error hinting to an unreachable LDAP server, and in production mode this wouldn't be shown to the user, and would be logged.
</details>

<details>
<summary>LDAP server reachable, with invalid search bind credentials</summary>

The `LdapUserProvider` tries to search the LDAP directory for the provided user. To search, it tries to authenticate using the (invalid) bind credentials, resulting in `Adapter/ExtLdap/Connection.php` throwing an `InvalidCredentialsException` which is not caught. As this is indicative of a misconfiguration within the application (ie. the app's search bind credentials are wrong, and searching for any user will always fail) I believe a 500 ISE is appropriate.

We could opt to catch the `InvalidCredentialsException` inside the `LdapUserProvider` and throw something more specific, to indicate it is the applications search bind credentials that are invalid, as opposed to the credentials the user provided during authentication.
</details>

<details>
<summary>LDAP server reachable, with valid search bind credentials, authenticating as an unknown user</summary>

As the search bind credentials are valid, the `LdapUserProvider` searches the LDAP directory, finds no entries, and throws a `UserNotFoundException` which results in the authenticator returning `{"code":401,"message":"Invalid credentials."}`. I believe this is good / expected behavior.
</details>

<details>
<summary>LDAP server reachable, with valid search bind credentials, using known user with invalid password</summary>

The `ldap/Adapter/ExtLdap/Connection.php` throws an `InvalidCredentialsException`. The `ldap/Security/CheckLdapCredentialsListener.php` now catches the `InvalidCredentialsException` (instead of the `ConnectionException`) and throws a `BadCredentialsException` such that the authenticator returns `{"code":401,"message":"Invalid credentials."}` 
</details>

<details>
<summary>LDAP server reachable, with valid search bind credentials, using known user with valid password</summary>

The credentials are validated and the user is logged in, everything works as expected
</details>
