### PR TITLE
[HttpKernel] Add timezone to DateTimeValueResolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/MapDateTime.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapDateTime.php
@@ -18,7 +18,8 @@ namespace Symfony\Component\HttpKernel\Attribute;
 class MapDateTime
 {
     public function __construct(
-        public readonly ?string $format = null
+        public readonly ?string $format = null,
+        public readonly ?string $timezone = null,
     ) {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | todo

## Motivation:

This was a source of confusion and bugs when working with SensioFrameworkExtraBundle's `DateTimeParamConverter` (3rd case is default and worse behavior). 

1. `$format` specified: `DateTime::fromFormat($format, $value)` parses the date using the **default timezone**. The output has the timezone specified in `$value` (and expected by `$format`), or the **default timezone**.
2. Timestamp: `new DateTime('@'.$timestamp)` parses the timestamp in **UTC**. The output has the timezone **UTC**.
3. Otherwise: `new DateTime('@'.strtotime($value))` parses the date using the **default timezone**. The output has the timezone **UTC**. *This is confusing*.

## Proposed change

The new option `timezone` forces the timezone of parser and output.

```php
    public function __invoke(
        #[MapDateTime(timezone: 'Antarctica/Troll')] \DateTimeInterface $date
    )
    // 2022-06-01 08:10:00 becomes 2022-06-01 08:10:00.0 Antarctica/Troll (+02:00)
    // 2022-06-01 08:10:00+05:00 becomes 2022-06-01 05:10:00.0 Antarctica/Troll (+02:00)

    public function __invoke(
        \DateTimeInterface $date
    )
    // 2022-06-01 08:10:00 becomes 2022-06-01 06:10:00.0 +00:00
    // 2022-06-01 08:10:00+05:00 becomes 2022-06-01 03:10:00.0 +00:00
```

Why not just set the default timezone? Because it can be different from one argument to an other.

```php
    public function __invoke(
        #[MapDateTime(timezone: 'Antarctica/Troll')] \DateTimeInterface $localDate
        #[MapDateTime(timezone: 'UTC')] \DateTimeInterface $universalDate
    )
```

This option is also useful to specify output timezone while requiring a timezone in the input format.

```php
    public function __invoke(
        #[MapDateTime('Y-m-d H:i:sP', timezone: 'UTC')] \DateTimeInterface $date
    )
    // 2022-06-01 08:10:00+05:00 becomes 2022-06-01 03:10:00.0 +00:00

    public function __invoke(
        #[MapDateTime('Y-m-d H:i:sP')] \DateTimeInterface $date
    )
    // 2022-06-01 08:10:00+05:00 becomes 2022-06-01 08:10:00 +05:00
```

The special value `timezone: 'default'` will get the current default timezone from `date_default_timezone_get()`.