### PR TITLE
[Uid] Added toHexString method to AbstractUid class

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -138,6 +138,14 @@ abstract class AbstractUid implements \JsonSerializable
     }
 
     /**
+     * Returns the identifier as a prefixed hexadecimal case insensitive string.
+     */
+    public function toHexString(): string
+    {
+        return '0x' . bin2hex($this->toBinary());
+    }
+
+    /**
      * Returns whether the argument is an AbstractUid and contains the same value as the current instance.
      */
     public function equals($other): bool

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -52,6 +52,12 @@ class UlidTest extends TestCase
         $this->assertTrue($ulid->equals(Ulid::fromString(hex2bin('7fffffffffffffffffffffffffffffff'))));
     }
 
+    public function testHexString()
+    {
+        $ulid = Ulid::fromString('1BVXue8CnY8ogucrHX3TeF');
+        $this->assertSame('0x0177058f4dacd0b2a990a49af02bc008', $ulid->toHexString());
+    }
+
     public function testFromUuid()
     {
         $uuid = new UuidV4();

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -116,6 +116,13 @@ class UuidTest extends TestCase
         $this->assertSame(self::A_UUID_V4, (string) $uuid);
     }
 
+    public function testHexString()
+    {
+        $uuid = new UuidV4(self::A_UUID_V4);
+
+        $this->assertSame('0xd6b3345b29054048a83cb5988e765d98', $uuid->toHexString());
+    }
+
     public function testFromUlid()
     {
         $ulid = new Ulid();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Fix | #42966
| License       | MIT

Added a small method to Uid component `AbstractUid` class called `toHexString` which would output binary value of identifier as prefixed hex string for e.g. `0x0000000`. This is really useful when using with Doctrine for Id generation as the storage of Uid is a binary format in the database, and in most cases, it is usually used with hex format to query it.