### PR TITLE
[Notifier] smsapi - send messages in test mode

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 6.1
 ---
 
- * Added `fast` option to the DSN that allows sending message with the highest priority that ensures the quickest possible time of delivery
+ * Add `fast` option to the DSN that allows sending message with the highest priority that ensures the quickest possible time of delivery
+ * Add `test` option to the DSN that allows sending message in test mode (message is validated, but not sent)
 
 5.2
 ---

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/README.md
@@ -7,13 +7,14 @@ DSN example
 -----------
 
 ```
-SMSAPI_DSN=smsapi://TOKEN@default?from=FROM&fast=FAST
+SMSAPI_DSN=smsapi://TOKEN@default?from=FROM&fast=FAST&test=TEST
 ```
 
 where:
  - `TOKEN` is your API Token (OAuth)
  - `FROM` is the sender name
  - `FAST` setting this parameter to "1" (default "0") will result in sending message with the highest priority which ensures the quickest possible time of delivery. Attention! Fast messages cost more than normal messages.
+ - `TEST` setting this parameter to "1" (default "0") will result in sending message in test mode (message is validated, but not sent).
 
 See your account info at https://ssl.smsapi.pl/
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
@@ -32,6 +32,7 @@ final class SmsapiTransport extends AbstractTransport
     private string $authToken;
     private string $from;
     private bool $fast = false;
+    private bool $test = false;
 
     public function __construct(string $authToken, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
@@ -47,6 +48,16 @@ final class SmsapiTransport extends AbstractTransport
     public function setFast(bool $fast): static
     {
         $this->fast = $fast;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setTest(bool $test): static
+    {
+        $this->test = $test;
 
         return $this;
     }
@@ -75,9 +86,9 @@ final class SmsapiTransport extends AbstractTransport
                 'to' => $message->getPhone(),
                 'message' => $message->getSubject(),
                 'fast' => $this->fast,
-                'encoding' => 'utf-8',
                 'format' => 'json',
                 'encoding' => 'utf-8',
+                'test' => $this->test,
             ],
         ]);
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
@@ -32,9 +32,14 @@ final class SmsapiTransportFactory extends AbstractTransportFactory
         $from = $dsn->getRequiredOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $fast = filter_var($dsn->getOption('fast', false), \FILTER_VALIDATE_BOOLEAN);
+        $test = filter_var($dsn->getOption('test', false), \FILTER_VALIDATE_BOOLEAN);
         $port = $dsn->getPort();
 
-        return (new SmsapiTransport($authToken, $from, $this->client, $this->dispatcher))->setFast($fast)->setHost($host)->setPort($port);
+        return (new SmsapiTransport($authToken, $from, $this->client, $this->dispatcher))
+            ->setFast($fast)
+            ->setHost($host)
+            ->setPort($port)
+            ->setTest($test);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
@@ -26,21 +26,28 @@ final class SmsapiTransportFactoryTest extends TransportFactoryTestCase
         yield [
             'smsapi://host.test?from=testFrom&fast=0',
             'smsapi://token@host.test?from=testFrom',
+            'smsapi://token@host.test?from=testFrom&fast=0&test=0',
         ];
 
         yield [
             'smsapi://host.test?from=testFrom&fast=0',
             'smsapi://token@host.test?from=testFrom&fast=0',
+            'smsapi://token@host.test?from=testFrom&fast=1&test=0',
+            'smsapi://token@host.test?from=testFrom&test=0',
         ];
 
         yield [
             'smsapi://host.test?from=testFrom&fast=1',
             'smsapi://token@host.test?from=testFrom&fast=1',
+            'smsapi://token@host.test?from=testFrom&fast=1&test=1',
+            'smsapi://token@host.test?from=testFrom&test=1',
         ];
 
         yield [
             'smsapi://host.test?from=testFrom&fast=1',
             'smsapi://token@host.test?from=testFrom&fast=true',
+            'smsapi://token@host.test?from=testFrom&fast=true&test=true',
+            'smsapi://token@host.test?from=testFrom&test=true',
         ];
     }
 
@@ -48,6 +55,7 @@ final class SmsapiTransportFactoryTest extends TransportFactoryTestCase
     {
         yield [true, 'smsapi://host?from=testFrom'];
         yield [true, 'smsapi://host?from=testFrom&fast=1'];
+        yield [true, 'smsapi://host?from=testFrom&fast=1&test=1'];
         yield [false, 'somethingElse://host?from=testFrom'];
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
@@ -25,7 +25,7 @@ final class SmsapiTransportTest extends TransportTestCase
 {
     public function createTransport(HttpClientInterface $client = null): SmsapiTransport
     {
-        return (new SmsapiTransport('testToken', 'testFrom', $client ?? $this->createMock(HttpClientInterface::class)))->setFast(true)->setHost('test.host');
+        return (new SmsapiTransport('testToken', 'testFrom', $client ?? $this->createMock(HttpClientInterface::class)))->setFast(true)->setHost('test.host')->setTest(true);
     }
 
     public function toStringProvider(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


Add possibility to send messages in test mode where they are validated only (not sent, not charged).

Official documentation: https://www.smsapi.pl/docs/#2-pojedynczy-sms
```
test - Wiadomość nie jest wysyłana, wyświetlana jest jedynie odpowiedź (w celach testowych). (&test=1)
```

Not sure about tests.