### PR TITLE
Fix compatibility of ldap 6.0 with security 5.x

### DIFF
--- a/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
+++ b/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
 
@@ -62,6 +63,14 @@ class LdapAuthenticator implements AuthenticationEntryPointInterface, Interactiv
         $passport->addBadge(new LdapBadge($this->ldapServiceId, $this->dnString, $this->searchDn, $this->searchPassword, $this->queryString));
 
         return $passport;
+    }
+
+    /**
+     * @internal
+     */
+    public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        throw new \BadMethodCallException(sprintf('The "%s()" method cannot be called.', __METHOD__));
     }
 
     public function createToken(Passport $passport, string $firewallName): TokenInterface

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapAuthenticatorTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapAuthenticatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Ldap\Security\LdapAuthenticator;
+use Symfony\Component\Ldap\Security\LdapBadge;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+
+class LdapAuthenticatorTest extends TestCase
+{
+    public function testAuthenticate()
+    {
+        $decorated = $this->createMock(AuthenticatorInterface::class);
+        $passport = new Passport(new UserBadge('test'), new PasswordCredentials('s3cret'));
+        $decorated
+            ->expects($this->once())
+            ->method('authenticate')
+            ->willReturn($passport)
+        ;
+
+        $authenticator = new LdapAuthenticator($decorated, 'serviceId');
+        $request = new Request();
+
+        $authenticator->authenticate($request);
+
+        /** @var LdapBadge $badge */
+        $badge = $passport->getBadge(LdapBadge::class);
+        $this->assertNotNull($badge);
+        $this->assertSame('serviceId', $badge->getLdapServiceId());
+    }
+}

--- a/src/Symfony/Component/Ldap/composer.json
+++ b/src/Symfony/Component/Ldap/composer.json
@@ -21,7 +21,8 @@
         "symfony/options-resolver": "^5.4|^6.0"
     },
     "require-dev": {
-        "symfony/security-core": "^5.4|^6.0"
+        "symfony/security-core": "^5.4|^6.0",
+        "symfony/security-http": "^5.4|^6.0"
     },
     "conflict": {
         "symfony/options-resolver": "<5.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

In version 5.4, the `LdapAuthenticator` class implements the `AuthenticatorInterface` and therefor implemented the deprecated `createAuthenticatedToken` method.

In version 6.0, we removed that method from both the interface and the `LdapAuthenticator` class.

But the 2 class/interface are located in 2 differents packages, an our composer.json allows the combination `symfony/ldap:6.0` + `synfony/security-http:5.4`. Leading to a fatal error `Class Symfony\Component\Ldap\Security\LdapAuthenticator contains 1 abstract method and must therefore be declared abstract or implement the remaining methods`

This PR re-add the method in the `ldap` component.