### PR TITLE
[Serializer] Add types to private and internal properties

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -40,7 +40,7 @@ class MainConfiguration implements ConfigurationInterface
     private array $userProviderFactories;
 
     /**
-     * @param array<array-key, AuthenticatorFactoryInterface> $factories
+     * @param array<AuthenticatorFactoryInterface> $factories
      */
     public function __construct(array $factories, array $userProviderFactories)
     {
@@ -173,7 +173,7 @@ class MainConfiguration implements ConfigurationInterface
     }
 
     /**
-     * @param array<array-key, AuthenticatorFactoryInterface> $factories
+     * @param array<AuthenticatorFactoryInterface> $factories
      */
     private function addFirewallsSection(ArrayNodeDefinition $rootNode, array $factories): void
     {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
@@ -30,7 +30,7 @@ final class AccessTokenFactory extends AbstractFactory implements StatelessAuthe
     private const PRIORITY = -40;
 
     /**
-     * @param array<array-key, TokenHandlerFactoryInterface> $tokenHandlerFactories
+     * @param array<TokenHandlerFactoryInterface> $tokenHandlerFactories
      */
     public function __construct(private readonly array $tokenHandlerFactories)
     {

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
@@ -26,7 +26,7 @@ class ChoiceGroupView implements \IteratorAggregate
     /**
      * Creates a new choice group view.
      *
-     * @param array<array-key, ChoiceGroupView|ChoiceView> $choices the choice views in the group
+     * @param array<ChoiceGroupView|ChoiceView> $choices the choice views in the group
      */
     public function __construct(string $label, array $choices = [])
     {

--- a/src/Symfony/Component/Serializer/Annotation/Context.php
+++ b/src/Symfony/Component/Serializer/Annotation/Context.php
@@ -33,9 +33,9 @@ class Context
      * @throws InvalidArgumentException
      */
     public function __construct(
-        private array $context = [],
-        private array $normalizationContext = [],
-        private array $denormalizationContext = [],
+        private readonly array $context = [],
+        private readonly array $normalizationContext = [],
+        private readonly array $denormalizationContext = [],
         string|array $groups = [],
     ) {
         if (!$context && !$normalizationContext && !$denormalizationContext) {

--- a/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
@@ -26,8 +26,8 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 class DiscriminatorMap
 {
     public function __construct(
-        private string $typeProperty,
-        private array $mapping,
+        private readonly string $typeProperty,
+        private readonly array $mapping,
     ) {
         if (empty($typeProperty)) {
             throw new InvalidArgumentException(sprintf('Parameter "typeProperty" of annotation "%s" cannot be empty.', static::class));

--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -28,7 +28,7 @@ class Groups
     /**
      * @var string[]
      */
-    private array $groups;
+    private readonly array $groups;
 
     /**
      * @param string|string[] $groups

--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 class MaxDepth
 {
-    public function __construct(private int $maxDepth)
+    public function __construct(private readonly int $maxDepth)
     {
         if ($maxDepth <= 0) {
             throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a positive integer.', static::class));

--- a/src/Symfony/Component/Serializer/Annotation/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedName.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 final class SerializedName
 {
-    public function __construct(private string $serializedName)
+    public function __construct(private readonly string $serializedName)
     {
         if ('' === $serializedName) {
             throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', self::class));

--- a/src/Symfony/Component/Serializer/CacheWarmer/CompiledClassMetadataCacheWarmer.php
+++ b/src/Symfony/Component/Serializer/CacheWarmer/CompiledClassMetadataCacheWarmer.php
@@ -21,20 +21,12 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
  */
 final class CompiledClassMetadataCacheWarmer implements CacheWarmerInterface
 {
-    private $classesToCompile;
-
-    private $classMetadataFactory;
-
-    private $classMetadataFactoryCompiler;
-
-    private $filesystem;
-
-    public function __construct(array $classesToCompile, ClassMetadataFactoryInterface $classMetadataFactory, ClassMetadataFactoryCompiler $classMetadataFactoryCompiler, Filesystem $filesystem)
-    {
-        $this->classesToCompile = $classesToCompile;
-        $this->classMetadataFactory = $classMetadataFactory;
-        $this->classMetadataFactoryCompiler = $classMetadataFactoryCompiler;
-        $this->filesystem = $filesystem;
+    public function __construct(
+        private readonly array $classesToCompile,
+        private readonly ClassMetadataFactoryInterface $classMetadataFactory,
+        private readonly ClassMetadataFactoryCompiler $classMetadataFactoryCompiler,
+        private readonly Filesystem $filesystem,
+    ) {
     }
 
     public function warmUp(string $cacheDir): array

--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -24,12 +24,17 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
  */
 class ChainDecoder implements ContextAwareDecoderInterface
 {
-    private array $decoders = [];
+    /**
+     * @var array<string, array-key>
+     */
     private array $decoderByFormat = [];
 
-    public function __construct(array $decoders = [])
-    {
-        $this->decoders = $decoders;
+    /**
+     * @param array<DecoderInterface> $decoders
+     */
+    public function __construct(
+        private readonly array $decoders = []
+    ) {
     }
 
     final public function decode(string $data, string $format, array $context = []): mixed

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -25,12 +25,17 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
  */
 class ChainEncoder implements ContextAwareEncoderInterface
 {
-    private array $encoders = [];
+    /**
+     * @var array<string, array-key>
+     */
     private array $encoderByFormat = [];
 
-    public function __construct(array $encoders = [])
-    {
-        $this->encoders = $encoders;
+    /**
+     * @param array<EncoderInterface> $encoders
+     */
+    public function __construct(
+        private readonly array $encoders = []
+    ) {
     }
 
     final public function encode(mixed $data, string $format, array $context = []): string

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -38,7 +38,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
     private const FORMULAS_START_CHARACTERS = ['=', '-', '+', '@', "\t", "\r"];
 
-    private $defaultContext = [
+    private array $defaultContext = [
         self::DELIMITER_KEY => ',',
         self::ENCLOSURE_KEY => '"',
         self::ESCAPE_CHAR_KEY => '',

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -34,7 +34,7 @@ class JsonDecode implements DecoderInterface
      */
     public const RECURSION_DEPTH = 'json_decode_recursion_depth';
 
-    private $defaultContext = [
+    private array $defaultContext = [
         self::ASSOCIATIVE => false,
         self::OPTIONS => 0,
         self::RECURSION_DEPTH => 512,

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -25,7 +25,7 @@ class JsonEncode implements EncoderInterface
      */
     public const OPTIONS = 'json_encode_options';
 
-    private $defaultContext = [
+    private array $defaultContext = [
         self::OPTIONS => \JSON_PRESERVE_ZERO_FRACTION,
     ];
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -59,7 +59,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     public const TYPE_CAST_ATTRIBUTES = 'xml_type_cast_attributes';
     public const VERSION = 'xml_version';
 
-    private $defaultContext = [
+    private array $defaultContext = [
         self::AS_COLLECTION => false,
         self::DECODER_IGNORED_NODE_TYPES => [\XML_PI_NODE, \XML_COMMENT_NODE],
         self::ENCODER_IGNORED_NODE_TYPES => [],

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -42,9 +42,9 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
     public const YAML_INDENT = 'yaml_indent';
     public const YAML_FLAGS = 'yaml_flags';
 
-    private $dumper;
-    private $parser;
-    private $defaultContext = [
+    private readonly Dumper $dumper;
+    private readonly Parser $parser;
+    private array $defaultContext = [
         self::YAML_INLINE => 0,
         self::YAML_INDENT => 0,
         self::YAML_FLAGS => 0,

--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
@@ -18,13 +18,11 @@ namespace Symfony\Component\Serializer\Exception;
  */
 class ExtraAttributesException extends RuntimeException
 {
-    private $extraAttributes;
-
-    public function __construct(array $extraAttributes, \Throwable $previous = null)
-    {
+    public function __construct(
+        private readonly array $extraAttributes,
+        \Throwable $previous = null,
+    ) {
         $msg = sprintf('Extra attributes are not allowed ("%s" %s unknown).', implode('", "', $extraAttributes), \count($extraAttributes) > 1 ? 'are' : 'is');
-
-        $this->extraAttributes = $extraAttributes;
 
         parent::__construct($msg, 0, $previous);
     }

--- a/src/Symfony/Component/Serializer/Exception/NotNormalizableValueException.php
+++ b/src/Symfony/Component/Serializer/Exception/NotNormalizableValueException.php
@@ -16,17 +16,18 @@ namespace Symfony\Component\Serializer\Exception;
  */
 class NotNormalizableValueException extends UnexpectedValueException
 {
-    private $currentType;
-    private $expectedTypes;
-    private $path;
-    private $useMessageForUser = false;
+    private ?string $currentType = null;
+    private ?array $expectedTypes = null;
+    private ?string $path = null;
+    private bool $useMessageForUser = false;
 
     /**
-     * @param bool $useMessageForUser If the message passed to this exception is something that can be shown
-     *                                safely to your user. In other words, avoid catching other exceptions and
-     *                                passing their message directly to this class.
+     * @param string[] $expectedTypes
+     * @param bool     $useMessageForUser If the message passed to this exception is something that can be shown
+     *                                    safely to your user. In other words, avoid catching other exceptions and
+     *                                    passing their message directly to this class.
      */
-    public static function createForUnexpectedDataType(string $message, $data, array $expectedTypes, string $path = null, bool $useMessageForUser = false, int $code = 0, \Throwable $previous = null): self
+    public static function createForUnexpectedDataType(string $message, mixed $data, array $expectedTypes, string $path = null, bool $useMessageForUser = false, int $code = 0, \Throwable $previous = null): self
     {
         $self = new self($message, $code, $previous);
 

--- a/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
+++ b/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
@@ -18,18 +18,18 @@ use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
  */
 final class ObjectPropertyListExtractor implements ObjectPropertyListExtractorInterface
 {
-    private $propertyListExtractor;
-    private $objectClassResolver;
+    private PropertyListExtractorInterface $propertyListExtractor;
+    private \Closure $objectClassResolver;
 
     public function __construct(PropertyListExtractorInterface $propertyListExtractor, callable $objectClassResolver = null)
     {
         $this->propertyListExtractor = $propertyListExtractor;
-        $this->objectClassResolver = $objectClassResolver;
+        $this->objectClassResolver = ($objectClassResolver ?? 'get_class')(...);
     }
 
     public function getProperties(object $object, array $context = []): ?array
     {
-        $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : $object::class;
+        $class = ($this->objectClassResolver)($object);
 
         return $this->propertyListExtractor->getProperties($class, $context);
     }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -23,32 +23,28 @@ class AttributeMetadata implements AttributeMetadataInterface
      *           class' serialized representation. Do not access it. Use
      *           {@link getName()} instead.
      */
-    public $name;
+    public string $name;
 
     /**
      * @internal This property is public in order to reduce the size of the
      *           class' serialized representation. Do not access it. Use
      *           {@link getGroups()} instead.
      */
-    public $groups = [];
+    public array $groups = [];
 
     /**
-     * @var int|null
-     *
      * @internal This property is public in order to reduce the size of the
      *           class' serialized representation. Do not access it. Use
      *           {@link getMaxDepth()} instead.
      */
-    public $maxDepth;
+    public ?int $maxDepth = null;
 
     /**
-     * @var string|null
-     *
      * @internal This property is public in order to reduce the size of the
      *           class' serialized representation. Do not access it. Use
      *           {@link getSerializedName()} instead.
      */
-    public $serializedName;
+    public ?string $serializedName = null;
 
     /**
      * @internal This property is public in order to reduce the size of the
@@ -58,13 +54,11 @@ class AttributeMetadata implements AttributeMetadataInterface
     public ?PropertyPath $serializedPath = null;
 
     /**
-     * @var bool
-     *
      * @internal This property is public in order to reduce the size of the
      *           class' serialized representation. Do not access it. Use
      *           {@link isIgnored()} instead.
      */
-    public $ignore = false;
+    public bool $ignore = false;
 
     /**
      * @var array[] Normalization contexts per group name ("*" applies to all groups)
@@ -73,7 +67,7 @@ class AttributeMetadata implements AttributeMetadataInterface
      *           class' serialized representation. Do not access it. Use
      *           {@link getNormalizationContexts()} instead.
      */
-    public $normalizationContexts = [];
+    public array $normalizationContexts = [];
 
     /**
      * @var array[] Denormalization contexts per group name ("*" applies to all groups)
@@ -82,7 +76,7 @@ class AttributeMetadata implements AttributeMetadataInterface
      *           class' serialized representation. Do not access it. Use
      *           {@link getDenormalizationContexts()} instead.
      */
-    public $denormalizationContexts = [];
+    public array $denormalizationContexts = [];
 
     public function __construct(string $name)
     {

--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
@@ -18,15 +18,11 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
  */
 class ClassDiscriminatorFromClassMetadata implements ClassDiscriminatorResolverInterface
 {
-    /**
-     * @var ClassMetadataFactoryInterface
-     */
-    private $classMetadataFactory;
-    private $mappingForMappedObjectCache = [];
+    private array $mappingForMappedObjectCache = [];
 
-    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory)
-    {
-        $this->classMetadataFactory = $classMetadataFactory;
+    public function __construct(
+        private readonly ClassMetadataFactoryInterface $classMetadataFactory,
+    ) {
     }
 
     public function getMappingForClass(string $class): ?ClassDiscriminatorMapping

--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
@@ -16,14 +16,13 @@ namespace Symfony\Component\Serializer\Mapping;
  */
 class ClassDiscriminatorMapping
 {
-    private $typeProperty;
-    private $typesMapping;
-
-    public function __construct(string $typeProperty, array $typesMapping = [])
-    {
-        $this->typeProperty = $typeProperty;
-        $this->typesMapping = $typesMapping;
-
+    /**
+     * @param array<string, string> $typesMapping
+     */
+    public function __construct(
+        private readonly string $typeProperty,
+        private array $typesMapping = [],
+    ) {
         uasort($this->typesMapping, static function (string $a, string $b): int {
             if (is_a($a, $b, true)) {
                 return -1;

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -21,7 +21,7 @@ class ClassMetadata implements ClassMetadataInterface
      *           class' serialized representation. Do not access it. Use
      *           {@link getName()} instead.
      */
-    public $name;
+    public string $name;
 
     /**
      * @var AttributeMetadataInterface[]
@@ -30,21 +30,16 @@ class ClassMetadata implements ClassMetadataInterface
      *           class' serialized representation. Do not access it. Use
      *           {@link getAttributesMetadata()} instead.
      */
-    public $attributesMetadata = [];
+    public array $attributesMetadata = [];
+
+    private ?\ReflectionClass $reflClass = null;
 
     /**
-     * @var \ReflectionClass
-     */
-    private $reflClass;
-
-    /**
-     * @var ClassDiscriminatorMapping|null
-     *
      * @internal This property is public in order to reduce the size of the
      *           class' serialized representation. Do not access it. Use
      *           {@link getClassDiscriminatorMapping()} instead.
      */
-    public $classDiscriminatorMapping;
+    public ?ClassDiscriminatorMapping $classDiscriminatorMapping;
 
     /**
      * Constructs a metadata for the given class.

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
@@ -37,7 +37,7 @@ interface ClassMetadataInterface
     /**
      * Gets the list of {@link AttributeMetadataInterface}.
      *
-     * @return AttributeMetadataInterface[]
+     * @return array<string, AttributeMetadataInterface>
      */
     public function getAttributesMetadata(): array;
 

--- a/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
@@ -24,21 +24,14 @@ class CacheClassMetadataFactory implements ClassMetadataFactoryInterface
     use ClassResolverTrait;
 
     /**
-     * @var ClassMetadataFactoryInterface
+     * @var array<string, ClassMetadataInterface>
      */
-    private $decorated;
+    private array $loadedClasses = [];
 
-    /**
-     * @var CacheItemPoolInterface
-     */
-    private $cacheItemPool;
-
-    private $loadedClasses = [];
-
-    public function __construct(ClassMetadataFactoryInterface $decorated, CacheItemPoolInterface $cacheItemPool)
-    {
-        $this->decorated = $decorated;
-        $this->cacheItemPool = $cacheItemPool;
+    public function __construct(
+        private readonly ClassMetadataFactoryInterface $decorated,
+        private readonly CacheItemPoolInterface $cacheItemPool,
+    ) {
     }
 
     public function getMetadataFor(string|object $value): ClassMetadataInterface

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactory.php
@@ -24,16 +24,14 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
 {
     use ClassResolverTrait;
 
-    private $loader;
-
     /**
-     * @var array
+     * @var array<string, ClassMetadataInterface>
      */
-    private $loadedClasses;
+    private array $loadedClasses;
 
-    public function __construct(LoaderInterface $loader)
-    {
-        $this->loader = $loader;
+    public function __construct(
+        private readonly LoaderInterface $loader,
+    ) {
     }
 
     public function getMetadataFor(string|object $value): ClassMetadataInterface

--- a/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
@@ -21,14 +21,14 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
  */
 final class CompiledClassMetadataFactory implements ClassMetadataFactoryInterface
 {
-    private $compiledClassMetadata = [];
+    private array $compiledClassMetadata = [];
 
-    private $loadedClasses = [];
+    private array $loadedClasses = [];
 
-    private $classMetadataFactory;
-
-    public function __construct(string $compiledClassMetadataFile, ClassMetadataFactoryInterface $classMetadataFactory)
-    {
+    public function __construct(
+        string $compiledClassMetadataFile,
+        private readonly ClassMetadataFactoryInterface $classMetadataFactory,
+    ) {
         if (!file_exists($compiledClassMetadataFile)) {
             throw new \RuntimeException("File \"{$compiledClassMetadataFile}\" could not be found.");
         }
@@ -39,7 +39,6 @@ final class CompiledClassMetadataFactory implements ClassMetadataFactoryInterfac
         }
 
         $this->compiledClassMetadata = $compiledClassMetadata;
-        $this->classMetadataFactory = $classMetadataFactory;
     }
 
     public function getMetadataFor(string|object $value): ClassMetadataInterface

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -43,11 +43,9 @@ class AnnotationLoader implements LoaderInterface
         Context::class,
     ];
 
-    private $reader;
-
-    public function __construct(Reader $reader = null)
-    {
-        $this->reader = $reader;
+    public function __construct(
+        private readonly ?Reader $reader = null,
+    ) {
     }
 
     public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool

--- a/src/Symfony/Component/Serializer/Mapping/Loader/LoaderChain.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/LoaderChain.php
@@ -27,8 +27,6 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
  */
 class LoaderChain implements LoaderInterface
 {
-    private $loaders;
-
     /**
      * Accepts a list of LoaderInterface instances.
      *
@@ -36,15 +34,13 @@ class LoaderChain implements LoaderInterface
      *
      * @throws MappingException If any of the loaders does not implement LoaderInterface
      */
-    public function __construct(array $loaders)
+    public function __construct(private readonly array $loaders)
     {
         foreach ($loaders as $loader) {
             if (!$loader instanceof LoaderInterface) {
                 throw new MappingException(sprintf('Class "%s" is expected to implement LoaderInterface.', get_debug_type($loader)));
             }
         }
-
-        $this->loaders = $loaders;
     }
 
     public function loadClassMetadata(ClassMetadataInterface $metadata): bool

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -31,7 +31,7 @@ class XmlFileLoader extends FileLoader
      *
      * @var \SimpleXMLElement[]|null
      */
-    private $classes;
+    private ?array $classes = null;
 
     public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool
     {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -27,14 +27,12 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlFileLoader extends FileLoader
 {
-    private $yamlParser;
+    private ?Parser $yamlParser = null;
 
     /**
      * An array of YAML class descriptions.
-     *
-     * @var array
      */
-    private $classes;
+    private ?array $classes = null;
 
     public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool
     {

--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -18,17 +18,14 @@ namespace Symfony\Component\Serializer\NameConverter;
  */
 class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
 {
-    private $attributes;
-    private $lowerCamelCase;
-
     /**
      * @param array|null $attributes     The list of attributes to rename or null for all attributes
      * @param bool       $lowerCamelCase Use lowerCamelCase style
      */
-    public function __construct(array $attributes = null, bool $lowerCamelCase = true)
-    {
-        $this->attributes = $attributes;
-        $this->lowerCamelCase = $lowerCamelCase;
+    public function __construct(
+        private ?array $attributes = null,
+        private bool $lowerCamelCase = true,
+    ) {
     }
 
     public function normalize(string $propertyName): string

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -20,23 +20,25 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
  */
 final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
 {
-    private $metadataFactory;
+    /**
+     * @var array<string, array<string, string|null>>
+     */
+    private static array $normalizeCache = [];
 
     /**
-     * @var NameConverterInterface|AdvancedNameConverterInterface|null
+     * @var array<string, array<string, string|null>>
      */
-    private $fallbackNameConverter;
+    private static array $denormalizeCache = [];
 
-    private static $normalizeCache = [];
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private static array $attributesMetadataCache = [];
 
-    private static $denormalizeCache = [];
-
-    private static $attributesMetadataCache = [];
-
-    public function __construct(ClassMetadataFactoryInterface $metadataFactory, NameConverterInterface $fallbackNameConverter = null)
-    {
-        $this->metadataFactory = $metadataFactory;
-        $this->fallbackNameConverter = $fallbackNameConverter;
+    public function __construct(
+        private readonly ClassMetadataFactoryInterface $metadataFactory,
+        private readonly ?NameConverterInterface $fallbackNameConverter = null,
+    ) {
     }
 
     public function normalize(string $propertyName, string $class = null, string $format = null, array $context = []): string
@@ -104,6 +106,9 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         return $this->fallbackNameConverter ? $this->fallbackNameConverter->denormalize($propertyName, $class, $format, $context) : $propertyName;
     }
 
+    /**
+     * @return array<string, string>
+     */
     private function getCacheValueForAttributesMetadata(string $class, array $context): array
     {
         if (!$this->metadataFactory->hasMetadataFor($class)) {

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -32,13 +32,10 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
     public const TYPE = 'type';
     public const PAYLOAD_FIELDS = 'payload_fields';
 
-    private $defaultContext;
-    private $nameConverter;
-
-    public function __construct(array $defaultContext = [], NameConverterInterface $nameConverter = null)
-    {
-        $this->defaultContext = $defaultContext;
-        $this->nameConverter = $nameConverter;
+    public function __construct(
+        private readonly array $defaultContext = [],
+        private readonly ?NameConverterInterface $nameConverter = null,
+    ) {
     }
 
     public function getSupportedTypes(?string $format): array

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -33,10 +33,7 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
         File::class => true,
     ];
 
-    /**
-     * @var MimeTypeGuesserInterface|null
-     */
-    private $mimeTypeGuesser;
+    private readonly ?MimeTypeGuesserInterface $mimeTypeGuesser;
 
     public function __construct(MimeTypeGuesserInterface $mimeTypeGuesser = null)
     {
@@ -150,11 +147,7 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
             return $object->getMimeType();
         }
 
-        if ($this->mimeTypeGuesser && $mimeType = $this->mimeTypeGuesser->guessMimeType($object->getPathname())) {
-            return $mimeType;
-        }
-
-        return 'application/octet-stream';
+        return $this->mimeTypeGuesser?->guessMimeType($object->getPathname()) ?: 'application/octet-stream';
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -26,7 +26,7 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
 {
     public const FORMAT_KEY = 'dateinterval_format';
 
-    private $defaultContext = [
+    private array $defaultContext = [
         self::FORMAT_KEY => '%rP%yY%mM%dDT%hH%iM%sS',
     ];
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -28,7 +28,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
     public const FORMAT_KEY = 'datetime_format';
     public const TIMEZONE_KEY = 'datetime_timezone';
 
-    private $defaultContext = [
+    private array $defaultContext = [
         self::FORMAT_KEY => \DateTime::RFC3339,
         self::TIMEZONE_KEY => null,
     ];

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -32,13 +32,11 @@ use Symfony\Component\Serializer\SerializerInterface;
 final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerInterface, SerializerAwareInterface, CacheableSupportsMethodInterface
 {
     private NormalizerInterface&DenormalizerInterface $serializer;
-    private PropertyNormalizer $normalizer;
     private array $headerClassMap;
     private \ReflectionProperty $headersProperty;
 
-    public function __construct(PropertyNormalizer $normalizer)
+    public function __construct(private readonly PropertyNormalizer $normalizer)
     {
-        $this->normalizer = $normalizer;
         $this->headerClassMap = (new \ReflectionClassConstant(Headers::class, 'HEADER_CLASS_MAP'))->getValue();
         $this->headersProperty = new \ReflectionProperty(Headers::class, 'headers');
     }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -32,9 +32,10 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 {
     protected $propertyAccessor;
 
-    private $discriminatorCache = [];
+    /** @var array<string, string|null> */
+    private array $discriminatorCache = [];
 
-    private $objectClassResolver;
+    private readonly \Closure $objectClassResolver;
 
     public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyAccessorInterface $propertyAccessor = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, callable $objectClassResolver = null, array $defaultContext = [])
     {
@@ -46,7 +47,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
 
-        $this->objectClassResolver = $objectClassResolver ?? fn ($class) => \is_object($class) ? $class::class : $class;
+        $this->objectClassResolver = ($objectClassResolver ?? static fn ($class) => \is_object($class) ? $class::class : $class)(...);
     }
 
     public function getSupportedTypes(?string $format): array

--- a/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
@@ -32,7 +32,7 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
         self::NORMALIZATION_FORMAT_RFC4122,
     ];
 
-    private $defaultContext = [
+    private array $defaultContext = [
         self::NORMALIZATION_FORMAT_KEY => self::NORMALIZATION_FORMAT_CANONICAL,
     ];
 

--- a/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
@@ -26,7 +26,7 @@ final class UnwrappingDenormalizer implements DenormalizerInterface, SerializerA
 
     public const UNWRAP_PATH = 'unwrap_path';
 
-    private $propertyAccessor;
+    private readonly PropertyAccessorInterface $propertyAccessor;
 
     public function __construct(PropertyAccessorInterface $propertyAccessor = null)
     {

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -62,25 +62,33 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
     ];
 
     /**
-     * @var Encoder\ChainEncoder
+     * @var ChainEncoder
      */
     protected $encoder;
 
     /**
-     * @var Encoder\ChainDecoder
+     * @var ChainDecoder
      */
     protected $decoder;
 
-    private $normalizers = [];
-    private $denormalizerCache = [];
-    private $normalizerCache = [];
+    /**
+     * @var array<string, array<string, array<bool>>>
+     */
+    private array $denormalizerCache = [];
+
+    /**
+     * @var array<string, array<string, array<bool>>>
+     */
+    private array $normalizerCache = [];
 
     /**
      * @param array<NormalizerInterface|DenormalizerInterface> $normalizers
      * @param array<EncoderInterface|DecoderInterface>         $encoders
      */
-    public function __construct(array $normalizers = [], array $encoders = [])
-    {
+    public function __construct(
+        private array $normalizers = [],
+        array $encoders = [],
+    ) {
         foreach ($normalizers as $normalizer) {
             if ($normalizer instanceof SerializerAwareInterface) {
                 $normalizer->setSerializer($this);
@@ -98,7 +106,6 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
                 throw new InvalidArgumentException(sprintf('The class "%s" neither implements "%s" nor "%s".', get_debug_type($normalizer), NormalizerInterface::class, DenormalizerInterface::class));
             }
         }
-        $this->normalizers = $normalizers;
 
         $decoders = [];
         $realEncoders = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR adds types to private and `@internal` properties of the serializer component. This time, I've also applied CPP and `readonly` flags where possible. If this makes the review too hard or there are other reasons not to do that, please tell me and I'll skip it in future PRs.