### PR TITLE
[Security] Fix tests with low deps

### DIFF
--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/security-core": "^5.4|^6.0",
+        "symfony/security-core": "^5.4.7|^6.0",
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/polyfill-mbstring": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Some tests on 6.1 don't expect `TokenInterface::getUser` to return a string while it's still the case on 5.4 stable (the fix's been merged but not released yet)