### PR TITLE
[Yaml] Making the parser stateless

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -98,6 +98,8 @@ class Parser
             if (null !== $mbEncoding) {
                 mb_internal_encoding($mbEncoding);
             }
+            $this->refsBeingParsed = [];
+            $this->offset = 0;
             $this->lines = [];
             $this->currentLine = '';
             $this->refs = [];

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -84,6 +84,20 @@ class ParserTest extends TestCase
         ];
     }
 
+    public function testParserIsStateless()
+    {
+        $yamlString = '# translations/messages.en.yaml
+
+';
+        $this->parser->parse($yamlString);
+        $this->parser->parse($yamlString);
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage("A YAML file cannot contain tabs as indentation at line 2 (near \"\tabc\")");
+
+        $this->parser->parse("abc:\n\tabc");
+    }
+
     /**
      * @dataProvider validTokenSeparators
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently if you parse multiple files with the same `Parser` instance, you get different results in the error reporting since the parser doesn't reset the offset.

## How to reproduce
If you remove the line added in the parser then the error message shows the incorrect line number and the test will fail.