### PR TITLE
[Messenger] Add sessionToken option to SQS transport

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Added `session_token` option to support short-lived AWS credentials
+
 5.3
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -56,6 +56,24 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testConfigureWithTemporaryCredentials()
+    {
+        $awsKey = 'some_aws_access_key_value';
+        $awsSecret = 'some_aws_secret_value';
+        $sessionToken = 'some_aws_sessionToken';
+        $region = 'eu-west-1';
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => $region, 'accessKeyId' => $awsKey, 'accessKeySecret' => $awsSecret, 'sessionToken' => $sessionToken], null, $httpClient)),
+            Connection::fromDsn('sqs://default/queue', [
+                'access_key' => $awsKey,
+                'secret_key' => $awsSecret,
+                'session_token' => $sessionToken,
+                'region' => $region,
+            ], $httpClient)
+        );
+    }
+
     public function testFromInvalidDsn()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -41,6 +41,7 @@ class Connection
         'auto_setup' => true,
         'access_key' => null,
         'secret_key' => null,
+        'session_token' => null,
         'endpoint' => 'https://sqs.eu-west-1.amazonaws.com',
         'region' => 'eu-west-1',
         'queue_name' => 'messages',
@@ -89,6 +90,7 @@ class Connection
      * * account: identifier of the AWS account
      * * access_key: AWS access key
      * * secret_key: AWS secret key
+     * * session_token: AWS session token (required only when using temporary credentials)
      * * buffer_size: number of messages to prefetch (Default: 9)
      * * wait_time: long polling duration in seconds (Default: 20)
      * * poll_timeout: amount of seconds the transport should wait for new message
@@ -135,6 +137,9 @@ class Connection
             'accessKeyId' => urldecode($parsedUrl['user'] ?? '') ?: $options['access_key'] ?? self::DEFAULT_OPTIONS['access_key'],
             'accessKeySecret' => urldecode($parsedUrl['pass'] ?? '') ?: $options['secret_key'] ?? self::DEFAULT_OPTIONS['secret_key'],
         ];
+        if (null !== $options['session_token']) {
+            $clientConfiguration['sessionToken'] = $options['session_token'];
+        }
         if (isset($options['debug'])) {
             $clientConfiguration['debug'] = $options['debug'];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | [symfony/symfony-docs#16411](https://github.com/symfony/symfony-docs/pull/16411)

When trying to authenticate to use an SQS transport, AWS Credentials have 3 "keys"
- aws_access_key_id
- aws_secret_access_key
- aws_session_token

The last one, `aws_session_token` is only required for temporary credentials. In those cases though, it must be passed as well otherwise AWS returns a 403 Access Denied.

The async-aws library supports this in its configuration https://async-aws.com/configuration.html#sessiontoken

This MR essentially makes sure the user can pass this parameter inside yaml options