### PR TITLE
[HttpClient] Let curl handle Content-Length headers

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -202,7 +202,12 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $options['headers'][] = 'Accept-Encoding: gzip'; // Expose only one encoding, some servers mess up when more are provided
         }
 
+        $hasContentLength = isset($options['normalized_headers']['content-length'][0]);
+
         foreach ($options['headers'] as $header) {
+            if ($hasContentLength && 0 === stripos($header, 'Content-Length:')) {
+                continue; // Let curl handle Content-Length headers
+            }
             if (':' === $header[-2] && \strlen($header) - 2 === strpos($header, ': ')) {
                 // curl requires a special syntax to send empty headers
                 $curlopts[\CURLOPT_HTTPHEADER][] = substr_replace($header, ';', -2);
@@ -229,7 +234,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
                 };
             }
 
-            if (isset($options['normalized_headers']['content-length'][0])) {
+            if ($hasContentLength) {
                 $curlopts[\CURLOPT_INFILESIZE] = substr($options['normalized_headers']['content-length'][0], \strlen('Content-Length: '));
             } elseif (!isset($options['normalized_headers']['transfer-encoding'])) {
                 $curlopts[\CURLOPT_HTTPHEADER][] = 'Transfer-Encoding: chunked'; // Enable chunked request bodies

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -203,6 +203,17 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         ])->getStatusCode());
     }
 
+    public function testRedirectAfterPost()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $response = $client->request('POST', 'http://localhost:8057/302/relative', [
+            'body' => 'abc',
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
     public function testNullBody()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45709
| License       | MIT
| Doc PR        | -
