### PR TITLE
[Console] Fix compact table style to avoid outputting a leading space

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -804,9 +804,9 @@ class Table
         $compact = new TableStyle();
         $compact
             ->setHorizontalBorderChars('')
-            ->setVerticalBorderChars(' ')
+            ->setVerticalBorderChars('')
             ->setDefaultCrossingChar('')
-            ->setCellRowContentFormat('%s')
+            ->setCellRowContentFormat('%s ')
         ;
 
         $styleGuide = new TableStyle();

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -118,11 +118,11 @@ TABLE
                 $books,
                 'compact',
 <<<'TABLE'
- ISBN          Title                    Author           
- 99921-58-10-7 Divine Comedy            Dante Alighieri  
- 9971-5-0210-0 A Tale of Two Cities     Charles Dickens  
- 960-425-059-0 The Lord of the Rings    J. R. R. Tolkien 
- 80-902734-1-6 And Then There Were None Agatha Christie  
+ISBN          Title                    Author           
+99921-58-10-7 Divine Comedy            Dante Alighieri  
+9971-5-0210-0 A Tale of Two Cities     Charles Dickens  
+960-425-059-0 The Lord of the Rings    J. R. R. Tolkien 
+80-902734-1-6 And Then There Were None Agatha Christie  
 
 TABLE
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This changes the `compact` output from:

```
 a   b   \n
 foo bar \n
```

To:

```
a   b   \n
foo bar \n
```

Note the only difference is the leading space which is not there anymore.

IMO this is a much better default, but I do understand it changes something which has been as it is for ages, which may be considered a BC break more than a bugfix.