### PR TITLE
[DependencyInjection] Skip preloading on PHP 8.0

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -324,6 +324,14 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require $autoloadFile;
+require __DIR__.'/{$options['class']}.php';
+
+if (\PHP_VERSION_ID < 80100) {
+    // Preloading on PHP 8.0 fails with a fatal error when typed properties are used
+    // if some of those types are referencing optional and non-installed dependencies.
+    return;
+}
+
 (require __DIR__.'/{$options['class']}.php')->set(\\Container{$hash}\\{$options['class']}::class, null);
 $preloadedFiles
 \$classes = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
@@ -131,6 +131,14 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+require __DIR__.'/ProjectServiceContainer.php';
+
+if (\PHP_VERSION_ID < 80100) {
+    // Preloading on PHP 8.0 fails with a fatal error when typed properties are used
+    // if some of those types are referencing optional and non-installed dependencies.
+    return;
+}
+
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 require __DIR__.'/Container%s/getClosureService.php';
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -897,6 +897,14 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+require __DIR__.'/ProjectServiceContainer.php';
+
+if (\PHP_VERSION_ID < 80100) {
+    // Preloading on PHP 8.0 fails with a fatal error when typed properties are used
+    // if some of those types are referencing optional and non-installed dependencies.
+    return;
+}
+
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 require __DIR__.'/Container%s/getThrowingOneService.php';
 require __DIR__.'/Container%s/getTaggedIteratorService.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -552,6 +552,14 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+require __DIR__.'/ProjectServiceContainer.php';
+
+if (\PHP_VERSION_ID < 80100) {
+    // Preloading on PHP 8.0 fails with a fatal error when typed properties are used
+    // if some of those types are referencing optional and non-installed dependencies.
+    return;
+}
+
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 
 $classes = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -169,6 +169,14 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+require __DIR__.'/ProjectServiceContainer.php';
+
+if (\PHP_VERSION_ID < 80100) {
+    // Preloading on PHP 8.0 fails with a fatal error when typed properties are used
+    // if some of those types are referencing optional and non-installed dependencies.
+    return;
+}
+
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 
 $classes = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
@@ -130,6 +130,14 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 }
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
+require __DIR__.'/ProjectServiceContainer.php';
+
+if (\PHP_VERSION_ID < 80100) {
+    // Preloading on PHP 8.0 fails with a fatal error when typed properties are used
+    // if some of those types are referencing optional and non-installed dependencies.
+    return;
+}
+
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
 require __DIR__.'/Container%s/proxy.php';
 require __DIR__.'/Container%s/getNonSharedFooService.php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44364
| License       | MIT
| Doc PR        | -

This PR replaces #44380, which IMHO is great, but is complexity we'd better not add to the codebase.

Instead, @jderusse has proposed to [disable preloading for PHP 8.0](https://github.com/symfony/symfony/pull/45377#issuecomment-1034324560) from 4.4. This PR does it.

The drawback of this approach is that many apps that don't use typed properties *would* benefit from the perf boost provided by preloading on PHP 7.4/8.0. But I still prefer this over merging #44380.

Another approach I took in #45377 is to:
- leave 4.4 to 6.0 branches as is, thus allowing ppl to benefit from preloading at their own risk
- bump 6.1 to php 8.1 and free ourselves and our users from the issue for the future.

I prefer #45377 but others in the core-team prefer to follow the existing Symfony policy: "don't bump in a minor", which I appreciate too. Not easy :)