### PR TITLE
[Security] Fix retrieving strategy for custom AccessDecisionManager

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -26,7 +26,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
 {
     private AccessDecisionManagerInterface $manager;
-    private AccessDecisionStrategyInterface $strategy;
+    private ?AccessDecisionStrategyInterface $strategy = null;
     /** @var iterable<mixed, VoterInterface> */
     private iterable $voters = [];
     private array $decisionLog = []; // All decision logs

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -274,4 +274,13 @@ class TraceableAccessDecisionManagerTest extends TestCase
             ],
         ], $sut->getDecisionLog());
     }
+
+    public function testCustomAccessDecisionManagerReturnsEmptyStrategy()
+    {
+        $admMock = $this->createMock(AccessDecisionManagerInterface::class);
+
+        $adm = new TraceableAccessDecisionManager($admMock);
+
+        $this->assertEquals('-', $adm->getStrategy());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Adding property types to `TraceableAccessDecisionManager` in 85065e4f76eb0e75163277498bbc4fadb3ae49f8 leads to the TypeError when using custom `AccessDecisionManager` in the application:
```
Error: Typed property Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager::$strategy must not be accessed before initialization
```

I'm targeting 6.1 branch, because property types are here only in 6.1 branch. Previously they were in 6.0 also, but later it was reverted.