### PR TITLE
[Mailer] ensure only a single tag can be used with Postmark

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mailer\Bridge\Postmark\Transport\MessageStreamHeader;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Address;
@@ -146,5 +147,21 @@ class PostmarkApiTransportTest extends TestCase
         $this->assertSame('password-reset', $payload['Tag']);
         $this->assertSame(['Color' => 'blue', 'Client-ID' => '12345'], $payload['Metadata']);
         $this->assertSame('broadcasts', $payload['MessageStream']);
+    }
+
+    public function testMultipleTagsAreNotAllowed()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new TagHeader('tag1'));
+        $email->getHeaders()->add(new TagHeader('tag2'));
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new PostmarkApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(PostmarkApiTransport::class, 'getPayload');
+        $method->setAccessible(true);
+
+        $this->expectException(TransportException::class);
+
+        $method->invoke($transport, $email, $envelope);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -15,6 +15,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\SentMessage;
@@ -97,6 +98,10 @@ class PostmarkApiTransport extends AbstractApiTransport
             }
 
             if ($header instanceof TagHeader) {
+                if (isset($payload['Tag'])) {
+                    throw new TransportException('Postmark only allows a single tag per email.');
+                }
+
                 $payload['Tag'] = $header->getValue();
 
                 continue;

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\Postmark\Transport;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\SentMessage;
@@ -53,6 +54,10 @@ class PostmarkSmtpTransport extends EsmtpTransport
 
         foreach ($headers->all() as $name => $header) {
             if ($header instanceof TagHeader) {
+                if ($headers->has('X-PM-Tag')) {
+                    throw new TransportException('Postmark only allows a single tag per email.');
+                }
+
                 $headers->addTextHeader('X-PM-Tag', $header->getValue());
                 $headers->remove($name);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Postmark only allows a single tag per email. This changes throws an exception if another is added.
