### PR TITLE
Replaced full CoC text with link to documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,83 +1,8 @@
-Code of Conduct
-===============
+# Code of Conduct
 
-Our Pledge
-----------
+This project follows a [Code of Conduct][code_of_conduct] in order to ensure an open and welcoming environment.
+Please read the full text for understanding the accepted and unaccepted behavior.
+Please read also the [reporting guidelines][guidelines], in case you encountered or witnessed any misbehavior.
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnic origin, gender identity and expression, level of
-experience, education, socio-economic status, nationality, personal appearance,
-religion, or sexual identity and orientation.
-
-Our Standards
--------------
-
-Examples of behavior that contributes to creating a positive environment
-include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-Our Responsibilities
---------------------
-
-[CoC Active Response Ensurers, or CARE][1], are responsible for clarifying the
-standards of acceptable behavior and are expected to take appropriate and fair
-corrective action in response to any instances of unacceptable behavior.
-
-CARE team members have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, or to ban temporarily or permanently any
-contributor for other behaviors that they deem inappropriate, threatening,
-offensive, or harmful.
-
-Scope
------
-
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by CARE team members.
-
-Enforcement
------------
-
-Instances of abusive, harassing, or otherwise unacceptable behavior
-[may be reported][2] by contacting the [CARE team members][1].
-All complaints will be reviewed and investigated and will result in a response
-that is deemed necessary and appropriate to the circumstances. The CARE team is
-obligated to maintain confidentiality with regard to the reporter of an
-incident. Further details of specific enforcement policies may be posted
-separately.
-
-CARE team members who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by the
-[core team][3].
-
-Attribution
------------
-
-This Code of Conduct is adapted from the [Contributor Covenant version 1.4][4].
-
-[1]: https://symfony.com/doc/current/contributing/code_of_conduct/care_team.html
-[2]: https://symfony.com/doc/current/contributing/code_of_conduct/reporting_guidelines.html
-[3]: https://symfony.com/doc/current/contributing/code/core_team.html
-[4]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+[code_of_conduct]: https://symfony.com/coc
+[guidelines]: https://symfony.com/doc/current/contributing/code_of_conduct/reporting_guidelines.html


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#16442

This ensures that we have 1 single source for the full text and not multiple versions in different repositories.
