### PR TITLE
[FrameworkBundle] require ext-sodium in tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,6 +45,7 @@ install:
     - echo extension=php_fileinfo.dll >> php.ini-max
     - echo extension=php_pdo_sqlite.dll >> php.ini-max
     - echo extension=php_curl.dll >> php.ini-max
+    - echo extension=php_sodium.dll >> php.ini-max
     - copy /Y php.ini-max php.ini
     - cd c:\projects\symfony
     - IF NOT EXIST composer.phar (appveyor DownloadFile https://github.com/composer/composer/releases/download/2.0.0/composer.phar)

--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,6 @@
         "masterminds/html5": "^2.6",
         "monolog/monolog": "^1.25.1|^2",
         "nyholm/psr7": "^1.0",
-        "paragonie/sodium_compat": "^1.8",
         "pda/pheanstalk": "^4.0",
         "php-http/httplug": "^1.0|^2.0",
         "phpstan/phpdoc-parser": "^1.0",

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Secrets\SodiumVault;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @requires extension sodium
+ */
 class SodiumVaultTest extends TestCase
 {
     private $secretsDir;

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -66,7 +66,6 @@
         "symfony/property-info": "^4.4|^5.0|^6.0",
         "symfony/web-link": "^4.4|^5.0|^6.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-        "paragonie/sodium_compat": "^1.8",
         "twig/twig": "^2.10|^3.0",
         "symfony/phpunit-bridge": "^5.3|^6.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This removes a deprecation on PHP 8.1 (reported as https://github.com/paragonie/sodium_compat/issues/140)
And skips two test cases that take more that 1 minute when running with the polyfill.