### PR TITLE
[Form] [ChoiceType] Implement "sorted_choices"

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -78,6 +78,10 @@
 {%- endblock choice_widget_collapsed -%}
 
 {%- block choice_widget_options -%}
+    {%- if sorted_choices is same as (true) and options|first is not iterable -%}
+        {% set options = options|sort((a, b) => (choice_translation_domain is same as(false) ? a.label : a.label|trans(a.labelTranslationParameters, choice_translation_domain)) <=> (choice_translation_domain is same as(false) ? b.label : b.label|trans(b.labelTranslationParameters, choice_translation_domain))) %}
+    {%- endif -%}
+
     {% for group_label, choice in options %}
         {%- if choice is iterable -%}
             <optgroup label="{{ choice_translation_domain is same as(false) ? group_label : group_label|trans({}, choice_translation_domain) }}">

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -275,6 +275,9 @@ class ChoiceType extends AbstractType
             // POST request.
             $view->vars['full_name'] .= '[]';
         }
+
+        // Add sorted_choices key
+        $view->vars['sorted_choices'] = $options['sorted_choices'];
     }
 
     /**
@@ -353,6 +356,7 @@ class ChoiceType extends AbstractType
             'multiple' => false,
             'expanded' => false,
             'choices' => [],
+            'sorted_choices' => null,
             'choice_filter' => null,
             'choice_loader' => null,
             'choice_label' => null,
@@ -377,7 +381,6 @@ class ChoiceType extends AbstractType
 
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);
         $resolver->setNormalizer('choice_translation_domain', $choiceTranslationDomainNormalizer);
-
         $resolver->setAllowedTypes('choices', ['null', 'array', \Traversable::class]);
         $resolver->setAllowedTypes('choice_translation_domain', ['null', 'bool', 'string']);
         $resolver->setAllowedTypes('choice_loader', ['null', ChoiceLoaderInterface::class, ChoiceLoader::class]);
@@ -389,6 +392,7 @@ class ChoiceType extends AbstractType
         $resolver->setAllowedTypes('choice_translation_parameters', ['null', 'array', 'callable', ChoiceTranslationParameters::class]);
         $resolver->setAllowedTypes('preferred_choices', ['array', \Traversable::class, 'callable', 'string', PropertyPath::class, PreferredChoice::class]);
         $resolver->setAllowedTypes('group_by', ['null', 'callable', 'string', PropertyPath::class, GroupBy::class]);
+        $resolver->setAllowedTypes('sorted_choices', ['null', 'bool']);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -2247,4 +2247,40 @@ class ChoiceTypeTest extends BaseTypeTest
             new ChoiceView('c', 'c', 'Kris'),
         ], $form->createView()->vars['choices']);
     }
+
+    public function testSortedChoices()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'choices' => $this->choices,
+            'sorted_choices' => true,
+        ]);
+
+        $this->assertEquals([
+            new ChoiceView('a', 'a', 'Bernhard'),
+            new ChoiceView('b', 'b', 'Fabien'),
+            new ChoiceView('c', 'c', 'Kris'),
+            new ChoiceView('d', 'd', 'Jon'),
+            new ChoiceView('e', 'e', 'Roman'),
+        ], $form->createView()->vars['choices']);
+        $this->assertTrue($form->createView()->vars['sorted_choices']);
+    }
+
+    public function testSortedChoiceLoader()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'choice_loader' => new CallbackChoiceLoader(function () {
+                return $this->choices;
+            }),
+            'sorted_choices' => true,
+        ]);
+
+        $this->assertEquals([
+            new ChoiceView('a', 'a', 'Bernhard'),
+            new ChoiceView('b', 'b', 'Fabien'),
+            new ChoiceView('c', 'c', 'Kris'),
+            new ChoiceView('d', 'd', 'Jon'),
+            new ChoiceView('e', 'e', 'Roman'),
+        ], $form->createView()->vars['choices']);
+        $this->assertTrue($form->createView()->vars['sorted_choices']);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -16,7 +16,8 @@
             "group_by",
             "multiple",
             "placeholder",
-            "preferred_choices"
+            "preferred_choices",
+            "sorted_choices"
         ],
         "overridden": {
             "Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType": [

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -19,7 +19,7 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   multiple                                             disabled                                              
   placeholder                                          form_attr                                             
   preferred_choices                                    getter                                                
-                                                       help                                                  
+  sorted_choices                                       help                                                  
                                                        help_attr                                             
                                                        help_html                                             
                                                        help_translation_parameters                           


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

This PR implement a new `sorted_choices` on ChoiceType that permit to order values by their translated label. In some ChoiceType we want to ordering alphabetically choices, but depending the language this order change.

This should be usefull with EnumType to, when creating an Enum we order cases alphabetically, but the `::label()` for exemple return translation key/label that can be different.