### PR TITLE
[Yaml] Improve the deprecation warnings for octal numbers to suggest migrating

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -646,21 +646,18 @@ class Inline
                         return (float) substr($scalar, 8);
                     case 0 === strpos($scalar, '!!binary '):
                         return self::evaluateBinaryScalar(substr($scalar, 9));
-                    default:
-                        throw new ParseException(sprintf('The string "%s" could not be parsed as it uses an unsupported built-in tag.', $scalar), self::$parsedLineNumber, $scalar, self::$parsedFilename);
                 }
-                // no break
+
+                throw new ParseException(sprintf('The string "%s" could not be parsed as it uses an unsupported built-in tag.', $scalar), self::$parsedLineNumber, $scalar, self::$parsedFilename);
             case preg_match('/^(?:\+|-)?0o(?P<value>[0-7_]++)$/', $scalar, $matches):
                 $value = str_replace('_', '', $matches['value']);
 
                 if ('-' === $scalar[0]) {
                     return -octdec($value);
-                } else {
-                    return octdec($value);
                 }
 
+                return octdec($value);
             // Optimize for returning strings.
-            // no break
             case \in_array($scalar[0], ['+', '-', '.'], true) || is_numeric($scalar[0]):
                 if (Parser::preg_match('{^[+-]?[0-9][0-9_]*$}', $scalar)) {
                     $scalar = str_replace('_', '', $scalar);
@@ -669,7 +666,7 @@ class Inline
                 switch (true) {
                     case ctype_digit($scalar):
                         if (preg_match('/^0[0-7]+$/', $scalar)) {
-                            trigger_deprecation('symfony/yaml', '5.1', 'Support for parsing numbers prefixed with 0 as octal numbers. They will be parsed as strings as of 6.0.');
+                            trigger_deprecation('symfony/yaml', '5.1', 'Support for parsing numbers prefixed with 0 as octal numbers. They will be parsed as strings as of 6.0. Use "%s" to represent the octal number.', '0o'.substr($scalar, 1));
 
                             return octdec($scalar);
                         }
@@ -679,7 +676,7 @@ class Inline
                         return ($scalar === (string) $cast) ? $cast : $scalar;
                     case '-' === $scalar[0] && ctype_digit(substr($scalar, 1)):
                         if (preg_match('/^-0[0-7]+$/', $scalar)) {
-                            trigger_deprecation('symfony/yaml', '5.1', 'Support for parsing numbers prefixed with 0 as octal numbers. They will be parsed as strings as of 6.0.');
+                            trigger_deprecation('symfony/yaml', '5.1', 'Support for parsing numbers prefixed with 0 as octal numbers. They will be parsed as strings as of 6.0. Use "%s" to represent the octal number.', '-0o'.substr($scalar, 2));
 
                             return -octdec(substr($scalar, 1));
                         }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -771,9 +771,9 @@ class InlineTest extends TestCase
      * @group legacy
      * @dataProvider getTestsForOctalNumbersYaml11Notation
      */
-    public function testParseOctalNumbersYaml11Notation(int $expected, string $yaml)
+    public function testParseOctalNumbersYaml11Notation(int $expected, string $yaml, string $replacement)
     {
-        $this->expectDeprecation('Since symfony/yaml 5.1: Support for parsing numbers prefixed with 0 as octal numbers. They will be parsed as strings as of 6.0.');
+        $this->expectDeprecation(sprintf('Since symfony/yaml 5.1: Support for parsing numbers prefixed with 0 as octal numbers. They will be parsed as strings as of 6.0. Use "%s" to represent the octal number.', $replacement));
 
         self::assertSame($expected, Inline::parse($yaml));
     }
@@ -781,9 +781,9 @@ class InlineTest extends TestCase
     public function getTestsForOctalNumbersYaml11Notation()
     {
         return [
-            'positive octal number' => [28, '034'],
-            'positive octal number with separator' => [1243, '0_2_3_3_3'],
-            'negative octal number' => [-28, '-034'],
+            'positive octal number' => [28, '034', '0o34'],
+            'positive octal number with separator' => [1243, '0_2_3_3_3', '0o2333'],
+            'negative octal number' => [-28, '-034', '-0o34'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

The existing deprecation messages made some people think that octal numbers are totally unsupported in newer Symfony versions (see https://github.com/thephpleague/flysystem-bundle/issues/81). This updates the deprecation message to provide the alternative when using an octal number is intended, to migrate to the Yaml 1.2 way of representing them.