### PR TITLE
[Notifier] Add `from` in `SmsMessage`

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
@@ -61,11 +61,13 @@ final class AllMySmsTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/sms/send/', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => $this->login.':'.$this->apiKey,
             'json' => [
-                'from' => $this->from,
+                'from' => $from,
                 'to' => $message->getPhone(),
                 'text' => $message->getSubject(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\AmazonSns;
 
 use AsyncAws\Sns\SnsClient;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -51,6 +52,10 @@ final class AmazonSnsTransport extends AbstractTransport
     {
         if (!$this->supports($message)) {
             throw new UnsupportedMessageTypeException(__CLASS__, sprintf('"%s" or "%s"', SmsMessage::class, ChatMessage::class), $message);
+        }
+
+        if ($message instanceof SmsMessage && '' !== $message->getFrom()) {
+            throw new InvalidArgumentException(sprintf('The "%s" transport does not support "from" in "%s".', __CLASS__, SmsMessage::class));
         }
 
         if ($message instanceof ChatMessage && $message->getOptions() instanceof AmazonSnsOptions) {

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Throw exception when `SmsMessage->from` defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportTest.php
@@ -15,6 +15,7 @@ use AsyncAws\Sns\Result\PublishResponse;
 use AsyncAws\Sns\SnsClient;
 use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsOptions;
 use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransport;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
@@ -44,6 +45,16 @@ class AmazonSnsTransportTest extends TransportTestCase
     {
         yield [$this->createMock(MessageInterface::class)];
         yield [new ChatMessage('hello', $this->createMock(MessageOptionsInterface::class))];
+    }
+
+    public function testSmsMessageWithFrom()
+    {
+        $transport = $this->createTransport();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransport" transport does not support "from" in "Symfony\Component\Notifier\Message\SmsMessage".');
+
+        $transport->send(new SmsMessage('0600000000', 'test', 'foo'));
     }
 
     public function testSmsMessageOptions()

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/ClickatellTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/ClickatellTransport.php
@@ -61,6 +61,8 @@ final class ClickatellTransport extends AbstractTransport
 
         $endpoint = sprintf('https://%s/rest/message', $this->getEndpoint());
 
+        $from = $message->getFrom() ?: $this->from;
+
         $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Accept' => 'application/json',
@@ -69,7 +71,7 @@ final class ClickatellTransport extends AbstractTransport
                 'X-Version' => 1,
             ],
             'json' => [
-                'from' => $this->from ?? '',
+                'from' => $from ?? '',
                 'to' => [$message->getPhone()],
                 'text' => $message->getSubject(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 ---
 
  * Add the bridge
+ * Throw exception when `SmsMessage->from` defined

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\ContactEveryone;
 
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
@@ -65,6 +66,10 @@ final class ContactEveryoneTransport extends AbstractTransport
     {
         if (!$message instanceof SmsMessage) {
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        if ('' !== $message->getFrom()) {
+            throw new InvalidArgumentException(sprintf('The "%s" transport does not support "from" in "%s".', __CLASS__, SmsMessage::class));
         }
 
         $endpoint = sprintf('https://%s/api/light/diffusions/sms', self::HOST);

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\ContactEveryone\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\ContactEveryone\ContactEveryoneTransport;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -59,5 +60,15 @@ final class ContactEveryoneTransportTest extends TransportTestCase
         $sentMessage = $transport->send(new SmsMessage('phone', 'testMessage'));
 
         $this->assertSame($messageId, $sentMessage->getMessageId());
+    }
+
+    public function testSmsMessageWithFrom()
+    {
+        $transport = $this->createTransport();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Notifier\Bridge\ContactEveryone\ContactEveryoneTransport" transport does not support "from" in "Symfony\Component\Notifier\Message\SmsMessage".');
+
+        $transport->send(new SmsMessage('0600000000', 'test', 'foo'));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
@@ -63,7 +63,9 @@ final class EsendexTransport extends AbstractTransport
             'body' => $message->getSubject(),
         ];
 
-        if (null !== $this->from) {
+        if ('' !== $message->getFrom()) {
+            $messageData['from'] = $message->getFrom();
+        } elseif (null !== $this->from) {
             $messageData['from'] = $this->from;
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsEmailTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsEmailTransport.php
@@ -64,8 +64,10 @@ final class FakeSmsEmailTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $email = (new Email())
-            ->from($this->from)
+            ->from($from)
             ->to($this->to)
             ->subject(sprintf('New SMS on phone number: %s', $message->getPhone()))
             ->html($message->getSubject())

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 6.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/FortySixElksTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/FortySixElksTransport.php
@@ -57,10 +57,12 @@ final class FortySixElksTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/a1/sms', self::HOST);
         $response = $this->client->request('POST', $endpoint, [
             'body' => [
-                'from' => $this->from,
+                'from' => $from,
                 'to' => $message->getPhone(),
                 'message' => $message->getSubject(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\FreeMobile;
 
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
@@ -55,6 +56,11 @@ final class FreeMobileTransport extends AbstractTransport
     {
         if (!$this->supports($message)) {
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        /** @var SmsMessage $message */
+        if ('' !== $message->getFrom()) {
+            throw new InvalidArgumentException(sprintf('The "%s" transport does not support "from" in "%s".', __CLASS__, SmsMessage::class));
         }
 
         $endpoint = sprintf('https://%s', $this->getEndpoint());

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\FreeMobile\Tests;
 
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransport;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -41,5 +42,15 @@ final class FreeMobileTransportTest extends TransportTestCase
         yield [new SmsMessage('0699887766', 'Hello!')]; // because this phone number is not configured on the transport!
         yield [new ChatMessage('Hello!')];
         yield [$this->createMock(MessageInterface::class)];
+    }
+
+    public function testSmsMessageWithFrom()
+    {
+        $transport = $this->createTransport();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransport" transport does not support "from" in "Symfony\Component\Notifier\Message\SmsMessage".');
+
+        $transport->send(new SmsMessage('+33611223344', 'test', 'foo'));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiTransport.php
@@ -55,12 +55,14 @@ final class GatewayApiTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/rest/mtsms', $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->authToken, ''],
             'json' => [
-                'sender' => $this->from,
+                'sender' => $from,
                 'recipients' => [['msisdn' => $message->getPhone()]],
                 'message' => $message->getSubject(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransport.php
@@ -54,6 +54,8 @@ final class InfobipTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/sms/2/text/advanced', $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
@@ -63,7 +65,7 @@ final class InfobipTransport extends AbstractTransport
             'json' => [
                 'messages' => [
                     [
-                        'from' => $this->from,
+                        'from' => $from,
                         'destinations' => [
                             [
                                 'to' => $message->getPhone(),

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
@@ -57,13 +57,15 @@ final class IqsmsTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/messages/v2/send.json', [
             'json' => [
                 'messages' => [
                     [
                         'phone' => $message->getPhone(),
                         'text' => $message->getSubject(),
-                        'sender' => $this->from,
+                        'sender' => $from,
                         'clientId' => uniqid(),
                     ],
                 ],

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 6.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
@@ -60,6 +60,8 @@ class KazInfoTehTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $originator = $message->getFrom() ?: $this->sender;
+
         $endpoint = sprintf('http://%s/api', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'query' => [
@@ -68,7 +70,7 @@ class KazInfoTehTransport extends AbstractTransport
                 'password' => $this->password,
                 'recipient' => $message->getPhone(),
                 'messagetype' => 'SMS:TEXT',
-                'originator' => $this->sender,
+                'originator' => $originator,
                 'messagedata' => $message->getSubject(),
             ],
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
@@ -100,10 +100,12 @@ final class LightSmsTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $data = [
             'login' => $this->login,
             'phone' => $phone = $this->escapePhoneNumber($message->getPhone()),
-            'sender' => $this->from,
+            'sender' => $from,
             'text' => $message->getSubject(),
             'timestamp' => time(),
         ];

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransport.php
@@ -55,12 +55,14 @@ final class MailjetTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/v4/sms-send', $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,
             'json' => [
-                'From' => $this->from,
+                'From' => $from,
                 'To' => $message->getPhone(),
                 'Text' => $message->getSubject(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
@@ -55,11 +55,13 @@ final class MessageBirdTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/messages', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => 'AccessKey:'.$this->token,
             'body' => [
-                'originator' => $this->from,
+                'originator' => $from,
                 'recipients' => $message->getPhone(),
                 'body' => $message->getSubject(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransport.php
@@ -62,6 +62,8 @@ final class MessageMediaTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/v1/messages', $this->getEndpoint());
         $response = $this->client->request(
             'POST',
@@ -72,7 +74,7 @@ final class MessageMediaTransport extends AbstractTransport
                     'messages' => [
                         [
                             'destination_number' => $message->getPhone(),
-                            'source_number' => $this->from,
+                            'source_number' => $from,
                             'content' => $message->getSubject(),
                         ],
                     ],

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
@@ -74,7 +74,11 @@ final class MobytTransport extends AbstractTransport
         $options['message'] ??= $message->getSubject();
         $options['recipient'] = [$message->getPhone()];
 
-        $options['sender'] ??= $this->from;
+        if ('' !== $message->getFrom()) {
+            $options['sender'] = $message->getFrom();
+        } else {
+            $options['sender'] ??= $this->from;
+        }
 
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/API/v1.0/REST/sms', [
             'headers' => [

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/OctopushTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/OctopushTransport.php
@@ -59,6 +59,8 @@ final class OctopushTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/api/sms/json', $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
@@ -70,7 +72,7 @@ final class OctopushTransport extends AbstractTransport
                 'api_key' => $this->apiKey,
                 'sms_text' => $message->getSubject(),
                 'sms_recipients' => $message->getPhone(),
-                'sms_sender' => $this->from,
+                'sms_sender' => $from,
                 'sms_type' => $this->type,
             ],
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 6.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/OrangeSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/OrangeSmsTransport.php
@@ -59,7 +59,9 @@ final class OrangeSmsTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $url = 'https://'.$this->getEndpoint().'/smsmessaging/v1/outbound/'.urlencode('tel:'.$this->from).'/requests';
+        $from = $message->getFrom() ?: $this->from;
+
+        $url = 'https://'.$this->getEndpoint().'/smsmessaging/v1/outbound/'.urlencode('tel:'.$from).'/requests';
         $headers = [
             'Authorization' => 'Bearer '.$this->getAccessToken(),
             'Content-Type' => 'application/json',
@@ -68,7 +70,7 @@ final class OrangeSmsTransport extends AbstractTransport
         $payload = [
             'outboundSMSMessageRequest' => [
                 'address' => 'tel:'.$message->getPhone(),
-                'senderAddress' => 'tel:'.$this->from,
+                'senderAddress' => 'tel:'.$from,
                 'outboundSMSTextMessage' => [
                     'message' => $message->getSubject(),
                 ],

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 6.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -97,7 +97,9 @@ final class OvhCloudTransport extends AbstractTransport
             'priority' => 'medium',
         ];
 
-        if ($this->sender) {
+        if ('' !== $message->getFrom()) {
+            $content['sender'] = $message->getFrom();
+        } elseif ($this->sender) {
             $content['sender'] = $this->sender;
         } else {
             $content['senderForResponse'] = true;

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 6.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
@@ -60,12 +60,14 @@ final class SendberryTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        if (!preg_match('/^[+]+[1-9][0-9]{9,14}$/', $this->from)) {
-            if ('' === $this->from) {
+        $from = $message->getFrom() ?: $this->from;
+
+        if (!preg_match('/^[+]+[1-9][0-9]{9,14}$/', $from)) {
+            if ('' === $from) {
                 throw new IncompleteDsnException('This phone number is invalid.');
             }
 
-            if (!preg_match('/^[a-zA-Z0-9 ]+$/', $this->from)) {
+            if (!preg_match('/^[a-zA-Z0-9 ]+$/', $from)) {
                 throw new IncompleteDsnException('The Sender ID is invalid.');
             }
         }
@@ -73,7 +75,7 @@ final class SendberryTransport extends AbstractTransport
         $endpoint = sprintf('https://%s/SMS/SEND', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'json' => [
-                'from' => $this->from,
+                'from' => $from,
                 'to' => [$message->getPhone()],
                 'content' => $message->getSubject(),
                 'key' => $this->authKey,

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransport.php
@@ -55,9 +55,11 @@ final class SendinblueTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $sender = $message->getFrom() ?: $this->sender;
+
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v3/transactionalSMS/sms', [
             'json' => [
-                'sender' => $this->sender,
+                'sender' => $sender,
                 'recipient' => $message->getPhone(),
                 'content' => $message->getSubject(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
@@ -57,11 +57,13 @@ final class SinchTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/xms/v1/%s/batches', $this->getEndpoint(), $this->accountSid);
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,
             'json' => [
-                'from' => $this->from,
+                'from' => $from,
                 'to' => [$message->getPhone()],
                 'body' => $message->getSubject(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
@@ -59,6 +59,8 @@ final class Sms77Transport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/api/sms', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'headers' => [
@@ -67,7 +69,7 @@ final class Sms77Transport extends AbstractTransport
                 'X-Api-Key' => $this->apiKey,
             ],
             'json' => [
-                'from' => $this->from,
+                'from' => $from,
                 'json' => 1,
                 'text' => $message->getSubject(),
                 'to' => $message->getPhone(),

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
@@ -77,6 +77,8 @@ final class SmsBiurasTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/api?', $this->getEndpoint());
 
         $response = $this->client->request('GET', $endpoint, [
@@ -84,7 +86,7 @@ final class SmsBiurasTransport extends AbstractTransport
                 'uid' => $this->uid,
                 'apikey' => $this->apiKey,
                 'message' => $message->getSubject(),
-                'from' => $this->from,
+                'from' => $from,
                 'test' => $this->testMode ? 0 : 1,
                 'to' => $message->getPhone(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 ---
 
  * Add the bridge
+ * Use `SmsMessage->from` when defined

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
@@ -74,7 +74,9 @@ final class SmsFactorTransport extends AbstractTransport
             'gsmsmsid' => $messageId,
         ];
 
-        if (null !== $this->sender) {
+        if ('' !== $message->getFrom()) {
+            $query['sender'] = $message->getFrom();
+        } elseif (null !== $this->sender) {
             $query['sender'] = $this->sender;
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 6.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
@@ -88,11 +88,13 @@ final class SmsapiTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://%s/sms.do', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,
             'body' => [
-                'from' => $this->from,
+                'from' => $from,
                 'to' => $message->getPhone(),
                 'message' => $message->getSubject(),
                 'fast' => $this->fast,

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
@@ -59,10 +59,12 @@ final class SmscTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $body = [
             'login' => $this->login,
             'psw' => $this->password,
-            'sender' => $this->from,
+            'sender' => $from,
             'phones' => $message->getPhone(),
             'mes' => $message->getSubject(),
             'fmt' => 3, // response as JSON

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
@@ -72,6 +72,8 @@ final class SpotHitTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $endpoint = sprintf('https://www.%s/api/envoyer/sms', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'body' => [
@@ -79,7 +81,7 @@ final class SpotHitTransport extends AbstractTransport
                 'destinataires' => $message->getPhone(),
                 'type' => 'premium',
                 'message' => $message->getSubject(),
-                'expediteur' => $this->from,
+                'expediteur' => $from,
             ],
         ]);
 

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransport.php
@@ -62,14 +62,16 @@ final class TelnyxTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        if (!preg_match('/^[+]+[1-9][0-9]{9,14}$/', $this->from)) {
-            if ('' === $this->from) {
+        $from = $message->getFrom() ?: $this->from;
+
+        if (!preg_match('/^[+]+[1-9][0-9]{9,14}$/', $from)) {
+            if ('' === $from) {
                 throw new IncompleteDsnException('This phone number is invalid.');
-            } elseif ('' !== $this->from && null === $this->messagingProfileId) {
+            } elseif ('' !== $from && null === $this->messagingProfileId) {
                 throw new IncompleteDsnException('The sending messaging profile must be specified.');
             }
 
-            if (!preg_match('/^[a-zA-Z0-9 ]+$/', $this->from)) {
+            if (!preg_match('/^[a-zA-Z0-9 ]+$/', $from)) {
                 throw new IncompleteDsnException('The Sender ID is invalid.');
             }
         }
@@ -78,7 +80,7 @@ final class TelnyxTransport extends AbstractTransport
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->apiKey,
             'json' => [
-                'from' => $this->from,
+                'from' => $from,
                 'to' => $message->getPhone(),
                 'text' => $message->getSubject(),
                 'messaging_profile_id' => $this->messagingProfileId ?? '',

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
@@ -148,4 +148,14 @@ final class TurboSmsTransportTest extends TransportTestCase
 
         $transport->send($message);
     }
+
+    public function testSmsMessageWithInvalidFrom()
+    {
+        $transport = $this->createTransport();
+
+        $this->expectException(LengthException::class);
+        $this->expectExceptionMessage('The sender length of a TurboSMS message must not exceed 20 characters.');
+
+        $transport->send(new SmsMessage('380931234567', 'test', 'abcdefghijklmnopqrstu'));
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
@@ -65,12 +65,20 @@ final class TurboSmsTransport extends AbstractTransport
 
         $this->assertValidSubject($message->getSubject());
 
+        $fromMessage = $message->getFrom();
+        if (null !== $fromMessage) {
+            $this->assertValidFrom($fromMessage);
+            $from = $fromMessage;
+        } else {
+            $from = $this->from;
+        }
+
         $endpoint = sprintf('https://%s/message/send.json', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,
             'json' => [
                 'sms' => [
-                    'sender' => $this->from,
+                    'sender' => $from,
                     'recipients' => [$message->getPhone()],
                     'text' => $message->getSubject(),
                 ],

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
@@ -57,6 +57,19 @@ final class TwilioTransportTest extends TransportTestCase
         $transport->send(new SmsMessage('+33612345678', 'Hello!'));
     }
 
+    /**
+     * @dataProvider invalidFromProvider
+     */
+    public function testInvalidArgumentExceptionIsThrownIfSmsMessageFromIsInvalid(string $from)
+    {
+        $transport = $this->createTransport();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $from));
+
+        $transport->send(new SmsMessage('+33612345678', 'Hello!', $from));
+    }
+
     public function invalidFromProvider(): iterable
     {
         // alphanumeric sender ids

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
@@ -58,15 +58,17 @@ final class TwilioTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        if (!preg_match('/^[a-zA-Z0-9\s]{2,11}$/', $this->from) && !preg_match('/^\+[1-9]\d{1,14}$/', $this->from)) {
-            throw new InvalidArgumentException(sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $this->from));
+        $from = $message->getFrom() ?: $this->from;
+
+        if (!preg_match('/^[a-zA-Z0-9\s]{2,11}$/', $from) && !preg_match('/^\+[1-9]\d{1,14}$/', $from)) {
+            throw new InvalidArgumentException(sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $from));
         }
 
         $endpoint = sprintf('https://%s/2010-04-01/Accounts/%s/Messages.json', $this->getEndpoint(), $this->accountSid);
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => $this->accountSid.':'.$this->authToken,
             'body' => [
-                'From' => $this->from,
+                'From' => $from,
                 'To' => $message->getPhone(),
                 'Body' => $message->getSubject(),
             ],

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Use `SmsMessage->from` when defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/VonageTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/VonageTransport.php
@@ -58,9 +58,11 @@ final class VonageTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $from = $message->getFrom() ?: $this->from;
+
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/sms/json', [
             'body' => [
-                'from' => $this->from,
+                'from' => $from,
                 'to' => $message->getPhone(),
                 'text' => $message->getSubject(),
                 'api_key' => $this->apiKey,

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Throw exception when `SmsMessage->from` defined
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Yunpian\Tests;
 
 use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransport;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -39,5 +40,15 @@ final class YunpianTransportTest extends TransportTestCase
     {
         yield [new ChatMessage('Hello!')];
         yield [$this->createMock(MessageInterface::class)];
+    }
+
+    public function testSmsMessageWithFrom()
+    {
+        $transport = $this->createTransport();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransport" transport does not support "from" in "Symfony\Component\Notifier\Message\SmsMessage".');
+
+        $transport->send(new SmsMessage('0600000000', 'test', 'foo'));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Yunpian;
 
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
@@ -51,6 +52,10 @@ class YunpianTransport extends AbstractTransport
     {
         if (!$message instanceof SmsMessage) {
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        if ('' !== $message->getFrom()) {
+            throw new InvalidArgumentException(sprintf('The "%s" transport does not support "from" in "%s".', __CLASS__, SmsMessage::class));
         }
 
         $endpoint = sprintf('https://%s/v2/sms/single_send.json', self::HOST);

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add PHPUnit constraints
+ * Add `from` property in `SmsMessage`
 
 6.1
 ---

--- a/src/Symfony/Component/Notifier/Message/SmsMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SmsMessage.php
@@ -23,8 +23,9 @@ class SmsMessage implements MessageInterface
     private ?string $transport = null;
     private string $subject;
     private string $phone;
+    private string $from;
 
-    public function __construct(string $phone, string $subject)
+    public function __construct(string $phone, string $subject, string $from = '')
     {
         if ('' === $phone) {
             throw new InvalidArgumentException(sprintf('"%s" needs a phone number, it cannot be empty.', __CLASS__));
@@ -32,6 +33,7 @@ class SmsMessage implements MessageInterface
 
         $this->subject = $subject;
         $this->phone = $phone;
+        $this->from = $from;
     }
 
     public static function fromNotification(Notification $notification, SmsRecipientInterface $recipient): self
@@ -91,6 +93,21 @@ class SmsMessage implements MessageInterface
     public function getTransport(): ?string
     {
         return $this->transport;
+    }
+
+    /**
+     * @return $this
+     */
+    public function from(string $from): static
+    {
+        $this->from = $from;
+
+        return $this;
+    }
+
+    public function getFrom(): string
+    {
+        return $this->from;
     }
 
     public function getOptions(): ?MessageOptionsInterface

--- a/src/Symfony/Component/Notifier/Tests/Message/SmsMessageTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Message/SmsMessageTest.php
@@ -25,6 +25,16 @@ class SmsMessageTest extends TestCase
 
         $this->assertSame('subject', $message->getSubject());
         $this->assertSame('+3312345678', $message->getPhone());
+        $this->assertSame('', $message->getFrom());
+    }
+
+    public function testCanBeConstructedWithFrom()
+    {
+        $message = new SmsMessage('+3312345678', 'subject', 'foo');
+
+        $this->assertSame('subject', $message->getSubject());
+        $this->assertSame('+3312345678', $message->getPhone());
+        $this->assertSame('foo', $message->getFrom());
     }
 
     public function testEnsureNonEmptyPhoneOnConstruction()
@@ -56,5 +66,16 @@ class SmsMessageTest extends TestCase
         $this->assertSame('+3312345678', $message->getPhone());
 
         $message->phone('');
+    }
+
+    public function testSetFrom()
+    {
+        $message = new SmsMessage('+3312345678', 'subject');
+
+        $this->assertSame('', $message->getFrom());
+
+        $message->from('foo');
+
+        $this->assertSame('foo', $message->getFrom());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45435 
| License       | MIT
| Doc PR        | symfony/symfony-docs#16701 [WIP]

This PR allow to define `From` in `SmsMessage`. When it defined, it override default `from` in transports.

```php
$sms = new SmsMessage(
  // the phone number to send the SMS message to
  '+1411111111',
  // the message
  'A new login was detected!',
  // [Optional] the From SMS message, it can also be a name
  '+1422222222',
);

// Can also be defined with setter
$sms->setFrom('+1422222222');

$sentMessage = $texter->send($sms);
```