### PR TITLE
[HttpClient] Fix overriding default options with null

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -187,11 +187,7 @@ trait HttpClientTrait
         // Option "query" is never inherited from defaults
         $options['query'] = $options['query'] ?? [];
 
-        foreach ($defaultOptions as $k => $v) {
-            if ('normalized_headers' !== $k && !isset($options[$k])) {
-                $options[$k] = $v;
-            }
-        }
+        $options += $defaultOptions;
 
         if (isset($defaultOptions['extra'])) {
             $options['extra'] += $defaultOptions['extra'];

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpClient\Tests;
 use Symfony\Component\HttpClient\Chunk\DataChunk;
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\NativeHttpClient;
@@ -148,6 +149,15 @@ class MockHttpClientTest extends HttpClientTestCase
         $this->assertInstanceOf(ErrorChunk::class, $chunks[2]);
         $this->assertSame(3, $chunks[2]->getOffset());
         $this->assertSame('bar ccc', $chunks[2]->getError());
+    }
+
+    public function testMergeDefaultOptions()
+    {
+        $mockHttpClient = new MockHttpClient(null, 'https://example.com');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid URL: scheme is missing');
+        $mockHttpClient->request('GET', '/foo', ['base_uri' => null]);
     }
 
     protected function getHttpClient(string $testCase): HttpClientInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45355
| License       | MIT
| Doc PR        | -