### PR TITLE
InputBag::get can return array, too

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -21,9 +21,9 @@ use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 final class InputBag extends ParameterBag
 {
     /**
-     * Returns a scalar input value by name.
+     * Returns an input value by name.
      *
-     * @param string|int|float|bool|null $default The default value if the input key does not exist
+     * @param array|string|int|float|bool|null $default The default value if the input key does not exist
      */
     public function get(string $key, mixed $default = null): string|int|float|bool|null
     {


### PR DESCRIPTION
Just a simple fix to help static code analysis. Simply using a form will trigger a returned array when calling `::get()` on the form name, for instance, containing all the keys.

| Q             | A
| ------------- | ---
| Branch?       | 6.1 (mostly not to break previous code analysis)
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This doesn't break test, as it only changes PHPDoc.

6.1 only (not going back to 5.4 so as not to break static code analysis (I suppose this is better as it's also absolutely not critical).