### PR TITLE
[DoctrineBridge] Allow to use a middleware instead of DbalLogger

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -75,13 +75,14 @@
                         <array>
                             <element key="0"><string>Cache\IntegrationTests</string></element>
                             <element key="1"><string>Doctrine\Common\Cache</string></element>
-                            <element key="2"><string>Symfony\Component\Cache</string></element>
-                            <element key="3"><string>Symfony\Component\Cache\Tests\Fixtures</string></element>
-                            <element key="4"><string>Symfony\Component\Cache\Tests\Traits</string></element>
-                            <element key="5"><string>Symfony\Component\Cache\Traits</string></element>
-                            <element key="6"><string>Symfony\Component\Console</string></element>
-                            <element key="7"><string>Symfony\Component\HttpFoundation</string></element>
-                            <element key="8"><string>Symfony\Component\Uid</string></element>
+                            <element key="2"><string>Symfony\Bridge\Doctrine\Middleware\Debug</string></element>
+                            <element key="3"><string>Symfony\Component\Cache</string></element>
+                            <element key="4"><string>Symfony\Component\Cache\Tests\Fixtures</string></element>
+                            <element key="5"><string>Symfony\Component\Cache\Tests\Traits</string></element>
+                            <element key="6"><string>Symfony\Component\Cache\Traits</string></element>
+                            <element key="7"><string>Symfony\Component\Console</string></element>
+                            <element key="8"><string>Symfony\Component\HttpFoundation</string></element>
+                            <element key="9"><string>Symfony\Component\Uid</string></element>
                         </array>
                     </element>
                 </array>

--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
@@ -31,17 +32,19 @@ class DoctrineDataCollector extends DataCollector
     private $registry;
     private $connections;
     private $managers;
+    private $debugDataHolder;
 
     /**
      * @var DebugStack[]
      */
     private $loggers = [];
 
-    public function __construct(ManagerRegistry $registry)
+    public function __construct(ManagerRegistry $registry, DebugDataHolder $debugDataHolder = null)
     {
         $this->registry = $registry;
         $this->connections = $registry->getConnectionNames();
         $this->managers = $registry->getManagerNames();
+        $this->debugDataHolder = $debugDataHolder;
     }
 
     /**
@@ -57,21 +60,41 @@ class DoctrineDataCollector extends DataCollector
      */
     public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
-        $queries = [];
-        foreach ($this->loggers as $name => $logger) {
-            $queries[$name] = $this->sanitizeQueries($name, $logger->queries);
-        }
-
         $this->data = [
-            'queries' => $queries,
+            'queries' => $this->collectQueries(),
             'connections' => $this->connections,
             'managers' => $this->managers,
         ];
     }
 
+    private function collectQueries(): array
+    {
+        $queries = [];
+
+        if (null !== $this->debugDataHolder) {
+            foreach ($this->debugDataHolder->getData() as $name => $data) {
+                $queries[$name] = $this->sanitizeQueries($name, $data);
+            }
+
+            return $queries;
+        }
+
+        foreach ($this->loggers as $name => $logger) {
+            $queries[$name] = $this->sanitizeQueries($name, $logger->queries);
+        }
+
+        return $queries;
+    }
+
     public function reset()
     {
         $this->data = [];
+
+        if (null !== $this->debugDataHolder) {
+            $this->debugDataHolder->reset();
+
+            return;
+        }
 
         foreach ($this->loggers as $logger) {
             $logger->queries = [];

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Connection.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Connection.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Middleware\Debug;
+
+use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement as DriverStatement;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ *
+ * @internal
+ */
+final class Connection extends AbstractConnectionMiddleware
+{
+    private $nestingLevel = 0;
+    private $debugDataHolder;
+    private $stopwatch;
+    private $connectionName;
+
+    public function __construct(ConnectionInterface $connection, DebugDataHolder $debugDataHolder, ?Stopwatch $stopwatch, string $connectionName)
+    {
+        parent::__construct($connection);
+
+        $this->debugDataHolder = $debugDataHolder;
+        $this->stopwatch = $stopwatch;
+        $this->connectionName = $connectionName;
+    }
+
+    public function prepare(string $sql): DriverStatement
+    {
+        return new Statement(
+            parent::prepare($sql),
+            $this->debugDataHolder,
+            $this->connectionName,
+            $sql
+        );
+    }
+
+    public function query(string $sql): Result
+    {
+        $this->debugDataHolder->addQuery($this->connectionName, $query = new Query($sql));
+
+        if (null !== $this->stopwatch) {
+            $this->stopwatch->start('doctrine', 'doctrine');
+        }
+
+        $query->start();
+
+        try {
+            $result = parent::query($sql);
+        } finally {
+            $query->stop();
+
+            if (null !== $this->stopwatch) {
+                $this->stopwatch->stop('doctrine');
+            }
+        }
+
+        return $result;
+    }
+
+    public function exec(string $sql): int
+    {
+        $this->debugDataHolder->addQuery($this->connectionName, $query = new Query($sql));
+
+        if (null !== $this->stopwatch) {
+            $this->stopwatch->start('doctrine', 'doctrine');
+        }
+
+        $query->start();
+
+        try {
+            $affectedRows = parent::exec($sql);
+        } finally {
+            $query->stop();
+
+            if (null !== $this->stopwatch) {
+                $this->stopwatch->stop('doctrine');
+            }
+        }
+
+        return $affectedRows;
+    }
+
+    public function beginTransaction(): bool
+    {
+        $query = null;
+        if (1 === ++$this->nestingLevel) {
+            $this->debugDataHolder->addQuery($this->connectionName, $query = new Query('"START TRANSACTION"'));
+        }
+
+        if (null !== $this->stopwatch) {
+            $this->stopwatch->start('doctrine', 'doctrine');
+        }
+
+        if (null !== $query) {
+            $query->start();
+        }
+
+        try {
+            $ret = parent::beginTransaction();
+        } finally {
+            if (null !== $query) {
+                $query->stop();
+            }
+
+            if (null !== $this->stopwatch) {
+                $this->stopwatch->stop('doctrine');
+            }
+        }
+
+        return $ret;
+    }
+
+    public function commit(): bool
+    {
+        $query = null;
+        if (1 === $this->nestingLevel--) {
+            $this->debugDataHolder->addQuery($this->connectionName, $query = new Query('"COMMIT"'));
+        }
+
+        if (null !== $this->stopwatch) {
+            $this->stopwatch->start('doctrine', 'doctrine');
+        }
+
+        if (null !== $query) {
+            $query->start();
+        }
+
+        try {
+            $ret = parent::commit();
+        } finally {
+            if (null !== $query) {
+                $query->stop();
+            }
+
+            if (null !== $this->stopwatch) {
+                $this->stopwatch->stop('doctrine');
+            }
+        }
+
+        return $ret;
+    }
+
+    public function rollBack(): bool
+    {
+        $query = null;
+        if (1 === $this->nestingLevel--) {
+            $this->debugDataHolder->addQuery($this->connectionName, $query = new Query('"ROLLBACK"'));
+        }
+
+        if (null !== $this->stopwatch) {
+            $this->stopwatch->start('doctrine', 'doctrine');
+        }
+
+        if (null !== $query) {
+            $query->start();
+        }
+
+        try {
+            $ret = parent::rollBack();
+        } finally {
+            if (null !== $query) {
+                $query->stop();
+            }
+
+            if (null !== $this->stopwatch) {
+                $this->stopwatch->stop('doctrine');
+            }
+        }
+
+        return $ret;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/DebugDataHolder.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/DebugDataHolder.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Middleware\Debug;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+class DebugDataHolder
+{
+    private $data = [];
+
+    public function addQuery(string $connectionName, Query $query): void
+    {
+        $this->data[$connectionName][] = [
+            'sql' => $query->getSql(),
+            'params' => $query->getParams(),
+            'types' => $query->getTypes(),
+            'executionMS' => [$query, 'getDuration'],  // stop() may not be called at this point
+        ];
+    }
+
+    public function getData(): array
+    {
+        foreach ($this->data as $connectionName => $dataForConn) {
+            foreach ($dataForConn as $idx => $data) {
+                if (\is_callable($data['executionMS'])) {
+                    $this->data[$connectionName][$idx]['executionMS'] = $data['executionMS']();
+                }
+            }
+        }
+
+        return $this->data;
+    }
+
+    public function reset(): void
+    {
+        $this->data = [];
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Driver.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Driver.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Middleware\Debug;
+
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ *
+ * @internal
+ */
+final class Driver extends AbstractDriverMiddleware
+{
+    private $debugDataHolder;
+    private $stopwatch;
+    private $connectionName;
+
+    public function __construct(DriverInterface $driver, DebugDataHolder $debugDataHolder, ?Stopwatch $stopwatch, string $connectionName)
+    {
+        parent::__construct($driver);
+
+        $this->debugDataHolder = $debugDataHolder;
+        $this->stopwatch = $stopwatch;
+        $this->connectionName = $connectionName;
+    }
+
+    public function connect(array $params): Connection
+    {
+        return new Connection(
+            parent::connect($params),
+            $this->debugDataHolder,
+            $this->stopwatch,
+            $this->connectionName
+        );
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Middleware.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Middleware.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Middleware\Debug;
+
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * Middleware to collect debug data.
+ *
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+final class Middleware implements MiddlewareInterface
+{
+    private $debugDataHolder;
+    private $stopwatch;
+    private $connectionName;
+
+    public function __construct(DebugDataHolder $debugDataHolder, ?Stopwatch $stopwatch, string $connectionName = 'default')
+    {
+        $this->debugDataHolder = $debugDataHolder;
+        $this->stopwatch = $stopwatch;
+        $this->connectionName = $connectionName;
+    }
+
+    public function wrap(DriverInterface $driver): DriverInterface
+    {
+        return new Driver($driver, $this->debugDataHolder, $this->stopwatch, $this->connectionName);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Middleware\Debug;
+
+use Doctrine\DBAL\ParameterType;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ *
+ * @internal
+ */
+class Query
+{
+    private $params = [];
+    private $types = [];
+
+    private $start;
+    private $duration;
+
+    private $sql;
+
+    public function __construct(string $sql)
+    {
+        $this->sql = $sql;
+    }
+
+    public function start(): void
+    {
+        $this->start = microtime(true);
+    }
+
+    public function stop(): void
+    {
+        if (null !== $this->start) {
+            $this->duration = microtime(true) - $this->start;
+        }
+    }
+
+    /**
+     * @param string|int                 $param
+     * @param string|int|float|bool|null $variable
+     */
+    public function setParam($param, &$variable, int $type): void
+    {
+        // Numeric indexes start at 0 in profiler
+        $idx = \is_int($param) ? $param - 1 : $param;
+
+        $this->params[$idx] = &$variable;
+        $this->types[$idx] = $type;
+    }
+
+    /**
+     * @param string|int                 $param
+     * @param string|int|float|bool|null $value
+     */
+    public function setValue($param, $value, int $type): void
+    {
+        // Numeric indexes start at 0 in profiler
+        $idx = \is_int($param) ? $param - 1 : $param;
+
+        $this->params[$idx] = $value;
+        $this->types[$idx] = $type;
+    }
+
+    /**
+     * @param array<string|int, string|int|float> $values
+     */
+    public function setValues(array $values): void
+    {
+        foreach ($values as $param => $value) {
+            $this->setValue($param, $value, ParameterType::STRING);
+        }
+    }
+
+    public function getSql(): string
+    {
+        return $this->sql;
+    }
+
+    /**
+     * @return array<int, string|int|float}>
+     */
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    /**
+     * Query duration in seconds.
+     */
+    public function getDuration(): ?float
+    {
+        return $this->duration;
+    }
+
+    public function __clone()
+    {
+        $copy = [];
+        foreach ($this->params as $param => $valueOrVariable) {
+            $copy[$param] = $valueOrVariable;
+        }
+        $this->params = $copy;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Statement.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Statement.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Middleware\Debug;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
+use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use Doctrine\DBAL\ParameterType;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ *
+ * @internal
+ */
+final class Statement extends AbstractStatementMiddleware
+{
+    private $debugDataHolder;
+    private $connectionName;
+    private $query;
+
+    public function __construct(StatementInterface $statement, DebugDataHolder $debugDataHolder, string $connectionName, string $sql)
+    {
+        parent::__construct($statement);
+
+        $this->debugDataHolder = $debugDataHolder;
+        $this->connectionName = $connectionName;
+        $this->query = new Query($sql);
+    }
+
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
+    {
+        $this->query->setParam($param, $variable, $type);
+
+        return parent::bindParam($param, $variable, $type, ...\array_slice(\func_get_args(), 3));
+    }
+
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
+    {
+        $this->query->setValue($param, $value, $type);
+
+        return parent::bindValue($param, $value, $type);
+    }
+
+    public function execute($params = null): ResultInterface
+    {
+        if (null !== $params) {
+            $this->query->setValues($params);
+        }
+
+        // clone to prevent variables by reference to change
+        $this->debugDataHolder->addQuery($this->connectionName, $query = clone $this->query);
+
+        $query->start();
+
+        try {
+            $result = parent::execute($params);
+        } finally {
+            $query->stop();
+        }
+
+        return $result;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTestTrait.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTestTrait.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\DataCollector;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+trait DoctrineDataCollectorTestTrait
+{
+    public function testCollectConnections()
+    {
+        $c = $this->createCollector([]);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEquals(['default' => 'doctrine.dbal.default_connection'], $c->getConnections());
+    }
+
+    public function testCollectManagers()
+    {
+        $c = $this->createCollector([]);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEquals(['default' => 'doctrine.orm.default_entity_manager'], $c->getManagers());
+    }
+
+    public function testCollectQueryCount()
+    {
+        $c = $this->createCollector([]);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEquals(0, $c->getQueryCount());
+
+        $queries = [
+            ['sql' => 'SELECT * FROM table1', 'params' => [], 'types' => [], 'executionMS' => 0],
+        ];
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEquals(1, $c->getQueryCount());
+    }
+
+    public function testCollectTime()
+    {
+        $c = $this->createCollector([]);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEquals(0, $c->getTime());
+
+        $queries = [
+            ['sql' => 'SELECT * FROM table1', 'params' => [], 'types' => [], 'executionMS' => 1],
+        ];
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEquals(1, $c->getTime());
+
+        $queries = [
+            ['sql' => 'SELECT * FROM table1', 'params' => [], 'types' => [], 'executionMS' => 1],
+            ['sql' => 'SELECT * FROM table2', 'params' => [], 'types' => [], 'executionMS' => 2],
+        ];
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+        $this->assertEquals(3, $c->getTime());
+    }
+
+    public function testCollectQueryWithNoTypes()
+    {
+        $queries = [
+            ['sql' => 'SET sql_mode=(SELECT REPLACE(@@sql_mode, \'ONLY_FULL_GROUP_BY\', \'\'))', 'params' => [], 'types' => null, 'executionMS' => 1],
+        ];
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+
+        $collectedQueries = $c->getQueries();
+        $this->assertSame([], $collectedQueries['default'][0]['types']);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\Middleware\Debug;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use Symfony\Bridge\Doctrine\Middleware\Debug\Middleware;
+use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class MiddlewareTest extends TestCase
+{
+    private $debugDataHolder;
+    private $conn;
+    private $stopwatch;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!interface_exists(MiddlewareInterface::class)) {
+            $this->markTestSkipped(sprintf('%s needed to run this test', MiddlewareInterface::class));
+        }
+
+        ClockMock::withClockMock(false);
+    }
+
+    private function init(bool $withStopwatch = true): void
+    {
+        $this->stopwatch = $withStopwatch ? new Stopwatch() : null;
+
+        $configuration = new Configuration();
+        $this->debugDataHolder = new DebugDataHolder();
+        $configuration->setMiddlewares([new Middleware($this->debugDataHolder, $this->stopwatch)]);
+
+        $this->conn = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        ], $configuration);
+
+        $this->conn->executeQuery(<<<EOT
+CREATE TABLE products (
+	id INTEGER PRIMARY KEY,
+	name TEXT NOT NULL,
+	price REAL NOT NULL,
+	stock INTEGER NOT NULL
+);
+EOT
+        );
+    }
+
+    public function provideExecuteMethod(): array
+    {
+        return [
+            'executeStatement' => [
+                static function(object $target, ...$args) {
+                    return $target->executeStatement(...$args);
+                },
+            ],
+            'executeQuery' => [
+                static function(object $target, ...$args): Result {
+                    return $target->executeQuery(...$args);
+                },
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideExecuteMethod
+     */
+    public function testWithoutBinding(callable $executeMethod)
+    {
+        $this->init();
+
+        $executeMethod($this->conn, 'INSERT INTO products(name, price, stock) VALUES ("product1", 12.5, 5)');
+
+        $debug = $this->debugDataHolder->getData()['default'] ?? [];
+        $this->assertCount(2, $debug);
+        $this->assertSame('INSERT INTO products(name, price, stock) VALUES ("product1", 12.5, 5)', $debug[1]['sql']);
+        $this->assertSame([], $debug[1]['params']);
+        $this->assertSame([], $debug[1]['types']);
+        $this->assertGreaterThan(0, $debug[1]['executionMS']);
+    }
+
+    /**
+     * @dataProvider provideExecuteMethod
+     */
+    public function testWithValueBound(callable $executeMethod)
+    {
+        $this->init();
+
+        $stmt = $this->conn->prepare('INSERT INTO products(name, price, stock) VALUES (?, ?, ?)');
+        $stmt->bindValue(1, 'product1');
+        $stmt->bindValue(2, 12.5);
+        $stmt->bindValue(3, 5, ParameterType::INTEGER);
+
+        $executeMethod($stmt);
+
+        $debug = $this->debugDataHolder->getData()['default'] ?? [];
+        $this->assertCount(2, $debug);
+        $this->assertSame('INSERT INTO products(name, price, stock) VALUES (?, ?, ?)', $debug[1]['sql']);
+        $this->assertSame(['product1', 12.5, 5], $debug[1]['params']);
+        $this->assertSame([ParameterType::STRING, ParameterType::STRING, ParameterType::INTEGER], $debug[1]['types']);
+        $this->assertGreaterThan(0, $debug[1]['executionMS']);
+    }
+
+    /**
+     * @dataProvider provideExecuteMethod
+     */
+    public function testWithParamBound(callable $executeMethod)
+    {
+        $this->init();
+
+        $product = 'product1';
+        $price = 12.5;
+        $stock = 5;
+
+        $stmt = $this->conn->prepare('INSERT INTO products(name, price, stock) VALUES (?, ?, ?)');
+        $stmt->bindParam(1, $product);
+        $stmt->bindParam(2, $price);
+        $stmt->bindParam(3, $stock, ParameterType::INTEGER);
+
+        $executeMethod($stmt);
+
+        // Debug data should not be affected by these changes
+        $product = 'product2';
+        $price = 13.5;
+        $stock = 4;
+
+        $debug = $this->debugDataHolder->getData()['default'] ?? [];
+        $this->assertCount(2, $debug);
+        $this->assertSame('INSERT INTO products(name, price, stock) VALUES (?, ?, ?)', $debug[1]['sql']);
+        $this->assertSame(['product1', '12.5', 5], $debug[1]['params']);
+        $this->assertSame([ParameterType::STRING, ParameterType::STRING, ParameterType::INTEGER], $debug[1]['types']);
+        $this->assertGreaterThan(0, $debug[1]['executionMS']);
+    }
+
+    public function provideEndTransactionMethod(): array
+    {
+        return [
+            'commit' => [
+                static function(Connection $conn): bool {
+                    return $conn->commit();
+                },
+                '"COMMIT"',
+            ],
+            'rollback' => [
+                static function(Connection $conn): bool {
+                    return $conn->rollBack();
+                },
+                '"ROLLBACK"',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideEndTransactionMethod
+     */
+    public function testTransaction(callable $endTransactionMethod, string $expectedEndTransactionDebug)
+    {
+        $this->init();
+
+        $this->conn->beginTransaction();
+        $this->conn->beginTransaction();
+        $this->conn->executeStatement('INSERT INTO products(name, price, stock) VALUES ("product1", 12.5, 5)');
+        $endTransactionMethod($this->conn);
+        $endTransactionMethod($this->conn);
+        $this->conn->beginTransaction();
+        $this->conn->executeStatement('INSERT INTO products(name, price, stock) VALUES ("product2", 15.5, 12)');
+        $endTransactionMethod($this->conn);
+
+        $debug = $this->debugDataHolder->getData()['default'] ?? [];
+        $this->assertCount(7, $debug);
+        $this->assertSame('"START TRANSACTION"', $debug[1]['sql']);
+        $this->assertGreaterThan(0, $debug[1]['executionMS']);
+        $this->assertSame('INSERT INTO products(name, price, stock) VALUES ("product1", 12.5, 5)', $debug[2]['sql']);
+        $this->assertGreaterThan(0, $debug[2]['executionMS']);
+        $this->assertSame($expectedEndTransactionDebug, $debug[3]['sql']);
+        $this->assertGreaterThan(0, $debug[3]['executionMS']);
+        $this->assertSame('"START TRANSACTION"', $debug[4]['sql']);
+        $this->assertGreaterThan(0, $debug[4]['executionMS']);
+        $this->assertSame('INSERT INTO products(name, price, stock) VALUES ("product2", 15.5, 12)', $debug[5]['sql']);
+        $this->assertGreaterThan(0, $debug[5]['executionMS']);
+        $this->assertSame($expectedEndTransactionDebug, $debug[6]['sql']);
+        $this->assertGreaterThan(0, $debug[6]['executionMS']);
+    }
+
+    public function provideExecuteAndEndTransactionMethods(): array
+    {
+        return [
+            'commit and exec' => [
+                static function(Connection $conn, string $sql) {
+                    return $conn->executeStatement($sql);
+                },
+                static function(Connection $conn): bool {
+                    return $conn->commit();
+                },
+            ],
+            'rollback and query' => [
+                static function(Connection $conn, string $sql): Result {
+                    return $conn->executeQuery($sql);
+                },
+                static function(Connection $conn): bool {
+                    return $conn->rollBack();
+                },
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideExecuteAndEndTransactionMethods
+     */
+    public function testGlobalDoctrineDuration(callable $sqlMethod, callable $endTransactionMethod)
+    {
+        $this->init();
+
+        $periods = $this->stopwatch->getEvent('doctrine')->getPeriods();
+        $this->assertCount(1, $periods);
+
+        $this->conn->beginTransaction();
+
+        $this->assertFalse($this->stopwatch->getEvent('doctrine')->isStarted());
+        $this->assertCount(2, $this->stopwatch->getEvent('doctrine')->getPeriods());
+
+        $sqlMethod($this->conn, 'SELECT * FROM products');
+
+        $this->assertFalse($this->stopwatch->getEvent('doctrine')->isStarted());
+        $this->assertCount(3, $this->stopwatch->getEvent('doctrine')->getPeriods());
+
+        $endTransactionMethod($this->conn);
+
+        $this->assertFalse($this->stopwatch->getEvent('doctrine')->isStarted());
+        $this->assertCount(4, $this->stopwatch->getEvent('doctrine')->getPeriods());
+    }
+
+    /**
+     * @dataProvider provideExecuteAndEndTransactionMethods
+     */
+    public function testWithoutStopwatch(callable $sqlMethod, callable $endTransactionMethod)
+    {
+        $this->init(false);
+
+        $this->conn->beginTransaction();
+        $sqlMethod($this->conn, 'SELECT * FROM products');
+        $endTransactionMethod($this->conn);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -34,6 +34,7 @@
         "symfony/http-kernel": "^5.0|^6.0",
         "symfony/messenger": "^4.4|^5.0|^6.0",
         "symfony/doctrine-messenger": "^5.1|^6.0",
+        "symfony/phpunit-bridge": "^4.4|^5.4|^6.0",
         "symfony/property-access": "^4.4|^5.0|^6.0",
         "symfony/property-info": "^5.0|^6.0",
         "symfony/proxy-manager-bridge": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Bridge/Doctrine/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Doctrine/phpunit.xml.dist
@@ -28,4 +28,14 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+            <arguments>
+                <array>
+                    <element key="time-sensitive"><string>Symfony\Bridge\Doctrine\Middleware\Debug</string></element>
+                </array>
+            </arguments>
+        </listener>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  Step toward the fix of doctrine/DoctrineBundle#1431  (mentioned too in #44313 and #44495) 
| License       | MIT
| Doc PR        | 

The SqlLogger that is used in doctrine bridge and doctrine bundle has been deprecated and replaced by a system of Middleware.

A work has started on Doctrine bundle with doctrine/DoctrineBundle#1456 and doctrine/DoctrineBundle#1472

This PR suggest to add a middleware thats covers what was previously done by `DbalLogger` and `DebugStack`.

Another PR will follow in DoctrineBundle for the integration.