### PR TITLE
[Config] Allow using environment variables in `EnumNode`

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Allow using environment variables in `EnumNode`
+
 6.0
 ---
 

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -54,12 +54,4 @@ class EnumNode extends ScalarNode
 
         return $value;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function allowPlaceholders(): bool
-    {
-        return false;
-    }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -55,4 +55,20 @@ class EnumNodeTest extends TestCase
         $node = new EnumNode('foo', null, ['foo', 'bar']);
         $node->finalize('foobar');
     }
+
+    public function testWithPlaceHolderWithValidValue()
+    {
+        $node = new EnumNode('cookie_samesite', null, ['lax', 'strict', 'none']);
+        EnumNode::setPlaceholder('custom', ['string' => 'lax']);
+        $this->assertSame('custom', $node->finalize('custom'));
+    }
+
+    public function testWithPlaceHolderWithInvalidValue()
+    {
+        $node = new EnumNode('cookie_samesite', null, ['lax', 'strict', 'none']);
+        EnumNode::setPlaceholder('custom', ['string' => 'foo']);
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The value "foo" is not allowed for path "cookie_samesite". Permissible values: "lax", "strict", "none"');
+        $node->finalize('custom');
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -153,19 +153,6 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->assertSame(['scalar_node' => $expected], $container->resolveEnvPlaceholders($ext->getConfig()));
     }
 
-    public function testEnvIsIncompatibleWithEnumNode()
-    {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('A dynamic value is not compatible with a "Symfony\Component\Config\Definition\EnumNode" node type at path "env_extension.enum_node".');
-        $container = new ContainerBuilder();
-        $container->registerExtension(new EnvExtension());
-        $container->prependExtensionConfig('env_extension', [
-            'enum_node' => '%env(FOO)%',
-        ]);
-
-        $this->doProcess($container);
-    }
-
     public function testEnvIsIncompatibleWithArrayNode()
     {
         $this->expectException(InvalidConfigurationException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

In the _EnumNode_ of the _Config_ component, we see that it does not allow the use of a placeholder: https://github.com/symfony/symfony/blob/5fbd0dc062443d1c5050081a7eba23ef47ba2a25/src/Symfony/Component/Config/Definition/EnumNode.php#L63

This is strange, because we could have some use cases where we would like to be able to define the value with a env variable. A good example is the samesite policy for the session cookie :  https://symfony.com/blog/new-in-symfony-4-2-samesite-cookie-configuration.

Note: I have not submitted any documentation update so far, I am not even sure it is a "new" feature.