### PR TITLE
[Translation] fixed help text of translation provider commands

### DIFF
--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -81,7 +81,7 @@ You can overwrite existing translations (and remove the missing ones on local si
 
 Full example:
 
-  <info>php %command.full_name% provider --force --domains=messages,validators --locales=en</>
+  <info>php %command.full_name% provider --force --domains=messages --domains=validators --locales=en</>
 
 This command pulls all translations associated with the <comment>messages</> and <comment>validators</> domains for the <comment>en</> locale.
 Local translations for the specified domains and locale are deleted if they're not present on the provider and overwritten if it's the case.

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -79,7 +79,7 @@ You can delete provider translations which are not present locally by using the 
 
 Full example:
 
-  <info>php %command.full_name% provider --force --delete-missing --domains=messages,validators --locales=en</>
+  <info>php %command.full_name% provider --force --delete-missing --domains=messages --domains=validators --locales=en</>
 
 This command pushes all translations associated with the <comment>messages</> and <comment>validators</> domains for the <comment>en</> locale.
 Provider translations for the specified domains and locale are deleted if they're not present locally and overwritten if it's the case.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The current description of the domains option does not match the code (there is no string to array functionality in the given code) or the standard [behavior of console commands](https://symfony.com/doc/current/console/input.html).

This fix just changes the text of the help description - no actual code is changed.