### PR TITLE
[ErrorHandler][HttpKernel] Read SYMFONY_IDE to render exception in case of fatal error

### DIFF
--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Report overridden `@final` constants and properties
+ * Read environment variable `SYMFONY_IDE` to configure file link format
 
 5.4
 ---

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/ErrorRendererInterface.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/ErrorRendererInterface.php
@@ -20,6 +20,16 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
  */
 interface ErrorRendererInterface
 {
+    public const IDE_LINK_FORMATS = [
+        'textmate' => 'txmt://open?url=file://%f&line=%l',
+        'macvim' => 'mvim://open?url=file://%f&line=%l',
+        'emacs' => 'emacs://open?url=file://%f&line=%l',
+        'sublime' => 'subl://open?url=file://%f&line=%l',
+        'phpstorm' => 'phpstorm://open?file=%f&line=%l',
+        'atom' => 'atom://core/open/file?filename=%f&line=%l',
+        'vscode' => 'vscode://file/%f:%l',
+    ];
+
     /**
      * Renders a Throwable as a FlattenException.
      */

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -50,7 +50,10 @@ class HtmlErrorRenderer implements ErrorRendererInterface
     {
         $this->debug = \is_bool($debug) ? $debug : $debug(...);
         $this->charset = $charset ?: (ini_get('default_charset') ?: 'UTF-8');
-        $this->fileLinkFormat = $fileLinkFormat ?: (ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format'));
+        $fileLinkFormat ??= $_SERVER['SYMFONY_IDE'] ?? null;
+        $this->fileLinkFormat = is_string($fileLinkFormat)
+            ? (ErrorRendererInterface::IDE_LINK_FORMATS[$fileLinkFormat] ?? $fileLinkFormat ?: false)
+            : ($fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format') ?: false);
         $this->projectDir = $projectDir;
         $this->outputBuffer = \is_string($outputBuffer) ? $outputBuffer : $outputBuffer(...);
         $this->logger = $logger;

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Debug;
 
+use Symfony\Component\ErrorHandler\ErrorRenderer\ErrorRendererInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -24,16 +25,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class FileLinkFormatter
 {
-    private const FORMATS = [
-        'textmate' => 'txmt://open?url=file://%f&line=%l',
-        'macvim' => 'mvim://open?url=file://%f&line=%l',
-        'emacs' => 'emacs://open?url=file://%f&line=%l',
-        'sublime' => 'subl://open?url=file://%f&line=%l',
-        'phpstorm' => 'phpstorm://open?file=%f&line=%l',
-        'atom' => 'atom://core/open/file?filename=%f&line=%l',
-        'vscode' => 'vscode://file/%f:%l',
-    ];
-
     private array|false $fileLinkFormat;
     private ?RequestStack $requestStack = null;
     private ?string $baseDir = null;
@@ -44,7 +35,8 @@ class FileLinkFormatter
      */
     public function __construct(string $fileLinkFormat = null, RequestStack $requestStack = null, string $baseDir = null, string|\Closure $urlFormat = null)
     {
-        $fileLinkFormat = (self::FORMATS[$fileLinkFormat] ?? $fileLinkFormat) ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format') ?: false;
+        $fileLinkFormat ??= $_SERVER['SYMFONY_IDE'] ?? null;
+        $fileLinkFormat = (ErrorRendererInterface::IDE_LINK_FORMATS[$fileLinkFormat] ?? $fileLinkFormat) ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format') ?: false;
         if ($fileLinkFormat && !\is_array($fileLinkFormat)) {
             $i = strpos($f = $fileLinkFormat, '&', max(strrpos($f, '%f'), strrpos($f, '%l'))) ?: \strlen($f);
             $fileLinkFormat = [substr($f, 0, $i)] + preg_split('/&([^>]++)>/', substr($f, $i), -1, \PREG_SPLIT_DELIM_CAPTURE);

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/error-handler": "^5.4|^6.0",
+        "symfony/error-handler": "^6.1",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/polyfill-ctype": "^1.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In #44575, the env var `SYMFONY_IDE` is read when `framework.ide` is not set. This works to format links in most runtime exceptions. But fatal errors that occurs before application boot  are not rendered using this config (ex: syntax error in service class).

Since the env var is globally available, it can be read even if it's not been injected.
The list of IDE formats have been duplicated from [`FileLinkFormatter`](https://github.com/symfony/symfony/blob/8e8207bb72d7f2cb8be355994ad2fcfa97c00f74/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php#L27-L35).

The update of `Symfony\Component\HttpKernel\Debug\FileLinkFormatter` is not necessary for my use-case, but for exhaustivity.