### PR TITLE
[ErrorHandler] Center icons vertically in trace list

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -184,7 +184,7 @@ header .container { display: flex; justify-content: space-between; }
 .trace-line + .trace-line { border-top: var(--border); }
 .trace-line:hover { background: var(--base-1); }
 .trace-line a { color: var(--base-6); }
-.trace-line .icon { opacity: .4; position: absolute; left: 10px; top: 11px; }
+.trace-line .icon { opacity: .4; position: absolute; left: 10px; }
 .trace-line .icon svg { height: 16px; width: 16px; }
 .trace-line-header { padding-left: 36px; padding-right: 10px; }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4, 5.4, 6.0, 6.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | none <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
Make icons centered in trace list and not on the bottom trace-line-header div

Before:
![grafik](https://user-images.githubusercontent.com/22859658/157042250-51bb70c3-0350-4d84-8c80-e5ceb2e72e36.png)
After:
![grafik](https://user-images.githubusercontent.com/22859658/157042208-8023d18a-f39b-45b1-a0ba-7f3522d3be0f.png)
