### PR TITLE
[DoctrineBridge] Fix invalid guess with enumType

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -152,13 +152,16 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
         }
 
         if ($metadata->hasField($property)) {
+            $nullable = $metadata instanceof ClassMetadataInfo && $metadata->isNullable($property);
+            if (null !== $enumClass = $metadata->getFieldMapping($property)['enumType'] ?? null) {
+                return [new Type(Type::BUILTIN_TYPE_OBJECT, $nullable, $enumClass)];
+            }
+
             $typeOfField = $metadata->getTypeOfField($property);
 
             if (!$builtinType = $this->getPhpType($typeOfField)) {
                 return null;
             }
-
-            $nullable = $metadata instanceof ClassMetadataInfo && $metadata->isNullable($property);
 
             switch ($builtinType) {
                 case Type::BUILTIN_TYPE_OBJECT:

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderEnum.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderEnum.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class DoctrineLoaderEnum
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(type="string", enumType="Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\EnumString", length=1)
+     */
+    public $enumString;
+
+    /**
+     * @ORM\Column(type="integer", enumType="Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\EnumInt")
+     */
+    public $enumInt;
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -15,12 +15,16 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Tools\Setup;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
 use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineDummy210;
+use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineEnum;
 use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineGeneratedValue;
 use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineRelation;
+use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\EnumInt;
+use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\EnumString;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -169,6 +173,18 @@ class DoctrineExtractorTest extends TestCase
         );
 
         $this->assertEquals($expectedTypes, $actualTypes);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testExtractEnum()
+    {
+        if (!property_exists(Column::class, 'enumType')) {
+            $this->markTestSkipped('The "enumType" requires doctrine/orm 2.11.');
+        }
+        $this->assertEquals([new Type(Type::BUILTIN_TYPE_OBJECT, false, EnumString::class)], $this->createExtractor()->getTypes(DoctrineEnum::class, 'enumString', []));
+        $this->assertEquals([new Type(Type::BUILTIN_TYPE_OBJECT, false, EnumInt::class)], $this->createExtractor()->getTypes(DoctrineEnum::class, 'enumInt', []));
     }
 
     public function typesProvider()

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineEnum.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineEnum.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+class DoctrineEnum
+{
+    /**
+     * @Id
+     * @Column(type="smallint")
+     */
+    public $id;
+
+    /**
+     * @Column(type="string", enumType="Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\EnumString")
+     */
+    protected $enumString;
+
+    /**
+     * @Column(type="integer", enumType="Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\EnumInt")
+     */
+    protected $enumInt;
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/EnumInt.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/EnumInt.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures;
+
+enum EnumInt: int
+{
+    case Foo = 0;
+    case Bar = 1;
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/EnumString.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/EnumString.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures;
+
+enum EnumString: string
+{
+    case Foo = 'f';
+    case Bar = 'b';
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Validator;
 
+use Doctrine\ORM\Mapping\Column;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\BaseUser;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderEmbed;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderEnum;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderNestedEmbed;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderNoAutoMappingEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderParentEntity;
@@ -147,6 +149,31 @@ class DoctrineLoaderTest extends TestCase
         $noAutoMappingConstraints = $noAutoMappingMetadata[0]->getConstraints();
         $this->assertCount(0, $noAutoMappingConstraints);
         $this->assertSame(AutoMappingStrategy::DISABLED, $noAutoMappingMetadata[0]->getAutoMappingStrategy());
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testExtractEnum()
+    {
+        if (!property_exists(Column::class, 'enumType')) {
+            $this->markTestSkipped('The "enumType" requires doctrine/orm 2.11.');
+        }
+
+        $validator = Validation::createValidatorBuilder()
+            ->addMethodMapping('loadValidatorMetadata')
+            ->enableAnnotationMapping()
+            ->addLoader(new DoctrineLoader(DoctrineTestHelper::createTestEntityManager(), '{^Symfony\\\\Bridge\\\\Doctrine\\\\Tests\\\\Fixtures\\\\DoctrineLoader}'))
+            ->getValidator()
+        ;
+
+        $classMetadata = $validator->getMetadataFor(new DoctrineLoaderEnum());
+
+        $enumStringMetadata = $classMetadata->getPropertyMetadata('enumString');
+        $this->assertCount(0, $enumStringMetadata); // asserts the length constraint is not added to an enum
+
+        $enumStringMetadata = $classMetadata->getPropertyMetadata('enumInt');
+        $this->assertCount(0, $enumStringMetadata); // asserts the length constraint is not added to an enum
     }
 
     public function testFieldMappingsConfiguration()

--- a/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException as OrmMappingException;
 use Doctrine\Persistence\Mapping\MappingException;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\AutoMappingStrategy;
@@ -99,7 +100,7 @@ final class DoctrineLoader implements LoaderInterface
                 $loaded = true;
             }
 
-            if (null === ($mapping['length'] ?? null) || !\in_array($mapping['type'], ['string', 'text'], true)) {
+            if (null === ($mapping['length'] ?? null) || null !== ($mapping['enumType'] ?? null) || !\in_array($mapping['type'], ['string', 'text'], true)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Since https://github.com/doctrine/orm/pull/9304 doctrine allows Enums with the new `enumType` option.
ie.

```php
#[ORM\Column(type: 'string', enumType: Status::class, length: 1)]
public Status $status;
```

The issue is, it break validations at several places:
- `doctrinerExtractor` guess it's a `string` (Because of `type = string`), and validation adds the constraint `Assert\Type(string)`
- `doctrineLoader` guess it's a string with a maxLength and validation adds a constrain `Assert\Length(max=1)`
-