### PR TITLE
[HttpClient] Add Proxy info to response->info array

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -65,8 +65,8 @@ final class CurlResponse implements ResponseInterface
         $this->info['http_method'] = $method;
         $this->info['user_data'] = $options['user_data'] ?? null;
         $this->info['start_time'] = $this->info['start_time'] ?? microtime(true);
-        $this->info['proxy']['HTTP_PROXY'] = array_key_exists('HTTP_PROXY', $_SERVER) ? $_SERVER['HTTP_PROXY'] : null;
-        $this->info['proxy']['HTTPS_PROXY'] = array_key_exists('HTTPS_PROXY', $_SERVER) ? $_SERVER['HTTPS_PROXY'] : null;
+        $this->info['proxy']['HTTP_PROXY'] = \array_key_exists('HTTP_PROXY', $_SERVER) ? $_SERVER['HTTP_PROXY'] : null;
+        $this->info['proxy']['HTTPS_PROXY'] = \array_key_exists('HTTPS_PROXY', $_SERVER) ? $_SERVER['HTTPS_PROXY'] : null;
         $info = &$this->info;
         $headers = &$this->headers;
         $debugBuffer = $this->debugBuffer;

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -65,6 +65,8 @@ final class CurlResponse implements ResponseInterface
         $this->info['http_method'] = $method;
         $this->info['user_data'] = $options['user_data'] ?? null;
         $this->info['start_time'] = $this->info['start_time'] ?? microtime(true);
+        $this->info['proxy']['HTTP_PROXY'] = array_key_exists('HTTP_PROXY', $_SERVER) ? $_SERVER['HTTP_PROXY'] : null;
+        $this->info['proxy']['HTTPS_PROXY'] = array_key_exists('HTTPS_PROXY', $_SERVER) ? $_SERVER['HTTPS_PROXY'] : null;
         $info = &$this->info;
         $headers = &$this->headers;
         $debugBuffer = $this->debugBuffer;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes - arguably :) 
| Deprecations? | no 
| License       | MIT

Adds the proxy information used by the Curl client when making the request to the debug information available from `$response->getInfo()`

This is not available from `curl_getinfo` unfortunately 

I've aimed this at 4.3 but arguably this is a new feature, even though its really just another array key in an existing array, up to you if you want to rebase on 6.1+ but that's not going to help me scratching my itch still in 5.x land. 

Developed and tested in 5.4 only sorry 

New array key dumped looks like this:

<img width="622" alt="Screenshot 2022-02-13 at 18 45 54" src="https://user-images.githubusercontent.com/400092/153769878-e85472b9-7d61-4e1c-bbfe-f5bf4d696806.png">

