### PR TITLE
[FrameworkBundle] Fix sorting bug in sorting of tagged services by priority

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -261,7 +261,7 @@ abstract class Descriptor implements DescriptorInterface
     {
         $maxPriority = [];
         foreach ($services as $service => $tags) {
-            $maxPriority[$service] = 0;
+            $maxPriority[$service] = \PHP_INT_MIN;
             foreach ($tags as $tag) {
                 $currentPriority = $tag['priority'] ?? 0;
                 if ($maxPriority[$service] < $currentPriority) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -171,6 +171,7 @@ class ObjectsProvider
         $definition1 = new Definition('Full\\Qualified\\Class1');
         $definition2 = new Definition('Full\\Qualified\\Class2');
         $definition3 = new Definition('Full\\Qualified\\Class3');
+        $definition4 = new Definition('Full\\Qualified\\Class4');
 
         return [
             'definition_1' => $definition1
@@ -199,6 +200,13 @@ class ObjectsProvider
                 ->setAbstract(false)
                 ->addTag('tag1', ['attr1' => 'val1', 'attr2' => 'val2', 'priority' => 0])
                 ->addTag('tag1', ['attr3' => 'val3', 'priority' => 40]),
+            'definition_4' => $definition4
+                ->setPublic(true)
+                ->setSynthetic(true)
+                ->setFile('/path/to/file')
+                ->setLazy(false)
+                ->setAbstract(false)
+                ->addTag('tag1', ['priority' => 0]),
         ];
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.json
@@ -63,6 +63,25 @@
                 }
             ]
         },
+        "definition_4": {
+            "class": "Full\\Qualified\\Class4",
+            "public": true,
+            "synthetic": true,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": false,
+            "file": "\/path\/to\/file",
+            "tags": [
+                {
+                    "name": "tag1",
+                    "parameters": {
+                        "priority": 0
+                    }
+                }
+            ]
+        },
         "definition_2": {
             "class": "Full\\Qualified\\Class2",
             "public": true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.md
@@ -44,6 +44,20 @@ Definitions
     - Attr2: val2
 - Tag: `tag2`
 
+### definition_4
+
+- Class: `Full\Qualified\Class4`
+- Public: yes
+- Synthetic: yes
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+- File: `/path/to/file`
+- Tag: `tag1`
+    - Priority: 0
+
 ### definition_2
 
 - Class: `Full\Qualified\Class2`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.txt
@@ -9,6 +9,7 @@
     "            val1    val2    0                                         
   definition_1   val1            30                 Full\Qualified\Class1  
     "                    val2                                              
+  definition_4                   0                  Full\Qualified\Class4  
   definition_2   val1    val2    -20                Full\Qualified\Class2  
  -------------- ------- ------- ---------- ------- ----------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.xml
@@ -29,6 +29,13 @@
       <tag name="tag2"/>
     </tags>
   </definition>
+  <definition id="definition_4" class="Full\Qualified\Class4" public="true" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file="/path/to/file">
+    <tags>
+      <tag name="tag1">
+        <parameter name="priority">0</parameter>
+      </tag>
+    </tags>
+  </definition>
   <definition id="definition_2" class="Full\Qualified\Class2" public="true" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file="/path/to/file">
     <tags>
       <tag name="tag1">


### PR DESCRIPTION
Fixed incorrect assumption that the minimum priority is zero
leading to an unsorted list of negative priorities.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #45396
| License       | MIT
| Doc PR        | 

Fixed an incorrect assumption that the minimum priority is zero which was leading to an unsorted list of negative priorities.
(See #45396)
