### PR TITLE
[Lock] SemaphoreStore catching exception from sem_get

### DIFF
--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -64,12 +64,12 @@ class SemaphoreStore implements StoreInterface, BlockingStoreInterface
         }
 
         $keyId = unpack('i', md5($key, true))[1];
-        $resource = sem_get($keyId);
-        $acquired = @sem_acquire($resource, !$blocking);
+        $resource = @sem_get($keyId);
+        $acquired = $resource && @sem_acquire($resource, !$blocking);
 
         while ($blocking && !$acquired) {
-            $resource = sem_get($keyId);
-            $acquired = @sem_acquire($resource);
+            $resource = @sem_get($keyId);
+            $acquired = $resource && @sem_acquire($resource);
         }
 
         if (!$acquired) {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no

We use on project symfony/lock and I found exception in our monitoring from `sem_get` PHP function.

Function `sem_get` is called before `sem_acquire` so resource is not locked and `sem_get` function call can run in same time as some code with locked resource in another process where removing semaphpore going on by function `sem_remove`.

PHP: 7.4.13
symfony/lock: 5.3.4

Exceptions:
`Symfony\Component\Lock\Exception\LockAcquiringException`
Failed to acquire the "some_our_resource_key" lock.
`ErrorException`
sem_get(): failed for key 0xffffffffb8cf1ec4: Identifier removed