### PR TITLE
[Translation] Get domains from provider if them are not specified explicitly

### DIFF
--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -22,7 +22,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Translation\Provider\TranslationProviderCollection;
 use Symfony\Component\Translation\Reader\TranslationReaderInterface;
-use Symfony\Component\Translation\TranslatorBag;
 
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
@@ -133,7 +132,7 @@ EOF
         $localTranslations = $this->readLocalTranslations($locales, $domains, $this->transPaths);
 
         if (!$domains) {
-            $domains = $this->getDomainsFromTranslatorBag($localTranslations);
+            $domains = $provider->getDomains();
         }
 
         if (!$deleteMissing && $force) {
@@ -167,16 +166,5 @@ EOF
         $io->success(sprintf('%s local translations has been sent to "%s" (for "%s" locale(s), and "%s" domain(s)).', $force ? 'All' : 'New', parse_url($provider, \PHP_URL_SCHEME), implode(', ', $locales), implode(', ', $domains)));
 
         return 0;
-    }
-
-    private function getDomainsFromTranslatorBag(TranslatorBag $translatorBag): array
-    {
-        $domains = [];
-
-        foreach ($translatorBag->getCatalogues() as $catalogue) {
-            $domains += $catalogue->getDomains();
-        }
-
-        return array_unique($domains);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

The command `translation:pull` gets domains from provider configuration if them are not specified in options but `translation:push` gets domans from local catalog. I find that the same behavior is more predictable in this case.

https://github.com/symfony/symfony/blob/1f514f97c0dd3c12fbe47787dae17b6e56e2637f/src/Symfony/Component/Translation/Command/TranslationPullCommand.php#L154-L156