### PR TITLE
[Mailer] Implement EmailTags for Amazon Mailer

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add support for `X-SES-MESSAGE-TAGS`
+
 6.0
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -89,6 +90,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             $this->assertSame('aws-configuration-set-name', $content['ConfigurationSetName']);
             $this->assertSame('aws-source-arn', $content['FromEmailAddressIdentityArn']);
             $this->assertSame('bounces@example.com', $content['FeedbackForwardingEmailAddress']);
+            $this->assertSame([['Name' => 'tagName1', 'Value' => 'tag Value1'], ['Name' => 'tagName2', 'Value' => 'tag Value2']], $content['EmailTags']);
 
             $json = '{"MessageId": "foobar"}';
 
@@ -111,6 +113,8 @@ class SesApiAsyncAwsTransportTest extends TestCase
 
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
         $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
+        $mail->getHeaders()->add(new MetadataHeader('tagName1', 'tag Value1'));
+        $mail->getHeaders()->add(new MetadataHeader('tagName2', 'tag Value2'));
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesHttpAsyncAwsTransport;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -86,6 +87,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
             $this->assertStringContainsString('Hello There!', $content);
             $this->assertSame('aws-configuration-set-name', $body['ConfigurationSetName']);
             $this->assertSame('aws-source-arn', $body['FromEmailAddressIdentityArn']);
+            $this->assertSame([['Name' => 'tagName1', 'Value' => 'tag Value1'], ['Name' => 'tagName2', 'Value' => 'tag Value2']], $body['EmailTags']);
 
             $json = '{"MessageId": "foobar"}';
 
@@ -104,6 +106,8 @@ class SesHttpAsyncAwsTransportTest extends TestCase
 
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
         $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
+        $mail->getHeaders()->add(new MetadataHeader('tagName1', 'tag Value1'));
+        $mail->getHeaders()->add(new MetadataHeader('tagName2', 'tag Value2'));
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesSmtpTransportTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesSmtpTransport;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mime\Email;
+
+class SesSmtpTransportTest extends TestCase
+{
+    public function testTagAndMetadataAndMessageStreamHeaders()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new MetadataHeader('tagName1', 'tag Value1'));
+        $email->getHeaders()->add(new MetadataHeader('tagName2', 'tag Value2'));
+
+        $transport = new SesSmtpTransport('user', 'pass');
+        $method = new \ReflectionMethod(SesSmtpTransport::class, 'addSesHeaders');
+        $method->setAccessible(true);
+        $method->invoke($transport, $email);
+
+        $this->assertCount(1, $email->getHeaders()->toArray());
+        $this->assertTrue($email->getHeaders()->has('X-SES-MESSAGE-TAGS'));
+        $this->assertSame('X-SES-MESSAGE-TAGS: tagName1=tag Value1, tagName2=tag Value2', $email->getHeaders()->get('X-SES-MESSAGE-TAGS')->toString());
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -15,6 +15,7 @@ use AsyncAws\Ses\Input\SendEmailRequest;
 use AsyncAws\Ses\ValueObject\Content;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\RuntimeException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -97,6 +98,12 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
         }
         if ($email->getReturnPath()) {
             $request['FeedbackForwardingEmailAddress'] = $email->getReturnPath()->toString();
+        }
+
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($header instanceof MetadataHeader) {
+                $request['EmailTags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
+            }
         }
 
         return new SendEmailRequest($request);

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -18,6 +18,7 @@ use AsyncAws\Ses\ValueObject\Destination;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Message;
@@ -86,6 +87,13 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
         if (($message->getOriginalMessage() instanceof Message)
             && $sourceArnHeader = $message->getOriginalMessage()->getHeaders()->get('X-SES-SOURCE-ARN')) {
             $request['FromEmailAddressIdentityArn'] = $sourceArnHeader->getBodyAsString();
+        }
+        if ($message->getOriginalMessage() instanceof Message) {
+            foreach ($message->getOriginalMessage()->getHeaders()->all() as $header) {
+                if ($header instanceof MetadataHeader) {
+                    $request['EmailTags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
+                }
+            }
         }
 
         return new SendEmailRequest($request);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR implements support for `X-SES-MESSAGE-TAGS` headers with the Amazon Mailer. See example of this here: https://docs.aws.amazon.com/ses/latest/dg/event-publishing-send-email.html

I'm sending this in because atm we can't provide support for this in Laravel 9 after switching to Symfony Mailer. Since the transports are completely closed from adding additional headers before sending them to the `SendEmailRequest` class, the only way to add this is by adding it directly in the transports.

I tried my best with writing a function that'll parse the header and prep the array to be sent to the `SendEmailRequest` class.

Ideally, it would be great if this could be added to 6.0 as well because Symfony 6.1 is due to be released in May while Laravel 9 is being released in less than two weeks. But, we can always re-implement our old SesTransport (something I'm going to prep regardless so that's ready to go if this can't be back ported to 6.0). 

I haven't sent in a PR to the docs because there aren't any docs yet for other X-SES- headers.

Thanks!

PS.: Because I used the GH CLI to send this in I didn't see the PR template. Therefor @carsonbot already added all these labels and I can't remove them anymore.