### PR TITLE
[Runtime] Fix dotenv_overload with commands

### DIFF
--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -98,24 +98,24 @@ class SymfonyRuntime extends GenericRuntime
         } elseif (isset($_SERVER['argv']) && class_exists(ArgvInput::class)) {
             $this->options = $options;
             $this->getInput();
-            $inputEnv = $_SERVER[$envKey] ?? null;
-            $inputDebug = $_SERVER[$debugKey] ?? null;
         }
 
         if (!($options['disable_dotenv'] ?? false) && isset($options['project_dir']) && !class_exists(MissingDotenv::class, false)) {
             (new Dotenv($envKey, $debugKey))
                 ->setProdEnvs((array) ($options['prod_envs'] ?? ['prod']))
                 ->usePutenv($options['use_putenv'] ?? false)
-                ->bootEnv($options['project_dir'].'/'.($options['dotenv_path'] ?? '.env'), 'dev', (array) ($options['test_envs'] ?? ['test']), $dotenvOverload = $options['dotenv_overload'] ?? false);
-            if ($dotenvOverload) {
-                if (isset($inputEnv) && $inputEnv !== $_SERVER[$envKey]) {
+                ->bootEnv($options['project_dir'].'/'.($options['dotenv_path'] ?? '.env'), 'dev', (array) ($options['test_envs'] ?? ['test']), $options['dotenv_overload'] ?? false);
+
+            if ($this->input && ($options['dotenv_overload'] ?? false)) {
+                if ($this->input->getParameterOption(['--env', '-e'], $_SERVER[$envKey], true) !== $_SERVER[$envKey]) {
                     throw new \LogicException(sprintf('Cannot use "--env" or "-e" when the "%s" file defines "%s" and the "dotenv_overload" runtime option is true.', $options['dotenv_path'] ?? '.env', $envKey));
                 }
 
-                if (isset($inputDebug) && $inputDebug !== $_SERVER[$debugKey]) {
-                    putenv($debugKey.'='.$_SERVER[$debugKey] = $_ENV[$debugKey] = $inputDebug);
+                if ($_SERVER[$debugKey] && $this->input->hasParameterOption('--no-debug', true)) {
+                    putenv($debugKey.'='.$_SERVER[$debugKey] = $_ENV[$debugKey] = '0');
                 }
             }
+
             $options['debug'] ?? $options['debug'] = '1' === $_SERVER[$debugKey];
             $options['disable_dotenv'] = true;
         } else {

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_0_to_1.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_0_to_1.php
@@ -1,0 +1,18 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+
+$_SERVER['DEBUG_ENABLED'] = '0';
+$_SERVER['APP_RUNTIME_OPTIONS'] = [
+    'debug_var_name' => 'DEBUG_ENABLED',
+    'dotenv_overload' => true,
+];
+
+require __DIR__.'/autoload.php';
+
+return static function (Command $command, OutputInterface $output, array $context): Command {
+    return $command->setCode(static function () use ($output, $context): void {
+        $output->writeln($context['DEBUG_ENABLED']);
+    });
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_0_to_1.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_0_to_1.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Dotenv overload with a command when debug=0 exists and debug=1 in .env and the --no-debug option is not used
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+$_SERVER['argv'] = [
+    'my_app',
+];
+$_SERVER['argc'] = 1;
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/dotenv_overload_command_debug_exists_0_to_1.php';
+
+?>
+--EXPECTF--
+1

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_1_to_0.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_1_to_0.php
@@ -1,0 +1,18 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+
+$_SERVER['DEBUG_MODE'] = '1';
+$_SERVER['APP_RUNTIME_OPTIONS'] = [
+    'debug_var_name' => 'DEBUG_MODE',
+    'dotenv_overload' => true,
+];
+
+require __DIR__.'/autoload.php';
+
+return static function (Command $command, OutputInterface $output, array $context): Command {
+    return $command->setCode(static function () use ($output, $context): void {
+        $output->writeln($context['DEBUG_MODE']);
+    });
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_1_to_0.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_1_to_0.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Dotenv overload with a command when debug=1 exists and debug=0 in .env and the --no-debug option is not used
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+$_SERVER['argv'] = [
+    'my_app',
+];
+$_SERVER['argc'] = 1;
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/dotenv_overload_command_debug_exists_1_to_0.php';
+
+?>
+--EXPECTF--
+0

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_env_exists.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_env_exists.php
@@ -1,0 +1,18 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+
+$_SERVER['ENV_MODE'] = 'notfoo';
+$_SERVER['APP_RUNTIME_OPTIONS'] = [
+    'env_var_name' => 'ENV_MODE',
+    'dotenv_overload' => true,
+];
+
+require __DIR__.'/autoload.php';
+
+return static function (Command $command, OutputInterface $output, array $context): Command {
+    return $command->setCode(static function () use ($output, $context): void {
+        $output->writeln($context['ENV_MODE']);
+    });
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_env_exists.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_env_exists.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Dotenv overload with a command when existing env=notfoo and env=foo in .env and the --env option is not used
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+$_SERVER['argv'] = [
+    'my_app',
+];
+$_SERVER['argc'] = 1;
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/dotenv_overload_command_env_exists.php';
+
+?>
+--EXPECTF--
+foo


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixes bugs introduced in https://github.com/symfony/symfony/pull/44997.

For example, if `$_SERVER['APP_ENV'] = 'foo';` exists and with `APP_ENV=prod` in `.env`, any command will throw `Cannot use "--env" or "-e" when the...` because `foo` is considered as the input env.

Determining the input env and debug from `$_SERVER` is wrong because when the `--no-debug` and `--env` are not used, we actually consider the existing env and debug as the input end and debug. We need to know and use the real input env and debug.