### PR TITLE
[VarExporter] Fix syntax that makes psalm crash

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Registry.php
+++ b/src/Symfony/Component/VarExporter/Internal/Registry.php
@@ -59,8 +59,9 @@ class Registry
     public static function f($class)
     {
         $reflector = self::$reflectors[$class] ?? self::getClassReflector($class, true, false);
+        self::$factories[$class] = $reflector->newInstanceWithoutConstructor(...);
 
-        return self::$factories[$class] = $reflector->newInstanceWithoutConstructor(...);
+        return self::$factories[$class];
     }
 
     public static function getClassReflector($class, $instantiableWithoutConstructor = false, $cloneable = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Should make running psalm possible again.

/cc @orklah FYI, running this code (before the change proposed her) with dev-master crashes:
`plasm --set-baseline=.github/psalm/psalm.baseline.xml --no-progress src/Symfony/Component/VarExporter/` 