### PR TITLE
[Mailer] fix: stringify from address for ses+api transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -82,7 +82,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             $this->assertSame('Hello!', $content['Content']['Simple']['Subject']['Data']);
             $this->assertSame('"Saif Eddin" <saif.gmati@symfony.com>', $content['Destination']['ToAddresses'][0]);
             $this->assertSame('=?UTF-8?B?SsOpcsOpbXk=?= <jeremy@derusse.com>', $content['Destination']['CcAddresses'][0]);
-            $this->assertSame('"Fabien" <fabpot@symfony.com>', $content['FromEmailAddress']);
+            $this->assertSame('=?UTF-8?B?RmFiacOpbg==?= <fabpot@symfony.com>', $content['FromEmailAddress']);
             $this->assertSame('Hello There!', $content['Content']['Simple']['Body']['Text']['Data']);
             $this->assertSame('<b>Hello There!</b>', $content['Content']['Simple']['Body']['Html']['Data']);
             $this->assertSame(['replyto-1@example.com', 'replyto-2@example.com'], $content['ReplyToAddresses']);
@@ -103,7 +103,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
             ->cc(new Address('jeremy@derusse.com', 'Jérémy'))
-            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->from(new Address('fabpot@symfony.com', 'Fabién'))
             ->text('Hello There!')
             ->html('<b>Hello There!</b>')
             ->replyTo(new Address('replyto-1@example.com'), new Address('replyto-2@example.com'))

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -53,7 +53,7 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
         $envelope = $message->getEnvelope();
 
         $request = [
-            'FromEmailAddress' => $envelope->getSender()->toString(),
+            'FromEmailAddress' => $this->stringifyAddress($envelope->getSender()),
             'Destination' => [
                 'ToAddresses' => $this->stringifyAddresses($this->getRecipients($email, $envelope)),
             ],
@@ -114,15 +114,20 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
     protected function stringifyAddresses(array $addresses): array
     {
         return array_map(function (Address $a) {
-            // AWS does not support UTF-8 address
-            if (preg_match('~[\x00-\x08\x10-\x19\x7F-\xFF\r\n]~', $name = $a->getName())) {
-                return sprintf('=?UTF-8?B?%s?= <%s>',
-                    base64_encode($name),
-                    $a->getEncodedAddress()
-                );
-            }
-
-            return $a->toString();
+            return $this->stringifyAddress($a);
         }, $addresses);
+    }
+
+    protected function stringifyAddress(Address $a): string
+    {
+        // AWS does not support UTF-8 address
+        if (preg_match('~[\x00-\x08\x10-\x19\x7F-\xFF\r\n]~', $name = $a->getName())) {
+            return sprintf('=?UTF-8?B?%s?= <%s>',
+                base64_encode($name),
+                $a->getEncodedAddress()
+            );
+        }
+
+        return $a->toString();
     }
 }


### PR DESCRIPTION
close: #45660

| Q             | A
| ------------- | ---
| Branch?       | 6.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/issues/45660 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

> There are non-ASCII characters in the email address—The email address string must be 7-bit ASCII. If you want to send to or from email addresses that contain Unicode characters in the domain part of an address, you must encode the domain using Punycode. Punycode is not permitted in the local part of the email address (the part before the @ sign) nor in the "friendly from" name. If you want to use Unicode characters in the "friendly from" name, you must encode the "friendly from" name using MIME encoded-word syntax, as described in [Sending raw email using the Amazon SES API](https://docs.aws.amazon.com/ses/latest/dg/send-email-raw.html). For more information about Punycode, see [RFC 3492](http://tools.ietf.org/html/rfc3492).

\- from [Amazon SES email sending errors](https://docs.aws.amazon.com/ses/latest/dg/troubleshoot-error-messages.html)

We have already stringify to addresses, and we should also stringify the from address.