### PR TITLE
[Validator] Support SVGs when validating image dimensions

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -3,7 +3,8 @@ CHANGELOG
 
 6.1
 ---
-
+ 
+ * Support `SVGs` when validating image dimensions
  * Deprecate `Constraint::$errorNames`, use `Constraint::ERROR_NAMES` instead
 
 6.0

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_svg.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_svg.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1" height="1" viewBox="0 0 1 1">
+
+<g />
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_svg_landscape.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_svg_landscape.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="2" height="1" viewBox="0 0 2 1">
+
+<g />
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_svg_portrait.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_svg_portrait.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1" height="2" viewBox="0 0 1 2">
+
+<g />
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -30,6 +30,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     protected $image4By3;
     protected $imageCorrupted;
     protected $notAnImage;
+    protected $imageSvg;
+    protected $imageSvgLandscape;
+    protected $imageSvgPortrait;
 
     protected function createValidator()
     {
@@ -47,6 +50,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->image16By9 = __DIR__.'/Fixtures/test_16by9.gif';
         $this->imageCorrupted = __DIR__.'/Fixtures/test_corrupted.gif';
         $this->notAnImage = __DIR__.'/Fixtures/ccc.txt';
+        $this->imageSvg = __DIR__.'/Fixtures/test_svg.svg';
+        $this->imageSvgLandscape = __DIR__.'/Fixtures/test_svg_landscape.svg';
+        $this->imageSvgPortrait = __DIR__.'/Fixtures/test_svg_portrait.svg';
     }
 
     public function testNullIsValid()
@@ -533,6 +539,62 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ types }}', '"image/*"')
             ->setParameter('{{ name }}', '"ccc.txt"')
             ->setCode(Image::INVALID_MIME_TYPE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testSvgSize()
+    {
+        $constraint = new Image([
+            'minWidth' => 1,
+            'maxWidth' => 2,
+            'minHeight' => 1,
+            'maxHeight' => 2,
+        ]);
+
+        $this->validator->validate($this->imageSvg, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider provideAllowSquareConstraints
+     */
+    public function testSquareNotAllowedOnSvg(Image $constraint)
+    {
+        $this->validator->validate($this->imageSvg, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 1)
+            ->setParameter('{{ height }}', 1)
+            ->setCode(Image::SQUARE_NOT_ALLOWED_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider provideAllowLandscapeConstraints
+     */
+    public function testLandscapeNotAllowedOnSvg(Image $constraint)
+    {
+        $this->validator->validate($this->imageSvgLandscape, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 2)
+            ->setParameter('{{ height }}', 1)
+            ->setCode(Image::LANDSCAPE_NOT_ALLOWED_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider provideAllowPortraitConstraints
+     */
+    public function testPortraitNotAllowedOnSvg(Image $constraint)
+    {
+        $this->validator->validate($this->imageSvgPortrait, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 1)
+            ->setParameter('{{ height }}', 2)
+            ->setCode(Image::PORTRAIT_NOT_ALLOWED_ERROR)
             ->assertRaised();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #45269
| License       | MIT
| Doc PR        | 

Add SVG support in Image Validator
