### PR TITLE
[Validator] Improve Image constraint invalid mime type message

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -189,5 +189,9 @@ class Image extends File
         $this->allowLandscapeMessage = $allowLandscapeMessage ?? $this->allowLandscapeMessage;
         $this->allowPortraitMessage = $allowPortraitMessage ?? $this->allowPortraitMessage;
         $this->corruptedMessage = $corruptedMessage ?? $this->corruptedMessage;
+
+        if (!\in_array('image/*', (array) $this->mimeTypes, true) && !\array_key_exists('mimeTypesMessage', $options ?? []) && null === $mimeTypesMessage) {
+            $this->mimeTypesMessage = 'The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.';
+        }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -547,4 +547,36 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             new Image(detectCorrupted: true, corruptedMessage: 'myMessage'),
         ];
     }
+
+    /**
+     * @dataProvider provideInvalidMimeTypeWithNarrowedSet
+     */
+    public function testInvalidMimeTypeWithNarrowedSet(Image $constraint)
+    {
+        $this->validator->validate($this->image, $constraint);
+
+        $this->buildViolation('The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.')
+            ->setParameter('{{ file }}', sprintf('"%s"', $this->image))
+            ->setParameter('{{ type }}', '"image/gif"')
+            ->setParameter('{{ types }}', '"image/jpeg", "image/png"')
+            ->setParameter('{{ name }}', '"test.gif"')
+            ->setCode(Image::INVALID_MIME_TYPE_ERROR)
+            ->assertRaised();
+    }
+
+    public function provideInvalidMimeTypeWithNarrowedSet()
+    {
+        yield 'Doctrine style' => [new Image([
+            'mimeTypes' => [
+                'image/jpeg',
+                'image/png',
+            ],
+        ])];
+        yield 'Named arguments' => [
+            new Image(mimeTypes: [
+                'image/jpeg',
+                'image/png',
+            ]),
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix -
| License       | MIT
| Doc PR        | -

Using:
```php
new Image(mimeTypes: ['image/jpeg', 'image/png']);
```

Uploading a `image/gif` file, I get:
```
This file is not a valid image.
```

The file is actually a valid image but its mime type is not whitelisted. In this case I propose to fall back to the original `File` constraint message which is better IMO:
```
The mime type of the file is invalid ("image/gif"). Allowed mime types are "image/jpeg", "image/png".
```

It gives more hints.