### PR TITLE
[FrameworkBundle] Ensure container is reset between tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * KernelTestCase is the base class for tests needing a Kernel.
@@ -131,8 +132,13 @@ abstract class KernelTestCase extends TestCase
     {
         if (null !== static::$kernel) {
             static::$kernel->boot();
+            $container = static::$kernel->getContainer();
             static::$kernel->shutdown();
             static::$booted = false;
+
+            if ($container instanceof ResetInterface) {
+                $container->reset();
+            }
         }
 
         static::$container = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45668
| License       | MIT
| Doc PR        | -

Calling boot() resets the container only if a request was handled before.
Since this is not always the case here, we need to reset the container explicitly.