### PR TITLE
Fix use_cookies framework session configuration

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -148,42 +148,45 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
             $sessionCookieSecure = $sessionOptions['cookie_secure'] ?? false;
             $sessionCookieHttpOnly = $sessionOptions['cookie_httponly'] ?? true;
             $sessionCookieSameSite = $sessionOptions['cookie_samesite'] ?? Cookie::SAMESITE_LAX;
+            $sessionUseCookies = $sessionOptions['use_cookies'] ?? true;
 
             SessionUtils::popSessionCookie($sessionName, $sessionId);
 
-            $request = $event->getRequest();
-            $requestSessionCookieId = $request->cookies->get($sessionName);
+            if ($sessionUseCookies) {
+                $request = $event->getRequest();
+                $requestSessionCookieId = $request->cookies->get($sessionName);
 
-            $isSessionEmpty = $session->isEmpty() && empty($_SESSION); // checking $_SESSION to keep compatibility with native sessions
-            if ($requestSessionCookieId && $isSessionEmpty) {
-                $response->headers->clearCookie(
-                    $sessionName,
-                    $sessionCookiePath,
-                    $sessionCookieDomain,
-                    $sessionCookieSecure,
-                    $sessionCookieHttpOnly,
-                    $sessionCookieSameSite
-                );
-            } elseif ($sessionId !== $requestSessionCookieId && !$isSessionEmpty) {
-                $expire = 0;
-                $lifetime = $sessionOptions['cookie_lifetime'] ?? null;
-                if ($lifetime) {
-                    $expire = time() + $lifetime;
-                }
-
-                $response->headers->setCookie(
-                    Cookie::create(
+                $isSessionEmpty = $session->isEmpty() && empty($_SESSION); // checking $_SESSION to keep compatibility with native sessions
+                if ($requestSessionCookieId && $isSessionEmpty) {
+                    $response->headers->clearCookie(
                         $sessionName,
-                        $sessionId,
-                        $expire,
                         $sessionCookiePath,
                         $sessionCookieDomain,
                         $sessionCookieSecure,
                         $sessionCookieHttpOnly,
-                        false,
                         $sessionCookieSameSite
-                    )
-                );
+                    );
+                } elseif ($sessionId !== $requestSessionCookieId && !$isSessionEmpty) {
+                    $expire = 0;
+                    $lifetime = $sessionOptions['cookie_lifetime'] ?? null;
+                    if ($lifetime) {
+                        $expire = time() + $lifetime;
+                    }
+
+                    $response->headers->setCookie(
+                        Cookie::create(
+                            $sessionName,
+                            $sessionId,
+                            $expire,
+                            $sessionCookiePath,
+                            $sessionCookieDomain,
+                            $sessionCookieSecure,
+                            $sessionCookieHttpOnly,
+                            false,
+                            $sessionCookieSameSite
+                        )
+                    );
+                }
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -66,13 +66,19 @@ class SessionListenerTest extends TestCase
         $listener->onKernelResponse(new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response));
 
         $cookies = $response->headers->getCookies();
-        $this->assertSame('PHPSESSID', $cookies[0]->getName());
-        $this->assertSame('123456', $cookies[0]->getValue());
-        $this->assertSame($expectedSessionOptions['cookie_path'], $cookies[0]->getPath());
-        $this->assertSame($expectedSessionOptions['cookie_domain'], $cookies[0]->getDomain());
-        $this->assertSame($expectedSessionOptions['cookie_secure'], $cookies[0]->isSecure());
-        $this->assertSame($expectedSessionOptions['cookie_httponly'], $cookies[0]->isHttpOnly());
-        $this->assertSame($expectedSessionOptions['cookie_samesite'], $cookies[0]->getSameSite());
+
+        if ($sessionOptions['use_cookies'] ?? true) {
+            $this->assertCount(1, $cookies);
+            $this->assertSame('PHPSESSID', $cookies[0]->getName());
+            $this->assertSame('123456', $cookies[0]->getValue());
+            $this->assertSame($expectedSessionOptions['cookie_path'], $cookies[0]->getPath());
+            $this->assertSame($expectedSessionOptions['cookie_domain'], $cookies[0]->getDomain());
+            $this->assertSame($expectedSessionOptions['cookie_secure'], $cookies[0]->isSecure());
+            $this->assertSame($expectedSessionOptions['cookie_httponly'], $cookies[0]->isHttpOnly());
+            $this->assertSame($expectedSessionOptions['cookie_samesite'], $cookies[0]->getSameSite());
+        } else {
+            $this->assertCount(0, $cookies);
+        }
     }
 
     public function provideSessionOptions(): \Generator
@@ -125,6 +131,12 @@ class SessionListenerTest extends TestCase
             'phpSessionOptions' => ['samesite' => Cookie::SAMESITE_STRICT],
             'sessionOptions' => ['cookie_path' => '/test/', 'cookie_httponly' => true, 'cookie_secure' => true, 'cookie_samesite' => Cookie::SAMESITE_LAX],
             'expectedSessionOptions' => ['cookie_path' => '/test/', 'cookie_domain' => '', 'cookie_secure' => true, 'cookie_httponly' => true, 'cookie_samesite' => Cookie::SAMESITE_LAX],
+        ];
+
+        yield 'set_use_cookies_false_by_symfony' => [
+            'phpSessionOptions' => [],
+            'sessionOptions' => ['use_cookies' => false, 'cookie_domain' => '', 'cookie_secure' => true, 'cookie_httponly' => true, 'cookie_samesite' => Cookie::SAMESITE_LAX],
+            'expectedSessionOptions' => [],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #45105
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Keep `use_cookies` false flag in mind.

Todo:

 - [x] test case