### PR TITLE
feature: debug:router sort mating routes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -130,6 +130,8 @@ EOF
             }
         }
 
+        natsort($foundRoutesNames);
+
         return $foundRoutesNames;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

When multiple routes matched it is easier to find the correct route when the list is sorted.

Another idea is to extends the `SymfonyStyle::choice` method with a sort parameter to provide a general feature. What do you think? Whould a PR for this accepted?