### PR TITLE
[RateLimiter] Resolve crash on near-round timestamps

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -122,6 +122,6 @@ final class SlidingWindow implements LimiterStateInterface
 
     public function getRetryAfter(): \DateTimeImmutable
     {
-        return \DateTimeImmutable::createFromFormat('U.u', $this->windowEndAt);
+        return \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $this->windowEndAt));
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowTest.php
@@ -102,4 +102,13 @@ class SlidingWindowTest extends TestCase
         // should be 500ms left (10 - 9.5)
         $this->assertEqualsWithDelta(0.5, $window->getRetryAfter()->format('U.u') - microtime(true), 0.2);
     }
+
+    public function testCreateAtExactTime()
+    {
+        ClockMock::register(SlidingWindow::class);
+        ClockMock::withClockMock(1234567890.000000);
+        $window = new SlidingWindow('foo', 10);
+        $window->getRetryAfter();
+        $this->assertEquals('1234567900.000000', $window->getRetryAfter()->format('U.u'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Occasionally timestamps will be fully round (eg. 1234567890.000000) or close to it (eg. 1234567890.000031). 

When converting those specific float timestamps to string in SlidingWindow (due to `DateTimeImmutable::createFromFormat`), the number is formatted by PHP without any digits. This causes the resulting value of SlidingWindow::getRetryAfter() to be violated with the boolean value `false`.

This patch formats the float to include the decimal digits.

```
Return value of Symfony\Component\RateLimiter\Policy\SlidingWindow::getRetryAfter() must be an instance of DateTimeImmutable, bool returned
#0 .../vendor/symfony/rate-limiter/Policy/SlidingWindowLimiter.php(84): Symfony\Component\RateLimiter\Policy\SlidingWindow->getRetryAfter()
#1 .../usercode.php(123): Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter->consume(1)
```