### PR TITLE
[Cache] Declaratively declare/hide DoctrineProvider to avoid breaking static analysis

### DIFF
--- a/src/Symfony/Component/Cache/DoctrineProvider.php
+++ b/src/Symfony/Component/Cache/DoctrineProvider.php
@@ -15,6 +15,10 @@ use Doctrine\Common\Cache\CacheProvider;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
+if (!class_exists(CacheProvider::class)) {
+    return;
+}
+
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/vimeo/psalm/issues/7680
| License       | MIT

I encountered this issue while upgrading both Psalm and Symfony. The `DoctrineProvider` got deprecated, and dropped somehow the transient dependency on `doctrine/common`. This meant that the Psalm loading step breaks while reading vendor, even if the class is unused, due to its extension of a missing class:
```
Uncaught Error: Class "Doctrine\Common\Cache\CacheProvider" not found in /var/www/insight/core/vendor/symfony/cache/DoctrineProvider.php:23
```
This optional declaration solves the issue, without impacting the code, since it would be broken if we tried to load it outside that  `class_exists` condition.