### PR TITLE
[HttpFoundation] Only manipulate headers if not already sent

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/SessionUtils.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionUtils.php
@@ -49,9 +49,11 @@ final class SessionUtils
             return null;
         }
 
-        header_remove('Set-Cookie');
-        foreach ($otherCookies as $h) {
-            header($h, false);
+        if (!headers_sent()) {
+            header_remove('Set-Cookie');
+            foreach ($otherCookies as $h) {
+                header($h, false);
+            }
         }
 
         return $sessionCookie;

--- a/src/Symfony/Component/HttpFoundation/Session/SessionUtils.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionUtils.php
@@ -53,7 +53,6 @@ final class SessionUtils
             return null;
         }
 
-
         header_remove('Set-Cookie');
         foreach ($otherCookies as $h) {
             header($h, false);

--- a/src/Symfony/Component/HttpFoundation/Session/SessionUtils.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionUtils.php
@@ -27,6 +27,10 @@ final class SessionUtils
      */
     public static function popSessionCookie(string $sessionName, string $sessionId): ?string
     {
+        if (headers_sent()) {
+            return null;
+        }
+
         $sessionCookie = null;
         $sessionCookiePrefix = sprintf(' %s=', urlencode($sessionName));
         $sessionCookieWithId = sprintf('%s%s;', $sessionCookiePrefix, urlencode($sessionId));
@@ -49,11 +53,10 @@ final class SessionUtils
             return null;
         }
 
-        if (!headers_sent()) {
-            header_remove('Set-Cookie');
-            foreach ($otherCookies as $h) {
-                header($h, false);
-            }
+
+        header_remove('Set-Cookie');
+        foreach ($otherCookies as $h) {
+            header($h, false);
         }
 
         return $sessionCookie;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| License       | MIT

When you want to send headers before request finishes via
```php
class MyController  {
  public function myAction() {
      $response = new Response();
      $response->headers->set(
          'Content-Disposition',
          HeaderUtils::makeDisposition(
              HeaderUtils::DISPOSITION_ATTACHMENT,
              'file.txt'
          )
      );
      
      $response->sendHeaders();
      flush();

      // do some work to populate response
      sleep(5); // this is only for demonstraton purposes

      return $response;
  }
}
```
I get a warning error 
> E_WARNING: Cannot modify header information - headers already sent in [Root folder]/vendor/symfony/http-foundation/Session/SessionUtils.php, line 54

The goal of above code is to trigger the download dialog to open before the actual data generation is finished.

With this PR the headers get only manipulated during `kernel.response` event if the headers have not already been sent.