### PR TITLE
[HttpClient] Remove deprecated usage of GuzzleHttp\Promise\promise_for

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/HttplugPromise.php
+++ b/src/Symfony/Component/HttpClient/Response/HttplugPromise.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpClient\Response;
 
-use function GuzzleHttp\Promise\promise_for;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface as GuzzlePromiseInterface;
 use Http\Promise\Promise as HttplugPromiseInterface;
 use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
@@ -74,7 +74,7 @@ final class HttplugPromise implements HttplugPromiseInterface
         }
 
         return static function ($value) use ($callback) {
-            return promise_for($callback($value));
+            return Create::promiseFor($callback($value));
         };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3,
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Similar to https://github.com/symfony/symfony/pull/44890 but this function was introduced in 5.1 https://github.com/symfony/symfony/pull/37927
