### PR TITLE
[Serializer] Allow to denormalize objects that have constructor checks without using constructor

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Return empty collections as `ArrayObject` from `Serializer::normalize()` when `PRESERVE_EMPTY_OBJECTS` is set
  * Add support for collecting type errors during denormalization
  * Add missing arguments in `MissingConstructorArgumentsException`
+ * Add support for denormalizing objects without using constructor
 
 5.3
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -80,6 +80,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     public const DEFAULT_CONSTRUCTOR_ARGUMENTS = 'default_constructor_arguments';
 
     /**
+     * Force to create new instance without using constructor.
+     */
+    public const CREATE_INSTANCE_WITHOUT_CONSTRUCTOR = 'create_instance_without_constructor';
+
+    /**
      * Hashmap of field name => callable to (de)normalize this field.
      *
      * The callable is called if the field is encountered with the arguments:
@@ -342,7 +347,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
         $constructor = $this->getConstructor($data, $class, $context, $reflectionClass, $allowedAttributes);
         if ($constructor) {
-            if (true !== $constructor->isPublic()) {
+            $createInstanceWithoutConstructor = (
+                \array_key_exists(self::CREATE_INSTANCE_WITHOUT_CONSTRUCTOR, $context)
+                && ($context[self::CREATE_INSTANCE_WITHOUT_CONSTRUCTOR] === true)
+            );
+            if (true !== $constructor->isPublic() || $createInstanceWithoutConstructor) {
                 return $reflectionClass->newInstanceWithoutConstructor();
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -349,7 +349,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         if ($constructor) {
             $createInstanceWithoutConstructor = (
                 \array_key_exists(self::CREATE_INSTANCE_WITHOUT_CONSTRUCTOR, $context)
-                && ($context[self::CREATE_INSTANCE_WITHOUT_CONSTRUCTOR] === true)
+                && (true === $context[self::CREATE_INSTANCE_WITHOUT_CONSTRUCTOR])
             );
             if (true !== $constructor->isPublic() || $createInstanceWithoutConstructor) {
                 return $reflectionClass->newInstanceWithoutConstructor();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -545,10 +545,10 @@ class PropertyConstructorWithValidationDummy
 
     public function __construct($foo, $bar)
     {
-        if ('foo' === $foo){
+        if ('foo' === $foo) {
             throw new \LogicException(sprintf('Argument "%s" is not acceptable as first argument of "%s"', $foo, self::class));
         }
-        if ('bar' === $bar){
+        if ('bar' === $bar) {
             throw new \LogicException(sprintf('Argument "%s" is not acceptable as second argument of "%s"', $bar, self::class));
         }
         $this->foo = $foo;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -545,10 +545,10 @@ class PropertyConstructorWithValidationDummy
 
     public function __construct($foo, $bar)
     {
-        if ($foo === 'foo'){
+        if ('foo' === $foo){
             throw new \LogicException(sprintf('Argument "%s" is not acceptable as first argument of "%s"', $foo, self::class));
         }
-        if ($bar === 'bar'){
+        if ('bar' === $bar){
             throw new \LogicException(sprintf('Argument "%s" is not acceptable as second argument of "%s"', $bar, self::class));
         }
         $this->foo = $foo;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -187,6 +187,25 @@ class PropertyNormalizerTest extends TestCase
         $this->assertEquals('bar', $obj->getBar());
     }
 
+    public function testConstructorDenormalizeWithInvalidArgument()
+    {
+        $obj = $this->normalizer->denormalize(
+            ['foo' => 'foo', 'bar' => 'bar'],
+            PropertyConstructorWithValidationDummy::class,
+            null,
+            ['create_instance_without_constructor' => true]
+        );
+        $this->assertEquals('foo', $obj->getFoo());
+        $this->assertEquals('bar', $obj->getBar());
+
+        $this->expectException(\LogicException::class);
+        $this->expectErrorMessage(sprintf('Argument "%s" is not acceptable as first argument of "%s"', 'foo', PropertyConstructorWithValidationDummy::class));
+        $this->normalizer->denormalize(
+            ['foo' => 'foo', 'bar' => 'bar'],
+            PropertyConstructorWithValidationDummy::class
+        );
+    }
+
     protected function getNormalizerForCallbacks(): PropertyNormalizer
     {
         return new PropertyNormalizer();
@@ -504,6 +523,34 @@ class PropertyConstructorDummy
 
     public function __construct($foo, $bar)
     {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+}
+
+class PropertyConstructorWithValidationDummy
+{
+    protected $foo;
+    private $bar;
+
+    public function __construct($foo, $bar)
+    {
+        if ($foo === 'foo'){
+            throw new \LogicException(sprintf('Argument "%s" is not acceptable as first argument of "%s"', $foo, self::class));
+        }
+        if ($bar === 'bar'){
+            throw new \LogicException(sprintf('Argument "%s" is not acceptable as second argument of "%s"', $bar, self::class));
+        }
         $this->foo = $foo;
         $this->bar = $bar;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | -

In some cases it would be great to be able to denormalize objects without having to pass by the constructor.
In my case, I have Value Objects that perform validations in their constructor. These objects are normalized, json encoded and persisted in a mongodb database.
If the validation rules changed, it is impossible to denormalize some objects because of the constructor checks, even if the properties exists.
This PR allow to use pure property reflection by skiping the constructor even if it is not private.

To allow this you only need to add the new context param **create_instance_without_constructor**