### PR TITLE
[Serializer] Fixed framework.serializer.default_context is not working for JsonEncoder

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
@@ -23,10 +23,10 @@ class JsonEncoder implements EncoderInterface, DecoderInterface
     protected $encodingImpl;
     protected $decodingImpl;
 
-    public function __construct(JsonEncode $encodingImpl = null, JsonDecode $decodingImpl = null)
+    public function __construct(JsonEncode $encodingImpl = null, JsonDecode $decodingImpl = null, array $defaultContext = [])
     {
-        $this->encodingImpl = $encodingImpl ?? new JsonEncode();
-        $this->decodingImpl = $decodingImpl ?? new JsonDecode([JsonDecode::ASSOCIATIVE => true]);
+        $this->encodingImpl = $encodingImpl ?? new JsonEncode($defaultContext);
+        $this->decodingImpl = $decodingImpl ?? new JsonDecode(array_merge([JsonDecode::ASSOCIATIVE => true], $defaultContext));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
@@ -66,6 +66,22 @@ class JsonEncoderTest extends TestCase
         $this->assertEquals($expected, $this->serializer->serialize($arr, 'json'), 'Context should not be persistent');
     }
 
+    public function testWithDefaultContext()
+    {
+        $defaultContext = [
+            'json_encode_options' => \JSON_UNESCAPED_UNICODE,
+            'json_decode_associative' => false,
+        ];
+
+        $encoder = new JsonEncoder(null, null, $defaultContext);
+
+        $data = new \stdClass();
+        $data->msg = '你好';
+
+        $this->assertEquals('{"msg":"你好"}', $json = $encoder->encode($data, 'json'));
+        $this->assertEquals($data, $encoder->decode($json, 'json'));
+    }
+
     public function testEncodeNotUtf8WithoutPartialOnError()
     {
         $this->expectException(UnexpectedValueException::class);


### PR DESCRIPTION
Fixed `framework.serializer.default_context` is not working for `JsonEncoder`

like `XmlEncoder` or `DateTimeNormalizer`, the `array $defaultContext` argument bindings from `SerializerPass`, but not working for `JsonEncoder`, I added `array $defaultContext` argument and passed to `JsonEncode` and `JsonDecode`.

https://github.com/symfony/serializer/blob/5.4/DependencyInjection/SerializerPass.php#L69-L75

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
