### PR TITLE
[DependencyInjection] adjust `Autowire` attribute implementation

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
@@ -28,17 +28,25 @@ class Autowire
     /**
      * Use only ONE of the following.
      *
+     * @param string|null $value      Parameter value (ie "%kernel.project_dir%/some/path")
      * @param string|null $service    Service ID (ie "some.service")
      * @param string|null $expression Expression (ie 'service("some.service").someMethod()')
-     * @param string|null $value      Parameter value (ie "%kernel.project_dir%/some/path")
      */
     public function __construct(
+        ?string $value = null,
         ?string $service = null,
         ?string $expression = null,
-        ?string $value = null
     ) {
         if (!($service xor $expression xor null !== $value)) {
             throw new LogicException('#[Autowire] attribute must declare exactly one of $service, $expression, or $value.');
+        }
+
+        if (null !== $value && str_starts_with($value, '@')) {
+            match (true) {
+                str_starts_with($value, '@@') => $value = substr($value, 1),
+                str_starts_with($value, '@=') => $expression = substr($value, 2),
+                default => $service = substr($value, 1),
+            };
         }
 
         $this->value = match (true) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1141,11 +1141,15 @@ class AutowirePassTest extends TestCase
 
         $definition = $container->getDefinition(AutowireAttribute::class);
 
-        $this->assertCount(4, $definition->getArguments());
+        $this->assertCount(8, $definition->getArguments());
         $this->assertEquals(new Reference('some.id'), $definition->getArgument(0));
         $this->assertEquals(new Expression("parameter('some.parameter')"), $definition->getArgument(1));
         $this->assertSame('%some.parameter%/bar', $definition->getArgument(2));
-        $this->assertEquals(new Reference('invalid.id', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(3));
+        $this->assertEquals(new Reference('some.id'), $definition->getArgument(3));
+        $this->assertEquals(new Expression("parameter('some.parameter')"), $definition->getArgument(4));
+        $this->assertSame('bar', $definition->getArgument(5));
+        $this->assertSame('@bar', $definition->getArgument(6));
+        $this->assertEquals(new Reference('invalid.id', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(7));
 
         $container->compile();
 
@@ -1154,6 +1158,10 @@ class AutowirePassTest extends TestCase
         $this->assertInstanceOf(\stdClass::class, $service->service);
         $this->assertSame('foo', $service->expression);
         $this->assertSame('foo/bar', $service->value);
+        $this->assertInstanceOf(\stdClass::class, $service->serviceAsValue);
+        $this->assertSame('foo', $service->expressionAsValue);
+        $this->assertSame('bar', $service->rawValue);
+        $this->assertSame('@bar', $service->escapedRawValue);
         $this->assertNull($service->invalid);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -37,6 +37,14 @@ class AutowireAttribute
         public string $expression,
         #[Autowire(value: '%some.parameter%/bar')]
         public string $value,
+        #[Autowire('@some.id')]
+        public \stdClass $serviceAsValue,
+        #[Autowire("@=parameter('some.parameter')")]
+        public string $expressionAsValue,
+        #[Autowire('bar')]
+        public string $rawValue,
+        #[Autowire('@@bar')]
+        public string $escapedRawValue,
         #[Autowire(service: 'invalid.id')]
         public ?\stdClass $invalid = null,
     ) {

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -467,9 +467,14 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $locator = $container->get($locatorId)->get('foo::fooAction');
 
+        $this->assertCount(7, $locator->getProvidedServices());
         $this->assertInstanceOf(\stdClass::class, $locator->get('service1'));
         $this->assertSame('foo/bar', $locator->get('value'));
         $this->assertSame('foo', $locator->get('expression'));
+        $this->assertInstanceOf(\stdClass::class, $locator->get('serviceAsValue'));
+        $this->assertInstanceOf(\stdClass::class, $locator->get('expressionAsValue'));
+        $this->assertSame('bar', $locator->get('rawValue'));
+        $this->assertSame('@bar', $locator->get('escapedRawValue'));
         $this->assertFalse($locator->has('service2'));
     }
 }
@@ -562,6 +567,14 @@ class WithAutowireAttribute
         string $value,
         #[Autowire(expression: "parameter('some.parameter')")]
         string $expression,
+        #[Autowire('@some.id')]
+        \stdClass $serviceAsValue,
+        #[Autowire("@=service('some.id')")]
+        \stdClass $expressionAsValue,
+        #[Autowire('bar')]
+        string $rawValue,
+        #[Autowire('@@bar')]
+        string $escapedRawValue,
         #[Autowire(service: 'invalid.id')]
         \stdClass $service2 = null,
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/45657#discussion_r829290509
| License       | MIT
| Doc PR        | todo

Per discussion with @nicolas-grekas, we've decided to improve the DX of the attribute a bit. The implementation from #45657 still works as described there. This allows for the first `Autowire` constructor argument to be used for services/expressions by adding a _familiar_ prefix (`@` for services, `@=` for expressions):

```php
class MyService
{
    public function __construct(
        #[Autowire('@some_service')]
        private $service1,

        #[Autowire('@=service("App\\Mail\\MailerConfiguration").getMailerMethod()')
        private $service2,

        #[Autowire('%env(json:file:resolve:AUTH_FILE)%')]
        private $parameter1,
    ) {}
}
```