### PR TITLE
[Config] Support \Stringable object as ScalarNode value

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Support `\Stringable` objects as `ScalarNode` value
+
 6.0
 ---
 

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -340,7 +340,7 @@ abstract class BaseNode implements NodeInterface
 
         // replace value with their equivalent
         foreach ($this->equivalentValues as $data) {
-            if ($data[0] === $value) {
+            if ($data[0] === ($value instanceof \Stringable ? (string) $value : $value)) {
                 $value = $data[1];
             }
         }
@@ -458,14 +458,20 @@ abstract class BaseNode implements NodeInterface
     private static function resolvePlaceholderValue(mixed $value): mixed
     {
         if (\is_string($value)) {
-            if (isset(self::$placeholders[$value])) {
-                return self::$placeholders[$value];
-            }
+            $v = $value;
+        } elseif ($value instanceof \Stringable) {
+            $v = (string) $value;
+        } else {
+            return $value;
+        }
 
-            foreach (self::$placeholderUniquePrefixes as $placeholderUniquePrefix) {
-                if (str_starts_with($value, $placeholderUniquePrefix)) {
-                    return [];
-                }
+        if (isset(self::$placeholders[$v])) {
+            return self::$placeholders[$v];
+        }
+
+        foreach (self::$placeholderUniquePrefixes as $placeholderUniquePrefix) {
+            if (str_starts_with($v, $placeholderUniquePrefix)) {
+                return [];
             }
         }
 

--- a/src/Symfony/Component/Config/Definition/ScalarNode.php
+++ b/src/Symfony/Component/Config/Definition/ScalarNode.php
@@ -30,10 +30,18 @@ class ScalarNode extends VariableNode
     /**
      * {@inheritdoc}
      */
+    protected function finalizeValue(mixed $value): mixed
+    {
+        return parent::finalizeValue($value instanceof \Stringable ? (string) $value : $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function validateType(mixed $value)
     {
-        if (!is_scalar($value) && null !== $value) {
-            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected "scalar", but got "%s".', $this->getPath(), get_debug_type($value)));
+        if (!is_scalar($value) && null !== $value && !$value instanceof \Stringable) {
+            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected "scalar" or "\Stringable", but got "%s".', $this->getPath(), get_debug_type($value)));
             if ($hint = $this->getInfo()) {
                 $ex->addHint($hint);
             }
@@ -54,7 +62,7 @@ class ScalarNode extends VariableNode
             return false;
         }
 
-        return null === $value || '' === $value;
+        return null === $value || '' === ($value instanceof \Stringable ? (string) $value : $value);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
@@ -115,6 +116,15 @@ class MergeExtensionConfigurationParameterBag extends EnvPlaceholderParameterBag
     {
         parent::__construct($parameterBag->all());
         $this->mergeEnvPlaceholders($parameterBag);
+    }
+
+    public function resolveValue(mixed $value, array $resolving = []): mixed
+    {
+        if ($value instanceof ParamConfigurator) {
+            $value = (string) $value;
+        }
+
+        return parent::resolveValue($value, $resolving);
     }
 
     public function freezeAfterProcessing(Extension $extension, ContainerBuilder $container)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When I work with the Config component, I like to use the "builder" pattern for some values. For example using the `EnvConfigurator` class in bundles `PrependExtensionInterface::prepend()`. It might sound exaggerated but I think it would be a great DX improvement to not have to cast the objects to string or call `__toString()` manually :-)