### PR TITLE
[PropertyInfo] PhpStanExtractor namespace missmatch issue

### DIFF
--- a/src/Symfony/Component/PropertyInfo/PhpStan/NameScope.php
+++ b/src/Symfony/Component/PropertyInfo/PhpStan/NameScope.php
@@ -22,14 +22,14 @@ namespace Symfony\Component\PropertyInfo\PhpStan;
  */
 final class NameScope
 {
-    private $className;
+    private $calledClassName;
     private $namespace;
     /** @var array<string, string> alias(string) => fullName(string) */
     private $uses;
 
-    public function __construct(string $className, string $namespace, array $uses = [])
+    public function __construct(string $calledClassName, string $namespace, array $uses = [])
     {
-        $this->className = $className;
+        $this->calledClassName = $calledClassName;
         $this->namespace = $namespace;
         $this->uses = $uses;
     }
@@ -60,6 +60,6 @@ final class NameScope
 
     public function resolveRootClass(): string
     {
-        return $this->resolveStringName($this->className);
+        return $this->resolveStringName($this->calledClassName);
     }
 }

--- a/src/Symfony/Component/PropertyInfo/PhpStan/NameScopeFactory.php
+++ b/src/Symfony/Component/PropertyInfo/PhpStan/NameScopeFactory.php
@@ -20,16 +20,18 @@ use phpDocumentor\Reflection\Types\ContextFactory;
  */
 final class NameScopeFactory
 {
-    public function create(string $fullClassName): NameScope
+    public function create(string $calledClassName, string $declaringClassName = null): NameScope
     {
-        $reflection = new \ReflectionClass($fullClassName);
-        $path = explode('\\', $fullClassName);
-        $className = array_pop($path);
-        [$namespace, $uses] = $this->extractFromFullClassName($reflection);
+        $declaringClassName = $declaringClassName ?? $calledClassName;
 
-        $uses = array_merge($uses, $this->collectUses($reflection));
+        $path = explode('\\', $calledClassName);
+        $calledClassName = array_pop($path);
 
-        return new NameScope($className, $namespace, $uses);
+        $declaringReflection = new \ReflectionClass($declaringClassName);
+        [$declaringNamespace, $declaringUses] = $this->extractFromFullClassName($declaringReflection);
+        $declaringUses = array_merge($declaringUses, $this->collectUses($declaringReflection));
+
+        return new NameScope($calledClassName, $declaringNamespace, $declaringUses);
     }
 
     private function collectUses(\ReflectionClass $reflection): array

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
@@ -20,6 +21,8 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\RootDummy\RootDummyItem;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type;
+
+require_once __DIR__.'/../Fixtures/Extractor/DummyNamespace.php';
 
 /**
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
@@ -31,9 +34,15 @@ class PhpStanExtractorTest extends TestCase
      */
     private $extractor;
 
+    /**
+     * @var PhpDocExtractor
+     */
+    private $phpDocExtractor;
+
     protected function setUp(): void
     {
         $this->extractor = new PhpStanExtractor();
+        $this->phpDocExtractor = new PhpDocExtractor();
     }
 
     /**
@@ -382,6 +391,15 @@ class PhpStanExtractorTest extends TestCase
             [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')],
             $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DummyNamespace', 'dummy')
         );
+    }
+
+    public function testDummyNamespaceWithProperty()
+    {
+        $phpStanTypes = $this->extractor->getTypes(\B\Dummy::class, 'property');
+        $phpDocTypes = $this->phpDocExtractor->getTypes(\B\Dummy::class, 'property');
+
+        $this->assertEquals('A\Property', $phpStanTypes[0]->getClassName());
+        $this->assertEquals($phpDocTypes[0]->getClassName(), $phpStanTypes[0]->getClassName());
     }
 }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/DummyNamespace.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/DummyNamespace.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace A {
+    class Property {
+
+    }
+
+    class Dummy {
+        /**
+         * @var Property
+         */
+        public $property;
+    }
+}
+
+namespace B {
+    class Dummy extends \A\Dummy {
+
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44431 
| License       | MIT
| Doc PR        | N/A

Thanks to @isypov-andrey report, we found out an issue with namespace matching and the PhpStanExtractor.
In this PR I'm fixing this issue.

- [x] Test to validate the issue
- [x] Fix