### PR TITLE
Add ReStructuredText descriptor for console component.

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add method `__toString()` to `InputInterface`
  * Deprecate `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead
+ * Add `ReStructuredTextDescriptor`
 
 6.0
 ---

--- a/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
@@ -24,11 +24,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ReStructuredTextDescriptor extends Descriptor
 {
-
-  private $applicationTitleUnderlineChar = '#';
-  private $commandTitleUnderlineChar = '*';
-  private $argumentsTitleUnderlineChar = '=';
-  private $argumentTitleUnderlineChar = '-';
+    private $applicationTitleUnderlineChar = '#';
+    private $commandTitleUnderlineChar = '*';
+    private $argumentsTitleUnderlineChar = '=';
+    private $argumentTitleUnderlineChar = '-';
 
     /**
      * {@inheritdoc}
@@ -52,155 +51,160 @@ class ReStructuredTextDescriptor extends Descriptor
     }
 
     /**
-   * {@inheritdoc}
-   */
-  protected function describeInputArgument(InputArgument $argument, array $options = []) {
-    $this->write(
-      '``' . ($argument->getName() ?: '<none>') . "``\n" . str_repeat($this->argumentTitleUnderlineChar, Helper::width($argument->getName()) + 4) . "\n\n"
-      . ($argument->getDescription() ? preg_replace('/\s*[\r\n]\s*/', "\n", $argument->getDescription()) . "\n\n" : '')
-      . '- Is required: ' . ($argument->isRequired() ? 'yes' : 'no') . "\n"
-      . '- Is array: ' . ($argument->isArray() ? 'yes' : 'no') . "\n"
-      . '- Default: ``' . str_replace("\n", '', var_export($argument->getDefault(), TRUE)) . '``'
+     * {@inheritdoc}
+     */
+    protected function describeInputArgument(InputArgument $argument, array $options = [])
+    {
+        $this->write(
+      '``'.($argument->getName() ?: '<none>')."``\n".str_repeat($this->argumentTitleUnderlineChar, Helper::width($argument->getName()) + 4)."\n\n"
+      .($argument->getDescription() ? preg_replace('/\s*[\r\n]\s*/', "\n", $argument->getDescription())."\n\n" : '')
+      .'- Is required: '.($argument->isRequired() ? 'yes' : 'no')."\n"
+      .'- Is array: '.($argument->isArray() ? 'yes' : 'no')."\n"
+      .'- Default: ``'.str_replace("\n", '', var_export($argument->getDefault(), true)).'``'
     );
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function describeInputOption(InputOption $option, array $options = []) {
-    $name = '--' . $option->getName();
-    if ($option->isNegatable()) {
-      $name .= '|--no-' . $option->getName();
-    }
-    if ($option->getShortcut()) {
-      $name .= '|-' . str_replace('|', '|-', $option->getShortcut()) . '';
     }
 
-    $this->write(
-      '``' . $name . '``' . "\n" . str_repeat($this->argumentTitleUnderlineChar, Helper::width($name) + 4) . "\n\n"
-      . ($option->getDescription() ? preg_replace('/\s*[\r\n]\s*/', "\n", $option->getDescription()) . "\n\n" : '')
-      . '- Accept value: ' . ($option->acceptValue() ? 'yes' : 'no') . "\n"
-      . '- Is value required: ' . ($option->isValueRequired() ? 'yes' : 'no') . "\n"
-      . '- Is multiple: ' . ($option->isArray() ? 'yes' : 'no') . "\n"
-      . '- Is negatable: ' . ($option->isNegatable() ? 'yes' : 'no') . "\n"
-      . '- Default: ``' . str_replace("\n", '', var_export($option->getDefault(), TRUE)) . '``'
+    /**
+     * {@inheritdoc}
+     */
+    protected function describeInputOption(InputOption $option, array $options = [])
+    {
+        $name = '--'.$option->getName();
+        if ($option->isNegatable()) {
+            $name .= '|--no-'.$option->getName();
+        }
+        if ($option->getShortcut()) {
+            $name .= '|-'.str_replace('|', '|-', $option->getShortcut()).'';
+        }
+
+        $this->write(
+      '``'.$name.'``'."\n".str_repeat($this->argumentTitleUnderlineChar, Helper::width($name) + 4)."\n\n"
+      .($option->getDescription() ? preg_replace('/\s*[\r\n]\s*/', "\n", $option->getDescription())."\n\n" : '')
+      .'- Accept value: '.($option->acceptValue() ? 'yes' : 'no')."\n"
+      .'- Is value required: '.($option->isValueRequired() ? 'yes' : 'no')."\n"
+      .'- Is multiple: '.($option->isArray() ? 'yes' : 'no')."\n"
+      .'- Is negatable: '.($option->isNegatable() ? 'yes' : 'no')."\n"
+      .'- Default: ``'.str_replace("\n", '', var_export($option->getDefault(), true)).'``'
     );
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function describeInputDefinition(InputDefinition $definition, array $options = []) {
-    if ($showArguments = \count($definition->getArguments()) > 0) {
-      $this->write("Arguments\n" . str_repeat($this->argumentsTitleUnderlineChar, 9)) . "\n\n";
-      foreach ($definition->getArguments() as $argument) {
-        $this->write("\n\n");
-        if (NULL !== $describeInputArgument = $this->describeInputArgument($argument)) {
-          $this->write($describeInputArgument);
-        }
-      }
     }
 
-    if (\count($definition->getOptions()) > 0) {
-      if ($showArguments) {
-        $this->write("\n\n");
-      }
-
-      $this->write("Options\n" . str_repeat($this->argumentsTitleUnderlineChar, 7)) . "\n\n";
-      foreach ($definition->getOptions() as $option) {
-        $this->write("\n\n");
-        if (NULL !== $describeInputOption = $this->describeInputOption($option)) {
-          $this->write($describeInputOption);
+    /**
+     * {@inheritdoc}
+     */
+    protected function describeInputDefinition(InputDefinition $definition, array $options = [])
+    {
+        if ($showArguments = \count($definition->getArguments()) > 0) {
+            $this->write("Arguments\n".str_repeat($this->argumentsTitleUnderlineChar, 9))."\n\n";
+            foreach ($definition->getArguments() as $argument) {
+                $this->write("\n\n");
+                if (null !== $describeInputArgument = $this->describeInputArgument($argument)) {
+                    $this->write($describeInputArgument);
+                }
+            }
         }
-      }
-    }
-  }
 
-  /**
-   * {@inheritdoc}
-   */
-  protected function describeCommand(Command $command, array $options = []) {
-    if ($options['short'] ?? FALSE) {
-      $this->write(
-        '``' . $command->getName() . "``\n"
-        . str_repeat($this->commandTitleUnderlineChar, Helper::width($command->getName()) + 4) . "\n\n"
-        . ($command->getDescription() ? $command->getDescription() . "\n\n" : '')
-        . "Usage\n" . str_repeat($this->argumentsTitleUnderlineChar, 5) . "\n\n"
-        . array_reduce($command->getAliases(), function ($carry, $usage) {
-          return $carry . '- ``' . $usage . '``' . "\n";
+        if (\count($definition->getOptions()) > 0) {
+            if ($showArguments) {
+                $this->write("\n\n");
+            }
+
+            $this->write("Options\n".str_repeat($this->argumentsTitleUnderlineChar, 7))."\n\n";
+            foreach ($definition->getOptions() as $option) {
+                $this->write("\n\n");
+                if (null !== $describeInputOption = $this->describeInputOption($option)) {
+                    $this->write($describeInputOption);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function describeCommand(Command $command, array $options = [])
+    {
+        if ($options['short'] ?? false) {
+            $this->write(
+        '``'.$command->getName()."``\n"
+        .str_repeat($this->commandTitleUnderlineChar, Helper::width($command->getName()) + 4)."\n\n"
+        .($command->getDescription() ? $command->getDescription()."\n\n" : '')
+        ."Usage\n".str_repeat($this->argumentsTitleUnderlineChar, 5)."\n\n"
+        .array_reduce($command->getAliases(), function ($carry, $usage) {
+            return $carry.'- ``'.$usage.'``'."\n";
         })
       );
 
-      return;
-    }
+            return;
+        }
 
-    $command->mergeApplicationDefinition(FALSE);
+        $command->mergeApplicationDefinition(false);
 
-    foreach ($command->getAliases() as $alias) {
-      $this->write('.. _' . $alias . ":\n\n");
-    }
-    $this->write(
-      '``' . $command->getName() . "``\n"
-      . str_repeat($this->commandTitleUnderlineChar, Helper::width($command->getName()) + 4) . "\n\n"
-      . ($command->getDescription() ? $command->getDescription() . "\n\n" : '')
-      . "Usage\n" . str_repeat($this->argumentsTitleUnderlineChar, 5) . "\n\n"
-      . array_reduce(array_merge([$command->getSynopsis()], $command->getAliases(), $command->getUsages()), function ($carry, $usage) {
-        return $carry . '- ``' . $usage . '``' . "\n";
+        foreach ($command->getAliases() as $alias) {
+            $this->write('.. _'.$alias.":\n\n");
+        }
+        $this->write(
+      '``'.$command->getName()."``\n"
+      .str_repeat($this->commandTitleUnderlineChar, Helper::width($command->getName()) + 4)."\n\n"
+      .($command->getDescription() ? $command->getDescription()."\n\n" : '')
+      ."Usage\n".str_repeat($this->argumentsTitleUnderlineChar, 5)."\n\n"
+      .array_reduce(array_merge([$command->getSynopsis()], $command->getAliases(), $command->getUsages()), function ($carry, $usage) {
+          return $carry.'- ``'.$usage.'``'."\n";
       })
     );
 
-    if ($help = $command->getProcessedHelp()) {
-      $this->write("\n");
-      $this->write($help);
+        if ($help = $command->getProcessedHelp()) {
+            $this->write("\n");
+            $this->write($help);
+        }
+
+        $definition = $command->getDefinition();
+        if ($definition->getOptions() || $definition->getArguments()) {
+            $this->write("\n\n");
+            $this->describeInputDefinition($definition);
+        }
     }
 
-    $definition = $command->getDefinition();
-    if ($definition->getOptions() || $definition->getArguments()) {
-      $this->write("\n\n");
-      $this->describeInputDefinition($definition);
-    }
-  }
+    /**
+     * {@inheritdoc}
+     */
+    protected function describeApplication(Application $application, array $options = [])
+    {
+        $describedNamespace = $options['namespace'] ?? null;
+        $description = new ApplicationDescription($application, $describedNamespace);
+        $title = $this->getApplicationTitle($application);
 
-  /**
-   * {@inheritdoc}
-   */
-  protected function describeApplication(Application $application, array $options = []) {
-    $describedNamespace = $options['namespace'] ?? NULL;
-    $description = new ApplicationDescription($application, $describedNamespace);
-    $title = $this->getApplicationTitle($application);
+        $this->write($title."\n".str_repeat($this->applicationTitleUnderlineChar, Helper::width($title)));
 
-    $this->write($title . "\n" . str_repeat($this->applicationTitleUnderlineChar, Helper::width($title)));
+        foreach ($description->getNamespaces() as $namespace) {
+            if (ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id']) {
+                $this->write("\n\n");
+                $this->write('**'.$namespace['id'].':**');
+            }
 
-    foreach ($description->getNamespaces() as $namespace) {
-      if (ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id']) {
-        $this->write("\n\n");
-        $this->write('**' . $namespace['id'] . ':**');
-      }
+            $this->write("\n\n");
+            $this->write(implode("\n", array_map(function ($commandName) {
+                return sprintf('- `%s`_', $commandName);
+            }, $namespace['commands'])));
+        }
 
-      $this->write("\n\n");
-      $this->write(implode("\n", array_map(function ($commandName) {
-        return sprintf('- `%s`_', $commandName);
-      }, $namespace['commands'])));
-    }
-
-    foreach ($description->getCommands() as $command) {
-      $this->write("\n\n");
-      if (NULL !== $describeCommand = $this->describeCommand($command, $options)) {
-        $this->write($describeCommand);
-      }
-    }
-  }
-
-  private function getApplicationTitle(Application $application): string {
-    if ('UNKNOWN' !== $application->getName()) {
-      if ('UNKNOWN' !== $application->getVersion()) {
-        return sprintf('%s %s', $application->getName(), $application->getVersion());
-      }
-
-      return $application->getName();
+        foreach ($description->getCommands() as $command) {
+            $this->write("\n\n");
+            if (null !== $describeCommand = $this->describeCommand($command, $options)) {
+                $this->write($describeCommand);
+            }
+        }
     }
 
-    return 'Console Tool';
-  }
+    private function getApplicationTitle(Application $application): string
+    {
+        if ('UNKNOWN' !== $application->getName()) {
+            if ('UNKNOWN' !== $application->getVersion()) {
+                return sprintf('%s %s', $application->getName(), $application->getVersion());
+            }
 
+            return $application->getName();
+        }
+
+        return 'Console Tool';
+    }
 }

--- a/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Descriptor;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * ReStructuredTextDescriptor descriptor.
+ */
+class ReStructuredTextDescriptor extends Descriptor
+{
+
+  private $applicationTitleUnderlineChar = '#';
+  private $commandTitleUnderlineChar = '*';
+  private $argumentsTitleUnderlineChar = '=';
+  private $argumentTitleUnderlineChar = '-';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function describe(OutputInterface $output, object $object, array $options = [])
+    {
+        $decorated = $output->isDecorated();
+        $output->setDecorated(false);
+
+        parent::describe($output, $object, $options);
+
+        $output->setDecorated($decorated);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(string $content, bool $decorated = true)
+    {
+        parent::write($content, $decorated);
+    }
+
+    /**
+   * {@inheritdoc}
+   */
+  protected function describeInputArgument(InputArgument $argument, array $options = []) {
+    $this->write(
+      '``' . ($argument->getName() ?: '<none>') . "``\n" . str_repeat($this->argumentTitleUnderlineChar, Helper::width($argument->getName()) + 4) . "\n\n"
+      . ($argument->getDescription() ? preg_replace('/\s*[\r\n]\s*/', "\n", $argument->getDescription()) . "\n\n" : '')
+      . '- Is required: ' . ($argument->isRequired() ? 'yes' : 'no') . "\n"
+      . '- Is array: ' . ($argument->isArray() ? 'yes' : 'no') . "\n"
+      . '- Default: ``' . str_replace("\n", '', var_export($argument->getDefault(), TRUE)) . '``'
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function describeInputOption(InputOption $option, array $options = []) {
+    $name = '--' . $option->getName();
+    if ($option->isNegatable()) {
+      $name .= '|--no-' . $option->getName();
+    }
+    if ($option->getShortcut()) {
+      $name .= '|-' . str_replace('|', '|-', $option->getShortcut()) . '';
+    }
+
+    $this->write(
+      '``' . $name . '``' . "\n" . str_repeat($this->argumentTitleUnderlineChar, Helper::width($name) + 4) . "\n\n"
+      . ($option->getDescription() ? preg_replace('/\s*[\r\n]\s*/', "\n", $option->getDescription()) . "\n\n" : '')
+      . '- Accept value: ' . ($option->acceptValue() ? 'yes' : 'no') . "\n"
+      . '- Is value required: ' . ($option->isValueRequired() ? 'yes' : 'no') . "\n"
+      . '- Is multiple: ' . ($option->isArray() ? 'yes' : 'no') . "\n"
+      . '- Is negatable: ' . ($option->isNegatable() ? 'yes' : 'no') . "\n"
+      . '- Default: ``' . str_replace("\n", '', var_export($option->getDefault(), TRUE)) . '``'
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function describeInputDefinition(InputDefinition $definition, array $options = []) {
+    if ($showArguments = \count($definition->getArguments()) > 0) {
+      $this->write("Arguments\n" . str_repeat($this->argumentsTitleUnderlineChar, 9)) . "\n\n";
+      foreach ($definition->getArguments() as $argument) {
+        $this->write("\n\n");
+        if (NULL !== $describeInputArgument = $this->describeInputArgument($argument)) {
+          $this->write($describeInputArgument);
+        }
+      }
+    }
+
+    if (\count($definition->getOptions()) > 0) {
+      if ($showArguments) {
+        $this->write("\n\n");
+      }
+
+      $this->write("Options\n" . str_repeat($this->argumentsTitleUnderlineChar, 7)) . "\n\n";
+      foreach ($definition->getOptions() as $option) {
+        $this->write("\n\n");
+        if (NULL !== $describeInputOption = $this->describeInputOption($option)) {
+          $this->write($describeInputOption);
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function describeCommand(Command $command, array $options = []) {
+    if ($options['short'] ?? FALSE) {
+      $this->write(
+        '``' . $command->getName() . "``\n"
+        . str_repeat($this->commandTitleUnderlineChar, Helper::width($command->getName()) + 4) . "\n\n"
+        . ($command->getDescription() ? $command->getDescription() . "\n\n" : '')
+        . "Usage\n" . str_repeat($this->argumentsTitleUnderlineChar, 5) . "\n\n"
+        . array_reduce($command->getAliases(), function ($carry, $usage) {
+          return $carry . '- ``' . $usage . '``' . "\n";
+        })
+      );
+
+      return;
+    }
+
+    $command->mergeApplicationDefinition(FALSE);
+
+    foreach ($command->getAliases() as $alias) {
+      $this->write('.. _' . $alias . ":\n\n");
+      //'.. _' . str_replace(':', '-', $command->getName()) . ':' . "\n\n"
+    }
+    $this->write(
+      '``' . $command->getName() . "``\n"
+      . str_repeat($this->commandTitleUnderlineChar, Helper::width($command->getName()) + 4) . "\n\n"
+      . ($command->getDescription() ? $command->getDescription() . "\n\n" : '')
+      . "Usage\n" . str_repeat($this->argumentsTitleUnderlineChar, 5) . "\n\n"
+      . array_reduce(array_merge([$command->getSynopsis()], $command->getAliases(), $command->getUsages()), function ($carry, $usage) {
+        return $carry . '- ``' . $usage . '``' . "\n";
+      })
+    );
+
+    if ($help = $command->getProcessedHelp()) {
+      $this->write("\n");
+      $this->write($help);
+    }
+
+    $definition = $command->getDefinition();
+    if ($definition->getOptions() || $definition->getArguments()) {
+      $this->write("\n\n");
+      $this->describeInputDefinition($definition);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function describeApplication(Application $application, array $options = []) {
+    $describedNamespace = $options['namespace'] ?? NULL;
+    $description = new ApplicationDescription($application, $describedNamespace);
+    $title = $this->getApplicationTitle($application);
+
+    $this->write($title . "\n" . str_repeat($this->applicationTitleUnderlineChar, Helper::width($title)));
+
+    foreach ($description->getNamespaces() as $namespace) {
+      if (ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id']) {
+        $this->write("\n\n");
+        $this->write('**' . $namespace['id'] . ':**');
+      }
+
+      $this->write("\n\n");
+      $this->write(implode("\n", array_map(function ($commandName) {
+        return sprintf('- `%s`_', $commandName);
+      }, $namespace['commands'])));
+    }
+
+    foreach ($description->getCommands() as $command) {
+      $this->write("\n\n");
+      if (NULL !== $describeCommand = $this->describeCommand($command, $options)) {
+        $this->write($describeCommand);
+      }
+    }
+  }
+
+  private function getApplicationTitle(Application $application): string {
+    if ('UNKNOWN' !== $application->getName()) {
+      if ('UNKNOWN' !== $application->getVersion()) {
+        return sprintf('%s %s', $application->getName(), $application->getVersion());
+      }
+
+      return $application->getName();
+    }
+
+    return 'Console Tool';
+  }
+
+}

--- a/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
@@ -138,7 +138,6 @@ class ReStructuredTextDescriptor extends Descriptor
 
     foreach ($command->getAliases() as $alias) {
       $this->write('.. _' . $alias . ":\n\n");
-      //'.. _' . str_replace(':', '-', $command->getName()) . ':' . "\n\n"
     }
     $this->write(
       '``' . $command->getName() . "``\n"

--- a/src/Symfony/Component/Console/Helper/DescriptorHelper.php
+++ b/src/Symfony/Component/Console/Helper/DescriptorHelper.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Helper;
 use Symfony\Component\Console\Descriptor\DescriptorInterface;
 use Symfony\Component\Console\Descriptor\JsonDescriptor;
 use Symfony\Component\Console\Descriptor\MarkdownDescriptor;
+use Symfony\Component\Console\Descriptor\ReStructuredTextDescriptor;
 use Symfony\Component\Console\Descriptor\TextDescriptor;
 use Symfony\Component\Console\Descriptor\XmlDescriptor;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
@@ -38,6 +39,7 @@ class DescriptorHelper extends Helper
             ->register('xml', new XmlDescriptor())
             ->register('json', new JsonDescriptor())
             ->register('md', new MarkdownDescriptor())
+            ->register('rst', new ReStructuredTextDescriptor())
         ;
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
@@ -87,7 +87,7 @@ class HelpCommandTest extends TestCase
     {
         yield 'option --format' => [
             ['--format', ''],
-            ['txt', 'xml', 'json', 'md'],
+            ['txt', 'xml', 'json', 'md', 'rst'],
         ];
 
         yield 'nothing' => [

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -131,7 +131,7 @@ EOF;
     {
         yield 'option --format' => [
             ['--format', ''],
-            ['txt', 'xml', 'json', 'md'],
+            ['txt', 'xml', 'json', 'md', 'rst'],
         ];
 
         yield 'namespace' => [

--- a/src/Symfony/Component/Console/Tests/Descriptor/ReStructuredTextDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/ReStructuredTextDescriptorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Descriptor;
+
+use Symfony\Component\Console\Descriptor\ReStructuredTextDescriptor;
+use Symfony\Component\Console\Tests\Fixtures\DescriptorApplicationMbString;
+use Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString;
+
+class ReStructuredTextDescriptorTest extends AbstractDescriptorTest
+{
+    public function getDescribeCommandTestData()
+    {
+        return $this->getDescriptionTestData(array_merge(
+            ObjectsProvider::getCommands(),
+            ['command_mbstring' => new DescriptorCommandMbString()]
+        ));
+    }
+
+    public function getDescribeApplicationTestData()
+    {
+        return $this->getDescriptionTestData(array_merge(
+            ObjectsProvider::getApplications(),
+            ['application_mbstring' => new DescriptorApplicationMbString()]
+        ));
+    }
+
+    protected function getDescriptor()
+    {
+        return new ReStructuredTextDescriptor();
+    }
+
+    protected function getFormat()
+    {
+        return 'rst';
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
@@ -1,0 +1,362 @@
+Console Tool
+============
+
+* [`completion`](#completion)
+* [`help`](#help)
+* [`list`](#list)
+
+`completion`
+------------
+
+Dump the shell completion script
+
+### Usage
+
+* `completion [--debug] [--] [<shell>]`
+
+The completion command dumps the shell completion script required
+to use shell autocompletion (currently only bash completion is supported).
+
+Static installation
+-------------------
+
+Dump the script to a global completion file and restart your shell:
+
+    %%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%
+
+Or dump the script to a local file and source it:
+
+    %%PHP_SELF%% completion bash > completion.sh
+
+    # source the file whenever you use the project
+    source completion.sh
+
+    # or add this line at the end of your "~/.bashrc" file:
+    source /path/to/completion.sh
+
+Dynamic installation
+--------------------
+
+Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
+
+    eval "$(%%PHP_SELF_FULL%% completion bash)"
+
+### Arguments
+
+#### `shell`
+
+The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+* Is required: no
+* Is array: no
+* Default: `NULL`
+
+### Options
+
+#### `--debug`
+
+Tail the completion debug log
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+`help`
+------
+
+Display help for a command
+
+### Usage
+
+* `help [--format FORMAT] [--raw] [--] [<command_name>]`
+
+The help command displays help for a given command:
+
+  %%PHP_SELF%% help list
+
+You can also output the help in other formats by using the --format option:
+
+  %%PHP_SELF%% help --format=xml list
+
+To display the list of available commands, please use the list command.
+
+### Arguments
+
+#### `command_name`
+
+The command name
+
+* Is required: no
+* Is array: no
+* Default: `'help'`
+
+### Options
+
+#### `--format`
+
+The output format (txt, xml, json, or md)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'txt'`
+
+#### `--raw`
+
+To output raw command help
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+`list`
+------
+
+List commands
+
+### Usage
+
+* `list [--raw] [--format FORMAT] [--short] [--] [<namespace>]`
+
+The list command lists all commands:
+
+  %%PHP_SELF%% list
+
+You can also display the commands for a specific namespace:
+
+  %%PHP_SELF%% list test
+
+You can also output the information in other formats by using the --format option:
+
+  %%PHP_SELF%% list --format=xml
+
+It's also possible to get raw list of commands (useful for embedding command runner):
+
+  %%PHP_SELF%% list --raw
+
+### Arguments
+
+#### `namespace`
+
+The namespace name
+
+* Is required: no
+* Is array: no
+* Default: `NULL`
+
+### Options
+
+#### `--raw`
+
+To output raw command list
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--format`
+
+The output format (txt, xml, json, or md)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'txt'`
+
+#### `--short`
+
+To skip describing commands' arguments
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
@@ -269,19 +269,19 @@ Usage
 
 The list command lists all commands:
 
-  ./phpunit list
+  %%PHP_SELF%% list
 
 You can also display the commands for a specific namespace:
 
-  ./phpunit list test
+  %%PHP_SELF%% list test
 
 You can also output the information in other formats by using the --format option:
 
-  ./phpunit list --format=xml
+  %%PHP_SELF%% list --format=xml
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  ./phpunit list --raw
+  %%PHP_SELF%% list --raw
 
 Arguments
 =========

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
@@ -1,18 +1,19 @@
 Console Tool
-============
+############
 
-* [`completion`](#completion)
-* [`help`](#help)
-* [`list`](#list)
+- `completion`_
+- `help`_
+- `list`_
 
-`completion`
-------------
+``completion``
+**************
 
 Dump the shell completion script
 
-### Usage
+Usage
+=====
 
-* `completion [--debug] [--] [<shell>]`
+- ``completion [--debug] [--] [<shell>]``
 
 The completion command dumps the shell completion script required
 to use shell autocompletion (currently only bash completion is supported).
@@ -22,11 +23,11 @@ Static installation
 
 Dump the script to a global completion file and restart your shell:
 
-    %%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%
+    ./phpunit completion bash | sudo tee /etc/bash_completion.d/phpunit
 
 Or dump the script to a local file and source it:
 
-    %%PHP_SELF%% completion bash > completion.sh
+    ./phpunit completion bash > completion.sh
 
     # source the file whenever you use the project
     source completion.sh
@@ -39,324 +40,359 @@ Dynamic installation
 
 Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
 
-    eval "$(%%PHP_SELF_FULL%% completion bash)"
+    eval "$(/Users/matt.grasmick/Sites/projects/symfony/phpunit completion bash)"
 
-### Arguments
+Arguments
+=========
 
-#### `shell`
+``shell``
+---------
 
 The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
 
-* Is required: no
-* Is array: no
-* Default: `NULL`
+- Is required: no
+- Is array: no
+- Default: ``NULL``
 
-### Options
+Options
+=======
 
-#### `--debug`
+``--debug``
+-----------
 
 Tail the completion debug log
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--help|-h`
+``--help|-h``
+-------------
 
 Display help for the given command. When no command is given display help for the list command
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--quiet|-q`
+``--quiet|-q``
+--------------
 
 Do not output any message
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--verbose|-v|-vv|-vvv`
+``--verbose|-v|-vv|-vvv``
+-------------------------
 
 Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--version|-V`
+``--version|-V``
+----------------
 
 Display this application version
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--ansi|--no-ansi`
+``--ansi|--no-ansi``
+--------------------
 
 Force (or disable --no-ansi) ANSI output
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: yes
-* Default: `NULL`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: yes
+- Default: ``NULL``
 
-#### `--no-interaction|-n`
+``--no-interaction|-n``
+-----------------------
 
 Do not ask any interactive question
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-`help`
-------
+``help``
+********
 
 Display help for a command
 
-### Usage
+Usage
+=====
 
-* `help [--format FORMAT] [--raw] [--] [<command_name>]`
+- ``help [--format FORMAT] [--raw] [--] [<command_name>]``
 
 The help command displays help for a given command:
 
-  %%PHP_SELF%% help list
+  ./phpunit help list
 
 You can also output the help in other formats by using the --format option:
 
-  %%PHP_SELF%% help --format=xml list
+  ./phpunit help --format=xml list
 
 To display the list of available commands, please use the list command.
 
-### Arguments
+Arguments
+=========
 
-#### `command_name`
+``command_name``
+----------------
 
 The command name
 
-* Is required: no
-* Is array: no
-* Default: `'help'`
+- Is required: no
+- Is array: no
+- Default: ``'help'``
 
-### Options
+Options
+=======
 
-#### `--format`
+``--format``
+------------
 
 The output format (txt, xml, json, or md)
 
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `'txt'`
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Is negatable: no
+- Default: ``'txt'``
 
-#### `--raw`
+``--raw``
+---------
 
 To output raw command help
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--help|-h`
+``--help|-h``
+-------------
 
 Display help for the given command. When no command is given display help for the list command
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--quiet|-q`
+``--quiet|-q``
+--------------
 
 Do not output any message
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--verbose|-v|-vv|-vvv`
+``--verbose|-v|-vv|-vvv``
+-------------------------
 
 Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--version|-V`
+``--version|-V``
+----------------
 
 Display this application version
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--ansi|--no-ansi`
+``--ansi|--no-ansi``
+--------------------
 
 Force (or disable --no-ansi) ANSI output
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: yes
-* Default: `NULL`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: yes
+- Default: ``NULL``
 
-#### `--no-interaction|-n`
+``--no-interaction|-n``
+-----------------------
 
 Do not ask any interactive question
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-`list`
-------
+``list``
+********
 
 List commands
 
-### Usage
+Usage
+=====
 
-* `list [--raw] [--format FORMAT] [--short] [--] [<namespace>]`
+- ``list [--raw] [--format FORMAT] [--short] [--] [<namespace>]``
 
 The list command lists all commands:
 
-  %%PHP_SELF%% list
+  ./phpunit list
 
 You can also display the commands for a specific namespace:
 
-  %%PHP_SELF%% list test
+  ./phpunit list test
 
 You can also output the information in other formats by using the --format option:
 
-  %%PHP_SELF%% list --format=xml
+  ./phpunit list --format=xml
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  %%PHP_SELF%% list --raw
+  ./phpunit list --raw
 
-### Arguments
+Arguments
+=========
 
-#### `namespace`
+``namespace``
+-------------
 
 The namespace name
 
-* Is required: no
-* Is array: no
-* Default: `NULL`
+- Is required: no
+- Is array: no
+- Default: ``NULL``
 
-### Options
+Options
+=======
 
-#### `--raw`
+``--raw``
+---------
 
 To output raw command list
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--format`
+``--format``
+------------
 
 The output format (txt, xml, json, or md)
 
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `'txt'`
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Is negatable: no
+- Default: ``'txt'``
 
-#### `--short`
+``--short``
+-----------
 
 To skip describing commands' arguments
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--help|-h`
+``--help|-h``
+-------------
 
 Display help for the given command. When no command is given display help for the list command
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--quiet|-q`
+``--quiet|-q``
+--------------
 
 Do not output any message
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--verbose|-v|-vv|-vvv`
+``--verbose|-v|-vv|-vvv``
+-------------------------
 
 Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--version|-V`
+``--version|-V``
+----------------
 
 Display this application version
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``
 
-#### `--ansi|--no-ansi`
+``--ansi|--no-ansi``
+--------------------
 
 Force (or disable --no-ansi) ANSI output
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: yes
-* Default: `NULL`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: yes
+- Default: ``NULL``
 
-#### `--no-interaction|-n`
+``--no-interaction|-n``
+-----------------------
 
 Do not ask any interactive question
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
@@ -40,7 +40,7 @@ Dynamic installation
 
 Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
 
-    eval "$(/Users/matt.grasmick/Sites/projects/symfony/phpunit completion bash)"
+    eval "$(/Users/matt.grasmick/Sites/projects/symfony-framework/phpunit completion bash)"
 
 Arguments
 =========

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
@@ -40,7 +40,7 @@ Dynamic installation
 
 Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
 
-    eval "$(/Users/matt.grasmick/Sites/projects/symfony-framework/phpunit completion bash)"
+    eval "$(%%PHP_SELF_FULL%% completion bash)"
 
 Arguments
 =========

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
@@ -146,11 +146,11 @@ Usage
 
 The help command displays help for a given command:
 
-  ./phpunit help list
+  %%PHP_SELF%% help list
 
 You can also output the help in other formats by using the --format option:
 
-  ./phpunit help --format=xml list
+  %%PHP_SELF%% help --format=xml list
 
 To display the list of available commands, please use the list command.
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.rst
@@ -23,11 +23,11 @@ Static installation
 
 Dump the script to a global completion file and restart your shell:
 
-    ./phpunit completion bash | sudo tee /etc/bash_completion.d/phpunit
+    %%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%
 
 Or dump the script to a local file and source it:
 
-    ./phpunit completion bash > completion.sh
+    %%PHP_SELF%% completion bash > completion.sh
 
     # source the file whenever you use the project
     source completion.sh

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
@@ -1,0 +1,613 @@
+My Symfony application v1.0
+===========================
+
+* [`alias1`](#descriptorcommand1)
+* [`alias2`](#descriptorcommand1)
+* [`completion`](#completion)
+* [`help`](#help)
+* [`list`](#list)
+
+**command4:**
+
+* [`command4:descriptor`](#descriptorcommand4)
+
+**descriptor:**
+
+* [`descriptor:alias_command4`](#descriptorcommand4)
+* [`descriptor:command1`](#descriptorcommand1)
+* [`descriptor:command2`](#descriptorcommand2)
+* [`descriptor:command4`](#descriptorcommand4)
+
+`completion`
+------------
+
+Dump the shell completion script
+
+### Usage
+
+* `completion [--debug] [--] [<shell>]`
+
+The completion command dumps the shell completion script required
+to use shell autocompletion (currently only bash completion is supported).
+
+Static installation
+-------------------
+
+Dump the script to a global completion file and restart your shell:
+
+    %%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%
+
+Or dump the script to a local file and source it:
+
+    %%PHP_SELF%% completion bash > completion.sh
+
+    # source the file whenever you use the project
+    source completion.sh
+
+    # or add this line at the end of your "~/.bashrc" file:
+    source /path/to/completion.sh
+
+Dynamic installation
+--------------------
+
+Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
+
+    eval "$(%%PHP_SELF_FULL%% completion bash)"
+
+### Arguments
+
+#### `shell`
+
+The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+* Is required: no
+* Is array: no
+* Default: `NULL`
+
+### Options
+
+#### `--debug`
+
+Tail the completion debug log
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+`help`
+------
+
+Display help for a command
+
+### Usage
+
+* `help [--format FORMAT] [--raw] [--] [<command_name>]`
+
+The help command displays help for a given command:
+
+  %%PHP_SELF%% help list
+
+You can also output the help in other formats by using the --format option:
+
+  %%PHP_SELF%% help --format=xml list
+
+To display the list of available commands, please use the list command.
+
+### Arguments
+
+#### `command_name`
+
+The command name
+
+* Is required: no
+* Is array: no
+* Default: `'help'`
+
+### Options
+
+#### `--format`
+
+The output format (txt, xml, json, or md)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'txt'`
+
+#### `--raw`
+
+To output raw command help
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+`list`
+------
+
+List commands
+
+### Usage
+
+* `list [--raw] [--format FORMAT] [--short] [--] [<namespace>]`
+
+The list command lists all commands:
+
+  %%PHP_SELF%% list
+
+You can also display the commands for a specific namespace:
+
+  %%PHP_SELF%% list test
+
+You can also output the information in other formats by using the --format option:
+
+  %%PHP_SELF%% list --format=xml
+
+It's also possible to get raw list of commands (useful for embedding command runner):
+
+  %%PHP_SELF%% list --raw
+
+### Arguments
+
+#### `namespace`
+
+The namespace name
+
+* Is required: no
+* Is array: no
+* Default: `NULL`
+
+### Options
+
+#### `--raw`
+
+To output raw command list
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--format`
+
+The output format (txt, xml, json, or md)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'txt'`
+
+#### `--short`
+
+To skip describing commands' arguments
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+`descriptor:command1`
+---------------------
+
+command 1 description
+
+### Usage
+
+* `descriptor:command1`
+* `alias1`
+* `alias2`
+
+command 1 help
+
+### Options
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+`descriptor:command2`
+---------------------
+
+command 2 description
+
+### Usage
+
+* `descriptor:command2 [-o|--option_name] [--] <argument_name>`
+* `descriptor:command2 -o|--option_name <argument_name>`
+* `descriptor:command2 <argument_name>`
+
+command 2 help
+
+### Arguments
+
+#### `argument_name`
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Options
+
+#### `--option_name|-o`
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+`descriptor:command4`
+---------------------
+
+### Usage
+
+* `descriptor:command4`
+* `descriptor:alias_command4`
+* `command4:descriptor`
+
+
+### Options
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
@@ -282,19 +282,19 @@ Usage
 
 The list command lists all commands:
 
-  ./phpunit list
+  %%PHP_SELF%% list
 
 You can also display the commands for a specific namespace:
 
-  ./phpunit list test
+  %%PHP_SELF%% list test
 
 You can also output the information in other formats by using the --format option:
 
-  ./phpunit list --format=xml
+  %%PHP_SELF%% list --format=xml
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  ./phpunit list --raw
+  %%PHP_SELF%% list --raw
 
 Arguments
 =========

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
@@ -53,7 +53,7 @@ Dynamic installation
 
 Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
 
-    eval "$(/Users/matt.grasmick/Sites/projects/symfony/phpunit completion bash)"
+    eval "$(%%PHP_SELF_FULL%% completion bash)"
 
 Arguments
 =========

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
@@ -159,11 +159,11 @@ Usage
 
 The help command displays help for a given command:
 
-  ./phpunit help list
+  %%PHP_SELF%% help list
 
 You can also output the help in other formats by using the --format option:
 
-  ./phpunit help --format=xml list
+  %%PHP_SELF%% help --format=xml list
 
 To display the list of available commands, please use the list command.
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.rst
@@ -36,11 +36,11 @@ Static installation
 
 Dump the script to a global completion file and restart your shell:
 
-    ./phpunit completion bash | sudo tee /etc/bash_completion.d/phpunit
+    %%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%
 
 Or dump the script to a local file and source it:
 
-    ./phpunit completion bash > completion.sh
+    %%PHP_SELF%% completion bash > completion.sh
 
     # source the file whenever you use the project
     source completion.sh

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
@@ -150,11 +150,11 @@ Usage
 
 The help command displays help for a given command:
 
-  ./phpunit help list
+  %%PHP_SELF%% help list
 
 You can also output the help in other formats by using the --format option:
 
-  ./phpunit help --format=xml list
+  %%PHP_SELF%% help --format=xml list
 
 To display the list of available commands, please use the list command.
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
@@ -273,19 +273,19 @@ Usage
 
 The list command lists all commands:
 
-  ./phpunit list
+  %%PHP_SELF%% list
 
 You can also display the commands for a specific namespace:
 
-  ./phpunit list test
+  %%PHP_SELF%% list test
 
 You can also output the information in other formats by using the --format option:
 
-  ./phpunit list --format=xml
+  %%PHP_SELF%% list --format=xml
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  ./phpunit list --raw
+  %%PHP_SELF%% list --raw
 
 Arguments
 =========

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
@@ -1,22 +1,13 @@
-My Symfony application v1.0
-###########################
+MbString åpplicätion
+####################
 
-- `alias1`_
-- `alias2`_
 - `completion`_
 - `help`_
 - `list`_
 
-**command4:**
-
-- `command4:descriptor`_
-
 **descriptor:**
 
-- `descriptor:alias_command4`_
-- `descriptor:command1`_
-- `descriptor:command2`_
-- `descriptor:command4`_
+- `descriptor:åèä`_
 
 ``completion``
 **************
@@ -410,112 +401,25 @@ Do not ask any interactive question
 - Is negatable: no
 - Default: ``false``
 
-.. _alias1:
+``descriptor:åèä``
+******************
 
-.. _alias2:
-
-``descriptor:command1``
-***********************
-
-command 1 description
+command åèä description
 
 Usage
 =====
 
-- ``descriptor:command1``
-- ``alias1``
-- ``alias2``
+- ``descriptor:åèä [-o|--option_åèä] [--] <argument_åèä>``
+- ``descriptor:åèä -o|--option_name <argument_name>``
+- ``descriptor:åèä <argument_name>``
 
-command 1 help
-
-Options
-=======
-
-``--help|-h``
--------------
-
-Display help for the given command. When no command is given display help for the list command
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-``--quiet|-q``
---------------
-
-Do not output any message
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-``--verbose|-v|-vv|-vvv``
--------------------------
-
-Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-``--version|-V``
-----------------
-
-Display this application version
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-``--ansi|--no-ansi``
---------------------
-
-Force (or disable --no-ansi) ANSI output
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: yes
-- Default: ``NULL``
-
-``--no-interaction|-n``
------------------------
-
-Do not ask any interactive question
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-``descriptor:command2``
-***********************
-
-command 2 description
-
-Usage
-=====
-
-- ``descriptor:command2 [-o|--option_name] [--] <argument_name>``
-- ``descriptor:command2 -o|--option_name <argument_name>``
-- ``descriptor:command2 <argument_name>``
-
-command 2 help
+command åèä help
 
 Arguments
 =========
 
-``argument_name``
------------------
+``argument_åèä``
+----------------
 
 - Is required: yes
 - Is array: no
@@ -524,98 +428,14 @@ Arguments
 Options
 =======
 
-``--option_name|-o``
---------------------
+``--option_åèä|-o``
+-------------------
 
 - Accept value: no
 - Is value required: no
 - Is multiple: no
 - Is negatable: no
 - Default: ``false``
-
-``--help|-h``
--------------
-
-Display help for the given command. When no command is given display help for the list command
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-``--quiet|-q``
---------------
-
-Do not output any message
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-``--verbose|-v|-vv|-vvv``
--------------------------
-
-Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-``--version|-V``
-----------------
-
-Display this application version
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-``--ansi|--no-ansi``
---------------------
-
-Force (or disable --no-ansi) ANSI output
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: yes
-- Default: ``NULL``
-
-``--no-interaction|-n``
------------------------
-
-Do not ask any interactive question
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Is negatable: no
-- Default: ``false``
-
-.. _descriptor:alias_command4:
-
-.. _command4:descriptor:
-
-``descriptor:command4``
-***********************
-
-Usage
-=====
-
-- ``descriptor:command4``
-- ``descriptor:alias_command4``
-- ``command4:descriptor``
-
-
-Options
-=======
 
 ``--help|-h``
 -------------

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
@@ -44,7 +44,7 @@ Dynamic installation
 
 Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
 
-    eval "$(/Users/matt.grasmick/Sites/projects/symfony/phpunit completion bash)"
+    eval "$(%%PHP_SELF_FULL%% completion bash)"
 
 Arguments
 =========

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.rst
@@ -27,11 +27,11 @@ Static installation
 
 Dump the script to a global completion file and restart your shell:
 
-    ./phpunit completion bash | sudo tee /etc/bash_completion.d/phpunit
+    %%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%
 
 Or dump the script to a local file and source it:
 
-    ./phpunit completion bash > completion.sh
+    %%PHP_SELF%% completion bash > completion.sh
 
     # source the file whenever you use the project
     source completion.sh

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.rst
@@ -1,0 +1,12 @@
+`descriptor:command1`
+---------------------
+
+command 1 description
+
+### Usage
+
+* `descriptor:command1`
+* `alias1`
+* `alias2`
+
+command 1 help

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.rst
@@ -1,12 +1,17 @@
-`descriptor:command1`
----------------------
+.. _alias1:
+
+.. _alias2:
+
+``descriptor:command1``
+***********************
 
 command 1 description
 
-### Usage
+Usage
+=====
 
-* `descriptor:command1`
-* `alias1`
-* `alias2`
+- ``descriptor:command1``
+- ``alias1``
+- ``alias2``
 
 command 1 help

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.rst
@@ -1,0 +1,30 @@
+`descriptor:command2`
+---------------------
+
+command 2 description
+
+### Usage
+
+* `descriptor:command2 [-o|--option_name] [--] <argument_name>`
+* `descriptor:command2 -o|--option_name <argument_name>`
+* `descriptor:command2 <argument_name>`
+
+command 2 help
+
+### Arguments
+
+#### `argument_name`
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Options
+
+#### `--option_name|-o`
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.rst
@@ -1,30 +1,35 @@
-`descriptor:command2`
----------------------
+``descriptor:command2``
+***********************
 
 command 2 description
 
-### Usage
+Usage
+=====
 
-* `descriptor:command2 [-o|--option_name] [--] <argument_name>`
-* `descriptor:command2 -o|--option_name <argument_name>`
-* `descriptor:command2 <argument_name>`
+- ``descriptor:command2 [-o|--option_name] [--] <argument_name>``
+- ``descriptor:command2 -o|--option_name <argument_name>``
+- ``descriptor:command2 <argument_name>``
 
 command 2 help
 
-### Arguments
+Arguments
+=========
 
-#### `argument_name`
+``argument_name``
+-----------------
 
-* Is required: yes
-* Is array: no
-* Default: `NULL`
+- Is required: yes
+- Is array: no
+- Default: ``NULL``
 
-### Options
+Options
+=======
 
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.rst
@@ -1,0 +1,30 @@
+`descriptor:åèä`
+----------------
+
+command åèä description
+
+### Usage
+
+* `descriptor:åèä [-o|--option_åèä] [--] <argument_åèä>`
+* `descriptor:åèä -o|--option_name <argument_name>`
+* `descriptor:åèä <argument_name>`
+
+command åèä help
+
+### Arguments
+
+#### `argument_åèä`
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Options
+
+#### `--option_åèä|-o`
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.rst
@@ -1,30 +1,35 @@
-`descriptor:åèä`
-----------------
+``descriptor:åèä``
+******************
 
 command åèä description
 
-### Usage
+Usage
+=====
 
-* `descriptor:åèä [-o|--option_åèä] [--] <argument_åèä>`
-* `descriptor:åèä -o|--option_name <argument_name>`
-* `descriptor:åèä <argument_name>`
+- ``descriptor:åèä [-o|--option_åèä] [--] <argument_åèä>``
+- ``descriptor:åèä -o|--option_name <argument_name>``
+- ``descriptor:åèä <argument_name>``
 
 command åèä help
 
-### Arguments
+Arguments
+=========
 
-#### `argument_åèä`
+``argument_åèä``
+----------------
 
-* Is required: yes
-* Is array: no
-* Default: `NULL`
+- Is required: yes
+- Is array: no
+- Default: ``NULL``
 
-### Options
+Options
+=======
 
-#### `--option_åèä|-o`
+``--option_åèä|-o``
+-------------------
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_1.rst
@@ -1,0 +1,5 @@
+#### `argument_name`
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_1.rst
@@ -1,5 +1,6 @@
-#### `argument_name`
+``argument_name``
+-----------------
 
-* Is required: yes
-* Is array: no
-* Default: `NULL`
+- Is required: yes
+- Is array: no
+- Default: ``NULL``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_2.rst
@@ -1,0 +1,7 @@
+#### `argument_name`
+
+argument description
+
+* Is required: no
+* Is array: yes
+* Default: `array ()`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_2.rst
@@ -1,7 +1,8 @@
-#### `argument_name`
+``argument_name``
+-----------------
 
 argument description
 
-* Is required: no
-* Is array: yes
-* Default: `array ()`
+- Is required: no
+- Is array: yes
+- Default: ``array ()``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_3.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_3.rst
@@ -1,0 +1,7 @@
+#### `argument_name`
+
+argument description
+
+* Is required: no
+* Is array: no
+* Default: `'default_value'`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_3.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_3.rst
@@ -1,7 +1,8 @@
-#### `argument_name`
+``argument_name``
+-----------------
 
 argument description
 
-* Is required: no
-* Is array: no
-* Default: `'default_value'`
+- Is required: no
+- Is array: no
+- Default: ``'default_value'``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_4.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_4.rst
@@ -1,0 +1,8 @@
+#### `argument_name`
+
+multiline
+argument description
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_4.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_4.rst
@@ -1,8 +1,9 @@
-#### `argument_name`
+``argument_name``
+-----------------
 
 multiline
 argument description
 
-* Is required: yes
-* Is array: no
-* Default: `NULL`
+- Is required: yes
+- Is array: no
+- Default: ``NULL``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_default_inf_value.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_default_inf_value.rst
@@ -1,0 +1,7 @@
+#### `argument_name`
+
+argument description
+
+* Is required: no
+* Is array: no
+* Default: `INF`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_default_inf_value.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_default_inf_value.rst
@@ -1,7 +1,8 @@
-#### `argument_name`
+``argument_name``
+-----------------
 
 argument description
 
-* Is required: no
-* Is array: no
-* Default: `INF`
+- Is required: no
+- Is array: no
+- Default: ``INF``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_style.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_style.rst
@@ -1,0 +1,7 @@
+#### `argument_name`
+
+argument description
+
+* Is required: no
+* Is array: no
+* Default: `'style'`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_style.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_style.rst
@@ -1,7 +1,8 @@
-#### `argument_name`
+``argument_name``
+-----------------
 
 argument description
 
-* Is required: no
-* Is array: no
-* Default: `'style'`
+- Is required: no
+- Is array: no
+- Default: ``'style'``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_2.rst
@@ -1,0 +1,7 @@
+### Arguments
+
+#### `argument_name`
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_2.rst
@@ -1,7 +1,9 @@
-### Arguments
+Arguments
+=========
 
-#### `argument_name`
+``argument_name``
+-----------------
 
-* Is required: yes
-* Is array: no
-* Default: `NULL`
+- Is required: yes
+- Is array: no
+- Default: ``NULL``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_3.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_3.rst
@@ -1,0 +1,9 @@
+### Options
+
+#### `--option_name|-o`
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_3.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_3.rst
@@ -1,9 +1,11 @@
-### Options
+Options
+=======
 
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_4.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_4.rst
@@ -1,0 +1,17 @@
+### Arguments
+
+#### `argument_name`
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Options
+
+#### `--option_name|-o`
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_4.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_4.rst
@@ -1,17 +1,21 @@
-### Arguments
+Arguments
+=========
 
-#### `argument_name`
+``argument_name``
+-----------------
 
-* Is required: yes
-* Is array: no
-* Default: `NULL`
+- Is required: yes
+- Is array: no
+- Default: ``NULL``
 
-### Options
+Options
+=======
 
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_1.rst
@@ -1,0 +1,7 @@
+#### `--option_name|-o`
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_1.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_1.rst
@@ -1,7 +1,8 @@
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``false``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_2.rst
@@ -1,0 +1,9 @@
+#### `--option_name|-o`
+
+option description
+
+* Accept value: yes
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `'default_value'`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_2.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_2.rst
@@ -1,9 +1,10 @@
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
 option description
 
-* Accept value: yes
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `'default_value'`
+- Accept value: yes
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``'default_value'``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_3.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_3.rst
@@ -1,0 +1,9 @@
+#### `--option_name|-o`
+
+option description
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `NULL`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_3.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_3.rst
@@ -1,9 +1,10 @@
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
 option description
 
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `NULL`
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Is negatable: no
+- Default: ``NULL``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_4.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_4.rst
@@ -1,0 +1,9 @@
+#### `--option_name|-o`
+
+option description
+
+* Accept value: yes
+* Is value required: no
+* Is multiple: yes
+* Is negatable: no
+* Default: `array ()`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_4.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_4.rst
@@ -1,9 +1,10 @@
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
 option description
 
-* Accept value: yes
-* Is value required: no
-* Is multiple: yes
-* Is negatable: no
-* Default: `array ()`
+- Accept value: yes
+- Is value required: no
+- Is multiple: yes
+- Is negatable: no
+- Default: ``array ()``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_5.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_5.rst
@@ -1,0 +1,10 @@
+#### `--option_name|-o`
+
+multiline
+option description
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `NULL`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_5.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_5.rst
@@ -1,10 +1,11 @@
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
 multiline
 option description
 
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `NULL`
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Is negatable: no
+- Default: ``NULL``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.rst
@@ -1,0 +1,9 @@
+#### `--option_name|-o|-O`
+
+option with multiple shortcuts
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `NULL`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.rst
@@ -1,9 +1,10 @@
-#### `--option_name|-o|-O`
+``--option_name|-o|-O``
+-----------------------
 
 option with multiple shortcuts
 
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `NULL`
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Is negatable: no
+- Default: ``NULL``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_default_inf_value.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_default_inf_value.rst
@@ -1,0 +1,9 @@
+#### `--option_name|-o`
+
+option description
+
+* Accept value: yes
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `INF`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_default_inf_value.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_default_inf_value.rst
@@ -1,9 +1,10 @@
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
 option description
 
-* Accept value: yes
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `INF`
+- Accept value: yes
+- Is value required: no
+- Is multiple: no
+- Is negatable: no
+- Default: ``INF``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_style.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_style.rst
@@ -1,0 +1,9 @@
+#### `--option_name|-o`
+
+option description
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'style'`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_style.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_style.rst
@@ -1,9 +1,10 @@
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
 option description
 
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `'style'`
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Is negatable: no
+- Default: ``'style'``

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_style_array.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_style_array.rst
@@ -1,0 +1,9 @@
+#### `--option_name|-o`
+
+option description
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: yes
+* Is negatable: no
+* Default: `array (  0 => 'Hello',  1 => 'world',)`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_style_array.rst
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_style_array.rst
@@ -1,9 +1,10 @@
-#### `--option_name|-o`
+``--option_name|-o``
+--------------------
 
 option description
 
-* Accept value: yes
-* Is value required: yes
-* Is multiple: yes
-* Is negatable: no
-* Default: `array (  0 => 'Hello',  1 => 'world',)`
+- Accept value: yes
+- Is value required: yes
+- Is multiple: yes
+- Is negatable: no
+- Default: ``array (  0 => 'Hello',  1 => 'world',)``

--- a/src/Symfony/Component/Console/Tests/Helper/DescriptorHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DescriptorHelperTest.php
@@ -24,6 +24,7 @@ class DescriptorHelperTest extends TestCase
             'xml',
             'json',
             'md',
+            'rst',
         ];
         $this->assertSame($expectedFormats, $helper->getFormats());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45717
| License       | MIT
| Doc PR        | n/a, descriptors are not documented.

### Description

The console component currently has descriptors for Markdown, Json, etc. This feature would add Restructured Text descriptor (rst) as an option.

### Example

    $helper = new DescriptorHelper();
    $helper->describe($output, $this->getApplication(), [
      'format' => 'rst',
    ]);
