### PR TITLE
Fix generic type for FormErrorIterator

### DIFF
--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -30,8 +30,8 @@ use Symfony\Component\Validator\ConstraintViolation;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @implements \ArrayAccess<int, FormError|FormErrorIterator>
- * @implements \RecursiveIterator<int, FormError>
- * @implements \SeekableIterator<int, FormError>
+ * @implements \RecursiveIterator<int, FormError|FormErrorIterator>
+ * @implements \SeekableIterator<int, FormError|FormErrorIterator>
  */
 class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \ArrayAccess, \Countable
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

After upgrading symfony/form (v5.4.2 => v5.4.3) I was getting weird phpstan errors 
```
Instanceof between Symfony\Component\Form\FormError and Symfony\Component\Form\FormErrorIterator will always evaluate to false.
```
I pass `FormErrorIterator $formErrors` and iterate over it, and do different things if it's an instance of `FormErrorIterator` or `FormError`
This change fixes it

It was introduced here
https://github.com/symfony/symfony/pull/42471/files#diff-48af5e26fa9979e5508cc18c8921ed13fd1a870706108285bada83f18278ff8eR32