### PR TITLE
[Notifier] Improve some type annotations

### DIFF
--- a/src/Symfony/Component/Notifier/Notification/Notification.php
+++ b/src/Symfony/Component/Notifier/Notification/Notification.php
@@ -44,12 +44,18 @@ class Notification
     private string $exceptionAsString = '';
     private string $importance = self::IMPORTANCE_HIGH;
 
+    /**
+     * @param list<string> $channels
+     */
     public function __construct(string $subject = '', array $channels = [])
     {
         $this->subject = $subject;
         $this->channels = $channels;
     }
 
+    /**
+     * @param list<string> $channels
+     */
     public static function fromThrowable(\Throwable $exception, array $channels = []): self
     {
         $parts = explode('\\', \get_class($exception));
@@ -147,6 +153,8 @@ class Notification
     }
 
     /**
+     * @param list<string> $channels
+     *
      * @return $this
      */
     public function channels(array $channels): static
@@ -156,6 +164,9 @@ class Notification
         return $this;
     }
 
+    /**
+     * @return list<string>
+     */
     public function getChannels(RecipientInterface $recipient): array
     {
         return $this->channels;

--- a/src/Symfony/Component/Notifier/Notifier.php
+++ b/src/Symfony/Component/Notifier/Notifier.php
@@ -65,6 +65,9 @@ final class Notifier implements NotifierInterface
         return $this->adminRecipients;
     }
 
+    /**
+     * @return iterable<ChannelInterface, string|null>
+     */
     private function getChannels(Notification $notification, RecipientInterface $recipient): iterable
     {
         $channels = $notification->getChannels($recipient);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 (not sure)
| Bug fix?      |  to some extent
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

In this PR, I tried to improve (add) some type annotations:
- the first one is a public API channels list type on Notification
- and the second one is an internal one in Notifier that eases understanding the code and what's expected to be returned

I'm not sure about the target branch. IMO it should target 5.4, but I'm open for your advices and set it to 6.1 for now.