### PR TITLE
[HttpKernel] fix using Target attribute with controller arguments

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -192,7 +192,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         $args[$p->name] = new Reference($erroredId, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE);
                     } else {
                         $target = ltrim($target, '\\');
-                        $args[$p->name] = $type ? new TypedReference($target, $type, $invalidBehavior, $p->name) : new Reference($target, $invalidBehavior);
+                        $args[$p->name] = $type ? new TypedReference($target, $type, $invalidBehavior, Target::parseName($p)) : new Reference($target, $invalidBehavior);
                     }
                 }
                 // register the maps as a per-method service-locators


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45021
| License       | MIT
| Doc PR        | n/a

This was supposed to fix #45021 but after adding what I suspected was a failing test, it works as expected. I guess I'm not testing the correct thing?

Here's a quick reproducer that shows the problem in a "real app":

```php
class HomepageController extends AbstractController
{
    public function __construct(#[Target('request.logger')] private LoggerInterface $logger)
    {
    }

    #[Route('/', name: 'app_homepage')]
    public function index(#[Target('request.logger')] LoggerInterface $logger): Response
    {
        dd(
            $this->logger->getName(), // "request" (expected)
            $logger->getName()        // "app" (not-expected)
        );

        // ...
    }
}
```