### PR TITLE
[HttpKernel] Allow `Kernel::getLogDir()` to return the empty string when there is no log dir

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate StreamedResponseListener, it's not needed anymore
  * Add `Profiler::isEnabled()` so collaborating collector services may elect to omit themselves.
  * Add the `UidValueResolver` argument value resolver
+ * Allow `Kernel::getLogDir()` to return the empty string when there is no log dir
 
 6.0
 ---

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -607,7 +607,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             'kernel.debug' => $this->debug,
             'kernel.build_dir' => realpath($buildDir = $this->warmupDir ?: $this->getBuildDir()) ?: $buildDir,
             'kernel.cache_dir' => realpath($cacheDir = ($this->getCacheDir() === $this->getBuildDir() ? ($this->warmupDir ?: $this->getCacheDir()) : $this->getCacheDir())) ?: $cacheDir,
-            'kernel.logs_dir' => realpath($this->getLogDir()) ?: $this->getLogDir(),
+            'kernel.logs_dir' => '' !== $this->getLogDir() ? realpath($this->getLogDir()) ?: $this->getLogDir() : '',
             'kernel.bundles' => $bundles,
             'kernel.bundles_metadata' => $bundlesMetadata,
             'kernel.charset' => $this->getCharset(),
@@ -623,6 +623,9 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     protected function buildContainer(): ContainerBuilder
     {
         foreach (['cache' => $this->getCacheDir(), 'build' => $this->warmupDir ?: $this->getBuildDir(), 'logs' => $this->getLogDir()] as $name => $dir) {
+            if ('logs' === $name && '' === $dir) {
+                continue;
+            }
             if (!is_dir($dir)) {
                 if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
                     throw new \RuntimeException(sprintf('Unable to create the "%s" directory (%s).', $name, $dir));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #44579
| License       | MIT
| Doc PR        | -

My proposal instead of #45579, for discussion.