### PR TITLE
[Routing] Avoid double encoded slashes in query parameters

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `getMissingParameters` and `getRouteName` methods on `MissingMandatoryParametersException`
  * Allow using UTF-8 parameter names
  * Support the `attribute` type (alias of `annotation`) in annotation loaders
+ * Already encoded slashes are not decoded nor double-encoded anymore when generating URLs (query parameters)
 
 5.3
 ---

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -30,6 +30,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     private const QUERY_FRAGMENT_DECODED = [
         // RFC 3986 explicitly allows those in the query/fragment to reference other URIs unencoded
         '%2F' => '/',
+        '%252F' => '%2F',
         '%3F' => '?',
         // reserved chars that have no special meaning for HTTP URIs in a query or fragment
         // this excludes esp. "&", "=" and also "+" because PHP would treat it as a space (form-encoded)

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -527,6 +527,13 @@ class UrlGeneratorTest extends TestCase
         $this->assertSame('/app.php/dir/foo/bar%2Fbaz/dir2', $this->getGenerator($routes)->generate('test', ['path' => 'foo/bar%2Fbaz']));
     }
 
+    public function testEncodingOfSlashInQueryParameters()
+    {
+        $routes = $this->getRoutes('test', new Route('/get'));
+        $this->assertSame('/app.php/get?query=foo/bar', $this->getGenerator($routes)->generate('test', ['query' => 'foo/bar']));
+        $this->assertSame('/app.php/get?query=foo%2Fbar', $this->getGenerator($routes)->generate('test', ['query' => 'foo%2Fbar']));
+    }
+
     public function testAdjacentVariables()
     {
         $routes = $this->getRoutes('test', new Route('/{x}{y}{z}.{_format}', ['z' => 'default-z', '_format' => 'html'], ['y' => '\d+']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45114
| License       | MIT
| Doc PR        | 

Similar feature as discussed in https://github.com/symfony/symfony/issues/13017 and implemented in https://github.com/symfony/symfony/pull/39732, however for query parameters and not for path parameters.

This allows to manually encode slashes in query parameters before handing them over to `UrlGenerator` and avoids these slashes to be double encoded. Currently, it's not possible to generate an output with single encoded slashes in query parameters.

See #45114 for further details.
