### PR TITLE
[Console] remove needless check for "disable_functions" ini setting

### DIFF
--- a/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
+++ b/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
@@ -39,15 +39,7 @@ final class SignalRegistry
 
     public static function isSupported(): bool
     {
-        if (!\function_exists('pcntl_signal')) {
-            return false;
-        }
-
-        if (\in_array('pcntl_signal', explode(',', ini_get('disable_functions')))) {
-            return false;
-        }
-
-        return true;
+        return \function_exists('pcntl_signal');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Since PHP8, disabled functions are not registered anymore. Using `function_exists()` is enough.