### PR TITLE
[Mailer] allow Mailchimp to handle multiple TagHeader's

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -148,6 +148,7 @@ class MandrillApiTransportTest extends TestCase
     {
         $email = new Email();
         $email->getHeaders()->add(new TagHeader('password-reset,user'));
+        $email->getHeaders()->add(new TagHeader('another'));
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new MandrillApiTransport('ACCESS_KEY');
@@ -158,6 +159,6 @@ class MandrillApiTransportTest extends TestCase
         $this->assertArrayHasKey('message', $payload);
         $this->assertArrayNotHasKey('headers', $payload['message']);
         $this->assertArrayHasKey('tags', $payload['message']);
-        $this->assertSame(['password-reset', 'user'], $payload['message']['tags']);
+        $this->assertSame(['password-reset', 'user', 'another'], $payload['message']['tags']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillHttpTransportTest.php
@@ -112,6 +112,7 @@ class MandrillHttpTransportTest extends TestCase
         $email = new Email();
         $email->getHeaders()->addTextHeader('foo', 'bar');
         $email->getHeaders()->add(new TagHeader('password-reset,user'));
+        $email->getHeaders()->add(new TagHeader('another'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
 
@@ -122,7 +123,7 @@ class MandrillHttpTransportTest extends TestCase
 
         $this->assertCount(3, $email->getHeaders()->toArray());
         $this->assertSame('foo: bar', $email->getHeaders()->get('FOO')->toString());
-        $this->assertSame('X-MC-Tags: password-reset,user', $email->getHeaders()->get('X-MC-Tags')->toString());
+        $this->assertSame('X-MC-Tags: password-reset,user,another', $email->getHeaders()->get('X-MC-Tags')->toString());
         $this->assertSame('X-MC-Metadata: '.json_encode(['Color' => 'blue', 'Client-ID' => '12345']), $email->getHeaders()->get('X-MC-Metadata')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillSmtpTransportTest.php
@@ -24,6 +24,7 @@ class MandrillSmtpTransportTest extends TestCase
         $email = new Email();
         $email->getHeaders()->addTextHeader('foo', 'bar');
         $email->getHeaders()->add(new TagHeader('password-reset,user'));
+        $email->getHeaders()->add(new TagHeader('another'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
 
@@ -34,7 +35,7 @@ class MandrillSmtpTransportTest extends TestCase
 
         $this->assertCount(3, $email->getHeaders()->toArray());
         $this->assertSame('foo: bar', $email->getHeaders()->get('FOO')->toString());
-        $this->assertSame('X-MC-Tags: password-reset,user', $email->getHeaders()->get('X-MC-Tags')->toString());
+        $this->assertSame('X-MC-Tags: password-reset,user,another', $email->getHeaders()->get('X-MC-Tags')->toString());
         $this->assertSame('X-MC-Metadata: '.json_encode(['Color' => 'blue', 'Client-ID' => '12345']), $email->getHeaders()->get('X-MC-Metadata')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -124,7 +124,10 @@ class MandrillApiTransport extends AbstractApiTransport
             }
 
             if ($header instanceof TagHeader) {
-                $payload['message']['tags'] = explode(',', $header->getValue());
+                $payload['message']['tags'] = array_merge(
+                    $payload['message']['tags'] ?? [],
+                    explode(',', $header->getValue())
+                );
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHeadersTrait.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHeadersTrait.php
@@ -36,15 +36,20 @@ trait MandrillHeadersTrait
     {
         $headers = $message->getHeaders();
         $metadata = [];
+        $tags = [];
 
         foreach ($headers->all() as $name => $header) {
             if ($header instanceof TagHeader) {
-                $headers->addTextHeader('X-MC-Tags', $header->getValue());
+                $tags[] = $header->getValue();
                 $headers->remove($name);
             } elseif ($header instanceof MetadataHeader) {
                 $metadata[$header->getKey()] = $header->getValue();
                 $headers->remove($name);
             }
+        }
+
+        if ($tags) {
+            $headers->addTextHeader('X-MC-Tags', implode(',', $tags));
         }
 
         if ($metadata) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

When adding multiple tags (for transports that support this), it's recommended to add multiple `TagHeader`'s instead of a single header with a transport-specific way to separating.

```php
$email->getHeaders()->add(new TagHeader('tag1'));
$email->getHeaders()->add(new TagHeader('tag2'));

// not
$email->getHeaders()->add(new TagHeader('tag1,tag2'));
```

This fixes mailchimp to allow this. I've left the comma separated method intact as to not cause a BC break.