### PR TITLE
[Validator] Supports backed enum in constraint groups

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `Constraint::$errorNames`, use `Constraint::ERROR_NAMES` instead
+ * Supports PHP backed enumerations in constraint groups
 
 6.0
 ---

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -103,11 +103,11 @@ abstract class Constraint
      * getRequiredOptions() to return the names of these options. If any
      * option is not set here, an exception is thrown.
      *
-     * @param mixed    $options The options (as associative array)
-     *                          or the value for the default
-     *                          option (any other type)
-     * @param string[] $groups  An array of validation groups
-     * @param mixed    $payload Domain-specific data attached to a constraint
+     * @param mixed                     $options The options (as associative array)
+     *                                           or the value for the default
+     *                                           option (any other type)
+     * @param array<string|\BackedEnum> $groups  An array of validation groups
+     * @param mixed                     $payload Domain-specific data attached to a constraint
      *
      * @throws InvalidOptionsException       When you pass the names of non-existing
      *                                       options
@@ -197,12 +197,30 @@ abstract class Constraint
     public function __set(string $option, mixed $value)
     {
         if ('groups' === $option) {
-            $this->groups = (array) $value;
+            $this->groups = $this->normalizeGroups((array) $value);
 
             return;
         }
 
         throw new InvalidOptionsException(sprintf('The option "%s" does not exist in constraint "%s".', $option, static::class), [$option]);
+    }
+
+    /**
+     * @param array<string|\BackedEnum> $groups
+     *
+     * @return array<string>
+     */
+    protected function normalizeGroups(array $groups): array
+    {
+        $normalized = [];
+        foreach ($groups as $group) {
+            if ($group instanceof \BackedEnum) {
+                $group = $group->value;
+            }
+            $normalized[] = $group;
+        }
+
+        return $normalized;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
+use Symfony\Component\Validator\Tests\Fixtures\BackedEnumA;
 use Symfony\Component\Validator\Tests\Fixtures\ClassConstraint;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
@@ -131,6 +132,20 @@ class ConstraintTest extends TestCase
         $constraint = new ConstraintA(['groups' => 'Foo']);
 
         $this->assertEquals(['Foo'], $constraint->groups);
+    }
+
+    public function testGroupsBackedEnumsAreConvertedToValue()
+    {
+        $constraint = new ConstraintA([], ['foo', BackedEnumA::READ]);
+
+        $this->assertSame(['foo', 'read'], $constraint->groups);
+    }
+
+    public function testOptionGroupsBackedEnumsAreConvertedToValue()
+    {
+        $constraint = new ConstraintA(['groups' => ['foo', BackedEnumA::READ]]);
+
+        $this->assertSame(['foo', 'read'], $constraint->groups);
     }
 
     public function testAddDefaultGroupAddsGroup()

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Tests\Fixtures\BackedEnumA;
 
 class GreaterThanTest extends TestCase
 {
@@ -38,6 +39,11 @@ class GreaterThanTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+
+        [$dConstraint] = $metadata->properties['d']->getConstraints();
+        self::assertSame(4711, $dConstraint->value);
+        self::assertNull($dConstraint->propertyPath);
+        self::assertSame(['read', 'write'], $dConstraint->groups);
     }
 }
 
@@ -51,4 +57,7 @@ class GreaterThanDummy
 
     #[GreaterThan(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
     private $c;
+
+    #[GreaterThan(value: 4711, groups: [BackedEnumA::READ, 'write'])]
+    private $d;
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/BackedEnumA.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/BackedEnumA.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+enum BackedEnumA: string
+{
+    case READ = 'read';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45494
| License       | MIT
| Doc PR        | symfony/symfony-docs/pull/16553

This PR allow to use Backed enum in constraints groups.

```php
#[GreaterThan(value: 4711, groups: [MyCustomEnum::WRITE])]
```