### PR TITLE
[Routing] Enrich MissingMandatoryParametersException

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.1
 ---
 
+ * Add `getMissingParameters` and `getRouteName` methods on `MissingMandatoryParametersException`
  * Allow using UTF-8 parameter names
 
 5.3

--- a/src/Symfony/Component/Routing/Exception/MissingMandatoryParametersException.php
+++ b/src/Symfony/Component/Routing/Exception/MissingMandatoryParametersException.php
@@ -19,4 +19,39 @@ namespace Symfony\Component\Routing\Exception;
  */
 class MissingMandatoryParametersException extends \InvalidArgumentException implements ExceptionInterface
 {
+    private string $routeName = '';
+    private array $missingParameters = [];
+
+    /**
+     * @param string[] $missingParameters
+     * @param int      $code
+     */
+    public function __construct(string $routeName = '', $missingParameters = null, $code = 0, \Throwable $previous = null)
+    {
+        if (\is_array($missingParameters)) {
+            $this->routeName = $routeName;
+            $this->missingParameters = $missingParameters;
+            $message = sprintf('Some mandatory parameters are missing ("%s") to generate a URL for route "%s".', implode('", "', $missingParameters), $routeName);
+        } else {
+            trigger_deprecation('symfony/routing', '6.1', 'Construction of "%s" with an exception message is deprecated, provide the route name and an array of missing parameters instead.', __CLASS__);
+            $message = $routeName;
+            $previous = $code instanceof \Throwable ? $code : null;
+            $code = (int) $missingParameters;
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMissingParameters(): array
+    {
+        return $this->missingParameters;
+    }
+
+    public function getRouteName(): string
+    {
+        return $this->routeName;
+    }
 }

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -171,7 +171,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
 
         // all params must be given
         if ($diff = array_diff_key($variables, $mergedParams)) {
-            throw new MissingMandatoryParametersException(sprintf('Some mandatory parameters are missing ("%s") to generate a URL for route "%s".', implode('", "', array_keys($diff)), $name));
+            throw new MissingMandatoryParametersException($name, array_keys($diff));
         }
 
         $url = '';

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -321,9 +321,33 @@ class UrlGeneratorTest extends TestCase
         $generator->generate($name);
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyThrowingMissingMandatoryParameters()
+    {
+        $this->expectDeprecation('Since symfony/routing 6.1: Construction of "Symfony\Component\Routing\Exception\MissingMandatoryParametersException" with an exception message is deprecated, provide the route name and an array of missing parameters instead.');
+
+        $exception = new MissingMandatoryParametersException('expected legacy message');
+        $this->assertSame('expected legacy message', $exception->getMessage());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyThrowingMissingMandatoryParametersWithAllParameters()
+    {
+        $this->expectDeprecation('Since symfony/routing 6.1: Construction of "Symfony\Component\Routing\Exception\MissingMandatoryParametersException" with an exception message is deprecated, provide the route name and an array of missing parameters instead.');
+
+        $exception = new MissingMandatoryParametersException('expected legacy message', 256, new \Exception());
+        $this->assertSame('expected legacy message', $exception->getMessage());
+        $this->assertInstanceOf(\Exception::class, $exception->getPrevious());
+    }
+
     public function testGenerateForRouteWithoutMandatoryParameter()
     {
         $this->expectException(MissingMandatoryParametersException::class);
+        $this->expectExceptionMessage('Some mandatory parameters are missing ("foo") to generate a URL for route "test".');
         $routes = $this->getRoutes('test', new Route('/testing/{foo}'));
         $this->getGenerator($routes)->generate('test', [], UrlGeneratorInterface::ABSOLUTE_URL);
     }
@@ -554,6 +578,7 @@ class UrlGeneratorTest extends TestCase
     public function testImportantVariableWithNoDefault()
     {
         $this->expectException(MissingMandatoryParametersException::class);
+        $this->expectExceptionMessage('Some mandatory parameters are missing ("_format") to generate a URL for route "test".');
         $routes = $this->getRoutes('test', new Route('/{page}.{!_format}'));
         $generator = $this->getGenerator($routes);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | NA
| License       | MIT
| Doc PR        | NA

This allows to more easily recover after a failing call to `UrlGenerator::generate`.