### PR TITLE
[Validator] Improve FileValidator sizes factorization edge case

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -225,6 +225,13 @@ class FileValidator extends ConstraintValidator
             $coefFactor = self::KB_BYTES;
         }
 
+        // If $limit < $coef, $limitAsString could be < 1 with less than 3 decimals.
+        // In this case, we would end up displaying an allowed size < 1 (eg: 0.1 MB).
+        // It looks better to keep on factorizing (to display 100 kB for example).
+        while ($limit < $coef) {
+            $coef /= $coefFactor;
+        }
+
         $limitAsString = (string) ($limit / $coef);
 
         // Restrict the limit to 2 decimals (without rounding! we

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -153,6 +153,11 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             [1048577, '1Mi', '1048577', '1048576', 'bytes'],
             [1053818, '1Mi', '1029.12', '1024', 'KiB'],
             [1053819, '1Mi', '1.01', '1', 'MiB'],
+
+            // $limit < $coef, @see FileValidator::factorizeSizes()
+            [169632, '100k', '169.63', '100', 'kB'],
+            [1000001, '990k', '1000', '990', 'kB'],
+            [123, '80', '123', '80', 'bytes'],
         ];
     }
 
@@ -508,8 +513,8 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             ], '1000G'];
 
             $tests[] = [(string) \UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
-                '{{ limit }}' => '0.1',
-                '{{ suffix }}' => 'MB',
+                '{{ limit }}' => '100',
+                '{{ suffix }}' => 'kB',
             ], '100K'];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

```php
new File(maxSize: '100k'); // 100_000 bytes
```

Uploading a `169_630 bytes` files (`169.63 KB`), I get:
```
The file is too large (0.17 MB). Allowed maximum size is 0.1 MB.
```

Displaying an allowed maximum size in MB while the maximum I specified is lower than 1 MB is not optimal IMO.

Most of the time the problem doesn't occur because the first division result in `FileValidator::factorizeSizes()` is a number < 1 but it has more than 2 decimals, so it's still go in the "while" loop. It's visible only with specific values, when the division result "tombe juste :fr:".

For example, If I change the maximum allowed size a bit:
```php
new File(maxSize: '101k'); // 101_000 bytes
```

I get:
```
The file is too large (169.63 kB). Allowed maximum size is 101 kB.
```