### PR TITLE
[Uid] Don't rely on switch loose comparison

### DIFF
--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -67,7 +67,7 @@ class Uuid extends AbstractUid
             return new NilUuid();
         }
 
-        switch ($uuid[14]) {
+        switch ((int) $uuid[14]) {
             case UuidV1::TYPE: return new UuidV1($uuid);
             case UuidV3::TYPE: return new UuidV3($uuid);
             case UuidV4::TYPE: return new UuidV4($uuid);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

We are relying on a switch loose comparison (for example `'1' == 1`), I don't think it's a good practice to promote. Also, changing this switch naively to a match breaks it (that's how I've found it :sweat_smile:).