### PR TITLE
[TwigBridge] [WIP] add `LocaleVariable`

### DIFF
--- a/src/Symfony/Bridge/Twig/LocaleVariable.php
+++ b/src/Symfony/Bridge/Twig/LocaleVariable.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+/**
+ * Exposes helpful methods and parameters related to the locale.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LocaleVariable implements ServiceSubscriberInterface
+{
+    public function __construct(
+        private ContainerInterface $container,
+        public readonly array $enabled,
+    ) {
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            UrlGeneratorInterface::class,
+            RequestStack::class,
+        ];
+    }
+
+    public function __toString(): string
+    {
+        return $this->getCurrent();
+    }
+
+    public function getCurrent(): string
+    {
+        return \Locale::getDefault();
+    }
+
+    /**
+     * Generate the current path switched to a new locale (requires i18n routing).
+     */
+    public function switchCurrentPath(string $locale): string
+    {
+        // todo error checking
+        $request = $this->container->get(RequestStack::class)->getCurrentRequest();
+
+        return $this->container->get(UrlGeneratorInterface::class)->generate(
+            $request->attributes->get('_route'),
+            \array_merge($request->attributes->get('_route_params'), ['_locale' => $locale])
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This is a proposal for a `locale` variable to be made globally available in twig. It can be used to ease the process of creating a language switcher.

**Proposed Usage:**

The following examples assume the current locale is `en` and the current page is `/en/some/page`.

```twig
{{ locale }} {# "en" #}
{{ locale.current }} {# "en" #}

{{ locale.enabled }} {# array of enabled locales: %kernel.enabled_locales% #}

{{ locale|locale_name }} {# "English" #}

{{ locale.switchCurrentPath('fr') }} {# "/fr/some/page" #}

{# create a basic language switcher: #}
<ul>
    {% for code in locale.enabled|filter(code => code != locale.current) %}
        <li><a href="{{ locale.switchCurrentPath(code) }}">{{ code|locale_name }}</a></li>
    {% endfor %}
</ul>
```

Looking for feedback before I go any further with this. Maybe this should live somewhere else (ie twig-extra-bundle) or merged with `AppVariable`?