### PR TITLE
[Filesystem] Missing return type in getFilenameWithoutExtension function

### DIFF
--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -257,7 +257,7 @@ final class Path
      * @param string|null $extension if specified, only that extension is cut
      *                               off (may contain leading dot)
      */
-    public static function getFilenameWithoutExtension(string $path, string $extension = null)
+    public static function getFilenameWithoutExtension(string $path, string $extension = null): string
     {
         if ('' === $path) {
             return '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Missing "**string**" return type in getFilenameWithoutExtension function.
