### PR TITLE
[Runtime] Fix passing $debug parameter to `ErrorHandler`

### DIFF
--- a/src/Symfony/Component/Runtime/Internal/SymfonyErrorHandler.php
+++ b/src/Symfony/Component/Runtime/Internal/SymfonyErrorHandler.php
@@ -29,7 +29,7 @@ class SymfonyErrorHandler
         if (class_exists(ErrorHandler::class)) {
             DebugClassLoader::enable();
             restore_error_handler();
-            ErrorHandler::register(new ErrorHandler(new BufferingLogger(), true));
+            ErrorHandler::register(new ErrorHandler(new BufferingLogger(), $debug));
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

As discussed with @nicolas-grekas on Slack, we think we should pass `$debug` parameter instead of `true`, since the 2nd argument of [`ErrorHandler`](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/ErrorHandler/ErrorHandler.php#L184) is called `$debug`.