### PR TITLE
[HttpClient] fix checking for unset property on PHP <= 7.1.4

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -189,7 +189,7 @@ trait HttpClientTrait
 
         $options += $defaultOptions;
 
-        foreach (self::$emptyDefaults ?? [] as $k => $v) {
+        foreach (isset(self::$emptyDefaults) ? self::$emptyDefaults : [] as $k => $v) {
             if (!isset($options[$k])) {
                 $options[$k] = $v;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As spotted by the CI and confirmed here: https://3v4l.org/2Xv3N