### PR TITLE
Remove composer/package-versions-deprecated from allowed plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,7 +154,6 @@
     },
     "config": {
         "allow-plugins": {
-            "composer/package-versions-deprecated": true,
             "symfony/runtime": true
         }
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Now that https://github.com/composer/composer/pull/10458 is out in Composer 2.2.5.