### PR TITLE
[Uid] Added toHexString method to AbstractUid class

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -128,6 +128,14 @@ abstract class AbstractUid implements \JsonSerializable
     }
 
     /**
+     * Returns the identifier as a prefixed hexadecimal case insensitive string.
+     */
+    public function toHex(): string
+    {
+        return '0x'.bin2hex($this->toBinary());
+    }
+
+    /**
      * Returns whether the argument is an AbstractUid and contains the same value as the current instance.
      */
     public function equals(mixed $other): bool

--- a/src/Symfony/Component/Uid/Command/InspectUlidCommand.php
+++ b/src/Symfony/Component/Uid/Command/InspectUlidCommand.php
@@ -63,6 +63,7 @@ EOF
             ['toBase32 (canonical)', (string) $ulid],
             ['toBase58', $ulid->toBase58()],
             ['toRfc4122', $ulid->toRfc4122()],
+            ['toHex', $ulid->toHex()],
             new TableSeparator(),
             ['Time', ($ulid->getDateTime())->format('Y-m-d H:i:s.v \U\T\C')],
         ]);

--- a/src/Symfony/Component/Uid/Command/InspectUuidCommand.php
+++ b/src/Symfony/Component/Uid/Command/InspectUuidCommand.php
@@ -73,6 +73,7 @@ EOF
             ['toRfc4122 (canonical)', (string) $uuid],
             ['toBase58', $uuid->toBase58()],
             ['toBase32', $uuid->toBase32()],
+            ['toHex', $uuid->toHex()],
         ];
 
         if ($uuid instanceof UuidV1 || $uuid instanceof UuidV6) {

--- a/src/Symfony/Component/Uid/Tests/Command/InspectUlidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/InspectUlidCommandTest.php
@@ -37,6 +37,7 @@ final class InspectUlidCommandTest extends TestCase
   toBase32 (canonical)   01E439TP9XJZ9RPFH3T1PYBCR8            
   toBase58               1BKocMc5BnrVcuq2ti4Eqm                
   toRfc4122              0171069d-593d-97d3-8b3e-23d06de5b308  
+  toHex                  0x0171069d593d97d38b3e23d06de5b308    
  ---------------------- -------------------------------------- 
   Time                   2020-03-23 08:58:27.517 UTC           
  ---------------------- -------------------------------------- 

--- a/src/Symfony/Component/Uid/Tests/Command/InspectUuidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/InspectUuidCommandTest.php
@@ -38,6 +38,7 @@ final class InspectUuidCommandTest extends TestCase
   toRfc4122 (canonical)   00000000-0000-0000-0000-000000000000  
   toBase58                1111111111111111111111                
   toBase32                00000000000000000000000000            
+  toHex                   0x00000000000000000000000000000000    
  ----------------------- -------------------------------------- 
 
 
@@ -58,6 +59,7 @@ EOF
   toRfc4122 (canonical)   461cc9b9-2397-0dba-91e9-33af4c63f7ec  
   toBase58                9f9nftX6dw4oVPm5uT17um                
   toBase32                263K4VJ8WQ1PX93T9KNX667XZC            
+  toHex                   0x461cc9b923970dba91e933af4c63f7ec    
  ----------------------- -------------------------------------- 
 
 
@@ -73,6 +75,7 @@ EOF
   toRfc4122 (canonical)   461cc9b9-2397-2dba-91e9-33af4c63f7ec  
   toBase58                9f9nftX6fjLfNnvSAHMV7Z                
   toBase32                263K4VJ8WQ5PX93T9KNX667XZC            
+  toHex                   0x461cc9b923972dba91e933af4c63f7ec    
  ----------------------- -------------------------------------- 
 
 
@@ -88,6 +91,7 @@ EOF
   toRfc4122 (canonical)   461cc9b9-2397-7dba-91e9-33af4c63f7ec  
   toBase58                9f9nftX6kE2K6HpooNEQ83                
   toBase32                263K4VJ8WQFPX93T9KNX667XZC            
+  toHex                   0x461cc9b923977dba91e933af4c63f7ec    
  ----------------------- -------------------------------------- 
 
 
@@ -103,6 +107,7 @@ EOF
   toRfc4122 (canonical)   461cc9b9-2397-cdba-91e9-33af4c63f7ec  
   toBase58                9f9nftX6pihxonjBST7K8X                
   toBase32                263K4VJ8WQSPX93T9KNX667XZC            
+  toHex                   0x461cc9b92397cdba91e933af4c63f7ec    
  ----------------------- -------------------------------------- 
 
 
@@ -123,6 +128,7 @@ EOF
   toRfc4122 (canonical)   4c8e3a2a-5993-11eb-a861-2bf05af69e52  
   toBase58                ATJGVdrgFqvc6thDFXv1Qu                
   toBase32                2CHRX2MPCK27NTGR9BY1DFD7JJ            
+  toHex                   0x4c8e3a2a599311eba8612bf05af69e52    
  ----------------------- -------------------------------------- 
   Time                    2021-01-18 13:44:34.438609 UTC        
  ----------------------- -------------------------------------- 
@@ -145,6 +151,7 @@ EOF
   toRfc4122 (canonical)   d108a1a0-957e-3c77-b110-d3f912374439  
   toBase58                Sp7q16VVeC7zPsMPVEToq2                
   toBase32                6H12GT15BY7HVV246KZ493EH1S            
+  toHex                   0xd108a1a0957e3c77b110d3f912374439    
  ----------------------- -------------------------------------- 
 
 
@@ -165,6 +172,7 @@ EOF
   toRfc4122 (canonical)   705c6eab-a535-4f49-bd51-436d0e81206a  
   toBase58                EsjuVs1nd42xt7jSB8hNQH                
   toBase32                3GBHQAQ99N9X4VTMA3DM78283A            
+  toHex                   0x705c6eaba5354f49bd51436d0e81206a    
  ----------------------- -------------------------------------- 
 
 
@@ -185,6 +193,7 @@ EOF
   toRfc4122 (canonical)   4ec6c3ad-de94-5f75-b5f0-ad56661a30c4  
   toBase58                AjCoyQeK6TtFemqYWV5uKZ                
   toBase32                2ERV1TVQMMBXTVBW5DASK1MC64            
+  toHex                   0x4ec6c3adde945f75b5f0ad56661a30c4    
  ----------------------- -------------------------------------- 
 
 
@@ -205,6 +214,7 @@ EOF
   toRfc4122 (canonical)   1eb59937-b0a7-6288-a861-db3dc2d8d4db  
   toBase58                4nwhs6vwvNU2AbcCSD1XP8                
   toBase32                0YPPCKFC57CA4AGREV7Q1DHN6V            
+  toHex                   0x1eb59937b0a76288a861db3dc2d8d4db    
  ----------------------- -------------------------------------- 
   Time                    2021-01-18 13:45:52.427892 UTC        
  ----------------------- -------------------------------------- 

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -52,6 +52,12 @@ class UlidTest extends TestCase
         $this->assertTrue($ulid->equals(Ulid::fromString(hex2bin('7fffffffffffffffffffffffffffffff'))));
     }
 
+    public function toHex()
+    {
+        $ulid = Ulid::fromString('1BVXue8CnY8ogucrHX3TeF');
+        $this->assertSame('0x0177058f4dacd0b2a990a49af02bc008', $ulid->toHex());
+    }
+
     public function testFromUuid()
     {
         $uuid = new UuidV4();

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -116,6 +116,13 @@ class UuidTest extends TestCase
         $this->assertSame(self::A_UUID_V4, (string) $uuid);
     }
 
+    public function testHex()
+    {
+        $uuid = new UuidV4(self::A_UUID_V4);
+
+        $this->assertSame('0xd6b3345b29054048a83cb5988e765d98', $uuid->toHex());
+    }
+
     public function testFromUlid()
     {
         $ulid = new Ulid();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Fix | #42966
| License       | MIT

Added a small method to Uid component `AbstractUid` class called `toHex` which would output binary value of identifier as prefixed hex string for e.g. `0x0000000`. This is really useful when using with Doctrine for Id generation as the storage of Uid is a binary format in the database, and in most cases, it is usually used with hex format to query it.

This PR is from #45939 as I needed to change the source branch to 6.1