### PR TITLE
[Routing] Add EnumRequirement to help generate route requirements from a \BackedEnum

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow using UTF-8 parameter names
  * Support the `attribute` type (alias of `annotation`) in annotation loaders
  * Already encoded slashes are not decoded nor double-encoded anymore when generating URLs (query parameters)
+ * Add `EnumRequirement` to help generate route requirements from a `\BackedEnum`
 
 5.3
 ---

--- a/src/Symfony/Component/Routing/Requirement/EnumRequirement.php
+++ b/src/Symfony/Component/Routing/Requirement/EnumRequirement.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Requirement;
+
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
+
+final class EnumRequirement implements \Stringable
+{
+    /**
+     * @var string[]
+     */
+    private readonly array $values;
+
+    /**
+     * @template T of \BackedEnum
+     * @param class-string<T> $enum
+     * @param T ...$cases
+     */
+    public function __construct(string $enum, \BackedEnum ...$cases)
+    {
+        if (!\is_subclass_of($enum, \BackedEnum::class, true)) {
+            throw new InvalidArgumentException(sprintf('"%s" is not a \BackedEnum class.', $enum));
+        }
+
+        foreach ($cases as $case) {
+            if (!$case instanceof $enum) {
+                throw new InvalidArgumentException(sprintf('"%s::%s" is not a case of "%s".', \get_class($case), $case->name, $enum));
+            }
+        }
+
+        $this->values = array_unique(array_map(
+            static fn (\BackedEnum $e): string => $e->value,
+            $cases ?: $enum::cases(),
+        ));
+    }
+
+    public function __toString(): string
+    {
+        return implode('|', array_map(preg_quote(...), $this->values));
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Enum/TestIntBackedEnum.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Enum/TestIntBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Enum;
+
+enum TestIntBackedEnum: int
+{
+    case Hearts = 10;
+    case Diamonds = 20;
+    case Clubs = 30;
+    case Spades = 40;
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Enum/TestStringBackedEnum.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Enum/TestStringBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Enum;
+
+enum TestStringBackedEnum: string
+{
+    case Hearts = 'hearts';
+    case Diamonds = 'diamonds';
+    case Clubs = 'clubs';
+    case Spades = 'spades';
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Enum/TestStringBackedEnum2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Enum/TestStringBackedEnum2.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Enum;
+
+enum TestStringBackedEnum2: string
+{
+    case Hearts = 'hearts';
+    case Diamonds = 'diamonds';
+    case Clubs = 'clubs';
+    case Spades = 'spa|des';
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Enum/TestUnitEnum.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Enum/TestUnitEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Enum;
+
+enum TestUnitEnum
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}

--- a/src/Symfony/Component/Routing/Tests/Requirement/EnumRequirementTest.php
+++ b/src/Symfony/Component/Routing/Tests/Requirement/EnumRequirementTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Requirement;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
+use Symfony\Component\Routing\Requirement\EnumRequirement;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Tests\Fixtures\Enum\TestIntBackedEnum;
+use Symfony\Component\Routing\Tests\Fixtures\Enum\TestStringBackedEnum;
+use Symfony\Component\Routing\Tests\Fixtures\Enum\TestStringBackedEnum2;
+use Symfony\Component\Routing\Tests\Fixtures\Enum\TestUnitEnum;
+
+class EnumRequirementTest extends TestCase
+{
+    public function testNotABackedEnum()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"Symfony\Component\Routing\Tests\Fixtures\Enum\TestUnitEnum" is not a \BackedEnum class.');
+
+        new EnumRequirement(TestUnitEnum::class);
+    }
+
+    public function testCaseFromAnotherEnum()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"Symfony\Component\Routing\Tests\Fixtures\Enum\TestStringBackedEnum2::Spades" is not a case of "Symfony\Component\Routing\Tests\Fixtures\Enum\TestStringBackedEnum".');
+
+        new EnumRequirement(TestStringBackedEnum::class, TestStringBackedEnum::Diamonds, TestStringBackedEnum2::Spades);
+    }
+
+    /**
+     * @dataProvider provideToString
+     */
+    public function testToString(string $expected, string $enum, \BackedEnum ...$cases)
+    {
+        $this->assertSame($expected, (string) new EnumRequirement($enum, ...$cases));
+    }
+
+    public function provideToString()
+    {
+        return [
+            ['hearts|diamonds|clubs|spades', TestStringBackedEnum::class],
+            ['10|20|30|40', TestIntBackedEnum::class],
+            ['diamonds|spades', TestStringBackedEnum::class, TestStringBackedEnum::Diamonds, TestStringBackedEnum::Spades],
+            ['hearts|diamonds|clubs|spa\|des', TestStringBackedEnum2::class],
+        ];
+    }
+
+    public function testInRoute()
+    {
+        $this->assertSame([
+            'bar' => 'hearts|diamonds|clubs|spades',
+        ], (new Route(
+            path: '/foo/{bar}',
+            requirements: [
+                'bar' => new EnumRequirement(TestStringBackedEnum::class),
+            ],
+        ))->getRequirements());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Ref https://github.com/symfony/symfony/pull/44831

I'd like to limit a route parameter allowed values to the backed values of an enum to use it in conjunction with the new `\BackedEnum` argument resolver (ie fail from the start).
Also, sometimes, I'd like to limit it only to a subset of the backed values.
I couldn't find a way to do that because enums can't implement `__toString()` and accessing `->value` is not considered a constant operation.
We can leverage the fact that route requirements can be a `\Stringable`.

Before (no enum):
```php
#[Route(path: '/foo/{bar}', requirements: ['bar' => FooEnum::AAA.'|'.FooEnum::BBB])]
```

Allow all enum cases:
```php
#[Route(path: '/foo/{bar}', requirements: ['bar' => new EnumRequirement(Foo::class)])]
```

Allow a subset:
```php
#[Route(path: '/foo/{bar}', requirements: ['bar' => new EnumRequirement(Foo::class, Foo::Aaa, Foo::Bbb)])]
```

Probably not the best solution but I hope we can find something for that use case for 6.1 :smile:

cc @ogizanagi 