### PR TITLE
[Form] Add inputmode attribute on NumberType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
@@ -47,6 +47,8 @@ class NumberType extends AbstractType
     {
         if ($options['html5']) {
             $view->vars['type'] = 'number';
+        } else {
+            $view->vars['attr']['inputmode'] = 0 === $options['scale'] ? 'numeric' : 'decimal';
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -202,4 +202,36 @@ class NumberTypeTest extends BaseTypeTest
             'html5' => true,
         ]);
     }
+
+    public function testNumericInputmode()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'scale' => 0,
+            'html5' => false,
+        ]);
+        $form->setData(12345.54321);
+
+        $this->assertSame('numeric', $form->createView()->vars['attr']['inputmode']);
+    }
+
+    public function testDecimalInputmode()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'scale' => 2,
+            'html5' => false,
+        ]);
+        $form->setData(12345.54321);
+
+        $this->assertSame('decimal', $form->createView()->vars['attr']['inputmode']);
+    }
+
+    public function testNoInputmodeWithHtml5Widget()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'html5' => true,
+        ]);
+        $form->setData(12345.54321);
+
+        $this->assertArrayNotHasKey('inputmode', $form->createView()->vars['attr']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #45099
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Quick add of `inputmode` attribute on NumberType, let's discuss about this:

- Should it be the default?
- Should we add a way to not add the attribute?

Thank you @GromNaN for the issue, I had this idea in mind for a long time :wink: 