### PR TITLE
[Form] Form with ChoiceType and option "expanded" return integer keys

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -168,7 +168,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
             $nextIndex = $index($choice, $key, $value);
 
             if (!\is_string($nextIndex)) {
-                trigger_deprecation('symfony/form', '6.0.0', 'The "choice_name" callback returns "%s", return "string" instead.', gettype($nextIndex));
+                trigger_deprecation('symfony/form', '6.0.0', 'The "choice_name" callback returns "%s", return "string" instead.', \gettype($nextIndex));
             }
         }
 

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -162,7 +162,15 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         // $value may be an integer or a string, since it's stored in the array
         // keys. We want to guarantee it's a string though.
         $key = $keys[$value];
-        $nextIndex = \is_int($index) ? $index++ : $index($choice, $key, $value);
+        if (\is_int($index)) {
+            $nextIndex = (string) $index++;
+        } else {
+            $nextIndex = $index($choice, $key, $value);
+
+            if (!\is_string($nextIndex)) {
+                trigger_deprecation('symfony/form', '6.0.0', 'The "choice_name" callback returns "%s", return "string" instead.', gettype($nextIndex));
+            }
+        }
 
         // BC normalize label to accept a false value
         if (null === $label) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *


### PR DESCRIPTION
…n no string

| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #44792
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

When creating a form with ChoiceType and the option "expanded" is set as true, the choices are changed into "checkbox" fields. But the keys of those fields are integers (0 for the first checkbox, 1 for the second checkbox). If you want to "get" one of those fields with FormBuilderInterface->get(string $name) that impossible with "declare(strict_types=1);" as the $name can only be string. In Symfony 5.4 it worked.

I converted the index to string and throw a deprecation if the callback doesn't return string. I'm not sure if the deprecation is the right solution?

If that the right solution, I still have to add tests for this, but that's difficult as the test don't have the "declare(strict_types=1);".