### PR TITLE
[Lock] Add `MysqlStore`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -177,7 +177,7 @@ jobs:
           MESSENGER_SQS_FIFO_QUEUE_DSN: "sqs://localhost:9494/messages.fifo?sslmode=disable&poll_timeout=0.01"
           KAFKA_BROKER: 127.0.0.1:9092
           POSTGRES_HOST: localhost
-          MYSQL_HOST: localhost # ubuntu-20.04 mysql defaults
+          MYSQL_DSN: mysql:host=localhost # ubuntu-20.04 mysql defaults
           MYSQL_USERNAME: root
           MYSQL_PASSWORD: root
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -161,6 +161,9 @@ jobs:
           ./phpunit install
           echo "::endgroup::"
 
+      - name: Start MySQL
+        run: sudo systemctl start mysql.service
+
       - name: Run tests
         run: ./phpunit --group integration -v
         env:
@@ -174,6 +177,9 @@ jobs:
           MESSENGER_SQS_FIFO_QUEUE_DSN: "sqs://localhost:9494/messages.fifo?sslmode=disable&poll_timeout=0.01"
           KAFKA_BROKER: 127.0.0.1:9092
           POSTGRES_HOST: localhost
+          MYSQL_HOST: localhost # ubuntu-20.04 mysql defaults
+          MYSQL_USERNAME: root
+          MYSQL_PASSWORD: root
 
       #- name: Run HTTP push tests
       #  if: matrix.php == '8.1'

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,6 @@
 CHANGELOG
 =========
-6.1
+6.2
 ---
 * Add `MysqlStore` based on MySQL `GET_LOCK()` functionality
 

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,5 +1,8 @@
 CHANGELOG
 =========
+6.1
+---
+* Add `MysqlStore` based on MySQL `GET_LOCK()` functionality
 
 6.0
 ---

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -223,6 +223,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
     private function getCurrentTimestampStatement(): string
     {
         $platform = $this->conn->getDatabasePlatform();
+
         return match (true) {
             $platform instanceof \Doctrine\DBAL\Platforms\MySQLPlatform,
             $platform instanceof \Doctrine\DBAL\Platforms\MySQL57Platform => 'UNIX_TIMESTAMP()',

--- a/src/Symfony/Component/Lock/Store/MysqlStore.php
+++ b/src/Symfony/Component/Lock/Store/MysqlStore.php
@@ -23,13 +23,13 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  */
 class MysqlStore implements PersistingStoreInterface
 {
-    private ?\PDO $conn = null;
+    private \PDO $conn;
 
-    private ?string $dsn;
+    private string $dsn;
 
     private array $options;
 
-    private ?int $connectionId = null;
+    private int $connectionId;
 
     /** @var bool[] */
     private static array $locksAcquired = [];
@@ -101,7 +101,7 @@ class MysqlStore implements PersistingStoreInterface
 
     private function getConnection(): \PDO
     {
-        if (!$this->conn) {
+        if (!isset($this->conn)) {
             $this->conn = new \PDO(
                 $this->dsn,
                 $this->options['db_username'] ?? null,
@@ -124,7 +124,7 @@ class MysqlStore implements PersistingStoreInterface
 
     private function getLockId(Key $key): string
     {
-        if (!$this->connectionId) {
+        if (!isset($this->connectionId)) {
             $this->connectionId = $this->getConnection()->query('SELECT CONNECTION_ID()')->fetchColumn();
         }
 

--- a/src/Symfony/Component/Lock/Store/MysqlStore.php
+++ b/src/Symfony/Component/Lock/Store/MysqlStore.php
@@ -23,11 +23,13 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  */
 class MysqlStore implements PersistingStoreInterface
 {
-    private ?\PDO $conn;
+    private ?\PDO $conn = null;
 
     private ?string $dsn;
 
     private array $options;
+
+    private ?int $connectionId = null;
 
     /** @var bool[] */
     private static array $locksAcquired = [];
@@ -122,7 +124,11 @@ class MysqlStore implements PersistingStoreInterface
 
     private function getLockId(Key $key): string
     {
-        return spl_object_id($this->getConnection()).'_'.spl_object_id($key);
+        if (!$this->connectionId) {
+            $this->connectionId = $this->getConnection()->query('SELECT CONNECTION_ID()')->fetchColumn();
+        }
+
+        return $this->connectionId.'_'.spl_object_id($key);
     }
 
     private static function getLockName(Key $key): string

--- a/src/Symfony/Component/Lock/Store/MysqlStore.php
+++ b/src/Symfony/Component/Lock/Store/MysqlStore.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Lock\Store;
 
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
@@ -61,7 +70,7 @@ class MysqlStore implements PersistingStoreInterface
             throw new LockConflictedException('Lock already acquired by this connection.');
         }
 
-        throw new LockAcquiringException('Failed to acquire lock due to mysql error');
+        throw new LockAcquiringException('Failed to acquire lock due to mysql error.');
     }
 
     public function putOffExpiration(Key $key, float $ttl): void

--- a/src/Symfony/Component/Lock/Store/MysqlStore.php
+++ b/src/Symfony/Component/Lock/Store/MysqlStore.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Symfony\Component\Lock\Store;
+
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
+
+/**
+ * @author rtek
+ * @author Jérôme TAMARELLE <jerome@tamarelle.net>
+ */
+class MysqlStore implements PersistingStoreInterface
+{
+    private \PDO $conn;
+
+    public function __construct(\PDO $conn)
+    {
+        if ('mysql' !== $driver = $conn->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+            throw new InvalidArgumentException(sprintf('The adapter "%s" does not support the "%s" driver.', __CLASS__, $driver));
+        }
+
+        if (\PDO::ERRMODE_EXCEPTION !== $conn->getAttribute(\PDO::ATTR_ERRMODE)) {
+            throw new InvalidArgumentException(sprintf('"%s" requires PDO error mode attribute be set to throw Exceptions (i.e. $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION)).', __METHOD__));
+        }
+
+        $this->conn = $conn;
+    }
+
+    public function save(Key $key): void
+    {
+        if ($key->hasState(__CLASS__)) {
+            return;
+        }
+
+        // todo ? check that mysql > 5.7.3
+
+        // mysql limits lock name length to 64 chars
+        $name = (string) $key;
+        $name = \strlen($name) > 64 ? hash('sha256', $name) : $name;
+
+        $stmt = $this->conn->prepare('SELECT IF(IS_USED_LOCK(:name) = CONNECTION_ID(), -1, GET_LOCK(:name, 0))');
+        $stmt->bindValue(':name', $name, \PDO::PARAM_STR);
+        $stmt->execute();
+        $result = $stmt->fetchColumn();
+
+        // lock acquired
+        if (1 === $result) {
+            $key->setState(__CLASS__, $name);
+
+            return;
+        }
+
+        if (0 === $result) {
+            throw new LockConflictedException('Lock already acquired by other connection.');
+        }
+
+        if (-1 === $result) {
+            throw new LockConflictedException('Lock already acquired by this connection.');
+        }
+
+        throw new LockAcquiringException('Failed to acquire lock due to mysql error');
+    }
+
+    public function putOffExpiration(Key $key, float $ttl): void
+    {
+        // noop - GET_LOCK() does not have a ttl
+    }
+
+    public function delete(Key $key): void
+    {
+        if (!$key->hasState(__CLASS__)) {
+            return;
+        }
+
+        $stmt = $this->conn->prepare('DO RELEASE_LOCK(:name)');
+        $stmt->bindValue(':name', $key->getState(__CLASS__), \PDO::PARAM_STR);
+        $stmt->execute();
+
+        $key->removeState(__CLASS__);
+    }
+
+    public function exists(Key $key): bool
+    {
+        if (!$key->hasState(__CLASS__)) {
+            return false;
+        }
+
+        $stmt = $this->conn->prepare('SELECT IF(IS_USED_LOCK(:name) = CONNECTION_ID(), 1, 0)');
+        $stmt->bindValue(':name', $key->getState(__CLASS__), \PDO::PARAM_STR);
+        $stmt->execute();
+
+        return 1 === $stmt->fetchColumn();
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -53,19 +53,6 @@ class MysqlStoreTest extends AbstractStoreTest
         new MysqlStore($pdo);
     }
 
-    public function testSelfConflictException()
-    {
-        $store = $this->getStore();
-        $store->save(new Key('foo'));
-
-        try {
-            $store->save(new Key('foo'));
-            $this->fail('Expected exception: '.LockConflictedException::class);
-        } catch (LockConflictedException $e) {
-            $this->assertStringContainsString('acquired by this', $e->getMessage());
-        }
-    }
-
     public function testOtherConflictException()
     {
         $storeA = $this->getStore();

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -12,8 +12,8 @@ class MysqlStoreTest extends AbstractStoreTest
 {
     protected function getEnv(): array
     {
-        if (!$host = getenv('MYSQL_HOST')) {
-            $this->markTestSkipped('Missing MYSQL_HOST env variable');
+        if (!$dsn = getenv('MYSQL_DSN')) {
+            $this->markTestSkipped('Missing MYSQL_DSN env variable');
         }
 
         if (!$user = getenv('MYSQL_USERNAME')) {
@@ -24,14 +24,14 @@ class MysqlStoreTest extends AbstractStoreTest
             $this->markTestSkipped('Missing MYSQL_PASSWORD env variable');
         }
 
-        return [$host, $user, $pass];
+        return [$dsn, $user, $pass];
     }
 
     protected function getPdo(): \PDO
     {
-        [$host, $user, $pass] = $this->getEnv();
+        [$dsn, $user, $pass] = $this->getEnv();
 
-        return new \PDO('mysql:host='.$host, $user, $pass);
+        return new \PDO($dsn, $user, $pass);
     }
 
     protected function getStore(): PersistingStoreInterface

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Lock\Store\MysqlStore;
 
 class MysqlStoreTest extends AbstractStoreTest
 {
-    protected function getPdo(): \PDO
+    protected function getEnv(): array
     {
         if (!$host = getenv('MYSQL_HOST')) {
             $this->markTestSkipped('Missing MYSQL_HOST env variable');
@@ -23,6 +23,13 @@ class MysqlStoreTest extends AbstractStoreTest
         if (!$pass = getenv('MYSQL_PASSWORD')) {
             $this->markTestSkipped('Missing MYSQL_PASSWORD env variable');
         }
+
+        return [$host, $user, $pass];
+    }
+
+    protected function getPdo(): \PDO
+    {
+        [$host, $user, $pass] = $this->getEnv();
 
         return new \PDO('mysql:host='.$host, $user, $pass);
     }
@@ -72,5 +79,13 @@ class MysqlStoreTest extends AbstractStoreTest
         } catch (LockConflictedException $e) {
             $this->assertStringContainsString('acquired by other', $e->getMessage());
         }
+    }
+
+    public function testDsnConstructor()
+    {
+        $this->expectNotToPerformAssertions();
+
+        [$host, $user, $pass] = $this->getEnv();
+        new MysqlStore("mysql:$host", ['db_username' => $user, 'db_password' => $pass]);
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Store\MysqlStore;
+
+class MysqlStoreTest extends AbstractStoreTest
+{
+    protected function getPdo(): \PDO
+    {
+        if (!$host = getenv('MYSQL_HOST')) {
+            $this->markTestSkipped('Missing MYSQL_HOST env variable');
+        }
+
+        if (!$user = getenv('MYSQL_USERNAME')) {
+            $this->markTestSkipped('Missing MYSQL_USERNAME env variable');
+        }
+
+        if (!$pass = getenv('MYSQL_PASSWORD')) {
+            $this->markTestSkipped('Missing MYSQL_PASSWORD env variable');
+        }
+
+        return new \PDO('mysql:host='.$host, $user, $pass);
+    }
+
+    protected function getStore(): PersistingStoreInterface
+    {
+        return new MysqlStore($this->getPdo());
+    }
+
+    public function testDriverRequirement(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new MysqlStore(new \PDO('sqlite::memory:'));
+    }
+
+    public function testExceptionModeRequirement(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $pdo = $this->getPdo();
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_SILENT);
+        new MysqlStore($pdo);
+    }
+
+    public function testSelfConflictException(): void
+    {
+        $store = $this->getStore();
+        $store->save(new Key('foo'));
+
+        try {
+            $store->save(new Key('foo'));
+            $this->fail('Expected exception: '.LockConflictedException::class);
+        } catch (LockConflictedException $e) {
+            $this->assertStringContainsString('acquired by this', $e->getMessage());
+        }
+    }
+
+    public function testOtherConflictException(): void
+    {
+        $storeA = $this->getStore();
+        $storeA->save(new Key('foo'));
+
+        $storeB = $this->getStore();
+
+        try {
+            $storeB->save(new Key('foo'));
+            $this->fail('Expected exception: '.LockConflictedException::class);
+        } catch (LockConflictedException $e) {
+            $this->assertStringContainsString('acquired by other', $e->getMessage());
+        }
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -73,6 +73,7 @@ class MysqlStoreTest extends AbstractStoreTest
         $this->expectNotToPerformAssertions();
 
         [$host, $user, $pass] = $this->getEnv();
-        new MysqlStore("mysql:$host", ['db_username' => $user, 'db_password' => $pass]);
+        $store = new MysqlStore("mysql:$host", ['db_username' => $user, 'db_password' => $pass]);
+        $store->save(new Key('foo'));
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -32,13 +32,13 @@ class MysqlStoreTest extends AbstractStoreTest
         return new MysqlStore($this->getPdo());
     }
 
-    public function testDriverRequirement(): void
+    public function testDriverRequirement()
     {
         $this->expectException(InvalidArgumentException::class);
         new MysqlStore(new \PDO('sqlite::memory:'));
     }
 
-    public function testExceptionModeRequirement(): void
+    public function testExceptionModeRequirement()
     {
         $this->expectException(InvalidArgumentException::class);
         $pdo = $this->getPdo();
@@ -46,7 +46,7 @@ class MysqlStoreTest extends AbstractStoreTest
         new MysqlStore($pdo);
     }
 
-    public function testSelfConflictException(): void
+    public function testSelfConflictException()
     {
         $store = $this->getStore();
         $store->save(new Key('foo'));
@@ -59,7 +59,7 @@ class MysqlStoreTest extends AbstractStoreTest
         }
     }
 
-    public function testOtherConflictException(): void
+    public function testOtherConflictException()
     {
         $storeA = $this->getStore();
         $storeA->save(new Key('foo'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | ~6.1~ 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45251
| License       | MIT
| Doc PR        | TODO

Add `MysqlStore` based on MySQL `GET_LOCK()` functionality

Based on #25578

Welcoming feedback before adding docs.

