### PR TITLE
[DependencyInjection] Don't reset env placeholders during compilation

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -79,10 +79,6 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
                     $container->getParameterBag()->mergeEnvPlaceholders($resolvingBag);
                 }
 
-                if ($configAvailable) {
-                    BaseNode::resetPlaceholders();
-                }
-
                 throw $e;
             }
 
@@ -93,10 +89,6 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
 
             $container->merge($tmpContainer);
             $container->getParameterBag()->add($parameters);
-        }
-
-        if ($configAvailable) {
-            BaseNode::resetPlaceholders();
         }
 
         $container->addDefinitions($definitions);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36466
| License       | MIT
| Doc PR        | -

Resetting causes placeholders to be lost when the env-var-in-config is used by several bundles (from linked issue.)