### PR TITLE
[Config] Fix using null values with config builders

### DIFF
--- a/src/Symfony/Component/Config/Builder/ClassBuilder.php
+++ b/src/Symfony/Component/Config/Builder/ClassBuilder.php
@@ -93,7 +93,7 @@ REQUIRE
 USE
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class CLASS IMPLEMENTS
 {
@@ -124,14 +124,15 @@ BODY
         $this->methods[] = new Method(strtr($body, ['NAME' => $this->camelCase($name)] + $params));
     }
 
-    public function addProperty(string $name, string $classType = null): Property
+    public function addProperty(string $name, string $classType = null, string $defaultValue = null): Property
     {
         $property = new Property($name, '_' !== $name[0] ? $this->camelCase($name) : $name);
         if (null !== $classType) {
             $property->setType($classType);
         }
         $this->properties[] = $property;
-        $property->setContent(sprintf('private $%s;', $property->getName()));
+        $defaultValue = null !== $defaultValue ? sprintf(' = %s', $defaultValue) : '';
+        $property->setContent(sprintf('private $%s%s;', $property->getName(), $defaultValue));
 
         return $property;
     }

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
@@ -8,12 +8,13 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class ReceivingConfig 
 {
     private $priority;
     private $color;
+    private $_usedProperties = [];
     
     /**
      * @default null
@@ -22,6 +23,7 @@ class ReceivingConfig
      */
     public function priority($value): self
     {
+        $this->_usedProperties['priority'] = true;
         $this->priority = $value;
     
         return $this;
@@ -34,6 +36,7 @@ class ReceivingConfig
      */
     public function color($value): self
     {
+        $this->_usedProperties['color'] = true;
         $this->color = $value;
     
         return $this;
@@ -42,12 +45,14 @@ class ReceivingConfig
     public function __construct(array $value = [])
     {
     
-        if (isset($value['priority'])) {
+        if (array_key_exists('priority', $value)) {
+            $this->_usedProperties['priority'] = true;
             $this->priority = $value['priority'];
             unset($value['priority']);
         }
     
-        if (isset($value['color'])) {
+        if (array_key_exists('color', $value)) {
+            $this->_usedProperties['color'] = true;
             $this->color = $value['color'];
             unset($value['color']);
         }
@@ -60,10 +65,10 @@ class ReceivingConfig
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->priority) {
+        if (isset($this->_usedProperties['priority'])) {
             $output['priority'] = $this->priority;
         }
-        if (null !== $this->color) {
+        if (isset($this->_usedProperties['color'])) {
             $output['color'] = $this->color;
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
@@ -8,11 +8,12 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class RoutingConfig 
 {
     private $senders;
+    private $_usedProperties = [];
     
     /**
      * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
@@ -20,6 +21,7 @@ class RoutingConfig
      */
     public function senders($value): self
     {
+        $this->_usedProperties['senders'] = true;
         $this->senders = $value;
     
         return $this;
@@ -28,7 +30,8 @@ class RoutingConfig
     public function __construct(array $value = [])
     {
     
-        if (isset($value['senders'])) {
+        if (array_key_exists('senders', $value)) {
+            $this->_usedProperties['senders'] = true;
             $this->senders = $value['senders'];
             unset($value['senders']);
         }
@@ -41,7 +44,7 @@ class RoutingConfig
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->senders) {
+        if (isset($this->_usedProperties['senders'])) {
             $output['senders'] = $this->senders;
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
@@ -9,16 +9,19 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class MessengerConfig 
 {
     private $routing;
     private $receiving;
+    private $_usedProperties = [];
     
     public function routing(string $message_class, array $value = []): \Symfony\Config\AddToList\Messenger\RoutingConfig
     {
         if (!isset($this->routing[$message_class])) {
+            $this->_usedProperties['routing'] = true;
+    
             return $this->routing[$message_class] = new \Symfony\Config\AddToList\Messenger\RoutingConfig($value);
         }
         if ([] === $value) {
@@ -30,18 +33,22 @@ class MessengerConfig
     
     public function receiving(array $value = []): \Symfony\Config\AddToList\Messenger\ReceivingConfig
     {
+        $this->_usedProperties['receiving'] = true;
+    
         return $this->receiving[] = new \Symfony\Config\AddToList\Messenger\ReceivingConfig($value);
     }
     
     public function __construct(array $value = [])
     {
     
-        if (isset($value['routing'])) {
+        if (array_key_exists('routing', $value)) {
+            $this->_usedProperties['routing'] = true;
             $this->routing = array_map(function ($v) { return new \Symfony\Config\AddToList\Messenger\RoutingConfig($v); }, $value['routing']);
             unset($value['routing']);
         }
     
-        if (isset($value['receiving'])) {
+        if (array_key_exists('receiving', $value)) {
+            $this->_usedProperties['receiving'] = true;
             $this->receiving = array_map(function ($v) { return new \Symfony\Config\AddToList\Messenger\ReceivingConfig($v); }, $value['receiving']);
             unset($value['receiving']);
         }
@@ -54,10 +61,10 @@ class MessengerConfig
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->routing) {
+        if (isset($this->_usedProperties['routing'])) {
             $output['routing'] = array_map(function ($v) { return $v->toArray(); }, $this->routing);
         }
-        if (null !== $this->receiving) {
+        if (isset($this->_usedProperties['receiving'])) {
             $output['receiving'] = array_map(function ($v) { return $v->toArray(); }, $this->receiving);
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
@@ -8,12 +8,13 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class TranslatorConfig 
 {
     private $fallbacks;
     private $sources;
+    private $_usedProperties = [];
     
     /**
      * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
@@ -21,6 +22,7 @@ class TranslatorConfig
      */
     public function fallbacks($value): self
     {
+        $this->_usedProperties['fallbacks'] = true;
         $this->fallbacks = $value;
     
         return $this;
@@ -32,6 +34,7 @@ class TranslatorConfig
      */
     public function source(string $source_class, $value): self
     {
+        $this->_usedProperties['sources'] = true;
         $this->sources[$source_class] = $value;
     
         return $this;
@@ -40,12 +43,14 @@ class TranslatorConfig
     public function __construct(array $value = [])
     {
     
-        if (isset($value['fallbacks'])) {
+        if (array_key_exists('fallbacks', $value)) {
+            $this->_usedProperties['fallbacks'] = true;
             $this->fallbacks = $value['fallbacks'];
             unset($value['fallbacks']);
         }
     
-        if (isset($value['sources'])) {
+        if (array_key_exists('sources', $value)) {
+            $this->_usedProperties['sources'] = true;
             $this->sources = $value['sources'];
             unset($value['sources']);
         }
@@ -58,10 +63,10 @@ class TranslatorConfig
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->fallbacks) {
+        if (isset($this->_usedProperties['fallbacks'])) {
             $output['fallbacks'] = $this->fallbacks;
         }
-        if (null !== $this->sources) {
+        if (isset($this->_usedProperties['sources'])) {
             $output['sources'] = $this->sources;
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
@@ -9,16 +9,18 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
 {
     private $translator;
     private $messenger;
+    private $_usedProperties = [];
     
     public function translator(array $value = []): \Symfony\Config\AddToList\TranslatorConfig
     {
         if (null === $this->translator) {
+            $this->_usedProperties['translator'] = true;
             $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value);
         } elseif ([] !== $value) {
             throw new InvalidConfigurationException('The node created by "translator()" has already been initialized. You cannot pass values the second time you call translator().');
@@ -30,6 +32,7 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
     public function messenger(array $value = []): \Symfony\Config\AddToList\MessengerConfig
     {
         if (null === $this->messenger) {
+            $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value);
         } elseif ([] !== $value) {
             throw new InvalidConfigurationException('The node created by "messenger()" has already been initialized. You cannot pass values the second time you call messenger().');
@@ -46,12 +49,14 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
     public function __construct(array $value = [])
     {
     
-        if (isset($value['translator'])) {
+        if (array_key_exists('translator', $value)) {
+            $this->_usedProperties['translator'] = true;
             $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value['translator']);
             unset($value['translator']);
         }
     
-        if (isset($value['messenger'])) {
+        if (array_key_exists('messenger', $value)) {
+            $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value['messenger']);
             unset($value['messenger']);
         }
@@ -64,10 +69,10 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->translator) {
+        if (isset($this->_usedProperties['translator'])) {
             $output['translator'] = $this->translator->toArray();
         }
-        if (null !== $this->messenger) {
+        if (isset($this->_usedProperties['messenger'])) {
             $output['messenger'] = $this->messenger->toArray();
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.output.php
@@ -20,6 +20,7 @@ return [
             'corge' => 'bar2_corge',
             'grault' => 'bar2_grault',
             'extra1' => 'bar2_extra1',
+            'extra4' => null,
             'extra2' => 'bar2_extra2',
             'extra3' => 'bar2_extra3',
         ],

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
@@ -7,12 +7,13 @@ use Symfony\Component\Config\Loader\ParamConfigurator;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class BarConfig 
 {
     private $corge;
     private $grault;
+    private $_usedProperties = [];
     private $_extraKeys;
     
     /**
@@ -22,6 +23,7 @@ class BarConfig
      */
     public function corge($value): self
     {
+        $this->_usedProperties['corge'] = true;
         $this->corge = $value;
     
         return $this;
@@ -34,6 +36,7 @@ class BarConfig
      */
     public function grault($value): self
     {
+        $this->_usedProperties['grault'] = true;
         $this->grault = $value;
     
         return $this;
@@ -42,12 +45,14 @@ class BarConfig
     public function __construct(array $value = [])
     {
     
-        if (isset($value['corge'])) {
+        if (array_key_exists('corge', $value)) {
+            $this->_usedProperties['corge'] = true;
             $this->corge = $value['corge'];
             unset($value['corge']);
         }
     
-        if (isset($value['grault'])) {
+        if (array_key_exists('grault', $value)) {
+            $this->_usedProperties['grault'] = true;
             $this->grault = $value['grault'];
             unset($value['grault']);
         }
@@ -59,10 +64,10 @@ class BarConfig
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->corge) {
+        if (isset($this->_usedProperties['corge'])) {
             $output['corge'] = $this->corge;
         }
-        if (null !== $this->grault) {
+        if (isset($this->_usedProperties['grault'])) {
             $output['grault'] = $this->grault;
         }
     
@@ -75,11 +80,7 @@ class BarConfig
      */
     public function set(string $key, $value): self
     {
-        if (null === $value) {
-            unset($this->_extraKeys[$key]);
-        } else {
-            $this->_extraKeys[$key] = $value;
-        }
+        $this->_extraKeys[$key] = $value;
     
         return $this;
     }

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BazConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BazConfig.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class BazConfig 
 {
@@ -33,11 +33,7 @@ class BazConfig
      */
     public function set(string $key, $value): self
     {
-        if (null === $value) {
-            unset($this->_extraKeys[$key]);
-        } else {
-            $this->_extraKeys[$key] = $value;
-        }
+        $this->_extraKeys[$key] = $value;
     
         return $this;
     }

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
@@ -7,12 +7,13 @@ use Symfony\Component\Config\Loader\ParamConfigurator;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class FooConfig 
 {
     private $baz;
     private $qux;
+    private $_usedProperties = [];
     private $_extraKeys;
     
     /**
@@ -22,6 +23,7 @@ class FooConfig
      */
     public function baz($value): self
     {
+        $this->_usedProperties['baz'] = true;
         $this->baz = $value;
     
         return $this;
@@ -34,6 +36,7 @@ class FooConfig
      */
     public function qux($value): self
     {
+        $this->_usedProperties['qux'] = true;
         $this->qux = $value;
     
         return $this;
@@ -42,12 +45,14 @@ class FooConfig
     public function __construct(array $value = [])
     {
     
-        if (isset($value['baz'])) {
+        if (array_key_exists('baz', $value)) {
+            $this->_usedProperties['baz'] = true;
             $this->baz = $value['baz'];
             unset($value['baz']);
         }
     
-        if (isset($value['qux'])) {
+        if (array_key_exists('qux', $value)) {
+            $this->_usedProperties['qux'] = true;
             $this->qux = $value['qux'];
             unset($value['qux']);
         }
@@ -59,10 +64,10 @@ class FooConfig
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->baz) {
+        if (isset($this->_usedProperties['baz'])) {
             $output['baz'] = $this->baz;
         }
-        if (null !== $this->qux) {
+        if (isset($this->_usedProperties['qux'])) {
             $output['qux'] = $this->qux;
         }
     
@@ -75,11 +80,7 @@ class FooConfig
      */
     public function set(string $key, $value): self
     {
-        if (null === $value) {
-            unset($this->_extraKeys[$key]);
-        } else {
-            $this->_extraKeys[$key] = $value;
-        }
+        $this->_extraKeys[$key] = $value;
     
         return $this;
     }

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
@@ -10,17 +10,19 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
 {
     private $foo;
     private $bar;
     private $baz;
+    private $_usedProperties = [];
     
     public function foo(array $value = []): \Symfony\Config\ArrayExtraKeys\FooConfig
     {
         if (null === $this->foo) {
+            $this->_usedProperties['foo'] = true;
             $this->foo = new \Symfony\Config\ArrayExtraKeys\FooConfig($value);
         } elseif ([] !== $value) {
             throw new InvalidConfigurationException('The node created by "foo()" has already been initialized. You cannot pass values the second time you call foo().');
@@ -31,12 +33,15 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
     
     public function bar(array $value = []): \Symfony\Config\ArrayExtraKeys\BarConfig
     {
+        $this->_usedProperties['bar'] = true;
+    
         return $this->bar[] = new \Symfony\Config\ArrayExtraKeys\BarConfig($value);
     }
     
     public function baz(array $value = []): \Symfony\Config\ArrayExtraKeys\BazConfig
     {
         if (null === $this->baz) {
+            $this->_usedProperties['baz'] = true;
             $this->baz = new \Symfony\Config\ArrayExtraKeys\BazConfig($value);
         } elseif ([] !== $value) {
             throw new InvalidConfigurationException('The node created by "baz()" has already been initialized. You cannot pass values the second time you call baz().');
@@ -53,17 +58,20 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
     public function __construct(array $value = [])
     {
     
-        if (isset($value['foo'])) {
+        if (array_key_exists('foo', $value)) {
+            $this->_usedProperties['foo'] = true;
             $this->foo = new \Symfony\Config\ArrayExtraKeys\FooConfig($value['foo']);
             unset($value['foo']);
         }
     
-        if (isset($value['bar'])) {
+        if (array_key_exists('bar', $value)) {
+            $this->_usedProperties['bar'] = true;
             $this->bar = array_map(function ($v) { return new \Symfony\Config\ArrayExtraKeys\BarConfig($v); }, $value['bar']);
             unset($value['bar']);
         }
     
-        if (isset($value['baz'])) {
+        if (array_key_exists('baz', $value)) {
+            $this->_usedProperties['baz'] = true;
             $this->baz = new \Symfony\Config\ArrayExtraKeys\BazConfig($value['baz']);
             unset($value['baz']);
         }
@@ -76,13 +84,13 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->foo) {
+        if (isset($this->_usedProperties['foo'])) {
             $output['foo'] = $this->foo->toArray();
         }
-        if (null !== $this->bar) {
+        if (isset($this->_usedProperties['bar'])) {
             $output['bar'] = array_map(function ($v) { return $v->toArray(); }, $this->bar);
         }
-        if (null !== $this->baz) {
+        if (isset($this->_usedProperties['baz'])) {
             $output['baz'] = $this->baz->toArray();
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
@@ -3,7 +3,7 @@
 use Symfony\Config\NodeInitialValuesConfig;
 
 return static function (NodeInitialValuesConfig $config) {
-    $config->someCleverName(['second' => 'foo'])->first('bar');
+    $config->someCleverName(['second' => 'foo', 'third' => null])->first('bar');
     $config->messenger()
         ->transports('fast_queue', ['dsn' => 'sync://'])
         ->serializer('acme');

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.output.php
@@ -4,6 +4,7 @@ return [
     'some_clever_name' => [
         'first' => 'bar',
         'second' => 'foo',
+        'third' => null,
     ],
     'messenger' => [
         'transports' => [

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.php
@@ -17,6 +17,7 @@ class NodeInitialValues implements ConfigurationInterface
                     ->children()
                         ->scalarNode('first')->end()
                         ->scalarNode('second')->end()
+                        ->scalarNode('third')->end()
                     ->end()
                 ->end()
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
@@ -8,13 +8,14 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class TransportsConfig 
 {
     private $dsn;
     private $serializer;
     private $options;
+    private $_usedProperties = [];
     
     /**
      * @default null
@@ -23,6 +24,7 @@ class TransportsConfig
      */
     public function dsn($value): self
     {
+        $this->_usedProperties['dsn'] = true;
         $this->dsn = $value;
     
         return $this;
@@ -35,6 +37,7 @@ class TransportsConfig
      */
     public function serializer($value): self
     {
+        $this->_usedProperties['serializer'] = true;
         $this->serializer = $value;
     
         return $this;
@@ -46,6 +49,7 @@ class TransportsConfig
      */
     public function options($value): self
     {
+        $this->_usedProperties['options'] = true;
         $this->options = $value;
     
         return $this;
@@ -54,17 +58,20 @@ class TransportsConfig
     public function __construct(array $value = [])
     {
     
-        if (isset($value['dsn'])) {
+        if (array_key_exists('dsn', $value)) {
+            $this->_usedProperties['dsn'] = true;
             $this->dsn = $value['dsn'];
             unset($value['dsn']);
         }
     
-        if (isset($value['serializer'])) {
+        if (array_key_exists('serializer', $value)) {
+            $this->_usedProperties['serializer'] = true;
             $this->serializer = $value['serializer'];
             unset($value['serializer']);
         }
     
-        if (isset($value['options'])) {
+        if (array_key_exists('options', $value)) {
+            $this->_usedProperties['options'] = true;
             $this->options = $value['options'];
             unset($value['options']);
         }
@@ -77,13 +84,13 @@ class TransportsConfig
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->dsn) {
+        if (isset($this->_usedProperties['dsn'])) {
             $output['dsn'] = $this->dsn;
         }
-        if (null !== $this->serializer) {
+        if (isset($this->_usedProperties['serializer'])) {
             $output['serializer'] = $this->serializer;
         }
-        if (null !== $this->options) {
+        if (isset($this->_usedProperties['options'])) {
             $output['options'] = $this->options;
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
@@ -8,15 +8,18 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class MessengerConfig 
 {
     private $transports;
+    private $_usedProperties = [];
     
     public function transports(string $name, array $value = []): \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig
     {
         if (!isset($this->transports[$name])) {
+            $this->_usedProperties['transports'] = true;
+    
             return $this->transports[$name] = new \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig($value);
         }
         if ([] === $value) {
@@ -29,7 +32,8 @@ class MessengerConfig
     public function __construct(array $value = [])
     {
     
-        if (isset($value['transports'])) {
+        if (array_key_exists('transports', $value)) {
+            $this->_usedProperties['transports'] = true;
             $this->transports = array_map(function ($v) { return new \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig($v); }, $value['transports']);
             unset($value['transports']);
         }
@@ -42,7 +46,7 @@ class MessengerConfig
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->transports) {
+        if (isset($this->_usedProperties['transports'])) {
             $output['transports'] = array_map(function ($v) { return $v->toArray(); }, $this->transports);
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
@@ -8,12 +8,14 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class SomeCleverNameConfig 
 {
     private $first;
     private $second;
+    private $third;
+    private $_usedProperties = [];
     
     /**
      * @default null
@@ -22,6 +24,7 @@ class SomeCleverNameConfig
      */
     public function first($value): self
     {
+        $this->_usedProperties['first'] = true;
         $this->first = $value;
     
         return $this;
@@ -34,7 +37,21 @@ class SomeCleverNameConfig
      */
     public function second($value): self
     {
+        $this->_usedProperties['second'] = true;
         $this->second = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function third($value): self
+    {
+        $this->_usedProperties['third'] = true;
+        $this->third = $value;
     
         return $this;
     }
@@ -42,14 +59,22 @@ class SomeCleverNameConfig
     public function __construct(array $value = [])
     {
     
-        if (isset($value['first'])) {
+        if (array_key_exists('first', $value)) {
+            $this->_usedProperties['first'] = true;
             $this->first = $value['first'];
             unset($value['first']);
         }
     
-        if (isset($value['second'])) {
+        if (array_key_exists('second', $value)) {
+            $this->_usedProperties['second'] = true;
             $this->second = $value['second'];
             unset($value['second']);
+        }
+    
+        if (array_key_exists('third', $value)) {
+            $this->_usedProperties['third'] = true;
+            $this->third = $value['third'];
+            unset($value['third']);
         }
     
         if ([] !== $value) {
@@ -60,11 +85,14 @@ class SomeCleverNameConfig
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->first) {
+        if (isset($this->_usedProperties['first'])) {
             $output['first'] = $this->first;
         }
-        if (null !== $this->second) {
+        if (isset($this->_usedProperties['second'])) {
             $output['second'] = $this->second;
+        }
+        if (isset($this->_usedProperties['third'])) {
+            $output['third'] = $this->third;
         }
     
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
@@ -9,16 +9,18 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
 {
     private $someCleverName;
     private $messenger;
+    private $_usedProperties = [];
     
     public function someCleverName(array $value = []): \Symfony\Config\NodeInitialValues\SomeCleverNameConfig
     {
         if (null === $this->someCleverName) {
+            $this->_usedProperties['someCleverName'] = true;
             $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value);
         } elseif ([] !== $value) {
             throw new InvalidConfigurationException('The node created by "someCleverName()" has already been initialized. You cannot pass values the second time you call someCleverName().');
@@ -30,6 +32,7 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
     public function messenger(array $value = []): \Symfony\Config\NodeInitialValues\MessengerConfig
     {
         if (null === $this->messenger) {
+            $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value);
         } elseif ([] !== $value) {
             throw new InvalidConfigurationException('The node created by "messenger()" has already been initialized. You cannot pass values the second time you call messenger().');
@@ -46,12 +49,14 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
     public function __construct(array $value = [])
     {
     
-        if (isset($value['some_clever_name'])) {
+        if (array_key_exists('some_clever_name', $value)) {
+            $this->_usedProperties['someCleverName'] = true;
             $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value['some_clever_name']);
             unset($value['some_clever_name']);
         }
     
-        if (isset($value['messenger'])) {
+        if (array_key_exists('messenger', $value)) {
+            $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value['messenger']);
             unset($value['messenger']);
         }
@@ -64,10 +69,10 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->someCleverName) {
+        if (isset($this->_usedProperties['someCleverName'])) {
             $output['some_clever_name'] = $this->someCleverName->toArray();
         }
-        if (null !== $this->messenger) {
+        if (isset($this->_usedProperties['messenger'])) {
             $output['messenger'] = $this->messenger->toArray();
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
@@ -8,13 +8,14 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
 {
     private $enabled;
     private $favoriteFloat;
     private $goodIntegers;
+    private $_usedProperties = [];
     
     /**
      * @default false
@@ -23,6 +24,7 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
      */
     public function enabled($value): self
     {
+        $this->_usedProperties['enabled'] = true;
         $this->enabled = $value;
     
         return $this;
@@ -35,6 +37,7 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
      */
     public function favoriteFloat($value): self
     {
+        $this->_usedProperties['favoriteFloat'] = true;
         $this->favoriteFloat = $value;
     
         return $this;
@@ -46,6 +49,7 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
      */
     public function goodIntegers($value): self
     {
+        $this->_usedProperties['goodIntegers'] = true;
         $this->goodIntegers = $value;
     
         return $this;
@@ -59,17 +63,20 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
     public function __construct(array $value = [])
     {
     
-        if (isset($value['enabled'])) {
+        if (array_key_exists('enabled', $value)) {
+            $this->_usedProperties['enabled'] = true;
             $this->enabled = $value['enabled'];
             unset($value['enabled']);
         }
     
-        if (isset($value['favorite_float'])) {
+        if (array_key_exists('favorite_float', $value)) {
+            $this->_usedProperties['favoriteFloat'] = true;
             $this->favoriteFloat = $value['favorite_float'];
             unset($value['favorite_float']);
         }
     
-        if (isset($value['good_integers'])) {
+        if (array_key_exists('good_integers', $value)) {
+            $this->_usedProperties['goodIntegers'] = true;
             $this->goodIntegers = $value['good_integers'];
             unset($value['good_integers']);
         }
@@ -82,13 +89,13 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->enabled) {
+        if (isset($this->_usedProperties['enabled'])) {
             $output['enabled'] = $this->enabled;
         }
-        if (null !== $this->favoriteFloat) {
+        if (isset($this->_usedProperties['favoriteFloat'])) {
             $output['favorite_float'] = $this->favoriteFloat;
         }
-        if (null !== $this->goodIntegers) {
+        if (isset($this->_usedProperties['goodIntegers'])) {
             $output['good_integers'] = $this->goodIntegers;
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.config.php
@@ -8,4 +8,5 @@ return static function (PrimitiveTypesConfig $config) {
     $config->floatNode(47.11);
     $config->integerNode(1337);
     $config->scalarNode('foobar');
+    $config->scalarNodeWithDefault(null);
 };

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.output.php
@@ -6,4 +6,5 @@ return [
     'float_node' => 47.11,
     'integer_node' => 1337,
     'scalar_node' => 'foobar',
+    'scalar_node_with_default' => null,
 ];

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.php
@@ -18,6 +18,7 @@ class PrimitiveTypes implements ConfigurationInterface
                 ->floatNode('float_node')->end()
                 ->integerNode('integer_node')->end()
                 ->scalarNode('scalar_node')->end()
+                ->scalarNode('scalar_node_with_default')->defaultTrue()->end()
             ->end()
         ;
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
@@ -8,7 +8,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
 {
@@ -17,6 +17,8 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     private $floatNode;
     private $integerNode;
     private $scalarNode;
+    private $scalarNodeWithDefault;
+    private $_usedProperties = [];
     
     /**
      * @default null
@@ -25,6 +27,7 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      */
     public function booleanNode($value): self
     {
+        $this->_usedProperties['booleanNode'] = true;
         $this->booleanNode = $value;
     
         return $this;
@@ -37,6 +40,7 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      */
     public function enumNode($value): self
     {
+        $this->_usedProperties['enumNode'] = true;
         $this->enumNode = $value;
     
         return $this;
@@ -49,6 +53,7 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      */
     public function floatNode($value): self
     {
+        $this->_usedProperties['floatNode'] = true;
         $this->floatNode = $value;
     
         return $this;
@@ -61,6 +66,7 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      */
     public function integerNode($value): self
     {
+        $this->_usedProperties['integerNode'] = true;
         $this->integerNode = $value;
     
         return $this;
@@ -73,7 +79,21 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      */
     public function scalarNode($value): self
     {
+        $this->_usedProperties['scalarNode'] = true;
         $this->scalarNode = $value;
+    
+        return $this;
+    }
+    
+    /**
+     * @default true
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function scalarNodeWithDefault($value): self
+    {
+        $this->_usedProperties['scalarNodeWithDefault'] = true;
+        $this->scalarNodeWithDefault = $value;
     
         return $this;
     }
@@ -86,29 +106,40 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     public function __construct(array $value = [])
     {
     
-        if (isset($value['boolean_node'])) {
+        if (array_key_exists('boolean_node', $value)) {
+            $this->_usedProperties['booleanNode'] = true;
             $this->booleanNode = $value['boolean_node'];
             unset($value['boolean_node']);
         }
     
-        if (isset($value['enum_node'])) {
+        if (array_key_exists('enum_node', $value)) {
+            $this->_usedProperties['enumNode'] = true;
             $this->enumNode = $value['enum_node'];
             unset($value['enum_node']);
         }
     
-        if (isset($value['float_node'])) {
+        if (array_key_exists('float_node', $value)) {
+            $this->_usedProperties['floatNode'] = true;
             $this->floatNode = $value['float_node'];
             unset($value['float_node']);
         }
     
-        if (isset($value['integer_node'])) {
+        if (array_key_exists('integer_node', $value)) {
+            $this->_usedProperties['integerNode'] = true;
             $this->integerNode = $value['integer_node'];
             unset($value['integer_node']);
         }
     
-        if (isset($value['scalar_node'])) {
+        if (array_key_exists('scalar_node', $value)) {
+            $this->_usedProperties['scalarNode'] = true;
             $this->scalarNode = $value['scalar_node'];
             unset($value['scalar_node']);
+        }
+    
+        if (array_key_exists('scalar_node_with_default', $value)) {
+            $this->_usedProperties['scalarNodeWithDefault'] = true;
+            $this->scalarNodeWithDefault = $value['scalar_node_with_default'];
+            unset($value['scalar_node_with_default']);
         }
     
         if ([] !== $value) {
@@ -119,20 +150,23 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->booleanNode) {
+        if (isset($this->_usedProperties['booleanNode'])) {
             $output['boolean_node'] = $this->booleanNode;
         }
-        if (null !== $this->enumNode) {
+        if (isset($this->_usedProperties['enumNode'])) {
             $output['enum_node'] = $this->enumNode;
         }
-        if (null !== $this->floatNode) {
+        if (isset($this->_usedProperties['floatNode'])) {
             $output['float_node'] = $this->floatNode;
         }
-        if (null !== $this->integerNode) {
+        if (isset($this->_usedProperties['integerNode'])) {
             $output['integer_node'] = $this->integerNode;
         }
-        if (null !== $this->scalarNode) {
+        if (isset($this->_usedProperties['scalarNode'])) {
             $output['scalar_node'] = $this->scalarNode;
+        }
+        if (isset($this->_usedProperties['scalarNodeWithDefault'])) {
+            $output['scalar_node_with_default'] = $this->scalarNodeWithDefault;
         }
     
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
@@ -8,11 +8,12 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 
 /**
- * This class is automatically generated to help creating config.
+ * This class is automatically generated to help in creating a config.
  */
 class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
 {
     private $anyValue;
+    private $_usedProperties = [];
     
     /**
      * @default null
@@ -21,6 +22,7 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
      */
     public function anyValue($value): self
     {
+        $this->_usedProperties['anyValue'] = true;
         $this->anyValue = $value;
     
         return $this;
@@ -34,7 +36,8 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
     public function __construct(array $value = [])
     {
     
-        if (isset($value['any_value'])) {
+        if (array_key_exists('any_value', $value)) {
+            $this->_usedProperties['anyValue'] = true;
             $this->anyValue = $value['any_value'];
             unset($value['any_value']);
         }
@@ -47,7 +50,7 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
     public function toArray(): array
     {
         $output = [];
-        if (null !== $this->anyValue) {
+        if (isset($this->_usedProperties['anyValue'])) {
             $output['any_value'] = $this->anyValue;
         }
     

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -19,6 +19,11 @@ use Symfony\Config\AddToListConfig;
  * Test to use the generated config and test its output.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @covers \Symfony\Component\Config\Builder\ClassBuilder
+ * @covers \Symfony\Component\Config\Builder\ConfigBuilderGenerator
+ * @covers \Symfony\Component\Config\Builder\Method
+ * @covers \Symfony\Component\Config\Builder\Property
  */
 class GeneratedConfigTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45782
| License       | MIT
| Doc PR        | -

The generated config builders will no longer discard `null` values.