### PR TITLE
[Form] Fix the usage of the Valid constraints in array-based forms

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -110,7 +110,7 @@ class FormValidator extends ConstraintValidator
                 foreach ($constraints as $constraint) {
                     // For the "Valid" constraint, validate the data in all groups
                     if ($constraint instanceof Valid) {
-                        if (\is_object($data)) {
+                        if (\is_object($data) || \is_array($data)) {
                             $validator->atPath('data')->validate($data, $constraint, $groups);
                         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -326,6 +327,35 @@ class FormValidatorFunctionalTest extends TestCase
         $this->assertSame('data.rating', $violations[0]->getPropertyPath());
         $this->assertSame('This value should not be blank.', $violations[1]->getMessage());
         $this->assertSame('children[author].data.email', $violations[1]->getPropertyPath());
+    }
+
+    public function testCascadeValidationToArrayChildForm()
+    {
+        $form = $this->formFactory->create(FormType::class, null, [
+            'data_class' => Review::class,
+        ])
+            ->add('title')
+            ->add('customers', CollectionType::class, [
+                'mapped' => false,
+                'entry_type' => CustomerType::class,
+                'allow_add' => true,
+                'constraints' => [new Valid()],
+            ]);
+
+        $form->submit([
+            'title' => 'Sample Title',
+            'customers' => [
+                ['email' => null],
+            ],
+        ]);
+
+        $violations = $this->validator->validate($form);
+
+        $this->assertCount(2, $violations);
+        $this->assertSame('This value should not be blank.', $violations[0]->getMessage());
+        $this->assertSame('data.rating', $violations[0]->getPropertyPath());
+        $this->assertSame('This value should not be blank.', $violations[1]->getMessage());
+        $this->assertSame('children[customers].data[0].email', $violations[1]->getPropertyPath());
     }
 
     public function testCascadeValidationToChildFormsUsingPropertyPathsValidatedInSequence()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This is a bug introduced in https://github.com/symfony/symfony/pull/39333. When wanting to exclude scalar forms, it also excluded array forms.
The code now uses the same `\is_object($data) || \is_array($data)` condition for `Valid` constraint than the condition it uses as part of the `$validateDataGraph` condition.

The new tests reflects my own use case: an unmapped collection field, were we want to run the validation on that subtree (which is not traversed for other reasons due to being unmapped, and so we need `Valid`). This was working fine in older versions of Symfony, but the validation was silently skipped in 4.4.18+.
