### PR TITLE
[ExpressionLanguage] Add support for null-safe operator

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -2,8 +2,9 @@ CHANGELOG
 =========
 
 6.1
------
+---
 
+ * Add support for null-safe syntax when parsing object's methods and properties
  * Support lexing numbers with the numeric literal separator `_`
  * Support lexing decimals with no leading zero
 

--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -73,6 +73,10 @@ class Lexer
                 // operators
                 $tokens[] = new Token(Token::OPERATOR_TYPE, $match[0], $cursor + 1);
                 $cursor += \strlen($match[0]);
+            } elseif ('?' === $expression[$cursor] && '.' === ($expression[$cursor + 1] ?? '')) {
+                // null-safe
+                $tokens[] = new Token(Token::PUNCTUATION_TYPE, '?.', ++$cursor);
+                ++$cursor;
             } elseif (str_contains('.,?:', $expression[$cursor])) {
                 // punctuation
                 $tokens[] = new Token(Token::PUNCTUATION_TYPE, $expression[$cursor], $cursor + 1);

--- a/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
@@ -20,11 +20,13 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  */
 class ConstantNode extends Node
 {
+    public readonly bool $isNullSafe;
     private bool $isIdentifier;
 
-    public function __construct(mixed $value, bool $isIdentifier = false)
+    public function __construct(mixed $value, bool $isIdentifier = false, bool $isNullSafe = false)
     {
         $this->isIdentifier = $isIdentifier;
+        $this->isNullSafe = $isNullSafe;
         parent::__construct(
             [],
             ['value' => $value]

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -335,7 +335,8 @@ class Parser
     {
         $token = $this->stream->current;
         while (Token::PUNCTUATION_TYPE == $token->type) {
-            if ('.' === $token->value) {
+            if ('.' === $token->value || '?.' === $token->value) {
+                $isNullSafe = '?.' === $token->value;
                 $this->stream->next();
                 $token = $this->stream->current;
                 $this->stream->next();
@@ -359,7 +360,7 @@ class Parser
                     throw new SyntaxError('Expected name.', $token->cursor, $this->stream->getExpression());
                 }
 
-                $arg = new Node\ConstantNode($token->value, true);
+                $arg = new Node\ConstantNode($token->value, true, $isNullSafe);
 
                 $arguments = new Node\ArgumentsNode();
                 if ($this->stream->current->test(Token::PUNCTUATION_TYPE, '(')) {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -148,6 +148,21 @@ class ParserTest extends TestCase
                 new Node\BinaryNode('contains', new Node\ConstantNode('foo'), new Node\ConstantNode('f')),
                 '"foo" contains "f"',
             ],
+            [
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar', true, true), new Node\ArgumentsNode(), Node\GetAttrNode::PROPERTY_CALL),
+                'foo?.bar',
+                ['foo'],
+            ],
+            [
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar', true, true), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
+                'foo?.bar()',
+                ['foo'],
+            ],
+            [
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('not', true, true), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
+                'foo?.not()',
+                ['foo'],
+            ],
 
             // chained calls
             [
@@ -279,6 +294,10 @@ class ParserTest extends TestCase
         return [
             'valid expression' => [
                 'expression' => 'foo["some_key"].callFunction(a ? b)',
+                'names' => ['foo', 'a', 'b'],
+            ],
+            'valid expression with null safety' => [
+                'expression' => 'foo["some_key"]?.callFunction(a ? b)',
                 'names' => ['foo', 'a', 'b'],
             ],
             'allow expression without names' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45411, #21691 
| License       | MIT
| Doc PR        | symfony/symfony-docs#16630

This is a long-time-lasting feature for the `ExpressionLanguage` component. I've been waiting for the support of `Nullsafe operator` in expressions dealing with mutable objects, until I finally decided to work on it once for all 👍 

The lack of [nullsafety feature](https://wiki.php.net/rfc/nullsafe_operator) has been repeatedly reported as a BUG several time  (e.g [#45411](https://github.com/symfony/symfony/issues/45411) & [#21691](https://github.com/symfony/symfony/issues/21691)) when it is actually a missing feature.

Currently, expressions like `foo.bar` assumes that the property `bar` "always" exists on the object `foo` and if doesn't the parser throws a `RuntimeException`. Although, sometimes, that's exactly the behavior we need, some other times we may work with mutable objects with uncontrolled structure, thus, such assumption is error-prone and will force adding extra checks making the expression uglier and less readable.

The proposed work, introduces the support for the `?.` syntax alongside with the usual `.` syntax to help working with objects with dynamic structure. The two notations works identically in all normal cases. The difference occurs when trying to access non-existant properties and/or methods where the `.` notation will throw a `RuntimeException` as usual and the `?.` notation will return `null` instead and no errors nor exceptions will be thrown. Hence the name "Null-Safe".

PS: This work account ONLY for accessing **object's** properties and methods. It does not account for non-existant **array** items which is a seperate problem that can be addressed by introducing the [null coalescing](https://wiki.php.net/rfc/isset_ternary) operator. Another feature that I'm currently working on as well 💯 