### PR TITLE
[DependencyInjection] Allow using expressions as service factories

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -15,6 +15,11 @@ Console
  * Add argument `$suggestedValues` to `Command::addArgument` and `Command::addOption`
  * Add argument `$suggestedValues` to `InputArgument` and `InputOption` constructors
 
+DependencyInjection
+-------------------
+
+ * Deprecate `ReferenceSetArgumentTrait`
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/DependencyInjection/Argument/IteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/IteratorArgument.php
@@ -18,5 +18,20 @@ namespace Symfony\Component\DependencyInjection\Argument;
  */
 class IteratorArgument implements ArgumentInterface
 {
-    use ReferenceSetArgumentTrait;
+    private array $values;
+
+    public function __construct(array $values)
+    {
+        $this->setValues($values);
+    }
+
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
+    public function setValues(array $values)
+    {
+        $this->values = $values;
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Argument/ReferenceSetArgumentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ReferenceSetArgumentTrait.php
@@ -11,12 +11,16 @@
 
 namespace Symfony\Component\DependencyInjection\Argument;
 
+trigger_deprecation('symfony/dependency-injection', '6.1', '"%s" is deprecated.', ReferenceSetArgumentTrait::class);
+
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated since Symfony 6.1
  */
 trait ReferenceSetArgumentTrait
 {

--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceClosureArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceClosureArgument.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Argument;
 
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Represents a service wrapped in a memoizing closure.
@@ -23,9 +22,9 @@ class ServiceClosureArgument implements ArgumentInterface
 {
     private array $values;
 
-    public function __construct(Reference $reference)
+    public function __construct(mixed $value)
     {
-        $this->values = [$reference];
+        $this->values = [$value];
     }
 
     /**
@@ -41,8 +40,8 @@ class ServiceClosureArgument implements ArgumentInterface
      */
     public function setValues(array $values)
     {
-        if ([0] !== array_keys($values) || !($values[0] instanceof Reference || null === $values[0])) {
-            throw new InvalidArgumentException('A ServiceClosureArgument must hold one and only one Reference.');
+        if ([0] !== array_keys($values)) {
+            throw new InvalidArgumentException('A ServiceClosureArgument must hold one and only one value.');
         }
 
         $this->values = $values;

--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceLocator.php
@@ -37,7 +37,11 @@ class ServiceLocator extends BaseServiceLocator
      */
     public function get(string $id): mixed
     {
-        return isset($this->serviceMap[$id]) ? ($this->factory)(...$this->serviceMap[$id]) : parent::get($id);
+        return match (\count($this->serviceMap[$id] ?? [])) {
+            0 => parent::get($id),
+            1 => $this->serviceMap[$id][0],
+            default => ($this->factory)(...$this->serviceMap[$id]),
+        };
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Argument;
 
-use Symfony\Component\DependencyInjection\Reference;
-
 /**
  * Represents a closure acting as a service locator.
  *
@@ -20,25 +18,31 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ServiceLocatorArgument implements ArgumentInterface
 {
-    use ReferenceSetArgumentTrait;
-
+    private array $values;
     private ?TaggedIteratorArgument $taggedIteratorArgument = null;
 
-    /**
-     * @param Reference[]|TaggedIteratorArgument $values
-     */
     public function __construct(array|TaggedIteratorArgument $values = [])
     {
         if ($values instanceof TaggedIteratorArgument) {
             $this->taggedIteratorArgument = $values;
-            $this->values = [];
-        } else {
-            $this->setValues($values);
+            $values = [];
         }
+
+        $this->setValues($values);
     }
 
     public function getTaggedIteratorArgument(): ?TaggedIteratorArgument
     {
         return $this->taggedIteratorArgument;
+    }
+
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
+    public function setValues(array $values)
+    {
+        $this->values = $values;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * Add `$exclude` to `tagged_iterator` and `tagged_locator` configurator
  * Add an `env` function to the expression language provider
  * Add an `Autowire` attribute to tell a parameter how to be autowired
+ * Allow using expressions as service factories
+ * Deprecate `ReferenceSetArgumentTrait`
 
 6.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -84,7 +84,7 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
         } elseif ($value instanceof ArgumentInterface) {
             $value->setValues($this->processValue($value->getValues()));
         } elseif ($value instanceof Expression && $this->processExpressions) {
-            $this->getExpressionLanguage()->compile((string) $value, ['this' => 'container']);
+            $this->getExpressionLanguage()->compile((string) $value, ['this' => 'container', 'args' => 'args']);
         } elseif ($value instanceof Definition) {
             $value->setArguments($this->processValue($value->getArguments()));
             $value->setProperties($this->processValue($value->getProperties()));
@@ -92,7 +92,16 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
 
             $changes = $value->getChanges();
             if (isset($changes['factory'])) {
-                $value->setFactory($this->processValue($value->getFactory()));
+                if (\is_string($factory = $value->getFactory()) && str_starts_with($factory, '@=')) {
+                    if (!class_exists(Expression::class)) {
+                        throw new LogicException('Expressions cannot be used in service factories without the ExpressionLanguage component. Try running "composer require symfony/expression-language".');
+                    }
+                    $factory = new Expression(substr($factory, 2));
+                }
+                if (($factory = $this->processValue($factory)) instanceof Expression) {
+                    $factory = '@='.$factory;
+                }
+                $value->setFactory($factory);
             }
             if (isset($changes['configurator'])) {
                 $value->setConfigurator($this->processValue($value->getConfigurator()));
@@ -112,6 +121,10 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
         }
 
         if (\is_string($factory = $definition->getFactory())) {
+            if (str_starts_with($factory, '@=')) {
+                return new \ReflectionFunction(static function (...$args) {});
+            }
+
             if (!\function_exists($factory)) {
                 throw new RuntimeException(sprintf('Invalid service "%s": function "%s" does not exist.', $this->currentId, $factory));
             }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -16,7 +16,9 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * Run this pass before passes that need to know more about the relation of
@@ -135,8 +137,16 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
 
         $byFactory = $this->byFactory;
         $this->byFactory = true;
-        $this->processValue($value->getFactory());
+        if (\is_string($factory = $value->getFactory()) && str_starts_with($factory, '@=')) {
+            if (!class_exists(Expression::class)) {
+                throw new LogicException('Expressions cannot be used in service factories without the ExpressionLanguage component. Try running "composer require symfony/expression-language".');
+            }
+
+            $factory = new Expression(substr($factory, 2));
+        }
+        $this->processValue($factory);
         $this->byFactory = $byFactory;
+
         $this->processValue($value->getArguments());
 
         $properties = $value->getProperties();

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1008,15 +1008,22 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             require_once $parameterBag->resolveValue($definition->getFile());
         }
 
-        $arguments = $this->doResolveServices($parameterBag->unescapeValue($parameterBag->resolveValue($definition->getArguments())), $inlineServices, $isConstructorArgument);
+        $arguments = $definition->getArguments();
 
         if (null !== $factory = $definition->getFactory()) {
             if (\is_array($factory)) {
                 $factory = [$this->doResolveServices($parameterBag->resolveValue($factory[0]), $inlineServices, $isConstructorArgument), $factory[1]];
             } elseif (!\is_string($factory)) {
                 throw new RuntimeException(sprintf('Cannot create service "%s" because of invalid factory.', $id));
+            } elseif (str_starts_with($factory, '@=')) {
+                $factory = function (ServiceLocator $arguments) use ($factory) {
+                    return $this->getExpressionLanguage()->evaluate(substr($factory, 2), ['container' => $this, 'args' => $arguments]);
+                };
+                $arguments = [new ServiceLocatorArgument($arguments)];
             }
         }
+
+        $arguments = $this->doResolveServices($parameterBag->unescapeValue($parameterBag->resolveValue($arguments)), $inlineServices, $isConstructorArgument);
 
         if (null !== $id && $definition->isShared() && isset($this->services[$id]) && ($tryProxy || !$definition->isLazy())) {
             return $this->services[$id];
@@ -1149,10 +1156,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         } elseif ($value instanceof ServiceLocatorArgument) {
             $refs = $types = [];
             foreach ($value->getValues() as $k => $v) {
-                if ($v) {
-                    $refs[$k] = [$v];
-                    $types[$k] = $v instanceof TypedReference ? $v->getType() : '?';
-                }
+                $refs[$k] = [$v, null];
+                $types[$k] = $v instanceof TypedReference ? $v->getType() : '?';
             }
             $value = new ServiceLocator($this->resolveServices(...), $refs, $types);
         } elseif ($value instanceof Reference) {
@@ -1583,8 +1588,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     private function getExpressionLanguage(): ExpressionLanguage
     {
         if (!isset($this->expressionLanguage)) {
-            if (!class_exists(\Symfony\Component\ExpressionLanguage\ExpressionLanguage::class)) {
-                throw new LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+            if (!class_exists(Expression::class)) {
+                throw new LogicException('Expressions cannot be used without the ExpressionLanguage component. Try running "composer require symfony/expression-language".');
             }
             $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders, null, $this->getEnv(...));
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -293,6 +293,9 @@ class XmlDumper extends Dumper
             } elseif ($value instanceof ServiceLocatorArgument) {
                 $element->setAttribute('type', 'service_locator');
                 $this->convertParameters($value->getValues(), $type, $element, 'key');
+            } elseif ($value instanceof ServiceClosureArgument && !$value->getValues()[0] instanceof Reference) {
+                $element->setAttribute('type', 'service_closure');
+                $this->convertParameters($value->getValues(), $type, $element, 'key');
             } elseif ($value instanceof Reference || $value instanceof ServiceClosureArgument) {
                 $element->setAttribute('type', 'service');
                 if ($value instanceof ServiceClosureArgument) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -245,7 +245,7 @@ class YamlDumper extends Dumper
         if ($value instanceof ServiceClosureArgument) {
             $value = $value->getValues()[0];
 
-            return new TaggedValue('service_closure', $this->getServiceCall((string) $value, $value));
+            return new TaggedValue('service_closure', $this->dumpValue($value));
         }
         if ($value instanceof ArgumentInterface) {
             $tag = $value;

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
@@ -60,6 +60,12 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
 
                 return ($this->getEnv)($value);
             }),
+
+            new ExpressionFunction('arg', function ($arg) {
+                return sprintf('$args?->get(%s)', $arg);
+            }, function (array $variables, $value) {
+                return $variables['args']?->get($value);
+            }),
         ];
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator\Traits;
 
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 trait FactoryTrait
 {
@@ -21,12 +22,16 @@ trait FactoryTrait
      *
      * @return $this
      */
-    final public function factory(string|array|ReferenceConfigurator $factory): static
+    final public function factory(string|array|ReferenceConfigurator|Expression $factory): static
     {
         if (\is_string($factory) && 1 === substr_count($factory, ':')) {
             $factoryParts = explode(':', $factory);
 
             throw new InvalidArgumentException(sprintf('Invalid factory "%s": the "service:method" notation is not available when using PHP-based DI configuration. Use "[service(\'%s\'), \'%s\']" instead.', $factory, $factoryParts[0], $factoryParts[1]));
+        }
+
+        if ($factory instanceof Expression) {
+            $factory = '@='.$factory;
         }
 
         $this->definition->setFactory(static::processValue($factory, true));

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -115,6 +115,17 @@
     <xsd:attribute name="function" type="xsd:string" />
   </xsd:complexType>
 
+  <xsd:complexType name="factory">
+    <xsd:choice minOccurs="0" maxOccurs="1">
+      <xsd:element name="service" type="service" minOccurs="0" maxOccurs="1" />
+    </xsd:choice>
+    <xsd:attribute name="service" type="xsd:string" />
+    <xsd:attribute name="class" type="xsd:string" />
+    <xsd:attribute name="method" type="xsd:string" />
+    <xsd:attribute name="function" type="xsd:string" />
+    <xsd:attribute name="expression" type="xsd:string" />
+  </xsd:complexType>
+
   <xsd:complexType name="defaults">
     <xsd:annotation>
       <xsd:documentation><![CDATA[
@@ -135,7 +146,7 @@
       <xsd:element name="file" type="xsd:string" minOccurs="0" maxOccurs="1" />
       <xsd:element name="argument" type="argument" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="configurator" type="callable" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="factory" type="callable" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="factory" type="factory" minOccurs="0" maxOccurs="1" />
       <xsd:element name="deprecated" type="deprecated" minOccurs="0" maxOccurs="1" />
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
@@ -179,7 +190,7 @@
     <xsd:choice maxOccurs="unbounded">
       <xsd:element name="argument" type="argument" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="configurator" type="callable" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="factory" type="callable" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="factory" type="factory" minOccurs="0" maxOccurs="1" />
       <xsd:element name="deprecated" type="deprecated" minOccurs="0" maxOccurs="1" />
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />

--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class ServiceLocator implements ServiceProviderInterface
+class ServiceLocator implements ServiceProviderInterface, \Countable
 {
     use ServiceLocatorTrait {
         get as private doGet;
@@ -74,6 +74,11 @@ class ServiceLocator implements ServiceProviderInterface
         $locator->container = $container;
 
         return $locator;
+    }
+
+    public function count(): int
+    {
+        return \count($this->getProvidedServices());
     }
 
     private function createNotFoundException(string $id): NotFoundExceptionInterface

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -42,10 +42,8 @@ class ServiceLocatorTagPassTest extends TestCase
         (new ServiceLocatorTagPass())->process($container);
     }
 
-    public function testInvalidServices()
+    public function testScalarServices()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid definition for service "foo": an array of references is expected as first argument when the "container.service_locator" tag is set, "string" found for key "0".');
         $container = new ContainerBuilder();
 
         $container->register('foo', ServiceLocator::class)
@@ -56,6 +54,8 @@ class ServiceLocatorTagPassTest extends TestCase
         ;
 
         (new ServiceLocatorTagPass())->process($container);
+
+        $this->assertSame('dummy', $container->get('foo')->get(0));
     }
 
     public function testProcessValue()

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1723,6 +1723,25 @@ class ContainerBuilderTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testExpressionInFactory()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo', 'stdClass')
+            ->setPublic(true)
+            ->setProperty('bar', new Reference('bar'))
+        ;
+        $container
+            ->register('bar', 'string')
+            ->setFactory('@=arg(0) + args.get(0) + args.count()')
+            ->addArgument(123)
+        ;
+
+        $container->compile();
+
+        $this->assertSame(247, $container->get('foo')->bar);
+    }
+
     public function testFindTags()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1510,6 +1510,30 @@ PHP
 
         $this->addToAssertionCount(1);
     }
+
+    public function testExpressionInFactory()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo', 'stdClass')
+            ->setPublic(true)
+            ->setProperty('bar', new Reference('bar'))
+        ;
+        $container
+            ->register('bar', 'string')
+            ->setFactory('@=arg(0) + args.get(0) + args.count()')
+            ->addArgument(123)
+        ;
+
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Expression_In_Factory']));
+
+        $container = new \Symfony_DI_PhpDumper_Test_Expression_In_Factory();
+
+        $this->assertSame(247, $container->get('foo')->bar);
+    }
 }
 
 class Rot13EnvVarProcessor implements EnvVarProcessorInterface

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/expression_factory.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/expression_factory.expected.yml
@@ -1,0 +1,13 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo:
+        class: Bar\FooClass
+        public: true
+    bar:
+        class: Bar\FooClass
+        public: true
+        factory: '@=service("foo").getInstance()'

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/expression_factory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/expression_factory.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $c) {
+    $s = $c->services()->defaults()->public();
+
+    $s->set('foo', 'Bar\FooClass');
+    $s->set('bar', 'Bar\FooClass')->factory(expr('service("foo").getInstance()'));
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -63,6 +63,9 @@
     <service id="new_factory5" class="FooBarClass">
       <factory service="baz" />
     </service>
+    <service id="factory_expression" class="FooClass">
+      <factory expression="service('foo').getInstance()" />
+    </service>
     <service id="alias_for_foo" alias="foo" />
     <service id="another_alias_for_foo" alias="foo" public="true"/>
     <service id="0" class="FooClass" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -40,6 +40,9 @@ services:
     new_factory3: { class: FooBarClass, factory: [BazClass, getInstance]}
     new_factory4: { class: BazClass, factory: [~, getInstance]}
     new_factory5: { class: FooBarClass, factory: '@baz' }
+    factory_expression:
+        class: FooClass
+        factory: "@=service('foo').getInstance()"
     Acme\WithShortCutArgs: [foo, '@baz']
     alias_for_foo: '@foo'
     another_alias_for_foo:

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -97,6 +97,7 @@ class PhpFileLoaderTest extends TestCase
         yield ['inline_binding'];
         yield ['remove'];
         yield ['config_builder'];
+        yield ['expression_factory'];
     }
 
     public function testAutoConfigureAndChildDefinition()

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -142,14 +142,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         [$bindingValue, $bindingId, , $bindingType, $bindingFile] = $binding->getValues();
                         $binding->setValues([$bindingValue, $bindingId, true, $bindingType, $bindingFile]);
 
-                        if (!$bindingValue instanceof Reference) {
-                            $args[$p->name] = new Reference('.value.'.$container->hash($bindingValue));
-                            $container->register((string) $args[$p->name], 'mixed')
-                                ->setFactory('current')
-                                ->addArgument([$bindingValue]);
-                        } else {
-                            $args[$p->name] = $bindingValue;
-                        }
+                        $args[$p->name] = $bindingValue;
 
                         continue;
                     } elseif (!$autowire || (!($autowireAttributes ??= $p->getAttributes(Autowire::class)) && (!$type || '\\' !== $target[0]))) {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -28,7 +28,7 @@
         "symfony/config": "^5.4|^6.0",
         "symfony/console": "^5.4|^6.0",
         "symfony/css-selector": "^5.4|^6.0",
-        "symfony/dependency-injection": "^5.4|^6.0",
+        "symfony/dependency-injection": "^6.1",
         "symfony/dom-crawler": "^5.4|^6.0",
         "symfony/expression-language": "^5.4|^6.0",
         "symfony/finder": "^5.4|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Replaces #45447

This PR allows using expressions as service factories:
- in YAML: `factory: '@=service("foo").bar()'`
- in PHP:  `->factory(expr('service("foo").bar()'))`
- in XML: `<factory expression="service('foo').bar()" />`

In addition, it allows the corresponding expressions to get access to the arguments of the service definition using the `arg($index)` function and `args` variable inside expressions:
```yaml
services:
  foo:
    factory: '@=arg(0).baz()' # works also: @=args.get(0).baz()
    arguments: ['@bar']
```

Internally, instead of allowing `Expression` objects in `Definition` objects as in #45447, factory expressions are conveyed as a strings that starts with `@=`. This is chosen by taking inspiration from yaml and to not collide with any existing callable.