### PR TITLE
[Messenger] AMQP reconnect if channel disconnected

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -501,6 +501,7 @@ class Connection
 
     public function queue(string $queueName): \AMQPQueue
     {
+        $this->clearWhenDisconnected();
         if (!isset($this->amqpQueues[$queueName])) {
             $queueConfig = $this->queuesOptions[$queueName];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
If connection broken Queue's methods `bind` and `unbind` throws the error 
```
AMQPChannelException: Could not bind queue. No channel available
```
No way to reconnect channel, because it can be done only with method `clearWhenDisconnected`, which is private.

The only one method that worked is (example code)
```
try {
    $amqpConnection->queue($queueName)->bind($exchange, $routingKey);
    } catch (AMQPException $e) {
    //Could not bind queue. No channel available.
    try {
        // Call internal clearWhenDisconnected
        $amqpConnection->publish('reconnect');
        $amqpConnection->queue($queueName)->bind($exchange, $routingKey);
    } catch (AMQPException $e) {
        //critical
    }
        }
```

After PR is merged no need to check the error, since `queue` method will call `clearWhenDisconnected` internally
