### PR TITLE
[PropertyAccess] Fix handling of uninitialized property of anonymous class

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -486,7 +486,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                     $r = new \ReflectionProperty($class, $matches[1]);
                     $type = ($type = $r->getType()) instanceof \ReflectionNamedType ? $type->getName() : (string) $type;
 
-                    throw new UninitializedPropertyException(sprintf('The property "%s::$%s" is not readable because it is typed "%s". You should initialize it or declare a default value instead.', !str_contains(\get_class($object), "@anonymous\0") ? \get_class($object) : (get_parent_class($object) ?: key(class_implements($object)) ?: 'class').'@anonymous', $r->getName(), $type), 0, $e);
+                    throw new UninitializedPropertyException(sprintf('The property "%s::$%s" is not readable because it is typed "%s". You should initialize it or declare a default value instead.', !str_contains(\get_class($object), "@anonymous\0") ? $r->getDeclaringClass()->getName() : (get_parent_class($object) ?: key(class_implements($object)) ?: 'class').'@anonymous', $r->getName(), $type), 0, $e);
                 }
 
                 throw $e;

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -482,11 +482,11 @@ class PropertyAccessor implements PropertyAccessorInterface
                 }
             } catch (\Error $e) {
                 // handle uninitialized properties in PHP >= 7.4
-                if (\PHP_VERSION_ID >= 70400 && preg_match('/^Typed property ([\w\\\]+)::\$(\w+) must not be accessed before initialization$/', $e->getMessage(), $matches)) {
-                    $r = new \ReflectionProperty($matches[1], $matches[2]);
+                if (\PHP_VERSION_ID >= 70400 && preg_match('/^Typed property [\w@\\\]+::\$(\w+) must not be accessed before initialization$/', $e->getMessage(), $matches)) {
+                    $r = new \ReflectionProperty($class, $matches[1]);
                     $type = ($type = $r->getType()) instanceof \ReflectionNamedType ? $type->getName() : (string) $type;
 
-                    throw new UninitializedPropertyException(sprintf('The property "%s::$%s" is not readable because it is typed "%s". You should initialize it or declare a default value instead.', $r->getDeclaringClass()->getName(), $r->getName(), $type), 0, $e);
+                    throw new UninitializedPropertyException(sprintf('The property "%s::$%s" is not readable because it is typed "%s". You should initialize it or declare a default value instead.', !str_contains(\get_class($object), "@anonymous\0") ? \get_class($object) : (get_parent_class($object) ?: key(class_implements($object)) ?: 'class').'@anonymous', $r->getName(), $type), 0, $e);
                 }
 
                 throw $e;

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -206,6 +206,41 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor->getValue($object, 'uninitialized');
     }
 
+    /**
+     * @requires PHP 7.4
+     */
+    public function testGetValueThrowsExceptionIfUninitializedNotNullablePropertyWithGetterOfAnonymousClass()
+    {
+        $this->expectException(UninitializedPropertyException::class);
+        $this->expectExceptionMessage('The property "class@anonymous::$uninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.');
+
+        $object = eval('return new class() {
+            private string $uninitialized;
+
+            public function getUninitialized(): string
+            {
+                return $this->uninitialized;
+            }
+        };');
+
+        $this->propertyAccessor->getValue($object, 'uninitialized');
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testGetValueThrowsExceptionIfUninitializedPropertyOfAnonymousClass()
+    {
+        $this->expectException(UninitializedPropertyException::class);
+        $this->expectExceptionMessage('The property "class@anonymous::$uninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.');
+
+        $object = eval('return new class() {
+            public string $uninitialized;
+        };');
+
+        $this->propertyAccessor->getValue($object, 'uninitialized');
+    }
+
     public function testGetValueThrowsExceptionIfUninitializedPropertyWithGetterOfAnonymousStdClass()
     {
         $this->expectException(AccessException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
|BC breaks?  | no
| Deprecations? | no
| License | MIT

```php
$object = new class() {
    public string $uninitialized;
};

$this->propertyAccessor->getValue($object, 'uninitialized');
```

**Expected**

Throws `UninitializedPropertyException` with message "The property "class@anonymous::$uninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.".

**Actual**

Throws `Error` with message "Typed property class@anonymous::$publication must not be accessed before initialization".

**Side efect**

Form with data of an anonymous class instance cannot be created. This code throws "Typed property class@anonymous::$name must not be accessed before initialization":

```php
// in controller

$data = new class() {
    public string $name;
};

$form = $this->createForm(SomeFormType::class, $data);
```

This works as expected:

```php
// in controller

class SomeClass {
    public string $name;
};

$data = new SomeClass;

$form = $this->createForm(SomeFormType::class, $data);
```

No exception is thrown because PropertyPathAccessor catches UninitializedPropertyException and returns null instead.