### PR TITLE
[Console] Revert StringInput bc break from #45088

### DIFF
--- a/src/Symfony/Component/Console/Input/StringInput.php
+++ b/src/Symfony/Component/Console/Input/StringInput.php
@@ -24,7 +24,8 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
  */
 class StringInput extends ArgvInput
 {
-    public const REGEX_STRING = '([^\s\\\\]+?)';
+    public const REGEX_STRING = '([^\s]+?)(?:\s|(?<!\\\\)"|(?<!\\\\)\'|$)';
+    public const REGEX_UNQUOTED_STRING = '([^\s\\\\]+?)';
     public const REGEX_QUOTED_STRING = '(?:"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\')';
 
     /**
@@ -64,7 +65,7 @@ class StringInput extends ArgvInput
                 $token .= $match[1].$match[2].stripcslashes(str_replace(['"\'', '\'"', '\'\'', '""'], '', substr($match[3], 1, -1)));
             } elseif (preg_match('/'.self::REGEX_QUOTED_STRING.'/A', $input, $match, 0, $cursor)) {
                 $token .= stripcslashes(substr($match[0], 1, -1));
-            } elseif (preg_match('/'.self::REGEX_STRING.'/A', $input, $match, 0, $cursor)) {
+            } elseif (preg_match('/'.self::REGEX_UNQUOTED_STRING.'/A', $input, $match, 0, $cursor)) {
                 $token .= $match[1];
             } else {
                 // should never happen


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix bobthecow/psysh#703
| License       | MIT
| Doc PR        | -

Fix a backwards compatibility break introduced in #45088 and released in v4.4.37, v5.3.14, v5.4.3 and v6.0.3.

I went with `REGEX_UNQUOTED_STRING` by analog to the `REGEX_QUOTED_STRING` constant name, but don't have a strong opinion on what it should be called :)