### PR TITLE
[Translation] [LocoProvider] Skip asset translation if message is untranslated

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -205,6 +205,11 @@ final class LocoProvider implements ProviderInterface
         $responses = [];
 
         foreach ($translations as $id => $message) {
+            // Skip if message is not translated yet to keep asset in "untranslated" state.
+            if (str_ends_with($id, $message)) {
+                continue;
+            }
+
             $responses[$id] = $this->client->request('POST', sprintf('translations/%s/%s', rawurlencode($id), rawurlencode($locale)), [
                 'body' => $message,
             ]);

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -35,14 +35,16 @@ final class LocoProvider implements ProviderInterface
     private $logger;
     private $defaultLocale;
     private $endpoint;
+    private $skipTranslationIfTargetEqualsSource;
 
-    public function __construct(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint)
+    public function __construct(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, bool $skipTranslationIfTargetEqualsSource = false)
     {
         $this->client = $client;
         $this->loader = $loader;
         $this->logger = $logger;
         $this->defaultLocale = $defaultLocale;
         $this->endpoint = $endpoint;
+        $this->skipTranslationIfTargetEqualsSource = $skipTranslationIfTargetEqualsSource;
     }
 
     public function __toString(): string
@@ -206,7 +208,7 @@ final class LocoProvider implements ProviderInterface
 
         foreach ($translations as $id => $message) {
             // Skip if message is not translated yet to keep asset in "untranslated" state.
-            if (str_ends_with($id, $message)) {
+            if ($this->skipTranslationIfTargetEqualsSource && str_ends_with($id, $message)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProviderFactory.php
@@ -58,7 +58,9 @@ final class LocoProviderFactory extends AbstractProviderFactory
             ],
         ]);
 
-        return new LocoProvider($client, $this->loader, $this->logger, $this->defaultLocale, $endpoint);
+        $skipTranslationIfTargetEqualsSource = (bool) $dsn->getOption('skipTranslationIfTargetEqualsSource');
+
+        return new LocoProvider($client, $this->loader, $this->logger, $this->defaultLocale, $endpoint, $skipTranslationIfTargetEqualsSource);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -23,6 +23,11 @@ class LocoProviderTest extends ProviderTestCase
         return new LocoProvider($client, $loader, $logger, $defaultLocale, $endpoint);
     }
 
+    public function createProviderWithSkip(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface
+    {
+        return new LocoProvider($client, $loader, $logger, $defaultLocale, $endpoint, true);
+    }
+
     public function toStringProvider(): iterable
     {
         yield [
@@ -402,7 +407,7 @@ class LocoProviderTest extends ProviderTestCase
             'validators' => ['post.num_comments' => '__post.num_comments'],
         ]));
 
-        $provider = $this->createProvider((new MockHttpClient($responses))->withOptions([
+        $provider = $this->createProviderWithSkip((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');
@@ -555,7 +560,7 @@ class LocoProviderTest extends ProviderTestCase
             'validators' => ['post.num_comments' => '__post.num_comments'],
         ]));
 
-        $provider = $this->createProvider((new MockHttpClient($responses))->withOptions([
+        $provider = $this->createProviderWithSkip((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

When using `translation:push`, assets in Loco are created in the `untranslated` state (https://github.com/symfony/loco-translation-provider/blob/5.4/LocoProvider.php#L187), but this is immediately overwritten when uploading a translation in the next step of the write process. Even if the message is not translated yet, for example after using `translation:extract`.

This leads to all assets having the `translated` status and always having 100% translation progress, which currently makes Loco unusable as a provider if you have more than a handful of messages.

This PR adds a small check after creating the asset, but before adding the translation. If the loco asset id ends with the exact translation message, it is skipped because it is not translated yet. This also takes into account the default "__" prefix when using `translation:extract`.

Examples:

| Loco Asset Id | Key | Message |  Skip? | Loco Status |
| --- | --- | --- |  --- |  --- |
|  messages__some_message |  some_message | some_message |  yes |  untranslated |
|  messages__some_message |  some_message | __some_message |  yes | untranslated |
|  messages__some_message |  some_message | Some message |  no |  translated |

Before:
<img width="580" alt="image" src="https://user-images.githubusercontent.com/25748293/158414348-c94c5053-c2b5-4d43-8026-8e3fc18bb2aa.png">



After:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/25748293/158414226-20aabd68-a238-478a-b03a-1778bb23da9c.png">


