### PR TITLE
Allow translators to return stringables

### DIFF
--- a/src/Symfony/Contracts/Translation/TranslatableInterface.php
+++ b/src/Symfony/Contracts/Translation/TranslatableInterface.php
@@ -16,5 +16,5 @@ namespace Symfony\Contracts\Translation;
  */
 interface TranslatableInterface
 {
-    public function trans(TranslatorInterface $translator, string $locale = null): string;
+    public function trans(TranslatorInterface $translator, string $locale = null): string|\Stringable;
 }

--- a/src/Symfony/Contracts/Translation/TranslatorInterface.php
+++ b/src/Symfony/Contracts/Translation/TranslatorInterface.php
@@ -59,7 +59,7 @@ interface TranslatorInterface
      *
      * @throws \InvalidArgumentException If the locale contains invalid characters
      */
-    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string;
+    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string|\Stringable;
 
     /**
      * Returns the default locale.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features
| Bug fix?      | no
| New feature?  | kinda?
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Extends the scope of possible return values from \Symfony\Contracts\Translation\TranslatableInterface::trans() and \Symfony\Contracts\Translation\TranslatorInterface::trans() to aid Symfony 6 adoption by Drupal 10. This change should not result in an changes to existing code as returning a string is still valid. 
