### PR TITLE
[FrameworkBundle] Add mechanism to prevent using outdated config

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -34,7 +34,7 @@ FrameworkBundle
    `Symfony\Component\Serializer\Normalizer\PropertyNormalizer` autowiring aliases, type-hint against
    `Symfony\Component\Serializer\Normalizer\NormalizerInterface` or implement `NormalizerAwareInterface` instead
  * Deprecate `AbstractController::renderForm()`, use `render()` instead
- * Deprecate `FrameworkExtension::registerRateLimiter()`, to be made private in 7.0
+ * Deprecate `FrameworkExtension::registerRateLimiter()`
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -22,7 +22,7 @@ CHANGELOG
  * Add a `framework.router.cache_dir` configuration option to configure the default `Router` `cache_dir` option
  * Add option `framework.messenger.buses.*.default_middleware.allow_no_senders` to enable throwing when a message doesn't have a sender
  * Deprecate `AbstractController::renderForm()`, use `render()` instead
- * Deprecate `FrameworkExtension::registerRateLimiter()`, to be made private in 7.0
+ * Deprecate `FrameworkExtension::registerRateLimiter()`
 
 6.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -98,6 +98,9 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface
             if (!interface_exists(LockInterface::class)) {
                 throw new LogicException(sprintf('Rate limiter "%s" requires the Lock component to be installed. Try running "composer require symfony/lock".', $name));
             }
+            if (!$container->hasDefinition('lock.factory.abstract')) {
+                throw new LogicException(sprintf('Rate limiter "%s" requires the Lock component to be configured.', $name));
+            }
 
             $limiter->replaceArgument(2, new Reference($limiterConfig['lock_factory']));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

The root issue of CVE 2022-23601 was because of the order of processing configurations (TL;DR: in some cases, we read `form.csrf_protection.enabled` BEFORE setting `form.csrf_protection.enabled = csrf_protection.enabled`)

This PR adds a mechanism to avoid such mistakes:
When an `enabled` attribute is read first THEN updated, an exception is thrown.