### PR TITLE
[Form] UrlType should not add protocol to emails

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
@@ -36,7 +36,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
     {
         $data = $event->getData();
 
-        if ($this->defaultProtocol && $data && \is_string($data) && !preg_match('~^[\w+.-]+://~', $data)) {
+        if ($this->defaultProtocol && $data && \is_string($data) && !preg_match('~^([\w+.-]+://|[^:/?@#]++@)~', $data)) {
             $event->setData($this->defaultProtocol.'://'.$data);
         }
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
@@ -20,45 +20,49 @@ use Symfony\Component\Form\FormEvent;
 
 class FixUrlProtocolListenerTest extends TestCase
 {
-    public function testFixHttpUrl()
-    {
-        $data = 'www.symfony.com';
-        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
-        $event = new FormEvent($form, $data);
-
-        $filter = new FixUrlProtocolListener('http');
-        $filter->onSubmit($event);
-
-        $this->assertEquals('http://www.symfony.com', $event->getData());
-    }
-
-    public function testSkipKnownUrl()
-    {
-        $data = 'http://www.symfony.com';
-        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
-        $event = new FormEvent($form, $data);
-
-        $filter = new FixUrlProtocolListener('http');
-        $filter->onSubmit($event);
-
-        $this->assertEquals('http://www.symfony.com', $event->getData());
-    }
-
-    public function provideUrlsWithSupportedProtocols()
+    public function provideUrlToFix()
     {
         return [
-            ['ftp://www.symfony.com'],
-            ['chrome-extension://foo'],
-            ['h323://foo'],
-            ['iris.beep://foo'],
-            ['foo+bar://foo'],
+            ['www.symfony.com'],
+            ['twitter.com/@symfony'],
+            ['symfony.com?foo@bar'],
+            ['symfony.com#foo@bar'],
+            ['localhost'],
         ];
     }
 
     /**
-     * @dataProvider provideUrlsWithSupportedProtocols
+     * @dataProvider provideUrlToFix
      */
-    public function testSkipOtherProtocol($url)
+    public function testFixUrl($data)
+    {
+        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
+        $event = new FormEvent($form, $data);
+
+        $filter = new FixUrlProtocolListener('http');
+        $filter->onSubmit($event);
+
+        $this->assertEquals('http://'.$data, $event->getData());
+    }
+
+    public function provideUrlToSkip()
+    {
+        return [
+            ['http://www.symfony.com'],
+            ['ftp://www.symfony.com'],
+            ['https://twitter.com/@symfony'],
+            ['chrome-extension://foo'],
+            ['h323://foo'],
+            ['iris.beep://foo'],
+            ['foo+bar://foo'],
+            ['fabien@symfony.com'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUrlToSkip
+     */
+    public function testSkipUrl($url)
     {
         $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
         $event = new FormEvent($form, $url);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43506
| License       | MIT
| Doc PR        | n/a

Replace #43707, since there is a bug in the `UrlType` auto-prepend behavior.

The regex was suggested by @nicolas-grekas https://github.com/symfony/symfony/pull/43707#discussion_r738437158