### PR TITLE
[PhpUnitBridge] Add option `ignoreFile` to configure a file that lists deprecation messages to ignore

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add option `ignoreFile` to configure a file that lists deprecation messages to ignore
+
 6.0
 ---
 

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -136,6 +136,9 @@ class DeprecationErrorHandler
         if ($deprecation->isMuted()) {
             return null;
         }
+        if ($this->getConfiguration()->isIgnoredDeprecation($deprecation)) {
+            return null;
+        }
         if ($this->getConfiguration()->isBaselineDeprecation($deprecation)) {
             return null;
         }

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -37,6 +37,11 @@ class Configuration
     private $verboseOutput;
 
     /**
+     * @var string[]
+     */
+    private $ignoreDeprecationPatterns = [];
+
+    /**
      * @var bool
      */
     private $generateBaseline = false;
@@ -60,11 +65,12 @@ class Configuration
      * @param int[]       $thresholds       A hash associating groups to thresholds
      * @param string      $regex            Will be matched against messages, to decide whether to display a stack trace
      * @param bool[]      $verboseOutput    Keyed by groups
+     * @param string      $ignoreFile       The path to the ignore deprecation patterns file
      * @param bool        $generateBaseline Whether to generate or update the baseline file
      * @param string      $baselineFile     The path to the baseline file
      * @param string|null $logFile          The path to the log file
      */
-    private function __construct(array $thresholds = [], $regex = '', $verboseOutput = [], $generateBaseline = false, $baselineFile = '', $logFile = null)
+    private function __construct(array $thresholds = [], $regex = '', $verboseOutput = [], $ignoreFile = '', $generateBaseline = false, $baselineFile = '', $logFile = null)
     {
         $groups = ['total', 'indirect', 'direct', 'self'];
 
@@ -108,6 +114,25 @@ class Configuration
                 throw new \InvalidArgumentException(sprintf('Unsupported verbosity group "%s", expected one of "%s".', $group, implode('", "', array_keys($this->verboseOutput))));
             }
             $this->verboseOutput[$group] = $status;
+        }
+
+        if ($ignoreFile) {
+            if (!is_file($ignoreFile)) {
+                throw new \InvalidArgumentException(sprintf('The ignoreFile "%s" does not exist.', $ignoreFile));
+            }
+            set_error_handler(static function ($t, $m) use ($ignoreFile, &$line) {
+                throw new \RuntimeException(sprintf('Invalid pattern found in "%s" on line "%d"', $ignoreFile, 1 + $line).substr($m, 12));
+            });
+            try {
+                foreach (file($ignoreFile) as $line => $pattern) {
+                    if ('#' !== trim($line)[0] ?? '#') {
+                        preg_match($pattern, '');
+                        $this->ignoreDeprecationPatterns[] = $pattern;
+                    }
+                }
+            } finally {
+                restore_error_handler();
+            }
         }
 
         if ($generateBaseline && !$baselineFile) {
@@ -163,6 +188,19 @@ class Configuration
         }
 
         return true;
+    }
+
+    public function isIgnoredDeprecation(Deprecation $deprecation): bool
+    {
+        if (!$this->ignoreDeprecationPatterns) {
+            return false;
+        }
+        $result = @preg_filter($this->ignoreDeprecationPatterns, '$0', $deprecation->getMessage());
+        if (\PREG_NO_ERROR !== preg_last_error()) {
+            throw new \RuntimeException(preg_last_error_msg());
+        }
+
+        return (bool) $result;
     }
 
     /**
@@ -266,7 +304,7 @@ class Configuration
     {
         parse_str($serializedConfiguration, $normalizedConfiguration);
         foreach (array_keys($normalizedConfiguration) as $key) {
-            if (!\in_array($key, ['max', 'disabled', 'verbose', 'quiet', 'generateBaseline', 'baselineFile', 'logFile'], true)) {
+            if (!\in_array($key, ['max', 'disabled', 'verbose', 'quiet', 'ignoreFile', 'generateBaseline', 'baselineFile', 'logFile'], true)) {
                 throw new \InvalidArgumentException(sprintf('Unknown configuration option "%s".', $key));
             }
         }
@@ -276,6 +314,7 @@ class Configuration
             'disabled' => false,
             'verbose' => true,
             'quiet' => [],
+            'ignoreFile' => '',
             'generateBaseline' => false,
             'baselineFile' => '',
             'logFile' => null,
@@ -300,6 +339,7 @@ class Configuration
             $normalizedConfiguration['max'] ?? [],
             '',
             $verboseOutput,
+            $normalizedConfiguration['ignoreFile'],
             filter_var($normalizedConfiguration['generateBaseline'], \FILTER_VALIDATE_BOOLEAN),
             $normalizedConfiguration['baselineFile'],
             $normalizedConfiguration['logFile']

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ignore.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ignore.phpt
@@ -1,0 +1,77 @@
+--TEST--
+Test DeprecationErrorHandler with an ignoreFile
+--FILE--
+<?php
+$filename = tempnam(sys_get_temp_dir(), 'sf-');
+$ignorePatterns = [
+  '/^ignored .* deprecation/',
+];
+file_put_contents($filename, implode("\n", $ignorePatterns));
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+unset($_SERVER[$k], $_ENV[$k]);
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'ignoreFile=' . urlencode($filename));
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+@trigger_error('root deprecation', E_USER_DEPRECATED);
+@trigger_error('ignored root deprecation', E_USER_DEPRECATED);
+
+eval(<<<'EOPHP'
+namespace PHPUnit\Util;
+
+class Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+EOPHP
+);
+
+class PHPUnit_Util_Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+
+class FooTestCase
+{
+    public function testLegacyFoo()
+    {
+        @trigger_error('ignored foo deprecation', E_USER_DEPRECATED);
+        @trigger_error('not ignored foo deprecation', E_USER_DEPRECATED);
+    }
+
+    public function testNonLegacyBar()
+    {
+        @trigger_error('ignored bar deprecation', E_USER_DEPRECATED);
+        @trigger_error('not ignored bar deprecation', E_USER_DEPRECATED);
+    }
+}
+
+$foo = new FooTestCase();
+$foo->testLegacyFoo();
+$foo->testNonLegacyBar();
+?>
+--EXPECTF--
+Legacy deprecation notices (1)
+
+Other deprecation notices (2)
+
+  1x: root deprecation
+
+  1x: not ignored bar deprecation
+    1x in FooTestCase::testNonLegacyBar


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no 
| Tickets       | Fix #45223 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
