### PR TITLE
[DependencyInjection] Add iterable to possible binding type

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -125,7 +125,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
                 $this->unusedBindings[$bindingId] = [$key, $this->currentId, $bindingType, $file];
             }
 
-            if (preg_match('/^(?:(?:array|bool|float|int|string|([^ $]++)) )\$/', $key, $m)) {
+            if (preg_match('/^(?:(?:array|bool|float|int|string|iterable|([^ $]++)) )\$/', $key, $m)) {
                 $bindingNames[substr($key, \strlen($m[0]))] = $binding;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedEnumArgumentDummy;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedIterableArgumentDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists;
 use Symfony\Component\DependencyInjection\TypedReference;
 
@@ -208,5 +209,18 @@ class ResolveBindingsPassTest extends TestCase
         $definition->setBindings($bindings);
         $pass = new ResolveBindingsPass();
         $pass->process($container);
+    }
+
+    public function testIterableBindingTypehint()
+    {
+        $container = new ContainerBuilder();
+        $definition = $container->register('bar', NamedIterableArgumentDummy::class);
+        $definition->setBindings([
+            'iterable $items' => new TaggedIteratorArgument('foo'),
+        ]);
+        $pass = new ResolveBindingsPass();
+        $pass->process($container);
+
+        $this->assertInstanceOf(TaggedIteratorArgument::class, $container->getDefinition('bar')->getArgument(0));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedIterableArgumentDummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedIterableArgumentDummy.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class NamedIterableArgumentDummy
+{
+    public function __construct(iterable $items)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When iterable type is set in binding like in example https://symfony.com/doc/current/service_container.html#binding-arguments-by-name-or-type, system tries to autoload class iterable here src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php:137
```
if (is_subclass_of($m[1], \UnitEnum::class)) {
```
