### PR TITLE
Remove extra space in NotificationEmail

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
@@ -43,7 +43,7 @@ class NotificationEmail extends TemplatedEmail
     {
         $missingPackages = [];
         if (!class_exists(CssInlinerExtension::class)) {
-            $missingPackages['twig/cssinliner-extra'] = ' CSS Inliner';
+            $missingPackages['twig/cssinliner-extra'] = 'CSS Inliner';
         }
 
         if (!class_exists(InkyExtension::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Hi, just a little space character being removed :)

Currently without this "patch" it renders:

> You cannot use "..." if the " CSS Inliner" and "Inky" Twig extensions are not available; try running "composer require twig/cssinliner-extra twig/inky-extra".