### PR TITLE
[symfony/mailjet-mailer] Fix invalid mailjet error managment

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -69,13 +69,15 @@ class MailjetApiTransport extends AbstractApiTransport
             $statusCode = $response->getStatusCode();
             $result = $response->toArray(false);
         } catch (DecodingExceptionInterface $e) {
-            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).sprintf(' (code %d).', $statusCode), $response);
+            throw new HttpTransportException(sprintf('Unable to send an email: "%s" (code %d).', $response->getContent(false), $statusCode), $response);
         } catch (TransportExceptionInterface $e) {
             throw new HttpTransportException('Could not reach the remote Mailjet server.', $response, 0, $e);
         }
 
         if (200 !== $statusCode) {
-            throw new HttpTransportException('Unable to send an email: '.$result['Message'].sprintf(' (code %d).', $statusCode), $response);
+            $errorDetails = $result['Messages'][0]['Errors'][0]['ErrorMessage'] ?? $response->getContent(false);
+
+            throw new HttpTransportException(sprintf('Unable to send an email: "%s" (code %d).', $errorDetails, $statusCode), $response);
         }
 
         // The response needs to contains a 'Messages' key that is an array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45420 
| License       | MIT
| Doc PR        |

When mailjet API status code is not 200, response [is structured](https://dev.mailjet.com/email/guides/send-api-v31/) (see-below) and is not currently well managed.

Example of bad request response:

```JSON
{
  "Messages": [
    {
      "Status": "error",
      "Errors": [
        {
          "ErrorIdentifier": "8e28ac9c-1fd7-41ad-825f-1d60bc459189",
          "ErrorCode": "mj-0005",
          "StatusCode": 400,
          "ErrorMessage": "The To is mandatory but missing from the input",
          "ErrorRelatedTo": ["To"]
        }
      ]
    }
  ]
}
```

This PR fix `Undefined index: Message` and add unit tests. 