### PR TITLE
[FrameworkBundle][Translation] add `LocaleSwitcher` service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ConfigureLocaleSwitcherPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ConfigureLocaleSwitcherPass.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+class ConfigureLocaleSwitcherPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has('translation.locale_switcher')) {
+            return;
+        }
+
+        $localeAwareServices = array_map(
+            fn (string $id) => new Reference($id),
+            array_keys($container->findTaggedServiceIds('kernel.locale_aware'))
+        );
+
+        if ($container->has('translation.locale_aware_request_context')) {
+            $localeAwareServices[] = new Reference('translation.locale_aware_request_context');
+        }
+
+        $container->getDefinition('translation.locale_switcher')
+            ->setArgument(1, new IteratorArgument($localeAwareServices))
+        ;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1056,6 +1056,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('console.command.router_debug');
             $container->removeDefinition('console.command.router_match');
             $container->removeDefinition('messenger.middleware.router_context');
+            $container->removeDefinition('translation.locale_aware_request_context');
 
             return;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddAnnotationsCa
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddDebugLogProcessorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AssetsContextPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConfigureLocaleSwitcherPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DataCollectorTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggingTranslatorPass;
@@ -158,6 +159,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterReverseContainerPass(true));
         $container->addCompilerPass(new RegisterReverseContainerPass(false), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RemoveUnusedSessionMarshallingHandlerPass());
+        $container->addCompilerPass(new ConfigureLocaleSwitcherPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TranslationsCacheWarmer;
+use Symfony\Bundle\FrameworkBundle\Translation\LocaleAwareRequestContext;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Translation\Dumper\CsvFileDumper;
 use Symfony\Component\Translation\Dumper\IcuResFileDumper;
@@ -39,6 +40,7 @@ use Symfony\Component\Translation\Loader\PoFileLoader;
 use Symfony\Component\Translation\Loader\QtFileLoader;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\Loader\YamlFileLoader;
+use Symfony\Component\Translation\LocaleSwitcher;
 use Symfony\Component\Translation\LoggingTranslator;
 use Symfony\Component\Translation\Reader\TranslationReader;
 use Symfony\Component\Translation\Reader\TranslationReaderInterface;
@@ -163,4 +165,21 @@ return static function (ContainerConfigurator $container) {
             ->tag('container.service_subscriber', ['id' => 'translator'])
             ->tag('kernel.cache_warmer')
     ;
+
+    if (class_exists(LocaleSwitcher::class)) {
+        $container->services()
+            ->set('translation.locale_switcher', LocaleSwitcher::class)
+            ->args([
+                param('kernel.default_locale'),
+                abstract_arg('LocaleAware services'),
+            ])
+            ->alias(LocaleSwitcher::class, 'translation.locale_switcher')
+
+            ->set('translation.locale_aware_request_context', LocaleAwareRequestContext::class)
+            ->args([
+                service('router.request_context'),
+                param('kernel.default_locale'),
+            ])
+        ;
+    }
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ConfigureLocaleSwitcherPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ConfigureLocaleSwitcherPassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConfigureLocaleSwitcherPass;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ConfigureLocaleSwitcherPassTest extends TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container->register('translation.locale_switcher')->setArgument(0, 'en');
+        $container->register('locale_aware_service')
+            ->addTag('kernel.locale_aware')
+        ;
+
+        $pass = new ConfigureLocaleSwitcherPass();
+        $pass->process($container);
+
+        $switcherDef = $container->getDefinition('translation.locale_switcher');
+
+        $this->assertInstanceOf(IteratorArgument::class, $switcherDef->getArgument(1));
+        $this->assertEquals([new Reference('locale_aware_service')], $switcherDef->getArgument(1)->getValues());
+    }
+
+    public function testProcessWithRequestContext()
+    {
+        $container = new ContainerBuilder();
+        $container->register('translation.locale_switcher');
+        $container->register('locale_aware_service')
+            ->addTag('kernel.locale_aware')
+        ;
+        $container->register('translation.locale_aware_request_context');
+
+        $pass = new ConfigureLocaleSwitcherPass();
+        $pass->process($container);
+
+        $switcherDef = $container->getDefinition('translation.locale_switcher');
+
+        $this->assertInstanceOf(IteratorArgument::class, $switcherDef->getArgument(1));
+        $this->assertEquals(
+            [
+                new Reference('locale_aware_service'),
+                new Reference('translation.locale_aware_request_context'),
+            ],
+            $switcherDef->getArgument(1)->getValues()
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\DependencyInjection\CachePoolPass;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -65,6 +66,7 @@ use Symfony\Component\Serializer\Normalizer\FormErrorNormalizer;
 use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Translation\DependencyInjection\TranslatorPass;
+use Symfony\Component\Translation\LocaleSwitcher;
 use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
 use Symfony\Component\Validator\Validation;
@@ -1965,6 +1967,26 @@ abstract class FrameworkExtensionTest extends TestCase
             $transportFactoryName = strtolower(preg_replace('/(.)([A-Z])/', '$1-$2', $bridgeDirectory->getFilename()));
             $this->assertTrue($container->hasDefinition('notifier.transport_factory.'.$transportFactoryName), sprintf('Did you forget to add the "%s" TransportFactory to the $classToServices array in FrameworkExtension?', $bridgeDirectory->getFilename()));
         }
+    }
+
+    public function testLocaleSwitcherServiceRegistered()
+    {
+        if (!class_exists(LocaleSwitcher::class)) {
+            $this->markTestSkipped('LocaleSwitcher not available.');
+        }
+
+        $container = $this->createContainerFromFile('full');
+
+        $this->assertTrue($container->has('translation.locale_switcher'));
+        $this->assertTrue($container->has('translation.locale_aware_request_context'));
+
+        $switcherDef = $container->getDefinition('translation.locale_switcher');
+        $localeAwareRequestContextDef = $container->getDefinition('translation.locale_aware_request_context');
+
+        $this->assertSame('%kernel.default_locale%', $switcherDef->getArgument(0));
+        $this->assertInstanceOf(AbstractArgument::class, $switcherDef->getArgument(1));
+        $this->assertEquals(new Reference('router.request_context'), $localeAwareRequestContextDef->getArgument(0));
+        $this->assertSame('%kernel.default_locale%', $localeAwareRequestContextDef->getArgument(1));
     }
 
     protected function createContainer(array $data = [])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/LocaleAwareRequestContextTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/LocaleAwareRequestContextTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Translation;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Translation\LocaleAwareRequestContext;
+use Symfony\Component\Routing\RequestContext;
+
+class LocaleAwareRequestContextTest extends TestCase
+{
+    public function testCanSwitchLocale()
+    {
+        $context = new RequestContext();
+        $service = new LocaleAwareRequestContext($context, 'en');
+
+        $this->assertSame('en', $service->getLocale());
+        $this->assertNull($context->getParameter('_locale'));
+
+        $service->setLocale('fr');
+
+        $this->assertSame('fr', $service->getLocale());
+        $this->assertSame('fr', $context->getParameter('_locale'));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/LocaleAwareRequestContext.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/LocaleAwareRequestContext.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Translation;
+
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LocaleAwareRequestContext implements LocaleAwareInterface
+{
+    public function __construct(private RequestContext $requestContext, private string $defaultLocale)
+    {
+    }
+
+    public function setLocale(string $locale): void
+    {
+        $this->requestContext->setParameter('_locale', $locale);
+    }
+
+    public function getLocale(): string
+    {
+        return $this->requestContext->getParameter('_locale') ?? $this->defaultLocale;
+    }
+}

--- a/src/Symfony/Component/Translation/LocaleSwitcher.php
+++ b/src/Symfony/Component/Translation/LocaleSwitcher.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+use Symfony\Contracts\Translation\LocaleAwareInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LocaleSwitcher implements LocaleAwareInterface
+{
+    /**
+     * @param LocaleAwareInterface[] $localeAwareServices
+     */
+    public function __construct(private string $locale, private iterable $localeAwareServices)
+    {
+    }
+
+    public function setLocale(string $locale): void
+    {
+        \Locale::setDefault($this->locale = $locale);
+
+        foreach ($this->localeAwareServices as $service) {
+            $service->setLocale($locale);
+        }
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    /**
+     * Switch to a new locale, execute a callback, then switch back to the original.
+     *
+     * @param callable():void $callback
+     */
+    public function runWithLocale(string $locale, callable $callback): void
+    {
+        $original = $this->getLocale();
+        $this->setLocale($locale);
+
+        try {
+            $callback();
+        } finally {
+            $this->setLocale($original);
+        }
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/LocaleSwitcherTest.php
+++ b/src/Symfony/Component/Translation/Tests/LocaleSwitcherTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\LocaleSwitcher;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
+
+class LocaleSwitcherTest extends TestCase
+{
+    private string $intlLocale;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->intlLocale = \Locale::getDefault();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        \Locale::setDefault($this->intlLocale);
+    }
+
+    public function testCanSwitchLocale()
+    {
+        \Locale::setDefault('en');
+
+        $service = new DummyLocaleAware('en');
+        $switcher = new LocaleSwitcher('en', [$service]);
+
+        $this->assertSame('en', \Locale::getDefault());
+        $this->assertSame('en', $service->getLocale());
+        $this->assertSame('en', $switcher->getLocale());
+
+        $switcher->setLocale('fr');
+
+        $this->assertSame('fr', \Locale::getDefault());
+        $this->assertSame('fr', $service->getLocale());
+        $this->assertSame('fr', $switcher->getLocale());
+    }
+
+    public function testCanSwitchLocaleForCallback()
+    {
+        \Locale::setDefault('en');
+
+        $service = new DummyLocaleAware('en');
+        $switcher = new LocaleSwitcher('en', [$service]);
+
+        $this->assertSame('en', \Locale::getDefault());
+        $this->assertSame('en', $service->getLocale());
+        $this->assertSame('en', $switcher->getLocale());
+
+        $switcher->runWithLocale('fr', function () use ($switcher, $service) {
+            $this->assertSame('fr', \Locale::getDefault());
+            $this->assertSame('fr', $service->getLocale());
+            $this->assertSame('fr', $switcher->getLocale());
+        });
+
+        $this->assertSame('en', \Locale::getDefault());
+        $this->assertSame('en', $service->getLocale());
+        $this->assertSame('en', $switcher->getLocale());
+    }
+}
+
+class DummyLocaleAware implements LocaleAwareInterface
+{
+    public function __construct(private string $locale)
+    {
+    }
+
+    public function setLocale(string $locale): void
+    {
+        $this->locale = $locale;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35925
| License       | MIT
| Doc PR        | todo

This adds a `LocaleSwitcher` object/service. When setting it's locale, it sets it for all `kernel.locale_aware` services, `\Locale`, and, if applicable, the `_locale` parameter for the `RequestContext`. A `switchLocale()` convenience method exists to do set the locale, execute a callback, and set the locale back to the original.

**Usage:**
```php
/** @var Symfony\Component\Translation\LocaleSwitcher $switcher */

$swicher->getLocale(); // kernel.defaul_locale

$switcher->setLocale('fr');

$switcher->getLocale(); // "fr"

$switcher->runWithLocale('de', function() use ($switcher) {
    $switcher->getLocale(); // "de"
});

$switcher->getLocale(); // "fr"
```

**Todo:**
- [x] tests
