### PR TITLE
[Process] Update PHPDoc to use proper placeholder syntax

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -177,7 +177,7 @@ class Process implements \IteratorAggregate
      * In order to inject dynamic values into command-lines, we strongly recommend using placeholders.
      * This will save escaping values, which is not portable nor secure anyway:
      *
-     *   $process = Process::fromShellCommandline('my_command "$MY_VAR"');
+     *   $process = Process::fromShellCommandline('my_command "${:MY_VAR}"');
      *   $process->run(null, ['MY_VAR' => $theValue]);
      *
      * @param string         $command The command line to pass to the shell of the OS


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

I'd like to add this PHPDoc comment to help make sure `Process::fromShellCommandline` is used securely. The other day, one of the developers at my company wrote some code that was roughly like:
```php
$process = Process::fromShellCommandline('find $FILENAME');
$process->run(null, ['FILENAME' => $fileName]);
```
Since `$fileName` is user input, he thought he was doing the secure thing by using placeholders. The issue is that a malicious user could have utilized the `-exec` option of `find` to gain arbitrary code execution, for example `$fileName = '. -exec echo Foo! ;'`. This can be fixed by simply surrounding `$FILENAME` with double quotes because this passes the input as a single argument to `find` instead of passing it as multiple arguments. I believe there are enough programs out there that can be manipulated if an attacker is able to control multiple arguments that it's worth putting a warning here to help prevent the mistake of not surrounding placeholders with quotes.
