### PR TITLE
[Contracts] EventDispatcherInterface phpdocs improvement for static analyze

### DIFF
--- a/src/Symfony/Contracts/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Contracts/EventDispatcher/EventDispatcherInterface.php
@@ -21,11 +21,13 @@ interface EventDispatcherInterface extends PsrEventDispatcherInterface
     /**
      * Dispatches an event to all registered listeners.
      *
-     * @param object      $event     The event to pass to the event handlers/listeners
+     * @template T of object
+     *
+     * @param T           $event     The event to pass to the event handlers/listeners
      * @param string|null $eventName The name of the event to dispatch. If not supplied,
      *                               the class of $event should be used instead.
      *
-     * @return object The passed $event MUST be returned
+     * @return T The passed $event MUST be returned
      */
     public function dispatch(object $event, string $eventName = null): object;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This PR helps to avoid a creation of a redundant variable during an event handling. Today this variable is only necessary for specifying the event type (to be able to call its methods without static analysis errors).