### PR TITLE
[Mailer] allow custom hosts for ses+smtp with amazon mailer

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `X-SES-MESSAGE-TAGS`
+ * Add support for custom ses+smtp hosts
 
 6.0
 ---

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
@@ -156,6 +156,16 @@ class SesTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('ses+smtps', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1', 'ping_threshold' => '10']),
             (new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger))->setPingThreshold(10),
         ];
+
+        yield [
+            new Dsn('ses+smtp', 'custom.vpc.endpoint', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1']),
+            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger, 'custom.vpc.endpoint'),
+        ];
+
+        yield [
+            new Dsn('ses+smtps', 'custom.vpc.endpoint', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1']),
+            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger, 'custom.vpc.endpoint'),
+        ];
     }
 
     public function unsupportedSchemeProvider(): iterable

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
@@ -28,9 +28,13 @@ class SesSmtpTransport extends EsmtpTransport
     /**
      * @param string|null $region Amazon SES region
      */
-    public function __construct(string $username, #[\SensitiveParameter] string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null, string $host = 'default')
     {
-        parent::__construct(sprintf('email-smtp.%s.amazonaws.com', $region ?: 'eu-west-1'), 465, true, $dispatcher, $logger);
+        if ('default' === $host) {
+            $host = sprintf('email-smtp.%s.amazonaws.com', $region ?: 'eu-west-1');
+        }
+
+        parent::__construct($host, 465, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
@@ -30,7 +30,7 @@ final class SesTransportFactory extends AbstractTransportFactory
         $region = $dsn->getOption('region');
 
         if ('ses+smtp' === $scheme || 'ses+smtps' === $scheme) {
-            $transport = new SesSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $region, $this->dispatcher, $this->logger);
+            $transport = new SesSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $region, $this->dispatcher, $this->logger, $dsn->getHost());
 
             if (null !== $pingThreshold = $dsn->getOption('ping_threshold')) {
                 $transport->setPingThreshold((int) $pingThreshold);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Specifically allows the use of VPC Endpoints without the need for Private DNS on EC2.  
