### PR TITLE
[HttpKernel][WebProfilerBundle] Fixed error count by log not displayed in WebProfilerBundle

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -108,7 +108,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
 
             $logs[] = [
                 'type' => $logType,
-                'errorCounter' => isset($rawLogData['errorCounter']) ? $rawLogData['errorCounter']->getValue() : 1,
+                'errorCount' => $rawLog['errorCount'] ?? 1,
                 'timestamp' => $rawLogData['timestamp_rfc3339']->getValue(),
                 'priority' => $rawLogData['priority']->getValue(),
                 'priorityName' => $rawLogData['priorityName']->getValue(),

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -80,7 +80,7 @@ class LoggerDataCollectorTest extends TestCase
         $this->assertCount(1, $processedLogs);
 
         $this->assertEquals($processedLogs[0]['type'], 'deprecation');
-        $this->assertEquals($processedLogs[0]['errorCounter'], 1);
+        $this->assertEquals($processedLogs[0]['errorCount'], 1);
         $this->assertEquals($processedLogs[0]['timestamp'], (new \DateTimeImmutable())->setTimestamp(filemtime($path))->format(\DateTimeInterface::RFC3339_EXTENDED));
         $this->assertEquals($processedLogs[0]['priority'], 100);
         $this->assertEquals($processedLogs[0]['priorityName'], 'DEBUG');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45183 
| License       | MIT
| Doc PR        | -

This PR is the following of #45198. Refer to this PR for details.

![image](https://user-images.githubusercontent.com/17042730/152384024-64ffecb3-d895-450b-a994-fe3d54582680.png)
