### PR TITLE
[Console] Console output formatter improvement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,3 @@ max_line_length = 80
 
 [COMMIT_EDITMSG]
 max_line_length = 0
-
-[*.txt]
-trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ max_line_length = 80
 
 [COMMIT_EDITMSG]
 max_line_length = 0
+
+[*.txt]
+trim_trailing_whitespace = false

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 ---
 
  * Add method `__toString()` to `InputInterface`
+ * Added `OutputWrapperInterface` and `OutputWrapper` to allow modifying your
+   wrapping strategy in `SymfonyStyle` or in other `OutputStyle`. Eg: you can
+   switch off to wrap URLs.
  * Deprecate `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead
 
 6.0

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -158,7 +158,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
             $offset = $pos + \strlen($text);
 
             // opening tag?
-            if ($open = ('/' != $text[1])) {
+            if ($open = ('/' !== $text[1])) {
                 $tag = $matches[1][$i][0];
             } else {
                 $tag = $matches[3][$i][0] ?? '';

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -141,8 +141,8 @@ class OutputFormatter implements WrappableOutputFormatterInterface
     {
         $offset = 0;
         $output = '';
-        $openTagRegex = OutputWrapperInterface::TAG_OPEN_REGEX;
-        $closeTagRegex = OutputWrapperInterface::TAG_CLOSE_REGEX;
+        $openTagRegex = OutputWrapperInterface::TAG_OPEN_REGEX_SEGMENT;
+        $closeTagRegex = OutputWrapperInterface::TAG_CLOSE_REGEX_SEGMENT;
         $currentLineLength = 0;
         preg_match_all("#<(($openTagRegex) | /($closeTagRegex)?)>#ix", $message, $matches, \PREG_OFFSET_CAPTURE);
         foreach ($matches[0] as $i => $match) {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Formatter;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Helper\OutputWrapperInterface;
 
 /**
  * Formatter class for console output.
@@ -140,8 +141,8 @@ class OutputFormatter implements WrappableOutputFormatterInterface
     {
         $offset = 0;
         $output = '';
-        $openTagRegex = '[a-z](?:[^\\\\<>]*+ | \\\\.)*';
-        $closeTagRegex = '[a-z][^<>]*+';
+        $openTagRegex = OutputWrapperInterface::TAG_OPEN_REGEX;
+        $closeTagRegex = OutputWrapperInterface::TAG_CLOSE_REGEX;
         $currentLineLength = 0;
         preg_match_all("#<(($openTagRegex) | /($closeTagRegex)?)>#ix", $message, $matches, \PREG_OFFSET_CAPTURE);
         foreach ($matches[0] as $i => $match) {
@@ -157,7 +158,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
             $offset = $pos + \strlen($text);
 
             // opening tag?
-            if ($open = '/' != $text[1]) {
+            if ($open = ('/' != $text[1])) {
                 $tag = $matches[1][$i][0];
             } else {
                 $tag = $matches[3][$i][0] ?? '';

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -62,7 +62,7 @@ final class OutputWrapper implements OutputWrapperInterface
 
     public function wrap(string $text, int $width, string $break = "\n"): string
     {
-        if (0 === $width) {
+        if (!$width) {
             return $text;
         }
 

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -66,7 +66,7 @@ class OutputWrapper implements OutputWrapperInterface
             return $text;
         }
 
-        $tagPattern = sprintf('<(?:(?:%1$s)|/(?:%1$s)?)>', '[a-z][^<>]*+');
+        $tagPattern = sprintf('<(?:(?:%s)|/(?:%s)?)>', OutputWrapperInterface::TAG_OPEN_REGEX, OutputWrapperInterface::TAG_CLOSE_REGEX);
         $limitPattern = "{1,$width}";
         $patternBlocks = [$tagPattern];
         if (!$this->allowCutUrls) {

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -44,7 +44,7 @@ namespace Symfony\Component\Console\Helper;
  */
 class OutputWrapper implements OutputWrapperInterface
 {
-    public const URL_PATTERN = 'https?://[^ ]+';
+    public const URL_PATTERN = 'https?://\S+';
 
     private bool $allowCutUrls = false;
 

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 /*
  * This file is part of the Symfony package.
@@ -48,19 +48,11 @@ class OutputWrapper implements OutputWrapperInterface
 
     private $keepUrlsTogether = true;
 
-    /**
-     * @return bool
-     */
     public function isKeepUrlsTogether(): bool
     {
         return $this->keepUrlsTogether;
     }
 
-    /**
-     * @param bool $keepUrlsTogether
-     *
-     * @return $this
-     */
     public function setKeepUrlsTogether(bool $keepUrlsTogether)
     {
         $this->keepUrlsTogether = $keepUrlsTogether;
@@ -84,8 +76,8 @@ class OutputWrapper implements OutputWrapperInterface
         $blocks = implode('|', $patternBlocks);
         $rowPattern = "(?:$blocks)$limitPattern";
         $pattern = sprintf('#(?:((?>(%1$s)((?<=[^\S\r\n])[^\S\r\n]?|(?=\r?\n)|$|[^\S\r\n]))|(%1$s))(?:\r?\n)?|(?:\r?\n|$))#imux', $rowPattern);
-        $output = rtrim(preg_replace($pattern, '\\1' . $break, $text), $break);
+        $output = rtrim(preg_replace($pattern, '\\1'.$break, $text), $break);
 
-        return str_replace(' ' . $break, $break, $output);
+        return str_replace(' '.$break, $break, $output);
     }
 }

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Console\Helper;
 
 /**
  * Simple output wrapper for "tagged outputs" instead of wordwrap(). This solution is based on a StackOverflow
- * answer: https://stackoverflow.com/a/20434776/1476819 from SLN.
+ * answer: https://stackoverflow.com/a/20434776/1476819 from user557597 (alias SLN).
  *
  *  (?:
  *       # -- Words/Characters
@@ -42,9 +42,9 @@ namespace Symfony\Component\Console\Helper;
  *
  * @see https://stackoverflow.com/a/20434776/1476819
  */
-class OutputWrapper implements OutputWrapperInterface
+final class OutputWrapper implements OutputWrapperInterface
 {
-    public const URL_PATTERN = 'https?://\S+';
+    private const URL_PATTERN = 'https?://\S+';
 
     private bool $allowCutUrls = false;
 
@@ -66,7 +66,7 @@ class OutputWrapper implements OutputWrapperInterface
             return $text;
         }
 
-        $tagPattern = sprintf('<(?:(?:%s)|/(?:%s)?)>', OutputWrapperInterface::TAG_OPEN_REGEX, OutputWrapperInterface::TAG_CLOSE_REGEX);
+        $tagPattern = sprintf('<(?:(?:%s)|/(?:%s)?)>', OutputWrapperInterface::TAG_OPEN_REGEX_SEGMENT, OutputWrapperInterface::TAG_CLOSE_REGEX_SEGMENT);
         $limitPattern = "{1,$width}";
         $patternBlocks = [$tagPattern];
         if (!$this->allowCutUrls) {

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -46,16 +46,16 @@ class OutputWrapper implements OutputWrapperInterface
 {
     const URL_PATTERN = 'https?://[^ ]+';
 
-    private $keepUrlsTogether = true;
+    private $allowCutUrls = false;
 
-    public function isKeepUrlsTogether(): bool
+    public function isAllowCutUrls(): bool
     {
-        return $this->keepUrlsTogether;
+        return $this->allowCutUrls;
     }
 
-    public function setKeepUrlsTogether(bool $keepUrlsTogether)
+    public function setAllowCutUrls(bool $allowCutUrls)
     {
-        $this->keepUrlsTogether = $keepUrlsTogether;
+        $this->allowCutUrls = $allowCutUrls;
 
         return $this;
     }
@@ -69,7 +69,7 @@ class OutputWrapper implements OutputWrapperInterface
         $tagPattern = sprintf('<(?:(?:%1$s)|/(?:%1$s)?)>', '[a-z][^<>]*+');
         $limitPattern = "{1,$width}";
         $patternBlocks = [$tagPattern];
-        if ($this->keepUrlsTogether) {
+        if (!$this->allowCutUrls) {
             $patternBlocks[] = self::URL_PATTERN;
         }
         $patternBlocks[] = '.';

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -44,9 +44,9 @@ namespace Symfony\Component\Console\Helper;
  */
 class OutputWrapper implements OutputWrapperInterface
 {
-    const URL_PATTERN = 'https?://[^ ]+';
+    public const URL_PATTERN = 'https?://[^ ]+';
 
-    private $allowCutUrls = false;
+    private bool $allowCutUrls = false;
 
     public function isAllowCutUrls(): bool
     {

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Helper;
+
+/**
+ * Simple output wrapper for "tagged outputs" instead of wordwrap(). This solution is based on a StackOverflow
+ * answer: https://stackoverflow.com/a/20434776/1476819 from SLN.
+ *
+ *  (?:
+ *       # -- Words/Characters
+ *       (                       # (1 start)
+ *            (?>                     # Atomic Group - Match words with valid breaks
+ *                 .{1,16}                 #  1-N characters
+ *                                         #  Followed by one of 4 prioritized, non-linebreak whitespace
+ *                 (?:                     #  break types:
+ *                      (?<= [^\S\r\n] )        # 1. - Behind a non-linebreak whitespace
+ *                      [^\S\r\n]?              #      ( optionally accept an extra non-linebreak whitespace )
+ *                   |  (?= \r? \n )            # 2. - Ahead a linebreak
+ *                   |  $                       # 3. - EOS
+ *                   |  [^\S\r\n]               # 4. - Accept an extra non-linebreak whitespace
+ *                 )
+ *            )                       # End atomic group
+ *         |
+ *            .{1,16}                 # No valid word breaks, just break on the N'th character
+ *       )                       # (1 end)
+ *       (?: \r? \n )?           # Optional linebreak after Words/Characters
+ *    |
+ *       # -- Or, Linebreak
+ *       (?: \r? \n | $ )        # Stand alone linebreak or at EOS
+ *  )
+ *
+ * @author Krisztián Ferenczi <ferenczi.krisztian@gmail.com>
+ *
+ * @see https://stackoverflow.com/a/20434776/1476819
+ */
+class OutputWrapper implements OutputWrapperInterface
+{
+    const URL_PATTERN = 'https?://[^ ]+';
+
+    private $keepUrlsTogether = true;
+
+    /**
+     * @return bool
+     */
+    public function isKeepUrlsTogether(): bool
+    {
+        return $this->keepUrlsTogether;
+    }
+
+    /**
+     * @param bool $keepUrlsTogether
+     *
+     * @return $this
+     */
+    public function setKeepUrlsTogether(bool $keepUrlsTogether)
+    {
+        $this->keepUrlsTogether = $keepUrlsTogether;
+
+        return $this;
+    }
+
+    public function wrap(string $text, int $width, string $break = "\n"): string
+    {
+        if (0 === $width) {
+            return $text;
+        }
+
+        $tagPattern = sprintf('<(?:(?:%1$s)|/(?:%1$s)?)>', '[a-z][^<>]*+');
+        $limitPattern = "{1,$width}";
+        $patternBlocks = [$tagPattern];
+        if ($this->keepUrlsTogether) {
+            $patternBlocks[] = self::URL_PATTERN;
+        }
+        $patternBlocks[] = '.';
+        $blocks = implode('|', $patternBlocks);
+        $rowPattern = "(?:$blocks)$limitPattern";
+        $pattern = sprintf('#(?:((?>(%1$s)((?<=[^\S\r\n])[^\S\r\n]?|(?=\r?\n)|$|[^\S\r\n]))|(%1$s))(?:\r?\n)?|(?:\r?\n|$))#imux', $rowPattern);
+        $output = rtrim(preg_replace($pattern, '\\1' . $break, $text), $break);
+
+        return str_replace(' ' . $break, $break, $output);
+    }
+}

--- a/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Symfony\Component\Console\Helper;
+
+interface OutputWrapperInterface
+{
+    const TAG_OPEN_REGEX = '[a-z](?:[^\\\\<>]*+ | \\\\.)*';
+    const TAG_CLOSE_REGEX = '[a-z][^<>]*+';
+
+    public function wrap(string $text, int $width, string $break = "\n"): string;
+}

--- a/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
@@ -1,4 +1,13 @@
-<?php declare(strict_types=1);
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Symfony\Component\Console\Helper;
 

--- a/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
@@ -16,5 +16,8 @@ interface OutputWrapperInterface
     public const TAG_OPEN_REGEX = '[a-z](?:[^\\\\<>]*+ | \\\\.)*';
     public const TAG_CLOSE_REGEX = '[a-z][^<>]*+';
 
+    /**
+     * @param positive-int|0 $width
+     */
     public function wrap(string $text, int $width, string $break = "\n"): string;
 }

--- a/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\Console\Helper;
 
 interface OutputWrapperInterface
 {
-    public const TAG_OPEN_REGEX = '[a-z](?:[^\\\\<>]*+ | \\\\.)*';
-    public const TAG_CLOSE_REGEX = '[a-z][^<>]*+';
+    public const TAG_OPEN_REGEX_SEGMENT = '[a-z](?:[^\\\\<>]*+ | \\\\.)*';
+    public const TAG_CLOSE_REGEX_SEGMENT = '[a-z][^<>]*+';
 
     /**
      * @param positive-int|0 $width

--- a/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\Console\Helper;
 
 interface OutputWrapperInterface
 {
-    const TAG_OPEN_REGEX = '[a-z](?:[^\\\\<>]*+ | \\\\.)*';
-    const TAG_CLOSE_REGEX = '[a-z][^<>]*+';
+    public const TAG_OPEN_REGEX = '[a-z](?:[^\\\\<>]*+ | \\\\.)*';
+    public const TAG_CLOSE_REGEX = '[a-z][^<>]*+';
 
     public function wrap(string $text, int $width, string $break = "\n"): string;
 }

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -469,7 +469,7 @@ class SymfonyStyle extends OutputStyle
 
         if (null !== $type) {
             $type = sprintf('[%s] ', $type);
-            $indentLength = Helper::strlen($type);
+            $indentLength = Helper::width($type);
             $lineIndentation = str_repeat(' ', $indentLength);
         }
 
@@ -479,7 +479,14 @@ class SymfonyStyle extends OutputStyle
                 $message = OutputFormatter::escape($message);
             }
 
-            $lines = array_merge($lines, explode(\PHP_EOL, $this->outputWrapper->wrap($message, $this->lineLength - $prefixLength - $indentLength, PHP_EOL)));
+            $lines = array_merge(
+                $lines,
+                explode(\PHP_EOL, $this->outputWrapper->wrap(
+                    $message,
+                    $this->lineLength - $prefixLength - $indentLength,
+                    PHP_EOL
+                ))
+            );
 
             if (\count($messages) > 1 && $key < \count($messages) - 1) {
                 $lines[] = '';

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -60,19 +60,11 @@ class SymfonyStyle extends OutputStyle
         parent::__construct($this->output = $output);
     }
 
-    /**
-     * @return OutputWrapperInterface
-     */
     public function getOutputWrapper(): OutputWrapperInterface
     {
         return $this->outputWrapper;
     }
 
-    /**
-     * @param OutputWrapperInterface $outputWrapper
-     *
-     * @return $this
-     */
     public function setOutputWrapper(OutputWrapperInterface $outputWrapper)
     {
         $this->outputWrapper = $outputWrapper;

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -484,7 +484,7 @@ class SymfonyStyle extends OutputStyle
                 explode(\PHP_EOL, $this->outputWrapper->wrap(
                     $message,
                     $this->lineLength - $prefixLength - $indentLength,
-                    PHP_EOL
+                    \PHP_EOL
                 ))
             );
 

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -15,6 +15,8 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Helper\OutputWrapper;
+use Symfony\Component\Console\Helper\OutputWrapperInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
 use Symfony\Component\Console\Helper\Table;
@@ -44,16 +46,38 @@ class SymfonyStyle extends OutputStyle
     private ProgressBar $progressBar;
     private int $lineLength;
     private TrimmedBufferOutput $bufferedOutput;
+    private OutputWrapperInterface $outputWrapper;
 
-    public function __construct(InputInterface $input, OutputInterface $output)
+    public function __construct(InputInterface $input, OutputInterface $output, OutputWrapperInterface $outputWrapper = null)
     {
         $this->input = $input;
         $this->bufferedOutput = new TrimmedBufferOutput(\DIRECTORY_SEPARATOR === '\\' ? 4 : 2, $output->getVerbosity(), false, clone $output->getFormatter());
         // Windows cmd wraps lines as soon as the terminal width is reached, whether there are following chars or not.
         $width = (new Terminal())->getWidth() ?: self::MAX_LINE_LENGTH;
         $this->lineLength = min($width - (int) (\DIRECTORY_SEPARATOR === '\\'), self::MAX_LINE_LENGTH);
+        $this->outputWrapper = $outputWrapper ?: new OutputWrapper();
 
         parent::__construct($this->output = $output);
+    }
+
+    /**
+     * @return OutputWrapperInterface
+     */
+    public function getOutputWrapper(): OutputWrapperInterface
+    {
+        return $this->outputWrapper;
+    }
+
+    /**
+     * @param OutputWrapperInterface $outputWrapper
+     *
+     * @return $this
+     */
+    public function setOutputWrapper(OutputWrapperInterface $outputWrapper)
+    {
+        $this->outputWrapper = $outputWrapper;
+
+        return $this;
     }
 
     /**
@@ -453,7 +477,7 @@ class SymfonyStyle extends OutputStyle
 
         if (null !== $type) {
             $type = sprintf('[%s] ', $type);
-            $indentLength = \strlen($type);
+            $indentLength = Helper::strlen($type);
             $lineIndentation = str_repeat(' ', $indentLength);
         }
 
@@ -463,12 +487,7 @@ class SymfonyStyle extends OutputStyle
                 $message = OutputFormatter::escape($message);
             }
 
-            $decorationLength = Helper::width($message) - Helper::width(Helper::removeDecoration($this->getFormatter(), $message));
-            $messageLineLength = min($this->lineLength - $prefixLength - $indentLength + $decorationLength, $this->lineLength);
-            $messageLines = explode(\PHP_EOL, wordwrap($message, $messageLineLength, \PHP_EOL, true));
-            foreach ($messageLines as $messageLine) {
-                $lines[] = $messageLine;
-            }
+            $lines = array_merge($lines, explode(\PHP_EOL, $this->outputWrapper->wrap($message, $this->lineLength - $prefixLength - $indentLength, PHP_EOL)));
 
             if (\count($messages) > 1 && $key < \count($messages) - 1) {
                 $lines[] = '';

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
@@ -9,6 +9,6 @@ return function (InputInterface $input, OutputInterface $output) {
     $output->setDecorated(true);
     $output = new SymfonyStyle($input, $output);
     $output->comment(
-        'Árvíztűrőtükörfúrógép Lorem ipsum dolor sit <comment>amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
+        'Árvíztűrőtükörfúrógép 🎼 Lorem ipsum dolor sit <comment>💕 amet, consectetur adipisicing elit, sed do eiusmod tempor incididu labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
     );
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
@@ -9,6 +9,6 @@ return function (InputInterface $input, OutputInterface $output) {
     $output->setDecorated(true);
     $output = new SymfonyStyle($input, $output);
     $output->comment(
-        'Lorem ipsum dolor sit <comment>amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
+        'Árvíztűrőtükörfúrógép Lorem ipsum dolor sit <comment>amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
     );
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_22.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_22.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+// ensure that nested tags have no effect on the color of the '//' prefix
+return function (InputInterface $input, OutputInterface $output) {
+    $output->setDecorated(true);
+    $output = new SymfonyStyle($input, $output);
+    $output->block(
+        'Árvíztűrőtükörfúrógép Lorem ipsum dolor sit <comment>amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
+        '★', // UTF-8 star!
+        null,
+        '<fg=default;bg=default> ║ </>', // UTF-8 double line!
+        false,
+        false
+    );
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
@@ -1,5 +1,5 @@
 
-[39;49m // [39;49mÁrvíztűrőtükörfúrógép Lorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut [39m
+[39;49m // [39;49mÁrvíztűrőtükörfúrógép 🎼 Lorem ipsum dolor sit [33m💕 amet, consectetur adipisicing elit, sed do eiusmod tempor incididu[39m
 [39;49m // [39;49m[33mlabore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex[39m
 [39;49m // [39;49m[33mea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla  [39m
 [39;49m // [39;49m[33mpariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est     

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
@@ -1,7 +1,7 @@
 
-[39;49m // [39;49mLorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore      [39m
-[39;49m // [39;49m[33mmagna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo      [39m
-[39;49m // [39;49m[33mconsequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla             [39m
-[39;49m // [39;49m[33mpariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id         
-[39;49m // [39;49mest laborum                                                                                                         
+[39;49m // [39;49mÁrvíztűrőtükörfúrógép Lorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut [39m
+[39;49m // [39;49m[33mlabore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex[39m
+[39;49m // [39;49m[33mea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla  [39m
+[39;49m // [39;49m[33mpariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est     
+[39;49m // [39;49mlaborum                                                                                                             
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_22.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_22.txt
@@ -1,0 +1,6 @@
+
+[39;49m ║ [39;49m[★] Árvíztűrőtükörfúrógép Lorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt [39m
+[39;49m ║ [39;49m[33m    ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut     [39m
+[39;49m ║ [39;49m[33m    aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu [39m
+[39;49m ║ [39;49m[33m    fugiat nulla pariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit 
+[39;49m ║ [39;49m    anim id est laborum                                                                                              

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_22.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_22.txt
@@ -4,3 +4,4 @@
 [39;49m ║ [39;49m[33m    aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu [39m
 [39;49m ║ [39;49m[33m    fugiat nulla pariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit 
 [39;49m ║ [39;49m    anim id est laborum                                                                                              
+

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -20,7 +20,7 @@ class OutputWrapperTest extends TestCase
     {
         $wrapper = new OutputWrapper();
         // Test UTF-8 chars + URL
-        $text = "Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.";
+        $text = 'Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.';
         $baseExpected = <<<EOS
 Árvíztűrőtükörfúrógé
 p https://github.com/symfony/symfony Lorem ipsum

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\OutputWrapper;
+
+class OutputWrapperTest extends TestCase
+{
+    public function testBasicWrap()
+    {
+        $wrapper = new OutputWrapper();
+        // Test UTF-8 chars + URL
+        $text = "Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.";
+        $baseExpected = <<<EOS
+Árvíztűrőtükörfúrógé
+p https://github.com/symfony/symfony Lorem ipsum
+<comment>dolor</comment> sit amet,
+consectetur
+adipiscing elit.
+Praesent vestibulum
+nulla quis urna
+maximus porttitor.
+Donec ullamcorper
+risus at <error>libero
+ornare</error> efficitur.
+EOS;
+        $result = $wrapper->wrap($text, 20);
+        $this->assertEquals($baseExpected, $result);
+
+        $URLwrappedExpected = <<<EOS
+Árvíztűrőtükörfúrógé
+p
+https://github.com/s
+ymfony/symfony Lorem
+ipsum <comment>dolor</comment> sit
+amet, consectetur
+adipiscing elit.
+Praesent vestibulum
+nulla quis urna
+maximus porttitor.
+Donec ullamcorper
+risus at <error>libero
+ornare</error> efficitur.
+EOS;
+        $wrapper->setKeepUrlsTogether(false);
+        $result = $wrapper->wrap($text, 20);
+        $this->assertEquals($URLwrappedExpected, $result);
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Helper\OutputWrapper;
 
 class OutputWrapperTest extends TestCase
 {
-    public function testBasicWrap()
+    public function testBasicWrap(): void
     {
         $wrapper = new OutputWrapper();
         // Test UTF-8 chars + URL

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -16,44 +16,60 @@ use Symfony\Component\Console\Helper\OutputWrapper;
 
 class OutputWrapperTest extends TestCase
 {
-    public function testBasicWrap(): void
+    /**
+     * @dataProvider textProvider
+     */
+    public function testBasicWrap(string $text, int $width, ?bool $allowCutUrls, string $expected): void
     {
         $wrapper = new OutputWrapper();
-        // Test UTF-8 chars + URL
-        $text = 'Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.';
-        $baseExpected = <<<EOS
-Árvíztűrőtükörfúrógé
-p https://github.com/symfony/symfony Lorem ipsum
-<comment>dolor</comment> sit amet,
-consectetur
-adipiscing elit.
-Praesent vestibulum
-nulla quis urna
-maximus porttitor.
-Donec ullamcorper
-risus at <error>libero
-ornare</error> efficitur.
-EOS;
-        $result = $wrapper->wrap($text, 20);
-        $this->assertEquals($baseExpected, $result);
+        if (is_bool($allowCutUrls)) {
+            $wrapper->setAllowCutUrls($allowCutUrls);
+        }
+        $result = $wrapper->wrap($text, $width);
+        $this->assertEquals($expected, $result);
+    }
 
-        $URLwrappedExpected = <<<EOS
-Árvíztűrőtükörfúrógé
-p
-https://github.com/s
-ymfony/symfony Lorem
-ipsum <comment>dolor</comment> sit
-amet, consectetur
-adipiscing elit.
-Praesent vestibulum
-nulla quis urna
-maximus porttitor.
-Donec ullamcorper
-risus at <error>libero
-ornare</error> efficitur.
-EOS;
-        $wrapper->setAllowCutUrls(true);
-        $result = $wrapper->wrap($text, 20);
-        $this->assertEquals($URLwrappedExpected, $result);
+    public static function textProvider(): iterable {
+        $baseTextWithUtf8AndUrl = 'Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.';
+
+        yield 'Default URL cut' => [
+            $baseTextWithUtf8AndUrl,
+            20,
+            null,
+            <<<'EOS'
+            Árvíztűrőtükörfúrógé
+            p https://github.com/symfony/symfony Lorem ipsum
+            <comment>dolor</comment> sit amet,
+            consectetur
+            adipiscing elit.
+            Praesent vestibulum
+            nulla quis urna
+            maximus porttitor.
+            Donec ullamcorper
+            risus at <error>libero
+            ornare</error> efficitur.
+            EOS,
+        ];
+
+        yield 'Allow URL cut' => [
+            $baseTextWithUtf8AndUrl,
+            20,
+            true,
+            <<<'EOS'
+            Árvíztűrőtükörfúrógé
+            p
+            https://github.com/s
+            ymfony/symfony Lorem
+            ipsum <comment>dolor</comment> sit
+            amet, consectetur
+            adipiscing elit.
+            Praesent vestibulum
+            nulla quis urna
+            maximus porttitor.
+            Donec ullamcorper
+            risus at <error>libero
+            ornare</error> efficitur.
+            EOS,
+        ];
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -52,7 +52,7 @@ Donec ullamcorper
 risus at <error>libero
 ornare</error> efficitur.
 EOS;
-        $wrapper->setAllowCutUrls(false);
+        $wrapper->setAllowCutUrls(true);
         $result = $wrapper->wrap($text, 20);
         $this->assertEquals($URLwrappedExpected, $result);
     }

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -22,7 +22,7 @@ class OutputWrapperTest extends TestCase
     public function testBasicWrap(string $text, int $width, ?bool $allowCutUrls, string $expected)
     {
         $wrapper = new OutputWrapper();
-        if (is_bool($allowCutUrls)) {
+        if (\is_bool($allowCutUrls)) {
             $wrapper->setAllowCutUrls($allowCutUrls);
         }
         $result = $wrapper->wrap($text, $width);

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -19,7 +19,7 @@ class OutputWrapperTest extends TestCase
     /**
      * @dataProvider textProvider
      */
-    public function testBasicWrap(string $text, int $width, ?bool $allowCutUrls, string $expected): void
+    public function testBasicWrap(string $text, int $width, ?bool $allowCutUrls, string $expected)
     {
         $wrapper = new OutputWrapper();
         if (is_bool($allowCutUrls)) {
@@ -29,7 +29,8 @@ class OutputWrapperTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public static function textProvider(): iterable {
+    public static function textProvider(): iterable
+    {
         $baseTextWithUtf8AndUrl = 'Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.';
 
         yield 'Default URL cut' => [

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -52,7 +52,7 @@ Donec ullamcorper
 risus at <error>libero
 ornare</error> efficitur.
 EOS;
-        $wrapper->setKeepUrlsTogether(false);
+        $wrapper->setAllowCutUrls(false);
         $result = $wrapper->wrap($text, 20);
         $this->assertEquals($URLwrappedExpected, $result);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #30920
| License       | MIT
| Doc PR        | symfony/symfony-docs#16476

Current `SymfonyStyle` can cause some problems:
- can cut format tags
- cut/split URLs, the user can't click on them in the terminal

I fixed the problem and added or modified some tests. This is a simple, fast, and working solution with a regular expression that won't wrap in the middle of a formatting tag or a link. The last one is optional, see the doc change.