### PR TITLE
[Translation] Allow usage of Provider domains if possible

### DIFF
--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Translation\Provider\FilteringProvider;
 use Symfony\Component\Translation\Provider\TranslationProviderCollection;
 use Symfony\Component\Translation\Reader\TranslationReaderInterface;
 use Symfony\Component\Translation\TranslatorBag;
@@ -133,7 +134,13 @@ EOF
         $localTranslations = $this->readLocalTranslations($locales, $domains, $this->transPaths);
 
         if (!$domains) {
-            $domains = $this->getDomainsFromTranslatorBag($localTranslations);
+            if ($provider instanceof FilteringProvider) {
+                $domains = $provider->getDomains();
+            }
+
+            if (!$domains) {
+                $domains = $this->getDomainsFromTranslatorBag($localTranslations);
+            }
         }
 
         if (!$deleteMissing && $force) {

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -17,7 +17,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Translation\Command\TranslationPushCommand;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\Provider\FilteringProvider;
 use Symfony\Component\Translation\Provider\ProviderInterface;
+use Symfony\Component\Translation\Provider\TranslationProviderCollection;
 use Symfony\Component\Translation\Reader\TranslationReader;
 use Symfony\Component\Translation\TranslatorBag;
 
@@ -257,6 +259,68 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
 
         $this->assertStringContainsString('[OK] Missing translations on "null" has been deleted (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
         $this->assertStringContainsString('[OK] All local translations has been sent to "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+    }
+
+    public function testPushWithProviderDomains()
+    {
+        $arrayLoader = new ArrayLoader();
+        $xliffLoader = new XliffFileLoader();
+        $locales = ['en', 'fr'];
+        $domains = ['messages'];
+
+        // Simulate existing messages on Provider
+        $providerReadTranslatorBag = new TranslatorBag();
+        $providerReadTranslatorBag->addCatalogue($arrayLoader->load(['note' => 'NOTE'], 'en'));
+        $providerReadTranslatorBag->addCatalogue($arrayLoader->load(['note' => 'NOTE'], 'fr'));
+
+        $provider = $this->createMock(FilteringProvider::class);
+        $provider->expects($this->once())
+            ->method('read')
+            ->with($domains, $locales)
+            ->willReturn($providerReadTranslatorBag);
+        $provider->expects($this->once())
+            ->method('getDomains')
+            ->willReturn(['messages']);
+
+        $filenameEn = $this->createFile([
+            'note' => 'NOTE',
+            'new.foo' => 'newFoo',
+        ]);
+        $filenameFr = $this->createFile([
+            'note' => 'NOTE',
+            'new.foo' => 'nouveauFoo',
+        ], 'fr');
+        $localTranslatorBag = new TranslatorBag();
+        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameEn, 'en'));
+        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameFr, 'fr'));
+
+        $provider->expects($this->once())
+            ->method('write')
+            ->with($localTranslatorBag->diff($providerReadTranslatorBag));
+
+        $provider->expects($this->once())
+            ->method('__toString')
+            ->willReturn('null://default');
+
+        $reader = new TranslationReader();
+        $reader->addLoader('xlf', new XliffFileLoader());
+
+        $command = new TranslationPushCommand(
+            new TranslationProviderCollection([
+                'loco' => $provider,
+            ]),
+            $reader,
+            [$this->translationAppDir.'/translations'],
+            $locales
+        );
+
+        $application = new Application();
+        $application->add($command);
+        $tester = new CommandTester($application->find('translation:push'));
+
+        $tester->execute(['--locales' => ['en', 'fr']]);
+
+        $this->assertStringContainsString('[OK] New local translations has been sent to "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR adds possibility for `translation:push` command to use the configured domains value for a provider, if there is no `--domains` option provided. 

Before that, the command tries to get the domains from the `MessageCatalog` of all local translations (including `validators` and `security` even if the user doesn't override these files).

Now, we can configure `domains` in `translation.yaml`:

```yaml
framework:
    default_locale: en
    translator:
        default_path: '%kernel.project_dir%/translations'
        fallbacks:
            - en
        providers:
            lokalise:
                dsn: '%env(LOKALISE_DSN)%'
                locales: ['de', 'en', 'es', 'fr', 'it', 'pl']
                domains: ['messages']
```

And `bin/console translation:push lokalise` will take `['messages']` as domains value, instead of `['messages', 'validators', 'security']`.