### PR TITLE
[Serializer] Set context annotation as not final

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/Context.php
+++ b/src/Symfony/Component/Serializer/Annotation/Context.php
@@ -23,7 +23,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-final class Context
+class Context
 {
     private array $groups;
 

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.1
 ---
 
+ * Set `Context` annotation as not final
  * Deprecate `ContextAwareNormalizerInterface`, use `NormalizerInterface` instead
  * Deprecate `ContextAwareDenormalizerInterface`, use `DenormalizerInterface` instead
  * Deprecate `ContextAwareEncoderInterface`, use `EncoderInterface` instead

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/DummyContextChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/DummyContextChild.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
+
+use Symfony\Component\Serializer\Annotation\Context;
+
+/**
+ * Annotation class for @DummyContextChild().
+ *
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"PROPERTY", "METHOD"})
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+class DummyContextChild extends Context
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #45106
| License       | MIT
| Doc PR        | N/A

Allow extending `Context` annotation for creating custom annotations.

This is my first PR for Symfony, don't hesitate to tell if something is wrong with it ;) 