### PR TITLE
[Validator] Allow creating constraints with required arguments

### DIFF
--- a/src/Symfony/Component/Validator/Attribute/HasNamedArguments.php
+++ b/src/Symfony/Component/Validator/Attribute/HasNamedArguments.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Attribute;
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class HasNamedArguments
+{
+}

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Deprecate `Constraint::$errorNames`, use `Constraint::ERROR_NAMES` instead
  * Deprecate constraint `ExpressionLanguageSyntax`, use `ExpressionSyntax` instead
  * Add method `__toString()` to `ConstraintViolationInterface` & `ConstraintViolationListInterface`
+ * Allow creating constraints with required arguments
 
 6.0
 ---

--- a/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Mapping\Loader;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\MappingException;
 
@@ -33,6 +34,11 @@ abstract class AbstractLoader implements LoaderInterface
     public const DEFAULT_NAMESPACE = '\\Symfony\\Component\\Validator\\Constraints\\';
 
     protected $namespaces = [];
+
+    /**
+     * @var array<class-string, bool>
+     */
+    private array $namedArgumentsCache = [];
 
     /**
      * Adds a namespace alias.
@@ -76,6 +82,10 @@ abstract class AbstractLoader implements LoaderInterface
             $className = $this->namespaces[$prefix].$className;
         } else {
             $className = self::DEFAULT_NAMESPACE.$name;
+        }
+
+        if ($this->namedArgumentsCache[$className] ??= (bool) (new \ReflectionMethod($className, '__construct'))->getAttributes(HasNamedArguments::class)) {
+            return new $className(...$options);
         }
 
         return new $className($options);

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithRequiredArgument.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithRequiredArgument.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+final class ConstraintWithRequiredArgument extends Constraint
+{
+    public string $requiredArg;
+
+    #[HasNamedArguments]
+    public function __construct(string $requiredArg, array $groups = null, mixed $payload = null)
+    {
+        parent::__construct([], $groups, $payload);
+
+        $this->requiredArg = $requiredArg;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Entity_81.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Entity_81.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class Entity_81
+{
+    public $title;
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -28,6 +28,8 @@ use Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\Annotation\GroupSequenceProviderEntity;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument;
+use Symfony\Component\Validator\Tests\Fixtures\Entity_81;
 
 class XmlFileLoaderTest extends TestCase
 {
@@ -96,6 +98,19 @@ class XmlFileLoaderTest extends TestCase
         $constraints = $properties[0]->getConstraints();
 
         $this->assertFalse($constraints[0]->match);
+    }
+
+    public function testLoadClassMetadataWithRequiredArguments()
+    {
+        $loader = new XmlFileLoader(__DIR__.'/constraint-mapping-required-arg.xml');
+        $metadata = new ClassMetadata(Entity_81::class);
+
+        $loader->loadClassMetadata($metadata);
+
+        $expected = new ClassMetadata(Entity_81::class);
+        $expected->addPropertyConstraint('title', new ConstraintWithRequiredArgument('X'));
+
+        $this->assertEquals($expected, $metadata);
     }
 
     public function testLoadGroupSequenceProvider()

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -25,6 +25,8 @@ use Symfony\Component\Validator\Tests\Fixtures\Annotation\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\Annotation\GroupSequenceProviderEntity;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument;
+use Symfony\Component\Validator\Tests\Fixtures\Entity_81;
 
 class YamlFileLoaderTest extends TestCase
 {
@@ -134,6 +136,19 @@ class YamlFileLoaderTest extends TestCase
 
         $expected = new ClassMetadata(Entity::class);
         $expected->addPropertyConstraint('firstName', new Range(['max' => \PHP_INT_MAX]));
+
+        $this->assertEquals($expected, $metadata);
+    }
+
+    public function testLoadClassMetadataWithRequiredArguments()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/constraint-mapping-required-arg.yml');
+        $metadata = new ClassMetadata(Entity_81::class);
+
+        $loader->loadClassMetadata($metadata);
+
+        $expected = new ClassMetadata(Entity_81::class);
+        $expected->addPropertyConstraint('title', new ConstraintWithRequiredArgument('X'));
 
         $this->assertEquals($expected, $metadata);
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-required-arg.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-required-arg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+    <class name="Symfony\Component\Validator\Tests\Fixtures\Entity_81">
+
+        <property name="title">
+            <constraint name="Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument">
+                <option name="requiredArg">X</option>
+            </constraint>
+        </property>
+    </class>
+
+</constraint-mapping>

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-required-arg.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-required-arg.yml
@@ -1,0 +1,5 @@
+Symfony\Component\Validator\Tests\Fixtures\Entity_81:
+  properties:
+    title:
+      - Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument:
+          requiredArg: 'X'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16770

Before PHP8 validation constraint usage was only possible with providing options as an array, but now with native PHP attributes we can provide as named arguments. And to require some arguments overriding `getRequiredOptions` method in Constraint was necessary to get proper validation. But since PHP8.1 we can just make arguments required in the Attribute constructor and try to unpack them because it is possible now.

