### PR TITLE
[FrameworkBundle] Fix resetting container between tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -19,7 +19,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile as HttpProfile;
-use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Client simulates a browser and makes requests to a Kernel object.
@@ -117,12 +116,8 @@ class Client extends HttpKernelBrowser
         // avoid shutting down the Kernel if no request has been performed yet
         // WebTestCase::createClient() boots the Kernel but do not handle a request
         if ($this->hasPerformedRequest && $this->reboot) {
-            $container = $this->kernel->getContainer();
+            $this->kernel->boot();
             $this->kernel->shutdown();
-
-            if ($container instanceof ResetInterface) {
-                $container->reset();
-            }
         } else {
             $this->hasPerformedRequest = true;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * KernelTestCase is the base class for tests needing a Kernel.
@@ -38,8 +37,6 @@ abstract class KernelTestCase extends TestCase
     protected static $container;
 
     protected static $booted = false;
-
-    private static $kernelContainer;
 
     private function doTearDown()
     {
@@ -77,11 +74,12 @@ abstract class KernelTestCase extends TestCase
     {
         static::ensureKernelShutdown();
 
-        static::$kernel = static::createKernel($options);
-        static::$kernel->boot();
+        $kernel = static::createKernel($options);
+        $kernel->boot();
+        self::$kernel = $kernel;
         static::$booted = true;
 
-        self::$kernelContainer = $container = static::$kernel->getContainer();
+        $container = static::$kernel->getContainer();
         static::$container = $container->has('test.service_container') ? $container->get('test.service_container') : $container;
 
         return static::$kernel;
@@ -132,14 +130,11 @@ abstract class KernelTestCase extends TestCase
     protected static function ensureKernelShutdown()
     {
         if (null !== static::$kernel) {
+            static::$kernel->boot();
             static::$kernel->shutdown();
             static::$booted = false;
         }
 
-        if (self::$kernelContainer instanceof ResetInterface) {
-            self::$kernelContainer->reset();
-        }
-
-        static::$container = self::$kernelContainer = null;
+        static::$container = null;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
@@ -51,6 +51,16 @@ class KernelBrowserTest extends AbstractWebTestCase
         $client->request('GET', '/');
     }
 
+    public function testRequestAfterKernelShutdownAndPerformedRequest()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $client = static::createClient(['test_case' => 'TestServiceContainer']);
+        $client->request('GET', '/');
+        static::ensureKernelShutdown();
+        $client->request('GET', '/');
+    }
+
     private function getKernelMock()
     {
         $mock = $this->getMockBuilder($this->getKernelClass())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40965, fix #45580
| License       | MIT
| Doc PR        | -

Replaces #45479 and #45581, related to #34078.

Calling `boot()` on an already booted kernel does reset the container, so we don't need to care anymore about the state of kernel.

#45580 is fixed by removing `private static $kernelContainer`, which can be out of sync with `static::$kernel->getContainer()` since `KernelBrowser` creates new containers when shutting down the kernel between requests.