### PR TITLE
[DependencyInjection] Fix AsEventListener not working on decorators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -637,6 +637,7 @@ class FrameworkExtension extends Extension
             'container.service_locator',
             'container.service_subscriber',
             'kernel.event_subscriber',
+            'kernel.event_listener',
             'kernel.locale_aware',
             'kernel.reset',
         ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1971,6 +1971,7 @@ abstract class FrameworkExtensionTest extends TestCase
             'container.service_locator',
             'container.service_subscriber',
             'kernel.event_subscriber',
+            'kernel.event_listener',
             'kernel.locale_aware',
             'kernel.reset',
         ], $container->getParameter('container.behavior_describing_tags'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When using the `AsEventListener` on a decorator, it is ignored instead of registering the decorator as an event listener. This is because autoconfigured tags are not applied to decorators since #30417.

`EventSubscriberInterface` works as expected since #38999, when the `kernel.event_subscriber'` tag was added to a list of "behavior describing tags" which can be autoconfigured onto decorators.

This PR adds `kernel.event_listener` to this default list of tags, making `AsEventListener` work as expected on decorators.
