### PR TITLE
[HttpKernel]  Resolve DateTime values with default timezone

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
@@ -62,10 +62,15 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface
             if ($class::getLastErrors()['warning_count']) {
                 $date = false;
             }
-        } elseif (false !== filter_var($value, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]])) {
-            $date = new $class('@'.$value);
-        } elseif (false !== $timestamp = strtotime($value))  {
-            $date = new $class('@'.$timestamp);
+        } else {
+            if (false !== filter_var($value, \FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]])) {
+                $value = '@'.$value;
+            }
+            try {
+                $date = new $class($value);
+            } catch (\Exception $e) {
+                $date = false;
+            }
         }
 
         if (!$date) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/45865#issuecomment-1081040415
| License       | MIT
| Doc PR        | -

Alternative to #45865 by Nicolas Grekas.

Make sure the date input is parsed using the default timezone and the resulting `DateTimeInterface` instance has the default timezone. Except for timestamps, which are UTC by standard.