### PR TITLE
Do not trigger deprecation when method has inheritdoc comment

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -570,7 +570,7 @@ class DebugClassLoader
                 if ($canAddReturnType && 'docblock' !== $this->patchTypes['force']) {
                     $this->patchMethod($method, $returnType, $declaringFile, $normalizedType);
                 }
-                if (!isset($doc['deprecated']) && strncmp($ns, $declaringClass, $len)) {
+                if (!isset($doc['deprecated']) && !isset($doc['inherit']) && strncmp($ns, $declaringClass, $len)) {
                     if ('docblock' === $this->patchTypes['force']) {
                         $this->patchMethod($method, $returnType, $declaringFile, $normalizedType);
                     } elseif ('' !== $declaringClass && $this->patchTypes['deprecations']) {
@@ -1150,6 +1150,10 @@ EOTXT;
                 }
                 $tagName = $tagContent = '';
                 continue;
+            }
+
+            if ('{@inheritdoc}' === strtolower($line)) {
+                $tags['inherit'] = true;
             }
 
             if ('@' === $line[0]) {

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
@@ -33,6 +33,10 @@ class ReturnType extends ReturnTypeParent implements ReturnTypeInterface, Fixtur
      * @return parent - same as parent
      */
     public function optOutThroughDoc() { }
+    /**
+     * {@inheritdoc}
+     */
+    public function inheritThroughDoc() { }
     public function manyIterables() { }
     public function nullableReturnableTypeNormalization() { }
     public function nonNullableReturnableTypeNormalization() { }

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
@@ -127,6 +127,13 @@ abstract class ReturnTypeParent extends ReturnTypeGrandParent implements ReturnT
     }
 
     /**
+     * @return self
+     */
+    public function inheritThroughDoc()
+    {
+    }
+
+    /**
      * @return \ArrayIterator[]|\DirectoryIterator[]
      */
     public function manyIterables()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


When a class use `{@inheritdoc}` it triggers a deprecation:
```php
class FooBar implements ArrayAccess
{
    /**
     * {@inheritdoc}
     */
    #[\ReturnTypeWillChange]
    public function offsetGet($key)
    {
        return $this->get($key, null);
    }
}
```
>   1x: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "FooBar" now to avoid errors or add an explicit @return annotation to suppress this message.

Adding a doc block `@return mixed` to please the deprecation is redundant with `{@inheritdoc}`

This PR silents deprecations (and "docblock patches") in such cases