### PR TITLE
[Messenger] Add HandlerArgumentsStamp

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/HandlerArgumentsStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/HandlerArgumentsStamp.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * @author Jáchym Toušek <enumag@gmail.com>
+ */
+final class HandlerArgumentsStamp implements NonSendableStampInterface
+{
+    public function __construct(
+        private array $additionalArguments,
+    ) {
+    }
+
+    public function getAdditionalArguments()
+    {
+        return $this->additionalArguments;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\StackMiddleware;
 use Symfony\Component\Messenger\Stamp\AckStamp;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\HandlerArgumentsStamp;
 use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
@@ -261,11 +262,52 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
 
         $this->assertSame([$message], $handler->processedMessages);
     }
+
+    public function testHandlerArgumentsStamp()
+    {
+        $message = new DummyMessage('Hey');
+        $envelope = new Envelope($message);
+        $envelope = $envelope->with(new HandlerArgumentsStamp(['additional argument']));
+
+        $handler = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [$handler],
+        ]));
+
+        $handler->expects($this->once())->method('__invoke')->with($message, 'additional argument');
+
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testHandlerArgumentsStampNamedArgument()
+    {
+        $message = new DummyMessage('Hey');
+        $envelope = new Envelope($message);
+        $envelope = $envelope->with(new HandlerArgumentsStamp(['namedArgument' => 'additional named argument']));
+
+        $handler = $this->createPartialMock(HandleMessageMiddlewareNamedArgumentTestCallable::class, ['__invoke']);
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [$handler],
+        ]));
+
+        $handler->expects($this->once())->method('__invoke')->with($message, 'additional named argument');
+
+        $middleware->handle($envelope, $this->getStackMock());
+    }
 }
 
 class HandleMessageMiddlewareTestCallable
 {
     public function __invoke()
+    {
+    }
+}
+
+class HandleMessageMiddlewareNamedArgumentTestCallable
+{
+    public function __invoke(object $message, $namedArgument)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #31075
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/17174

As discussed in #31075 sometimes it's desirable for the messenger handler to receive additional argument than just the message itself. I understand the voiced concerns about passing the entire envelope but instead of that we could use the approach from this PR which doesn't add any additional arguments by default but is actually even more powerful since it gives the user full control what should be sent to the handler if desired.

This is just a prototype of course. With https://github.com/symfony/symfony/pull/45377 in mind I used a readonly property from PHP 8.1 but of course such details can be easily adjusted.

Let me know if such feature is wanted in Symfony. If yes then I'll add tests and a doc PR.
