### PR TITLE
[HttpKernel] Add DateTimeValueResolver

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\BackedEnumValueResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DateTimeValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver;
@@ -47,14 +48,13 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('argument_resolver.backed_enum_resolver', BackedEnumValueResolver::class)
-            ->tag('controller.argument_value_resolver', [
-                'priority' => 105, // prior to the RequestAttributeValueResolver
-            ])
+            ->tag('controller.argument_value_resolver', ['priority' => 100])
 
         ->set('argument_resolver.uid', UidValueResolver::class)
-            ->tag('controller.argument_value_resolver', [
-                'priority' => 100, // same priority than RequestAttributeValueResolver, but registered before
-            ])
+            ->tag('controller.argument_value_resolver', ['priority' => 100])
+
+        ->set('argument_resolver.datetime', DateTimeValueResolver::class)
+            ->tag('controller.argument_value_resolver', ['priority' => 100])
 
         ->set('argument_resolver.request_attribute', RequestAttributeValueResolver::class)
             ->tag('controller.argument_value_resolver', ['priority' => 100])

--- a/src/Symfony/Component/HttpKernel/Attribute/MapDateTime.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapDateTime.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+/**
+ * Controller parameter tag to configure DateTime arguments.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class MapDateTime
+{
+    public function __construct(
+        public readonly ?string $format = null
+    ) {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `BackedEnumValueResolver` to resolve backed enum cases from request attributes in controller arguments
+ * Add `DateTimeValueResolver` to resolve request attributes into DateTime objects in controller arguments
  * Deprecate StreamedResponseListener, it's not needed anymore
  * Add `Profiler::isEnabled()` so collaborating collector services may elect to omit themselves.
  * Add the `UidValueResolver` argument value resolver

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\MapDateTime;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Convert DateTime instances from request attribute variable.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Tim Goudriaan <tim@codedmonkey.com>
+ */
+final class DateTimeValueResolver implements ArgumentValueResolverInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, ArgumentMetadata $argument): bool
+    {
+        return is_a($argument->getType(), \DateTimeInterface::class, true) && $request->attributes->has($argument->getName());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        $value = $request->attributes->get($argument->getName());
+
+        if ($argument->isNullable() && !$value) {
+            yield null;
+
+            return;
+        }
+
+        $class = \DateTimeInterface::class === $argument->getType() ? \DateTimeImmutable::class : $argument->getType();
+        $format = null;
+
+        if ($attributes = $argument->getAttributes(MapDateTime::class, ArgumentMetadata::IS_INSTANCEOF)) {
+            $attribute = $attributes[0];
+            $format = $attribute->format;
+        }
+
+        $date = false;
+
+        if (null !== $format) {
+            $date = $class::createFromFormat($format, $value);
+
+            if ($class::getLastErrors()['warning_count']) {
+                $date = false;
+            }
+        } elseif (false !== filter_var($value, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]])) {
+            $date = new $class('@'.$value);
+        } elseif (false !== $timestamp = strtotime($value))  {
+            $date = new $class('@'.$timestamp);
+        }
+
+        if (!$date) {
+            throw new NotFoundHttpException(sprintf('Invalid date given for parameter "%s".', $argument->getName()));
+        }
+
+        yield $date;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\MapDateTime;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DateTimeValueResolver;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class DateTimeValueResolverTest extends TestCase
+{
+    public function testSupports()
+    {
+        $resolver = new DateTimeValueResolver();
+
+        $argument = new ArgumentMetadata('dummy', \DateTime::class, false, false, null);
+        $request = self::requestWithAttributes(['dummy' => 'now']);
+        $this->assertTrue($resolver->supports($request, $argument));
+
+        $argument = new ArgumentMetadata('dummy', FooDateTime::class, false, false, null);
+        $request = self::requestWithAttributes(['dummy' => 'now']);
+        $this->assertTrue($resolver->supports($request, $argument));
+
+        $argument = new ArgumentMetadata('dummy', \stdClass::class, false, false, null);
+        $request = self::requestWithAttributes(['dummy' => 'now']);
+        $this->assertFalse($resolver->supports($request, $argument));
+    }
+
+    public function testFullDate()
+    {
+        $resolver = new DateTimeValueResolver();
+
+        $argument = new ArgumentMetadata('dummy', \DateTime::class, false, false, null);
+        $request = self::requestWithAttributes(['dummy' => '2012-07-21 00:00:00']);
+
+        /** @var \Generator $results */
+        $results = $resolver->resolve($request, $argument);
+        $results = iterator_to_array($results);
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(\DateTime::class, $results[0]);
+        $this->assertEquals('2012-07-21', $results[0]->format('Y-m-d'));
+    }
+
+    public function testUnixTimestamp()
+    {
+        $resolver = new DateTimeValueResolver();
+
+        $argument = new ArgumentMetadata('dummy', \DateTime::class, false, false, null);
+        $request = self::requestWithAttributes(['dummy' => '989541720']);
+
+        /** @var \Generator $results */
+        $results = $resolver->resolve($request, $argument);
+        $results = iterator_to_array($results);
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(\DateTime::class, $results[0]);
+        $this->assertEquals('2001-05-11', $results[0]->format('Y-m-d'));
+    }
+
+    public function testNullableWithEmptyAttribute()
+    {
+        $resolver = new DateTimeValueResolver();
+
+        $argument = new ArgumentMetadata('dummy', \DateTime::class, false, false, null, true);
+        $request = self::requestWithAttributes(['dummy' => '']);
+
+        /** @var \Generator $results */
+        $results = $resolver->resolve($request, $argument);
+        $results = iterator_to_array($results);
+
+        $this->assertCount(1, $results);
+        $this->assertNull($results[0]);
+    }
+
+    public function testCustomClass()
+    {
+        $resolver = new DateTimeValueResolver();
+
+        $argument = new ArgumentMetadata('dummy', FooDateTime::class, false, false, null);
+        $request = self::requestWithAttributes(['dummy' => '2016-09-08 00:00:00']);
+
+        /** @var \Generator $results */
+        $results = $resolver->resolve($request, $argument);
+        $results = iterator_to_array($results);
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(FooDateTime::class, $results[0]);
+        $this->assertEquals('2016-09-08', $results[0]->format('Y-m-d'));
+    }
+
+    public function testDateTimeImmutable()
+    {
+        $resolver = new DateTimeValueResolver();
+
+        $argument = new ArgumentMetadata('dummy', \DateTimeImmutable::class, false, false, null);
+        $request = self::requestWithAttributes(['dummy' => '2016-09-08 00:00:00']);
+
+        /** @var \Generator $results */
+        $results = $resolver->resolve($request, $argument);
+        $results = iterator_to_array($results);
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $results[0]);
+        $this->assertEquals('2016-09-08', $results[0]->format('Y-m-d'));
+    }
+
+    public function provideInvalidDates()
+    {
+        return [
+            'invalid date' => [
+                new ArgumentMetadata('dummy', \DateTime::class, false, false, null),
+                self::requestWithAttributes(['dummy' => 'Invalid DateTime Format'])
+            ],
+            'invalid format' => [
+                new ArgumentMetadata('dummy', \DateTime::class, false, false, null, false, [new MapDateTime(format: 'd.m.Y')]),
+                self::requestWithAttributes(['dummy' => '2012-07-21']),
+            ],
+            'invalid ymd format' => [
+                new ArgumentMetadata('dummy', \DateTime::class, false, false, null, false, [new MapDateTime(format: 'Y-m-d')]),
+                self::requestWithAttributes(['dummy' => '2012-21-07']),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidDates
+     */
+    public function test404Exception(ArgumentMetadata $argument, Request $request)
+    {
+        $resolver = new DateTimeValueResolver();
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('Invalid date given for parameter "dummy".');
+
+        /** @var \Generator $results */
+        $results = $resolver->resolve($request, $argument);
+        iterator_to_array($results);
+    }
+
+    private static function requestWithAttributes(array $attributes): Request
+    {
+        $request = Request::create('/');
+
+        foreach ($attributes as $name => $value) {
+            $request->attributes->set($name, $value);
+        }
+
+        return $request;
+    }
+}
+
+class FooDateTime extends \DateTime
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #44705
| License       | MIT
| Doc PR        | symfony/symfony-docs#16562

This PR replaces the [DateTimeParamConverter](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/src/Request/ParamConverter/DateTimeParamConverter.php) from the SensioFrameworkExtraBundle with a value resolver in the Symfony Core.

Note that the behavior of the resolver is enabled by default when using the Symfony framework.