### PR TITLE
[Translation] Add icu message support for the lokalise provider

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -857,7 +857,7 @@ class Configuration implements ConfigurationInterface
                                 ->fixXmlConfig('locale')
                                 ->children()
                                     ->scalarNode('dsn')->end()
-                                    ->booleanNode('enable_intl_icu')->defaultFalse()->end()
+                                    ->booleanNode('intl_icu_enabled')->defaultFalse()->end()
                                     ->arrayNode('domains')
                                         ->prototype('scalar')->end()
                                         ->defaultValue([])

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -857,6 +857,7 @@ class Configuration implements ConfigurationInterface
                                 ->fixXmlConfig('locale')
                                 ->children()
                                     ->scalarNode('dsn')->end()
+                                    ->booleanNode('enable_intl_icu')->defaultFalse()->end()
                                     ->arrayNode('domains')
                                         ->prototype('scalar')->end()
                                         ->defaultValue([])

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1476,6 +1476,8 @@ class FrameworkExtension extends Extension
         ;
 
         $container->getDefinition('translation.provider_collection')->setArgument(0, $config['providers']);
+
+        $container->getDefinition('translation.provider_factory.lokalise')->setArgument(4, $config['providers']['lokalise']['enable_intl_icu']);
     }
 
     private function registerValidationConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader, bool $propertyInfoEnabled)

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1477,7 +1477,7 @@ class FrameworkExtension extends Extension
 
         $container->getDefinition('translation.provider_collection')->setArgument(0, $config['providers']);
 
-        $container->getDefinition('translation.provider_factory.lokalise')->setArgument(4, $config['providers']['lokalise']['enable_intl_icu']);
+        $container->getDefinition('translation.provider_factory.lokalise')->setArgument(4, $config['providers']['lokalise']['intl_icu_enabled']);
     }
 
     private function registerValidationConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader, bool $propertyInfoEnabled)

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class CrowdinProviderTest extends ProviderTestCase
 {
-    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface
+    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled): ProviderInterface
     {
         return new CrowdinProvider($client, $loader, $logger, $this->getXliffFileDumper(), $defaultLocale, $endpoint);
     }

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class CrowdinProviderTest extends ProviderTestCase
 {
-    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled): ProviderInterface
+    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled = false): ProviderInterface
     {
         return new CrowdinProvider($client, $loader, $logger, $this->getXliffFileDumper(), $defaultLocale, $endpoint);
     }

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class LocoProviderTest extends ProviderTestCase
 {
-    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled): ProviderInterface
+    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled = false): ProviderInterface
     {
         return new LocoProvider($client, $loader, $logger, $defaultLocale, $endpoint);
     }

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class LocoProviderTest extends ProviderTestCase
 {
-    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface
+    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled): ProviderInterface
     {
         return new LocoProvider($client, $loader, $logger, $defaultLocale, $endpoint);
     }

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -37,6 +37,7 @@ final class LokaliseProvider implements ProviderInterface
     private $logger;
     private $defaultLocale;
     private $endpoint;
+    private $icuEnabled;
 
     public function __construct(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint)
     {
@@ -45,6 +46,7 @@ final class LokaliseProvider implements ProviderInterface
         $this->logger = $logger;
         $this->defaultLocale = $defaultLocale;
         $this->endpoint = $endpoint;
+        $this->icuEnabled = class_exists(\MessageFormatter::class);
     }
 
     public function __toString(): string
@@ -102,7 +104,12 @@ final class LokaliseProvider implements ProviderInterface
 
         foreach ($translations as $locale => $files) {
             foreach ($files as $filename => $content) {
-                $translatorBag->addCatalogue($this->loader->load($content['content'], $locale, str_replace('.xliff', '', $filename)));
+                $domain = str_replace('.xliff', '', $filename);
+                if ($this->icuEnabled) {
+                    $domain .= MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
+                }
+
+                $translatorBag->addCatalogue($this->loader->load($content['content'], $locale, $domain));
             }
         }
 
@@ -149,6 +156,7 @@ final class LokaliseProvider implements ProviderInterface
                 'filter_langs' => array_values($locales),
                 'filter_filenames' => array_map([$this, 'getLokaliseFilenameFromDomain'], $domains),
                 'export_empty_as' => 'skip',
+                'placeholder_format' => $this->icuEnabled ? 'icu' : 'symfony'
             ],
         ]);
 

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -156,7 +156,7 @@ final class LokaliseProvider implements ProviderInterface
                 'filter_langs' => array_values($locales),
                 'filter_filenames' => array_map([$this, 'getLokaliseFilenameFromDomain'], $domains),
                 'export_empty_as' => 'skip',
-                'placeholder_format' => $this->icuEnabled ? 'icu' : 'symfony'
+                'placeholder_format' => $this->icuEnabled ? 'icu' : 'symfony',
             ],
         ]);
 

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -37,16 +37,16 @@ final class LokaliseProvider implements ProviderInterface
     private $logger;
     private $defaultLocale;
     private $endpoint;
-    private $icuEnabled;
+    private $intlIcuEnabled;
 
-    public function __construct(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint)
+    public function __construct(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled = false)
     {
         $this->client = $client;
         $this->loader = $loader;
         $this->logger = $logger;
         $this->defaultLocale = $defaultLocale;
         $this->endpoint = $endpoint;
-        $this->icuEnabled = class_exists(\MessageFormatter::class);
+        $this->intlIcuEnabled = $intlIcuEnabled;
     }
 
     public function __toString(): string
@@ -105,7 +105,7 @@ final class LokaliseProvider implements ProviderInterface
         foreach ($translations as $locale => $files) {
             foreach ($files as $filename => $content) {
                 $domain = str_replace('.xliff', '', $filename);
-                if ($this->icuEnabled) {
+                if ($this->intlIcuEnabled) {
                     $domain .= MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
                 }
 
@@ -156,7 +156,7 @@ final class LokaliseProvider implements ProviderInterface
                 'filter_langs' => array_values($locales),
                 'filter_filenames' => array_map([$this, 'getLokaliseFilenameFromDomain'], $domains),
                 'export_empty_as' => 'skip',
-                'placeholder_format' => $this->icuEnabled ? 'icu' : 'symfony',
+                'placeholder_format' => $this->intlIcuEnabled ? 'icu' : 'symfony',
             ],
         ]);
 

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProviderFactory.php
@@ -30,13 +30,15 @@ final class LokaliseProviderFactory extends AbstractProviderFactory
     private $logger;
     private $defaultLocale;
     private $loader;
+    private $intlIcuEnabled;
 
-    public function __construct(HttpClientInterface $client, LoggerInterface $logger, string $defaultLocale, LoaderInterface $loader)
+    public function __construct(HttpClientInterface $client, LoggerInterface $logger, string $defaultLocale, LoaderInterface $loader, bool $intlIcuEnabled = false)
     {
         $this->client = $client;
         $this->logger = $logger;
         $this->defaultLocale = $defaultLocale;
         $this->loader = $loader;
+        $this->intlIcuEnabled = $intlIcuEnabled;
     }
 
     /**
@@ -58,7 +60,7 @@ final class LokaliseProviderFactory extends AbstractProviderFactory
             ],
         ]);
 
-        return new LokaliseProvider($client, $this->loader, $this->logger, $this->defaultLocale, $endpoint);
+        return new LokaliseProvider($client, $this->loader, $this->logger, $this->defaultLocale, $endpoint, $this->intlIcuEnabled);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderFactoryTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderFactoryTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Translation\Bridge\Lokalise\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Translation\Bridge\Lokalise\LokaliseProvider;
 use Symfony\Component\Translation\Bridge\Lokalise\LokaliseProviderFactory;
 use Symfony\Component\Translation\Provider\Dsn;
 use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
@@ -55,6 +56,16 @@ class LokaliseProviderFactoryTest extends ProviderFactoryTestCase
         $provider->read(['messages'], ['en']);
 
         $this->assertMatchesRegularExpression('/https:\/\/api.lokalise.com\/api2\/projects\/PROJECT_ID\/*/', $response->getRequestUrl());
+    }
+
+    public function testIntlIcuEnabled()
+    {
+        $response = new MockResponse(json_encode(['files' => []]));
+        $httpClient = new MockHttpClient([$response]);
+        $factory = new LokaliseProviderFactory($httpClient, $this->getLogger(), $this->getDefaultLocale(), $this->getLoader(), true);
+        $provider = $factory->create(new Dsn('lokalise://PROJECT_ID:API_KEY@default'));
+
+        $this->assertInstanceOf(LokaliseProvider::class, $provider);
     }
 
     public function createFactory(): ProviderFactoryInterface

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -638,7 +638,7 @@ XLIFF
         $loader = $this->getLoader();
         $loader->expects($this->once())
             ->method('load')
-            ->willReturn((new XliffFileLoader())->load($responseContent, $locale, $domain));
+            ->willReturn((new XliffFileLoader())->load($responseContent, $locale, $domain.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX));
 
         $provider = $this->createProvider((new MockHttpClient($response))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -663,7 +663,7 @@ XLIFF
         $expectedTranslatorBagEn->addCatalogue($arrayLoader->load([
             'index.hello' => 'Hello',
             'index.greetings' => 'Welcome, {firstname}!',
-        ], 'en', 'messages' . MessageCatalogueInterface::INTL_DOMAIN_SUFFIX));
+        ], 'en', 'messages'.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX));
 
         yield ['en', 'messages', <<<'XLIFF'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -693,7 +693,7 @@ XLIFF
         $expectedTranslatorBagFr->addCatalogue($arrayLoader->load([
             'index.hello' => 'Bonjour',
             'index.greetings' => 'Bienvenue, {firstname} !',
-        ], 'fr', 'messages' . MessageCatalogueInterface::INTL_DOMAIN_SUFFIX));
+        ], 'fr', 'messages'.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX));
 
         yield ['fr', 'messages', <<<'XLIFF'
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -28,7 +28,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class LokaliseProviderTest extends ProviderTestCase
 {
-    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled): ProviderInterface
+    public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled = false): ProviderInterface
     {
         return new LokaliseProvider($client, $loader, $logger, $defaultLocale, $endpoint, $intlIcuEnabled);
     }
@@ -39,7 +39,7 @@ class LokaliseProviderTest extends ProviderTestCase
             $this->createProvider($this->getClient()->withOptions([
                 'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
                 'headers' => ['X-Api-Token' => 'API_KEY'],
-            ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com', false),
+            ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com'),
             'lokalise://api.lokalise.com',
         ];
 
@@ -47,7 +47,7 @@ class LokaliseProviderTest extends ProviderTestCase
             $this->createProvider($this->getClient()->withOptions([
                 'base_uri' => 'https://example.com',
                 'headers' => ['X-Api-Token' => 'API_KEY'],
-            ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'example.com', false),
+            ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'example.com'),
             'lokalise://example.com',
         ];
 
@@ -55,7 +55,7 @@ class LokaliseProviderTest extends ProviderTestCase
             $this->createProvider($this->getClient()->withOptions([
                 'base_uri' => 'https://example.com:99',
                 'headers' => ['X-Api-Token' => 'API_KEY'],
-            ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'example.com:99', false),
+            ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'example.com:99'),
             'lokalise://example.com:99',
         ];
     }
@@ -287,7 +287,7 @@ class LokaliseProviderTest extends ProviderTestCase
         $provider = $this->createProvider((new MockHttpClient($response))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), $loader, $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com', false);
+        ]), $loader, $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
         $translatorBag = $provider->read([$domain], [$locale]);
 
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
@@ -331,7 +331,7 @@ class LokaliseProviderTest extends ProviderTestCase
         $provider = $this->createProvider((new MockHttpClient($response))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), $loader, $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com', false);
+        ]), $loader, $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
 
         $translatorBag = $provider->read($domains, $locales);
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
@@ -414,8 +414,7 @@ class LokaliseProviderTest extends ProviderTestCase
             $this->getLoader(),
             $this->getLogger(),
             $this->getDefaultLocale(),
-            'api.lokalise.com',
-            false
+            'api.lokalise.com'
         );
 
         $provider->delete($translatorBag);

--- a/src/Symfony/Component/Translation/Test/ProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Test/ProviderTestCase.php
@@ -34,7 +34,7 @@ abstract class ProviderTestCase extends TestCase
     protected $loader;
     protected $xliffFileDumper;
 
-    abstract public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled): ProviderInterface;
+    abstract public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled = false): ProviderInterface;
 
     /**
      * @return iterable<array{0: string, 1: ProviderInterface}>

--- a/src/Symfony/Component/Translation/Test/ProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Test/ProviderTestCase.php
@@ -34,7 +34,7 @@ abstract class ProviderTestCase extends TestCase
     protected $loader;
     protected $xliffFileDumper;
 
-    abstract public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface;
+    abstract public function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $intlIcuEnabled): ProviderInterface;
 
     /**
      * @return iterable<array{0: string, 1: ProviderInterface}>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

This PR would add the support for the ICU message format when using the lokalise provider. I saw that the unit tests are written as it would support the ICU message format so therefore the PR aims the 5.4 branch as a bugfix.

The API from lokalise needs a flag for the format to be downloaded, otherwise it return the file in the "classic" format with `%` as the delimiter for the placeholders. Also the file was always saved without the suffix. For this i looked up how the ICU support was implemented in symfony and tried to adapt this approach.

I think i would need some assitance how to write tests with and without the intl extension. Right now, some tests fail since the intl extension in enabled and i did not adjust them yet.
