### PR TITLE
[RateLimiter] Implicit conversion fix

### DIFF
--- a/src/Symfony/Component/RateLimiter/RateLimit.php
+++ b/src/Symfony/Component/RateLimiter/RateLimit.php
@@ -72,6 +72,6 @@ class RateLimit
             return;
         }
 
-        usleep($delta * 1e6);
+        usleep((int) ($delta * 1e6));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT


This PR fixes the deprecation notice "Deprecated: Implicit conversion from float <float_number> to int loses precision"
