### PR TITLE
[HttpKernel] Add Http Status 423 LockedHttpException

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/LockedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/LockedHttpException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * @author Peter Dietrich <xosofox@gmail.com>
+ */
+class LockedHttpException extends HttpException
+{
+    public function __construct(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
+    {
+        parent::__construct(423, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/LockedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/LockedHttpExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\LengthRequiredHttpException;
+use Symfony\Component\HttpKernel\Exception\LockedHttpException;
+
+class LockedHttpExceptionTest extends HttpExceptionTest
+{
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
+    {
+        return new LockedHttpException($message, $previous, $code, $headers);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| Tickets       | none
| License       | MIT
| Doc PR        | none

Add LockedHttpException (http status 423) to the list of predefined exceptions in HttpKernel

Not sure if this is considered to be a "new feature" that can only be merged into 6.x... I assume this could also be added to 5.x or 4.x even as it does not have any dependencies or side effects

Let me know if the base should be changed