### PR TITLE
[Messenger] DoctrineTransportFactory works with notify and decorated PostgreSQL driver

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
-use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\Persistence\ConnectionRegistry;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Messenger\Exception\TransportException;
@@ -48,7 +48,7 @@ class DoctrineTransportFactory implements TransportFactoryInterface
             throw new TransportException(sprintf('Could not find Doctrine connection from Messenger DSN "%s".', $dsn), 0, $e);
         }
 
-        if ($useNotify && $driverConnection->getDriver() instanceof AbstractPostgreSQLDriver) {
+        if ($useNotify && $driverConnection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             $connection = new PostgreSqlConnection($configuration, $driverConnection);
         } else {
             $connection = new Connection($configuration, $driverConnection);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45835 
| License       | MIT
| Doc PR        |

This PR allow to use Notify connection with Decorated PostgreSQL driver and not only for `AbstractPostgreSQLDriver`