### PR TITLE
[Security] Fix return value of `NullToken::getUser()`

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
@@ -33,7 +33,7 @@ class NullToken implements TokenInterface
 
     public function getUser()
     {
-        return '';
+        return null;
     }
 
     public function setUser($user)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/44909
| License       | MIT
| Doc PR        | -

We went back & forth on this one but according to the history, we've just forgot to do it in https://github.com/symfony/symfony/pull/42650.
Note: it's already `null` on 6.0+