### PR TITLE
Updating twig required version (fixing vulnerability) 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "friendsofphp/proxy-manager-lts": "^1.0.2",
         "doctrine/event-manager": "~1.0",
         "doctrine/persistence": "^1.3|^2",
-        "twig/twig": "^1.43|^2.13|^3.0.4",
+        "twig/twig": "^1.43|^2.14.11|^3.3.8",
         "psr/cache": "^1.0|^2.0",
         "psr/container": "^1.0",
         "psr/link": "^1.0",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.1.3",
         "symfony/polyfill-php80": "^1.16",
         "symfony/translation-contracts": "^1.1|^2",
-        "twig/twig": "^1.43|^2.13|^3.0.4"
+        "twig/twig": "^1.43|^2.14.11|^3.3.8"
     },
     "require-dev": {
         "egulias/email-validator": "^2.1.10|^3",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -64,7 +64,7 @@
         "symfony/property-info": "^3.4|^4.0|^5.0",
         "symfony/web-link": "^4.4|^5.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-        "twig/twig": "^1.43|^2.13|^3.0.4"
+        "twig/twig": "^1.43|^2.14.11|^3.3.8"
     },
     "conflict": {
         "doctrine/persistence": "<1.3",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -44,7 +44,7 @@
         "symfony/twig-bundle": "^4.4|^5.0",
         "symfony/validator": "^3.4|^4.0|^5.0",
         "symfony/yaml": "^3.4|^4.0|^5.0",
-        "twig/twig": "^1.43|^2.13|^3.0.4"
+        "twig/twig": "^1.43|^2.14.11|^3.3.8"
     },
     "conflict": {
         "symfony/browser-kit": "<4.2",

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^4.4",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-php80": "^1.16",
-        "twig/twig": "^1.43|^2.14|^3.3.8"
+        "twig/twig": "^1.43|^2.14.11|^3.3.8"
     },
     "require-dev": {
         "symfony/asset": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^4.4",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-php80": "^1.16",
-        "twig/twig": "^1.43|^2.13|^3.0.4"
+        "twig/twig": "^1.43|^2.14|^3.0.4"
     },
     "require-dev": {
         "symfony/asset": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^4.4",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-php80": "^1.16",
-        "twig/twig": "^1.43|^2.14|^3.0.4"
+        "twig/twig": "^1.43|^2.14|^3.3.8"
     },
     "require-dev": {
         "symfony/asset": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/polyfill-php80": "^1.16",
         "symfony/routing": "^4.3|^5.0",
         "symfony/twig-bundle": "^4.2|^5.0",
-        "twig/twig": "^1.43|^2.13|^3.0.4"
+        "twig/twig": "^1.43|^2.14.11|^3.3.8"
     },
     "require-dev": {
         "symfony/browser-kit": "^4.3|^5.0",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -42,7 +42,7 @@
         "symfony/translation": "^4.2|^5.0",
         "symfony/translation-contracts": "^1.1|^2",
         "psr/cache": "^1.0|^2.0|^3.0",
-        "twig/twig": "^1.43|^2.13|^3.0.4"
+        "twig/twig": "^1.43|^2.14.11|^3.3.8"
     },
     "provide": {
         "psr/log-implementation": "1.0|2.0"
@@ -53,7 +53,7 @@
         "symfony/console": ">=5",
         "symfony/dependency-injection": "<4.3",
         "symfony/translation": "<4.2",
-        "twig/twig": "<1.43|<2.13,>=2"
+        "twig/twig": "<1.43|<2.14.11,>=2"
     },
     "suggest": {
         "symfony/browser-kit": "",

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -25,7 +25,7 @@
         "ext-iconv": "*",
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/process": "^4.4|^5.0",
-        "twig/twig": "^1.43|^2.13|^3.0.4"
+        "twig/twig": "^1.43|^2.14.11|^3.3.8"
     },
     "conflict": {
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

https://symfony.com/blog/twig-security-release-disallow-non-closures-in-the-sort-filter
