### PR TITLE
Use source() function to include assets in template

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
+++ b/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
@@ -3,7 +3,7 @@
 {% block toolbar %}
     {% if collector.dumpsCount %}
         {% set icon %}
-            {{ include('@Debug/Profiler/icon.svg') }}
+            {{ source('@Debug/Profiler/icon.svg') }}
             <span class="sf-toolbar-value">{{ collector.dumpsCount }}</span>
         {% endset %}
 
@@ -35,7 +35,7 @@
 
 {% block menu %}
     <span class="label {{ collector.dumpsCount == 0 ? 'disabled' }}">
-        <span class="icon">{{ include('@Debug/Profiler/icon.svg') }}</span>
+        <span class="icon">{{ source('@Debug/Profiler/icon.svg') }}</span>
         <strong>Debug</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -5,7 +5,7 @@
 {% block toolbar %}
     {% if collector.firewall %}
         {% set icon %}
-            {{ include('@Security/Collector/icon.svg') }}
+            {{ source('@Security/Collector/icon.svg') }}
             <span class="sf-toolbar-value">{{ collector.user|default('n/a') }}</span>
         {% endset %}
 
@@ -109,7 +109,7 @@
 
 {% block menu %}
     <span class="label {{ not collector.firewall or not collector.token ? 'disabled' }}">
-        <span class="icon">{{ include('@Security/Collector/icon.svg') }}</span>
+        <span class="icon">{{ source('@Security/Collector/icon.svg') }}</span>
         <strong>Security</strong>
     </span>
 {% endblock %}
@@ -130,7 +130,7 @@
                             </div>
 
                             <div class="metric">
-                                <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.authenticated ? 'yes' : 'no') ~ '.svg') }}</span>
+                                <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.authenticated ? 'yes' : 'no') ~ '.svg') }}</span>
                                 <span class="label">Authenticated</span>
                             </div>
                         </div>
@@ -187,11 +187,11 @@
                                 <span class="label">Name</span>
                             </div>
                             <div class="metric">
-                                <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.security_enabled ? 'yes' : 'no') ~ '.svg') }}</span>
+                                <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.firewall.security_enabled ? 'yes' : 'no') ~ '.svg') }}</span>
                                 <span class="label">Security enabled</span>
                             </div>
                             <div class="metric">
-                                <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.stateless ? 'yes' : 'no') ~ '.svg') }}</span>
+                                <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.firewall.stateless ? 'yes' : 'no') ~ '.svg') }}</span>
                                 <span class="label">Stateless</span>
                             </div>
                         </div>
@@ -310,7 +310,7 @@
 
                                 <tr>
                                     <td class="font-normal">{{ profiler_dump(authenticator.stub) }}</td>
-                                    <td class="no-wrap">{{ include('@WebProfiler/Icon/' ~ (authenticator.supports ? 'yes' : 'no') ~ '.svg') }}</td>
+                                    <td class="no-wrap">{{ source('@WebProfiler/Icon/' ~ (authenticator.supports ? 'yes' : 'no') ~ '.svg') }}</td>
                                     <td class="no-wrap">{{ '%0.2f'|format(authenticator.duration * 1000) }} ms</td>
                                     <td class="font-normal">{{ authenticator.passport ? profiler_dump(authenticator.passport) : '(none)' }}</td>
                                 </tr>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/ajax.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/ajax.html.twig
@@ -2,7 +2,7 @@
 
 {% block toolbar %}
     {% set icon %}
-        {{ include('@WebProfiler/Icon/ajax.svg') }}
+        {{ source('@WebProfiler/Icon/ajax.svg') }}
         <span class="sf-toolbar-value sf-toolbar-ajax-request-counter">0</span>
     {% endset %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
@@ -3,7 +3,7 @@
 {% block toolbar %}
     {% if collector.totals.calls > 0 %}
         {% set icon %}
-            {{ include('@WebProfiler/Icon/cache.svg') }}
+            {{ source('@WebProfiler/Icon/cache.svg') }}
             <span class="sf-toolbar-value">{{ collector.totals.calls }}</span>
             <span class="sf-toolbar-info-piece-additional-detail">
                 <span class="sf-toolbar-label">in</span>
@@ -37,7 +37,7 @@
 {% block menu %}
     <span class="label {{ collector.totals.calls == 0 ? 'disabled' }}">
     <span class="icon">
-        {{ include('@WebProfiler/Icon/cache.svg') }}
+        {{ source('@WebProfiler/Icon/cache.svg') }}
     </span>
     <strong>Cache</strong>
 </span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -20,7 +20,7 @@
 
     {% set icon %}
         <span class="sf-toolbar-label">
-            {{ include('@WebProfiler/Icon/symfony.svg') }}
+            {{ source('@WebProfiler/Icon/symfony.svg') }}
         </span>
         <span class="sf-toolbar-value">{{ collector.symfonyState is defined ? collector.symfonyversion : 'n/a' }}</span>
     {% endset %}
@@ -108,7 +108,7 @@
 
 {% block menu %}
     <span class="label label-status-{{ collector.symfonyState == 'eol' ? 'red' : collector.symfonyState in ['eom', 'dev'] ? 'yellow' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/config.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/config.svg') }}</span>
         <strong>Configuration</strong>
     </span>
 {% endblock %}
@@ -191,17 +191,17 @@
 
     <div class="metrics">
         <div class="metric">
-            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.haszendopcache ? 'yes' : 'no') ~ '.svg') }}</span>
+            <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.haszendopcache ? 'yes' : 'no') ~ '.svg') }}</span>
             <span class="label">OPcache</span>
         </div>
 
         <div class="metric">
-            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.hasapcu ? 'yes' : 'no-gray') ~ '.svg') }}</span>
+            <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.hasapcu ? 'yes' : 'no-gray') ~ '.svg') }}</span>
             <span class="label">APCu</span>
         </div>
 
         <div class="metric">
-            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.hasxdebug ? 'yes' : 'no-gray') ~ '.svg') }}</span>
+            <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.hasxdebug ? 'yes' : 'no-gray') ~ '.svg') }}</span>
             <span class="label">Xdebug</span>
         </div>
     </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
@@ -4,7 +4,7 @@
 
 {% block menu %}
 <span class="label">
-    <span class="icon">{{ include('@WebProfiler/Icon/event.svg') }}</span>
+    <span class="icon">{{ source('@WebProfiler/Icon/event.svg') }}</span>
     <strong>Events</strong>
 </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -12,7 +12,7 @@
 
 {% block menu %}
     <span class="label {{ collector.hasexception ? 'label-status-error' : 'disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/exception.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/exception.svg') }}</span>
         <strong>Exception</strong>
         {% if collector.hasexception %}
             <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -6,7 +6,7 @@
     {% if collector.data.nb_errors > 0 or collector.data.forms|length %}
         {% set status_color = collector.data.nb_errors ? 'red' %}
         {% set icon %}
-            {{ include('@WebProfiler/Icon/form.svg') }}
+            {{ source('@WebProfiler/Icon/form.svg') }}
             <span class="sf-toolbar-value">
                 {{ collector.data.nb_errors ?: collector.data.forms|length }}
             </span>
@@ -29,7 +29,7 @@
 
 {% block menu %}
     <span class="label label-status-{{ collector.data.nb_errors ? 'error' }} {{ collector.data.forms is empty ? 'disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/form.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/form.svg') }}</span>
         <strong>Forms</strong>
         {% if collector.data.nb_errors > 0 %}
             <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
@@ -3,7 +3,7 @@
 {% block toolbar %}
     {% if collector.requestCount %}
         {% set icon %}
-            {{ include('@WebProfiler/Icon/http-client.svg') }}
+            {{ source('@WebProfiler/Icon/http-client.svg') }}
             {% set status_color = '' %}
             <span class="sf-toolbar-value">{{ collector.requestCount }}</span>
         {% endset %}
@@ -25,7 +25,7 @@
 
 {% block menu %}
 <span class="label {{ collector.requestCount == 0 ? 'disabled' }}">
-    <span class="icon">{{ include('@WebProfiler/Icon/http-client.svg') }}</span>
+    <span class="icon">{{ source('@WebProfiler/Icon/http-client.svg') }}</span>
     <strong>HTTP Client</strong>
     {% if collector.requestCount %}
         <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -6,7 +6,7 @@
     {% if collector.counterrors or collector.countdeprecations or collector.countwarnings %}
         {% set icon %}
             {% set status_color = collector.counterrors ? 'red' : collector.countwarnings ? 'yellow' : 'none' %}
-            {{ include('@WebProfiler/Icon/logger.svg') }}
+            {{ source('@WebProfiler/Icon/logger.svg') }}
             <span class="sf-toolbar-value">{{ collector.counterrors ?: (collector.countdeprecations + collector.countwarnings) }}</span>
         {% endset %}
 
@@ -33,7 +33,7 @@
 
 {% block menu %}
     <span class="label label-status-{{ collector.counterrors ? 'error' : collector.countwarnings ? 'warning' : 'none' }} {{ collector.logs is empty ? 'disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/logger.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/logger.svg') }}</span>
         <strong>Logs</strong>
         {% if collector.counterrors or collector.countdeprecations or collector.countwarnings %}
             <span class="count">
@@ -83,7 +83,7 @@
 
             <details id="log-filter-priority" class="log-filter">
                 <summary>
-                    <span class="icon">{{ include('@WebProfiler/Icon/filter.svg') }}</span>
+                    <span class="icon">{{ source('@WebProfiler/Icon/filter.svg') }}</span>
                     Level (<span class="filter-active-num">{{ filters.priority|length - 1 }}</span>)
                 </summary>
 
@@ -104,7 +104,7 @@
 
             <details id="log-filter-channel" class="log-filter">
                 <summary>
-                    <span class="icon">{{ include('@WebProfiler/Icon/filter.svg') }}</span>
+                    <span class="icon">{{ source('@WebProfiler/Icon/filter.svg') }}</span>
                     Channel (<span class="filter-active-num">{{ filters.channel|length - 1 }}</span>)
                 </summary>
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -5,7 +5,7 @@
 
     {% if events.messages|length %}
         {% set icon %}
-            {% include('@WebProfiler/Icon/mailer.svg') %}
+            {{ source('@WebProfiler/Icon/mailer.svg') }}
             <span class="sf-toolbar-value">{{ events.messages|length }}</span>
         {% endset %}
 
@@ -65,7 +65,7 @@
     {% set events = collector.events %}
 
     <span class="label {{ events.messages is empty ? 'disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/mailer.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/mailer.svg') }}</span>
 
         <strong>E-mails</strong>
         {% if events.messages|length > 0 %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
@@ -3,7 +3,7 @@
 {% block toolbar %}
     {% set icon %}
         {% set status_color = (collector.memory / 1024 / 1024) > 50 ? 'yellow' %}
-        {{ include('@WebProfiler/Icon/memory.svg') }}
+        {{ source('@WebProfiler/Icon/memory.svg') }}
         <span class="sf-toolbar-value">{{ '%.1f'|format(collector.memory / 1024 / 1024) }}</span>
         <span class="sf-toolbar-label">MiB</span>
     {% endset %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -6,7 +6,7 @@
     {% if collector.messages|length > 0 %}
         {% set status_color = collector.exceptionsCount ? 'red' %}
         {% set icon %}
-            {{ include('@WebProfiler/Icon/messenger.svg') }}
+            {{ source('@WebProfiler/Icon/messenger.svg') }}
             <span class="sf-toolbar-value">{{ collector.messages|length }}</span>
         {% endset %}
 
@@ -31,7 +31,7 @@
 
 {% block menu %}
     <span class="label{{ collector.exceptionsCount ? ' label-status-error' }}{{ collector.messages is empty ? ' disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/messenger.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/messenger.svg') }}</span>
         <strong>Messages</strong>
         {% if collector.exceptionsCount > 0 %}
             <span class="count">
@@ -119,8 +119,8 @@
                         <span class="label status-error">exception</span>
                     {% endif %}
                     <a class="toggle-button">
-                        <span class="icon icon-close">{{ include('@WebProfiler/images/icon-minus-square.svg') }}</span>
-                        <span class="icon icon-open">{{ include('@WebProfiler/images/icon-plus-square.svg') }}</span>
+                        <span class="icon icon-close">{{ source('@WebProfiler/images/icon-minus-square.svg') }}</span>
+                        <span class="icon icon-open">{{ source('@WebProfiler/images/icon-plus-square.svg') }}</span>
                     </a>
                 </th>
             </tr>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
@@ -5,7 +5,7 @@
 
     {% if events.messages|length %}
         {% set icon %}
-            {% include('@WebProfiler/Icon/notifier.svg') %}
+            {{ source('@WebProfiler/Icon/notifier.svg') }}
             <span class="sf-toolbar-value">{{ events.messages|length }}</span>
         {% endset %}
 
@@ -68,7 +68,7 @@
     {% set events = collector.events %}
 
     <span class="label {{ events.messages|length ? '' : 'disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/notifier.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/notifier.svg') }}</span>
 
         <strong>Notifications</strong>
         {% if events.messages|length > 0 %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -24,8 +24,8 @@
     {% set icon %}
         <span class="sf-toolbar-status sf-toolbar-status-{{ request_status_code_color }}">{{ collector.statuscode }}</span>
         {% if collector.route %}
-            {% if collector.redirect %}{{ include('@WebProfiler/Icon/redirect.svg') }}{% endif %}
-            {% if collector.forwardtoken %}{{ include('@WebProfiler/Icon/forward.svg') }}{% endif %}
+            {% if collector.redirect %}{{ source('@WebProfiler/Icon/redirect.svg') }}{% endif %}
+            {% if collector.forwardtoken %}{{ source('@WebProfiler/Icon/forward.svg') }}{% endif %}
             <span class="sf-toolbar-label">{{ 'GET' != collector.method ? collector.method }} @</span>
             <span class="sf-toolbar-value sf-toolbar-info-piece-additional">{{ collector.route }}</span>
         {% endif %}
@@ -99,7 +99,7 @@
 
 {% block menu %}
     <span class="label">
-        <span class="icon">{{ include('@WebProfiler/Icon/request.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/request.svg') }}</span>
         <strong>Request / Response</strong>
     </span>
 {% endblock %}
@@ -265,7 +265,7 @@
                     </div>
 
                     <div class="metric">
-                        <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.statelesscheck ? 'yes' : 'no') ~ '.svg') }}</span>
+                        <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.statelesscheck ? 'yes' : 'no') ~ '.svg') }}</span>
                         <span class="label">Stateless check enabled</span>
                     </div>
                 </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/router.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/router.html.twig
@@ -4,7 +4,7 @@
 
 {% block menu %}
 <span class="label">
-    <span class="icon">{{ include('@WebProfiler/Icon/router.svg') }}</span>
+    <span class="icon">{{ source('@WebProfiler/Icon/router.svg') }}</span>
     <strong>Routing</strong>
 </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -9,7 +9,7 @@
     {% set status_color = has_time_events and collector.duration > 1000 ? 'yellow' %}
 
     {% set icon %}
-        {{ include('@WebProfiler/Icon/time.svg') }}
+        {{ source('@WebProfiler/Icon/time.svg') }}
         <span class="sf-toolbar-value">{{ total_time }}</span>
         <span class="sf-toolbar-label">ms</span>
     {% endset %}
@@ -30,7 +30,7 @@
 
 {% block menu %}
     <span class="label">
-        <span class="icon">{{ include('@WebProfiler/Icon/time.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/time.svg') }}</span>
         <strong>Performance</strong>
     </span>
 {% endblock %}
@@ -144,10 +144,10 @@
   </defs>
 </svg>
 <style type="text/css">
-{% include '@WebProfiler/Collector/time.css.twig' %}
+{{ include('@WebProfiler/Collector/time.css.twig') }}
 </style>
 <script>
-{% include '@WebProfiler/Collector/time.js' %}
+{{ source('@WebProfiler/Collector/time.js') }}
 </script>
 {% endblock %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -5,7 +5,7 @@
 {% block toolbar %}
     {% if collector.messages|length %}
         {% set icon %}
-            {{ include('@WebProfiler/Icon/translation.svg') }}
+            {{ source('@WebProfiler/Icon/translation.svg') }}
             {% set status_color = collector.countMissings ? 'red' : collector.countFallbacks ? 'yellow' %}
             {% set error_count = collector.countMissings + collector.countFallbacks %}
             <span class="sf-toolbar-value">{{ error_count ?: collector.countDefines }}</span>
@@ -44,7 +44,7 @@
 
 {% block menu %}
     <span class="label label-status-{{ collector.countMissings ? 'error' : collector.countFallbacks ? 'warning' }} {{ collector.messages is empty ? 'disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/translation.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/translation.svg') }}</span>
         <strong>Translation</strong>
         {% if collector.countMissings or collector.countFallbacks %}
             {% set error_count = collector.countMissings + collector.countFallbacks %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -3,7 +3,7 @@
 {% block toolbar %}
     {% set time = collector.templatecount ? '%0.0f'|format(collector.time) : 'n/a' %}
     {% set icon %}
-        {{ include('@WebProfiler/Icon/twig.svg') }}
+        {{ source('@WebProfiler/Icon/twig.svg') }}
         <span class="sf-toolbar-value">{{ time }}</span>
         <span class="sf-toolbar-label">ms</span>
     {% endset %}
@@ -32,7 +32,7 @@
 
 {% block menu %}
     <span class="label {{ 0 == collector.templateCount ? 'disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/twig.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/twig.svg') }}</span>
         <strong>Twig</strong>
     </span>
 {% endblock %}
@@ -88,7 +88,7 @@
                     {%- set file = collector.templatePaths[template]|default(false) -%}
                     {%- set link = file ? file|file_link(1) : false -%}
                     <td>
-                        <span class="sf-icon icon-twig">{{ include('@WebProfiler/Icon/twig.svg') }}</span>
+                        <span class="sf-icon icon-twig">{{ source('@WebProfiler/Icon/twig.svg') }}</span>
                         {% if link %}
                             <a href="{{ link }}" title="{{ file }}">{{ template }}</a>
                             <div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
@@ -4,7 +4,7 @@
     {% if collector.violationsCount > 0 or collector.calls|length %}
         {% set status_color = collector.violationsCount ? 'red' %}
         {% set icon %}
-            {{ include('@WebProfiler/Icon/validator.svg') }}
+            {{ source('@WebProfiler/Icon/validator.svg') }}
             <span class="sf-toolbar-value">
                 {{ collector.violationsCount ?: collector.calls|length }}
             </span>
@@ -27,7 +27,7 @@
 
 {% block menu %}
     <span class="label {{- collector.violationsCount ? ' label-status-error' }} {{ collector.calls is empty ? 'disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/validator.svg') }}</span>
+        <span class="icon">{{ source('@WebProfiler/Icon/validator.svg') }}</span>
         <strong>Validator</strong>
         {% if collector.violationsCount > 0 %}
             <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/cancel.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/cancel.html.twig
@@ -1,6 +1,6 @@
 {% block toolbar %}
     {% set icon %}
-        {{ include('@WebProfiler/Icon/symfony.svg') }}
+        {{ source('@WebProfiler/Icon/symfony.svg') }}
 
         <span class="sf-toolbar-value sf-toolbar-ajax-request-counter">
             Loading&hellip;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/header.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/header.html.twig
@@ -1,6 +1,6 @@
 <div id="header">
     <div class="container">
-        <h1>{{ include('@WebProfiler/Icon/symfony.svg') }} Symfony <span>Profiler</span></h1>
+        <h1>{{ source('@WebProfiler/Icon/symfony.svg') }} Symfony <span>Profiler</span></h1>
 
         <div class="search">
             <form method="get" action="https://symfony.com/search" target="_blank">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -105,7 +105,7 @@
                         <a class="btn btn-sm" href="{{ path('_profiler', { token: 'latest' }|merge(request.query.all)) }}">Latest</a>
 
                         <a class="sf-toggle btn btn-sm" data-toggle-selector="#sidebar-search" {% if tokens is defined or about is defined %}data-toggle-initial="display"{% endif %}>
-                            {{ include('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>
+                            {{ source('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>
                         </a>
 
                         {{ render(controller('web_profiler.controller.profiler::searchBarAction', request.query.all)) }}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -2,7 +2,7 @@
 
 {% macro profile_search_filter(request, result, property) %}
     {%- if request.hasSession -%}
-        <a href="{{ path('_profiler_search_results', request.query.all|merge({token: result.token})|merge({ (property): result[property] })) }}" title="Search"><span title="Search" class="sf-icon sf-search">{{ include('@WebProfiler/Icon/search.svg') }}</span></a>
+        <a href="{{ path('_profiler_search_results', request.query.all|merge({token: result.token})|merge({ (property): result[property] })) }}" title="Search"><span title="Search" class="sf-icon sf-search">{{ source('@WebProfiler/Icon/search.svg') }}</span></a>
     {%- endif -%}
 {% endmacro %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -1,7 +1,7 @@
 <!-- START of Symfony Web Debug Toolbar -->
 <div id="sfMiniToolbar-{{ token }}" class="sf-minitoolbar" data-no-turbolink>
     <button type="button" title="Show Symfony toolbar" id="sfToolbarMiniToggler-{{ token }}" accesskey="D" aria-expanded="false" aria-controls="sfToolbarMainContent-{{ token }}">
-        {{ include('@WebProfiler/Icon/symfony.svg') }}
+        {{ source('@WebProfiler/Icon/symfony.svg') }}
     </button>
 </div>
 <div id="sfToolbarClearer-{{ token }}" class="sf-toolbar-clearer"></div>
@@ -40,7 +40,7 @@
     {% endif %}
 
     <button class="hide-button" type="button" id="sfToolbarHideButton-{{ token }}" title="Close Toolbar" accesskey="D" aria-expanded="true" aria-controls="sfToolbarMainContent-{{ token }}">
-        {{ include('@WebProfiler/Icon/close.svg') }}
+        {{ source('@WebProfiler/Icon/close.svg') }}
     </button>
 </div>
 <!-- END of Symfony Web Debug Toolbar -->

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -1,12 +1,12 @@
 <div id="sfwdt{{ token }}" class="sf-toolbar sf-display-none" role="region" aria-label="Symfony Web Debug Toolbar">
-    {% include('@WebProfiler/Profiler/toolbar.html.twig') with {
+    {{ include('@WebProfiler/Profiler/toolbar.html.twig', {
         templates: {
             'request': '@WebProfiler/Profiler/cancel.html.twig'
         },
         profile: null,
         profiler_url: url('_profiler', {token: token}),
         profiler_markup_version: 2,
-    } %}
+    }) }}
 </div>
 
 {{ include('@WebProfiler/Profiler/base_js.html.twig') }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

- Use the `source()` function to include static assets. Avoids twig parsing and compilation and prevents potential syntax error.
- Replace `{% include %}` with `{{ include() }}` where remaining.