### PR TITLE
[RateLimiter] Always store SlidingWindows with an expiration set

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -85,4 +85,19 @@ final class Window implements LimiterStateInterface
 
         return $cyclesRequired * $this->intervalInSeconds;
     }
+
+    public function __serialize(): array
+    {
+        return [
+            $this->id => $this->timer,
+            pack('NN', $this->hitCount, $this->intervalInSeconds) => $this->maxSize,
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        [$this->timer, $this->maxSize] = array_values($data);
+        [$this->id, $pack] = array_keys($data);
+        ['a' => $this->hitCount, 'b' => $this->intervalInSeconds] = unpack('Na/Nb', $pack);
+    }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowTest.php
@@ -28,8 +28,9 @@ class SlidingWindowTest extends TestCase
         $this->assertSame(2 * 10, $window->getExpirationTime());
 
         $data = serialize($window);
+        sleep(10);
         $cachedWindow = unserialize($data);
-        $this->assertNull($cachedWindow->getExpirationTime());
+        $this->assertSame(10, $cachedWindow->getExpirationTime());
 
         $new = SlidingWindow::createFromPreviousWindow($cachedWindow, 15);
         $this->assertSame(2 * 15, $new->getExpirationTime());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Refs https://github.com/symfony/symfony/issues/44995
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

See https://github.com/symfony/symfony/issues/44995 for more details. The short story is that this code causes the cache item to be overwritten without TTL in https://github.com/symfony/symfony/blob/6bffe4127a7e6af5b3ccc6895b6cd034f5d90b02/src/Symfony/Component/RateLimiter/Storage/CacheStorage.php#L31-L37

So our redis DB is filling up with rate limiter data, which is not the expected outcome. I couldn't really figure out why the logic was the way it was so it seems safe for me to remove this, but maybe I missed something.

As a related side note, implementing __serialize/__unserialize in SlidingWindow and co would be good as it would reduce the storage requirements in the cache from 400 bytes to 100 bytes per rate limiter stored. I'm happy to help with that just let me know, I am not sure if there was a good reason not to implement this or if storage size was simply not a consideration. I see __sleep is implemented but that does not seem to help here, not sure what the purpose is/was.