### PR TITLE
[Dotenv] Fix reading config for symfony/runtime when running dump command

### DIFF
--- a/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
@@ -95,7 +95,7 @@ EOF
     private function createCommand(): CommandTester
     {
         $application = new Application();
-        $application->add(new DotenvDumpCommand(__DIR__.'/.env'));
+        $application->add(new DotenvDumpCommand(__DIR__));
 
         return new CommandTester($application->find('dotenv:dump'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Same as https://github.com/symfony/flex/pull/867
Fix https://github.com/symfony/flex/issues/855