### PR TITLE
[VarDumper] Fix dumping mysqli_driver instances

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/MysqliCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/MysqliCaster.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+final class MysqliCaster
+{
+    public static function castMysqliDriver(\mysqli_driver $c, array $a, Stub $stub, bool $isNested): array
+    {
+        foreach ($a as $k => $v) {
+            if (isset($c->$k)) {
+                $a[$k] = $c->$k;
+            }
+        }
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -144,6 +144,8 @@ abstract class AbstractCloner implements ClonerInterface
         'Ds\Pair' => ['Symfony\Component\VarDumper\Caster\DsCaster', 'castPair'],
         'Symfony\Component\VarDumper\Caster\DsPairStub' => ['Symfony\Component\VarDumper\Caster\DsCaster', 'castPairStub'],
 
+        'mysqli_driver' => ['Symfony\Component\VarDumper\Caster\MysqliCaster', 'castMysqliDriver'],
+
         'CurlHandle' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castCurl'],
         ':curl' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castCurl'],
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/MysqliCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/MysqliCasterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+/**
+ * @requires extension mysqli
+ * @group integration
+ */
+class MysqliCasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    public function testNotConnected()
+    {
+        $driver = new \mysqli_driver();
+        $driver->report_mode = 3;
+
+        $xCast = <<<EODUMP
+mysqli_driver {%A
+  +reconnect: false
+  +report_mode: 3
+}
+EODUMP;
+
+        $this->assertDumpMatchesFormat($xCast, $driver);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45487
| License       | MIT
| Doc PR        | -

See linked issue and https://www.php.net/manual/en/class.mysqli-driver.php