### PR TITLE
[HttpKernel] Avoid resolving values which are obviously wrong when other value resolvers may be able to resolve them

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
@@ -43,7 +43,7 @@ final class RequestAttributeValueResolver implements ArgumentValueResolverInterf
 
         // at this point we have a typehint which is either a scalar, a class or an intersection type (which must be a class too)
         // if the type is not a scalar type and the value is not an object we should skip here and let other value resolvers do their job
-        if (!in_array($type, ['string', 'int', 'float', 'bool'], true) && gettype($request->attributes->get($argument->getName())) !== 'object') {
+        if (!\in_array($type, ['string', 'int', 'float', 'bool'], true) && 'object' !== \gettype($request->attributes->get($argument->getName()))) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I was confused why my argument resolver was not called for a param like `Class $class`. Reading the fine-print on https://symfony.com/doc/current/controller/argument_value_resolver.html hinted that I should set a priority >100 if I want to resolve from a route attribute which exists.. 

But IMO this is a bit of a poor DX default that a priority of 0 means your custom resolvers get shadowed by this internal one which does completely broken things. Sending a string to a `Foo $foo` arg is never going to work and we should avoid doing this.

cc @linaori for a sanity check here please, did I miss the point completely? :)