### PR TITLE
[Console] Render all throwables the same, including \Error subclasses

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -147,7 +147,7 @@ class Application implements ResetInterface
 
         try {
             $exitCode = $this->doRun($input, $output);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             if (!$this->catchExceptions) {
                 throw $e;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I'm not sure why only \Exception was caught here. These should also be included and rendered nicely IMO:

```
Error
  ArithmeticError
    DivisionByZeroError
  AssertionError
  CompileError
    ParseError
  TypeError
    ArgumentCountError
  UnhandledMatchError
  ValueError
```

I believe it's an omission and hence worth a bugfix, but maybe I missed something.