### PR TITLE
[Mailer] Add downloadable attachments to profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add a download link in mailer profiler for email attachments
+
 5.4
 ---
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -187,6 +187,15 @@
                                                     <div class="tab">
                                                         <h3 class="tab-title">Attachment #{{ loop.index }}</h3>
                                                         <div class="tab-content">
+                                                            <p>
+                                                                <a href="data:{{ attachment.contentType|default('application/octet-stream') }};base64,{{ collector.base64Encode(attachment.body) }}" download="{{ attachment.filename|default('attachment') }}">
+                                                                    {% if attachment.filename|default %}
+                                                                        {{ attachment.filename }}
+                                                                    {% else %}
+                                                                        <em>(no filename)</em>
+                                                                    {% endif %}
+                                                                </a>
+                                                            </p>
                                                             <pre class="prewrap" style="max-height: 600px">{{ attachment.toString() }}</pre>
                                                         </div>
                                                     </div>

--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add `DataPart::getFilename()` and `DataPart::getContentType()`
+
 6.0
 ---
 

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -122,6 +122,16 @@ class DataPart extends TextPart
         return $str;
     }
 
+    public function getFilename(): ?string
+    {
+        return $this->filename;
+    }
+
+    public function getContentType(): string
+    {
+        return implode('/', [$this->getMediaType(), $this->getMediaSubtype()]);
+    }
+
     private function generateContentId(): string
     {
         return bin2hex(random_bytes(16)).'@symfony';

--- a/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
@@ -135,6 +135,24 @@ class DataPartTest extends TestCase
         $this->assertTrue($p->hasContentId());
     }
 
+    public function testGetFilename()
+    {
+        $p = new DataPart('content', null);
+        self::assertNull($p->getFilename());
+
+        $p = new DataPart('content', 'filename');
+        self::assertSame('filename', $p->getFilename());
+    }
+
+    public function testGetContentType()
+    {
+        $p = new DataPart('content');
+        self::assertSame('application/octet-stream', $p->getContentType());
+
+        $p = new DataPart('content', null, 'application/pdf');
+        self::assertSame('application/pdf', $p->getContentType());
+    }
+
     public function testSerialize()
     {
         $r = fopen('php://memory', 'r+', false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This PR allows developers to download email attachments from the profiler. This is very useful for debugging if you are sending emails with PDF attachments for example, and you want to check some data within the attachment through the profiler.
