### PR TITLE
[PropertyAccess] Fix handling of uninitialized property of parent class

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -401,7 +401,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                         && $object instanceof $trace['class']
                         && preg_match('/Return value (?:of .*::\w+\(\) )?must be of (?:the )?type (\w+), null returned$/', $e->getMessage(), $matches)
                     ) {
-                        throw new AccessException(sprintf('The method "%s::%s()" returned "null", but expected type "%3$s". Did you forget to initialize a property or to make the return type nullable using "?%3$s"?', !str_contains(\get_class($object), "@anonymous\0") ? \get_class($object) : (get_parent_class($object) ?: 'class').'@anonymous', $access[self::ACCESS_NAME], $matches[1]), 0, $e);
+                        throw new AccessException(sprintf('The method "%s::%s()" returned "null", but expected type "%3$s". Did you forget to initialize a property or to make the return type nullable using "?%3$s"?', get_debug_type($object), $access[self::ACCESS_NAME], $matches[1]), 0, $e);
                     }
 
                     throw $e;
@@ -436,8 +436,8 @@ class PropertyAccessor implements PropertyAccessorInterface
             }
         } catch (\Error $e) {
             // handle uninitialized properties in PHP >= 7.4
-            if (\PHP_VERSION_ID >= 70400 && preg_match('/^Typed property ('.preg_quote(get_debug_type($object), '/').')::\$(\w+) must not be accessed before initialization$/', $e->getMessage(), $matches)) {
-                $r = new \ReflectionProperty($class, $matches[2]);
+            if (\PHP_VERSION_ID >= 70400 && preg_match('/^Typed property ([\w\\\\@]+)::\$(\w+) must not be accessed before initialization$/', $e->getMessage(), $matches)) {
+                $r = new \ReflectionProperty(str_contains($matches[1], '@anonymous') ? $class : $matches[1], $matches[2]);
                 $type = ($type = $r->getType()) instanceof \ReflectionNamedType ? $type->getName() : (string) $type;
 
                 throw new AccessException(sprintf('The property "%s::$%s" is not readable because it is typed "%s". You should initialize it or declare a default value instead.', $matches[1], $r->getName(), $type), 0, $e);

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/ExtendedUninitializedProperty.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/ExtendedUninitializedProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class ExtendedUninitializedProperty extends UninitializedProperty
+{
+
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/UninitializedProperty.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/UninitializedProperty.php
@@ -14,4 +14,15 @@ namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
 class UninitializedProperty
 {
     public string $uninitialized;
+    private string $privateUninitialized;
+
+    public function getPrivateUninitialized(): string
+    {
+        return $this->privateUninitialized;
+    }
+
+    public function setPrivateUninitialized(string $privateUninitialized): void
+    {
+        $this->privateUninitialized = $privateUninitialized;
+    }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\ExtendedUninitializedProperty;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\ReturnTyped;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestAdderRemoverInvalidArgumentLength;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestAdderRemoverInvalidMethods;
@@ -209,6 +210,28 @@ class PropertyAccessorTest extends TestCase
         };');
 
         $this->propertyAccessor->getValue($object, 'uninitialized');
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testGetValueThrowsExceptionIfUninitializedNotNullableOfParentClass()
+    {
+        $this->expectException(AccessException::class);
+        $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedProperty::$uninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.');
+
+        $this->propertyAccessor->getValue(new ExtendedUninitializedProperty(), 'uninitialized');
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testGetValueThrowsExceptionIfUninitializedNotNullablePropertyWithGetterOfParentClass()
+    {
+        $this->expectException(AccessException::class);
+        $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedProperty::$privateUninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.');
+
+        $this->propertyAccessor->getValue(new ExtendedUninitializedProperty(), 'privateUninitialized');
     }
 
     public function testGetValueThrowsExceptionIfUninitializedPropertyWithGetterOfAnonymousStdClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| Tickets  | Fix #45233
| New feature?  | no
| Deprecations? | no
| License       | MIT

[This fix](https://github.com/symfony/symfony/pull/45002/commits/27d5edf3d239274fac5b5b1300fa464020f6b190#r795578649) introduced a new bug:

```php
class X
{
    public int $a;
}

class Y extends X
{
}

(new Y)->a;

// PropertyAccessor expects: Typed property Y::$a must not be accessed before initialization
// Actual exception message: Typed property X::$a must not be accessed before initialization
```

This prevents from throwing `AccessException` exception and it bubbles up and causes this exception after form submit: "Typed property X::$a must not be accessed before initialization" which would otherwise be handled by PropertyPathAccessor:

```php
        } catch (PropertyAccessException $e) {
            // ...

            return null;
        }
```