### PR TITLE
[Serializer] Improve performance by exposing supports-never/-always 

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -102,6 +102,7 @@ Serializer
  * Deprecate calling `AttributeMetadata::setSerializedName()`, `ClassMetadata::setClassDiscriminatorMapping()` without arguments
  * Change the signature of `AttributeMetadataInterface::setSerializedName()` to `setSerializedName(?string)`
  * Change the signature of `ClassMetadataInterface::setClassDiscriminatorMapping()` to `setClassDiscriminatorMapping(?ClassDiscriminatorMapping)`
+ * Deprecate `Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface`, use `Symfony\Component\Serializer\Normalizer\CacheableSupport` instead
 
 Translation
 -----------

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+* Cache normalizer selection based on format and type
+* Deprecate `Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface`, use `Symfony\Component\Serializer\Normalizer\CacheableSupport` instead
+
 6.2
 ---
 

--- a/src/Symfony/Component/Serializer/Normalizer/CacheableSupport.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CacheableSupport.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+/**
+ * The return value of supports*() methods in {@see NormalizerInterface} and {@see DenormalizerInterface}.
+ * Tells if the result should be cached based on type and format.
+ *
+ * -1 : no, never supports the $format+$type, cache it
+ * 0  : no, no cache
+ * 1  : yes, no cache
+ * 2  : yes, always supports the $format+$type, cache it
+ *
+ * @author Jeroen Spee <https://github.com/Jeroeny>
+ */
+enum CacheableSupport: int
+{
+    case SupportNever = -1;
+    case SupportNot = 0;
+    case Support = 1;
+    case SupportAlways = 2;
+
+    public function supports(): bool
+    {
+        return match ($this) {
+            CacheableSupport::SupportNever, CacheableSupport::SupportNot => false,
+            CacheableSupport::Support, CacheableSupport::SupportAlways => true,
+        };
+    }
+}

--- a/src/Symfony/Component/Serializer/Normalizer/CacheableSupportsMethodInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CacheableSupportsMethodInterface.php
@@ -19,6 +19,8 @@ namespace Symfony\Component\Serializer\Normalizer;
  * supports*() methods will be cached by type and format.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated since symfony/serializer 6.1, return CacheableSupport from the supports*() method instead
  */
 interface CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -34,8 +34,6 @@ interface DenormalizerInterface
      * @param string $format  Format the given data was extracted from
      * @param array  $context Options available to the denormalizer
      *
-     * @return mixed
-     *
      * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
      * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported
      * @throws UnexpectedValueException Occurs when the item cannot be hydrated with the given data
@@ -49,12 +47,11 @@ interface DenormalizerInterface
     /**
      * Checks whether the given class is supported for denormalization by this normalizer.
      *
-     * @param mixed  $data    Data to denormalize from
-     * @param string $type    The class to which the data should be denormalized
-     * @param string $format  The format being deserialized from
-     * @param array  $context Options available to the denormalizer
+     * @param mixed  $data   Data to denormalize from
+     * @param string $type   The class to which the data should be denormalized
+     * @param string $format The format being deserialized from
      *
-     * @return bool
+     * @return CacheableSupport|bool returning a boolean is deprecated
      */
     public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */);
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -41,11 +41,10 @@ interface NormalizerInterface
     /**
      * Checks whether the given class is supported for normalization by this normalizer.
      *
-     * @param mixed  $data    Data to normalize
-     * @param string $format  The format being (de-)serialized from or into
-     * @param array  $context Context options for the normalizer
+     * @param mixed  $data   Data to normalize
+     * @param string $format The format being (de-)serialized from or into
      *
-     * @return bool
+     * @return CacheableSupport|bool returning a boolean is deprecated
      */
     public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | Likely yes
| License       | MIT
| Doc PR        | Not yet initiated

**Description**

In the Serializer component, there is a `CacheableSupportsMethodInterface`. It can indicate the fact the normalizer's `supports*` method result can be cached.
Unfortunately, every normalizer that determines this result using `$context` cannot have its result cached (because it's based on `format`+`type`).

However there is some information with that supports call that often can be cached. Which is when a normalizer _never_ supports a `format`+`type`, regardless of context. 

For example:

```php
public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */)
{
    return $data instanceof DateTime && ($context['DB_TYPES') ?? false);
}
```

This normalizer would not be able to have its result cached. Even though we know that if the `$data` is not an instance of `DateTime`, it will _never_  be supported, regardless of `$context`.

**Solution(s)**

This pull request proposes to introduce the ability to return `always/never supports $format+$type`, to increase performance.  
By introducing or altering a method to return one of 4 values: 

- support never
- support not
- support
- support always

There are multiple ways to achieve this. 

1. The one that is done in this PR for now, is to use the existing `supportsNormalization` method.
It would be changed to allow it to return one of the enum values (e.g. using integers -1 to 2, or bitwise), while still allowing `bool` return for backwards compatibilty. 
This has the advantage of only needing one method for the caching and supports information. And no extra interfaces, so `CacheableSupportsMethodInterface` can be deprecated.

With this, the example from earlier would become:

```php
public function supportsNormalization(mixed $data, string $format = null /*, array $context = [] */)
{
    if (! $data instanceof DateTime) {
        return SUPPORT_NEVER; // a const, or could use an enum/integer directly
    }

    return ($context['DB_TYPES') ?? false) ? SUPPORT : SUPPORT_NOT;
}
```

2. A new method `CacheableSupportsInterface::supportsNormalizationCached($data, $format, $context): int`. Possibly with a trait that implements the `supportsNormalization` to prevent duplicate logic (by doing `return $this->supportsNormalizationCached(..) >= SUPPORT`).

The solutions apply to both normalization and denormalization.

**Performance impact example**

- If there are 10 (de)normalizers, that cannot use `CacheableSupportsMethodInterface` because of `$context`, but can return `SUPPORT_NEVER` like the example above. 
- The last of the normalizers supports the `DateTime` type. 

Now you normalize a `$dateTime` 1000 times:

- Before: 10.000 calls to `supportsNormalization()` and iterated over 10.010 `$cached` normalizers .
- After: 1.009 calls to `supportsNormalization()` and iterated over 1.010 `$cached` normalizers (`$this->normalizerCache[$format][DateTime::class]` now only contains the one relevant normalizer).

A decrease in method calls of 89.91%.