### PR TITLE
[HttpKernel] Use existing session id

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -79,7 +79,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
                  * Do not set it when a native php session is active.
                  */
                 if ($sess && !$sess->isStarted() && \PHP_SESSION_ACTIVE !== session_status()) {
-                    $sessionId = $request->cookies->get($sess->getName(), '');
+                    $sessionId = $request->cookies->get($sess->getName(), $sess->getId());
                     $sess->setId($sessionId);
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Session id is being overwritten by listener even if it is already set.

I have an application that is overriding the session id when the session factory creates the session. However, when this listener runs, it's overriding the session id that has already been set.

