### PR TITLE
[Notifier] fix Microsoft Teams webhook url

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsOptions.php
@@ -81,8 +81,8 @@ final class MicrosoftTeamsOptions implements MessageOptionsInterface
      */
     public function recipient(string $path): self
     {
-        if (!preg_match('/^\/webhook\//', $path)) {
-            throw new InvalidArgumentException(sprintf('"%s" require recipient id format to be "/webhook/{uuid}@{uuid}/IncomingWebhook/{id}/{uuid}", "%s" given.', __CLASS__, $path));
+        if (!preg_match('/^\/webhookb2\//', $path)) {
+            throw new InvalidArgumentException(sprintf('"%s" require recipient id format to be "/webhookb2/{uuid}@{uuid}/IncomingWebhook/{id}/{uuid}", "%s" given.', __CLASS__, $path));
         }
 
         $this->options['recipient_id'] = $path;

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/README.md
@@ -12,7 +12,7 @@ MICROSOFT_TEAMS_DSN=microsoftteams://default/PATH
 ```
 
 where:
- - `PATH` has the following format: `webhook/{uuid}@{uuid}/IncomingWebhook/{id}/{uuid}`
+ - `PATH` has the following format: `webhookb2/{uuid}@{uuid}/IncomingWebhook/{id}/{uuid}`
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Tests/MicrosoftTeamsOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Tests/MicrosoftTeamsOptionsTest.php
@@ -30,7 +30,7 @@ final class MicrosoftTeamsOptionsTest extends TestCase
     public function testGetRecipientIdReturnsRecipientWhenSetViaConstructor()
     {
         $options = new MicrosoftTeamsOptions([
-            'recipient_id' => $recipient = '/webhook/foo',
+            'recipient_id' => $recipient = '/webhookb2/foo',
         ]);
 
         $this->assertSame($recipient, $options->getRecipientId());
@@ -39,7 +39,7 @@ final class MicrosoftTeamsOptionsTest extends TestCase
     public function testGetRecipientIdReturnsRecipientWhenSetSetter()
     {
         $options = (new MicrosoftTeamsOptions())
-            ->recipient($recipient = '/webhook/foo');
+            ->recipient($recipient = '/webhookb2/foo');
 
         $this->assertSame($recipient, $options->getRecipientId());
     }
@@ -58,7 +58,7 @@ final class MicrosoftTeamsOptionsTest extends TestCase
         $recipient = 'foo';
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('"%s" require recipient id format to be "/webhook/{uuid}@{uuid}/IncomingWebhook/{id}/{uuid}", "%s" given.', MicrosoftTeamsOptions::class, $recipient));
+        $this->expectExceptionMessage(sprintf('"%s" require recipient id format to be "/webhookb2/{uuid}@{uuid}/IncomingWebhook/{id}/{uuid}", "%s" given.', MicrosoftTeamsOptions::class, $recipient));
 
         $options->recipient($recipient);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Incoming webhooks for Microsoft Teams require a new webhook URL format as described in [this post](https://office365itpros.com/2021/02/03/new-format-webhook-url/) which references Office 365 Notification MC234048.

The old format is no longer supported since April 11, 2021 so I replaced it completely.