### PR TITLE
[Notifier] [OvhCloud] Add `no_stop_clause` to DSN

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+* Add `no_stop_clause` option to the DSN that allows removing "STOP clause" at the end of the message for non-commercial use
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -33,6 +33,7 @@ final class OvhCloudTransport extends AbstractTransport
     private string $consumerKey;
     private string $serviceName;
     private ?string $sender = null;
+    private bool $noStopClause = false;
 
     public function __construct(string $applicationKey, string $applicationSecret, string $consumerKey, string $serviceName, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
@@ -47,10 +48,20 @@ final class OvhCloudTransport extends AbstractTransport
     public function __toString(): string
     {
         if (null !== $this->sender) {
-            return sprintf('ovhcloud://%s?consumer_key=%s&service_name=%s&sender=%s', $this->getEndpoint(), $this->consumerKey, $this->serviceName, $this->sender);
+            return sprintf('ovhcloud://%s?consumer_key=%s&service_name=%s&sender=%s&no_stop_clause=%s', $this->getEndpoint(), $this->consumerKey, $this->serviceName, $this->sender, (int) $this->noStopClause);
         }
 
-        return sprintf('ovhcloud://%s?consumer_key=%s&service_name=%s', $this->getEndpoint(), $this->consumerKey, $this->serviceName);
+        return sprintf('ovhcloud://%s?consumer_key=%s&service_name=%s&no_stop_clause=%s', $this->getEndpoint(), $this->consumerKey, $this->serviceName, (int) $this->noStopClause);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setNoStopClause(bool $noStopClause): static
+    {
+        $this->noStopClause = $noStopClause;
+
+        return $this;
     }
 
     /**
@@ -82,7 +93,7 @@ final class OvhCloudTransport extends AbstractTransport
             'coding' => '8bit',
             'message' => $message->getSubject(),
             'receivers' => [$message->getPhone()],
-            'noStopClause' => false,
+            'noStopClause' => $this->noStopClause,
             'priority' => 'medium',
         ];
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
@@ -33,10 +33,11 @@ final class OvhCloudTransportFactory extends AbstractTransportFactory
         $consumerKey = $dsn->getRequiredOption('consumer_key');
         $serviceName = $dsn->getRequiredOption('service_name');
         $sender = $dsn->getOption('sender');
+        $noStopClause = filter_var($dsn->getOption('no_stop_clause', false), \FILTER_VALIDATE_BOOLEAN);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new OvhCloudTransport($applicationKey, $applicationSecret, $consumerKey, $serviceName, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSender($sender);
+        return (new OvhCloudTransport($applicationKey, $applicationSecret, $consumerKey, $serviceName, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSender($sender)->setNoStopClause($noStopClause);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/README.md
@@ -7,7 +7,7 @@ DSN example
 -----------
 
 ```
-OVHCLOUD_DSN=ovhcloud://APPLICATION_KEY:APPLICATION_SECRET@default?consumer_key=CONSUMER_KEY&service_name=SERVICE_NAME&sender=SENDER
+OVHCLOUD_DSN=ovhcloud://APPLICATION_KEY:APPLICATION_SECRET@default?consumer_key=CONSUMER_KEY&service_name=SERVICE_NAME&sender=SENDER&no_stop_clause=NO_STOP_CLAUSE
 ```
 
 where:
@@ -16,6 +16,8 @@ where:
  - `CONSUMER_KEY` is your OvhCloud consumer key
  - `SERVICE_NAME` is your OvhCloud service name
  - `SENDER` is your sender (optional)
+ - `NO_STOP_CLAUSE` setting this parameter to "1" (default "0") allow removing "STOP clause" at the end of the message for non-commercial use (optional)
+
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
@@ -24,19 +24,35 @@ final class OvhCloudTransportFactoryTest extends TransportFactoryTestCase
     public function createProvider(): iterable
     {
         yield [
-            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName',
+            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=0',
             'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName',
         ];
 
         yield [
-            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&sender=sender',
+            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&sender=sender&no_stop_clause=0',
             'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName&sender=sender',
+        ];
+
+        yield [
+            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=0',
+            'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=0',
+        ];
+
+        yield [
+            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=1',
+            'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=1',
+        ];
+
+        yield [
+            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=1',
+            'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=true',
         ];
     }
 
     public function supportsProvider(): iterable
     {
         yield [true, 'ovhcloud://key:secret@default?consumer_key=consumerKey&service_name=serviceName&sender=sender'];
+        yield [true, 'ovhcloud://key:secret@default?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=1'];
         yield [false, 'somethingElse://key:secret@default?consumer_key=consumerKey&service_name=serviceName&sender=sender'];
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -22,15 +22,16 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class OvhCloudTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $sender = null): OvhCloudTransport
+    public function createTransport(HttpClientInterface $client = null, string $sender = null, bool $noStopClause = false): OvhCloudTransport
     {
-        return (new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $client ?? $this->createMock(HttpClientInterface::class)))->setSender($sender);
+        return (new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $client ?? $this->createMock(HttpClientInterface::class)))->setSender($sender)->setNoStopClause($noStopClause);
     }
 
     public function toStringProvider(): iterable
     {
-        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName', $this->createTransport()];
-        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&sender=sender', $this->createTransport(null, 'sender')];
+        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=0', $this->createTransport()];
+        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=1', $this->createTransport(null, null, true)];
+        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&sender=sender&no_stop_clause=0', $this->createTransport(null, 'sender')];
     }
 
     public function supportedMessagesProvider(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45932
| License       | MIT

This PR allow to configure `no_stop_clause` (default false) for OvhCloud. Was always false before.