### PR TITLE
[Messenger] Adds option to force indexes creation in Mysql platform for Doctrine transport

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 4.4.0
 -----
-
+ * Added option for forcing mysql indexes creation for doctrine transport
  * Added support for auto trimming of Redis streams.
  * `InMemoryTransport` handle acknowledged and rejected messages.
  * Made all dispatched worker event classes final.

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -462,7 +462,7 @@ class ConnectionTest extends TestCase
         yield 'MySQL with forced index' => [
             MySQL57Platform::class,
             [['queue_name'], ['available_at'], ['delivered_at']],
-            ['force_indexes_creation' => true]
+            ['force_indexes_creation' => true],
         ];
 
         yield 'Other platforms' => [

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -414,7 +414,7 @@ class ConnectionTest extends TestCase
     /**
      * @dataProvider setupIndicesProvider
      */
-    public function testSetupIndices(string $platformClass, array $expectedIndices)
+    public function testSetupIndices(string $platformClass, array $expectedIndices, array $options = [])
     {
         $driverConnection = $this->createMock(DBALConnection::class);
         $driverConnection->method('getConfiguration')->willReturn(new Configuration());
@@ -448,7 +448,7 @@ class ConnectionTest extends TestCase
             ->willReturn([]);
         $driverConnection->method('getDatabasePlatform')->willReturn($platformMock);
 
-        $connection = new Connection([], $driverConnection);
+        $connection = new Connection($options, $driverConnection);
         $connection->setup();
     }
 
@@ -457,6 +457,12 @@ class ConnectionTest extends TestCase
         yield 'MySQL' => [
             MySQL57Platform::class,
             [['delivered_at']],
+        ];
+
+        yield 'MySQL with forced index' => [
+            MySQL57Platform::class,
+            [['queue_name'], ['available_at'], ['delivered_at']],
+            ['force_indexes_creation' => true]
         ];
 
         yield 'Other platforms' => [

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -41,6 +41,7 @@ class Connection
         'queue_name' => 'default',
         'redeliver_timeout' => 3600,
         'auto_setup' => true,
+        'force_indexes_creation' => false,
     ];
 
     /**
@@ -53,6 +54,7 @@ class Connection
      * * queue_name: name of the queue
      * * redeliver_timeout: Timeout before redeliver messages still in handling state (i.e: delivered_at is not null and message is still in table). Default 3600
      * * auto_setup: Whether the table should be created automatically during send / get. Default : true
+     * * force_indexes_creation: Wheter mysql indexes should be created also on mysql
      */
     private $configuration = [];
     private $driverConnection;
@@ -397,7 +399,7 @@ class Connection
             ->setNotnull(false);
         $table->setPrimaryKey(['id']);
         // No indices on queue_name and available_at on MySQL to prevent deadlock issues when running multiple consumers.
-        if (!$this->driverConnection->getDatabasePlatform() instanceof MySqlPlatform) {
+        if ($this->configuration['force_indexes_creation'] || !$this->driverConnection->getDatabasePlatform() instanceof MySqlPlatform) {
             $table->addIndex(['queue_name']);
             $table->addIndex(['available_at']);
         }

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -54,7 +54,7 @@ class Connection
      * * queue_name: name of the queue
      * * redeliver_timeout: Timeout before redeliver messages still in handling state (i.e: delivered_at is not null and message is still in table). Default 3600
      * * auto_setup: Whether the table should be created automatically during send / get. Default : true
-     * * force_indexes_creation: Wheter mysql indexes should be created also on mysql
+     * * force_indexes_creation: Whether indexes should be created also on mysql
      */
     private $configuration = [];
     private $driverConnection;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | maybe
| New feature?  | yes
| Deprecations? | no
| Tickets       |  #42868
| License       | MIT
| Doc PR        | TBA

After upgrading to 5.4 I've had a migration on messenger_messages caused by #42345.

Considering that:

1- doctrine_transport is often used for failed messages
2- with large tables we have degraded performance without indexes
3- get/findAll/count methods in Connection.php are using `createAvailableMessagesQueryBuilder` https://github.com/symfony/symfony/blob/9f5238d4f65c33568757273ab1058047f95cece7/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php#L304-L312 method, that adds where conditions on `available_at` and `queue_name` are used.

I would like to specify that in my conditions a migration for removing indexes should not be created.

Can I help in porting it in 5.4 or you have your flow for porting? 

Thank you

