### PR TITLE
[Mime] Added getter for "TextPart::$name"

### DIFF
--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -101,6 +101,14 @@ class TextPart extends AbstractPart
         return $this;
     }
 
+    /**
+     * Gets the name of the file (used by FormDataPart).
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
     public function getBody(): string
     {
         if (null === $this->seekable) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 6.0
| Bug fix      | no
| New feature  | no?
| Deprecations | no
| License       | MIT

`TextPart` and it's children has no way to get a `$name`/`$filename` as these properties are private and no getters provided. This PR adds a getter for `TextPart::$name`

This can be useful to make some flexible logging using Symfony Mailer when working with attachments.
