### PR TITLE
[PropertyInfo] strip only leading `\` when unknown docType

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\PseudoTypeDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type;
@@ -348,6 +349,11 @@ class PhpDocExtractorTest extends TestCase
             [ParentDummy::class, 'parentAnnotationNoParent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'parent')]],
             [Dummy::class, 'parentAnnotation', [new Type(Type::BUILTIN_TYPE_OBJECT, false, ParentDummy::class)]],
         ];
+    }
+
+    public function testUnknownPseudoType()
+    {
+        $this->assertEquals([new Type(Type::BUILTIN_TYPE_OBJECT, false, 'scalar')], $this->extractor->getTypes(PseudoTypeDummy::class, 'unknownPseudoType'));
     }
 
     protected function isPhpDocumentorV5()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypeDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypeDummy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class PseudoTypeDummy
+{
+    /**
+     * @var scalar
+     */
+    public $unknownPseudoType;
+}

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -164,6 +164,6 @@ final class PhpDocTypeHelper
             return ['object', $docType];
         }
 
-        return ['object', substr($docType, 1)];
+        return ['object', ltrim($docType, '\\')];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4, 5.4, 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44455 (partially)
| License       | MIT
| Doc PR        | -

Fixes issue in `PhpDocExtractor` when dealing with some pseudo-types (`non-empty-string`, `positive-int`, etc.):
```php
class TestClass {
    /** @var non-empty-string */
    public $foo;

    /** @var positive-int */
    public $bar;
}

$extractor = new \Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor();
$fooType = $extractor->getTypes(TestClass::class, 'foo'); // $builtinType: object, $class: on-empty-string (first character trimmed)
$barType = $extractor->getTypes(TestClass::class, 'bar'); // $builtinType: object, $class: ositive-int (first character trimmed)
```

The bug exists in 4.4, 5.4 and 6.0. It may exist in 6.1 as the invalid line is still there, but due to changes made in #44451, above snippet will no longer produce the bug. I was not able to reproduce the error in 6.1, but I suspect there may exist some pseudo-type that is still affected by the bug.

I'm not sure if the test I wrote is OK, but it is the only way I could think of to validate my fix. In my opinion (see #44455), unknown pseudo-type should not be mapped to an object, so after the fix handling of pseudo-types is still broken but at least the results are consistent between `PhpStanExtractor` and `PhpDocExtractor`. But I agree with @derrabus (https://github.com/symfony/symfony/issues/44455#issuecomment-1065195055) that until there is no way to detect if we are dealing with a pseudo-type, assuming it is a reference to an object is the sanest thing to do.