### PR TITLE
Fixed typing for Symfony\Component\Validator\Constraint::$groups

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -26,6 +26,8 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  * Constraint instances are immutable and serializable.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @property string[] $groups
  */
 abstract class Constraint
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features / 4.4, 5.3, 5.4 or 6.0 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

At the moment it's typed as `string[]` while in fact it's `string[]|null`.

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
