### PR TITLE
[DependencyInjection][EventDispatcher] Avoid instantiating not called listeners when tracing 

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1739,7 +1739,18 @@ EOF;
 
                     $code = sprintf('return %s;', $code);
 
-                    return sprintf("function ()%s {\n            %s\n        }", $returnedType, $code);
+                    $attribute = '';
+                    if ($value) {
+                        $attribute = 'name: '.$this->dumpValue((string) $value, $interpolate);
+
+                        if ($this->container->hasDefinition($value) && ($class = $this->container->findDefinition($value)->getClass()) && $class !== (string) $value) {
+                            $attribute .= ', class: '.$this->dumpValue($class, $interpolate);
+                        }
+
+                        $attribute = sprintf('#[\Closure(%s)] ', $attribute);
+                    }
+
+                    return sprintf("%sfunction ()%s {\n            %s\n        }", $attribute, $returnedType, $code);
                 }
 
                 if ($value instanceof IteratorArgument) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
@@ -29,7 +29,7 @@ class getClosureService extends ProjectServiceContainer
     {
         $container->services['closure'] = $instance = new \stdClass();
 
-        $instance->closures = [0 => function () use ($container): ?\stdClass {
+        $instance->closures = [0 => #[\Closure(name: 'foo', class: 'FooClass')] function () use ($container): ?\stdClass {
             return ($container->services['foo'] ?? null);
         }];
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_closure_argument_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_closure_argument_compiled.php
@@ -55,7 +55,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getServiceClosureService()
     {
-        return $this->services['service_closure'] = new \Bar(function () {
+        return $this->services['service_closure'] = new \Bar(#[\Closure(name: 'foo', class: 'Foo')] function () {
             return ($this->services['foo'] ?? ($this->services['foo'] = new \Foo()));
         });
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -70,9 +70,9 @@ class ProjectServiceContainer extends Container
      */
     protected function getFooServiceService()
     {
-        return $this->services['foo_service'] = new \Symfony\Component\DependencyInjection\ServiceLocator(['bar' => function () {
+        return $this->services['foo_service'] = new \Symfony\Component\DependencyInjection\ServiceLocator(['bar' => #[\Closure(name: 'bar_service', class: 'stdClass')] function () {
             return ($this->services['bar_service'] ?? $this->getBarServiceService());
-        }, 'baz' => function (): \stdClass {
+        }, 'baz' => #[\Closure(name: 'baz_service', class: 'stdClass')] function (): \stdClass {
             return ($this->privates['baz_service'] ?? ($this->privates['baz_service'] = new \stdClass()));
         }, 'nil' => function () {
             return NULL;
@@ -116,7 +116,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getTranslator1Service()
     {
-        return $this->services['translator_1'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_1' => function () {
+        return $this->services['translator_1'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_1' => #[\Closure(name: 'translator.loader_1', class: 'stdClass')] function () {
             return ($this->services['translator.loader_1'] ?? ($this->services['translator.loader_1'] = new \stdClass()));
         }]));
     }
@@ -128,7 +128,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getTranslator2Service()
     {
-        $this->services['translator_2'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_2' => function () {
+        $this->services['translator_2'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_2' => #[\Closure(name: 'translator.loader_2', class: 'stdClass')] function () {
             return ($this->services['translator.loader_2'] ?? ($this->services['translator.loader_2'] = new \stdClass()));
         }]));
 
@@ -144,7 +144,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getTranslator3Service()
     {
-        $this->services['translator_3'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_3' => function () {
+        $this->services['translator_3'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_3' => #[\Closure(name: 'translator.loader_3', class: 'stdClass')] function () {
             return ($this->services['translator.loader_3'] ?? ($this->services['translator.loader_3'] = new \stdClass()));
         }]));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
@@ -58,11 +58,11 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
         $instance->foo1 = ($this->services['foo1'] ?? null);
         $instance->foo2 = null;
         $instance->foo3 = ($this->privates['foo3'] ?? null);
-        $instance->closures = [0 => function () {
+        $instance->closures = [0 => #[\Closure(name: 'foo1', class: 'stdClass')] function () {
             return ($this->services['foo1'] ?? null);
-        }, 1 => function () {
+        }, 1 => #[\Closure(name: 'foo2')] function () {
             return null;
-        }, 2 => function () {
+        }, 2 => #[\Closure(name: 'foo3', class: 'stdClass')] function () {
             return ($this->privates['foo3'] ?? null);
         }];
         $instance->iter = new RewindableGenerator(function () {

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\EventDispatcher\Debug;
 
 use Psr\EventDispatcher\StoppableEventInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -187,7 +188,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
     public function getNotCalledListeners(Request $request = null): array
     {
         try {
-            $allListeners = $this->getListeners();
+            $allListeners = $this->dispatcher instanceof EventDispatcher ? $this->getListenersWithPriority() : $this->getListenersWithoutPriority();
         } catch (\Exception $e) {
             $this->logger?->info('An exception was thrown while getting the uncalled listeners.', ['exception' => $e]);
 
@@ -209,11 +210,12 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         }
 
         $notCalled = [];
+
         foreach ($allListeners as $eventName => $listeners) {
-            foreach ($listeners as $listener) {
+            foreach ($listeners as [$listener, $priority]) {
                 if (!\in_array($listener, $calledListeners, true)) {
                     if (!$listener instanceof WrappedListener) {
-                        $listener = new WrappedListener($listener, null, $this->stopwatch, $this);
+                        $listener = new WrappedListener($listener, null, $this->stopwatch, $this, $priority);
                     }
                     $notCalled[] = $listener->getInfo($eventName);
                 }
@@ -323,7 +325,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         }
     }
 
-    private function sortNotCalledListeners(array $a, array $b)
+    private function sortNotCalledListeners(array $a, array $b): int
     {
         if (0 !== $cmp = strcmp($a['event'], $b['event'])) {
             return $cmp;
@@ -346,5 +348,36 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         }
 
         return 1;
+    }
+
+    private function getListenersWithPriority(): array
+    {
+        $result = [];
+
+        $allListeners = new \ReflectionProperty(EventDispatcher::class, 'listeners');
+        $allListeners->setAccessible(true);
+
+        foreach ($allListeners->getValue($this->dispatcher) as $eventName => $listenersByPriority) {
+            foreach ($listenersByPriority as $priority => $listeners) {
+                foreach ($listeners as $listener) {
+                    $result[$eventName][] = [$listener, $priority];
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    private function getListenersWithoutPriority(): array
+    {
+        $result = [];
+
+        foreach ($this->getListeners() as $eventName => $listeners) {
+            foreach ($listeners as $listener) {
+                $result[$eventName][] = [$listener, null];
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -29,20 +29,23 @@ final class WrappedListener
     private Stopwatch $stopwatch;
     private ?EventDispatcherInterface $dispatcher;
     private string $pretty;
+    private string $callableRef;
     private ClassStub|string $stub;
     private ?int $priority = null;
     private static bool $hasClassStub;
 
-    public function __construct(callable|array $listener, ?string $name, Stopwatch $stopwatch, EventDispatcherInterface $dispatcher = null)
+    public function __construct(callable|array $listener, ?string $name, Stopwatch $stopwatch, EventDispatcherInterface $dispatcher = null, int $priority = null)
     {
         $this->listener = $listener;
         $this->optimizedListener = $listener instanceof \Closure ? $listener : (\is_callable($listener) ? \Closure::fromCallable($listener) : null);
         $this->stopwatch = $stopwatch;
         $this->dispatcher = $dispatcher;
+        $this->priority = $priority;
 
         if (\is_array($listener)) {
-            $this->name = \is_object($listener[0]) ? get_debug_type($listener[0]) : $listener[0];
+            [$this->name, $this->callableRef] = $this->parseListener($listener);
             $this->pretty = $this->name.'::'.$listener[1];
+            $this->callableRef .= '::'.$listener[1];
         } elseif ($listener instanceof \Closure) {
             $r = new \ReflectionFunction($listener);
             if (str_contains($r->name, '{closure}')) {
@@ -58,6 +61,7 @@ final class WrappedListener
         } else {
             $this->name = get_debug_type($listener);
             $this->pretty = $this->name.'::__invoke';
+            $this->callableRef = \get_class($listener).'::__invoke';
         }
 
         if (null !== $name) {
@@ -89,11 +93,11 @@ final class WrappedListener
 
     public function getInfo(string $eventName): array
     {
-        $this->stub ??= self::$hasClassStub ? new ClassStub($this->pretty.'()', $this->listener) : $this->pretty.'()';
+        $this->stub ??= self::$hasClassStub ? new ClassStub($this->pretty.'()', $this->callableRef ?? $this->listener) : $this->pretty.'()';
 
         return [
             'event' => $eventName,
-            'priority' => $this->priority ?? $this->dispatcher?->getListenerPriority($eventName, $this->listener),
+            'priority' => $this->priority ??= $this->dispatcher?->getListenerPriority($eventName, $this->listener),
             'pretty' => $this->pretty,
             'stub' => $this->stub,
         ];
@@ -104,7 +108,7 @@ final class WrappedListener
         $dispatcher = $this->dispatcher ?: $dispatcher;
 
         $this->called = true;
-        $this->priority = $dispatcher->getListenerPriority($eventName, $this->listener);
+        $this->priority ??= $dispatcher->getListenerPriority($eventName, $this->listener);
 
         $e = $this->stopwatch->start($this->name, 'event_listener');
 
@@ -117,5 +121,22 @@ final class WrappedListener
         if ($event instanceof StoppableEventInterface && $event->isPropagationStopped()) {
             $this->stoppedPropagation = true;
         }
+    }
+
+    private function parseListener(array $listener): array
+    {
+        if ($listener[0] instanceof \Closure) {
+            foreach ((new \ReflectionFunction($listener[0]))->getAttributes(\Closure::class) as $attribute) {
+                if ($name = $attribute->getArguments()['name'] ?? false) {
+                    return [$name, $attribute->getArguments()['class'] ?? $name];
+                }
+            }
+        }
+
+        if (\is_object($listener[0])) {
+            return [get_debug_type($listener[0]), \get_class($listener[0])];
+        }
+
+        return [$listener[0], $listener[0]];
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -125,6 +125,18 @@ class TraceableEventDispatcherTest extends TestCase
         $this->assertEquals([], $tdispatcher->getNotCalledListeners());
     }
 
+    public function testGetNotCalledClosureListeners()
+    {
+        $instantiationCount = 0;
+
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', [static function () use (&$instantiationCount) { ++$instantiationCount; }, 'onFoo']);
+
+        $tdispatcher->getNotCalledListeners();
+
+        $this->assertSame(0, $instantiationCount);
+    }
+
     public function testClearCalledListeners()
     {
         $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
@@ -40,6 +40,7 @@ class WrappedListenerTest extends TestCase
             [\Closure::fromCallable([new FooListener(), 'listen']), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listen'],
             [\Closure::fromCallable(['Symfony\Component\EventDispatcher\Tests\Debug\FooListener', 'listenStatic']), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listenStatic'],
             [\Closure::fromCallable(function () {}), 'closure'],
+            [[#[\Closure(name: FooListener::class)] static fn () => new FooListener(), 'listen'], 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listen'],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #43658
| License       | MIT
| Doc PR        | 

This PR removes useless listeners instantiation when `TraceableEventDispatcher::getNotCalledListeners()` is called.

Even if this PR is in WIP, I created it to allow comments from @nicolas-grekas (and anyone interested in of course).