### PR TITLE
[Notifier] Fix encoding of messages with FreeMobileTransport

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
@@ -60,7 +60,7 @@ final class FreeMobileTransport extends AbstractTransport
         $endpoint = sprintf('https://%s', $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
-            'json' => [
+            'query' => [
                 'user' => $this->login,
                 'pass' => $this->password,
                 'msg' => $message->getSubject(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix sending accents chars
| License       | MIT

When I first [introduce this transport](https://github.com/symfony/symfony/pull/35690) I used to test it with basic text, now with some French accent I need this fix otherwise the accent chars are not sent

