### PR TITLE
[FrameworkBundle][HttpKernel] Add deprecation warning to show `HttpKernel::handle()` will catch throwables

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 * Deprecate the `Symfony\Component\Serializer\Normalizer\ObjectNormalizer` and
   `Symfony\Component\Serializer\Normalizer\PropertyNormalizer` autowiring aliases, type-hint against
   `Symfony\Component\Serializer\Normalizer\NormalizerInterface` or implement `NormalizerAwareInterface` instead
+ * Add option `framework.catch_all_throwables` to allow `Symfony\Component\HttpKernel\HttpKernel` to catch all kinds of `Throwable`
 
 6.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -133,6 +133,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('error_controller')
                     ->defaultValue('error_controller')
                 ->end()
+                ->booleanNode('catch_all_throwables')->defaultFalse()->info('HttpKernel will catch all kinds of \Throwable')->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -320,6 +320,7 @@ class FrameworkExtension extends Extension
 
         $container->getDefinition('locale_listener')->replaceArgument(3, $config['set_locale_from_accept_language']);
         $container->getDefinition('response_listener')->replaceArgument(1, $config['set_content_language_from_locale']);
+        $container->getDefinition('http_kernel')->replaceArgument(4, $config['catch_all_throwables']);
 
         // If the slugger is used but the String component is not available, we should throw an error
         if (!ContainerBuilder::willBeAvailable('symfony/string', SluggerInterface::class, ['symfony/framework-bundle'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -85,6 +85,7 @@ return static function (ContainerConfigurator $container) {
                 service('controller_resolver'),
                 service('request_stack'),
                 service('argument_resolver'),
+                false,
             ])
             ->tag('container.hot_path')
             ->tag('container.preload', ['class' => HttpKernelRunner::class])

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ExceptionSubscriber.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ExceptionSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * This event subscriber allows you to inspect all exceptions thrown by the application.
+ * This is useful since the HttpKernel catches all throwables and turns them into
+ * an HTTP response.
+ *
+ * This class should only be used in tests.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class ExceptionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var list<\Throwable>
+     */
+    private static array $exceptions = [];
+
+    public function onKernelException(ExceptionEvent $event)
+    {
+        self::$exceptions[] = $event->getThrowable();
+    }
+
+    /**
+     * @return list<\Throwable>
+     */
+    public static function shiftAll(): array
+    {
+        $exceptions = self::$exceptions;
+        self::$exceptions = [];
+
+        return $exceptions;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => 'onKernelException',
+        ];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -656,6 +656,7 @@ class ConfigurationTest extends TestCase
                 'sanitizers' => [],
             ],
             'exceptions' => [],
+            'catch_all_throwables' => false,
         ];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Uid/config_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Uid/config_disabled.yml
@@ -5,3 +5,8 @@ framework:
     http_method_override: false
     uid:
         enabled: false
+
+services:
+    Symfony\Bundle\FrameworkBundle\Test\ExceptionSubscriber:
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -11,6 +11,7 @@ framework:
     enabled_locales: ['en', 'fr']
     session:
         storage_factory_id: session.storage.factory.mock_file
+    catch_all_throwables: true
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -86,6 +86,7 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
             'http_method_override' => false,
             'secret' => '$ecret',
             'router' => ['utf8' => true],
+            'catch_all_throwables' => true,
         ]);
 
         $c->setParameter('halloween', 'Have a great day!');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -122,6 +122,7 @@ class MicroKernelTraitTest extends TestCase
                 $c->extension('framework', [
                     'http_method_override' => false,
                     'router' => ['utf8' => true],
+                    'catch_all_throwables' => true,
                 ]);
                 $c->services()->set('logger', NullLogger::class);
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
@@ -100,6 +100,10 @@ class FlexStyleMicroKernel extends Kernel
                 ->factory([$this, 'createHalloween'])
                 ->arg('$halloween', '%halloween%');
 
-        $c->extension('framework', ['http_method_override' => false, 'router' => ['utf8' => true]]);
+        $c->extension('framework', [
+            'http_method_override' => false,
+            'router' => ['utf8' => true],
+            'catch_all_throwables' => true,
+        ]);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/error-handler": "^6.1",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/http-foundation": "^5.4|^6.0",
-        "symfony/http-kernel": "^6.1",
+        "symfony/http-kernel": "^6.2",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "^5.4|^6.0",
         "symfony/finder": "^5.4|^6.0",

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
@@ -7,6 +7,7 @@ framework:
     profiler: false
     session:
         storage_factory_id: session.storage.factory.mock_file
+    catch_all_throwables: true
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -11,6 +11,7 @@ framework:
     session:
         storage_factory_id: session.storage.factory.mock_file
     profiler: { only_exceptions: false }
+    catch_all_throwables: true
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -12,6 +12,7 @@ framework:
     session:
         storage_factory_id: session.storage.factory.mock_file
     profiler: { only_exceptions: false }
+    catch_all_throwables: true
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -38,7 +38,7 @@
         "symfony/dom-crawler": "^5.4|^6.0",
         "symfony/expression-language": "^5.4|^6.0",
         "symfony/form": "^5.4|^6.0",
-        "symfony/framework-bundle": "^5.4|^6.0",
+        "symfony/framework-bundle": "^6.2",
         "symfony/ldap": "^5.4|^6.0",
         "symfony/process": "^5.4|^6.0",
         "symfony/rate-limiter": "^5.4|^6.0",
@@ -53,7 +53,7 @@
     "conflict": {
         "symfony/browser-kit": "<5.4",
         "symfony/console": "<5.4",
-        "symfony/framework-bundle": "<5.4",
+        "symfony/framework-bundle": "<6.2",
         "symfony/ldap": "<5.4",
         "symfony/twig-bundle": "<5.4"
     },

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\WebProfilerBundle\Tests\Functional;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\FrameworkBundle\Test\ExceptionSubscriber;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -50,13 +51,20 @@ class WebProfilerBundleKernel extends Kernel
 
     protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
     {
-        $containerBuilder->loadFromExtension('framework', [
+        $config = [
             'http_method_override' => false,
             'secret' => 'foo-secret',
             'profiler' => ['only_exceptions' => false],
             'session' => ['storage_factory_id' => 'session.storage.factory.mock_file'],
             'router' => ['utf8' => true],
-        ]);
+        ];
+
+        // If Symfony >= 6.2
+        if (class_exists(ExceptionSubscriber::class)) {
+            $config['catch_all_throwables'] = true;
+        }
+
+        $containerBuilder->loadFromExtension('framework', $config);
 
         $containerBuilder->loadFromExtension('web_profiler', [
             'toolbar' => true,

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add constructor argument `bool $catchThrowable` to `HttpKernel`
+
 6.1
 ---
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -376,7 +376,7 @@ class RequestDataCollectorTest extends TestCase
     protected function injectController($collector, $controller, $request)
     {
         $resolver = $this->createMock(ControllerResolverInterface::class);
-        $httpKernel = new HttpKernel(new EventDispatcher(), $resolver, null, $this->createMock(ArgumentResolverInterface::class));
+        $httpKernel = new HttpKernel(new EventDispatcher(), $resolver, null, $this->createMock(ArgumentResolverInterface::class), true);
         $event = new ControllerEvent($httpKernel, $controller, $request, HttpKernelInterface::MAIN_REQUEST);
         $collector->onKernelController($event);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -119,6 +119,6 @@ class TraceableEventDispatcherTest extends TestCase
         $argumentResolver = $this->createMock(ArgumentResolverInterface::class);
         $argumentResolver->expects($this->once())->method('getArguments')->willReturn([]);
 
-        return new HttpKernel($dispatcher, $controllerResolver, new RequestStack(), $argumentResolver);
+        return new HttpKernel($dispatcher, $controllerResolver, new RequestStack(), $argumentResolver, true);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -173,7 +173,7 @@ class RouterListenerTest extends TestCase
             return new Response('Exception handled', 400);
         }));
 
-        $kernel = new HttpKernel($dispatcher, new ControllerResolver(), $requestStack, new ArgumentResolver());
+        $kernel = new HttpKernel($dispatcher, new ControllerResolver(), $requestStack, new ArgumentResolver(), true);
 
         $request = Request::create('http://localhost/');
         $request->headers->set('host', '###');
@@ -195,7 +195,7 @@ class RouterListenerTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new RouterListener($requestMatcher, $requestStack, new RequestContext()));
 
-        $kernel = new HttpKernel($dispatcher, new ControllerResolver(), $requestStack, new ArgumentResolver());
+        $kernel = new HttpKernel($dispatcher, new ControllerResolver(), $requestStack, new ArgumentResolver(), true);
 
         $request = Request::create('http://localhost/');
         $response = $kernel->handle($request);

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -142,7 +142,7 @@ class InlineFragmentRendererTest extends TestCase
             ->willReturn([])
         ;
 
-        $kernel = new HttpKernel(new EventDispatcher(), $controllerResolver, new RequestStack(), $argumentResolver);
+        $kernel = new HttpKernel(new EventDispatcher(), $controllerResolver, new RequestStack(), $argumentResolver, true);
         $renderer = new InlineFragmentRenderer($kernel);
 
         // simulate a main request with output buffering

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
@@ -36,7 +36,7 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface, 
         $this->headers = $headers;
         $this->customizer = $customizer;
 
-        parent::__construct(new EventDispatcher(), $this, null, $this);
+        parent::__construct(new EventDispatcher(), $this, null, $this, true);
     }
 
     public function assert(\Closure $callback)

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
@@ -35,7 +35,7 @@ class TestMultipleHttpKernel extends HttpKernel implements ControllerResolverInt
             $this->headers[] = $response['headers'];
         }
 
-        parent::__construct(new EventDispatcher(), $this, null, $this);
+        parent::__construct(new EventDispatcher(), $this, null, $this, true);
     }
 
     public function getBackendRequest()

--- a/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
@@ -22,7 +22,7 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface, 
 {
     public function __construct()
     {
-        parent::__construct(new EventDispatcher(), $this, null, $this);
+        parent::__construct(new EventDispatcher(), $this, null, $this, true);
     }
 
     public function getController(Request $request): callable|false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #16205
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I suggest that starting from Symfony 7.0 the `HttpKernel` will start to catch `\Throwable` and convert them to a `Response`.

This was first asked in #16205, I face a similar issue with Runtime component and Bref.. 

----------

The reason I push for this change is to embrace the request/response workflow of the Kernel without trusting the custom error handler. In an environment where you serve multiple requests with the same PHP process (read: RoadRunner, Swoole, Bref) you would write something like: 

```php
$kernel = new Kernel('prod', false);
while (true) {
  $request = /* create sf request from custom environment */
  try {
    $response = $kernel->handle(request);
    return ResponseConverter::convert($response);
  } catch (\Throwable $e) {
    exit(1);
  }
}
```
(pseudo code of course. Here is a [real example](https://github.com/php-runtime/bref/blob/0.3.1/src/BrefRunner.php#L30-L43))

The `exit(1)` means a hard crash. For Bref Runtime it would result in a 500 error from API-gateway. Since the `\Throwable` is caught, the Symfony error handler is not used. If we would not to catch the `\Throwable`, then the Symfony error handler would be used, but it would print a Response instead of returning it. (Printing a response will just add HTML on the CLI...)

-----------

Other PRs and issues related to this: 

- https://github.com/symfony/symfony/issues/45301
- https://github.com/symfony/symfony/pull/26514
- https://github.com/symfony/symfony/issues/22128
- https://github.com/symfony/symfony/pull/36885
- https://github.com/symfony/symfony/issues/25467

I'm happy to let the `HttpKernel` to catch the `\Throwable` exception right now, but I thought this very conservative PR would have a higher change to get merged. 

Also note that we do not specify any behaviour on our [HttpKernelInterface](https://github.com/symfony/symfony/blob/v6.0.7/src/Symfony/Component/HttpKernel/HttpKernelInterface.php#L43)


-------

To remove the deprecation message you need to add this to your config: 

```yaml
framework:
    catch_all_throwables: true
```