### PR TITLE
[HttpKernel] Reset services between requests performed by KernelBrowser

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile as HttpProfile;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Client simulates a browser and makes requests to a Kernel object.
@@ -116,7 +117,12 @@ class Client extends HttpKernelBrowser
         // avoid shutting down the Kernel if no request has been performed yet
         // WebTestCase::createClient() boots the Kernel but do not handle a request
         if ($this->hasPerformedRequest && $this->reboot) {
+            $container = $this->kernel->getContainer();
             $this->kernel->shutdown();
+
+            if ($container instanceof ResetInterface) {
+                $container->reset();
+            }
         } else {
             $this->hasPerformedRequest = true;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
@@ -54,7 +54,7 @@ class KernelBrowserTest extends AbstractWebTestCase
     private function getKernelMock()
     {
         $mock = $this->getMockBuilder($this->getKernelClass())
-            ->setMethods(['shutdown', 'boot', 'handle'])
+            ->setMethods(['shutdown', 'boot', 'handle', 'getContainer'])
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40965
| License       | MIT
| Doc PR        | -

This fixes memory leaks caused by the container not being reset between requests made via `KernelBrowser` when *not* calling `KernelBrowser::disableReboot();`.

There is already a call to `$container->reset()` in `KernelTestCase::ensureKernelShutdown()`, but `KernelBrowser` creates new container instances for each requests, and those containers were never reset.