### PR TITLE
[Security] Login link with custom router params and query params

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
@@ -38,9 +38,9 @@ class FirewallAwareLoginLinkHandler implements LoginLinkHandlerInterface
         $this->requestStack = $requestStack;
     }
 
-    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails
+    public function createLoginLink(UserInterface $user, Request $request = null, array $options = []): LoginLinkDetails
     {
-        return $this->getForFirewall()->createLoginLink($user, $request);
+        return $this->getForFirewall()->createLoginLink($user, $request, $options);
     }
 
     public function consumeLoginLink(Request $request): UserInterface

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+6.1
+---
+* LoginLinkHandler and LoginLinkHandlerInterface accept options for: customizing lifetime and route_name parameters and allow passing custom parameters to the login link uri. 
+
 6.0
 ---
 

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -24,7 +24,7 @@ interface LoginLinkHandlerInterface
     /**
      * Generate a link that can be used to authenticate as the given user.
      */
-    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails;
+    public function createLoginLink(UserInterface $user, Request $request = null, array $options = []): LoginLinkDetails;
 
     /**
      * Validates if this request contains a login link and returns the associated User.

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -274,7 +274,7 @@ class TestLoginLinkHandlerUserProvider implements UserProviderInterface
 
     public function refreshUser(UserInterface $user): TestLoginLinkHandlerUser
     {
-        return $this->users[$username];
+        return $this->users[$user->getUserIdentifier()];
     }
 
     public function supportsClass(string $class): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  This is in part related to https://github.com/symfony/symfony/issues/41151
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16385

Hey there :) !

In the company I work for, we had the need of using an autologin system without using database, so LoginLink seamed to fit our needs, but, because of the requirements of the company's project we had 2 needs:

- Allowing to customize the host based on a router variable called site (instead of locale)
- Allowing to pass the uri to which the user will be internally redirected, after a success login. We pass this uri encrypted, (the way is encrypted is out of this topic )

So in the pull request the strategy is: allowing to pass custom router variables and additional url parameters to the login link. Apart from this allowing the customization of route_name and lifetime in a non global way. This gives us certain flexibility, a change that I also proposed in this pull request because we saw it had certain demand (see related ticket).

Had to change the signature of createLoginLink, in LoginLinkHandlerInterface
Had to modify createLoginLink in LoginLinkHandler
Had to modify createLoginLink in FirewallAwareLoginLinkHandler
Had to adapt the tests found in: phpunit src/Symfony/Component/Security/Http/Tests/LoginLink

As far as I know, there could be a backward compatibility if some one used LoginLinkHandlerInterface in their project, because the signature changes although the array $options parameter is optional and initialized to empty [].

Thank you very much in advance!