### PR TITLE
[HttpClient] Improve default content-type handling

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -97,6 +97,10 @@ trait HttpClientTrait
         }
 
         if (isset($options['body'])) {
+            if (\is_array($options['body'])) {
+                $options['normalized_headers']['content-type'] = ['Content-Type: application/x-www-form-urlencoded'];
+            }
+
             $options['body'] = self::normalizeBody($options['body']);
 
             if (\is_string($options['body'])

--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -252,8 +252,8 @@ class HttpClientDataCollectorTest extends TestCase
   --request POST \\
   --url %1$shttp://localhost:8057/json%1$s \\
   --header %1$sAccept: */*%1$s \\
-  --header %1$sContent-Length: 32%1$s \\
   --header %1$sContent-Type: application/x-www-form-urlencoded%1$s \\
+  --header %1$sContent-Length: 32%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
   --header %1$sUser-Agent: Symfony HttpClient/Native%1$s \\
   --data %1$sfoo=fooval%1$s --data %1$sbar=barval%1$s --data %1$sbaz=bazval%1$s',

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -455,4 +455,22 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
             'other host' => ['url' => 'http://127.0.0.1:8057/302', 'redirectWithAuth' => false],
         ];
     }
+
+    public function testDefaultContentType()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $client = $client->withOptions(['headers' => ['Content-Type: application/json']]);
+
+        $response = $client->request('POST', 'http://localhost:8057/post', [
+            'body' => ['abc' => 'def'],
+        ]);
+
+        $this->assertSame(['abc' => 'def', 'REQUEST_METHOD' => 'POST'], $response->toArray());
+
+        $response = $client->request('POST', 'http://localhost:8057/post', [
+            'body' => '{"abc": "def"}',
+        ]);
+
+        $this->assertSame(['abc' => 'def', 'content-type' => 'application/json', 'REQUEST_METHOD' => 'POST'], $response->toArray());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes (minor)
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This improves the default behavior of handling the content-type header: with this PR, when an array is passed as body, the content-type is forced to `application/x-www-form-urlencoded`.

This allows setting a content-type in the default options and have it overridden when passing an array as body.

Spotted while reviewing https://github.com/symfony/symfony/pull/45791, where the proposed behavior would have allowed a cleaner patch.