### PR TITLE
[FrameworkBundle] Avoid calling rtrim(null, '/') in AssetsInstallCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -99,8 +99,7 @@ EOT
     {
         /** @var KernelInterface $kernel */
         $kernel = $this->getApplication()->getKernel();
-        $targetArg = rtrim($input->getArgument('target'), '/');
-
+        $targetArg = rtrim($input->getArgument('target') ?? '', '/');
         if (!$targetArg) {
             $targetArg = $this->getPublicDirectory($kernel->getContainer());
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Avoid following deprecation notice:
```
php.INFO: Deprecated: rtrim(): Passing null to parameter #1 ($string) of type string is deprecated
```