### PR TITLE
[DependencyInjection] Allow using expressions as service factories

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `$exclude` to `TaggedIterator` and `TaggedLocator` attributes
  * Add `$exclude` to `tagged_iterator` and `tagged_locator` configurator
  * Add an `env` function to the expression language provider
+ * Add support for using expressions as service factories
 
 6.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -123,6 +123,10 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
             return $r;
         }
 
+        if ($factory instanceof Expression) {
+            return new \ReflectionFunction(static function () {});
+        }
+
         if ($factory) {
             [$class, $method] = $factory;
 

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1013,6 +1013,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         if (null !== $factory = $definition->getFactory()) {
             if (\is_array($factory)) {
                 $factory = [$this->doResolveServices($parameterBag->resolveValue($factory[0]), $inlineServices, $isConstructorArgument), $factory[1]];
+            } elseif ($factory instanceof Expression) {
+                $factory = function () use ($factory) {
+                    return $this->getExpressionLanguage()->evaluate($factory, ['container' => $this]);
+                };
             } elseif (!\is_string($factory)) {
                 throw new RuntimeException(sprintf('Cannot create service "%s" because of invalid factory.', $id));
             }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * Definition represents a service definition.
@@ -26,7 +27,7 @@ class Definition
 
     private ?string $class = null;
     private ?string $file = null;
-    private string|array|null $factory = null;
+    private string|array|Expression|null $factory = null;
     private bool $shared = true;
     private array $deprecation = [];
     private array $properties = [];
@@ -94,11 +95,11 @@ class Definition
     /**
      * Sets a factory.
      *
-     * @param string|array|Reference|null $factory A PHP function, reference or an array containing a class/Reference and a method to call
+     * @param string|array|Expression|Reference|null $factory A PHP function, reference or an array containing a class/Reference and a method to call
      *
      * @return $this
      */
-    public function setFactory(string|array|Reference|null $factory): static
+    public function setFactory(string|array|Expression|Reference|null $factory): static
     {
         $this->changes['factory'] = true;
 
@@ -116,9 +117,9 @@ class Definition
     /**
      * Gets the factory.
      *
-     * @return string|array|null The PHP function or an array containing a class/Reference and a method to call
+     * @return string|array|Expression|null The PHP function or an array containing a class/Reference and a method to call
      */
-    public function getFactory(): string|array|null
+    public function getFactory(): string|array|Expression|null
     {
         return $this->factory;
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1159,6 +1159,10 @@ EOTXT
                 return $return.sprintf("[%s, '%s'](%s)", $class, $callable[1], $arguments ? implode(', ', $arguments) : '').$tail;
             }
 
+            if ($callable instanceof Expression) {
+                return $return.$this->getExpressionLanguage()->compile((string) $callable, ['this' => 'container']).$tail;
+            }
+
             return $return.sprintf('%s(%s)', $this->dumpLiteralClass($this->dumpValue($callable)), $arguments ? implode(', ', $arguments) : '').$tail;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -171,6 +171,8 @@ class XmlDumper extends Dumper
                     $factory->setAttribute($callable[0] instanceof Reference ? 'service' : 'class', $callable[0]);
                 }
                 $factory->setAttribute('method', $callable[1]);
+            } elseif ($callable instanceof Expression) {
+                $factory->setAttribute('expression', $callable);
             } else {
                 $factory->setAttribute('function', $callable);
             }

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -224,6 +224,10 @@ class YamlDumper extends Dumper
      */
     private function dumpCallable(mixed $callable): mixed
     {
+        if ($callable instanceof Expression) {
+            return $this->getExpressionCall((string) $callable);
+        }
+
         if (\is_array($callable)) {
             if ($callable[0] instanceof Reference) {
                 $callable = [$this->getServiceCall((string) $callable[0], $callable[0]), $callable[1]];

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator\Traits;
 
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 trait FactoryTrait
 {
@@ -21,7 +22,7 @@ trait FactoryTrait
      *
      * @return $this
      */
-    final public function factory(string|array|ReferenceConfigurator $factory): static
+    final public function factory(string|array|Expression|ReferenceConfigurator $factory): static
     {
         if (\is_string($factory) && 1 === substr_count($factory, ':')) {
             $factoryParts = explode(':', $factory);

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -304,6 +304,8 @@ class XmlFileLoader extends FileLoader
             $factory = $factories[0];
             if ($function = $factory->getAttribute('function')) {
                 $definition->setFactory($function);
+            } elseif ($expression = $factory->getAttribute('expression')) {
+                $definition->setFactory(new Expression($expression));
             } else {
                 if ($childService = $factory->getAttribute('service')) {
                     $class = new Reference($childService, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -701,9 +701,13 @@ class YamlFileLoader extends FileLoader
     /**
      * @throws InvalidArgumentException When errors occur
      */
-    private function parseCallable(mixed $callable, string $parameter, string $id, string $file): string|array|Reference
+    private function parseCallable(mixed $callable, string $parameter, string $id, string $file): string|array|Expression|Reference
     {
         if (\is_string($callable)) {
+            if ('factory' === $parameter && str_starts_with($callable, '@=')) {
+                return $this->resolveServices($callable, $file);
+            }
+
             if ('' !== $callable && '@' === $callable[0]) {
                 if (!str_contains($callable, ':')) {
                     return [$this->resolveServices($callable, $file), '__invoke'];

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -115,6 +115,17 @@
     <xsd:attribute name="function" type="xsd:string" />
   </xsd:complexType>
 
+  <xsd:complexType name="factory">
+    <xsd:choice minOccurs="0" maxOccurs="1">
+      <xsd:element name="service" type="service" minOccurs="0" maxOccurs="1" />
+    </xsd:choice>
+    <xsd:attribute name="service" type="xsd:string" />
+    <xsd:attribute name="class" type="xsd:string" />
+    <xsd:attribute name="method" type="xsd:string" />
+    <xsd:attribute name="function" type="xsd:string" />
+    <xsd:attribute name="expression" type="xsd:string" />
+  </xsd:complexType>
+
   <xsd:complexType name="defaults">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
@@ -135,7 +146,7 @@
       <xsd:element name="file" type="xsd:string" minOccurs="0" maxOccurs="1" />
       <xsd:element name="argument" type="argument" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="configurator" type="callable" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="factory" type="callable" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="factory" type="factory" minOccurs="0" maxOccurs="1" />
       <xsd:element name="deprecated" type="deprecated" minOccurs="0" maxOccurs="1" />
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
@@ -179,7 +190,7 @@
     <xsd:choice maxOccurs="unbounded">
       <xsd:element name="argument" type="argument" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="configurator" type="callable" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="factory" type="callable" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="factory" type="factory" minOccurs="0" maxOccurs="1" />
       <xsd:element name="deprecated" type="deprecated" minOccurs="0" maxOccurs="1" />
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -413,6 +413,21 @@ class ContainerBuilderTest extends TestCase
         $this->assertTrue($builder->get('baz')->called, '->createService() uses another service as factory');
     }
 
+    public function testCreateServiceFactoryExpression()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('foo', 'Bar\FooClass')
+            ->setPublic(true)
+        ;
+        $builder->register('bar', 'Bar\FooClass')
+            ->setFactory(new Expression('service("foo").getInstance()'))
+            ->setPublic(true)
+        ;
+        $builder->compile();
+
+        $this->assertTrue($builder->get('bar')->called, '->createService() uses expression as factory');
+    }
+
     public function testCreateServiceMethodCalls()
     {
         $builder = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1367,6 +1367,24 @@ PHP
         $this->assertSame($foo5, $locator->get('foo5'));
     }
 
+    public function testFactoryExpression()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('foo', 'Bar\FooClass');
+        $builder->register('bar', 'Bar\FooClass')
+            ->setFactory(new Expression('service("foo").getInstance()'))
+            ->setPublic(true)
+        ;
+        $builder->compile();
+
+        $dumper = new PhpDumper($builder);
+        eval('?>'.$dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Factory_Expression']));
+
+        $container = new \Symfony_DI_PhpDumper_Test_Factory_Expression();
+
+        $this->assertTrue($container->get('bar')->called, '->createService() uses expression as factory');
+    }
+
     public function testScalarService()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooWithAbstractArgument;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 class XmlDumperTest extends TestCase
 {
@@ -242,6 +243,28 @@ class XmlDumperTest extends TestCase
         $dumper = new XmlDumper($container);
 
         $this->assertEquals(file_get_contents(self::$fixturesPath.'/xml/services_abstract.xml'), $dumper->dump());
+    }
+
+    public function testDumpExpressionFactory()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', 'Bar\FooClass')
+            ->setFactory(new Expression("service('foo').getInstance()"))
+            ->setPublic(true)
+        ;
+
+        $dumper = new XmlDumper($container);
+
+        $this->assertEquals("<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<container xmlns=\"http://symfony.com/schema/dic/services\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd\">
+  <services>
+    <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"true\" synthetic=\"true\"/>
+    <service id=\"bar\" class=\"Bar\FooClass\" public=\"true\">
+      <factory expression=\"service('foo').getInstance()\"/>
+    </service>
+  </services>
+</container>
+", $dumper->dump());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooWithAbstractArgument;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Yaml;
 
@@ -131,6 +132,29 @@ class YamlDumperTest extends TestCase
 
         $dumper = new YamlDumper($container);
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_with_service_closure.yml', $dumper->dump());
+    }
+
+    public function testDumpExpressionFactory()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', 'Bar\FooClass')
+            ->setFactory(new Expression('service("foo").getInstance()'))
+            ->setPublic(true)
+        ;
+
+        $dumper = new YamlDumper($container);
+
+        $this->assertEquals("
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    bar:
+        class: Bar\FooClass
+        public: true
+        factory: '@=service(\"foo\").getInstance()'
+", $dumper->dump());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/expression_factory.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/expression_factory.expected.yml
@@ -1,0 +1,13 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo:
+        class: Bar\FooClass
+        public: true
+    bar:
+        class: Bar\FooClass
+        public: true
+        factory: '@=service("foo").getInstance()'

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/expression_factory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/expression_factory.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $c) {
+    $s = $c->services()->defaults()->public();
+
+    $s->set('foo', 'Bar\FooClass');
+    $s->set('bar', 'Bar\FooClass')->factory(expr('service("foo").getInstance()'));
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -63,6 +63,9 @@
     <service id="new_factory5" class="FooBarClass">
       <factory service="baz" />
     </service>
+    <service id="factory_expression" class="FooClass">
+      <factory expression="service('foo').getInstance()" />
+    </service>
     <service id="alias_for_foo" alias="foo" />
     <service id="another_alias_for_foo" alias="foo" public="true"/>
     <service id="0" class="FooClass" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -40,6 +40,9 @@ services:
     new_factory3: { class: FooBarClass, factory: [BazClass, getInstance]}
     new_factory4: { class: BazClass, factory: [~, getInstance]}
     new_factory5: { class: FooBarClass, factory: '@baz' }
+    factory_expression:
+        class: FooClass
+        factory: "@=service('foo').getInstance()"
     Acme\WithShortCutArgs: [foo, '@baz']
     alias_for_foo: '@foo'
     another_alias_for_foo:

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -97,6 +97,7 @@ class PhpFileLoaderTest extends TestCase
         yield ['inline_binding'];
         yield ['remove'];
         yield ['config_builder'];
+        yield ['expression_factory'];
     }
 
     public function testAutoConfigureAndChildDefinition()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -344,6 +344,7 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals(['BazClass', 'getInstance'], $services['new_factory3']->getFactory(), '->load() parses the factory tag');
         $this->assertSame([null, 'getInstance'], $services['new_factory4']->getFactory(), '->load() accepts factory tag without class');
         $this->assertEquals([new Reference('baz'), '__invoke'], $services['new_factory5']->getFactory(), '->load() accepts service reference as invokable factory');
+        $this->assertInstanceOf(Expression::class, $services['factory_expression']->getFactory(), '->load() parses a factory expression');
 
         $aliases = $container->getAliases();
         $this->assertArrayHasKey('alias_for_foo', $aliases, '->load() parses <service> elements');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -231,6 +231,7 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame([null, 'getInstance'], $services['new_factory4']->getFactory(), '->load() accepts factory tag without class');
         $this->assertEquals([new Reference('baz'), '__invoke'], $services['new_factory5']->getFactory(), '->load() accepts service reference as invokable factory');
         $this->assertEquals(['foo', new Reference('baz')], $services['Acme\WithShortCutArgs']->getArguments(), '->load() parses short service definition');
+        $this->assertInstanceOf(Expression::class, $services['factory_expression']->getFactory(), '->load() parses a factory expression');
 
         $aliases = $container->getAliases();
         $this->assertArrayHasKey('alias_for_foo', $aliases, '->load() parses aliases');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16516

This makes it easier to create services base on more complex expressions like for example switching the implementation based on an env variable.

```php
namespace Symfony\Component\DependencyInjection\Loader\Configurator;
use App\MyServiceInterface;
return function(ContainerConfigurator $configurator) {
    $services = $configurator->services();
    $services->set(MyServiceInterface::class)
        ->factory(expr("env('MY_ENV_VAR') ? service('some_service') : service('some_other_service')"));
};
```

I often find myself having to do this kind of switching and having a way to do it directly in services configuration instead of having to create a factory for it would be great.

I was actually surprise by how small the required patch was to support it.