### PR TITLE
[HttpKernel] Deprecate StreamedResponseListener, it serves no purpose anymore

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -12,6 +12,11 @@ Console
 
  * Deprecate `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead
 
+HttpKernel
+----------
+
+ * Deprecate StreamedResponseListener, it's not needed anymore
+
 Serializer
 ----------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpKernel\EventListener\DisallowRobotsIndexingListener;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener;
 use Symfony\Component\HttpKernel\EventListener\ResponseListener;
-use Symfony\Component\HttpKernel\EventListener\StreamedResponseListener;
 use Symfony\Component\HttpKernel\EventListener\ValidateRequestListener;
 
 return static function (ContainerConfigurator $container) {
@@ -77,9 +76,6 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.charset'),
                 abstract_arg('The "set_content_language_from_locale" config value'),
             ])
-            ->tag('kernel.event_subscriber')
-
-        ->set('streamed_response_listener', StreamedResponseListener::class)
             ->tag('kernel.event_subscriber')
 
         ->set('locale_listener', LocaleListener::class)

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `BackedEnumValueResolver` to resolve backed enum cases from request attributes in controller arguments
+ * Deprecate StreamedResponseListener, it's not needed anymore
 
 6.0
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -246,7 +246,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
     {
         return [
             KernelEvents::REQUEST => ['onKernelRequest', 128],
-            // low priority to come after regular response listeners, but higher than StreamedResponseListener
+            // low priority to come after regular response listeners
             KernelEvents::RESPONSE => ['onKernelResponse', -1000],
         ];
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/StreamedResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/StreamedResponseListener.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
+trigger_deprecation('symfony/http-kernel', '6.1', 'The "%s" class is deprecated.', StreamedResponseListener::class);
+
 /**
  * StreamedResponseListener is responsible for sending the Response
  * to the client.
@@ -23,6 +25,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * @author Fabien Potencier <fabien@symfony.com>
  *
  * @final
+ *
+ * @deprecated since Symfony 6.1
  */
 class StreamedResponseListener implements EventSubscriberInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

`StreamedResponseListener` has been introduced at the same time as `StreamedResponse` in #2935.

Its purpose was to make catching exceptions easier by wrapping the call to `$response->send()` in the main try/catch of `HttpKernel`.

Since #12998, we have `HttpKernel::terminateWithException()`, and we don't need that anymore, so we can just remove the listener.

This will help [integrate Symfony into e.g. Swoole](https://github.com/php-runtime/runtime/issues/115) /cc @alexander-schranz.