### PR TITLE
[FrameworkBundle] Fix getting the container from a non-booted kernel in KernelBrowser

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -117,7 +117,12 @@ class Client extends HttpKernelBrowser
         // avoid shutting down the Kernel if no request has been performed yet
         // WebTestCase::createClient() boots the Kernel but do not handle a request
         if ($this->hasPerformedRequest && $this->reboot) {
-            $container = $this->kernel->getContainer();
+            try {
+                $container = $this->kernel->getContainer();
+            } catch (\LogicException $e) {
+                $container = null;
+            }
+
             $this->kernel->shutdown();
 
             if ($container instanceof ResetInterface) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
@@ -51,6 +51,16 @@ class KernelBrowserTest extends AbstractWebTestCase
         $client->request('GET', '/');
     }
 
+    public function testRequestAfterKernelShutdownAndPerformedRequest()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $client = static::createClient(['test_case' => 'TestServiceContainer']);
+        $client->request('GET', '/');
+        static::ensureKernelShutdown();
+        $client->request('GET', '/');
+    }
+
     private function getKernelMock()
     {
         $mock = $this->getMockBuilder($this->getKernelClass())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/pull/45479 is causing a regression on some tests.

The kernel might not be booted and with Symfony > 4.4, an exception is thrown.