### PR TITLE
[Messenger] Add RedeliveryStamp (de)normalizer to avoid deprecations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1958,6 +1958,7 @@ class FrameworkExtension extends Extension
 
         if (!interface_exists(DenormalizerInterface::class)) {
             $container->removeDefinition('serializer.normalizer.flatten_exception');
+            $container->removeDefinition('serializer.normalizer.redelivery_stamp');
         }
 
         if (ContainerBuilder::willBeAvailable('symfony/amqp-messenger', AmqpTransportFactory::class, ['symfony/framework-bundle', 'symfony/messenger'], true)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -38,6 +38,7 @@ use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Transport\InMemoryTransportFactory;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
 use Symfony\Component\Messenger\Transport\Serialization\Normalizer\FlattenExceptionNormalizer;
+use Symfony\Component\Messenger\Transport\Serialization\Normalizer\RedeliveryStampNormalizer;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -72,6 +73,9 @@ return static function (ContainerConfigurator $container) {
 
         ->set('serializer.normalizer.flatten_exception', FlattenExceptionNormalizer::class)
             ->tag('serializer.normalizer', ['priority' => -880])
+
+        ->set('serializer.normalizer.redelivery_stamp', RedeliveryStampNormalizer::class)
+            ->tag('serializer.normalizer')
 
         ->set('messenger.transport.native_php_serializer', PhpSerializer::class)
 

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
@@ -15,7 +15,6 @@ use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class RedeliveryStampNormalizer implements DenormalizerInterface
 {
@@ -53,8 +52,6 @@ class RedeliveryStampNormalizer implements DenormalizerInterface
 
     public function supportsNormalization($data, string $format = null): bool
     {
-        return Kernel::VERSION_ID >= 50200
-            && $data instanceof RedeliveryStamp
-        ;
+        return $data instanceof RedeliveryStamp;
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Component\Messenger\Transport\Serialization\Normalizer;
 
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
@@ -18,7 +17,7 @@ class RedeliveryStampNormalizer implements DenormalizerInterface
 
     public function supportsDenormalization($data, string $type, string $format = null): bool
     {
-        return $type === RedeliveryStamp::class
+        return RedeliveryStamp::class === $type
             && null === ($data['exceptionMessage'] ?? null)
             && null === ($data['flattenException'] ?? null)
         ;

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Component\Messenger\Transport\Serialization\Normalizer;
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class RedeliveryStampNormalizer implements DenormalizerInterface
+{
+    public function denormalize($data, string $type, string $format = null, array $context = [])
+    {
+        return new RedeliveryStamp(
+            $data['retryCount'] ?? 0,
+            $data['redeliveredAt'] ?? null
+        );
+    }
+
+    public function supportsDenormalization($data, string $type, string $format = null): bool
+    {
+        return $type === RedeliveryStamp::class
+            && null === ($data['exceptionMessage'] ?? null)
+            && null === ($data['flattenException'] ?? null)
+        ;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Messenger\Transport\Serialization\Normalizer;
 
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/RedeliveryStampNormalizer.php
@@ -12,15 +12,20 @@
 namespace Symfony\Component\Messenger\Transport\Serialization\Normalizer;
 
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class RedeliveryStampNormalizer implements DenormalizerInterface
 {
     public function denormalize($data, string $type, string $format = null, array $context = [])
     {
+        $redeliveredAt = $data['redeliveredAt'] ?? null;
+
         return new RedeliveryStamp(
             $data['retryCount'] ?? 0,
-            $data['redeliveredAt'] ?? null
+            $redeliveredAt ? new \DateTimeImmutable($redeliveredAt) : null
         );
     }
 
@@ -29,6 +34,27 @@ class RedeliveryStampNormalizer implements DenormalizerInterface
         return RedeliveryStamp::class === $type
             && null === ($data['exceptionMessage'] ?? null)
             && null === ($data['flattenException'] ?? null)
+        ;
+    }
+
+    public function normalize($object, string $format = null, array $context = [])
+    {
+        if (! $object instanceof RedeliveryStamp) {
+            throw new InvalidArgumentException();
+        }
+
+        $dateTimeFormat = $context[DateTimeNormalizer::FORMAT_KEY] ?? \DateTimeInterface::RFC3339;
+
+        return [
+            'retryCount' => $object->getRetryCount(),
+            'redeliveredAt' => $object->getRedeliveredAt()->format($dateTimeFormat),
+        ];
+    }
+
+    public function supportsNormalization($data, string $format = null): bool
+    {
+        return Kernel::VERSION_ID >= 50200
+            && $data instanceof RedeliveryStamp
         ;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no (silencing existing ones)
| Tickets       | N/A
| License       | MIT

While working on the deprecations triggered by my 5.4 app, this is the first one that I stumbled upon:

https://github.com/symfony/symfony/blob/b30675a253e9cdda17842d0d3b530024f576b97a/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php#L30-L36

This was not intentionally triggered by me, but it stemmed from the normal JSON deserialization process that the Symfony serializer does; if I upgraded to 6.0 today I wouldn't need to do anything about it, hence these deprecations are just noise to me.

By adding this proposed denormalizer, we avoid triggering the deprecation in systems that already handle it correctly due to framework upgrades.

I don't know if existing tests already cover this, please point me to where I can add them if needed.