### PR TITLE
[DependencyInjection] Fix type binding

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -152,10 +152,10 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         }
 
                         continue;
+                    } elseif (!$type || !$autowire || '\\' !== $target[0]) {
+                        continue;
                     } elseif (is_subclass_of($type, \UnitEnum::class)) {
                         // do not attempt to register enum typed arguments if not already present in bindings
-                        continue;
-                    } elseif (!$type || !$autowire || '\\' !== $target[0]) {
                         continue;
                     } elseif (!$p->allowsNull()) {
                         $invalidBehavior = ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| License       | MIT

If $type is a scalar compiler pass should not check it in function is_subclass_of($type, \UnitEnum::class), because is_subclass_of trying to autoload class with name array, string, etc.

Related to https://github.com/symfony/symfony/pull/44979

