### PR TITLE
[Form] Add prototype_options to CollectionType

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add a `prototype_options` option to `CollectionType`
+
 6.0
 ---
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -30,7 +30,7 @@ class CollectionType extends AbstractType
             $prototypeOptions = array_replace([
                 'required' => $options['required'],
                 'label' => $options['prototype_name'].'label__',
-            ], $options['entry_options']);
+            ], array_replace($options['entry_options'], $options['prototype_options']));
 
             if (null !== $options['prototype_data']) {
                 $prototypeOptions['data'] = $options['prototype_data'];
@@ -120,12 +120,15 @@ class CollectionType extends AbstractType
             'prototype_name' => '__name__',
             'entry_type' => TextType::class,
             'entry_options' => [],
+            'prototype_options' => [],
             'delete_empty' => false,
             'invalid_message' => 'The collection is invalid.',
         ]);
 
         $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);
+
         $resolver->setAllowedTypes('delete_empty', ['bool', 'callable']);
+        $resolver->setAllowedTypes('prototype_options', 'array');
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -430,6 +430,23 @@ class CollectionTypeTest extends BaseTypeTest
         $this->assertFalse($child->createView()->vars['prototype']->vars['required'], '"Prototype" should not be required');
     }
 
+    public function testPrototypeOptionsOverrideEntryOptions()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, [], [
+            'allow_add' => true,
+            'prototype' => true,
+            'entry_type' => TextTypeTest::TESTED_TYPE,
+            'entry_options' => [
+                'help' => null,
+            ],
+            'prototype_options' => [
+                'help' => 'foo',
+            ],
+        ]);
+
+        $this->assertSame('foo', $form->createView()->vars['prototype']->vars['help']);
+    }
+
     public function testEntriesBlockPrefixes()
     {
         $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16664

Allows defining options for the form for new entries (the prototype form) which differ from the options for the form for existing entries.

My use case: I need this when using EasyAdminBundle. In the form for an entity `Person` I have a `CollectionType` for a related entity `Books`. There I can edit the `Books` that a `Person` already has and add new `Books`. The change would allow me to show (or disable, etc.) a form field in the `Book` form only when an existing `Book` is edited (and not show it when a new `Book` is added).

As far as I can tell it is not a BC break to add this new option. I can provide another PR for the docs if this should get merged.
