### PR TITLE
[Messenger] reset connection on worker shutdown

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Worker;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @group time-sensitive
@@ -83,6 +84,19 @@ class WorkerTest extends TestCase
 
         $this->assertSame(1, $receiver->getRejectCount());
         $this->assertSame(0, $receiver->getAcknowledgeCount());
+    }
+
+    public function testWorkerResetsConnectionIfReceiverIsResettable()
+    {
+        $resettableReceiver = new ResettableDummyReceiver([]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $dispatcher = new EventDispatcher();
+
+        $worker = new Worker([$resettableReceiver], $bus, $dispatcher);
+        $worker->stop();
+        $worker->run();
+        $this->assertTrue($resettableReceiver->hasBeenReset());
     }
 
     public function testWorkerDoesNotSendNullMessagesToTheBus()
@@ -281,5 +295,20 @@ class DummyReceiver implements ReceiverInterface
     public function getRejectCount(): int
     {
         return $this->rejectCount;
+    }
+}
+
+class ResettableDummyReceiver extends DummyReceiver implements ResetInterface
+{
+    private $hasBeenReset = false;
+
+    public function reset()
+    {
+        $this->hasBeenReset = true;
+    }
+
+    public function hasBeenReset(): bool
+    {
+        return $this->hasBeenReset;
     }
 }

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -25,6 +25,7 @@ use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
@@ -102,6 +103,7 @@ class Worker
         }
 
         $this->dispatchEvent(new WorkerStoppedEvent($this));
+        $this->resetReceiverConnections();
     }
 
     private function handleMessage(Envelope $envelope, ReceiverInterface $receiver, string $transportName): void
@@ -153,6 +155,15 @@ class Worker
     public function stop(): void
     {
         $this->shouldStop = true;
+    }
+
+    private function resetReceiverConnections(): void
+    {
+        foreach ($this->receivers as $transportName => $receiver) {
+            if ($receiver instanceof ResetInterface) {
+                $receiver->reset();
+            }
+        }
     }
 
     private function dispatchEvent($event)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45778 
| License       | MIT

As seen in the issue. Amazon SQS transport uses a buffer. Messages can be lost when the buffer contains these messages and some container executing the process is shut down. The connection contains a [reset](https://github.com/symfony/amazon-sqs-messenger/blob/5.4/Transport/Connection.php#L366) method and implements the `ResetInterface`. If this method were to be called on shutdown the messages will be marked as visible again.
