### PR TITLE
[Process] Fix Process::getEnv() when setEnv() hasn't been called before

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -53,7 +53,7 @@ class Process implements \IteratorAggregate
     private $hasCallback = false;
     private $commandline;
     private $cwd;
-    private $env;
+    private $env = [];
     private $input;
     private $starttime;
     private $lastOutputTime;

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1505,8 +1505,11 @@ class ProcessTest extends TestCase
 
     public function testEnvArgument()
     {
-        $env = ['FOO' => 'Foo', 'BAR' => 'Bar'];
         $cmd = '\\' === \DIRECTORY_SEPARATOR ? 'echo !FOO! !BAR! !BAZ!' : 'echo $FOO $BAR $BAZ';
+        $p = Process::fromShellCommandline($cmd);
+        $this->assertSame([], $p->getEnv());
+
+        $env = ['FOO' => 'Foo', 'BAR' => 'Bar'];
         $p = Process::fromShellCommandline($cmd, null, $env);
         $p->run(null, ['BAR' => 'baR', 'BAZ' => 'baZ']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

-----

AS `getEnv()` return type is array, if a `Process` object has no default env and is NULL value, calling `getEnv()` will get error.

``` php
$process = $someObject->createProcess(); // Get process from some object, but we don't know the environment

// We want to check the env
$env = $process->getEnv(); // Error: return type must be array, NULL given.

```

