### PR TITLE
[Finder] Fix finding VCS re-included files in excluded directory

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
@@ -60,8 +60,6 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
 
         foreach ($this->parentsDirectoryDownward($fileRealPath) as $parentDirectory) {
             if ($this->isIgnored($parentDirectory)) {
-                $ignored = true;
-
                 // rules in ignored directories are ignored, no need to check further.
                 break;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #45048
| License       | MIT
| Doc PR        | -

This PR fixes a bug where `Finder` would not return a file inside a directory when gitignore rules exclude the directory but re-include the file.

The first commit makes `Finder` return the file. Though, as shown by the second commit, the directory is still not returned. Strictly speaking, the directory *is* ignored, so in some sense `Finder` is correct. But then it contains a file that is not ignored. In this case, Git would see the directory anyway. Should `Finder` return any ignored directory as soon as it contains a file that is not ignored? Even if that file is not part of `Finder` results?