### PR TITLE
[DependencyInjection] Clarify that using expressions in parameters is not allowed

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -34,6 +36,10 @@ class ParametersConfigurator extends AbstractConfigurator
      */
     final public function set(string $name, $value): self
     {
+        if ($value instanceof Expression) {
+            throw new InvalidArgumentException(sprintf('Using an expression in parameter "%s" is not allowed.', $name));
+        }
+
         $this->container->setParameter($name, static::processValue($value, true));
 
         return $this;

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -822,6 +822,10 @@ class YamlFileLoader extends FileLoader
                 $value[$k] = $this->resolveServices($v, $file, $isParameter);
             }
         } elseif (\is_string($value) && str_starts_with($value, '@=')) {
+            if ($isParameter) {
+                throw new InvalidArgumentException(sprintf('Using expressions in parameters is not allowed in "%s".', $file));
+            }
+
             if (!class_exists(Expression::class)) {
                 throw new \LogicException('The "@=" expression syntax cannot be used without the ExpressionLanguage component. Try running "composer require symfony/expression-language".');
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33603
| License       | MIT
| Doc PR        | -

This already fails, but in an uncontrolled way (for xml, the xsd already forbids it.)