### PR TITLE
[HttpClient] Fix Content-Length header when possible

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -86,6 +86,14 @@ trait HttpClientTrait
 
         if (isset($options['body'])) {
             $options['body'] = self::normalizeBody($options['body']);
+
+            if (\is_string($options['body'])
+                && (string) \strlen($options['body']) !== substr($h = $options['normalized_headers']['content-length'][0] ?? '', 16)
+                && ('' !== $h || ('' !== $options['body'] && !isset($options['normalized_headers']['transfer-encoding'])))
+            ) {
+                $options['normalized_headers']['content-length'] = [substr_replace($h ?: 'Content-Length: ', \strlen($options['body']), 16)];
+                $options['headers'] = array_merge(...array_values($options['normalized_headers']));
+            }
         }
 
         if (isset($options['peer_fingerprint'])) {

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -180,6 +180,20 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertNotEmpty($traceInfo['debug']);
     }
 
+    public function testFixContentLength()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $response = $client->request('POST', 'http://localhost:8057/post', [
+            'body' => 'abc=def',
+            'headers' => ['Content-Length: 4'],
+        ]);
+
+        $body = $response->toArray();
+
+        $this->assertSame(['abc' => 'def', 'REQUEST_METHOD' => 'POST'], $body);
+    }
+
     public function testNegativeTimeout()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45260
| License       | MIT
| Doc PR        | -

When userland fails to compute the correct Content-Length header and we can fix it, as is the case in the linked issue.