### PR TITLE
[Serializer] Try all possible denormalization route with union types when ALLOW_EXTRA_ATTRIBUTES=false

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -370,7 +370,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             }
         }
 
-        if (!empty($extraAttributes)) {
+        if ($extraAttributes) {
             throw new ExtraAttributesException($extraAttributes);
         }
 
@@ -405,6 +405,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         $expectedTypes = [];
         $isUnionType = \count($types) > 1;
+        $extraAttributesException = null;
         foreach ($types as $type) {
             if (null === $data && $type->isNullable()) {
                 return null;
@@ -494,7 +495,19 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 if (!$isUnionType) {
                     throw $e;
                 }
+            } catch (ExtraAttributesException $e) {
+                if (!$isUnionType) {
+                    throw $e;
+                }
+
+                if (!$extraAttributesException) {
+                    $extraAttributesException = $e;
+                }
             }
+        }
+
+        if ($extraAttributesException) {
+            throw $extraAttributesException;
         }
 
         if ($context[self::DISABLE_TYPE_ENFORCEMENT] ?? $this->defaultContext[self::DISABLE_TYPE_ENFORCEMENT] ?? false) {

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -31,6 +32,7 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
@@ -573,6 +575,35 @@ class SerializerTest extends TestCase
         $this->assertEquals(new DummyUnionType(), $actual, 'Union type denormalization third case failed.');
     }
 
+    public function testUnionTypeDeserializableWithoutAllowedExtraAttributes()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+        $serializer = new Serializer(
+            [
+                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, new ClassDiscriminatorFromClassMetadata($classMetadataFactory)),
+            ],
+            ['json' => new JsonEncoder()]
+        );
+
+        $actual = $serializer->deserialize('{ "v": { "a": 0 }}', DummyUnionWithAAndB::class, 'json', [
+            AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
+        ]);
+
+        $this->assertEquals(new DummyUnionWithAAndB(new DummyATypeForUnion()), $actual);
+
+        $actual = $serializer->deserialize('{ "v": { "b": 1 }}', DummyUnionWithAAndB::class, 'json', [
+            AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
+        ]);
+
+        $this->assertEquals(new DummyUnionWithAAndB(new DummyBTypeForUnion()), $actual);
+
+        $this->expectException(ExtraAttributesException::class);
+        $serializer->deserialize('{ "v": { "b": 1, "c": "i am not allowed" }}', DummyUnionWithAAndB::class, 'json', [
+            AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
+        ]);
+    }
+
     /**
      * @requires PHP 8.2
      */
@@ -675,6 +706,30 @@ class DummyUnionType
         $this->changed = $changed;
 
         return $this;
+    }
+}
+
+class DummyATypeForUnion
+{
+    public $a = 0;
+}
+
+class DummyBTypeForUnion
+{
+    public $b = 1;
+}
+
+class DummyUnionWithAAndB
+{
+    /** @var DummyATypeForUnion|DummyBTypeForUnion */
+    public $v;
+
+    /**
+     * @param DummyATypeForUnion|DummyBTypeForUnion $v
+     */
+    public function __construct($v)
+    {
+        $this->v = $v;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #45860
| License       | MIT
| Doc PR        | -

I found a similar bug, (I think this is a bug, but it is possible, it is an intended behaviour) to my previous report.
