### PR TITLE
[Mime] Fix embed logic for background attributes

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -460,8 +460,17 @@ class Email extends Message
         if (null !== $this->html) {
             $htmlPart = new TextPart($html, $this->htmlCharset, 'html');
             $html = $htmlPart->getBody();
-            preg_match_all('(<img\s+[^>]*src\s*=\s*(?:([\'"])cid:([^"]+)\\1|cid:([^>\s]+)))i', $html, $names);
-            $names = array_filter(array_unique(array_merge($names[2], $names[3])));
+
+            $regexes = [
+                '<img\s+[^>]*src\s*=\s*(?:([\'"])cid:([^"]+)\\1|cid:([^>\s]+))',
+                '<\w+\s+[^>]*background\s*=\s*(?:([\'"])cid:([^"]+)\\1|cid:([^>\s]+))',
+            ];
+            $tmpMatches = [];
+            foreach ($regexes as $regex) {
+                preg_match_all('/'.$regex.'/i', $html, $tmpMatches);
+                $names = array_merge($names, $tmpMatches[2], $tmpMatches[3]);
+            }
+            $names = array_filter(array_unique($names));
         }
 
         $attachmentParts = $inlineParts = [];

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -351,6 +351,14 @@ class EmailTest extends TestCase
         // 2 parts only, not 3 (text + embedded image once)
         $this->assertCount(2, $parts = $body->getParts());
         $this->assertStringMatchesFormat('html content <img src=3D"cid:%s@symfony">', $parts[0]->bodyToString());
+
+        $e = (new Email())->from('me@example.com')->to('you@example.com');
+        $e->html('<div background="cid:test.gif"></div>');
+        $e->embed($image, 'test.gif');
+        $body = $e->getBody();
+        $this->assertInstanceOf(RelatedPart::class, $body);
+        $this->assertCount(2, $parts = $body->getParts());
+        $this->assertStringMatchesFormat('<div background=3D"cid:%s@symfony"></div>', $parts[0]->bodyToString());
     }
 
     public function testAttachments()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42921
| License       | MIT
| Doc PR        | 

As suggested by @fabpot here https://github.com/symfony/symfony/pull/43255#issuecomment-1030025526, this is the most minimal fix for the linked issue. I guess the same problem can happen if you use e.g.

```html
<div style="background-image:url(cid:test.gif)"></div>
```

I have changed it so that there is now an array of regexes to look for embedded images, so at least code for the `background-image` case (or others that might be found later on) can easily be added.
