### PR TITLE
[Process] Don't return executable directories in PhpExecutableFinder

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -47,6 +47,10 @@ class PhpExecutableFinder
                 }
             }
 
+            if (@is_dir($php)) {
+                return false;
+            }
+
             return $php;
         }
 
@@ -59,7 +63,7 @@ class PhpExecutableFinder
         }
 
         if ($php = getenv('PHP_PATH')) {
-            if (!@is_executable($php)) {
+            if (!@is_executable($php) || @is_dir($php)) {
                 return false;
             }
 
@@ -67,12 +71,12 @@ class PhpExecutableFinder
         }
 
         if ($php = getenv('PHP_PEAR_PHP_BIN')) {
-            if (@is_executable($php)) {
+            if (@is_executable($php) && !@is_dir($php)) {
                 return $php;
             }
         }
 
-        if (@is_executable($php = \PHP_BINDIR.('\\' === \DIRECTORY_SEPARATOR ? '\\php.exe' : '/php'))) {
+        if (@is_executable($php = \PHP_BINDIR.('\\' === \DIRECTORY_SEPARATOR ? '\\php.exe' : '/php')) && !@is_dir($php)) {
             return $php;
         }
 

--- a/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
@@ -50,12 +50,32 @@ class PhpExecutableFinderTest extends TestCase
     public function testNotExitsBinaryFile()
     {
         $f = new PhpExecutableFinder();
-        $phpBinaryEnv = \PHP_BINARY;
-        putenv('PHP_BINARY=/usr/local/php/bin/php-invalid');
 
-        $this->assertFalse($f->find(), '::find() returns false because of not exist file');
-        $this->assertFalse($f->find(false), '::find(false) returns false because of not exist file');
+        $originalPhpBinary = getenv('PHP_BINARY');
 
-        putenv('PHP_BINARY='.$phpBinaryEnv);
+        try {
+            putenv('PHP_BINARY=/usr/local/php/bin/php-invalid');
+
+            $this->assertFalse($f->find(), '::find() returns false because of not exist file');
+            $this->assertFalse($f->find(false), '::find(false) returns false because of not exist file');
+        } finally {
+            putenv('PHP_BINARY='.$originalPhpBinary);
+        }
+    }
+
+    public function testFindWithExecutableDirectory()
+    {
+        $originalPhpBinary = getenv('PHP_BINARY');
+
+        try {
+            $executableDirectoryPath = sys_get_temp_dir().'/PhpExecutableFinderTest_testFindWithExecutableDirectory';
+            @mkdir($executableDirectoryPath);
+            $this->assertTrue(is_executable($executableDirectoryPath));
+            putenv('PHP_BINARY='.$executableDirectoryPath);
+
+            $this->assertFalse((new PhpExecutableFinder())->find());
+        } finally {
+            putenv('PHP_BINARY='.$originalPhpBinary);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/45620
| License       | MIT
| Doc PR        | -

Directories can be executable and be wrongly returned if some env vars have directory paths as their values.