### PR TITLE
[DependencyInjection] remove arbitratry limitation to exclude inline services from bindings

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
@@ -12,10 +12,8 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator\Traits;
 
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\Configurator\DefaultsConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\InstanceofConfigurator;
-use Symfony\Component\DependencyInjection\Reference;
 
 trait BindTrait
 {
@@ -34,9 +32,6 @@ trait BindTrait
     final public function bind(string $nameOrFqcn, $valueOrRef): self
     {
         $valueOrRef = static::processValue($valueOrRef, true);
-        if (!preg_match('/^(?:(?:array|bool|float|int|string|iterable)[ \t]*+)?\$/', $nameOrFqcn) && !$valueOrRef instanceof Reference) {
-            throw new InvalidArgumentException(sprintf('Invalid binding for service "%s": named arguments must start with a "$", and FQCN must map to references. Neither applies to binding "%s".', $this->id, $nameOrFqcn));
-        }
         $bindings = $this->definition->getBindings();
         $type = $this instanceof DefaultsConfigurator ? BoundArgument::DEFAULTS_BINDING : ($this instanceof InstanceofConfigurator ? BoundArgument::INSTANCEOF_BINDING : BoundArgument::SERVICE_BINDING);
         $bindings[$nameOrFqcn] = new BoundArgument($valueOrRef, true, $type, $this->path ?? null);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
 
 class Foo implements FooInterface, Sub\BarInterface
 {
-    public function __construct($bar = null, iterable $foo = null)
+    public function __construct($bar = null, iterable $foo = null, object $baz = null)
     {
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.expected.yml
@@ -15,14 +15,14 @@ services:
             - { name: t, a: b }
         autowire: true
         autoconfigure: true
-        arguments: ['@bar', !tagged_iterator foo]
+        arguments: ['@bar', !tagged_iterator foo, !service { class: Baz }]
     bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
         public: true
         tags:
             - { name: t, a: b }
         autowire: true
-        arguments: [null, !tagged_iterator foo]
+        arguments: [null, !tagged_iterator foo, !service { class: Baz }]
         calls:
             - [setFoo, ['@bar']]
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.php
@@ -15,6 +15,7 @@ return function (ContainerConfigurator $c) {
         ->tag('t', ['a' => 'b'])
         ->bind(Foo::class, ref('bar'))
         ->bind('iterable $foo', tagged_iterator('foo'))
+        ->bind('object $baz', inline('Baz'))
         ->public();
 
     $s->set(Foo::class)->args([ref('bar')])->public();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40469
| License       | MIT
| Doc PR        | -