### PR TITLE
[ExpressionLanguage] Fix matches when the regexp is not valid

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ExpressionLanguage\Node;
 
 use Symfony\Component\ExpressionLanguage\Compiler;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -46,8 +47,12 @@ class BinaryNode extends Node
         $operator = $this->attributes['operator'];
 
         if ('matches' == $operator) {
+            if ($this->nodes['right'] instanceof ConstantNode) {
+                $this->evaluateMatches($this->nodes['right']->evaluate([], []), '');
+            }
+
             $compiler
-                ->raw('preg_match(')
+                ->raw('(static function ($regexp, $str) { set_error_handler(function ($t, $m) use ($regexp, $str) { throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr($m, 12)); }); try { return preg_match($regexp, $str); } finally { restore_error_handler(); } })(')
                 ->compile($this->nodes['right'])
                 ->raw(', ')
                 ->compile($this->nodes['left'])
@@ -159,12 +164,24 @@ class BinaryNode extends Node
 
                 return $left % $right;
             case 'matches':
-                return preg_match($right, $left);
+                return $this->evaluateMatches($right, $left);
         }
     }
 
     public function toArray()
     {
         return ['(', $this->nodes['left'], ' '.$this->attributes['operator'].' ', $this->nodes['right'], ')'];
+    }
+
+    private function evaluateMatches(string $regexp, string $str): int
+    {
+        set_error_handler(function ($t, $m) use ($regexp) {
+            throw new SyntaxError(sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr($m, 12));
+        });
+        try {
+            return preg_match($regexp, $str);
+        } finally {
+            restore_error_handler();
+        }
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
@@ -11,9 +11,12 @@
 
 namespace Symfony\Component\ExpressionLanguage\Tests\Node;
 
+use Symfony\Component\ExpressionLanguage\Compiler;
 use Symfony\Component\ExpressionLanguage\Node\ArrayNode;
 use Symfony\Component\ExpressionLanguage\Node\BinaryNode;
 use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
+use Symfony\Component\ExpressionLanguage\Node\NameNode;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
 
 class BinaryNodeTest extends AbstractNodeTest
 {
@@ -111,7 +114,7 @@ class BinaryNodeTest extends AbstractNodeTest
 
             ['range(1, 3)', new BinaryNode('..', new ConstantNode(1), new ConstantNode(3))],
 
-            ['preg_match("/^[a-z]+/i\$/", "abc")', new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('/^[a-z]+/i$/'))],
+            ['(static function ($regexp, $str) { set_error_handler(function ($t, $m) use ($regexp, $str) { throw new \Symfony\Component\ExpressionLanguage\SyntaxError(sprintf(\'Regexp "%s" passed to "matches" is not valid\', $regexp).substr($m, 12)); }); try { return preg_match($regexp, $str); } finally { restore_error_handler(); } })("/^[a-z]+\$/", "abc")', new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('/^[a-z]+$/'))],
         ];
     }
 
@@ -160,7 +163,42 @@ class BinaryNodeTest extends AbstractNodeTest
 
             ['(1 .. 3)', new BinaryNode('..', new ConstantNode(1), new ConstantNode(3))],
 
-            ['("abc" matches "/^[a-z]+/i$/")', new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('/^[a-z]+/i$/'))],
+            ['("abc" matches "/^[a-z]+$/")', new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('/^[a-z]+$/'))],
         ];
+    }
+
+    public function testEvaluateMatchesWithInvalidRegexp()
+    {
+        $node = new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('this is not a regexp'));
+
+        $this->expectExceptionObject(new SyntaxError('Regexp "this is not a regexp" passed to "matches" is not valid: Delimiter must not be alphanumeric or backslash'));
+        $node->evaluate([], []);
+    }
+
+    public function testEvaluateMatchesWithInvalidRegexpAsExpression()
+    {
+        $node = new BinaryNode('matches', new ConstantNode('abc'), new NameNode('regexp'));
+
+        $this->expectExceptionObject(new SyntaxError('Regexp "this is not a regexp" passed to "matches" is not valid: Delimiter must not be alphanumeric or backslash'));
+        $node->evaluate([], ['regexp' => 'this is not a regexp']);
+    }
+
+    public function testCompileMatchesWithInvalidRegexp()
+    {
+        $node = new BinaryNode('matches', new ConstantNode('abc'), new ConstantNode('this is not a regexp'));
+
+        $this->expectExceptionObject(new SyntaxError('Regexp "this is not a regexp" passed to "matches" is not valid: Delimiter must not be alphanumeric or backslash'));
+        $compiler = new Compiler([]);
+        $node->compile($compiler);
+    }
+
+    public function testCompileMatchesWithInvalidRegexpAsExpression()
+    {
+        $node = new BinaryNode('matches', new ConstantNode('abc'), new NameNode('regexp'));
+
+        $this->expectExceptionObject(new SyntaxError('Regexp "this is not a regexp" passed to "matches" is not valid: Delimiter must not be alphanumeric or backslash'));
+        $compiler = new Compiler([]);
+        $node->compile($compiler);
+        eval('$regexp = "this is not a regexp"; '.$compiler->getSource().';');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a
