### PR TITLE
[Uid] Add `Stringable` type to `Ulid` & `AbstractUuid` classes

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Uid;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-abstract class AbstractUid implements \JsonSerializable
+abstract class AbstractUid implements \JsonSerializable, \Stringable
 {
     /**
      * The identifier in its canonic representation.

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -19,6 +19,14 @@ use Symfony\Component\Uid\UuidV4;
 
 class UlidTest extends TestCase
 {
+    public function testStringable()
+    {
+        $ulid = new Ulid('00000000000000000000000000');
+
+        $this->assertInstanceOf(\Stringable::class, $ulid);
+        $this->assertSame('00000000000000000000000000', (string) $ulid);
+    }
+
     /**
      * @group time-sensitive
      */

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -27,6 +27,14 @@ class UuidTest extends TestCase
     private const A_UUID_V1 = 'd9e7a184-5d5b-11ea-a62a-3499710062d0';
     private const A_UUID_V4 = 'd6b3345b-2905-4048-a83c-b5988e765d98';
 
+    public function testStringable()
+    {
+        $uuid = Uuid::fromString(self::A_UUID_V4);
+
+        $this->assertInstanceOf(\Stringable::class, $uuid);
+        $this->assertSame(self::A_UUID_V4, (string) $uuid);
+    }
+
     /**
      * @dataProvider provideInvalidUuids
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

This PR makes `Ulid` and `AbstractUuid` classes implement the `Stringable` interface as they both already implement the magic `__toString` method.

This changes makes it more convenient for an application to pass a `Uuid` or `string` without worrying about the type.

For instance when finding a Doctrine entity by its guid:

```php
class ArticleRepository extends ServiceEntityRepository
{
    public function findPublishedById(\Stringable $id): ?Article
    {
        // ...
    }
}
```
