### PR TITLE
[DependencyInjection] Add an env function to DI expression language

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `$exclude` to `TaggedIterator` and `TaggedLocator` attributes
  * Add `$exclude` to `tagged_iterator` and `tagged_locator` configurator
+ * Add an `env` function to the expression language provider
 
 6.0
 ---

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1586,7 +1586,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             if (!class_exists(\Symfony\Component\ExpressionLanguage\ExpressionLanguage::class)) {
                 throw new LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
-            $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders);
+            $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders, null, \Closure::fromCallable([$this, 'getEnv']));
         }
 
         return $this->expressionLanguage;

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
@@ -30,10 +30,10 @@ class ExpressionLanguage extends BaseExpressionLanguage
     /**
      * {@inheritdoc}
      */
-    public function __construct(CacheItemPoolInterface $cache = null, array $providers = [], callable $serviceCompiler = null)
+    public function __construct(CacheItemPoolInterface $cache = null, array $providers = [], callable $serviceCompiler = null, \Closure $getEnv = null)
     {
         // prepend the default provider to let users override it easily
-        array_unshift($providers, new ExpressionLanguageProvider($serviceCompiler));
+        array_unshift($providers, new ExpressionLanguageProvider($serviceCompiler, $getEnv));
 
         parent::__construct($cache, $providers);
     }

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
@@ -19,6 +20,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
  *
  * To get a service, use service('request').
  * To get a parameter, use parameter('kernel.debug').
+ * To get an env variable, use env('SOME_VARIABLE').
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -26,9 +28,12 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
 {
     private ?\Closure $serviceCompiler;
 
-    public function __construct(callable $serviceCompiler = null)
+    private ?\Closure $getEnv;
+
+    public function __construct(callable $serviceCompiler = null, \Closure $getEnv = null)
     {
         $this->serviceCompiler = null !== $serviceCompiler && !$serviceCompiler instanceof \Closure ? \Closure::fromCallable($serviceCompiler) : $serviceCompiler;
+        $this->getEnv = $getEnv;
     }
 
     public function getFunctions(): array
@@ -44,6 +49,16 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
                 return sprintf('$this->getParameter(%s)', $arg);
             }, function (array $variables, $value) {
                 return $variables['container']->getParameter($value);
+            }),
+
+            new ExpressionFunction('env', function ($arg) {
+                return sprintf('$this->getEnv(%s)', $arg);
+            }, function (array $variables, $value) {
+                if (!$this->getEnv) {
+                    throw new LogicException('You need to pass a getEnv closure to the expression langage provider to use the "env" function.');
+                }
+
+                return ($this->getEnv)($value);
             }),
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -517,6 +517,19 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals('foobar', $builder->get('foo')->arguments['foo']);
     }
 
+    public function testEnvExpressionFunction()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', 'BarClass')
+            ->setPublic(true)
+            ->setProperty('foo', new Expression('env("BAR_FOO")'));
+        $container->compile(true);
+
+        $_ENV['BAR_FOO'] = 'Foo value';
+
+        $this->assertEquals('Foo value', $container->get('bar')->foo);
+    }
+
     public function testCreateServiceWithAbstractArgument()
     {
         $this->expectException(RuntimeException::class);

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -961,6 +961,24 @@ class PhpDumperTest extends TestCase
         $this->assertInstanceOf(\BazClass::class, $container->get('bar')->getBaz());
     }
 
+    public function testEnvExpressionFunction()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', 'BarClass')
+            ->setPublic(true)
+            ->setProperty('foo', new Expression('env("BAR_FOO")'));
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Env_Expression_Function']));
+
+        $container = new \Symfony_DI_PhpDumper_Test_Env_Expression_Function();
+
+        $_ENV['BAR_FOO'] = 'Foo value';
+
+        $this->assertEquals('Foo value', $container->get('bar')->foo);
+    }
+
     public function testArrayParameters()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16518

This add an `env` function to the DI expression language provider to ease creating expressions that depends on an environment variable.