### PR TITLE
[TwigBridge] Add a twig-lint binary

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+6.1
+---
+ * Add a `twig-lint` binary
+
 5.4
 ---
 

--- a/src/Symfony/Bridge/Twig/Resources/bin/twig-lint
+++ b/src/Symfony/Bridge/Twig/Resources/bin/twig-lint
@@ -1,0 +1,47 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Runs the Twig lint command.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+
+use Symfony\Bridge\Twig\Command\LintCommand;
+use Symfony\Component\Console\Application;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+function includeIfExists(string $file): bool
+{
+    return file_exists($file) && include $file;
+}
+
+if (
+    !includeIfExists(__DIR__ . '/../../../../autoload.php') &&
+    !includeIfExists(__DIR__ . '/../../vendor/autoload.php') &&
+    !includeIfExists(__DIR__ . '/../../../../../../vendor/autoload.php')
+) {
+    fwrite(STDERR, 'Dependencies are missing, try running "composer install".'.PHP_EOL);
+    exit(1);
+}
+
+if (!class_exists(Application::class)) {
+    fwrite(STDERR, 'You cannot use the twig-lint binary as the Console component is not installed. Try running "composer require symfony/console".'.PHP_EOL);
+    exit(1);
+}
+
+(new Application())->add($command = new LintCommand(new Environment(new ArrayLoader())))
+    ->getApplication()
+    ->setDefaultCommand($command->getName(), true)
+    ->run()
+;

--- a/src/Symfony/Bridge/Twig/Tests/phpt/lint-twig.phpt
+++ b/src/Symfony/Bridge/Twig/Tests/phpt/lint-twig.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test twig-lint binary
+--FILE--
+<?php
+$filename = tempnam(sys_get_temp_dir(), 'sf-');
+file_put_contents($filename, "{{ foo }}");
+passthru('php '.__DIR__.'/../../Resources/bin/twig-lint '.$filename);
+@unlink($filename);
+?>
+--EXPECT--
+[OK] All 1 Twig files contain valid syntax.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I see such binary in several projects and it seems consistent with what we did for the `yaml-lint` bin.