### PR TITLE
[DependencyInjection] fix `ServiceSubscriberTrait` bug where parent has `__call()`

### DIFF
--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -35,7 +35,7 @@ trait ServiceSubscriberTrait
             return $services;
         }
 
-        $services = \is_callable(['parent', __FUNCTION__]) ? parent::getSubscribedServices() : [];
+        $services = method_exists(get_parent_class(self::class) ?: '', __FUNCTION__) ? parent::getSubscribedServices() : [];
 
         foreach ((new \ReflectionClass(self::class))->getMethods() as $method) {
             if ($method->isStatic() || $method->isAbstract() || $method->isGenerator() || $method->isInternal() || $method->getNumberOfRequiredParameters()) {
@@ -69,7 +69,7 @@ trait ServiceSubscriberTrait
     {
         $this->container = $container;
 
-        if (\is_callable(['parent', __FUNCTION__])) {
+        if (method_exists(get_parent_class(self::class) ?: '', __FUNCTION__)) {
             return parent::setContainer($container);
         }
 

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -36,6 +36,32 @@ class ServiceSubscriberTraitTest extends TestCase
         $this->assertSame($container, (new TestService())->setContainer($container));
     }
 
+    public function testParentNotCalledIfHasMagicCall()
+    {
+        $container = new class([]) implements ContainerInterface {
+            use ServiceLocatorTrait;
+        };
+        $service = new class() extends ParentWithMagicCall {
+            use ServiceSubscriberTrait;
+        };
+
+        $this->assertNull($service->setContainer($container));
+        $this->assertSame([], $service::getSubscribedServices());
+    }
+
+    public function testParentNotCalledIfNoParent()
+    {
+        $container = new class([]) implements ContainerInterface {
+            use ServiceLocatorTrait;
+        };
+        $service = new class() {
+            use ServiceSubscriberTrait;
+        };
+
+        $this->assertNull($service->setContainer($container));
+        $this->assertSame([], $service::getSubscribedServices());
+    }
+
     /**
      * @requires PHP 8
      */
@@ -75,5 +101,18 @@ class ChildTestService extends TestService
 {
     public function aChildService(): Service3
     {
+    }
+}
+
+class ParentWithMagicCall
+{
+    public function __call($method, $args)
+    {
+        throw new \BadMethodCallException('Should not be called.');
+    }
+
+    public static function __callStatic($method, $args)
+    {
+        throw new \BadMethodCallException('Should not be called.');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

`is_callable(['parent', __FUNCTION__])` is true if the parent has magic `__call()/__callStatic` methods. Discovered this when trying to use `ServiceSubscriberTrait` with a Doctrine `ServiceEntityRepository`.
