### PR TITLE
[Console] Fix typo in completion command help text

### DIFF
--- a/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
+++ b/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
@@ -68,7 +68,7 @@ Or dump the script to a local file and source it:
 <comment>Dynamic installation
 --------------------</>
 
-Add this add the end of your shell configuration file (e.g. <info>"~/.bashrc"</>):
+Add this to the end of your shell configuration file (e.g. <info>"~/.bashrc"</>):
 
     <info>eval "$(${fullCommand} completion bash)"</>
 EOH


### PR DESCRIPTION
This commit fixes a minor typo in the "completion" command's help text

| Q             | A
| ------------- | ---
| Branch?       |  set this to 5.4 since that is the last LTS
| Bug fix?      | yes/no (typo so I'm not sure where to categorize this)
| New feature?  | no
| Deprecations? | no
| Tickets       |  N/A
| License       | MIT
| Doc PR        | N/A

I noticed this when exporting usage markdown for a personal project and figured I may as well update this typo.  Not sure how to categorize this since no actual business logic was impacted, just the helptext for the "completion" commmand.