### PR TITLE
[Messenger] Fix dealing with unexpected payload in Redis transport

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
@@ -46,6 +46,10 @@ class RedisReceiver implements ReceiverInterface
 
         $redisEnvelope = json_decode($message['data']['message'] ?? '', true);
 
+        if (null === $redisEnvelope) {
+            return [];
+        }
+
         try {
             if (\array_key_exists('body', $redisEnvelope) && \array_key_exists('headers', $redisEnvelope)) {
                 $envelope = $this->serializer->decode([


### PR DESCRIPTION
[Redis-Messenger] Exits with error when Messenger starts consuming message

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix # [45022](https://github.com/symfony/symfony/issues/45022)
| License       | MIT
| Doc PR        | n/a

