### PR TITLE
[HttpFoundation] Propagate SessionNotFoundException in Request::getSession docBlock

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -690,6 +690,8 @@ class Request
 
     /**
      * Gets the Session.
+     *
+     * @throws SessionNotFoundException When session is not set properly
      */
     public function getSession(): SessionInterface
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features / 4.4, 5.4 or 6.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | 

Looks like [RequestStack::getSession](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/HttpFoundation/RequestStack.php#L99) throws `SessionNotFoundException` exception in Docblock , but [Request](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/HttpFoundation/Request.php#L694) don't.

The PR adds missing Docblock to Request to solve misleadings.