### PR TITLE
[Mailer] Return-Path has higher priority for envelope address than From address

### DIFF
--- a/src/Symfony/Component/Mailer/DelayedEnvelope.php
+++ b/src/Symfony/Component/Mailer/DelayedEnvelope.php
@@ -86,11 +86,11 @@ final class DelayedEnvelope extends Envelope
         if ($sender = $headers->get('Sender')) {
             return $sender->getAddress();
         }
-        if ($from = $headers->get('From')) {
-            return $from->getAddresses()[0];
-        }
         if ($return = $headers->get('Return-Path')) {
             return $return->getAddress();
+        }
+        if ($from = $headers->get('From')) {
+            return $from->getAddresses()[0];
         }
 
         throw new LogicException('Unable to determine the sender of the message.');

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -84,19 +84,19 @@ class EnvelopeTest extends TestCase
     public function testSenderFromHeadersWithMulitpleHeaders()
     {
         $headers = new Headers();
-        $headers->addMailboxListHeader('From', [$from = new Address('from@symfony.com', 'from'), 'some@symfony.com']);
-        $headers->addPathHeader('Return-Path', $return = new Address('return@symfony.com', 'return'));
+        $headers->addMailboxListHeader('From', [new Address('from@symfony.com', 'from'), 'some@symfony.com']);
+        $headers->addPathHeader('Return-Path', new Address('return@symfony.com', 'return'));
         $headers->addMailboxHeader('Sender', $sender = new Address('sender@symfony.com', 'sender'));
         $headers->addMailboxListHeader('To', ['to@symfony.com']);
         $e = Envelope::create(new Message($headers));
         $this->assertEquals($sender, $e->getSender());
 
         $headers = new Headers();
-        $headers->addMailboxListHeader('From', [$from = new Address('from@symfony.com', 'from'), 'some@symfony.com']);
+        $headers->addMailboxListHeader('From', [new Address('from@symfony.com', 'from'), 'some@symfony.com']);
         $headers->addPathHeader('Return-Path', $return = new Address('return@symfony.com', 'return'));
         $headers->addMailboxListHeader('To', ['to@symfony.com']);
         $e = Envelope::create(new Message($headers));
-        $this->assertEquals($from, $e->getSender());
+        $this->assertEquals($return, $e->getSender());
     }
 
     public function testRecipientsFromHeaders()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41322
| License       | MIT
| Doc PR        | -