### PR TITLE
[Translation] Fix PhpExtractor with trans call has inline var assignation

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -157,7 +157,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
 
         for (; $tokenIterator->valid(); $tokenIterator->next()) {
             $t = $tokenIterator->current();
-            if ('.' === $t) {
+            if ('.' === $t || '=' === $t) {
                 // Concatenate with next token
                 continue;
             }
@@ -196,6 +196,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
                     $docPart = '';
                     break;
                 case \T_WHITESPACE:
+                case \T_VARIABLE:
                     break;
                 default:
                     break 2;

--- a/src/Symfony/Component/Translation/Tests/Extractor/PhpExtractorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/PhpExtractorTest.php
@@ -64,6 +64,9 @@ EOF;
                 'typecast' => 'prefixtypecast',
                 'msg1' => 'prefixmsg1',
                 'msg2' => 'prefixmsg2',
+                'variable-assignation-inlined-in-trans-method-call1' => 'prefixvariable-assignation-inlined-in-trans-method-call1',
+                'variable-assignation-inlined-in-trans-method-call2' => 'prefixvariable-assignation-inlined-in-trans-method-call2',
+                'variable-assignation-inlined-in-trans-method-call3' => 'prefixvariable-assignation-inlined-in-trans-method-call3',
             ],
         ];
         $actualCatalogue = $catalogue->all();

--- a/src/Symfony/Component/Translation/Tests/fixtures/extractor/translation.html.php
+++ b/src/Symfony/Component/Translation/Tests/fixtures/extractor/translation.html.php
@@ -57,3 +57,6 @@ EOF
 <?php echo $view['translator']->transChoice('msg2', ceil(4.5), [], 'not_messages'); ?>
 
 <?php echo $view['translator']->trans('default domain', [], null); ?>
+<?php echo $view['translator']->trans($key = 'variable-assignation-inlined-in-trans-method-call1', $parameters = [], $domain = 'not_messages'); ?>
+<?php echo $view['translator']->trans('variable-assignation-inlined-in-trans-method-call2', $parameters = [], $domain = 'not_messages'); ?>
+<?php echo $view['translator']->trans('variable-assignation-inlined-in-trans-method-call3', [], $domain = 'not_messages'); ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #42285 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This kind of `trans` call was misunderstood by `PhpExtractor`:

```php
$this->translator->trans('This is the string I would like to translate', $parameters = [], $domain = 'validators');
```

The translation key was inserted in `messages.en.xlf` instead of `validators.en.xlf`.

This PR fix the issue when `trans` method is called with "inline variable assignations"
