### PR TITLE
[Form] Add support for submitting forms with unchecked checkboxes in request handlers

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add support for submitting forms with unchecked checkboxes in request handlers
  * Add `ResetFlowType` button in `NavigatorFlowType` that you can display with `with_reset` option
  * Allow injecting a `ViolationMapperInterface` into `FormTypeValidatorExtension`
  * Deprecate passing boolean as the second argument of `ValidatorExtension` and `FormTypeValidatorExtension`'s constructors; pass a `ViolationMapperInterface` instead

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\HttpFoundation;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\MissingDataHandler;
 use Symfony\Component\Form\RequestHandlerInterface;
 use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\Form\Util\ServerParams;
@@ -30,10 +31,12 @@ use Symfony\Component\HttpFoundation\Request;
 class HttpFoundationRequestHandler implements RequestHandlerInterface
 {
     private ServerParams $serverParams;
+    private MissingDataHandler $missingDataHandler;
 
     public function __construct(?ServerParams $serverParams = null)
     {
         $this->serverParams = $serverParams ?? new ServerParams();
+        $this->missingDataHandler = new MissingDataHandler();
     }
 
     public function handleRequest(FormInterface $form, mixed $request = null): void
@@ -44,6 +47,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
 
         $name = $form->getName();
         $method = $form->getConfig()->getMethod();
+        $missingData = $this->missingDataHandler->missingData;
 
         if ($method !== $request->getMethod()) {
             return;
@@ -55,13 +59,15 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             if ('' === $name) {
                 $data = $request->query->all();
             } else {
-                // Don't submit GET requests if the form's name does not exist
-                // in the request
-                if (!$request->query->has($name)) {
+                $queryData = $request->query->all()[$name] ?? $missingData;
+
+                $data = $this->missingDataHandler->handle($form, $queryData);
+
+                if ($missingData === $data) {
+                    // Don't submit GET requests if the form's name does not exist
+                    // in the request
                     return;
                 }
-
-                $data = $request->query->all()[$name];
             }
         } else {
             // Mark the form with an error if the uploaded size was too large
@@ -88,6 +94,15 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
                 $params = $request->request->all()[$name] ?? $default;
                 $files = $request->files->get($name, $default);
             } else {
+                $params = $missingData;
+                $files = null;
+            }
+
+            if ('PATCH' !== $method) {
+                $params = $this->missingDataHandler->handle($form, $params);
+            }
+
+            if ($missingData === $params) {
                 // Don't submit the form if it is not present in the request
                 return;
             }

--- a/src/Symfony/Component/Form/MissingDataHandler.php
+++ b/src/Symfony/Component/Form/MissingDataHandler.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form;
+
+/**
+ * @internal
+ */
+class MissingDataHandler
+{
+    public readonly \stdClass $missingData;
+
+    public function __construct()
+    {
+        $this->missingData = new \stdClass();
+    }
+
+    public function handle(FormInterface $form, mixed $data): mixed
+    {
+        $processedData = $this->handleMissingData($form, $data);
+
+        return $processedData === $this->missingData ? $data : $processedData;
+    }
+
+    private function handleMissingData(FormInterface $form, mixed $data): mixed
+    {
+        $config = $form->getConfig();
+        $missingData = $this->missingData;
+        $falseValues = $config->getOption('false_values', null);
+
+        if (\is_array($falseValues)) {
+            if ($data === $missingData) {
+                return $falseValues[0] ?? null;
+            }
+
+            if (\in_array($data, $falseValues)) {
+                return $data;
+            }
+        }
+
+        if (null === $data || $missingData === $data) {
+            $data = $config->getCompound() ? [] : $data;
+        }
+
+        if (\is_array($data)) {
+            $children = $config->getCompound() ? $form->all() : [$form];
+
+            foreach ($children as $child) {
+                $name = $child->getName();
+                $childData = $missingData;
+
+                if (\array_key_exists($name, $data)) {
+                    $childData = $data[$name];
+                }
+
+                $value = $this->handleMissingData($child, $childData);
+
+                if ($missingData !== $value) {
+                    $data[$name] = $value;
+                }
+            }
+
+            return $data ?: $missingData;
+        }
+
+        return $data;
+    }
+}

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -23,6 +23,7 @@ use Symfony\Component\Form\Util\ServerParams;
 class NativeRequestHandler implements RequestHandlerInterface
 {
     private ServerParams $serverParams;
+    private MissingDataHandler $missingDataHandler;
 
     /**
      * The allowed keys of the $_FILES array.
@@ -39,6 +40,7 @@ class NativeRequestHandler implements RequestHandlerInterface
     public function __construct(?ServerParams $params = null)
     {
         $this->serverParams = $params ?? new ServerParams();
+        $this->missingDataHandler = new MissingDataHandler();
     }
 
     /**
@@ -52,6 +54,7 @@ class NativeRequestHandler implements RequestHandlerInterface
 
         $name = $form->getName();
         $method = $form->getConfig()->getMethod();
+        $missingData = $this->missingDataHandler->missingData;
 
         if ($method !== self::getRequestMethod()) {
             return;
@@ -63,13 +66,14 @@ class NativeRequestHandler implements RequestHandlerInterface
             if ('' === $name) {
                 $data = $_GET;
             } else {
-                // Don't submit GET requests if the form's name does not exist
-                // in the request
-                if (!isset($_GET[$name])) {
+                $queryData = $_GET[$name] ?? $missingData;
+                $data = $this->missingDataHandler->handle($form, $queryData);
+
+                if ($missingData === $data) {
+                    // Don't submit GET requests if the form's name does not exist
+                    // in the request
                     return;
                 }
-
-                $data = $_GET[$name];
             }
         } else {
             // Mark the form with an error if the uploaded size was too large
@@ -101,6 +105,15 @@ class NativeRequestHandler implements RequestHandlerInterface
                 $params = \array_key_exists($name, $_POST) ? $_POST[$name] : $default;
                 $files = \array_key_exists($name, $fixedFiles) ? $fixedFiles[$name] : $default;
             } else {
+                $params = $missingData;
+                $files = null;
+            }
+
+            if ('PATCH' !== $method) {
+                $params = $this->missingDataHandler->handle($form, $params);
+            }
+
+            if ($missingData === $params) {
                 // Don't submit the form if it is not present in the request
                 return;
             }

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -15,7 +15,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
@@ -58,6 +60,84 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
         $this->requestHandler = $this->getRequestHandler();
         $this->factory = Forms::createFormFactoryBuilder()->getFormFactory();
         $this->request = null;
+    }
+
+    #[DataProvider('methodExceptPatchProvider')]
+    public function testSubmitCheckboxInCollectionFormWithEmptyData($method)
+    {
+        $form = $this->factory->create(CollectionType::class, [true, false, true], [
+            'entry_type' => CheckboxType::class,
+            'method' => $method,
+        ]);
+
+        $this->setRequestData($method, []);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+
+        $this->assertEqualsCanonicalizing([false, false, false], $form->getData());
+    }
+
+    #[DataProvider('methodExceptPatchProvider')]
+    public function testSubmitCheckboxInCollectionFormWithPartialData($method)
+    {
+        $form = $this->factory->create(CollectionType::class, [true, false, true], [
+            'entry_type' => CheckboxType::class,
+            'method' => $method,
+        ]);
+
+        $this->setRequestData($method, [
+            'collection' => [
+                1 => true,
+            ],
+        ]);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+
+        $this->assertEqualsCanonicalizing([false, true, false], $form->getData());
+    }
+
+    #[DataProvider('methodExceptPatchProvider')]
+    public function testSubmitCheckboxFormWithEmptyData($method)
+    {
+        $form = $this->factory->create(FormType::class, ['subform' => ['checkbox' => true]], [
+            'method' => $method,
+        ])
+            ->add('subform', FormType::class, [
+                'compound' => true,
+            ]);
+
+        $form->get('subform')
+            ->add('checkbox', CheckboxType::class);
+
+        $this->setRequestData($method, []);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+
+        $this->assertEquals(['subform' => ['checkbox' => false]], $form->getData());
+    }
+
+    #[DataProvider('methodExceptPatchProvider')]
+    public function testSubmitSimpleCheckboxFormWithEmptyData($method)
+    {
+        $form = $this->factory->createNamed('checkbox', CheckboxType::class, true, [
+            'method' => $method,
+        ]);
+
+        $this->setRequestData($method, []);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+
+        $this->assertFalse($form->getData());
+    }
+
+    public static function methodExceptPatchProvider(): array
+    {
+        return [
+            ['POST'],
+            ['PUT'],
+            ['DELETE'],
+            ['GET'],
+        ];
     }
 
     public static function methodExceptGetProvider(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #20179, #14938
| License       | MIT

When a form contains only checkboxes (or a collection of checkboxes), there is no way to distinguish between:

- A user visiting a page that contains the form (not a submission)
- A user submitting the form with all checkboxes unchecked

This is because unchecked checkboxes are omitted entirely from the HTTP request. When the form's name is absent from the request, the current handlers bail out early and don't submit the form - so unchecked checkboxes can never reset a true default value.

This PR introduces `MissingDataHandler`, which walks the form's children recursively at request-handling time to detect whether the form would have appeared in the request had any checkbox been checked. Concretely:

- If a form (or any of its children) has a `false_values` option (the marker used by `CheckboxType`), it means the form contains a checkbox. When that checkbox key is absent from the submitted data, `MissingDataHandler` injects the first false value (i.e. `'0'` for a standard checkbox) so the form is submitted and data is set to `false`.
- An `stdClass` sentinel object is used to distinguish "key was absent" from `null`, making the logic explicit and identity-safe.
- `PATCH` requests are excluded intentionally, since PATCH is meant for partial updates and omitted fields should be left untouched.

Before/after

```php
// Form with a single checkbox, default data = true
$form = $factory->createNamed('agree', CheckboxType::class, true);

// POST request with no body (all checkboxes unchecked)
$handler->handleRequest($form, $request);

// Before: form is never submitted, data stays true
// After:  form is submitted, data is false ✓
```
