### PR TITLE
[DependencyInjection] copy synthetic status when resolving child definitions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
@@ -114,6 +114,8 @@ class ResolveChildDefinitionsPass extends AbstractRecursivePass
 
         $def->setBindings($definition->getBindings() + $parentDef->getBindings());
 
+        $def->setSynthetic($definition->isSynthetic());
+
         // overwrite with values specified in the decorator
         $changes = $definition->getChanges();
         if (isset($changes['class'])) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -412,4 +412,21 @@ class ResolveChildDefinitionsPassTest extends TestCase
 
         $this->process($container);
     }
+
+    public function testProcessCopiesSyntheticStatus()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('parent');
+
+        $container
+            ->setDefinition('child', new ChildDefinition('parent'))
+            ->setSynthetic(true)
+        ;
+
+        $this->process($container);
+
+        $def = $container->getDefinition('child');
+        $this->assertTrue($def->isSynthetic());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44972
| License       | MIT
| Doc PR        | n/a

Appears to be the simplest fix for #44972. The only place this appears to be a problem is when using the `lint:container` command with an auto-configured kernel in 5.3+.