### PR TITLE
Mailer - Display email recipients in Profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -129,6 +129,13 @@
 
                                                             <span class="label">To</span>
                                                             <pre class="prewrap">{{ (message.headers.get('to').bodyAsString() ?? '(empty)')|replace({'To:': ''}) }}</pre>
+
+                                                            {% if event.envelope.recipients|length > 0 %}
+                                                                <span class="label">Recipients</span>
+                                                                {% for recipient in event.envelope.recipients %}
+                                                                    <pre class="prewrap">{{ recipient.address }}</pre>
+                                                                {% endfor %}
+                                                            {% endif %}
                                                         </div>
                                                         <div class="col">
                                                             <span class="label">Headers</span>


### PR DESCRIPTION
This information is important to see the real receivers of sent emails. It was shown using Swiftmailer.

| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix https://github.com/symfony/symfony/issues/45747
| License       | MIT

This information was displayed in headers using Swiftmailer "X-Swift-To".

![image](https://user-images.githubusercontent.com/652505/158553811-5d58efc6-85d0-47dd-b1f4-b198c76c15f0.png)

I put it as bug fix in the sense it's a missing information.

With the following PR a new Recipients info is displayed

![image](https://user-images.githubusercontent.com/652505/158554069-5fbd945e-9c39-48d0-9326-3b36ea02d54a.png)

