### PR TITLE
[WebProfilerBundle] Display again the number of occurrences of log messages

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -156,6 +156,10 @@
                                     {% endif %}
                                 </span>
                             {% endif %}
+
+                            {% if log.errorCounter > 1 %}
+                                <span class="log-type-badge badge badge-{{ css_class }} log-message-counter" title="This log message occurred {{ log.errorCounter }} times"><strong>{{ log.errorCounter }}</strong> times</span>
+                            {% endif %}
                         </td>
 
                         <td class="font-normal">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -1207,6 +1207,16 @@ tr.log-status-silenced {
     border-left: 4px solid #A78BFA;
 }
 
+.log-message-counter {
+    display: block;
+    font-size: 12px;
+    font-weight: normal;
+    margin-top: 4px;
+}
+.log-message-counter.log-type-badge {
+    background: transparent;
+}
+
 .container-compilation-logs {
     background: var(--table-background);
     border: 1px solid var(--base-2);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45183
| License       | MIT
| Doc PR        | -

It looks like this:

<img width="238" alt="log-occurrences" src="https://user-images.githubusercontent.com/73419/151319063-554a4ed9-8827-468c-bd89-54378bb4f1ea.png">
