### PR TITLE
[HttpClient] Handle requests with null body

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 trait HttpClientTrait
 {
     private static $CHUNK_SIZE = 16372;
+    private static $emptyDefaults;
 
     /**
      * Validates and normalizes method, URL and options, and merges them with defaults.
@@ -37,6 +38,16 @@ trait HttpClientTrait
             }
             if (!$method) {
                 throw new InvalidArgumentException('The HTTP method can not be empty.');
+            }
+        }
+
+        if (null === self::$emptyDefaults) {
+            self::$emptyDefaults = [];
+
+            foreach ($defaultOptions as $k => $v) {
+                if (null !== $v) {
+                    self::$emptyDefaults[$k] = $v;
+                }
             }
         }
 
@@ -189,6 +200,16 @@ trait HttpClientTrait
 
         $options += $defaultOptions;
 
+        if (null === self::$emptyDefaults) {
+            self::$emptyDefaults = [];
+        }
+
+        foreach (self::$emptyDefaults as $k => $v) {
+            if (!isset($options[$k])) {
+                $options[$k] = $v;
+            }
+        }
+
         if (isset($defaultOptions['extra'])) {
             $options['extra'] += $defaultOptions['extra'];
         }
@@ -221,9 +242,9 @@ trait HttpClientTrait
 
             $alternatives = [];
 
-            foreach ($defaultOptions as $key => $v) {
-                if (levenshtein($name, $key) <= \strlen($name) / 3 || str_contains($key, $name)) {
-                    $alternatives[] = $key;
+            foreach ($defaultOptions as $k => $v) {
+                if (levenshtein($name, $k) <= \strlen($name) / 3 || str_contains($k, $name)) {
+                    $alternatives[] = $k;
                 }
             }
 

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -148,6 +148,17 @@ class CurlHttpClientTest extends HttpClientTestCase
         self::assertNotSame($initialShareId, $clientState->share);
     }
 
+    public function testNullBody()
+    {
+        $httpClient = $this->getHttpClient(__FUNCTION__);
+
+        $httpClient->request('POST', 'http://localhost:8057/post', [
+            'body' => null,
+        ]);
+
+        $this->expectNotToPerformAssertions();
+    }
+
     public function testProcessAfterReset()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

since #45527 passing null to the `body` parameters leads to an exception (which [breaks async-aws](https://github.com/async-aws/aws/blob/09723ddca29b8d1d522426f81dd422373de1785f/src/Core/src/AbstractApi.php#L157))

> Argument #2 ($body) must be of type Closure, null given, called in /home/runner/work/aws/aws/vendor/symfony/http-client/CurlHttpClient.php on line 221

In curl client: `null` is not a string and `self::readRequestBody` expects a closure.

https://github.com/symfony/symfony/blob/08fa74a16c84895575e305b2a7ee3a03e371f79b/src/Symfony/Component/HttpClient/CurlHttpClient.php#L214-L221

In NativeClient, `getBodyAsString` will fail to return `null` because of the `string` return type.

Before #45527 null was converted to `""` thanks to the defaultOptions, but this is not the case anymore. 



In many places, we check if the body is `!== ""` but rarely check if the body is null, this PR restores the original behaviors for the `body` parameters and converts nulls to `""`.