### PR TITLE
 [Translation] Add the possibilty to export xliff translation with the .xliff suffix

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Environment variable `SYMFONY_IDE` is read by default when `framework.ide` config is not set.
  * Load PHP configuration files by default in the `MicroKernelTrait`
  * Add `cache:pool:invalidate-tags` command
+ * Add `XliffFileDumper` with `xliff` as the extension as a service
 
 6.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
@@ -114,6 +114,10 @@ return static function (ContainerConfigurator $container) {
         ->set('translation.dumper.xliff', XliffFileDumper::class)
             ->tag('translation.dumper', ['alias' => 'xlf'])
 
+        ->set('translation.dumper.xliff.xliff', XliffFileDumper::class)
+            ->args(['xliff'])
+            ->tag('translation.dumper', ['alias' => 'xliff'])
+
         ->set('translation.dumper.po', PoFileDumper::class)
             ->tag('translation.dumper', ['alias' => 'po'])
 

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Parameters implementing `TranslatableInterface` are processed
+ * `XliffFileDumper` can now be instantiated with the extension for example `xliff`
 
 5.4
 ---

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -21,6 +21,11 @@ use Symfony\Component\Translation\MessageCatalogue;
  */
 class XliffFileDumper extends FileDumper
 {
+    public function __construct(
+        private string $extension = 'xlf',
+    ) {
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -52,7 +57,7 @@ class XliffFileDumper extends FileDumper
      */
     protected function getExtension(): string
     {
-        return 'xlf';
+        return $this->extension;
     }
 
     private function dumpXliff1(string $defaultLocale, MessageCatalogue $messages, ?string $domain, array $options = [])

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -128,4 +128,23 @@ class XliffFileDumperTest extends TestCase
             $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'fr_FR', 'xliff_version' => '2.0'])
         );
     }
+
+    public function testDumpCatalogueWithXliffExtension()
+    {
+        $catalogue = new MessageCatalogue('en_US');
+        $catalogue->add([
+            'foo' => 'bar',
+            'key' => '',
+            'key.with.cdata' => '<source> & <target>',
+        ]);
+        $catalogue->setMetadata('foo', ['notes' => [['priority' => 1, 'from' => 'bar', 'content' => 'baz']]]);
+        $catalogue->setMetadata('key', ['notes' => [['content' => 'baz'], ['content' => 'qux']]]);
+
+        $dumper = new XliffFileDumper('xliff');
+
+        $this->assertStringEqualsFile(
+            __DIR__.'/../fixtures/resources-clean.xliff',
+            $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'fr_FR'])
+        );
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources-clean.xliff
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources-clean.xliff
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="fr-FR" target-language="en-US" datatype="plaintext" original="file.ext">
+    <header>
+      <tool tool-id="symfony" tool-name="Symfony"/>
+    </header>
+    <body>
+      <trans-unit id="LCa0a2j" resname="foo">
+        <source>foo</source>
+        <target>bar</target>
+        <note priority="1" from="bar">baz</note>
+      </trans-unit>
+      <trans-unit id="LHDhK3o" resname="key">
+        <source>key</source>
+        <target></target>
+        <note>baz</note>
+        <note>qux</note>
+      </trans-unit>
+      <trans-unit id="2DA_bnh" resname="key.with.cdata">
+        <source>key.with.cdata</source>
+        <target><![CDATA[<source> & <target>]]></target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Like the `YamlFileDumper` now the `XliffFileDumper` has the extension as an parameter. This enables the user to export xliff translation files with the suffix `.xlf` and `.xliff`. This is needed for example for the translation provider Lokalise and the GitLab integration for this provider.
