### PR TITLE
Make constraint violation interfaces stringable

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -33,3 +33,5 @@ Validator
 
  * Deprecate `Constraint::$errorNames`, use `Constraint::ERROR_NAMES` instead
  * Deprecate constraint `ExpressionLanguageSyntax`, use `ExpressionSyntax` instead
+ * Implementing the `ConstraintViolationInterface` or `ConstraintViolationListInterface`
+   without implementing the `__toString()` method is deprecated

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate `Constraint::$errorNames`, use `Constraint::ERROR_NAMES` instead
  * Deprecate constraint `ExpressionLanguageSyntax`, use `ExpressionSyntax` instead
+ * Add method `__toString()` to `ConstraintViolationInterface` & `ConstraintViolationListInterface`
 
 6.0
 ---

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -64,7 +64,7 @@ class ConstraintViolation implements ConstraintViolationInterface
     }
 
     /**
-     * Converts the violation into a string for debugging purposes.
+     * {@inheritdoc}
      */
     public function __toString(): string
     {

--- a/src/Symfony/Component/Validator/ConstraintViolationInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationInterface.php
@@ -30,6 +30,8 @@ namespace Symfony\Component\Validator;
  * element is still the person, but the property path is "address.street".
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @method string __toString() Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
  */
 interface ConstraintViolationInterface
 {

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -46,7 +46,7 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
     }
 
     /**
-     * Converts the violation into a string for debugging purposes.
+     * {@inheritdoc}
      */
     public function __toString(): string
     {

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\Validator;
  *
  * @extends \ArrayAccess<int, ConstraintViolationInterface>
  * @extends \Traversable<int, ConstraintViolationInterface>
+ *
+ * @method string __toString() Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
  */
 interface ConstraintViolationListInterface extends \Traversable, \Countable, \ArrayAccess
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the `ConstraintViolationInterface` & `ConstraintViolationListInterface` don't have a `__toString()` method even though their only implementations do. Since the `validate` method returns a `ConstraintViolationListInterface` trying to cast the errors into a string doesn't sit well with static analysis tools.

Here I've used an [example from the docs](https://symfony.com/doc/current/validation.html#using-the-validator-service):
![Screen](https://user-images.githubusercontent.com/2445045/154810607-4c95ee66-9d21-4456-b857-3cfa7a8f1b80.png)

This PR adds a `__toString()` method to the interfaces via an `@method` tag. In Symfony 7 the `Stringable` interface can be implemented instead.