### PR TITLE
Release v5.3.15

### DIFF
--- a/CHANGELOG-5.3.md
+++ b/CHANGELOG-5.3.md
@@ -7,6 +7,10 @@ in 5.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.3.0...v5.3.1
 
+* 5.3.15 (2022-01-29)
+
+ * security #cve-2022-xxxx [FrameworkBundle] Enable CSRF in FORM by default (jderusse)
+
 * 5.3.14 (2022-01-28)
 
  * bug #44860 [Validator] Fix Choice constraint with associative choices array (derrabus)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -75,12 +75,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    public const VERSION = '5.3.15-DEV';
+    public const VERSION = '5.3.15';
     public const VERSION_ID = 50315;
     public const MAJOR_VERSION = 5;
     public const MINOR_VERSION = 3;
     public const RELEASE_VERSION = 15;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '01/2022';
     public const END_OF_LIFE = '01/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.3.14...v5.3.15)

 * security #cve-2022-xxxx [FrameworkBundle] Enable CSRF in FORM by default (@jderusse)
