### PR TITLE
[Messenger] Resolve handled classes when only method in tag is provided

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `SerializedMessageStamp` to avoid serializing a message when a retry occurs.
+ * Automatically resolve handled message type when method different from `__invoke` is used as handler.
 
 6.0
 ---

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -78,7 +78,7 @@ class MessengerPass implements CompilerPassInterface
                 if (isset($tag['handles'])) {
                     $handles = isset($tag['method']) ? [$tag['handles'] => $tag['method']] : [$tag['handles']];
                 } else {
-                    $handles = $this->guessHandledClasses($r, $serviceId);
+                    $handles = $this->guessHandledClasses($r, $serviceId, $tag['method'] ?? '__invoke');
                 }
 
                 $message = null;
@@ -197,25 +197,29 @@ class MessengerPass implements CompilerPassInterface
         }
     }
 
-    private function guessHandledClasses(\ReflectionClass $handlerClass, string $serviceId): iterable
+    private function guessHandledClasses(\ReflectionClass $handlerClass, string $serviceId, string $methodName): iterable
     {
         if ($handlerClass->implementsInterface(MessageSubscriberInterface::class)) {
             return $handlerClass->getName()::getHandledMessages();
         }
 
         try {
-            $method = $handlerClass->getMethod('__invoke');
+            $method = $handlerClass->getMethod($methodName);
         } catch (\ReflectionException $e) {
-            throw new RuntimeException(sprintf('Invalid handler service "%s": class "%s" must have an "__invoke()" method.', $serviceId, $handlerClass->getName()));
+            throw new RuntimeException(sprintf('Invalid handler service "%s": class "%s" must have an "%s()" method.', $serviceId, $handlerClass->getName(), $methodName));
         }
 
         if (0 === $method->getNumberOfRequiredParameters()) {
-            throw new RuntimeException(sprintf('Invalid handler service "%s": method "%s::__invoke()" requires at least one argument, first one being the message it handles.', $serviceId, $handlerClass->getName()));
+            throw new RuntimeException(sprintf('Invalid handler service "%s": method "%s::%s()" requires at least one argument, first one being the message it handles.', $serviceId, $handlerClass->getName(), $methodName));
         }
 
         $parameters = $method->getParameters();
-        if (!$type = $parameters[0]->getType()) {
-            throw new RuntimeException(sprintf('Invalid handler service "%s": argument "$%s" of method "%s::__invoke()" must have a type-hint corresponding to the message class it handles.', $serviceId, $parameters[0]->getName(), $handlerClass->getName()));
+
+        /** @var \ReflectionNamedType|\ReflectionUnionType|null */
+        $type = $parameters[0]->getType();
+
+        if (!$type) {
+            throw new RuntimeException(sprintf('Invalid handler service "%s": argument "$%s" of method "%s::%s()" must have a type-hint corresponding to the message class it handles.', $serviceId, $parameters[0]->getName(), $handlerClass->getName(), $methodName));
         }
 
         if ($type instanceof \ReflectionUnionType) {
@@ -232,10 +236,10 @@ class MessengerPass implements CompilerPassInterface
         }
 
         if ($type->isBuiltin()) {
-            throw new RuntimeException(sprintf('Invalid handler service "%s": type-hint of argument "$%s" in method "%s::__invoke()" must be a class , "%s" given.', $serviceId, $parameters[0]->getName(), $handlerClass->getName(), $type instanceof \ReflectionNamedType ? $type->getName() : (string) $type));
+            throw new RuntimeException(sprintf('Invalid handler service "%s": type-hint of argument "$%s" in method "%s::%s()" must be a class , "%s" given.', $serviceId, $parameters[0]->getName(), $handlerClass->getName(), $methodName, $type instanceof \ReflectionNamedType ? $type->getName() : (string) $type));
         }
 
-        return [$type->getName()];
+        return ('__invoke' === $methodName) ? [$type->getName()] : [$type->getName() => $methodName];
     }
 
     private function registerReceivers(ContainerBuilder $container, array $busIds)

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandlerWithCustomMethods.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandlerWithCustomMethods.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class TaggedDummyHandlerWithCustomMethods
+{
+    public function handleDummyMessage(DummyMessage $message)
+    {
+    }
+
+    public function handleSecondMessage(SecondMessage $message)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  /
| License       | MIT
| Doc PR        | /

When tagging Messenger handlers, if the `method` attribute is set, the compiler pass does not resolve the message type before handling it - it requires the `handles` attribute to be set as well.

With this PR, the message type is being resolved even if method other than `__invoke` is being used.

I'm not sure if this is a bug fix or just an improvement :/