### PR TITLE
[Cache] TagAwareAdapterInterface is no longer Mockable

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AdapterInterface.php
+++ b/src/Symfony/Component/Cache/Adapter/AdapterInterface.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Component\Cache\Adapter;
 
-use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 // Help opcache.preload discover always-needed symbols
-class_exists(CacheItemInterface::class);
+class_exists(ItemInterface::class);
 
 /**
  * Interface for adapters managing instances of Symfony's CacheItem.
@@ -27,12 +27,12 @@ interface AdapterInterface extends CacheItemPoolInterface
     /**
      * {@inheritdoc}
      */
-    public function getItem(mixed $key): CacheItemInterface;
+    public function getItem(mixed $key): ItemInterface;
 
     /**
      * {@inheritdoc}
      *
-     * @return iterable<string, CacheItemInterface>
+     * @return iterable<string, ItemInterface>
      */
     public function getItems(array $keys = []): iterable;
 

--- a/src/Symfony/Component/Cache/Adapter/AdapterInterface.php
+++ b/src/Symfony/Component/Cache/Adapter/AdapterInterface.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Cache\Adapter;
 
-use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
 
 // Help opcache.preload discover always-needed symbols
 class_exists(CacheItemInterface::class);

--- a/src/Symfony/Component/Cache/Adapter/AdapterInterface.php
+++ b/src/Symfony/Component/Cache/Adapter/AdapterInterface.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Cache\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\CacheItem;
+use Psr\Cache\CacheItemInterface;
 
 // Help opcache.preload discover always-needed symbols
-class_exists(CacheItem::class);
+class_exists(CacheItemInterface::class);
 
 /**
  * Interface for adapters managing instances of Symfony's CacheItem.
@@ -27,12 +27,12 @@ interface AdapterInterface extends CacheItemPoolInterface
     /**
      * {@inheritdoc}
      */
-    public function getItem(mixed $key): CacheItem;
+    public function getItem(mixed $key): CacheItemInterface;
 
     /**
      * {@inheritdoc}
      *
-     * @return iterable<string, CacheItem>
+     * @return iterable<string, CacheItemInterface>
      */
     public function getItems(array $keys = []): iterable;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45113
| License       | MIT

Refer to the issue for description and discussion https://github.com/symfony/symfony/issues/45113