### PR TITLE
[HttpClient] on redirections don't send content related request headers

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -204,9 +204,11 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
         $hasContentLength = isset($options['normalized_headers']['content-length'][0]);
 
-        foreach ($options['headers'] as $header) {
+        foreach ($options['headers'] as $i => $header) {
             if ($hasContentLength && 0 === stripos($header, 'Content-Length:')) {
-                continue; // Let curl handle Content-Length headers
+                // Let curl handle Content-Length headers
+                unset($options['headers'][$i]);
+                continue;
             }
             if (':' === $header[-2] && \strlen($header) - 2 === strpos($header, ': ')) {
                 // curl requires a special syntax to send empty headers

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -430,9 +430,12 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
                 if ('POST' === $options['method'] || 303 === $info['http_code']) {
                     $info['http_method'] = $options['method'] = 'HEAD' === $options['method'] ? 'HEAD' : 'GET';
                     $options['content'] = '';
-                    $options['header'] = array_filter($options['header'], static function ($h) {
+                    $filterContentHeaders = static function ($h) {
                         return 0 !== stripos($h, 'Content-Length:') && 0 !== stripos($h, 'Content-Type:');
-                    });
+                    };
+                    $options['header'] = array_filter($options['header'], $filterContentHeaders);
+                    $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], $filterContentHeaders);
+                    $redirectHeaders['with_auth'] = array_filter($redirectHeaders['with_auth'], $filterContentHeaders);
 
                     stream_context_set_option($context, ['http' => $options]);
                 }

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -194,6 +194,18 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertSame(['abc' => 'def', 'REQUEST_METHOD' => 'POST'], $body);
     }
 
+    public function testDropContentRelatedHeadersWhenFollowingRequestIsUsingGet()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $response = $client->request('POST', 'http://localhost:8057/302', [
+            'body' => 'foo',
+            'headers' => ['Content-Length: 3'],
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
     public function testNegativeTimeout()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45709, #45735
| License       | MIT
| Doc PR        | 