### PR TITLE
[VarExporter] Fix exporting objects with readonly properties

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -140,7 +140,7 @@ class Exporter
                 $i = 0;
                 $n = (string) $name;
                 if ('' === $n || "\0" !== $n[0]) {
-                    $c = 'stdClass';
+                    $c = \PHP_VERSION_ID >= 80100 && $reflector->hasProperty($n) && ($p = $reflector->getProperty($n))->isReadOnly() ? $p->class : 'stdClass';
                 } elseif ('*' === $n[1]) {
                     $n = substr($n, 3);
                     $c = $reflector->getProperty($n)->class;

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/FooReadonly.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/FooReadonly.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures;
+
+class FooReadonly
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $value,
+    ) {
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/readonly.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/readonly.php
@@ -1,0 +1,20 @@
+<?php
+
+return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
+    $o = [
+        clone (\Symfony\Component\VarExporter\Internal\Registry::$prototypes['Symfony\\Component\\VarExporter\\Tests\\Fixtures\\FooReadonly'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('Symfony\\Component\\VarExporter\\Tests\\Fixtures\\FooReadonly')),
+    ],
+    null,
+    [
+        'Symfony\\Component\\VarExporter\\Tests\\Fixtures\\FooReadonly' => [
+            'name' => [
+                'k',
+            ],
+            'value' => [
+                'v',
+            ],
+        ],
+    ],
+    $o[0],
+    []
+);

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 use Symfony\Component\VarExporter\Exception\ClassNotFoundException;
 use Symfony\Component\VarExporter\Exception\NotInstantiableTypeException;
 use Symfony\Component\VarExporter\Internal\Registry;
+use Symfony\Component\VarExporter\Tests\Fixtures\FooReadonly;
 use Symfony\Component\VarExporter\Tests\Fixtures\FooSerializable;
 use Symfony\Component\VarExporter\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\VarExporter\Tests\Fixtures\MySerializable;
@@ -244,9 +245,12 @@ class VarExporterTest extends TestCase
 
         yield ['php74-serializable', new Php74Serializable()];
 
-        if (\PHP_VERSION_ID >= 80100) {
-            yield ['unit-enum', [FooUnitEnum::Bar], true];
+        if (\PHP_VERSION_ID < 80100) {
+            return;
         }
+
+        yield ['unit-enum', [FooUnitEnum::Bar], true];
+        yield ['readonly', new FooReadonly('k', 'v')];
     }
 
     public function testUnicodeDirectionality()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45886
| License       | MIT
| Doc PR        | -