### PR TITLE
Add visibility context option in PropertyNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
 * Add support for constructor promoted properties to `Context` attribute
+* Add context option `PropertyNormalizer::NORMALIZE_VISIBILITY` with bitmask flags `PropertyNormalizer::NORMALIZE_PUBLIC`, `PropertyNormalizer::NORMALIZE_PROTECTED`, `PropertyNormalizer::NORMALIZE_PRIVATE`
+* Add method `withNormalizeVisibility` to `PropertyNormalizerContextBuilder`
 
 6.1
 ---

--- a/src/Symfony/Component/Serializer/Context/Normalizer/PropertyNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/PropertyNormalizerContextBuilder.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Serializer\Context\Normalizer;
 
+use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
+
 /**
  * A helper providing autocompletion for available PropertyNormalizer options.
  *
@@ -18,4 +20,11 @@ namespace Symfony\Component\Serializer\Context\Normalizer;
  */
 final class PropertyNormalizerContextBuilder extends AbstractObjectNormalizerContextBuilder
 {
+    /**
+     * Configures whether fields should be output based on visibility.
+     */
+    public function withNormalizeVisibility(int $normalizeVisibility): static
+    {
+        return $this->with(PropertyNormalizer::NORMALIZE_VISIBILITY, $normalizeVisibility);
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/PropertyNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/PropertyNormalizerContextBuilderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Normalizer\PropertyNormalizerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
+
+/**
+ * @author Antoine Lamirault <lamiraultantoine@gmail.com>
+ */
+class PropertyNormalizerContextBuilderTest extends TestCase
+{
+    private PropertyNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new PropertyNormalizerContextBuilder();
+    }
+
+    public function testWithNormalizeVisibility()
+    {
+        $context = $this->contextBuilder
+            ->withNormalizeVisibility(PropertyNormalizer::NORMALIZE_PUBLIC | PropertyNormalizer::NORMALIZE_PROTECTED)
+            ->toArray();
+
+        $this->assertSame([
+            PropertyNormalizer::NORMALIZE_VISIBILITY => PropertyNormalizer::NORMALIZE_PUBLIC | PropertyNormalizer::NORMALIZE_PROTECTED,
+        ], $context);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -122,6 +122,54 @@ class PropertyNormalizerTest extends TestCase
         );
     }
 
+    public function testNormalizeOnlyPublic()
+    {
+        $obj = new PropertyDummy();
+        $obj->foo = 'foo';
+        $obj->setBar('bar');
+        $obj->setCamelCase('camelcase');
+        $this->assertEquals(
+            ['foo' => 'foo'],
+            $this->normalizer->normalize($obj, 'any', ['normalize_visibility' => PropertyNormalizer::NORMALIZE_PUBLIC])
+        );
+    }
+
+    public function testNormalizeOnlyProtected()
+    {
+        $obj = new PropertyDummy();
+        $obj->foo = 'foo';
+        $obj->setBar('bar');
+        $obj->setCamelCase('camelcase');
+        $this->assertEquals(
+            ['camelCase' => 'camelcase'],
+            $this->normalizer->normalize($obj, 'any', ['normalize_visibility' => PropertyNormalizer::NORMALIZE_PROTECTED])
+        );
+    }
+
+    public function testNormalizeOnlyPrivate()
+    {
+        $obj = new PropertyDummy();
+        $obj->foo = 'foo';
+        $obj->setBar('bar');
+        $obj->setCamelCase('camelcase');
+        $this->assertEquals(
+            ['bar' => 'bar'],
+            $this->normalizer->normalize($obj, 'any', ['normalize_visibility' => PropertyNormalizer::NORMALIZE_PRIVATE])
+        );
+    }
+
+    public function testNormalizePublicAndProtected()
+    {
+        $obj = new PropertyDummy();
+        $obj->foo = 'foo';
+        $obj->setBar('bar');
+        $obj->setCamelCase('camelcase');
+        $this->assertEquals(
+            ['foo' => 'foo', 'camelCase' => 'camelcase'],
+            $this->normalizer->normalize($obj, 'any', ['normalize_visibility' => PropertyNormalizer::NORMALIZE_PUBLIC | PropertyNormalizer::NORMALIZE_PROTECTED])
+        );
+    }
+
     public function testDenormalize()
     {
         $obj = $this->normalizer->denormalize(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #39143
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR is an attempt to fix #39143 request.
It allows to control which object property visibility we want to normalize. By defaut publuc, protected and private properties are normalized but sometime only public are enough

if it's ok for you, I will create PR for docs