### PR TITLE
[Serializer] Make `ContextBuilderTrait::$context` private

### DIFF
--- a/src/Symfony/Component/Serializer/Context/ContextBuilderTrait.php
+++ b/src/Symfony/Component/Serializer/Context/ContextBuilderTrait.php
@@ -19,7 +19,7 @@ trait ContextBuilderTrait
     /**
      * @var array<string, mixed>
      */
-    protected array $context = [];
+    private array $context = [];
 
     protected function with(string $key, mixed $value): static
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I can't think of a case where `protected` is needed.
/cc @mtarld 