### PR TITLE
Release v6.0.4

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -7,6 +7,10 @@ in 6.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.0.0...v6.0.1
 
+* 6.0.4 (2022-01-29)
+
+ * security #cve-2022-xxxx [FrameworkBundle] Enable CSRF in FORM by default (jderusse)
+
 * 6.0.3 (2022-01-28)
 
  * bug #45193 [FrameworkBundle] Fix missing arguments when a serialization default context is bound (ArnoudThibaut)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,12 +78,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.0.4-DEV';
+    public const VERSION = '6.0.4';
     public const VERSION_ID = 60004;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 4;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2022';
     public const END_OF_LIFE = '07/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.0.3...v6.0.4)

 * security #cve-2022-xxxx [FrameworkBundle] Enable CSRF in FORM by default (@jderusse)
