### PR TITLE
[String] Add conflict for translation-contracts v3

### DIFF
--- a/src/Symfony/Component/String/composer.json
+++ b/src/Symfony/Component/String/composer.json
@@ -29,6 +29,9 @@
         "symfony/translation-contracts": "^1.1|^2",
         "symfony/var-exporter": "^4.4|^5.0"
     },
+    "conflict": {
+        "symfony/translation-contracts": ">=3.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\String\\": "" },
         "files": [ "Resources/functions.php" ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Installing translation-contracts v3 with string v5.3 leads to a signature mismatch between `LocaleAwareInterface::getLocale(): string` and `AsciiSlugger::getLocale()`.
See https://github.com/lexik/LexikJWTAuthenticationBundle/runs/4711850818?check_suite_focus=true#step:8:136