### PR TITLE
[FrameworkBundle] Add support for first-class callable route controller in MicroKernelTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `xliff` support in addition to `xlf` for `XliffFileDumper`
  * Deprecate the `reset_on_message` config option. It can be set to `true` only and does nothing now
  * Add `trust_x_sendfile_type_header` option
+ * Add support for first-class callable route controller in `MicroKernelTrait`
 
 6.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -214,6 +214,8 @@ trait MicroKernelTrait
 
             if (\is_array($controller) && [0, 1] === array_keys($controller) && $this === $controller[0]) {
                 $route->setDefault('_controller', ['kernel', $controller[1]]);
+            } elseif ($controller instanceof \Closure && $this === ($r = new \ReflectionFunction($controller))->getClosureThis() && !str_contains($r->name, '{closure}')) {
+                $route->setDefault('_controller', ['kernel', $r->name]);
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -89,6 +89,11 @@ class MicroKernelTraitTest extends TestCase
         $response = $kernel->handle($request);
 
         $this->assertEquals('Have a great day!', $response->getContent());
+
+        $request = Request::create('/h');
+        $response = $kernel->handle($request);
+
+        $this->assertEquals('Have a great day!', $response->getContent());
     }
 
     public function testSecretLoadedFromExtension()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
@@ -74,6 +74,7 @@ class FlexStyleMicroKernel extends Kernel
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
         $routes->add('halloween', '/')->controller([$this, 'halloweenAction']);
+        $routes->add('halloween2', '/h')->controller($this->halloweenAction(...));
     }
 
     protected function configureContainer(ContainerConfigurator $c): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I have some routes defined in `Kernel.php` with the following syntax:
```php
$routes->add('app_foo', '/foo')
    ->methods(['GET'])
    ->controller([$this, 'fooRoute']);
```

I'd like to switch them to:
```php
$routes->add('app_foo', '/foo')
    ->methods(['GET'])
    ->controller($this->fooRoute(...));
```

Because I'd like to use first-class callable syntax everywhere in the project.