### PR TITLE
[Cache] Fix connecting to Redis via a socket file

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
       redis:
         image: redis:6.0.0
         ports:
-          - 6379:6379
+          - 16379:6379
       redis-cluster:
         image: grokzen/redis-cluster:5.0.4
         ports:
@@ -67,6 +67,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install system dependencies
+        run: |
+          echo "::group::apt-get update"
+          sudo apt-get update
+          echo "::endgroup::"
+
+          echo "::group::install tools & libraries"
+          sudo apt-get install redis-server
+          sudo -- sh -c 'echo unixsocket /var/run/redis/redis-server.sock >> /etc/redis/redis.conf'
+          sudo -- sh -c 'echo unixsocketperm 777 >> /etc/redis/redis.conf'
+          sudo service redis-server restart
+          echo "::endgroup::"
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -99,6 +112,7 @@ jobs:
       - name: Run tests
         run: ./phpunit --group integration -v
         env:
+          REDIS_HOST: 'localhost:16379'
           REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
           REDIS_SENTINEL_HOSTS: 'localhost:26379'
           REDIS_SENTINEL_SERVICE: redis_sentinel

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
         <env name="LDAP_HOST" value="localhost" />
         <env name="LDAP_PORT" value="3389" />
         <env name="REDIS_HOST" value="localhost" />
+        <env name="REDIS_SOCKET" value="/var/run/redis/redis-server.sock" />
         <env name="MESSENGER_REDIS_DSN" value="redis://localhost/messages" />
         <env name="MEMCACHED_HOST" value="localhost" />
         <env name="MONGODB_HOST" value="localhost" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -121,7 +121,7 @@ class CachePoolsTest extends AbstractWebTestCase
     private function skipIfRedisUnavailable()
     {
         try {
-            (new \Redis())->connect(getenv('REDIS_HOST'));
+            (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
             self::markTestSkipped($e->getMessage());
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_custom_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_custom_config.yml
@@ -8,8 +8,8 @@ services:
     cache.test_redis_connection:
         public: false
         class: Redis
-        calls:
-            - [connect, ['%env(REDIS_HOST)%']]
+        factory: ['Symfony\Component\Cache\Adapter\RedisAdapter', 'createConnection']
+        arguments: ['redis://%env(REDIS_HOST)%']
 
     cache.app:
         parent: cache.adapter.redis

--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -36,9 +36,9 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
             throw new SkippedTestSuiteError('Extension redis required.');
         }
         try {
-            (new \Redis())->connect(getenv('REDIS_HOST'));
+            (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
-            throw new SkippedTestSuiteError($e->getMessage());
+            throw new SkippedTestSuiteError(getenv('REDIS_HOST').': '.$e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -22,7 +22,7 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        self::$redis = new \Predis\Client(['host' => getenv('REDIS_HOST')], ['prefix' => 'prefix_']);
+        self::$redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379]), ['prefix' => 'prefix_']);
     }
 
     public function testCreateConnection()
@@ -35,10 +35,11 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
         $connection = $redis->getConnection();
         $this->assertInstanceOf(StreamConnection::class, $connection);
 
+        $redisHost = explode(':', $redisHost);
         $params = [
             'scheme' => 'tcp',
-            'host' => $redisHost,
-            'port' => 6379,
+            'host' => $redisHost[0],
+            'port' => (int) ($redisHost[1] ?? 6379),
             'persistent' => 0,
             'timeout' => 3,
             'read_write_timeout' => 0,

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
@@ -19,7 +19,7 @@ class PredisClusterAdapterTest extends AbstractRedisAdapterTest
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        self::$redis = new \Predis\Client([['host' => getenv('REDIS_HOST')]], ['prefix' => 'prefix_']);
+        self::$redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379]), ['prefix' => 'prefix_']);
     }
 
     public static function tearDownAfterClass(): void

--- a/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
@@ -39,7 +39,7 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
             throw new SkippedTestSuiteError('Extension redis required.');
         }
         try {
-            (new \Redis())->connect(getenv('REDIS_HOST'));
+            (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
             throw new SkippedTestSuiteError($e->getMessage());
         }

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -185,7 +185,7 @@ trait RedisTrait
 
             $initializer = static function ($redis) use ($connect, $params, $dsn, $auth, $hosts, $tls) {
                 $host = $hosts[0]['host'] ?? $hosts[0]['path'];
-                $port = $hosts[0]['port'] ?? 6379;
+                $port = $hosts[0]['port'] ?? 0;
 
                 if (isset($hosts[0]['host']) && $tls) {
                     $host = 'tls://'.$host;

--- a/src/Symfony/Component/Cache/phpunit.xml.dist
+++ b/src/Symfony/Component/Cache/phpunit.xml.dist
@@ -11,6 +11,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="REDIS_HOST" value="localhost" />
+        <env name="REDIS_SOCKET" value="/var/run/redis/redis-server.sock" />
         <env name="MEMCACHED_HOST" value="localhost" />
     </php>
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
@@ -45,7 +45,7 @@ abstract class AbstractRedisSessionHandlerTestCase extends TestCase
             self::markTestSkipped('Extension redis required.');
         }
         try {
-            (new \Redis())->connect(getenv('REDIS_HOST'));
+            (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
             self::markTestSkipped($e->getMessage());
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisClusterSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisClusterSessionHandlerTest.php
@@ -20,6 +20,6 @@ class PredisClusterSessionHandlerTest extends AbstractRedisSessionHandlerTestCas
 {
     protected function createRedisClient(string $host): Client
     {
-        return new Client([['host' => $host]]);
+        return new Client([array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379])]);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisSessionHandlerTest.php
@@ -20,6 +20,6 @@ class PredisSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
 {
     protected function createRedisClient(string $host): Client
     {
-        return new Client(['host' => $host]);
+        return new Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379]));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -22,7 +22,7 @@ class RedisSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
     protected function createRedisClient(string $host)
     {
         $client = new \Redis();
-        $client->connect($host);
+        $client->connect(...explode(':', $host));
 
         return $client;
     }

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -41,7 +41,7 @@ class CombinedStoreTest extends AbstractStoreTest
      */
     public function getStore(): PersistingStoreInterface
     {
-        $redis = new \Predis\Client('tcp://'.getenv('REDIS_HOST').':6379');
+        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]));
         try {
             $redis->connect();
         } catch (\Exception $e) {

--- a/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
@@ -21,7 +21,7 @@ class PredisStoreTest extends AbstractRedisStoreTest
 {
     public static function setUpBeforeClass(): void
     {
-        $redis = new \Predis\Client('tcp://'.getenv('REDIS_HOST').':6379');
+        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]));
         try {
             $redis->connect();
         } catch (\Exception $e) {
@@ -31,7 +31,7 @@ class PredisStoreTest extends AbstractRedisStoreTest
 
     protected function getRedisConnection()
     {
-        $redis = new \Predis\Client('tcp://'.getenv('REDIS_HOST').':6379');
+        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]));
         $redis->connect();
 
         return $redis;

--- a/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
@@ -27,7 +27,7 @@ class RedisArrayStoreTest extends AbstractRedisStoreTest
             throw new SkippedTestSuiteError('The RedisArray class is required.');
         }
         try {
-            (new \Redis())->connect(getenv('REDIS_HOST'));
+            (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
             throw new SkippedTestSuiteError($e->getMessage());
         }

--- a/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
@@ -26,7 +26,7 @@ class RedisStoreTest extends AbstractRedisStoreTest
     public static function setUpBeforeClass(): void
     {
         try {
-            (new \Redis())->connect(getenv('REDIS_HOST'));
+            (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
             throw new SkippedTestSuiteError($e->getMessage());
         }
@@ -35,7 +35,7 @@ class RedisStoreTest extends AbstractRedisStoreTest
     protected function getRedisConnection()
     {
         $redis = new \Redis();
-        $redis->connect(getenv('REDIS_HOST'));
+        $redis->connect(...explode(':', getenv('REDIS_HOST')));
 
         return $redis;
     }

--- a/src/Symfony/Component/Lock/Tests/Store/RetryTillSaveStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RetryTillSaveStoreTest.php
@@ -24,7 +24,7 @@ class RetryTillSaveStoreTest extends AbstractStoreTest
 
     public function getStore(): PersistingStoreInterface
     {
-        $redis = new \Predis\Client('tcp://'.getenv('REDIS_HOST').':6379');
+        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]));
         try {
             $redis->connect();
         } catch (\Exception $e) {

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
@@ -48,7 +48,7 @@ class RedisTransportFactoryTest extends TestCase
     private function skipIfRedisUnavailable()
     {
         try {
-            (new \Redis())->connect(getenv('REDIS_HOST'));
+            (new \Redis())->connect(...explode(':', getenv('REDIS_HOST')));
         } catch (\Exception $e) {
             self::markTestSkipped($e->getMessage());
         }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php
@@ -38,10 +38,10 @@ EODUMP;
 
     public function testConnected()
     {
-        $redisHost = getenv('REDIS_HOST');
+        $redisHost = explode(':', getenv('REDIS_HOST')) + [1 => 6379];
         $redis = new \Redis();
         try {
-            $redis->connect($redisHost);
+            $redis->connect(...$redisHost);
         } catch (\Exception $e) {
             self::markTestSkipped($e->getMessage());
         }
@@ -49,8 +49,8 @@ EODUMP;
         $xCast = <<<EODUMP
 Redis {%A
   isConnected: true
-  host: "$redisHost"
-  port: 6379
+  host: "{$redisHost[0]}"
+  port: {$redisHost[1]}
   auth: null
   mode: ATOMIC
   dbNum: 0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #45277
| License       | MIT
| Doc PR        | 


In the [commit](https://github.com/symfony/symfony/commit/99b4885e7e26715bc981d73b310aacc04aa42fd3) was done follow changes in Traits/RedisTrait.php(188)

Old code:

```$port = $hosts[0]['port'] ?? null;```

New code:

```$port = $hosts[0]['port'] ?? 6379;```

With DSN "redis:///var/run/redis/redis.sock" raise an error:

```
Redis connection "redis:///var/run/redis/redis.sock?dbindex=5" failed: php_network_getaddresses: getaddrinfo failed: Name or service not known
```

Because phpredis doesn't allow socket connections with a port

```
(new Redis)->connect('/var/run/redis/redis.sock', 6379);
```

**Error**

```
PHP Warning:  Redis::connect(): php_network_getaddresses: getaddrinfo failed: Name or service not known in /root/test_redis.php on line 5
PHP Fatal error:  Uncaught RedisException: php_network_getaddresses: getaddrinfo failed: Name or service not known in /root/test_redis.php:5
Stack trace:
#0 /root/test_redis.php(5): Redis->connect()
#1 {main}
  thrown in /root/test_redis.php on line 5
```

I added additional validation of connection type (by host or socket). Also I fixed condition when RedisSentinel connection call as it supports connections by host only.
