### PR TITLE
[Security]  Fix wrong authenticator class in debug logs

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -25,6 +25,7 @@ use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusExce
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
@@ -151,7 +152,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             // lazily (after initialization).
             if (false === $authenticator->supports($request)) {
                 if (null !== $this->logger) {
-                    $this->logger->debug('Skipping the "{authenticator}" authenticator as it did not support the request.', ['authenticator' => \get_class($authenticator)]);
+                    $this->logger->debug('Skipping the "{authenticator}" authenticator as it did not support the request.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
                 }
 
                 continue;
@@ -160,7 +161,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             $response = $this->executeAuthenticator($authenticator, $request);
             if (null !== $response) {
                 if (null !== $this->logger) {
-                    $this->logger->debug('The "{authenticator}" authenticator set the response. Any later authenticator will not be called', ['authenticator' => \get_class($authenticator)]);
+                    $this->logger->debug('The "{authenticator}" authenticator set the response. Any later authenticator will not be called', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
                 }
 
                 return $response;
@@ -210,7 +211,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             $this->eventDispatcher->dispatch(new AuthenticationSuccessEvent($authenticatedToken), AuthenticationEvents::AUTHENTICATION_SUCCESS);
 
             if (null !== $this->logger) {
-                $this->logger->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => \get_class($authenticator)]);
+                $this->logger->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
             }
         } catch (AuthenticationException $e) {
             // oh no! Authentication failed!
@@ -229,7 +230,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug('Authenticator set no success response: request continues.', ['authenticator' => \get_class($authenticator)]);
+            $this->logger->debug('Authenticator set no success response: request continues.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
         }
 
         return null;
@@ -262,7 +263,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
     private function handleAuthenticationFailure(AuthenticationException $authenticationException, Request $request, AuthenticatorInterface $authenticator, ?PassportInterface $passport): ?Response
     {
         if (null !== $this->logger) {
-            $this->logger->info('Authenticator failed.', ['exception' => $authenticationException, 'authenticator' => \get_class($authenticator)]);
+            $this->logger->info('Authenticator failed.', ['exception' => $authenticationException, 'authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
         }
 
         // Avoid leaking error details in case of invalid user (e.g. user not found or invalid account status)
@@ -273,7 +274,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
 
         $response = $authenticator->onAuthenticationFailure($request, $authenticationException);
         if (null !== $response && null !== $this->logger) {
-            $this->logger->debug('The "{authenticator}" authenticator set the failure response.', ['authenticator' => \get_class($authenticator)]);
+            $this->logger->debug('The "{authenticator}" authenticator set the failure response.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
         }
 
         $this->eventDispatcher->dispatch($loginFailureEvent = new LoginFailureEvent($authenticationException, $authenticator, $request, $response, $this->firewallName, $passport));

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -100,6 +100,14 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
         return $this->authenticator instanceof InteractiveAuthenticatorInterface && $this->authenticator->isInteractive();
     }
 
+    /**
+     * @internal
+     */
+    public function getAuthenticator(): AuthenticatorInterface
+    {
+        return $this->authenticator;
+    }
+
     public function __call($method, $args)
     {
         return $this->authenticator->{$method}(...$args);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Before:
<img width="1034" alt="Screenshot 2022-02-07 at 02 00 25" src="https://user-images.githubusercontent.com/7502063/152709794-4bc64ae0-caa9-4e28-b60e-6acff8070248.png">

After:
<img width="1033" alt="Screenshot 2022-02-07 at 02 01 08" src="https://user-images.githubusercontent.com/7502063/152709801-2c84ed0c-3bce-4bb0-98ee-bad309f29c96.png">
