### PR TITLE
[WebProfilerBundle] Fixes weird spacing in log message context/trace output

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -1160,10 +1160,10 @@ table.logs .log-timestamp {
 table.logs .log-metadata {
     margin: 8px 0 0;
 }
-table.logs .log-metadata span {
+table.logs .log-metadata > span {
     display: inline-block;
 }
-table.logs .log-metadata span + span {
+table.logs .log-metadata > span + span {
     margin-left: 10px;
 }
 table.logs .log-metadata .log-channel {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This is a fix for a small issue created in bcb3329279a0774861e0c37155867ff45f7b7b6f. Where there is space created in the expanded log message context/trace output as seen below while preserving the space between the log message level, and context and trace toggles.

![image](https://user-images.githubusercontent.com/310006/151540656-03c49473-d7bd-4ee1-9bef-201b7ece2124.png)
