### PR TITLE
[Messenger] Removed goto usage

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -153,7 +153,6 @@ class Connection implements ResetInterface
 
     public function get(): ?array
     {
-        get:
         $this->driverConnection->beginTransaction();
         try {
             $query = $this->createAvailableMessagesQueryBuilder()
@@ -214,7 +213,8 @@ class Connection implements ResetInterface
 
             if ($this->autoSetup && $e instanceof TableNotFoundException) {
                 $this->setup();
-                goto get;
+                
+                return $this->get();
             }
 
             throw $e;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -213,7 +213,7 @@ class Connection implements ResetInterface
 
             if ($this->autoSetup && $e instanceof TableNotFoundException) {
                 $this->setup();
-                
+
                 return $this->get();
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Removed goto usage from the doctrine connection since this was not necessary. This goto can easily be replaced with a function call the the function itself.