### PR TITLE
[Notifier] Use the UTF-8 encoding in smsapi-notifier

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
@@ -64,6 +64,7 @@ final class SmsapiTransport extends AbstractTransport
                 'to' => $message->getPhone(),
                 'message' => $message->getSubject(),
                 'format' => 'json',
+                'encoding' => 'utf-8',
             ],
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

THIS PR is splitted version of PR #45139 (see discussion)

Currently smsapi-notifier does not specify encoding in payload request to provider api which generates such errors.
![image](https://user-images.githubusercontent.com/57309/151045363-a5b97e9a-94b5-4fba-b93a-76ab72a8bd5f.png)
(sms message with invalid encoding)
api.smsapi.pl use windows-1250 as a default value. I propose to set explicitly `utf-8`.
After changes:
![Zrzut ekranu 2022-01-23 o 21 52 28](https://user-images.githubusercontent.com/57309/151045277-2c11b5c5-8b0f-4f1d-b749-2661a6443a4c.png)
