### PR TITLE
[Serializer] Fix nested deserialization_path computation when there is no metadata for the attribute

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -239,11 +239,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      */
     private function getAttributeDenormalizationContext(string $class, string $attribute, array $context): array
     {
+        $context['deserialization_path'] = ($context['deserialization_path'] ?? false) ? $context['deserialization_path'].'.'.$attribute : $attribute;
+
         if (null === $metadata = $this->getAttributeMetadata($class, $attribute)) {
             return $context;
         }
-
-        $context['deserialization_path'] = ($context['deserialization_path'] ?? false) ? $context['deserialization_path'].'.'.$attribute : $attribute;
 
         return array_merge($context, $metadata->getDenormalizationContextForGroups($this->getGroups($context)));
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
@@ -29,6 +29,8 @@ final class Php74Full
     public array $collection;
     public Php74FullWithConstructor $php74FullWithConstructor;
     public DummyMessageInterface $dummyMessage;
+    /** @var TestFoo[] $nestedArray */
+    public TestFoo $nestedObject;
 }
 
 
@@ -37,4 +39,9 @@ final class Php74FullWithConstructor
     public function __construct($constructorArgument)
     {
     }
+}
+
+final class TestFoo
+{
+    public int $int;
 }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -739,8 +739,12 @@ class SerializerTest extends TestCase
         );
     }
 
-    /** @requires PHP 7.4 */
-    public function testCollectDenormalizationErrors()
+    /**
+     * @dataProvider provideCollectDenormalizationErrors
+     *
+     * @requires PHP 7.4
+     */
+    public function testCollectDenormalizationErrors(?ClassMetadataFactory $classMetadataFactory)
     {
         $json = '
         {
@@ -764,10 +768,12 @@ class SerializerTest extends TestCase
             ],
             "php74FullWithConstructor": {},
             "dummyMessage": {
+            },
+            "nestedObject": {
+                "int": "string"
             }
         }';
 
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
 
         $serializer = new Serializer(
@@ -777,7 +783,7 @@ class SerializerTest extends TestCase
                 new DateTimeZoneNormalizer(),
                 new DataUriNormalizer(),
                 new UidNormalizer(),
-                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, new ClassDiscriminatorFromClassMetadata($classMetadataFactory)),
+                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, $classMetadataFactory ? new ClassDiscriminatorFromClassMetadata($classMetadataFactory) : null),
             ],
             ['json' => new JsonEncoder()]
         );
@@ -913,22 +919,45 @@ class SerializerTest extends TestCase
                 'useMessageForUser' => true,
                 'message' => 'Failed to create object because the object miss the "constructorArgument" property.',
             ],
-            [
-                'currentType' => 'null',
-                'expectedTypes' => [
-                    'string',
+            $classMetadataFactory ?
+                [
+                    'currentType' => 'null',
+                    'expectedTypes' => [
+                        'string',
+                    ],
+                    'path' => 'dummyMessage.type',
+                    'useMessageForUser' => false,
+                    'message' => 'Type property "type" not found for the abstract object "Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface".',
+                ] :
+                [
+                    'currentType' => 'array',
+                    'expectedTypes' => [
+                        DummyMessageInterface::class,
+                    ],
+                    'path' => 'dummyMessage',
+                    'useMessageForUser' => false,
+                    'message' => 'The type of the "dummyMessage" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74Full" must be one of "Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface" ("array" given).',
                 ],
-                'path' => 'dummyMessage.type',
-                'useMessageForUser' => false,
-                'message' => 'Type property "type" not found for the abstract object "Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface".',
+            [
+                'currentType' => 'string',
+                'expectedTypes' => [
+                    'int',
+                ],
+                'path' => 'nestedObject[int]',
+                'useMessageForUser' => true,
+                'message' => 'The type of the key "int" must be "int" ("string" given).',
             ],
         ];
 
         $this->assertSame($expected, $exceptionsAsArray);
     }
 
-    /** @requires PHP 7.4 */
-    public function testCollectDenormalizationErrors2()
+    /**
+     * @dataProvider provideCollectDenormalizationErrors
+     *
+     * @requires PHP 7.4
+     */
+    public function testCollectDenormalizationErrors2(?ClassMetadataFactory $classMetadataFactory)
     {
         $json = '
         [
@@ -940,13 +969,12 @@ class SerializerTest extends TestCase
             }
         ]';
 
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
 
         $serializer = new Serializer(
             [
                 new ArrayDenormalizer(),
-                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, new ClassDiscriminatorFromClassMetadata($classMetadataFactory)),
+                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, $classMetadataFactory ? new ClassDiscriminatorFromClassMetadata($classMetadataFactory) : null),
             ],
             ['json' => new JsonEncoder()]
         );
@@ -999,17 +1027,20 @@ class SerializerTest extends TestCase
         $this->assertSame($expected, $exceptionsAsArray);
     }
 
-    /** @requires PHP 8.0 */
-    public function testCollectDenormalizationErrorsWithConstructor()
+    /**
+     * @dataProvider provideCollectDenormalizationErrors
+     *
+     * @requires PHP 8.0
+     */
+    public function testCollectDenormalizationErrorsWithConstructor(?ClassMetadataFactory $classMetadataFactory)
     {
         $json = '{"bool": "bool"}';
 
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
 
         $serializer = new Serializer(
             [
-                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, new ClassDiscriminatorFromClassMetadata($classMetadataFactory)),
+                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, $classMetadataFactory ? new ClassDiscriminatorFromClassMetadata($classMetadataFactory) : null),
             ],
             ['json' => new JsonEncoder()]
         );
@@ -1049,6 +1080,14 @@ class SerializerTest extends TestCase
         ];
 
         $this->assertSame($expected, $exceptionsAsArray);
+    }
+
+    public function provideCollectDenormalizationErrors()
+    {
+        return [
+            [null],
+            [new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()))],
+        ];
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | _
| Tickets       | https://github.com/symfony/symfony/issues/45470)
| License       | MIT
| Doc PR        | -

`deserialization_path` always needs to be prepended with the attribute.