### PR TITLE
fixed bug with return-path

### DIFF
--- a/src/Symfony/Component/Mailer/DelayedEnvelope.php
+++ b/src/Symfony/Component/Mailer/DelayedEnvelope.php
@@ -83,14 +83,14 @@ final class DelayedEnvelope extends Envelope
 
     private static function getSenderFromHeaders(Headers $headers): Address
     {
+        if ($return = $headers->get('Return-Path')) {
+            return $return->getAddress();
+        }
         if ($sender = $headers->get('Sender')) {
             return $sender->getAddress();
         }
         if ($from = $headers->get('From')) {
             return $from->getAddresses()[0];
-        }
-        if ($return = $headers->get('Return-Path')) {
-            return $return->getAddress();
         }
 
         throw new LogicException('Unable to determine the sender of the message.');


### PR DESCRIPTION
mailer info was ignoring return-path setting more info here https://github.com/symfony/symfony/issues/41322

| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41322
| License       | MIT
| Doc PR        | symfony/symfony-docs#

