### PR TITLE
[Messenger] Support setting `connection_name` for AMQP

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -57,6 +57,7 @@ class Connection
         'key',
         'verify',
         'sasl_method',
+        'connection_name',
     ];
 
     private const AVAILABLE_QUEUE_OPTIONS = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      |  6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | Will add if needed

The PR provides an opportunity to set "[connection_name](https://www.rabbitmq.com/connections.html)" for AMQP messenger connection to understand and debug connections like this:
```php
['options' => [
   'connection_name' => $hostname . ' backend ' . time(),
]
];
```
RabbitMQ UI

![image](https://user-images.githubusercontent.com/661654/154217123-045d28e7-a582-45e3-a2c5-129de8188e3d.png)
