### PR TITLE
[SecurityHttp] Implementing Null Object Design Pattern in AuthenticatorManager

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Authentication;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -64,7 +65,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         $this->tokenStorage = $tokenStorage;
         $this->eventDispatcher = $eventDispatcher;
         $this->firewallName = $firewallName;
-        $this->logger = $logger;
+        $this->logger = is_null($logger) ? new NullLogger() : $logger;
         $this->eraseCredentials = $eraseCredentials;
         $this->hideUserNotFoundExceptions = $hideUserNotFoundExceptions;
         $this->requiredBadges = $requiredBadges;
@@ -89,31 +90,25 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
 
     public function supports(Request $request): ?bool
     {
-        if (null !== $this->logger) {
-            $context = ['firewall_name' => $this->firewallName];
+        $context = ['firewall_name' => $this->firewallName];
 
-            if ($this->authenticators instanceof \Countable || \is_array($this->authenticators)) {
-                $context['authenticators'] = \count($this->authenticators);
-            }
-
-            $this->logger->debug('Checking for authenticator support.', $context);
+        if ($this->authenticators instanceof \Countable || \is_array($this->authenticators)) {
+            $context['authenticators'] = \count($this->authenticators);
         }
+
+        $this->logger->debug('Checking for authenticator support.', $context);
 
         $authenticators = [];
         $skippedAuthenticators = [];
         $lazy = true;
         foreach ($this->authenticators as $authenticator) {
-            if (null !== $this->logger) {
-                $this->logger->debug('Checking support on authenticator.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
-            }
+            $this->logger->debug('Checking support on authenticator.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
 
             if (false !== $supports = $authenticator->supports($request)) {
                 $authenticators[] = $authenticator;
                 $lazy = $lazy && null === $supports;
             } else {
-                if (null !== $this->logger) {
-                    $this->logger->debug('Authenticator does not support the request.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
-                }
+                $this->logger->debug('Authenticator does not support the request.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
                 $skippedAuthenticators[] = $authenticator;
             }
         }
@@ -151,18 +146,14 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             // eagerly (before token storage is initialized), whereas authenticate() is called
             // lazily (after initialization).
             if (false === $authenticator->supports($request)) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('Skipping the "{authenticator}" authenticator as it did not support the request.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
-                }
+                $this->logger->debug('Skipping the "{authenticator}" authenticator as it did not support the request.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
 
                 continue;
             }
 
             $response = $this->executeAuthenticator($authenticator, $request);
             if (null !== $response) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('The "{authenticator}" authenticator set the response. Any later authenticator will not be called', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
-                }
+                $this->logger->debug('The "{authenticator}" authenticator set the response. Any later authenticator will not be called', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
 
                 return $response;
             }
@@ -210,9 +201,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
 
             $this->eventDispatcher->dispatch(new AuthenticationSuccessEvent($authenticatedToken), AuthenticationEvents::AUTHENTICATION_SUCCESS);
 
-            if (null !== $this->logger) {
-                $this->logger->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
-            }
+            $this->logger->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
         } catch (AuthenticationException $e) {
             // oh no! Authentication failed!
             $response = $this->handleAuthenticationFailure($e, $request, $authenticator, $passport);
@@ -229,9 +218,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             return $response;
         }
 
-        if (null !== $this->logger) {
-            $this->logger->debug('Authenticator set no success response: request continues.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
-        }
+        $this->logger->debug('Authenticator set no success response: request continues.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
 
         return null;
     }
@@ -262,9 +249,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
      */
     private function handleAuthenticationFailure(AuthenticationException $authenticationException, Request $request, AuthenticatorInterface $authenticator, ?PassportInterface $passport): ?Response
     {
-        if (null !== $this->logger) {
-            $this->logger->info('Authenticator failed.', ['exception' => $authenticationException, 'authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
-        }
+        $this->logger->info('Authenticator failed.', ['exception' => $authenticationException, 'authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
 
         // Avoid leaking error details in case of invalid user (e.g. user not found or invalid account status)
         // to prevent user enumeration via response content comparison
@@ -273,7 +258,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         }
 
         $response = $authenticator->onAuthenticationFailure($request, $authenticationException);
-        if (null !== $response && null !== $this->logger) {
+        if (null !== $response) {
             $this->logger->debug('The "{authenticator}" authenticator set the failure response.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
         }
 

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -65,7 +65,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         $this->tokenStorage = $tokenStorage;
         $this->eventDispatcher = $eventDispatcher;
         $this->firewallName = $firewallName;
-        $this->logger = is_null($logger) ? new NullLogger() : $logger;
+        $this->logger = null === $logger ? new NullLogger() : $logger;
         $this->eraseCredentials = $eraseCredentials;
         $this->hideUserNotFoundExceptions = $hideUserNotFoundExceptions;
         $this->requiredBadges = $requiredBadges;


### PR DESCRIPTION
Implementing Null Object Design Pattern for $logger and removing 15 (fifteen) ifs.

Slower (in theory) but cleaner.

| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

This is PR is not about bug fix or feature, only about cleaner code (in my humble opinion, less code = less bug).

If you think the CPU cost is first priority (though I think it's negligible), I'll understand you dismiss this PR.

About the tests :
```bash
php ./phpunit src/Symfony/Component/Security/Http/
#!/usr/bin/env php
PHPUnit 9.5.20 #StandWithUkraine

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing /home/flo/Develop/symfony/src/Symfony/Component/Security/Http
...............................................................  63 / 474 ( 13%)
............................................................... 126 / 474 ( 26%)
............................................................... 189 / 474 ( 39%)
............................................................... 252 / 474 ( 53%)
............................................................... 315 / 474 ( 66%)
............................................................... 378 / 474 ( 79%)
............................................................... 441 / 474 ( 93%)
.................................                               474 / 474 (100%)

Time: 00:00.488, Memory: 22.00 MB

OK (474 tests, 981 assertions)

Legacy deprecation notices (103)
``` 

Have a nice day.

Florent