### PR TITLE
[Dotenv] add json output to DebugCommand.php

### DIFF
--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -75,7 +75,7 @@ EOF
         });
 
         if ('json' == $input->getOption('format')) {
-            $io->writeln(json_encode($this->getVariablesasArray($availableFiles), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+            $io->writeln(json_encode($this->getVariablesasArray($availableFiles), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR));
 
             return 0;
         }

--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -47,8 +47,8 @@ final class DebugCommand extends Command
 
         parent::__construct();
     }
-    
-        protected function configure()
+
+    protected function configure()
     {
         $this
             ->setDescription(self::$defaultDescription)
@@ -74,9 +74,10 @@ EOF
         $availableFiles = array_filter($envFiles, function (string $file) {
             return is_file($this->getFilePath($file));
         });
-        
-        if ($input->getOption('format') == "json") {
+
+        if ('json' == $input->getOption('format')) {
             $io->writeln(json_encode($this->getVariablesasArray($availableFiles), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
             return 0;
         }
 
@@ -131,7 +132,7 @@ EOF
 
         return $output;
     }
-    
+
     private function getVariablesasArray(array $envFiles): array
     {
         $vars = explode(',', $_SERVER['SYMFONY_DOTENV_VARS'] ?? '');

--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -51,7 +51,6 @@ final class DebugCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription(self::$defaultDescription)
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format')
              ->setHelp(<<<EOF
   <info>php %command.full_name% </info>


### PR DESCRIPTION
adds an optional json output to 'debug:dotenv' command

| Q             | A
| ------------- | ---
| Branch?       | 6.1 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        |  /

