### PR TITLE
[Messenger] Retain correlation id from \AmqpEnvelope when retrying a message

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpStampTest.php
@@ -42,6 +42,7 @@ class AmqpStampTest extends TestCase
         $amqpEnvelope->method('getDeliveryMode')->willReturn(2);
         $amqpEnvelope->method('getPriority')->willReturn(5);
         $amqpEnvelope->method('getAppId')->willReturn('appid');
+        $amqpEnvelope->method('getCorrelationId')->willReturn('foo');
 
         $stamp = AmqpStamp::createFromAmqpEnvelope($amqpEnvelope);
 
@@ -49,6 +50,7 @@ class AmqpStampTest extends TestCase
         $this->assertSame($amqpEnvelope->getDeliveryMode(), $stamp->getAttributes()['delivery_mode']);
         $this->assertSame($amqpEnvelope->getPriority(), $stamp->getAttributes()['priority']);
         $this->assertSame($amqpEnvelope->getAppId(), $stamp->getAttributes()['app_id']);
+        $this->assertSame($amqpEnvelope->getCorrelationId(), $stamp->getAttributes()['correlation_id']);
         $this->assertSame(\AMQP_NOPARAM, $stamp->getFlags());
     }
 
@@ -59,8 +61,12 @@ class AmqpStampTest extends TestCase
         $amqpEnvelope->method('getDeliveryMode')->willReturn(2);
         $amqpEnvelope->method('getPriority')->willReturn(5);
         $amqpEnvelope->method('getAppId')->willReturn('appid');
+        $amqpEnvelope->method('getCorrelationId')->willReturn('foo');
 
-        $previousStamp = new AmqpStamp('otherroutingkey', \AMQP_MANDATORY, ['priority' => 8]);
+        $previousStamp = new AmqpStamp('otherroutingkey', \AMQP_MANDATORY, [
+            'priority' => 8,
+            'correlation_id' => 'bar',
+        ]);
 
         $stamp = AmqpStamp::createFromAmqpEnvelope($amqpEnvelope, $previousStamp);
 
@@ -68,6 +74,7 @@ class AmqpStampTest extends TestCase
         $this->assertSame($amqpEnvelope->getDeliveryMode(), $stamp->getAttributes()['delivery_mode']);
         $this->assertSame(8, $stamp->getAttributes()['priority']);
         $this->assertSame($amqpEnvelope->getAppId(), $stamp->getAttributes()['app_id']);
+        $this->assertSame('bar', $stamp->getAttributes()['correlation_id']);
         $this->assertSame(\AMQP_MANDATORY, $stamp->getFlags());
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpStamp.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpStamp.php
@@ -61,6 +61,7 @@ final class AmqpStamp implements NonSendableStampInterface
         $attr['expiration'] = $attr['expiration'] ?? $amqpEnvelope->getExpiration();
         $attr['type'] = $attr['type'] ?? $amqpEnvelope->getType();
         $attr['reply_to'] = $attr['reply_to'] ?? $amqpEnvelope->getReplyTo();
+        $attr['correlation_id'] = $attr['correlation_id'] ?? $amqpEnvelope->getCorrelationId();
 
         return new self($previousStamp->routingKey ?? $amqpEnvelope->getRoutingKey(), $previousStamp->flags ?? \AMQP_NOPARAM, $attr);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Ref https://github.com/symfony/symfony/pull/34134

The correlation id is lost when the message is retried.