### PR TITLE
[Translation] Fix intersect in TranslatorBag

### DIFF
--- a/src/Symfony/Component/Translation/Tests/TranslatorBagTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorBagTest.php
@@ -82,8 +82,8 @@ class TranslatorBagTest extends TestCase
 
         $this->assertEquals([
             'en' => [
-                'domain1' => ['bar' => 'bar'],
-                'domain2' => ['qux' => 'qux'],
+                'domain1' => ['foo' => 'foo'],
+                'domain2' => ['baz' => 'baz'],
             ],
         ], $this->getAllMessagesFromTranslatorBag($bagResult));
     }

--- a/src/Symfony/Component/Translation/TranslatorBag.php
+++ b/src/Symfony/Component/Translation/TranslatorBag.php
@@ -94,7 +94,10 @@ final class TranslatorBag implements TranslatorBagInterface
             $obsoleteCatalogue = new MessageCatalogue($locale);
 
             foreach ($operation->getDomains() as $domain) {
-                $obsoleteCatalogue->add($operation->getObsoleteMessages($domain), $domain);
+                $obsoleteCatalogue->add(
+                    array_diff($operation->getMessages($domain), $operation->getNewMessages($domain)),
+                    $domain
+                );
             }
 
             $diff->addCatalogue($obsoleteCatalogue);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Actually `TranslatorBag::intersect` does the same as `TranslatorBag::diff`, you can see this in tests. This PR fixes it.