### PR TITLE
[Filesystem] Replace occurrences of `operation system` to `operating system`

### DIFF
--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -183,11 +183,11 @@ final class Path
      *  - UNIX
      *  - Windows8 and upper
      *
-     * If your operation system or environment isn't supported, an exception is thrown.
+     * If your operating system or environment isn't supported, an exception is thrown.
      *
      * The result is a canonical path.
      *
-     * @throws RuntimeException If your operation system or environment isn't supported
+     * @throws RuntimeException If your operating system or environment isn't supported
      */
     public static function getHomeDirectory(): string
     {
@@ -201,7 +201,7 @@ final class Path
             return self::canonicalize(getenv('HOMEDRIVE').getenv('HOMEPATH'));
         }
 
-        throw new RuntimeException("Cannot find the home directory path: Your environment or operation system isn't supported.");
+        throw new RuntimeException("Cannot find the home directory path: Your environment or operating system isn't supported.");
     }
 
     /**

--- a/src/Symfony/Component/Filesystem/Tests/PathTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/PathTest.php
@@ -1024,10 +1024,10 @@ class PathTest extends TestCase
         $this->assertSame('/path/to/test/subdir', Path::join('/path', 'to', '/test', 'subdir/'));
     }
 
-    public function testGetHomeDirectoryFailsIfNotSupportedOperationSystem()
+    public function testGetHomeDirectoryFailsIfNotSupportedOperatingSystem()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Your environment or operation system isn\'t supported');
+        $this->expectExceptionMessage('Your environment or operating system isn\'t supported');
 
         putenv('HOME=');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | **Not sure, see below**
| Tickets       | _N/A_
| License       | MIT
| Doc PR        | _N/A_

Just came across this typo. I'm very unsure it is a breaking change or not. I would say yes if people are testing against the exact exception message. However, I wasn't able to find a matching rule inside the Backward Compatibility Promise page. Any idea?