### PR TITLE
[HttpKernel] Add `ControllerEvent::getAttributes()` to handle attributes on controllers

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add constructor argument `bool $catchThrowable` to `HttpKernel`
+ * Add `ControllerEvent::getAttributes()` to handle attributes on controllers
 
 6.1
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -45,8 +45,9 @@ final class ArgumentResolver implements ArgumentResolverInterface
     public function getArguments(Request $request, callable $controller): array
     {
         $arguments = [];
+        $reflectors = $request->attributes->get('_controller_reflectors') ?? [];
 
-        foreach ($this->argumentMetadataFactory->createArgumentMetadata($controller) as $metadata) {
+        foreach ($this->argumentMetadataFactory->createArgumentMetadata($controller, ...$reflectors) as $metadata) {
             foreach ($this->argumentValueResolvers as $resolver) {
                 if (!$resolver->supports($request, $metadata)) {
                     continue;

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
@@ -21,22 +21,15 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createArgumentMetadata(string|object|array $controller): array
+    public function createArgumentMetadata(string|object|array $controller, \ReflectionClass $class = null, \ReflectionFunction $reflection = null): array
     {
         $arguments = [];
 
-        if (\is_array($controller)) {
-            $reflection = new \ReflectionMethod($controller[0], $controller[1]);
-            $class = $reflection->class;
-        } elseif (\is_object($controller) && !$controller instanceof \Closure) {
-            $reflection = new \ReflectionMethod($controller, '__invoke');
-            $class = $reflection->class;
-        } else {
-            $reflection = new \ReflectionFunction($controller);
-            if ($class = str_contains($reflection->name, '{closure}') ? null : $reflection->getClosureScopeClass()) {
-                $class = $class->name;
-            }
+        if (null === $reflection) {
+            $reflection = new \ReflectionFunction($controller(...));
+            $class = str_contains($reflection->name, '{closure}') ? null : $reflection->getClosureScopeClass();
         }
+        $class = $class?->name;
 
         foreach ($reflection->getParameters() as $param) {
             $attributes = [];

--- a/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
@@ -28,25 +28,32 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 final class ControllerArgumentsEvent extends KernelEvent
 {
-    private $controller;
+    private ControllerEvent $controllerEvent;
     private array $arguments;
 
-    public function __construct(HttpKernelInterface $kernel, callable $controller, array $arguments, Request $request, ?int $requestType)
+    public function __construct(HttpKernelInterface $kernel, callable|ControllerEvent $controller, array $arguments, Request $request, ?int $requestType)
     {
         parent::__construct($kernel, $request, $requestType);
 
-        $this->controller = $controller;
+        if (!$controller instanceof ControllerEvent) {
+            $controller = new ControllerEvent($kernel, $controller, $request, $requestType);
+        }
+
+        $this->controllerEvent = $controller;
         $this->arguments = $arguments;
     }
 
     public function getController(): callable
     {
-        return $this->controller;
+        return $this->controllerEvent->getController();
     }
 
-    public function setController(callable $controller)
+    /**
+     * @param array<class-string, list<object>>|null $attributes
+     */
+    public function setController(callable $controller, array $attributes = null): void
     {
-        $this->controller = $controller;
+        $this->controllerEvent->setController($controller, $attributes);
     }
 
     public function getArguments(): array
@@ -57,5 +64,13 @@ final class ControllerArgumentsEvent extends KernelEvent
     public function setArguments(array $arguments)
     {
         $this->arguments = $arguments;
+    }
+
+    /**
+     * @return array<class-string, list<object>>
+     */
+    public function getAttributes(): array
+    {
+        return $this->controllerEvent->getAttributes();
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -152,10 +152,11 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         // controller arguments
         $arguments = $this->argumentResolver->getArguments($request, $controller);
 
-        $event = new ControllerArgumentsEvent($this, $controller, $arguments, $request, $type);
+        $event = new ControllerArgumentsEvent($this, $event, $arguments, $request, $type);
         $this->dispatcher->dispatch($event, KernelEvents::CONTROLLER_ARGUMENTS);
         $controller = $event->getController();
         $arguments = $event->getArguments();
+        $request->attributes->remove('_controller_reflectors');
 
         // call controller
         $response = $controller(...$arguments);

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -154,23 +154,23 @@ class ArgumentMetadataFactoryTest extends TestCase
         ], $arguments);
     }
 
-    private function signature1(self $foo, array $bar, callable $baz)
+    public function signature1(self $foo, array $bar, callable $baz)
     {
     }
 
-    private function signature2(self $foo = null, FakeClassThatDoesNotExist $bar = null, ImportedAndFake $baz = null)
+    public function signature2(self $foo = null, FakeClassThatDoesNotExist $bar = null, ImportedAndFake $baz = null)
     {
     }
 
-    private function signature3(FakeClassThatDoesNotExist $bar, ImportedAndFake $baz)
+    public function signature3(FakeClassThatDoesNotExist $bar, ImportedAndFake $baz)
     {
     }
 
-    private function signature4($foo = 'default', $bar = 500, $baz = [])
+    public function signature4($foo = 'default', $bar = 500, $baz = [])
     {
     }
 
-    private function signature5(array $foo = null, $bar = null)
+    public function signature5(array $foo = null, $bar = null)
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Event/ControllerArgumentsEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/ControllerArgumentsEventTest.php
@@ -14,13 +14,51 @@ namespace Symfony\Component\HttpKernel\Tests\Event;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Bar;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\AttributeController;
 use Symfony\Component\HttpKernel\Tests\TestHttpKernel;
 
 class ControllerArgumentsEventTest extends TestCase
 {
     public function testControllerArgumentsEvent()
     {
-        $filterController = new ControllerArgumentsEvent(new TestHttpKernel(), function () {}, ['test'], new Request(), 1);
-        $this->assertEquals($filterController->getArguments(), ['test']);
+        $event = new ControllerArgumentsEvent(new TestHttpKernel(), function () {}, ['test'], new Request(), HttpKernelInterface::MAIN_REQUEST);
+        $this->assertEquals($event->getArguments(), ['test']);
+    }
+
+    public function testSetAttributes()
+    {
+        $controller = function () {};
+        $event = new ControllerArgumentsEvent(new TestHttpKernel(), $controller, ['test'], new Request(), HttpKernelInterface::MAIN_REQUEST);
+        $event->setController($controller, []);
+
+        $this->assertSame([], $event->getAttributes());
+    }
+
+    public function testGetAttributes()
+    {
+        $controller = new AttributeController();
+        $request = new Request();
+
+        $controllerEvent = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $event = new ControllerArgumentsEvent(new TestHttpKernel(), $controllerEvent, ['test'], new Request(), HttpKernelInterface::MAIN_REQUEST);
+
+        $expected = [
+            Bar::class => [
+                new Bar('class'),
+                new Bar('method'),
+            ],
+        ];
+
+        $this->assertEquals($expected, $event->getAttributes());
+
+        $expected[Bar::class][] = new Bar('foo');
+        $event->setController($controller, $expected);
+
+        $this->assertEquals($expected, $event->getAttributes());
+        $this->assertSame($controllerEvent->getAttributes(), $event->getAttributes());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Event/ControllerEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/ControllerEventTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Bar;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\AttributeController;
+use Symfony\Component\HttpKernel\Tests\TestHttpKernel;
+
+class ControllerEventTest extends TestCase
+{
+    public function testSetAttributes()
+    {
+        $request = new Request();
+        $request->attributes->set('_controller_reflectors', [1, 2]);
+        $controller = [new AttributeController(), 'action'];
+        $event = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+        $event->setController($controller, []);
+
+        $this->assertSame([], $event->getAttributes());
+    }
+
+    /**
+     * @dataProvider provideGetAttributes
+     */
+    public function testGetAttributes(callable $controller)
+    {
+        $request = new Request();
+        $reflector = new \ReflectionFunction($controller(...));
+        $request->attributes->set('_controller_reflectors', [str_contains($reflector->name, '{closure}') ? null : $reflector->getClosureScopeClass(), $reflector]);
+
+        $event = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $expected = [
+            Bar::class => [
+                new Bar('class'),
+                new Bar('method'),
+            ],
+        ];
+
+        $this->assertEquals($expected, $event->getAttributes());
+    }
+
+    public function provideGetAttributes()
+    {
+        yield [[new AttributeController(), '__invoke']];
+        yield [new AttributeController()];
+        yield [(new AttributeController())->__invoke(...)];
+        yield [#[Bar('class'), Bar('method')] static function () {}];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Bar.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Bar.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
+class Bar
+{
+    public function __construct(
+        public mixed $foo,
+    ) {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
@@ -11,10 +11,17 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
 
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Bar;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Foo;
 
+#[Bar('class'), Undefined('class')]
 class AttributeController
 {
+    #[Bar('method'), Undefined('method')]
+    public function __invoke()
+    {
+    }
+
     public function action(#[Foo('bar')] string $baz)
     {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Replacing #45457. Paving the way toward #44705