### PR TITLE
[DependencyInjection] Support \Stringable values in the PHP-DSL

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `$exclude` to `TaggedIterator` and `TaggedLocator` attributes
  * Add `$exclude` to `tagged_iterator` and `tagged_locator` configurator
+ * Support `\Stringable` values in the PHP-DSL
 
 6.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
@@ -87,10 +86,6 @@ abstract class AbstractConfigurator
             return $def;
         }
 
-        if ($value instanceof ParamConfigurator) {
-            return (string) $value;
-        }
-
         if ($value instanceof self) {
             throw new InvalidArgumentException(sprintf('"%s()" can be used only at the root of service configuration files.', $value::FACTORY));
         }
@@ -109,6 +104,10 @@ abstract class AbstractConfigurator
                 if ($allowServices) {
                     return $value;
                 }
+        }
+
+        if ($value instanceof \Stringable) {
+            return (string) $value;
         }
 
         throw new InvalidArgumentException(sprintf('Cannot use values of type "%s" in service configuration files.', get_debug_type($value)));

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stringable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stringable.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services
+        ->set('foo', \stdClass::class)
+        ->public()
+        ->args([
+            new class() implements \Stringable {
+                public function __toString(): string
+                {
+                    return 'foobarccc';
+                }
+            }
+        ]);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -182,4 +182,13 @@ class PhpFileLoaderTest extends TestCase
 
         $loader->load($fixtures.'/config/when_env.php');
     }
+
+    public function testStringable()
+    {
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator(realpath(__DIR__.'/../Fixtures').'/config'), 'some-env');
+        $loader->load('stringable.php');
+
+        $this->assertSame('foobarccc', $container->getDefinition('foo')->getArgument(0));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Same reasons than https://github.com/symfony/symfony/pull/45231 but at another level.