### PR TITLE
Improve testsuite

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,7 +66,7 @@ jobs:
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
 
           echo COLUMNS=120 >> $GITHUB_ENV
-          echo PHPUNIT="$(pwd)/phpunit --exclude-group tty,benchmark,intl-data" >> $GITHUB_ENV
+          echo PHPUNIT="$(pwd)/phpunit --exclude-group tty,benchmark,intl-data,integration" >> $GITHUB_ENV
           echo COMPOSER_UP='composer update --no-progress --ansi' >> $GITHUB_ENV
 
           SYMFONY_VERSIONS=$(git ls-remote -q --heads | cut -f2 | grep -o '/[1-9][0-9]*\.[0-9].*' | sort -V)

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Lock\Strategy\UnanimousStrategy;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
+ * @group integration
  */
 class CombinedStoreTest extends AbstractStoreTest
 {
@@ -41,7 +42,8 @@ class CombinedStoreTest extends AbstractStoreTest
      */
     public function getStore(): PersistingStoreInterface
     {
-        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]));
+        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379]));
+
         try {
             $redis->connect();
         } catch (\Exception $e) {

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Lock\Store\PdoStore;
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
  * @requires extension pdo_sqlite
+ * @group integration
  */
 class PdoStoreTest extends AbstractStoreTest
 {

--- a/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Lock\Store\ZookeeperStore;
  * @author Ganesh Chandrasekaran <gchandrasekaran@wayfair.com>
  *
  * @requires extension zookeeper
+ * @group integration
  */
 class ZookeeperStoreTest extends AbstractStoreTest
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

Work done:
Integration tests are excluded from unit testsuite because:
- they are already tested in integration testsuite
- they rely on enviroment and because of that they become skipped
- they generate a huge list of false skipped tests in unit testsuite

Fixed Predis Client initialization in CombinedStoreTest because ```array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null])``` always results in ```localhost:``` as redis host which fails in host resolving
