### PR TITLE
Allow a zero time-limit for messenger:consume

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -173,7 +173,7 @@ EOF
             $this->eventDispatcher->addSubscriber(new StopWorkerOnMemoryLimitListener($this->convertToBytes($memoryLimit), $this->logger));
         }
 
-        if ($timeLimit = $input->getOption('time-limit')) {
+        if (null !== ($timeLimit = $input->getOption('time-limit'))) {
             $stopsWhen[] = "been running for {$timeLimit}s";
             $this->eventDispatcher->addSubscriber(new StopWorkerOnTimeLimitListener($timeLimit, $this->logger));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

By default `messenger:consume` will run indefinitely and as the docs mention you should monitor the process via Supervisor for example. However on shared hostings this is usually not an option and thus this command will be run via a cronjob there (at least I assume that's the intended best practise in such a case). To ensure the worker exits for each cronjob run, you can use the `--time-limit` option, e.g.

```
bin/console messenger:consume --time-limit=1
```

However, this would allow the worker to consume multiple message for the duration of 1000ms - so technically if you want the worker to _immediately_ exit each time after it processed the current message queue it should actually be

```
bin/console messenger:consume --time-limit=0
```

But this does not currently work, as the zero is falsey and thus the `StopWorkerOnTimeLimitListener` will not actually be added.

This PR fixes that by checking whether the option was actually supplied or not.