### PR TITLE
[FrameworkBundle] Deprecate the messenger.reset_on_message config option

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -15,6 +15,12 @@ Console
  * Add argument `$suggestedValues` to `Command::addArgument` and `Command::addOption`
  * Add argument `$suggestedValues` to `InputArgument` and `InputOption` constructors
 
+FrameworkBundle
+---------------
+
+ * Deprecate the `reset_on_message` config option. It can be set to `true` only and does nothing now.
+   To prevent services resetting after each message the "--no-reset" option in "messenger:consume" command can be set
+
 HttpKernel
 ----------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Load PHP configuration files by default in the `MicroKernelTrait`
  * Add `cache:pool:invalidate-tags` command
  * Add `xliff` support in addition to `xlf` for `XliffFileDumper`
+ * Deprecate the `reset_on_message` config option. It can be set to `true` only and does nothing now
 
 6.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1426,6 +1426,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('reset_on_message')
                             ->defaultTrue()
                             ->info('Reset container services after each message.')
+                            ->setDeprecated('symfony/framework-bundle', '6.1', 'Option "%node%" at "%path%" is deprecated. It does nothing and will be removed in version 7.0.')
                             ->validate()
                                 ->ifTrue(static fn ($v) => true !== $v)
                                 ->thenInvalid('The "framework.messenger.reset_on_message" configuration option can be set to "true" only. To prevent services resetting after each message you can set the "--no-reset" option in "messenger:consume" command.')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Continues https://github.com/symfony/symfony/pull/43203#issuecomment-954750050
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
