### PR TITLE
[Mailer] allow Mailgun to handle multiple tags

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -215,7 +215,8 @@ class MailgunApiTransportTest extends TestCase
         $email = new Email();
         $email->getHeaders()->addTextHeader('h:X-Mailgun-Variables', $json);
         $email->getHeaders()->addTextHeader('Custom-Header', 'value');
-        $email->getHeaders()->add(new TagHeader('password-reset'));
+        $email->getHeaders()->add(new TagHeader('tag1'));
+        $email->getHeaders()->add(new TagHeader('tag2'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
@@ -229,7 +230,7 @@ class MailgunApiTransportTest extends TestCase
         $this->assertArrayHasKey('h:custom-header', $payload);
         $this->assertEquals('value', $payload['h:custom-header']);
         $this->assertArrayHasKey('o:tag', $payload);
-        $this->assertSame('password-reset', $payload['o:tag']);
+        $this->assertSame(['tag1', 'tag2'], $payload['o:tag']);
         $this->assertArrayHasKey('v:Color', $payload);
         $this->assertSame('blue', $payload['v:Color']);
         $this->assertArrayHasKey('v:Client-ID', $payload);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
@@ -121,7 +121,8 @@ class MailgunHttpTransportTest extends TestCase
     {
         $email = new Email();
         $email->getHeaders()->addTextHeader('foo', 'bar');
-        $email->getHeaders()->add(new TagHeader('password-reset'));
+        $email->getHeaders()->add(new TagHeader('tag1'));
+        $email->getHeaders()->add(new TagHeader('tag2'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
 
@@ -130,9 +131,10 @@ class MailgunHttpTransportTest extends TestCase
         $method->setAccessible(true);
         $method->invoke($transport, $email);
 
-        $this->assertCount(3, $email->getHeaders()->toArray());
+        $this->assertCount(4, $email->getHeaders()->toArray());
         $this->assertSame('foo: bar', $email->getHeaders()->get('foo')->toString());
-        $this->assertSame('X-Mailgun-Tag: password-reset', $email->getHeaders()->get('X-Mailgun-Tag')->toString());
+        $this->assertStringContainsString('X-Mailgun-Tag: tag1', $email->getHeaders()->toString());
+        $this->assertStringContainsString('X-Mailgun-Tag: tag2', $email->getHeaders()->toString());
         $this->assertSame('X-Mailgun-Variables: '.json_encode(['Color' => 'blue', 'Client-ID' => '12345']), $email->getHeaders()->get('X-Mailgun-Variables')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunSmtpTransportTest.php
@@ -26,7 +26,8 @@ class MailgunSmtpTransportTest extends TestCase
     {
         $email = new Email();
         $email->getHeaders()->addTextHeader('foo', 'bar');
-        $email->getHeaders()->add(new TagHeader('password-reset'));
+        $email->getHeaders()->add(new TagHeader('tag1'));
+        $email->getHeaders()->add(new TagHeader('tag2'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
 
@@ -35,9 +36,10 @@ class MailgunSmtpTransportTest extends TestCase
         $method->setAccessible(true);
         $method->invoke($transport, $email);
 
-        $this->assertCount(3, $email->getHeaders()->toArray());
+        $this->assertCount(4, $email->getHeaders()->toArray());
         $this->assertSame('foo: bar', $email->getHeaders()->get('foo')->toString());
-        $this->assertSame('X-Mailgun-Tag: password-reset', $email->getHeaders()->get('X-Mailgun-Tag')->toString());
+        $this->assertStringContainsString('X-Mailgun-Tag: tag1', $email->getHeaders()->toString());
+        $this->assertStringContainsString('X-Mailgun-Tag: tag2', $email->getHeaders()->toString());
         $this->assertSame('X-Mailgun-Variables: '.json_encode(['Color' => 'blue', 'Client-ID' => '12345']), $email->getHeaders()->get('X-Mailgun-Variables')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -123,7 +123,7 @@ class MailgunApiTransport extends AbstractApiTransport
             }
 
             if ($header instanceof TagHeader) {
-                $payload['o:tag'] = $header->getValue();
+                $payload['o:tag'][] = $header->getValue();
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
@@ -51,7 +51,8 @@ class SendinblueApiTransportTest extends TestCase
         $email = new Email();
         $email->getHeaders()
             ->add(new MetadataHeader('custom', $json))
-            ->add(new TagHeader('TagInHeaders'))
+            ->add(new TagHeader('tag1'))
+            ->add(new TagHeader('tag2'))
             ->addTextHeader('templateId', 1)
             ->addParameterizedHeader('params', 'params', $params)
             ->addTextHeader('foo', 'bar')
@@ -67,7 +68,7 @@ class SendinblueApiTransportTest extends TestCase
         $this->assertEquals($json, $payload['headers']['X-Mailin-Custom']);
 
         $this->assertArrayHasKey('tags', $payload);
-        $this->assertEquals('TagInHeaders', current($payload['tags']));
+        $this->assertEquals(['tag1', 'tag2'], $payload['tags']);
         $this->assertArrayHasKey('templateId', $payload);
         $this->assertEquals(1, $payload['templateId']);
         $this->assertArrayHasKey('params', $payload);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Mailgun's SMTP transport supported but the API transport did not.
