### PR TITLE
[HttpFoundation] : add support for text/vnd.turbo-stream.html

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1861,6 +1861,7 @@ class Request
             'atom' => ['application/atom+xml'],
             'rss' => ['application/rss+xml'],
             'form' => ['application/x-www-form-urlencoded', 'multipart/form-data'],
+            'turbo_stream' => ['text/vnd.turbo-stream.html'],
         ];
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -499,6 +499,7 @@ class RequestTest extends TestCase
             ['rdf', ['application/rdf+xml']],
             ['atom', ['application/atom+xml']],
             ['form', ['application/x-www-form-urlencoded', 'multipart/form-data']],
+            ['turbo_stream', ['text/vnd.turbo-stream.html']],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This will allow simplifying Symfony UX Turbo:

* https://github.com/symfony/ux/blob/2.x/src/Turbo/Stream/TurboStreamResponse.php#L25-L26
* https://github.com/symfony/ux/blob/2.x/src/Turbo/Stream/AddTurboStreamFormatSubscriber.php