### PR TITLE
[FrameworkBundle] Fix exit codes in debug:translation command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -133,7 +133,7 @@ EOF
         $locale = $input->getArgument('locale');
         $domain = $input->getOption('domain');
 
-        $exitCode = 0;
+        $exitCode = self::SUCCESS;
 
         /** @var KernelInterface $kernel */
         $kernel = $this->getApplication()->getKernel();
@@ -219,16 +219,21 @@ EOF
                     if (!$currentCatalogue->defines($messageId, $domain)) {
                         $states[] = self::MESSAGE_MISSING;
 
-                        $exitCode = $exitCode | self::EXIT_CODE_MISSING;
+                        if (!$input->getOption('only-unused')) {
+                            $exitCode = $exitCode | self::EXIT_CODE_MISSING;
+                        }
                     }
                 } elseif ($currentCatalogue->defines($messageId, $domain)) {
                     $states[] = self::MESSAGE_UNUSED;
 
-                    $exitCode = $exitCode | self::EXIT_CODE_UNUSED;
+                    if (!$input->getOption('only-missing')) {
+                        $exitCode = $exitCode | self::EXIT_CODE_UNUSED;
+                    }
                 }
 
-                if (!\in_array(self::MESSAGE_UNUSED, $states) && true === $input->getOption('only-unused')
-                    || !\in_array(self::MESSAGE_MISSING, $states) && true === $input->getOption('only-missing')) {
+                if (!\in_array(self::MESSAGE_UNUSED, $states) && $input->getOption('only-unused')
+                    || !\in_array(self::MESSAGE_MISSING, $states) && $input->getOption('only-missing')
+                ) {
                     continue;
                 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\ExtensionWithoutConfigTestBundle\ExtensionWithoutConfigTestBundle;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
@@ -36,7 +37,7 @@ class TranslationDebugCommandTest extends TestCase
         $res = $tester->execute(['locale' => 'en', 'bundle' => 'foo']);
 
         $this->assertMatchesRegularExpression('/missing/', $tester->getDisplay());
-        $this->assertEquals(TranslationDebugCommand::EXIT_CODE_MISSING, $res);
+        $this->assertSame(TranslationDebugCommand::EXIT_CODE_MISSING, $res);
     }
 
     public function testDebugUnusedMessages()
@@ -45,7 +46,7 @@ class TranslationDebugCommandTest extends TestCase
         $res = $tester->execute(['locale' => 'en', 'bundle' => 'foo']);
 
         $this->assertMatchesRegularExpression('/unused/', $tester->getDisplay());
-        $this->assertEquals(TranslationDebugCommand::EXIT_CODE_UNUSED, $res);
+        $this->assertSame(TranslationDebugCommand::EXIT_CODE_UNUSED, $res);
     }
 
     public function testDebugFallbackMessages()
@@ -54,7 +55,7 @@ class TranslationDebugCommandTest extends TestCase
         $res = $tester->execute(['locale' => 'fr', 'bundle' => 'foo']);
 
         $this->assertMatchesRegularExpression('/fallback/', $tester->getDisplay());
-        $this->assertEquals(TranslationDebugCommand::EXIT_CODE_FALLBACK, $res);
+        $this->assertSame(TranslationDebugCommand::EXIT_CODE_FALLBACK, $res);
     }
 
     public function testNoDefinedMessages()
@@ -63,7 +64,7 @@ class TranslationDebugCommandTest extends TestCase
         $res = $tester->execute(['locale' => 'fr', 'bundle' => 'test']);
 
         $this->assertMatchesRegularExpression('/No defined or extracted messages for locale "fr"/', $tester->getDisplay());
-        $this->assertEquals(TranslationDebugCommand::EXIT_CODE_GENERAL_ERROR, $res);
+        $this->assertSame(TranslationDebugCommand::EXIT_CODE_GENERAL_ERROR, $res);
     }
 
     public function testDebugDefaultDirectory()
@@ -74,7 +75,7 @@ class TranslationDebugCommandTest extends TestCase
 
         $this->assertMatchesRegularExpression('/missing/', $tester->getDisplay());
         $this->assertMatchesRegularExpression('/unused/', $tester->getDisplay());
-        $this->assertEquals($expectedExitStatus, $res);
+        $this->assertSame($expectedExitStatus, $res);
     }
 
     public function testDebugDefaultRootDirectory()
@@ -92,7 +93,7 @@ class TranslationDebugCommandTest extends TestCase
 
         $this->assertMatchesRegularExpression('/missing/', $tester->getDisplay());
         $this->assertMatchesRegularExpression('/unused/', $tester->getDisplay());
-        $this->assertEquals($expectedExitStatus, $res);
+        $this->assertSame($expectedExitStatus, $res);
     }
 
     public function testDebugCustomDirectory()
@@ -112,7 +113,7 @@ class TranslationDebugCommandTest extends TestCase
 
         $this->assertMatchesRegularExpression('/missing/', $tester->getDisplay());
         $this->assertMatchesRegularExpression('/unused/', $tester->getDisplay());
-        $this->assertEquals($expectedExitStatus, $res);
+        $this->assertSame($expectedExitStatus, $res);
     }
 
     public function testDebugInvalidDirectory()
@@ -126,6 +127,22 @@ class TranslationDebugCommandTest extends TestCase
 
         $tester = $this->createCommandTester([], [], $kernel);
         $tester->execute(['locale' => 'en', 'bundle' => 'dir']);
+    }
+
+    public function testNoErrorWithOnlyMissingOptionAndNoResults()
+    {
+        $tester = $this->createCommandTester([], ['foo' => 'foo']);
+        $res = $tester->execute(['locale' => 'en', '--only-missing' => true]);
+
+        $this->assertSame(Command::SUCCESS, $res);
+    }
+
+    public function testNoErrorWithOnlyUnusedOptionAndNoResults()
+    {
+        $tester = $this->createCommandTester(['foo' => 'foo']);
+        $res = $tester->execute(['locale' => 'en', '--only-unused' => true]);
+
+        $this->assertSame(Command::SUCCESS, $res);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I noticed this bug while working on a CI job to check translations with `debug:translation --only-missing`. The output of the command was empty (no results in the table), so there were no missing messages. But the command still failed with non-zero exit code.

After a bit of investigation I noticed that there were no **missing** messages, but a few **unused** messages. And the command failed with the exit code for **unused** messages, despite running it with `--only-missing`. After confirming this as the problem, the fix was pretty straightforward.

The `--only-missing` and `--only-unused` options should be independent of each other.

When using the `--only-missing` option, only **missing** messages should be relevant to the outcome of the execution. If there are no missing messages, but some unused messages, the execution of the command was still successful and no non-zero exit code should be returned.

The same applies when using the `--only-unused` option. In this case, only **unused** messages should be relevant to the execution result, even if there are some missing messages.

