### PR TITLE
[DependencyInjection] Add support of array argument to #[When]

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/When.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/When.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Attribute;
 
 /**
- * An attribute to tell under which environement this class should be registered as a service.
+ * An attribute to tell under which environment this class should be registered as a service.
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
@@ -20,7 +20,7 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 class When
 {
     public function __construct(
-        public string $env,
+        public array|string $env,
     ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `$exclude` to `TaggedIterator` and `TaggedLocator` attributes
  * Add `$exclude` to `tagged_iterator` and `tagged_locator` configurator
  * Add an `env` function to the expression language provider
+ * Add support of environments array for `#[When]`
 
 6.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -111,7 +111,9 @@ abstract class FileLoader extends BaseFileLoader
                 $r = $this->container->getReflectionClass($class);
                 $attribute = null;
                 foreach ($r->getAttributes(When::class) as $attribute) {
-                    if ($this->env === $attribute->newInstance()->env) {
+                    $attributeEnv = (array) $attribute->newInstance()->env;
+
+                    if (\in_array($this->env, $attributeEnv, true)) {
                         $attribute = null;
                         break;
                     }

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -102,7 +102,9 @@ class PhpFileLoader extends FileLoader
 
         $attribute = null;
         foreach ($r->getAttributes(When::class) as $attribute) {
-            if ($this->env === $attribute->newInstance()->env) {
+            $attributeEnv = (array) $attribute->newInstance()->env;
+
+            if (\in_array($this->env, $attributeEnv, true)) {
                 $attribute = null;
                 break;
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Qux.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Qux.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
+
+use Symfony\Component\DependencyInjection\Attribute\When;
+
+#[When(env: ['prod', 'dev'])]
+class Qux
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
@@ -16,6 +16,9 @@ services:
 
         shared: false
         configurator: c
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Qux:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Qux
+        public: true
     foo:
         class: App\FooService
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.expected.yml
@@ -16,6 +16,19 @@ services:
             message: '%service_id%'
         arguments: [1]
         factory: f
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Qux:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Qux
+        public: true
+        tags:
+            - foo
+            - baz
+        deprecated:
+            package: vendor/package
+            version: '1.1'
+            message: '%service_id%'
+        lazy: true
+        arguments: [1]
+        factory: f
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
@@ -16,6 +16,19 @@ services:
             message: '%service_id%'
         arguments: [1]
         factory: f
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Qux:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Qux
+        public: true
+        tags:
+            - foo
+            - baz
+        deprecated:
+            package: vendor/package
+            version: '1.1'
+            message: '%service_id%'
+        lazy: true
+        arguments: [1]
+        factory: f
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/when_multiple_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/when_multiple_env.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Attribute\When;
+
+return #[When(env: ['test', 'prod'])] function () {
+    throw new RuntimeException('This code should not be run.');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\FooInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\AnotherSub\DeeperBaz;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Baz;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Qux;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\BarInterface;
 
@@ -265,6 +266,25 @@ class FileLoaderTest extends TestCase
         );
 
         $this->assertSame($expected, $container->has(Foo::class));
+    }
+
+    /**
+     * @testWith ["prod", true]
+     *           ["dev", true]
+     *           ["bar", false]
+     *           [null, true]
+     */
+    public function testRegisterClassesWithWhenEnvAsArray(?string $env, bool $expected)
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'), $env);
+        $loader->registerClasses(
+            (new Definition())->setAutoconfigured(true),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\\',
+            'Prototype/{Qux.php}'
+        );
+
+        $this->assertSame($expected, $container->has(Qux::class));
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -182,4 +182,13 @@ class PhpFileLoaderTest extends TestCase
 
         $loader->load($fixtures.'/config/when_env.php');
     }
+
+    public function testWhenEnvAsArray()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator(), 'dev', new ConfigBuilderGenerator(sys_get_temp_dir()));
+
+        $loader->load($fixtures.'/config/when_multiple_env.php');
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -720,7 +720,7 @@ class XmlFileLoaderTest extends TestCase
 
         $ids = array_keys($container->getDefinitions());
         sort($ids);
-        $this->assertSame([Prototype\Foo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
+        $this->assertSame([Prototype\Foo::class, Prototype\Qux::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
 
         $resources = array_map('strval', $container->getResources());
 
@@ -752,7 +752,7 @@ class XmlFileLoaderTest extends TestCase
 
         $ids = array_keys($container->getDefinitions());
         sort($ids);
-        $this->assertSame([Prototype\Foo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
+        $this->assertSame([Prototype\Foo::class, Prototype\Qux::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
 
         $resources = array_map('strval', $container->getResources());
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -499,7 +499,7 @@ class YamlFileLoaderTest extends TestCase
 
         $ids = array_keys($container->getDefinitions());
         sort($ids);
-        $this->assertSame([Prototype\Foo::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
+        $this->assertSame([Prototype\Foo::class, Prototype\Qux::class, Prototype\Sub\Bar::class, 'service_container'], $ids);
 
         $resources = array_map('strval', $container->getResources());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | symfony/symfony-docs#16552

I think being able to pass envs as an array to `#[When]` instead of repeating the Attribute numerous times could be convenient and good for DX, especially if you have to deal with numerous envs.