### PR TITLE
[BrowserKit] Add `toArray` to `Response`

### DIFF
--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add `toArray` method to `Response`
+
 5.3
 ---
 

--- a/src/Symfony/Component/BrowserKit/Exception/JsonException.php
+++ b/src/Symfony/Component/BrowserKit/Exception/JsonException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\BrowserKit\Exception;
+
+class JsonException extends \JsonException
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

Adds a `toArray` method to BrowserKit's `Response` similar to the one in HttpClient. Is useful when working with json responses.