### PR TITLE
[Process] Avoid calling fclose on an already closed resource

### DIFF
--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -47,7 +47,9 @@ abstract class AbstractPipes implements PipesInterface
     public function close()
     {
         foreach ($this->pipes as $pipe) {
-            fclose($pipe);
+            if (\is_resource($pipe)) {
+                fclose($pipe);
+            }
         }
         $this->pipes = [];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I got this in Composer while interrupting an install process with Ctrl-C.

```
PHP Fatal error:  Uncaught TypeError: fclose(): supplied resource is not a valid stream resource in /var/www/composer/vendor/symfony/process/Pipes/AbstractPipes.php:50
Stack trace:
#0 /var/www/composer/vendor/symfony/process/Pipes/AbstractPipes.php(50): fclose()
#1 /var/www/composer/vendor/symfony/process/Pipes/UnixPipes.php(50): Symfony\Component\Process\Pipes\AbstractPipes->close()
#2 [internal function]: Symfony\Component\Process\Pipes\UnixPipes->__destruct()
#3 {main}
  thrown in /var/www/composer/vendor/symfony/process/Pipes/AbstractPipes.php on line 50
```

I am assuming it's due to a process which was not closed properly, which is very likely given we run a bunch of them concurrently.. It's pretty hard to debug as it's also hard to reproduce, so I am not sure what to do except handle this case gracefully in the close/__destruct function and hope that at least lets it clean up processes without crashing this way.