### PR TITLE
Add generics to ArgumentMetadata::getAttributes

### DIFF
--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -101,7 +101,10 @@ class ArgumentMetadata
     }
 
     /**
-     * @return object[]
+     * @param class-string          $name
+     * @param self::IS_INSTANCEOF|0 $flags
+     *
+     * @return array<object>
      */
     public function getAttributes(string $name = null, int $flags = 0): array
     {
@@ -109,6 +112,19 @@ class ArgumentMetadata
             return $this->attributes;
         }
 
+        return $this->getAttributesOfType($name, $flags);
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T>       $name
+     * @param self::IS_INSTANCEOF|0 $flags
+     *
+     * @return array<T>
+     */
+    public function getAttributesOfType(string $name, int $flags = 0): array
+    {
         $attributes = [];
         if ($flags & self::IS_INSTANCEOF) {
             foreach ($this->attributes as $attribute) {

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataTest.php
@@ -48,4 +48,10 @@ class ArgumentMetadataTest extends TestCase
         $argument = new ArgumentMetadata('foo', 'string', false, true, 'default value', true, [new Foo('bar')]);
         $this->assertEquals([new Foo('bar')], $argument->getAttributes());
     }
+
+    public function testGetAttributesOfType()
+    {
+        $argument = new ArgumentMetadata('foo', 'string', false, true, 'default value', true, [new Foo('bar')]);
+        $this->assertEquals([new Foo('bar')], $argument->getAttributesOfType(Foo::class));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is a bit of an unfortunate situation because the function does too many things. If stronger typing was applied earlier on, it would have been evident that typing this correctly is pretty much impossible, and that would have helped guide the design to use a separate function to retrieve all attributes and some attributes.

e.g. the ideal outcome would be for `getAttributes(Foo::class)` to be typed as such:

```
    /**
     * @template T
     * @param class-string<T> $name
     * @return array<T>
     */
```

So that the result is guaranteed to be an array of Foo objects.

The fact that $name is nullable throws all this off though.. So I guess the only good way forward would be to deprecate null, or deprecate passing `$name` and add a `getAttributesByClassName(string $class, int $flags = 0)` ?

I'm not sure if merging this as is is valuable or not, or if you'd rather get the deprecation and new method targetting 6.1?