### PR TITLE
[Asset] Update the error message when assets are not built

### DIFF
--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -54,7 +54,7 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
     {
         if (null === $this->manifestData) {
             if (!file_exists($this->manifestPath)) {
-                throw new \RuntimeException(sprintf('Asset manifest file "%s" does not exist.', $this->manifestPath));
+                throw new \RuntimeException(sprintf('Asset manifest file "%s" does not exist. Did you forget to build the assets with npm or yarn?', $this->manifestPath));
             }
 
             $this->manifestData = json_decode(file_get_contents($this->manifestPath), true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The current error message is very precise about what happened, but not very helpful about how to solve it. I propose to improve this using the same _"Did you forget ...?"_ pattern used in other Symfony errors.