### PR TITLE
[FrameworkBundle] KernelTestCase resets internal state on tearDown

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -44,6 +44,7 @@ abstract class KernelTestCase extends TestCase
     private function doTearDown()
     {
         static::ensureKernelShutdown();
+        static::$class = null;
         static::$kernel = null;
         static::$booted = false;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
@@ -44,4 +44,22 @@ class TestServiceContainerTest extends AbstractWebTestCase
         $this->assertTrue(static::$container->has('private_service'));
         $this->assertFalse(static::$container->has(UnusedPrivateService::class));
     }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testBootKernel()
+    {
+        static::bootKernel(['test_case' => 'TestServiceContainer']);
+    }
+
+    /**
+     * @depends testBootKernel
+     */
+    public function testKernelIsNotInitialized()
+    {
+        self::assertNull(self::$class);
+        self::assertNull(self::$kernel);
+        self::assertFalse(self::$booted);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When using the `KernelTestCase` for multiple different test kernels, the `KernelTestCase::$class` is not reseted after the test has finished. All other class variables are set to the initial state, so this change should be a bugfix.
