### PR TITLE
[HttpFoundation] Allow dynamic session "ttl" when using a remote storage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -77,7 +77,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('session.abstract_handler', AbstractSessionHandler::class)
             ->factory([SessionHandlerFactory::class, 'createHandler'])
-            ->args([abstract_arg('A string or a connection object')])
+            ->args([abstract_arg('A string or a connection object'), []])
 
         ->set('session_listener', SessionListener::class)
             ->args([

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add stale while revalidate and stale if error cache header
+ * Allow dynamic session "ttl" when using a remote storage
 
 6.0
 ---

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -26,7 +26,7 @@ class MemcachedSessionHandler extends AbstractSessionHandler
     /**
      * Time to live in seconds.
      */
-    private ?int $ttl;
+    private int|\Closure|null $ttl;
 
     /**
      * Key prefix for shared environments.
@@ -69,7 +69,8 @@ class MemcachedSessionHandler extends AbstractSessionHandler
 
     public function updateTimestamp(string $sessionId, string $data): bool
     {
-        $this->memcached->touch($this->prefix.$sessionId, time() + (int) ($this->ttl ?? ini_get('session.gc_maxlifetime')));
+        $ttl = ($this->ttl instanceof \Closure ? ($this->ttl)() : $this->ttl) ?? ini_get('session.gc_maxlifetime');
+        $this->memcached->touch($this->prefix.$sessionId, time() + (int) $ttl);
 
         return true;
     }
@@ -79,7 +80,9 @@ class MemcachedSessionHandler extends AbstractSessionHandler
      */
     protected function doWrite(string $sessionId, string $data): bool
     {
-        return $this->memcached->set($this->prefix.$sessionId, $data, time() + (int) ($this->ttl ?? ini_get('session.gc_maxlifetime')));
+        $ttl = ($this->ttl instanceof \Closure ? ($this->ttl)() : $this->ttl) ?? ini_get('session.gc_maxlifetime');
+
+        return $this->memcached->set($this->prefix.$sessionId, $data, time() + (int) $ttl);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -80,6 +80,11 @@ class PdoSessionHandler extends AbstractSessionHandler
     private string $timeCol = 'sess_time';
 
     /**
+     * Time to live in seconds.
+     */
+    private int|\Closure|null $ttl;
+
+    /**
      * Username when lazy-connect.
      */
     private string $username = '';
@@ -137,6 +142,7 @@ class PdoSessionHandler extends AbstractSessionHandler
      *  * db_password: The password when lazy-connect [default: '']
      *  * db_connection_options: An array of driver-specific connection options [default: []]
      *  * lock_mode: The strategy for locking, see constants [default: LOCK_TRANSACTIONAL]
+     *  * ttl: The time to live in seconds.
      *
      * @param \PDO|string|null $pdoOrDsn A \PDO instance or DSN string or URL string or null
      *
@@ -166,6 +172,7 @@ class PdoSessionHandler extends AbstractSessionHandler
         $this->password = $options['db_password'] ?? $this->password;
         $this->connectionOptions = $options['db_connection_options'] ?? $this->connectionOptions;
         $this->lockMode = $options['lock_mode'] ?? $this->lockMode;
+        $this->ttl = $options['ttl'] ?? null;
     }
 
     /**
@@ -275,7 +282,7 @@ class PdoSessionHandler extends AbstractSessionHandler
      */
     protected function doWrite(string $sessionId, string $data): bool
     {
-        $maxlifetime = (int) ini_get('session.gc_maxlifetime');
+        $maxlifetime = (int) (($this->ttl instanceof \Closure ? ($this->ttl)() : $this->ttl) ?? ini_get('session.gc_maxlifetime'));
 
         try {
             // We use a single MERGE SQL query when supported by the database.
@@ -318,7 +325,7 @@ class PdoSessionHandler extends AbstractSessionHandler
 
     public function updateTimestamp(string $sessionId, string $data): bool
     {
-        $expiry = time() + (int) ini_get('session.gc_maxlifetime');
+        $expiry = time() + (int) (($this->ttl instanceof \Closure ? ($this->ttl)() : $this->ttl) ?? ini_get('session.gc_maxlifetime'));
 
         try {
             $updateStmt = $this->pdo->prepare(

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
@@ -164,6 +164,19 @@ abstract class AbstractRedisSessionHandlerTestCase extends TestCase
 
         $this->assertLessThan($redisTtl, $ttl - 5);
         $this->assertGreaterThan($redisTtl, $ttl + 5);
+
+        $options = [
+            'prefix' => self::PREFIX,
+            'ttl' => fn () => $ttl,
+        ];
+
+        $handler = new RedisSessionHandler($this->redisClient, $options);
+        $handler->write('id', 'data');
+        $redisTtl = $this->redisClient->ttl(self::PREFIX.'id');
+
+        $this->assertLessThan($redisTtl, $ttl - 5);
+        $this->assertGreaterThan($redisTtl, $ttl + 5);
+
     }
 
     public function getTtlFixtures(): array

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -134,7 +134,7 @@ class MemcachedSessionHandlerTest extends TestCase
         return [
             [['prefix' => 'session'], true],
             [['expiretime' => 100], true],
-            [['prefix' => 'session', 'expiretime' => 200], true],
+            [['prefix' => 'session', 'ttl' => 200], true],
             [['expiretime' => 100, 'foo' => 'bar'], false],
         ];
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -345,6 +345,21 @@ class PdoSessionHandlerTest extends TestCase
         yield ['mssql://localhost:56/test', 'sqlsrv:server=localhost,56;Database=test'];
     }
 
+    public function testTtl()
+    {
+        foreach ([60, fn () => 60] as $ttl) {
+            $pdo = $this->getMemorySqlitePdo();
+            $storage = new PdoSessionHandler($pdo, ['ttl' => $ttl]);
+
+            $storage->open('', 'sid');
+            $storage->read('id');
+            $storage->write('id', 'data');
+            $storage->close();
+
+            $this->assertEqualsWithDelta(time() + 60, $pdo->query('SELECT sess_lifetime FROM sessions')->fetchColumn(), 5);
+        }
+    }
+
     /**
      * @return resource
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionHandlerFactoryTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionHandlerFactoryTest.php
@@ -71,5 +71,9 @@ class SessionHandlerFactoryTest extends TestCase
 
         $ttlProperty = $reflection->getProperty('ttl');
         $this->assertSame(3600, $ttlProperty->getValue($handler));
+
+        $handler = SessionHandlerFactory::createHandler('redis://localhost?prefix=foo&ttl=3600&ignored=bar', ['ttl' => function () { return 123; }]);
+
+        $this->assertInstanceOf(\Closure::class, $reflection->getProperty('ttl')->getValue($handler));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #44368
| License       | MIT
| Doc PR        | -

This is my proposal instead of #44368. My goal here it to *not* make the session handler mutable.
Instead, I propose to allow defining the "ttl" option as a closure.
Here is how this would work in practice:

```yaml
services:
  my.session.handler:
    parent: session.abstract_handler
    arguments:
      index_0: 'redis://localhost'
      index_1: {ttl: !closure ['@my.ttl.handler']}
```

Where `my.ttl.handler` would be an invokable that returns the ttl for the current user (based on the session object from the request stack, or from the token storage I suppose).

/cc @Seldaek I'd be happy to have your thoughts here (and also your help for tests/doc ideally :angel:)