### PR TITLE
[Serializer] Fixes message for http client errors

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
@@ -73,7 +73,7 @@ class JsonLoginTest extends AbstractWebTestCase
 
         $this->assertSame(400, $response->getStatusCode());
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
-        $this->assertSame(['type' => 'https://tools.ietf.org/html/rfc2616#section-10', 'title' => 'An error occurred', 'status' => 400, 'detail' => 'Bad Request'], json_decode($response->getContent(), true));
+        $this->assertSame(['type' => 'https://tools.ietf.org/html/rfc2616#section-10', 'title' => 'An error occurred', 'status' => 400, 'detail' => 'Invalid JSON.'], json_decode($response->getContent(), true));
     }
 
     /**
@@ -143,6 +143,6 @@ class JsonLoginTest extends AbstractWebTestCase
 
         $this->assertSame(400, $response->getStatusCode());
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
-        $this->assertSame(['type' => 'https://tools.ietf.org/html/rfc2616#section-10', 'title' => 'An error occurred', 'status' => 400, 'detail' => 'Bad Request'], json_decode($response->getContent(), true));
+        $this->assertSame(['type' => 'https://tools.ietf.org/html/rfc2616#section-10', 'title' => 'An error occurred', 'status' => 400, 'detail' => 'Invalid JSON.'], json_decode($response->getContent(), true));
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -54,7 +54,7 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
             'type' => $context['type'],
             'title' => $context['title'],
             'status' => $context['status'] ?? $object->getStatusCode(),
-            'detail' => $debug ? $object->getMessage() : $object->getStatusText(),
+            'detail' => $debug || $object->getStatusCode() < 500 ? $object->getMessage() : $object->getStatusText(),
         ];
         if ($debug) {
             $data['class'] = $object->getClass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

We don't explain the detail of a bad request with `APP_ENV=prod` in json error. The message of the exception is replaced by the status text depending on the debug flag. We need to check the HTTP code :
- 4xx means client error
- 5xx means server error with sensitive information

How a client fixes a bad request if they ignore their error?

Sample:
```php
<?php

namespace App\Controller;

use Symfony\Component\HttpFoundation\JsonResponse;
use Symfony\Component\HttpFoundation\Request;
use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
use Symfony\Component\Routing\Annotation\Route;

class DefaultController
{
    #[Route('/', name: 'index')]
    public function index(Request $request)
    {
        if (!$request->headers()->has('User-Agent')) {
            throw new BadRequestHttpException('A User-Agent header is required.');
        }

        return new JsonResponse('Hello world!');
    }
}
```

Actual output:
```json
{
  "type": "https:\/\/tools.ietf.org\/html\/rfc2616#section-10",
  "title": "An error occurred",
  "status": 400,
  "detail": "Bad Request"
}
```

Expected output:
```json
{
  "type": "https:\/\/tools.ietf.org\/html\/rfc2616#section-10",
  "title": "An error occurred",
  "status": 400,
  "detail": "A User-Agent header is required."
}
```