### PR TITLE
[Messenger] Leverage nullsafe operator in worker

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -175,6 +175,25 @@ class WorkerTest extends TestCase
         $worker->run();
     }
 
+    public function testWorkerWithoutDispatcher()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $receiver = new DummyReceiver([[$envelope]]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $worker = new Worker([$receiver], $bus);
+
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->willReturnCallback(static function () use ($worker, $envelope) {
+                $worker->stop();
+
+                return $envelope;
+            });
+
+        $worker->run();
+    }
+
     public function testWorkerDispatchesEventsOnError()
     {
         $envelope = new Envelope(new DummyMessage('Hello'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR inlines the private `dispatchEvent()` method by leveraging the nullsafe operator of PHP 8. It also adds a test to make sure the worker actually works without a dispatcher.