### PR TITLE
Don't replace symfony/security-guard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,6 @@
         "symfony/security-bundle": "self.version",
         "symfony/security-core": "self.version",
         "symfony/security-csrf": "self.version",
-        "symfony/security-guard": "self.version",
         "symfony/security-http": "self.version",
         "symfony/semaphore": "self.version",
         "symfony/serializer": "self.version",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The package `symfony/security-guard` has never been released as 6.0. Because of that, the monorepo should not replace it anymore.