### PR TITLE
[Finder] Add support of no-capture regex modifier in MultiplePcreFilterIterator

### DIFF
--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add support of no-capture regex modifier `/n` in MultiplePcreFilterIterator (available from PHP 8.2)
+
 6.0
 ---
 

--- a/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
@@ -80,7 +80,13 @@ abstract class MultiplePcreFilterIterator extends \FilterIterator
      */
     protected function isRegex(string $str): bool
     {
-        if (preg_match('/^(.{3,}?)[imsxuADU]*$/', $str, $m)) {
+        $availableModifiers = 'imsxuADU';
+
+        if (\PHP_VERSION_ID >= 80200) {
+            $availableModifiers .= 'n';
+        }
+
+        if (preg_match('/^(.{3,}?)['.$availableModifiers.']*$/', $str, $m)) {
             $start = substr($m[1], 0, 1);
             $end = substr($m[1], -1);
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/MultiplePcreFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/MultiplePcreFilterIteratorTest.php
@@ -27,24 +27,26 @@ class MultiplePcreFilterIteratorTest extends TestCase
 
     public function getIsRegexFixtures()
     {
-        return [
-            ['foo', false, 'string'],
-            [' foo ', false, '" " is not a valid delimiter'],
-            ['\\foo\\', false, '"\\" is not a valid delimiter'],
-            ['afooa', false, '"a" is not a valid delimiter'],
-            ['//', false, 'the pattern should contain at least 1 character'],
-            ['/a/', true, 'valid regex'],
-            ['/foo/', true, 'valid regex'],
-            ['/foo/i', true, 'valid regex with a single modifier'],
-            ['/foo/imsxu', true, 'valid regex with multiple modifiers'],
-            ['#foo#', true, '"#" is a valid delimiter'],
-            ['{foo}', true, '"{,}" is a valid delimiter pair'],
-            ['[foo]', true, '"[,]" is a valid delimiter pair'],
-            ['(foo)', true, '"(,)" is a valid delimiter pair'],
-            ['<foo>', true, '"<,>" is a valid delimiter pair'],
-            ['*foo.*', false, '"*" is not considered as a valid delimiter'],
-            ['?foo.?', false, '"?" is not considered as a valid delimiter'],
-        ];
+        yield ['foo', false, 'string'];
+        yield [' foo ', false, '" " is not a valid delimiter'];
+        yield ['\\foo\\', false, '"\\" is not a valid delimiter'];
+        yield ['afooa', false, '"a" is not a valid delimiter'];
+        yield ['//', false, 'the pattern should contain at least 1 character'];
+        yield ['/a/', true, 'valid regex'];
+        yield ['/foo/', true, 'valid regex'];
+        yield ['/foo/i', true, 'valid regex with a single modifier'];
+        yield ['/foo/imsxu', true, 'valid regex with multiple modifiers'];
+        yield ['#foo#', true, '"#" is a valid delimiter'];
+        yield ['{foo}', true, '"{,}" is a valid delimiter pair'];
+        yield ['[foo]', true, '"[,]" is a valid delimiter pair'];
+        yield ['(foo)', true, '"(,)" is a valid delimiter pair'];
+        yield ['<foo>', true, '"<,>" is a valid delimiter pair'];
+        yield ['*foo.*', false, '"*" is not considered as a valid delimiter'];
+        yield ['?foo.?', false, '"?" is not considered as a valid delimiter'];
+
+        if (\PHP_VERSION_ID >= 80200) {
+            yield ['/foo/n', true, 'valid regex with the no-capture modifier'];
+        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 (when available)
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

The no-capture regex modifier has been implemented in PHP 8.2. `MultiplePcreFilterIterator` should support it, if available.

- PHP Core PR: https://github.com/php/php-src/commit/e089a50f53c8fd1eb9a932f1856a524d4ac83406
- Human Readable article about it: https://php.watch/versions/8.2/preg-n-no-capture-modifier