### PR TITLE
[Serializer] Add support to only check first element of $data in ArrayDenormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Deprecate `ContextAwareDenormalizerInterface`, use `DenormalizerInterface` instead
  * Deprecate `ContextAwareEncoderInterface`, use `EncoderInterface` instead
  * Deprecate `ContextAwareDecoderInterface`, use `DecoderInterface` instead
+ * Add the ability to only check the first element in `ArrayDenormalizer`
 
 6.0
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -26,6 +26,10 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
 {
     use DenormalizerAwareTrait;
 
+    public function __construct(private bool $checkFirstElement = false)
+    {
+    }
+
     /**
      * {@inheritdoc}
      *
@@ -69,8 +73,16 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
             throw new BadMethodCallException(sprintf('The nested denormalizer needs to be set to allow "%s()" to be used.', __METHOD__));
         }
 
-        return str_ends_with($type, '[]')
-            && $this->denormalizer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);
+        if (!str_ends_with($type, '[]')) {
+            return false;
+        }
+
+        if ($this->checkFirstElement) {
+            $data = \is_array($data) ? $data : [];
+            $data = 0 === \count($data) ? null : reset($data);
+        }
+
+        return $this->denormalizer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -111,6 +111,89 @@ class ArrayDenormalizerTest extends TestCase
             )
         );
     }
+
+    public function testSupportsOtherDatatype()
+    {
+        $this->assertFalse(
+            $this->denormalizer->supportsDenormalization(
+                '83fd8e7c-61d4-4318-af88-fb34bd05e31f',
+                __NAMESPACE__.'\Uuid'
+            )
+        );
+
+        $denormalizer2 = new ArrayDenormalizer(true);
+        $denormalizer2->setDenormalizer($this->serializer);
+
+        $this->assertFalse(
+            $denormalizer2->supportsDenormalization(
+                '83fd8e7c-61d4-4318-af88-fb34bd05e31f',
+                __NAMESPACE__.'\Uuid'
+            )
+        );
+    }
+
+    public function testSupportsValidFirstArrayElement()
+    {
+        $denormalizer = new ArrayDenormalizer(true);
+        $denormalizer->setDenormalizer($this->serializer);
+
+        $this->serializer->expects($this->once())
+            ->method('supportsDenormalization')
+            ->with(['foo' => 'one', 'bar' => 'two'], ArrayDummy::class, 'json', [])
+            ->willReturn(true);
+
+        $this->assertTrue(
+            $denormalizer->supportsDenormalization(
+                [
+                    ['foo' => 'one', 'bar' => 'two'],
+                    ['foo' => 'three', 'bar' => 'four'],
+                ],
+                __NAMESPACE__.'\ArrayDummy[]',
+                'json'
+            )
+        );
+    }
+
+    public function testSupportsInValidFirstArrayElement()
+    {
+        $denormalizer = new ArrayDenormalizer(true);
+        $denormalizer->setDenormalizer($this->serializer);
+
+        $this->serializer->expects($this->once())
+            ->method('supportsDenormalization')
+            ->with(['foo' => 'one', 'bar' => 'two'], ArrayDummy::class, 'json', [])
+            ->willReturn(false);
+
+        $this->assertFalse(
+            $denormalizer->supportsDenormalization(
+                [
+                    ['foo' => 'one', 'bar' => 'two'],
+                    ['foo' => 'three', 'bar' => 'four'],
+                ],
+                __NAMESPACE__.'\ArrayDummy[]',
+                'json'
+            )
+        );
+    }
+
+    public function testSupportsNoFirstArrayElement()
+    {
+        $denormalizer = new ArrayDenormalizer(true);
+        $denormalizer->setDenormalizer($this->serializer);
+
+        $this->serializer->expects($this->once())
+            ->method('supportsDenormalization')
+            ->with($this->isNull(), ArrayDummy::class, 'json', [])
+            ->willReturn(true);
+
+        $this->assertTrue(
+            $denormalizer->supportsDenormalization(
+                [],
+                __NAMESPACE__.'\ArrayDummy[]',
+                'json'
+            )
+        );
+    }
 }
 
 class ArrayDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| Tickets       | Fix #20837 
| License       | MIT
| Doc PR        | symfony/symfony-docs#16489

Based on an old discussion an implementation is made for option three/ four discussed in the ticket. With option four breaking changes will be prevented, so checking the first element will be an opt-in "feature".

To enable the check first element the following config can be used:

```yaml
    Symfony\Component\Serializer\Normalizer\ArrayDenormalizer:
        class: Symfony\Component\Serializer\Normalizer\ArrayDenormalizer
        arguments: [true]
```  