### PR TITLE
[PHPUnitBridge] Fix max threshold when only ignoreFile is set in SYMFONY_DEPRECATIONS_HELPER

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -310,7 +310,7 @@ class Configuration
         }
 
         $normalizedConfiguration += [
-            'max' => [],
+            'max' => ['total' => 0],
             'disabled' => false,
             'verbose' => true,
             'quiet' => [],
@@ -336,7 +336,7 @@ class Configuration
         }
 
         return new self(
-            $normalizedConfiguration['max'] ?? [],
+            $normalizedConfiguration['max'],
             '',
             $verboseOutput,
             $normalizedConfiguration['ignoreFile'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #45919  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
