### PR TITLE
[Cache] Throw exception if incompatible version of psr/simple-cache is used

### DIFF
--- a/src/Symfony/Component/Cache/Psr16Cache.php
+++ b/src/Symfony/Component/Cache/Psr16Cache.php
@@ -19,6 +19,10 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\Traits\ProxyTrait;
 
+if (null !== (new \ReflectionMethod(CacheInterface::class, 'get'))->getReturnType()) {
+    throw new \LogicException('psr/simple-cache 3.0+ is not compatible with this version of symfony/cache. Please upgrade symfony/cache to 6.0+ or downgrade psr/simple-cache to 1.x or 2.x.');
+}
+
 /**
  * Turns a PSR-6 cache into a PSR-16 one.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44738
| License       | MIT
| Doc PR        | n/a

Addresses #44738 by throwing an explanatory exception when an incompatible version of psr/simple-log is used.

❗ **Important:** This change should not be included in 6.0+, as those newer versions do not have this compatibility issue!  This commit should instead be reverted during that merge.