### PR TITLE
[Messenger] Allow AsMessageHandler attribute on methods

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -622,11 +622,16 @@ class FrameworkExtension extends Extension
         $container->registerAttributeForAutoconfiguration(AsController::class, static function (ChildDefinition $definition, AsController $attribute): void {
             $definition->addTag('controller.service_arguments');
         });
-        $container->registerAttributeForAutoconfiguration(AsMessageHandler::class, static function (ChildDefinition $definition, AsMessageHandler $attribute): void {
+        $container->registerAttributeForAutoconfiguration(AsMessageHandler::class, static function (ChildDefinition $definition, AsMessageHandler $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
             $tagAttributes = get_object_vars($attribute);
             $tagAttributes['from_transport'] = $tagAttributes['fromTransport'];
             unset($tagAttributes['fromTransport']);
-
+            if ($reflector instanceof \ReflectionMethod) {
+                if (isset($tagAttributes['method'])) {
+                    throw new LogicException(sprintf('AsMessageHandler attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
+                }
+                $tagAttributes['method'] = $reflector->getName();
+            }
             $definition->addTag('messenger.message_handler', $tagAttributes);
         });
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -47,7 +47,7 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/lock": "^5.4|^6.0",
         "symfony/mailer": "^5.4|^6.0",
-        "symfony/messenger": "^5.4|^6.0",
+        "symfony/messenger": "^6.1",
         "symfony/mime": "^5.4|^6.0",
         "symfony/notifier": "^5.4|^6.0",
         "symfony/process": "^5.4|^6.0",

--- a/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Messenger\Attribute;
  *
  * @author Alireza Mirsepassi <alirezamirsepassi@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class AsMessageHandler
 {
     public function __construct(

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `SerializedMessageStamp` to avoid serializing a message when a retry occurs.
  * Automatically resolve handled message type when method different from `__invoke` is used as handler.
+ * Allow `#[AsMessageHandler]` attribute on methods.
 
 6.0
 ---

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandler.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandler.php
@@ -10,4 +10,9 @@ class TaggedDummyHandler
     public function __invoke(DummyMessage $message)
     {
     }
+
+    #[AsMessageHandler]
+    public function handleSecondMessage(SecondMessage $message)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | tbd

Similar to the `#[AsEventListener]` attribute, this PR allows for using the `#[AsMessageHandler]` attribute on methods.

Combining class-level and method-level usage inside a single class is supported, as shown by the adapted `MessengerPassTest::testTaggedMessageHandler` test. 