### PR TITLE
[TwigBridge] Make LintCommand::$namePatterns private

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -39,16 +39,13 @@ use Twig\Source;
 #[AsCommand(name: 'lint:twig', description: 'Lint a Twig template and outputs encountered errors')]
 class LintCommand extends Command
 {
-    protected string|array $namePatterns;
-    private Environment $twig;
     private string $format;
 
-    public function __construct(Environment $twig, string|array $namePatterns = ['*.twig'])
-    {
+    public function __construct(
+        private Environment $twig,
+        private array $namePatterns = ['*.twig'],
+    ) {
         parent::__construct();
-
-        $this->twig = $twig;
-        $this->namePatterns = $namePatterns;
     }
 
     protected function configure()

--- a/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
+++ b/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\TwigBundle\Command;
 
 use Symfony\Bridge\Twig\Command\LintCommand as BaseLintCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Finder\Finder;
 
 /**
  * Command that will validate your template syntax and output encountered errors.
@@ -47,9 +46,7 @@ EOF
     protected function findFiles(string $filename): iterable
     {
         if (str_starts_with($filename, '@')) {
-            $dir = $this->getApplication()->getKernel()->locateResource($filename);
-
-            return Finder::create()->files()->in($dir)->name($this->namePatterns);
+            $filename = $this->getApplication()->getKernel()->locateResource($filename);
         }
 
         return parent::findFiles($filename);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Dunno why this wasn't done in #45845. /cc @GromNaN any idea?