### PR TITLE
[FrameworkBundle][Translation][TwigBridge] Add option to extract blank messages

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Wrap help messages on form elements in `div` instead of `p`
+ * Implement new virtual method `blank()` of the `ExtractorInterface`, which allows to extract blank strings instead of a prefixed copy of the translation key, in the `TwigExtractor`
 
 5.4
 ---

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -53,6 +53,38 @@ class TwigExtractorTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider getExtractData
+     */
+    public function testExtractBlank($template, $messages)
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $twig = new Environment($loader, [
+            'strict_variables' => true,
+            'debug' => true,
+            'cache' => false,
+            'autoescape' => false,
+        ]);
+        $twig->addExtension(new TranslationExtension($this->createMock(TranslatorInterface::class)));
+
+        $extractor = new TwigExtractor($twig);
+        $extractor->setPrefix('prefix');
+        $extractor->blank(true);
+        $catalogue = new MessageCatalogue('en');
+
+        $m = new \ReflectionMethod($extractor, 'extractTemplate');
+        $m->invoke($extractor, $template, $catalogue);
+
+        if (0 === \count($messages)) {
+            $this->assertSame($catalogue->all(), $messages);
+        }
+
+        foreach ($messages as $key => $domain) {
+            $this->assertTrue($catalogue->has($key, $domain));
+            $this->assertEquals('', $catalogue->get($key, $domain));
+        }
+    }
+
     public function getExtractData()
     {
         return [

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -38,6 +38,11 @@ class TwigExtractor extends AbstractFileExtractor implements ExtractorInterface
      */
     private string $prefix = '';
 
+    /**
+     * Extract new-found messages as blank strings.
+     */
+    private bool $blank = false;
+
     private Environment $twig;
 
     public function __construct(Environment $twig)
@@ -67,6 +72,14 @@ class TwigExtractor extends AbstractFileExtractor implements ExtractorInterface
         $this->prefix = $prefix;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function blank(bool $blank): void
+    {
+        $this->blank = $blank;
+    }
+
     protected function extractTemplate(string $template, MessageCatalogue $catalogue)
     {
         $visitor = $this->twig->getExtension(TranslationExtension::class)->getTranslationNodeVisitor();
@@ -75,7 +88,7 @@ class TwigExtractor extends AbstractFileExtractor implements ExtractorInterface
         $this->twig->parse($this->twig->tokenize(new Source($template, '')));
 
         foreach ($visitor->getMessages() as $message) {
-            $catalogue->set(trim($message[0]), $this->prefix.trim($message[0]), $message[1] ?: $this->defaultDomain);
+            $catalogue->set(trim($message[0]), $this->blank ? '' : $this->prefix.trim($message[0]), $message[1] ?: $this->defaultDomain);
         }
 
         $visitor->disable();

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `cache:pool:invalidate-tags` command
  * Add `xliff` support in addition to `xlf` for `XliffFileDumper`
  * Deprecate the `reset_on_message` config option. It can be set to `true` only and does nothing now
+ * Add `--blank` option to the `translation:extract` command, which extracts blank strings instead of a prefixed copy of the translation key
 
 6.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -37,10 +37,36 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
     }
 
+    public function testDumpBlankMessagesAndCleanWithDeprecatedCommandName()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => '']]);
+        $tester->execute(['command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
+        $this->assertMatchesRegularExpression('/foo/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
+    }
+
     public function testDumpMessagesAndClean()
     {
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo']]);
         $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true]);
+        $this->assertMatchesRegularExpression('/foo/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
+    }
+
+    public function testDumpBlankMessagesAndClean()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
         $this->assertMatchesRegularExpression('/foo/', $tester->getDisplay());
         $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
     }
@@ -53,10 +79,36 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
     }
 
+    public function testDumpBlankMessagesAsTreeAndClean()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--as-tree' => 1, '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
+        $this->assertMatchesRegularExpression('/foo/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
+    }
+
     public function testDumpSortedMessagesAndClean()
     {
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo', 'test' => 'test', 'bar' => 'bar']]);
         $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--sort' => 'asc']);
+        $this->assertMatchesRegularExpression("/\*bar\*foo\*test/", preg_replace('/\s+/', '', $tester->getDisplay()));
+        $this->assertMatchesRegularExpression('/3 messages were successfully extracted/', $tester->getDisplay());
+    }
+
+    public function testDumpSortedBlankMessagesAndClean()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => '', 'test' => '', 'bar' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--sort' => 'asc', '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
         $this->assertMatchesRegularExpression("/\*bar\*foo\*test/", preg_replace('/\s+/', '', $tester->getDisplay()));
         $this->assertMatchesRegularExpression('/3 messages were successfully extracted/', $tester->getDisplay());
     }
@@ -69,6 +121,19 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertMatchesRegularExpression('/3 messages were successfully extracted/', $tester->getDisplay());
     }
 
+    public function testDumpReverseSortedBlankMessagesAndClean()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => '', 'test' => '', 'bar' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--sort' => 'desc', '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
+        $this->assertMatchesRegularExpression("/\*test\*foo\*bar/", preg_replace('/\s+/', '', $tester->getDisplay()));
+        $this->assertMatchesRegularExpression('/3 messages were successfully extracted/', $tester->getDisplay());
+    }
+
     public function testDumpSortWithoutValueAndClean()
     {
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo', 'test' => 'test', 'bar' => 'bar']]);
@@ -77,10 +142,35 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertMatchesRegularExpression('/3 messages were successfully extracted/', $tester->getDisplay());
     }
 
+    public function testDumpSortWithoutValueAndCleanBlank()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => '', 'test' => '', 'bar' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--sort', '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
+        $this->assertMatchesRegularExpression("/\*bar\*foo\*test/", preg_replace('/\s+/', '', $tester->getDisplay()));
+        $this->assertMatchesRegularExpression('/3 messages were successfully extracted/', $tester->getDisplay());
+    }
+
     public function testDumpWrongSortAndClean()
     {
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo', 'test' => 'test', 'bar' => 'bar']]);
         $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--sort' => 'test']);
+        $this->assertMatchesRegularExpression('/\[ERROR\] Wrong sort order/', $tester->getDisplay());
+    }
+
+    public function testDumpWrongSortAndCleanBlank()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => '', 'test' => '', 'bar' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--sort' => 'test', '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
         $this->assertMatchesRegularExpression('/\[ERROR\] Wrong sort order/', $tester->getDisplay());
     }
 
@@ -97,10 +187,42 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
     }
 
+    public function testDumpBlankMessagesAndCleanInRootDirectory()
+    {
+        $this->fs->remove($this->translationDir);
+        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
+        $this->fs->mkdir($this->translationDir.'/translations');
+        $this->fs->mkdir($this->translationDir.'/templates');
+
+        $tester = $this->createCommandTester(['messages' => ['foo' => '']], [], null, [$this->translationDir.'/trans'], [$this->translationDir.'/views']);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', '--dump-messages' => true, '--clean' => true, '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
+        $this->assertMatchesRegularExpression('/foo/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
+    }
+
     public function testDumpTwoMessagesAndClean()
     {
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo', 'bar' => 'bar']]);
         $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true]);
+        $this->assertMatchesRegularExpression('/foo/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/bar/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/2 messages were successfully extracted/', $tester->getDisplay());
+    }
+
+    public function testDumpTwoBlankMessagesAndClean()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => '', 'bar' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
         $this->assertMatchesRegularExpression('/foo/', $tester->getDisplay());
         $this->assertMatchesRegularExpression('/bar/', $tester->getDisplay());
         $this->assertMatchesRegularExpression('/2 messages were successfully extracted/', $tester->getDisplay());
@@ -114,10 +236,35 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
     }
 
+    public function testDumpBlankMessagesForSpecificDomain()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => ''], 'mydomain' => ['bar' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--domain' => 'mydomain', '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
+        $this->assertMatchesRegularExpression('/bar/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/1 message was successfully extracted/', $tester->getDisplay());
+    }
+
     public function testWriteMessages()
     {
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo']]);
         $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--force' => true]);
+        $this->assertMatchesRegularExpression('/Translation files were successfully updated./', $tester->getDisplay());
+    }
+
+    public function testWriteBlankMessages()
+    {
+        $tester = $this->createCommandTester(['messages' => ['foo' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', 'bundle' => 'foo', '--force' => true, '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
         $this->assertMatchesRegularExpression('/Translation files were successfully updated./', $tester->getDisplay());
     }
 
@@ -130,6 +277,23 @@ class TranslationUpdateCommandTest extends TestCase
 
         $tester = $this->createCommandTester(['messages' => ['foo' => 'foo']]);
         $tester->execute(['command' => 'translation:extract', 'locale' => 'en', '--force' => true]);
+        $this->assertMatchesRegularExpression('/Translation files were successfully updated./', $tester->getDisplay());
+    }
+
+    public function testWriteBlankMessagesInRootDirectory()
+    {
+        $this->fs->remove($this->translationDir);
+        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
+        $this->fs->mkdir($this->translationDir.'/translations');
+        $this->fs->mkdir($this->translationDir.'/templates');
+
+        $tester = $this->createCommandTester(['messages' => ['foo' => '']]);
+        $tester->execute(['command' => 'translation:extract', 'locale' => 'en', '--force' => true, '--blank' => true]);
+        if (!method_exists($tester, 'blank')) {
+            $this->assertMatchesRegularExpression('/The --blank option is not supported by this extractor./', $tester->getDisplay());
+
+            return;
+        }
         $this->assertMatchesRegularExpression('/Translation files were successfully updated./', $tester->getDisplay());
     }
 

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Parameters implementing `TranslatableInterface` are processed
  * Add the file extension to the `XliffFileDumper` constructor
+ * Add virtual method `blank()` to `ExtractorInterface`, which allows to extract blank strings instead of a prefixed copy of the translation key and implement it in the `PhpExtractor` and `ChainExtractor`
 
 5.4
 ---

--- a/src/Symfony/Component/Translation/Extractor/ChainExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/ChainExtractor.php
@@ -48,6 +48,16 @@ class ChainExtractor implements ExtractorInterface
     /**
      * {@inheritdoc}
      */
+    public function blank(bool $blank): void
+    {
+        foreach ($this->extractors as $extractor) {
+            $extractor->blank($blank);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function extract(string|iterable $directory, MessageCatalogue $catalogue)
     {
         foreach ($this->extractors as $extractor) {

--- a/src/Symfony/Component/Translation/Extractor/ExtractorInterface.php
+++ b/src/Symfony/Component/Translation/Extractor/ExtractorInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\Translation\MessageCatalogue;
  * New found messages are injected to the catalogue using the prefix.
  *
  * @author Michel Salib <michelsalib@hotmail.com>
+ *
+ * @method void blank(bool $blank) Extract new-found messages as blank strings.
  */
 interface ExtractorInterface
 {

--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -31,6 +31,11 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
     private string $prefix = '';
 
     /**
+     * Extract new-found messages as blank strings.
+     */
+    private bool $blank = false;
+
+    /**
      * The sequence that captures translation messages.
      */
     protected $sequences = [
@@ -147,6 +152,14 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
     public function setPrefix(string $prefix)
     {
         $this->prefix = $prefix;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function blank(bool $blank): void
+    {
+        $this->blank = $blank;
     }
 
     /**
@@ -295,7 +308,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
                 }
 
                 if ($message) {
-                    $catalog->set($message, $this->prefix.$message, $domain);
+                    $catalog->set($message, $this->blank ? '' : $this->prefix.$message, $domain);
                     $metadata = $catalog->getMetadata($message, $domain) ?? [];
                     $normalizedFilename = preg_replace('{[\\\\/]+}', '/', $filename);
                     $metadata['sources'][] = $normalizedFilename.':'.$tokens[$key][2];

--- a/src/Symfony/Component/Translation/Tests/Extractor/PhpExtractorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/PhpExtractorTest.php
@@ -130,6 +130,120 @@ EOF;
         $this->assertEquals(['sources' => [$filename.':37']], $catalogue->getMetadata('other-domain-test-no-params-short-array', 'not_messages'));
     }
 
+    /**
+     * @dataProvider resourcesProvider
+     *
+     * @param array|string $resource
+     */
+    public function testBlankExtraction($resource)
+    {
+        // Arrange
+        $extractor = new PhpExtractor();
+        $extractor->setPrefix('prefix');
+        $extractor->blank(true);
+        $catalogue = new MessageCatalogue('en');
+
+        // Act
+        $extractor->extract($resource, $catalogue);
+
+        $expectedHeredoc = <<<EOF
+heredoc key with whitespace and escaped \$\n sequences
+EOF;
+        $expectedNowdoc = <<<'EOF'
+nowdoc key with whitespace and nonescaped \$\n sequences
+EOF;
+        // Assert
+        $expectedCatalogue = [
+            'messages' => [
+                'translatable single-quoted key' => '',
+                'translatable double-quoted key' => '',
+                'translatable heredoc key' => '',
+                'translatable nowdoc key' => '',
+                "translatable double-quoted key with whitespace and escaped \$\n\" sequences" => '',
+                'translatable single-quoted key with whitespace and nonescaped \$\n\' sequences' => '',
+                'translatable single-quoted key with "quote mark at the end"' => '',
+                'translatable '.$expectedHeredoc => '',
+                'translatable '.$expectedNowdoc => '',
+                'translatable concatenated message with heredoc and nowdoc' => '',
+                'translatable default domain' => '',
+                'translatable-fqn single-quoted key' => '',
+                'translatable-fqn double-quoted key' => '',
+                'translatable-fqn heredoc key' => '',
+                'translatable-fqn nowdoc key' => '',
+                "translatable-fqn double-quoted key with whitespace and escaped \$\n\" sequences" => '',
+                'translatable-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences' => '',
+                'translatable-fqn single-quoted key with "quote mark at the end"' => '',
+                'translatable-fqn '.$expectedHeredoc => '',
+                'translatable-fqn '.$expectedNowdoc => '',
+                'translatable-fqn concatenated message with heredoc and nowdoc' => '',
+                'translatable-fqn default domain' => '',
+                'translatable-short single-quoted key' => '',
+                'translatable-short double-quoted key' => '',
+                'translatable-short heredoc key' => '',
+                'translatable-short nowdoc key' => '',
+                "translatable-short double-quoted key with whitespace and escaped \$\n\" sequences" => '',
+                'translatable-short single-quoted key with whitespace and nonescaped \$\n\' sequences' => '',
+                'translatable-short single-quoted key with "quote mark at the end"' => '',
+                'translatable-short '.$expectedHeredoc => '',
+                'translatable-short '.$expectedNowdoc => '',
+                'translatable-short concatenated message with heredoc and nowdoc' => '',
+                'translatable-short default domain' => '',
+                'single-quoted key' => '',
+                'double-quoted key' => '',
+                'heredoc key' => '',
+                'nowdoc key' => '',
+                "double-quoted key with whitespace and escaped \$\n\" sequences" => '',
+                'single-quoted key with whitespace and nonescaped \$\n\' sequences' => '',
+                'single-quoted key with "quote mark at the end"' => '',
+                $expectedHeredoc => '',
+                $expectedNowdoc => '',
+                'concatenated message with heredoc and nowdoc' => '',
+                'default domain' => '',
+            ],
+            'not_messages' => [
+                'translatable other-domain-test-no-params-short-array' => '',
+                'translatable other-domain-test-no-params-long-array' => '',
+                'translatable other-domain-test-params-short-array' => '',
+                'translatable other-domain-test-params-long-array' => '',
+                'translatable typecast' => '',
+                'translatable-fqn other-domain-test-no-params-short-array' => '',
+                'translatable-fqn other-domain-test-no-params-long-array' => '',
+                'translatable-fqn other-domain-test-params-short-array' => '',
+                'translatable-fqn other-domain-test-params-long-array' => '',
+                'translatable-fqn typecast' => '',
+                'translatable-short other-domain-test-no-params-short-array' => '',
+                'translatable-short other-domain-test-no-params-long-array' => '',
+                'translatable-short other-domain-test-params-short-array' => '',
+                'translatable-short other-domain-test-params-long-array' => '',
+                'translatable-short typecast' => '',
+                'other-domain-test-no-params-short-array' => '',
+                'other-domain-test-no-params-long-array' => '',
+                'other-domain-test-params-short-array' => '',
+                'other-domain-test-params-long-array' => '',
+                'typecast' => '',
+            ],
+        ];
+        $actualCatalogue = $catalogue->all();
+
+        $this->assertEquals($expectedCatalogue, $actualCatalogue);
+
+        $filename = str_replace(\DIRECTORY_SEPARATOR, '/', __DIR__).'/../fixtures/extractor/translatable.html.php';
+        $this->assertEquals(['sources' => [$filename.':2']], $catalogue->getMetadata('translatable single-quoted key'));
+        $this->assertEquals(['sources' => [$filename.':37']], $catalogue->getMetadata('translatable other-domain-test-no-params-short-array', 'not_messages'));
+
+        $filename = str_replace(\DIRECTORY_SEPARATOR, '/', __DIR__).'/../fixtures/extractor/translatable-fqn.html.php';
+        $this->assertEquals(['sources' => [$filename.':2']], $catalogue->getMetadata('translatable-fqn single-quoted key'));
+        $this->assertEquals(['sources' => [$filename.':37']], $catalogue->getMetadata('translatable-fqn other-domain-test-no-params-short-array', 'not_messages'));
+
+        $filename = str_replace(\DIRECTORY_SEPARATOR, '/', __DIR__).'/../fixtures/extractor/translatable-short.html.php';
+        $this->assertEquals(['sources' => [$filename.':2']], $catalogue->getMetadata('translatable-short single-quoted key'));
+        $this->assertEquals(['sources' => [$filename.':37']], $catalogue->getMetadata('translatable-short other-domain-test-no-params-short-array', 'not_messages'));
+
+        $filename = str_replace(\DIRECTORY_SEPARATOR, '/', __DIR__).'/../fixtures/extractor/translation.html.php';
+        $this->assertEquals(['sources' => [$filename.':2']], $catalogue->getMetadata('single-quoted key'));
+        $this->assertEquals(['sources' => [$filename.':37']], $catalogue->getMetadata('other-domain-test-no-params-short-array', 'not_messages'));
+    }
+
     public function testExtractionFromIndentedHeredocNowdoc()
     {
         $catalogue = new MessageCatalogue('en');
@@ -142,6 +256,25 @@ EOF;
             'messages' => [
                 "heredoc\nindented\n  further" => "prefixheredoc\nindented\n  further",
                 "nowdoc\nindented\n  further" => "prefixnowdoc\nindented\n  further",
+            ],
+        ];
+
+        $this->assertEquals($expectedCatalogue, $catalogue->all());
+    }
+
+    public function testBlankExtractionFromIndentedHeredocNowdoc()
+    {
+        $catalogue = new MessageCatalogue('en');
+
+        $extractor = new PhpExtractor();
+        $extractor->setPrefix('prefix');
+        $extractor->blank(true);
+        $extractor->extract(__DIR__.'/../fixtures/extractor-7.3/translation.html.php', $catalogue);
+
+        $expectedCatalogue = [
+            'messages' => [
+                "heredoc\nindented\n  further" => '',
+                "nowdoc\nindented\n  further" => '',
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#16621

Currently, new messages are extracted as a prefixed copy of the key (`"foo" -> "__foo"`) when using the `translation:extract` command. 

With his PR I propose a `--blank` option that would extract new messages as blank strings (`"foo" -> ""`). 

This allows for smoother workflows with translation providers like Loco, Lokalise or CrowdIn, because by some of them the prefixed copy is considered **translated**, while blank strings are considered **untranslated**. 

The result is that you currently have 100% translation progress immediately after `translation:push`, even if *none* of the translation keys are actually translated. This makes working with hundreds or thousands of translation keys or general collaboration through these tools unnecessarily hard. 

For example lets say you have 1000 translation keys in your application and want to add a new locale. You extract and push them to the provider. Then you or some translator starts work on them. They won't finish all keys in one session, but instead maybe finish 100 of them and continue work the next day. However, because all the messages already have the "translated" status, its hard to know where to continue. You have to look at every single message again and determine if it is **really** translated, or **if the strings are just technically different**. 

**It is very easy to miss untranslated messages if all of them have a green checkmark, regardless of the real translation status.**

The benefit of pushing blank strings as translation messages is that it allows you to **easily filter for untranslated messages as a "todo list"**, instead of checking each message manually for its translation status.