### PR TITLE
[DependencyInjection] add a `Service` attribute to explicitly choose the injected service id

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Service.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Service.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class Service
+{
+    public function __construct(public string $id)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `$exclude` to `TaggedIterator` and `TaggedLocator` attributes
  * Add `$exclude` to `tagged_iterator` and `tagged_locator` configurator
  * Add an `env` function to the expression language provider
+ * Add a `Service` attribute to explicitly choose the injected service id
 
 6.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\Service;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
 use Symfony\Component\DependencyInjection\Attribute\Target;
@@ -22,6 +23,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\AutowiringFailedException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\LazyProxy\ProxyHelper;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\TypedReference;
 
 /**
@@ -254,6 +256,12 @@ class AutowirePass extends AbstractRecursivePass
                     if (TaggedLocator::class === $attribute->getName()) {
                         $attribute = $attribute->newInstance();
                         $arguments[$index] = new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, true, $attribute->defaultPriorityMethod, (array) $attribute->exclude));
+                        break;
+                    }
+
+                    if (Service::class === $attribute->getName()) {
+                        $attribute = $attribute->newInstance();
+                        $arguments[$index] = new Reference($attribute->id);
                         break;
                     }
                 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1121,4 +1121,23 @@ class AutowirePassTest extends TestCase
         static::assertInstanceOf(DecoratedDecorator::class, $container->get(DecoratorInterface::class));
         static::assertInstanceOf(DecoratedDecorator::class, $container->get(DecoratorImpl::class));
     }
+
+    public function testServiceAttributeParameter()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(AutowireServiceParameter::class)
+            ->setAutowired(true)
+        ;
+
+        $container->register('some.id', \stdClass::class);
+
+        (new ResolveClassPass())->process($container);
+        (new AutowirePass())->process($container);
+
+        $definition = $container->getDefinition(AutowireServiceParameter::class);
+
+        $this->assertCount(1, $definition->getArguments());
+        $this->assertSame('some.id', (string) $definition->getArgument(0));
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
+use Symfony\Component\DependencyInjection\Attribute\Service;
 use Symfony\Contracts\Service\Attribute\Required;
 
 class AutowireSetter
@@ -25,4 +26,11 @@ class AutowireProperty
 {
     #[Required]
     public Foo $foo;
+}
+
+class AutowireServiceParameter
+{
+    public function __construct(#[Service('some.id')] $service)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This is a sister PR to #44780. This removes the need to reach for a separate config file when needing to inject a service with a specific service id. This could be used as a [_less brittle_](https://github.com/symfony/symfony/issues/45020) alternative to the `Target` attribute.

```php
use Psr\Log\LoggerInterface;
use Symfony\Component\DependencyInjection\Attribute\Service;

class MyClass
{
    public function __construct(
        #[Service('monolog.logger.request')]
        private LoggerInterface $logger
    ) {}
}
```

**TODO**
- [ ] Controller argument support

