### PR TITLE
[PropertyInfo] Add PHP 8.0 promoted properties `@param` mutation support to `PhpDocExtractor`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for phpDocumentor and PHPStan pseudo-types
+ * Add PHP 8.0 promoted properties `@param` mutation support to `PhpDocExtractor`
 
 6.0
 ---

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -249,9 +249,21 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             return $this->docBlocks[$propertyHash];
         }
 
+        $reflectionProperty = null;
+
+        try {
+            $reflectionProperty = new \ReflectionProperty($class, $property);
+        } catch (\ReflectionException $e) {
+        }
+
         $ucFirstProperty = ucfirst($property);
 
         switch (true) {
+            case $reflectionProperty?->isPromoted()
+                && ($docBlock = $this->getDocBlockFromConstructor($class, $property)):
+                $data = [$docBlock, self::MUTATOR, null];
+                break;
+
             case $docBlock = $this->getDocBlockFromProperty($class, $property):
                 $data = [$docBlock, self::PROPERTY, null];
                 break;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type;
@@ -427,6 +428,22 @@ class PhpDocExtractorTest extends TestCase
             ['numericString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
             ['traitString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
             ['positiveInt', [new Type(Type::BUILTIN_TYPE_INT, false, null)]],
+        ];
+    }
+
+    /**
+     * @dataProvider promotedPropertyProvider
+     */
+    public function testExtractPromotedProperty(string $property, ?array $types)
+    {
+        $this->assertEquals($types, $this->extractor->getTypes(Php80Dummy::class, $property));
+    }
+
+    public function promotedPropertyProvider(): array
+    {
+        return [
+            ['promoted', null],
+            ['promotedAndMutated', [new Type(Type::BUILTIN_TYPE_STRING)]],
         ];
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
@@ -6,6 +6,13 @@ class Php80Dummy
 {
     public mixed $mixedProperty;
 
+    /**
+     * @param string $promotedAndMutated
+     */
+    public function __construct(private mixed $promoted, private mixed $promotedAndMutated)
+    {
+    }
+
     public function getFoo(): array|null
     {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

By definition, PHP 8 promoted properties are declared in the constructor. Therefore, a new particular case raises when trying to extract (using [PhpDocExtractor](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php)) a promoted property that is mutated via `@param` in the constructor.
```
class Php80Dummy {
    /**
     * @param string $promotedAndMutatedProperty
     */
    public function __construct(private mixed $promotedAndMutatedProperty)
    {
    }
}
```

`$promotedAndMutatedProperty` extracted types is currently `[null]` (because of "mixed"), but IMO should be `[string]`.

However, I'm not sure if this is the intended behaviour for everyone (opinions welcomed). If it is, I guess I should update [PhpDocExtractorTest](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php) too to reflect the new priority ?