### PR TITLE
[Mailer] Fix string-cast of exceptions thrown by authenticator in EsmtpTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -173,7 +173,7 @@ class EsmtpTransport extends SmtpTransport
                 }
 
                 // keep the error message, but tries the other authenticators
-                $errors[$authenticator->getAuthKeyword()] = $e;
+                $errors[$authenticator->getAuthKeyword()] = $e->getMessage();
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45308 
| License       | MIT

Replace an exception that was being cast to string with a call to `getMessage()`.
This prevents information about the system leaking into the exception, (files/directories, stack trace).

Additionally (see https://symfony.com/releases):

I wasn't able to inject mocked authenticators, as they are instantiated in the constructor.
This makes unit testing very hard.
I was able to reproduce the problem with this test, but it will hit a real smtp server and should not be added to a testsuite.

```php
   // EsmtpTransportTest.php
   
    public function testAuthExceptionContainsNoStackTrace()
    {
        $transport = new EsmtpTransport('smtp.ionos.de', 465, true);
        $transport->setUsername("test");
        $transport->setPassword("test");
        $message = new Message();
        $message->setHeaders(new Headers(
            new MailboxListHeader("From", [Address::create('test@gmail.com')]),
            new MailboxListHeader("To", [Address::create('test@gmail.com')]))
        );
        try {
            $transport->send($message);
            $this->fail("Expected TransportException");
        } catch (TransportExceptionInterface $e) {
            $this->assertStringNotContainsString("Stack trace:", $e->getMessage());
            $this->assertStringNotContainsString('Symfony\Component\Mailer\Transport\Smtp', $e->getMessage());
        }
    }
```
