### PR TITLE
[RateLimiter] Adding default empty string value on Security::LAST_USERNAME

### DIFF
--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -37,7 +37,7 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
 
     protected function getLimiters(Request $request): array
     {
-        $username = $request->attributes->get(Security::LAST_USERNAME);
+        $username = $request->attributes->get(Security::LAST_USERNAME, '');
         $username = preg_match('//u', $username) ? mb_strtolower($username, 'UTF-8') : strtolower($username);
 
         return [


### PR DESCRIPTION
Because `Security::LAST_USERNAME` not always exist, it can trigger a `preg_match(): Argument #2 ($subject) must be of type string` if $username is null

The error is critical when having `declare(strict_types=1)`, to avoid issue when people create their own LoginRateLimiter from the DefaultLoginRateLimiter we can juste set a default empty string.

| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| License       | MIT
