### PR TITLE
[EventDispatcher] Remove unused variables

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -108,7 +108,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         // we might have wrapped listeners for the event (if called while dispatching)
         // in that case get the priority by wrapper
         if (isset($this->wrappedListeners[$eventName])) {
-            foreach ($this->wrappedListeners[$eventName] as $index => $wrappedListener) {
+            foreach ($this->wrappedListeners[$eventName] as $wrappedListener) {
                 if ($wrappedListener->getWrappedListener() === $listener) {
                     return $this->dispatcher->getListenerPriority($eventName, $wrappedListener);
                 }

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -240,7 +240,7 @@ class EventDispatcher implements EventDispatcherInterface
         $this->sorted[$eventName] = [];
 
         foreach ($this->listeners[$eventName] as &$listeners) {
-            foreach ($listeners as $k => &$listener) {
+            foreach ($listeners as &$listener) {
                 if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure && 2 >= \count($listener)) {
                     $listener[0] = $listener[0]();
                     $listener[1] ??= '__invoke';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The removed variable in `EventDispatcher::sortListeners()` has not been used since
https://github.com/symfony/symfony/commit/d6a594bf426527a61bb404fdbbf5125d9ef0c9a5#diff-27b473156e98208bb0270a426172f4c20c45595ca7babfe8fd653a817bd0741cL230 and the removed variable in `TraceableEventDispatcher::getListenerPriority()` has never been used: https://github.com/symfony/symfony/commit/79b71c069dc2ecbafdce190b78f5a9f989ada033#diff-bcbd20f9d547cfc56597d5f4f3a611b06c5f3b69f610e5e2b8922401dad1fbf3R110-R114
