### PR TITLE
[DependencyInjection] add AsDecorator class attribute and InnerService parameter attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsDecorator.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsDecorator
+{
+    public function __construct(
+        public string $decorates,
+        public int $priority = 0,
+        public int $onInvalid = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/InnerService.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/InnerService.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class InnerService
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireAsDecoratorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireAsDecoratorPass.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Reads #[AsDecorator] attributes on definitions that are autowired
+ * and don't have the "container.ignore_attributes" tag.
+ */
+final class AutowireAsDecoratorPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            if ($this->accept($definition) && $reflectionClass = $container->getReflectionClass($definition->getClass(), false)) {
+                $this->processClass($definition, $reflectionClass);
+            }
+        }
+    }
+
+    private function accept(Definition $definition): bool
+    {
+        return !$definition->hasTag('container.ignore_attributes') && $definition->isAutowired();
+    }
+
+    private function processClass(Definition $definition, \ReflectionClass $reflectionClass)
+    {
+        foreach ($reflectionClass->getAttributes(AsDecorator::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $attribute = $attribute->newInstance();
+
+            $definition->setDecoratedService($attribute->decorates, null, $attribute->priority, $attribute->onInvalid);
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Attribute\InnerService;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
 use Symfony\Component\DependencyInjection\Attribute\Target;
@@ -268,6 +269,12 @@ class AutowirePass extends AbstractRecursivePass
                         }
 
                         $arguments[$index] = $value;
+
+                        break;
+                    }
+
+                    if (InnerService::class === $attribute->getName()) {
+                        $arguments[$index] = new Reference($this->currentId.'.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE);
 
                         break;
                     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -43,6 +43,7 @@ class PassConfig
             100 => [
                 new ResolveClassPass(),
                 new RegisterAutoconfigureAttributesPass(),
+                new AutowireAsDecoratorPass(),
                 new AttributeAutoconfigurationPass(),
                 new ResolveInstanceofConditionalsPass(),
                 new RegisterEnvVarProcessorsPass(),

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -2,7 +2,10 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Attribute\InnerService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
 class AutowireSetter
@@ -48,5 +51,37 @@ class AutowireAttribute
         #[Autowire(service: 'invalid.id')]
         public ?\stdClass $invalid = null,
     ) {
+    }
+}
+
+interface AsDecoratorInterface
+{
+}
+
+class AsDecoratorFoo implements AsDecoratorInterface
+{
+}
+
+#[AsDecorator(decorates: AsDecoratorFoo::class, priority: 10)]
+class AsDecoratorBar10 implements AsDecoratorInterface
+{
+    public function __construct(string $arg1, #[InnerService] AsDecoratorInterface $inner)
+    {
+    }
+}
+
+#[AsDecorator(decorates: AsDecoratorFoo::class, priority: 20)]
+class AsDecoratorBar20 implements AsDecoratorInterface
+{
+    public function __construct(string $arg1, #[InnerService] AsDecoratorInterface $inner)
+    {
+    }
+}
+
+#[AsDecorator(decorates: \NonExistent::class, onInvalid: ContainerInterface::NULL_ON_INVALID_REFERENCE)]
+class AsDecoratorBaz implements AsDecoratorInterface
+{
+    public function __construct(#[InnerService] AsDecoratorInterface $inner = null)
+    {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | WIP

The aim f this PR is to allow decorator declaration with PHP8 attributes by using `AsDecorator` attribute on class and, optionally, `InnerService` parameter attribute to inject decorated service.

To use it :
```php
interface FooInterface
{
    public function myMethod(): string;
}

final class Foo implements FooInterface
{
    public function myMethod(): string
    {
        return 'foo';
    }
}

#[AsDecorator(
    decorates: Foo::class, 
    priority: 5, 
    onInvalid: ContainerInterface::NULL_ON_INVALID_REFERENCE,
)]
final class Bar implements FooInterface
{
    private string $arg1;
    private ?FooInterface $foo;

    public function __construct(string $arg1, #[InnerService] FooInterface $foo = null)
    {
        $this->arg1 = $arg1;
        $this->foo = $foo;
    }

    public function myMethod(): string
    {
        if (null === $this->foo) {
            return 'bar';
        }

        return $this->foo->myMethod().' bar ';
    }
}
```