### PR TITLE
[ErrorHandler] trigger deprecations for `@final` properties

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -1,10 +1,16 @@
 UPGRADE FROM 6.0 to 6.1
 =======================
 
+All components
+--------------
+
+ * Public and protected properties are now considered final;
+   instead of overriding a property, consider setting its value in the constructor
+
 Console
 -------
 
- * Deprecate `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead.
+ * Deprecate `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead
 
 Serializer
 ----------

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -79,10 +79,10 @@ class MaxIdLengthAdapterTest extends TestCase
 
 abstract class MaxIdLengthAdapter extends AbstractAdapter
 {
-    protected $maxIdLength = 50;
-
     public function __construct(string $ns)
     {
+        $this->maxIdLength = 50;
+
         parent::__construct($ns);
     }
 }

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Add method `__toString()` to `InputInterface`
- * Deprecate `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead.
+ * Deprecate `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead
 
 6.0
 ---

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -503,13 +503,27 @@ class Php8Command2 extends Command
 
 class MyCommand extends Command
 {
+    /**
+     * @deprecated since Symfony 6.1
+     */
     protected static $defaultName = 'my:command';
+
+    /**
+     * @deprecated since Symfony 6.1
+     */
     protected static $defaultDescription = 'This is a command I wrote all by myself';
 }
 
 #[AsCommand(name: 'my:command', description: 'This is a command I wrote all by myself')]
 class MyAnnotatedCommand extends Command
 {
+    /**
+     * @deprecated since Symfony 6.1
+     */
     protected static $defaultName = 'i-shall-be-ignored';
+
+    /**
+     * @deprecated since Symfony 6.1
+     */
     protected static $defaultDescription = 'This description should be ignored.';
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -413,16 +413,6 @@ class ProjectServiceContainer extends Container
     public $__foo_bar;
     public $__foo_baz;
     public $__internal;
-    protected $privates;
-    protected $methodMap = [
-        'bar' => 'getBarService',
-        'foo_bar' => 'getFooBarService',
-        'foo.baz' => 'getFoo_BazService',
-        'circular' => 'getCircularService',
-        'throw_exception' => 'getThrowExceptionService',
-        'throws_exception_on_service_configuration' => 'getThrowsExceptionOnServiceConfigurationService',
-        'internal_dependency' => 'getInternalDependencyService',
-    ];
 
     public function __construct()
     {
@@ -434,6 +424,15 @@ class ProjectServiceContainer extends Container
         $this->__internal = new \stdClass();
         $this->privates = [];
         $this->aliases = ['alias' => 'bar'];
+        $this->methodMap = [
+            'bar' => 'getBarService',
+            'foo_bar' => 'getFooBarService',
+            'foo.baz' => 'getFoo_BazService',
+            'circular' => 'getCircularService',
+            'throw_exception' => 'getThrowExceptionService',
+            'throws_exception_on_service_configuration' => 'getThrowsExceptionOnServiceConfigurationService',
+            'internal_dependency' => 'getInternalDependencyService',
+        ];
     }
 
     protected function getInternalService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -89,7 +89,7 @@ class FileLoaderTest extends TestCase
         $container = new ContainerBuilder();
         $container->setParameter('sub_dir', 'Sub');
         $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
-        $loader->autoRegisterAliasesForSinglyImplementedInterfaces = false;
+        $loader->noAutoRegisterAliasesForSinglyImplementedInterfaces();
 
         $loader->registerClasses(new Definition(), 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\\', 'Prototype/%sub_dir%/*');
         $loader->registerClasses(new Definition(), 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\\', 'Prototype/%sub_dir%/*'); // loading twice should not be an issue
@@ -270,7 +270,10 @@ class FileLoaderTest extends TestCase
 
 class TestFileLoader extends FileLoader
 {
-    public $autoRegisterAliasesForSinglyImplementedInterfaces = true;
+    public function noAutoRegisterAliasesForSinglyImplementedInterfaces()
+    {
+        $this->autoRegisterAliasesForSinglyImplementedInterfaces = false;
+    }
 
     public function load(mixed $resource, string $type = null): mixed
     {

--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 6.1
 ---
 
- * Report overridden `@final` constants
+ * Report overridden `@final` constants and properties
 
 5.4
 ---

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -408,6 +408,8 @@ class DebugClassLoaderTest extends TestCase
         $e = error_reporting(E_USER_DEPRECATED);
 
         class_exists(Fixtures\OverrideFinalProperty::class, true);
+        class_exists(Fixtures\FinalProperty\OverrideFinalPropertySameNamespace::class, true);
+        class_exists('Test\\'.OverrideOutsideFinalProperty::class, true);
 
         error_reporting($e);
         restore_error_handler();
@@ -415,6 +417,8 @@ class DebugClassLoaderTest extends TestCase
         $this->assertSame([
             'The "Symfony\Component\ErrorHandler\Tests\Fixtures\FinalProperty\FinalProperty::$pub" property is considered final. You should not override it in "Symfony\Component\ErrorHandler\Tests\Fixtures\OverrideFinalProperty".',
             'The "Symfony\Component\ErrorHandler\Tests\Fixtures\FinalProperty\FinalProperty::$prot" property is considered final. You should not override it in "Symfony\Component\ErrorHandler\Tests\Fixtures\OverrideFinalProperty".',
+            'The "Symfony\Component\ErrorHandler\Tests\Fixtures\FinalProperty\FinalProperty::$implicitlyFinal" property is considered final. You should not override it in "Symfony\Component\ErrorHandler\Tests\Fixtures\OverrideFinalProperty".',
+            'The "Test\Symfony\Component\ErrorHandler\Tests\FinalProperty\OutsideFinalProperty::$final" property is considered final. You should not override it in "Test\Symfony\Component\ErrorHandler\Tests\OverrideOutsideFinalProperty".'
         ], $deprecations);
     }
 
@@ -540,6 +544,10 @@ class ClassLoader
             return $fixtureDir.\DIRECTORY_SEPARATOR.'ReturnType.php';
         } elseif ('Test\\'.Fixtures\OutsideInterface::class === $class) {
             return $fixtureDir.\DIRECTORY_SEPARATOR.'OutsideInterface.php';
+        } elseif ('Test\\'.OverrideOutsideFinalProperty::class === $class) {
+            return $fixtureDir.'OverrideOutsideFinalProperty.php';
+        } elseif ('Test\\Symfony\\Component\\ErrorHandler\\Tests\\FinalProperty\\OutsideFinalProperty' === $class) {
+            return $fixtureDir.'FinalProperty'.\DIRECTORY_SEPARATOR.'OutsideFinalProperty.php';
         }
     }
 }

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -401,13 +401,30 @@ class DebugClassLoaderTest extends TestCase
         ], $deprecations);
     }
 
+    public function testOverrideFinalProperty()
+    {
+        $deprecations = [];
+        set_error_handler(function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
+        $e = error_reporting(E_USER_DEPRECATED);
+
+        class_exists(Fixtures\OverrideFinalProperty::class, true);
+
+        error_reporting($e);
+        restore_error_handler();
+
+        $this->assertSame([
+            'The "Symfony\Component\ErrorHandler\Tests\Fixtures\FinalProperty\FinalProperty::$pub" property is considered final. You should not override it in "Symfony\Component\ErrorHandler\Tests\Fixtures\OverrideFinalProperty".',
+            'The "Symfony\Component\ErrorHandler\Tests\Fixtures\FinalProperty\FinalProperty::$prot" property is considered final. You should not override it in "Symfony\Component\ErrorHandler\Tests\Fixtures\OverrideFinalProperty".',
+        ], $deprecations);
+    }
+
     public function testOverrideFinalConstant()
     {
         $deprecations = [];
         set_error_handler(function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
         $e = error_reporting(E_USER_DEPRECATED);
 
-        class_exists( Fixtures\FinalConstant\OverrideFinalConstant::class, true);
+        class_exists(Fixtures\FinalConstant\OverrideFinalConstant::class, true);
 
         error_reporting($e);
         restore_error_handler();

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/FinalProperty/FinalProperty.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/FinalProperty/FinalProperty.php
@@ -18,4 +18,15 @@ class FinalProperty
      * @final
      */
     private $priv;
+
+    /**
+     * @final
+     */
+    public $notOverriden;
+
+    protected $implicitlyFinal;
+
+    protected string $typedSoNotFinal;
+
+    protected $deprecated;
 }

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/FinalProperty/FinalProperty.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/FinalProperty/FinalProperty.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures\FinalProperty;
+
+class FinalProperty
+{
+    /**
+     * @final
+     */
+    public $pub;
+
+    /**
+     * @final
+     */
+    protected $prot;
+
+    /**
+     * @final
+     */
+    private $priv;
+}

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/FinalProperty/OutsideFinalProperty.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/FinalProperty/OutsideFinalProperty.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Test\Symfony\Component\ErrorHandler\Tests\FinalProperty;
+
+class OutsideFinalProperty
+{
+    /**
+     * @final
+     */
+    public $final;
+
+    protected $notImplicitlyFinalBecauseNotInSymfony;
+
+    /**
+     * @final
+     */
+    public $notOverriden;
+
+    /**
+     * @final
+     */
+    protected $deprecated;
+}

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/FinalProperty/OverrideFinalPropertySameNamespace.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/FinalProperty/OverrideFinalPropertySameNamespace.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures\FinalProperty;
+
+class OverrideFinalPropertySameNamespace extends FinalProperty
+{
+    public $pub;
+}

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/OverrideFinalProperty.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/OverrideFinalProperty.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+use Symfony\Component\ErrorHandler\Tests\Fixtures\FinalProperty\FinalProperty;
+
+class OverrideFinalProperty extends FinalProperty
+{
+    public $pub;
+    protected $prot;
+    private $priv;
+}

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/OverrideFinalProperty.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/OverrideFinalProperty.php
@@ -9,4 +9,10 @@ class OverrideFinalProperty extends FinalProperty
     public $pub;
     protected $prot;
     private $priv;
+    protected $implicitlyFinal;
+    protected string $typedSoNotFinal;
+    /**
+     * @deprecated
+     */
+    protected $deprecated;
 }

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/OverrideOutsideFinalProperty.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/OverrideOutsideFinalProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Test\Symfony\Component\ErrorHandler\Tests;
+
+use Test\Symfony\Component\ErrorHandler\Tests\FinalProperty\OutsideFinalProperty;
+
+class OverrideOutsideFinalProperty extends OutsideFinalProperty
+{
+    public $final;
+    protected $notImplicitlyFinalBecauseNotInSymfony;
+    /**
+     * @deprecated
+     */
+    protected $deprecated;
+}

--- a/src/Symfony/Component/Form/Tests/VersionAwareTest.php
+++ b/src/Symfony/Component/Form/Tests/VersionAwareTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests;
 
 trait VersionAwareTest
 {
-    protected static $supportedFeatureSetVersion = 404;
+    protected static int $supportedFeatureSetVersion = 404;
 
     protected function requiresFeatureSet(int $requiredFeatureSetVersion)
     {

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -26,9 +26,6 @@ class Query extends AbstractQuery
 {
     public const PAGINATION_OID = \LDAP_CONTROL_PAGEDRESULTS;
 
-    /** @var Connection */
-    protected $connection;
-
     /** @var resource[]|Result[] */
     private array $results;
 

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -39,6 +39,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * A test case to ease testing Constraint Validators.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T of ConstraintValidatorInterface
  */
 abstract class ConstraintValidatorTestCase extends TestCase
 {
@@ -48,7 +50,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
     protected $context;
 
     /**
-     * @var ConstraintValidatorInterface
+     * @var T
      */
     protected $validator;
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -18,16 +18,11 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 /**
  * @requires extension fileinfo
+ *
+ * @extends ConstraintValidatorTestCase<ImageValidator>
  */
 class ImageValidatorTest extends ConstraintValidatorTestCase
 {
-    protected $context;
-
-    /**
-     * @var ImageValidator
-     */
-    protected $validator;
-
     protected $path;
     protected $image;
     protected $imageLandscape;

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/Entity.php
@@ -46,7 +46,7 @@ class Entity extends EntityParent implements EntityInterfaceB
         Assert\NotNull,
         Assert\Range(min: 3),
     ]
-    public $firstName;
+    public string $firstName;
     #[Assert\Valid]
     public $childA;
     #[Assert\Valid]

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/EntityParent.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/EntityParent.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Tests\Fixtures\EntityInterfaceA;
 
 class EntityParent implements EntityInterfaceA
 {
-    protected $firstName;
+    protected string $firstName;
     private $internal;
     private $data = 'Data';
     private $child;

--- a/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php
@@ -67,7 +67,7 @@ class Entity extends EntityParent implements EntityInterfaceB
             new Assert\Range(min: 5),
         ]),
     ]
-    public $firstName;
+    public string $firstName;
     #[Assert\Valid]
     public $childA;
     #[Assert\Valid]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #43600
| License       | MIT
| Doc PR        | -

This PR makes DebugClassLoader trigger a deprecation when a property in a child class is redefined while the same property is `@final` on the parent class (the deprecation is silenced when both classes live in the exact same namespace or when the child property is deprecated.)

It also makes all properties in the `Symfony\`  namespace implicitly `@final`, unless they are typed. The goal here is to be able to add types to all properties in 7.0, thus fixing #43600.