### PR TITLE
[Validator] Allow empty string on LengthValidator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -30,7 +30,7 @@ class LengthValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Length::class);
         }
 
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -30,20 +30,11 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function testEmptyStringIsInvalid()
+    public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Length([
-            'value' => $limit = 6,
-            'exactMessage' => 'myMessage',
-        ]));
+        $this->validator->validate('', new Length(['value' => 6]));
 
-        $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', '""')
-            ->setParameter('{{ limit }}', $limit)
-            ->setInvalidValue('')
-            ->setPlural($limit)
-            ->setCode(Length::NOT_EQUAL_LENGTH_ERROR)
-            ->assertRaised();
+        $this->assertNoViolation();
     }
 
     public function testExpectsStringCompatibleType()

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -2202,10 +2202,9 @@ class RecursiveValidatorTest extends TestCase
 
         $violations = $this->validator->validate($entity, null, ['one', 'two']);
 
-        $this->assertCount(3, $violations);
+        $this->assertCount(2, $violations);
         $this->assertInstanceOf(NotBlank::class, $violations->get(0)->getConstraint());
         $this->assertInstanceOf(Length::class, $violations->get(1)->getConstraint());
-        $this->assertInstanceOf(Length::class, $violations->get(2)->getConstraint());
     }
 
     public function testRequiredConstraintIsIgnored()


### PR DESCRIPTION
Allow empty string to match documentation "As with most of the other constraints, null and empty strings are considered valid values".

| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes (?)
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | See note at the bottom of the "Basic usage" on [LengthValidator documentation](https://symfony.com/doc/current/reference/constraints/Length.html). To prevent empty string, Length constraint should be associated with NotBlank.
