### PR TITLE
[HttpFoundation] Fixed functional testing description in MockFileSessionStorage

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
@@ -13,7 +13,8 @@ namespace Symfony\Component\HttpFoundation\Session\Storage;
 
 /**
  * MockFileSessionStorage is used to mock sessions for
- * functional testing when done in a single PHP process.
+ * functional testing where you may need to persist session data
+ * across separate PHP processes.
  *
  * No PHP session is actually started since a session can be initialized
  * and shutdown only once per PHP execution cycle and this class does


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Hi guys! 
According to the "Testing with Sessions" documentation https://symfony.com/doc/4.4/components/http_foundation/session_testing.html#functional-testing

There is the wrong description in the class:
`src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php`