### PR TITLE
[Routing] Add params variable to condition expression

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -1,0 +1,7 @@
+UPGRADE FROM 6.1 to 6.2
+=======================
+
+Routing
+-------
+
+ * Add argument `$routeParameters` to `UrlMatcher::handleRouteRequirements()`

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add `params` variable to condition expression
+ * Deprecate not passing route parameters as the forth argument to `UrlMatcher::handleRouteRequirements()`
+
 6.1
 ---
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
@@ -115,7 +115,7 @@ EOF;
             }
 
             $checkConditionCode = <<<EOF
-    static function (\$condition, \$context, \$request) { // \$checkCondition
+    static function (\$condition, \$context, \$request, \$params) { // \$checkCondition
         switch (\$condition) {
 {$this->indent(implode("\n", $conditions), 3)}
         }
@@ -426,7 +426,7 @@ EOF;
         }
 
         if ($condition = $route->getCondition()) {
-            $condition = $this->getExpressionLanguage()->compile($condition, ['context', 'request']);
+            $condition = $this->getExpressionLanguage()->compile($condition, ['context', 'request', 'params']);
             $condition = $conditions[$condition] ??= (str_contains($condition, '$request') ? 1 : -1) * \count($conditions);
         } else {
             $condition = null;

--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherTrait.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherTrait.php
@@ -92,10 +92,6 @@ trait CompiledUrlMatcherTrait
         $supportsRedirections = 'GET' === $canonicalMethod && $this instanceof RedirectableUrlMatcherInterface;
 
         foreach ($this->staticRoutes[$trimmedPathinfo] ?? [] as [$ret, $requiredHost, $requiredMethods, $requiredSchemes, $hasTrailingSlash, , $condition]) {
-            if ($condition && !($this->checkCondition)($condition, $context, 0 < $condition ? $request ??= $this->request ?: $this->createRequest($pathinfo) : null)) {
-                continue;
-            }
-
             if ($requiredHost) {
                 if ('{' !== $requiredHost[0] ? $requiredHost !== $host : !preg_match($requiredHost, $host, $hostMatches)) {
                     continue;
@@ -104,6 +100,10 @@ trait CompiledUrlMatcherTrait
                     $hostMatches['_route'] = $ret['_route'];
                     $ret = $this->mergeDefaults($hostMatches, $ret);
                 }
+            }
+
+            if ($condition && !($this->checkCondition)($condition, $context, 0 < $condition ? $request ??= $this->request ?: $this->createRequest($pathinfo) : null, $ret)) {
+                continue;
             }
 
             if ('/' !== $pathinfo && $hasTrailingSlash === ($trimmedPathinfo === $pathinfo)) {
@@ -132,13 +132,8 @@ trait CompiledUrlMatcherTrait
         foreach ($this->regexpList as $offset => $regex) {
             while (preg_match($regex, $matchedPathinfo, $matches)) {
                 foreach ($this->dynamicRoutes[$m = (int) $matches['MARK']] as [$ret, $vars, $requiredMethods, $requiredSchemes, $hasTrailingSlash, $hasTrailingVar, $condition]) {
-                    if (null !== $condition) {
-                        if (0 === $condition) { // marks the last route in the regexp
-                            continue 3;
-                        }
-                        if (!($this->checkCondition)($condition, $context, 0 < $condition ? $request ??= $this->request ?: $this->createRequest($pathinfo) : null)) {
-                            continue;
-                        }
+                    if (0 === $condition) { // marks the last route in the regexp
+                        continue 3;
                     }
 
                     $hasTrailingVar = $trimmedPathinfo !== $pathinfo && $hasTrailingVar;
@@ -151,17 +146,21 @@ trait CompiledUrlMatcherTrait
                         }
                     }
 
+                    foreach ($vars as $i => $v) {
+                        if (isset($matches[1 + $i])) {
+                            $ret[$v] = $matches[1 + $i];
+                        }
+                    }
+
+                    if ($condition && !($this->checkCondition)($condition, $context, 0 < $condition ? $request ??= $this->request ?: $this->createRequest($pathinfo) : null, $ret)) {
+                        continue;
+                    }
+
                     if ('/' !== $pathinfo && !$hasTrailingVar && $hasTrailingSlash === ($trimmedPathinfo === $pathinfo)) {
                         if ($supportsRedirections && (!$requiredMethods || isset($requiredMethods['GET']))) {
                             return $allow = $allowSchemes = [];
                         }
                         continue;
-                    }
-
-                    foreach ($vars as $i => $v) {
-                        if (isset($matches[1 + $i])) {
-                            $ret[$v] = $matches[1 + $i];
-                        }
                     }
 
                     if ($requiredSchemes && !isset($requiredSchemes[$context->getScheme()])) {

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -115,7 +115,9 @@ class TraceableUrlMatcher extends UrlMatcher
                 continue;
             }
 
-            $status = $this->handleRouteRequirements($pathinfo, $name, $route);
+            $attributes = $this->getAttributes($route, $name, array_replace($matches, $hostMatches));
+
+            $status = $this->handleRouteRequirements($pathinfo, $name, $route, $attributes);
 
             if (self::REQUIREMENT_MISMATCH === $status[0]) {
                 $this->addTrace(sprintf('Condition "%s" does not evaluate to "true"', $route->getCondition()), self::ROUTE_ALMOST_MATCHES, $name, $route);
@@ -146,7 +148,7 @@ class TraceableUrlMatcher extends UrlMatcher
 
             $this->addTrace('Route matches!', self::ROUTE_MATCHES, $name, $route);
 
-            return $this->getAttributes($route, $name, array_replace($matches, $hostMatches, $status[1] ?? []));
+            return array_replace($attributes, $status[1] ?? []);
         }
 
         return [];

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -167,7 +167,9 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
                 continue;
             }
 
-            $status = $this->handleRouteRequirements($pathinfo, $name, $route);
+            $attributes = $this->getAttributes($route, $name, array_replace($matches, $hostMatches));
+
+            $status = $this->handleRouteRequirements($pathinfo, $name, $route, $attributes);
 
             if (self::REQUIREMENT_MISMATCH === $status[0]) {
                 continue;
@@ -190,7 +192,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
                 continue;
             }
 
-            return $this->getAttributes($route, $name, array_replace($matches, $hostMatches, $status[1] ?? []));
+            return array_replace($attributes, $status[1] ?? []);
         }
 
         return [];
@@ -220,10 +222,25 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
      *
      * @return array The first element represents the status, the second contains additional information
      */
-    protected function handleRouteRequirements(string $pathinfo, string $name, Route $route): array
+    protected function handleRouteRequirements(string $pathinfo, string $name, Route $route/*, array $routeParameters*/): array
     {
+        if (\func_num_args() < 4) {
+            trigger_deprecation('symfony/routing', '6.2', 'The "%s()" method will have a new "array $routeParameters" argument in version 7.0, not defining it is deprecated.', __METHOD__);
+            $routeParameters = [];
+        } else {
+            $routeParameters = func_get_arg(3);
+
+            if (!\is_array($routeParameters)) {
+                throw new \TypeError(sprintf('"%s": Argument $routeParameters is expected to be an array, got "%s".', __METHOD__, get_debug_type($routeParameters)));
+            }
+        }
+
         // expression condition
-        if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(), ['context' => $this->context, 'request' => $this->request ?: $this->createRequest($pathinfo)])) {
+        if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(), [
+            'context' => $this->context,
+            'request' => $this->request ?: $this->createRequest($pathinfo),
+            'params' => $routeParameters,
+        ])) {
             return [self::REQUIREMENT_MISMATCH, null];
         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/compiled_url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/compiled_url_matcher3.php
@@ -14,17 +14,20 @@ return [
     [ // $regexpList
         0 => '{^(?'
                 .'|/rootprefix/([^/]++)(*:27)'
+                .'|/with\\-condition/(\\d+)(*:56)'
             .')/?$}sD',
     ],
     [ // $dynamicRoutes
-        27 => [
-            [['_route' => 'dynamic'], ['var'], null, null, false, true, null],
+        27 => [[['_route' => 'dynamic'], ['var'], null, null, false, true, null]],
+        56 => [
+            [['_route' => 'with-condition-dynamic'], ['id'], null, null, false, true, -2],
             [null, null, null, null, false, false, 0],
         ],
     ],
-    static function ($condition, $context, $request) { // $checkCondition
+    static function ($condition, $context, $request, $params) { // $checkCondition
         switch ($condition) {
             case -1: return ($context->getMethod() == "GET");
+            case -2: return ($params["id"] < 100);
         }
     },
 ];

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
@@ -296,6 +296,10 @@ class CompiledUrlMatcherDumperTest extends TestCase
         $route = new Route('/with-condition');
         $route->setCondition('context.getMethod() == "GET"');
         $rootprefixCollection->add('with-condition', $route);
+        $route = new Route('/with-condition/{id}');
+        $route->setRequirement('id', '\d+');
+        $route->setCondition("params['id'] < 100");
+        $rootprefixCollection->add('with-condition-dynamic', $route);
 
         /* test case 4 */
         $headMatchCasesCollection = new RouteCollection();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16747

Currently it's not possible to use `request.attributes.get('_route_params')` in route conditions because the parameter is not yet set when the expression is being evaluated. That happens [after the matcher is finished](https://github.com/symfony/symfony/blob/6ecd17e7b249edad650f3fb6d9a126eee4e132f3/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php#L120).

This PR adds a new `params` variable to the condition option expression syntax:

```php
class FooController
{
    #[Route('/foo/{id}', requirements: ['id' => '\d+'], condition: "params['id'] < 100")]
    public function index(int $id): Response
    {
    }
}
```