### PR TITLE
Add BC layer to handle old objects already present in cache

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -114,6 +114,18 @@ final class SlidingWindow implements LimiterStateInterface
 
     public function __unserialize(array $data): void
     {
+        // BC layer for old objects serialized via __sleep
+        if (5 === \count($data)) {
+            $data = array_values($data);
+            $this->id = $data[0];
+            $this->hitCount = $data[1];
+            $this->intervalInSeconds = $data[2];
+            $this->hitCountForLastWindow = $data[3];
+            $this->windowEndAt = $data[4];
+
+            return;
+        }
+
         $pack = key($data);
         $this->windowEndAt = $data[$pack];
         ['a' => $this->hitCount, 'b' => $this->hitCountForLastWindow, 'c' => $this->intervalInSeconds] = unpack('Na/Nb/Nc', $pack);

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
@@ -98,6 +98,18 @@ final class TokenBucket implements LimiterStateInterface
 
     public function __unserialize(array $data): void
     {
+        // BC layer for old objects serialized via __sleep
+        if (5 === \count($data)) {
+            $data = array_values($data);
+            $this->id = $data[0];
+            $this->tokens = $data[1];
+            $this->timer = $data[2];
+            $this->burstSize = $data[3];
+            $this->rate = Rate::fromString($data[4]);
+
+            return;
+        }
+
         [$this->tokens, $this->timer] = array_values($data);
         [$pack, $rate] = array_keys($data);
         $this->rate = Rate::fromString($rate);

--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -96,6 +96,18 @@ final class Window implements LimiterStateInterface
 
     public function __unserialize(array $data): void
     {
+        // BC layer for old objects serialized via __sleep
+        if (5 === \count($data)) {
+            $data = array_values($data);
+            $this->id = $data[0];
+            $this->hitCount = $data[1];
+            $this->intervalInSeconds = $data[2];
+            $this->maxSize = $data[3];
+            $this->timer = $data[4];
+
+            return;
+        }
+
         [$this->timer, $this->maxSize] = array_values($data);
         [$this->id, $pack] = array_keys($data);
         ['a' => $this->hitCount, 'b' => $this->intervalInSeconds] = unpack('Na/Nb', $pack);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Refs https://github.com/symfony/symfony/pull/44996
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When reloading an old RateLimiter instance from cache with the new code I did get an exception because windowEndAt was a string and getHitCount does windowEndAt - intervalInSeconds, and string - int fails.

The reason is the new code assigns the id to windowEndAt via:

```
        $pack = key($data);
        $this->windowEndAt = $data[$pack];
```

I dumped $this and  $data in __unserialize just FYI and you get this:

```
object(Symfony\Component\RateLimiter\Policy\SlidingWindow)[959]
  private 'id' => null
  private 'hitCount' => int 0
  private 'hitCountForLastWindow' => int 0
  private 'intervalInSeconds' => null
  private 'windowEndAt' => null
```

```
array (size=5)
  '�Symfony\Component\RateLimiter\Policy\SlidingWindow�id' => string 'login_per_ip-127.0.0.1' (length=22)
  '�Symfony\Component\RateLimiter\Policy\SlidingWindow�hitCount' => int 2
  '�Symfony\Component\RateLimiter\Policy\SlidingWindow�intervalInSeconds' => int 60
  '�Symfony\Component\RateLimiter\Policy\SlidingWindow�hitCountForLastWindow' => int 0
  '�Symfony\Component\RateLimiter\Policy\SlidingWindow�windowEndAt' => float 1648544909.4762
```

I only tested the code in real conditions for SlidingWindow, but I do believe/hope the same applies for the other two policies.