### PR TITLE
Fix Mailgun header format for Reply-To

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -139,7 +139,7 @@ class MailgunApiTransport extends AbstractApiTransport
             if (\in_array($prefix, ['h:', 't:', 'o:', 'v:']) || \in_array($name, ['recipient-variables', 'template', 'amp-html'])) {
                 $headerName = $name;
             } else {
-                $headerName = 'h:'.$name;
+                $headerName = 'h:'.mb_convert_case($name, MB_CASE_TITLE, 'UTF-8');
             }
 
             $payload[$headerName] = $header->getBodyAsString();


### PR DESCRIPTION
In this moment is sent in lower case so: h:reply-to
You can see the article is h:Reply-To
https://help.mailgun.com/hc/en-us/articles/4401814149147-Adding-A-Reply-To-Address

| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features / 4.4, 5.4 or 6.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
