### PR TITLE
[DependencyInjection] use `#[Required]` for `ServiceSubscriberTrait::setContainer()`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -42,6 +42,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\WebLink\EventListener\AddLinkHeaderListener;
 use Symfony\Component\WebLink\GenericLinkProvider;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Twig\Environment;
 
@@ -60,6 +61,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     /**
      * @required
      */
+    #[Required]
     public function setContainer(ContainerInterface $container): ?ContainerInterface
     {
         $previous = $this->container;

--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -12,6 +12,7 @@
 namespace Symfony\Contracts\Service;
 
 use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Service\Attribute\SubscribedService;
 
 /**
@@ -67,9 +68,7 @@ trait ServiceSubscriberTrait
         return $services;
     }
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setContainer(ContainerInterface $container): ?ContainerInterface
     {
         $this->container = $container;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45679
| License       | MIT
| Doc PR        | n/a

Can't use for `Symfony\Bundle\FrameworkBundle\Controller::setContainer()` until we bump the min version of `service-contracts`.