### PR TITLE
[PropertyInfo] [WIP] Phpstan extractor may return errored property types

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -383,6 +383,23 @@ class PhpStanExtractorTest extends TestCase
             $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DummyNamespace', 'dummy')
         );
     }
+
+    public function testInheritedNamespace(): void
+    {
+        $this->assertEquals(
+            [
+                new Type(
+                    Type::BUILTIN_TYPE_OBJECT,
+                    false,
+                    'Symfony\Component\PropertyInfo\Tests\Fixtures\Inheritance\Parent\SiblingDummy'
+                )
+            ],
+            $this->extractor->getTypes(
+                'Symfony\Component\PropertyInfo\Tests\Fixtures\Inheritance\Child\ChildDummy',
+                'sibling'
+            )
+        );
+    }
 }
 
 class PhpStanOmittedParamTagTypeDocBlock

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -384,7 +384,7 @@ class PhpStanExtractorTest extends TestCase
         );
     }
 
-    public function testInheritedNamespace(): void
+    public function testInheritedNamespace()
     {
         $this->assertEquals(
             [
@@ -392,7 +392,7 @@ class PhpStanExtractorTest extends TestCase
                     Type::BUILTIN_TYPE_OBJECT,
                     false,
                     'Symfony\Component\PropertyInfo\Tests\Fixtures\Inheritance\Parent\SiblingDummy'
-                )
+                ),
             ],
             $this->extractor->getTypes(
                 'Symfony\Component\PropertyInfo\Tests\Fixtures\Inheritance\Child\ChildDummy',

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Inheritance/Child/ChildDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Inheritance/Child/ChildDummy.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\Inheritance\Child;
+
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Inheritance\Parent\ParentDummy;
+
+final class ChildDummy extends ParentDummy
+{
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Inheritance/Parent/ParentDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Inheritance/Parent/ParentDummy.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\Inheritance\Parent;
+
+class ParentDummy
+{
+    /**
+     * @return SiblingDummy
+     */
+    public function getSibling()
+    {
+        return new SiblingDummy();
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Inheritance/Parent/SiblingDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Inheritance/Parent/SiblingDummy.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\Inheritance\Parent;
+
+final class SiblingDummy
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |  Test for #45517
| License       | MIT
| Doc PR        | 

Add test to reproduce the issue reported in #45517.
Didn't yet try to reproduce it on other versions.