### PR TITLE
[DependencyInjection] add `Autowire` parameter attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+/**
+ * Attribute to tell a parameter how to be autowired.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class Autowire
+{
+    public readonly string|Expression|Reference $value;
+
+    /**
+     * Use only ONE of the following.
+     *
+     * @param string|null $service    Service ID (ie "some.service")
+     * @param string|null $expression Expression (ie 'service("some.service").someMethod()')
+     * @param string|null $value      Parameter value (ie "%kernel.project_dir%/some/path")
+     */
+    public function __construct(
+        ?string $service = null,
+        ?string $expression = null,
+        ?string $value = null
+    ) {
+        if (!($service xor $expression xor null !== $value)) {
+            throw new LogicException('#[Autowire] attribute must declare exactly one of $service, $expression, or $value.');
+        }
+
+        $this->value = match (true) {
+            null !== $service => new Reference($service),
+            null !== $expression => class_exists(Expression::class) ? new Expression($expression) : throw new LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed. Try running "composer require symfony/expression-language".'),
+            null !== $value => $value,
+        };
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `$exclude` to `TaggedIterator` and `TaggedLocator` attributes
  * Add `$exclude` to `tagged_iterator` and `tagged_locator` configurator
  * Add an `env` function to the expression language provider
+ * Add an `Autowire` attribute to tell a parameter how to be autowired
 
 6.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+
+class AutowireTest extends TestCase
+{
+    public function testCanOnlySetOneParameter()
+    {
+        $this->expectException(LogicException::class);
+
+        new Autowire(service: 'id', expression: 'expr');
+    }
+
+    public function testMustSetOneParameter()
+    {
+        $this->expectException(LogicException::class);
+
+        new Autowire();
+    }
+
+    public function testCanUseZeroForValue()
+    {
+        $this->assertSame('0', (new Autowire(value: '0'))->value);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Service\Attribute\Required;
 
 class AutowireSetter
@@ -25,4 +26,19 @@ class AutowireProperty
 {
     #[Required]
     public Foo $foo;
+}
+
+class AutowireAttribute
+{
+    public function __construct(
+        #[Autowire(service: 'some.id')]
+        public \stdClass $service,
+        #[Autowire(expression: "parameter('some.parameter')")]
+        public string $expression,
+        #[Autowire(value: '%some.parameter%/bar')]
+        public string $value,
+        #[Autowire(service: 'invalid.id')]
+        public ?\stdClass $invalid = null,
+    ) {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

Replaces #45573 & #44780 with a single new `Autowire` attribute:

```php
class MyService
{
    public function __construct(
        #[Autowire(service: 'some_service')]
        private $service1,

        #[Autowire(expression: 'service("App\\Mail\\MailerConfiguration").getMailerMethod()')
        private $service2,

        #[Autowire(value: '%env(json:file:resolve:AUTH_FILE)%')]
        private $parameter1,

        #[Autowire(value: '%kernel.project_dir%/config/dir')]
        private $parameter2,
    ) {}
}
```

Works with controller arguments as well:

```php
class MyController
{
    public function someAction(
        #[Autowire(service: 'some_service')]
        $service1,

        #[Autowire(expression: 'service("App\\Mail\\MailerConfiguration").getMailerMethod()')
        $service2,

        #[Autowire(value: '%env(json:file:resolve:AUTH_FILE)%')]
        $parameter1,

        #[Autowire(value: '%kernel.project_dir%/config/dir')]
        $parameter2,
    ): Response {}
}
```