### PR TITLE
[Serializer][PropertyInfo] Fix support for "false" built-in type on PHP 8.2

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -273,6 +273,21 @@ class ReflectionExtractorTest extends TestCase
     }
 
     /**
+     * @dataProvider php82TypesProvider
+     * @requires PHP 8.2
+     */
+    public function testExtractPhp82Type($property, array $type = null)
+    {
+        $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php82Dummy', $property, []));
+    }
+
+    public function php82TypesProvider()
+    {
+        yield ['nil', null];
+        yield ['false', [new Type(Type::BUILTIN_TYPE_FALSE)]];
+    }
+
+    /**
      * @dataProvider defaultValueProvider
      */
     public function testExtractWithDefaultValue($property, $type)

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php82Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php82Dummy.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class Php82Dummy
+{
+    public null $nil = null;
+
+    public false $false = false;
+}

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -28,6 +28,7 @@ class Type
     public const BUILTIN_TYPE_OBJECT = 'object';
     public const BUILTIN_TYPE_ARRAY = 'array';
     public const BUILTIN_TYPE_NULL = 'null';
+    public const BUILTIN_TYPE_FALSE = 'false';
     public const BUILTIN_TYPE_CALLABLE = 'callable';
     public const BUILTIN_TYPE_ITERABLE = 'iterable';
 
@@ -45,6 +46,7 @@ class Type
         self::BUILTIN_TYPE_OBJECT,
         self::BUILTIN_TYPE_ARRAY,
         self::BUILTIN_TYPE_CALLABLE,
+        self::BUILTIN_TYPE_FALSE,
         self::BUILTIN_TYPE_NULL,
         self::BUILTIN_TYPE_ITERABLE,
     ];

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -483,7 +483,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                     return (float) $data;
                 }
 
-                if (('is_'.$builtinType)($data)) {
+                if ('false' === $builtinType || ('is_'.$builtinType)($data)) {
                     return $data;
                 }
             } catch (NotNormalizableValueException $e) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/FalseBuiltInDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/FalseBuiltInDummy.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class FalseBuiltInDummy
+{
+    public false $false = false;
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -51,6 +51,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo;
+use Symfony\Component\Serializer\Tests\Fixtures\FalseBuiltInDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\TraversableDummy;
 use Symfony\Component\Serializer\Tests\Normalizer\TestDenormalizer;
@@ -570,6 +571,19 @@ class SerializerTest extends TestCase
         ]);
 
         $this->assertEquals(new DummyUnionType(), $actual, 'Union type denormalization third case failed.');
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testFalseBuiltInTypes()
+    {
+        $extractor = new PropertyInfoExtractor([], [new ReflectionExtractor()]);
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, $extractor)], ['json' => new JsonEncoder()]);
+
+        $actual = $serializer->deserialize('{"false":false}', FalseBuiltInDummy::class, 'json');
+
+        $this->assertEquals(new FalseBuiltInDummy(), $actual);
     }
 
     private function serializerWithClassDiscriminator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes (new language feature support)
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

`false` and `null` built-in types have been merged in PHP 8.2 a few hours ago: https://github.com/php/php-src/pull/7546 :tada: 
RFC: https://wiki.php.net/rfc/null-false-standalone-types

PropertyInfo and Serializer both need an update to support them.