### PR TITLE
[HttpKernel] Use the existing session id if available.

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -72,17 +72,17 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
             $request->setSessionFactory(function () use (&$sess, $request) {
                 if (!$sess) {
                     $sess = $this->getSession();
-                }
 
-                /*
-                 * For supporting sessions in php runtime with runners like roadrunner or swoole, the session
-                 * cookie needs to be read from the cookie bag and set on the session storage.
-                 *
-                 * Do not set it when a native php session is active.
-                 */
-                if ($sess && !$sess->isStarted() && \PHP_SESSION_ACTIVE !== session_status()) {
-                    $sessionId = $request->cookies->get($sess->getName(), '');
-                    $sess->setId($sessionId);
+                    /*
+                     * For supporting sessions in php runtime with runners like roadrunner or swoole, the session
+                     * cookie needs to be read from the cookie bag and set on the session storage.
+                     *
+                     * Do not set it when a native php session is active.
+                     */
+                    if ($sess && !$sess->isStarted() && \PHP_SESSION_ACTIVE !== session_status()) {
+                        $sessionId = $sess->getId() ?: $request->cookies->get($sess->getName(), '');
+                        $sess->setId($sessionId);
+                    }
                 }
 
                 return $sess;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -205,6 +205,40 @@ class SessionListenerTest extends TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testNewSessionIdIsNotOverwritten()
+    {
+        $newSessionId = $this->createValidSessionId();
+
+        $this->assertNotEmpty($newSessionId);
+
+        $request = new Request();
+        $request->cookies->set('PHPSESSID', 'OLD-SESSION-ID');
+
+        $listener = $this->createListener($request, new NativeSessionStorageFactory());
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $session = $request->getSession();
+        $this->assertSame($newSessionId, $session->getId());
+        $session->set('hello', 'world');
+
+        $response = new Response();
+        $listener->onKernelResponse(new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response));
+        $this->assertSame($newSessionId, $session->getId());
+
+        $cookies = $response->headers->getCookies();
+
+        $this->assertCount(1, $cookies);
+        $sessionCookie = $cookies[0];
+
+        $this->assertSame('PHPSESSID', $sessionCookie->getName());
+        $this->assertSame($newSessionId, $sessionCookie->getValue());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testSessionCookieClearedWhenInvalidated()
     {
         $sessionId = $this->createValidSessionId();
@@ -488,7 +522,7 @@ class SessionListenerTest extends TestCase
     public function testSurrogateMainRequestIsPublic()
     {
         $session = $this->createMock(Session::class);
-        $session->expects($this->exactly(2))->method('getName')->willReturn('PHPSESSID');
+        $session->expects($this->exactly(1))->method('getName')->willReturn('PHPSESSID');
         $session->expects($this->exactly(4))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1, 1, 1));
 
         $container = new Container();
@@ -528,7 +562,7 @@ class SessionListenerTest extends TestCase
     public function testGetSessionIsCalledOnce()
     {
         $session = $this->createMock(Session::class);
-        $session->expects($this->exactly(2))->method('getName')->willReturn('PHPSESSID');
+        $session->expects($this->exactly(1))->method('getName')->willReturn('PHPSESSID');
         $sessionStorage = $this->createMock(NativeSessionStorage::class);
         $kernel = $this->createMock(KernelInterface::class);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Session id is being overwritten by listener even if it is already set.

I have an application that is overriding the session id when the session factory creates the session. However, when this listener runs, it's overriding the session id that has already been set.