### PR TITLE
[HttpClient] on redirections don't send content related request headers

### DIFF
--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -376,7 +376,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
         if (0 < $maxRedirects = $options['max_redirects']) {
             $redirectHeaders = ['host' => $host];
             $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = array_filter($options['headers'], static function ($h) {
-                return 0 !== stripos($h, 'Host:');
+                return 0 !== stripos($h, 'Host:') && 0 !== stripos($h, 'Content-Length:') && 0 !== stripos($h, 'Content-Type:');
             });
 
             if (isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45709
| License       | MIT
| Doc PR        | 

TODOs:

- [ ] patch `AmpHttpClient`
- [ ] patch `CurlHttpClient`
- [x] patch `NativeHttpClient`
- [ ] update tests