### PR TITLE
[Messenger] Add option `allow_no_senders` to enable throwing when a message doesn't have a sender

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
  * Remove `@internal` tag from secret vaults to allow them to be used directly outside the framework bundle and custom vaults to be added
  * Deprecate `framework.form.legacy_error_messages` config node
  * Add a `framework.router.cache_dir` configuration option to configure the default `Router` `cache_dir` option
+ * Add option `framework.messenger.buses.*.default_middleware.allow_no_senders` to enable throwing when a message doesn't have a sender
 
 6.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2035,12 +2035,9 @@ class FrameworkExtension extends Extension
         foreach ($config['buses'] as $busId => $bus) {
             $middleware = $bus['middleware'];
 
-            if ($bus['default_middleware']) {
-                if ('allow_no_handlers' === $bus['default_middleware']) {
-                    $defaultMiddleware['after'][1]['arguments'] = [true];
-                } else {
-                    unset($defaultMiddleware['after'][1]['arguments']);
-                }
+            if ($bus['default_middleware']['enabled']) {
+                $defaultMiddleware['after'][0]['arguments'] = [$bus['default_middleware']['allow_no_senders']];
+                $defaultMiddleware['after'][1]['arguments'] = [$bus['default_middleware']['allow_no_handlers']];
 
                 // argument to add_bus_name_stamp_middleware
                 $defaultMiddleware['before'][0]['arguments'] = [$busId];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -55,6 +55,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('senders service locator'),
             ])
         ->set('messenger.middleware.send_message', SendMessageMiddleware::class)
+            ->abstract()
             ->args([
                 service('messenger.senders_locator'),
                 service('event_dispatcher'),

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -426,7 +426,7 @@
         </xsd:restriction>
     </xsd:simpleType>
 
-    <xsd:simpleType name="default_middleware">
+    <xsd:simpleType name="default_middleware_attr">
         <xsd:restriction base="xsd:string">
             <xsd:enumeration value="true" />
             <xsd:enumeration value="false" />
@@ -435,6 +435,12 @@
             <xsd:enumeration value="allow_no_handlers" />
         </xsd:restriction>
     </xsd:simpleType>
+
+    <xsd:complexType name="default_middleware_elem">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="allow_no_handlers" type="xsd:boolean" />
+        <xsd:attribute name="allow_no_senders" type="xsd:boolean" />
+    </xsd:complexType>
 
     <xsd:simpleType name="cookie_secure">
         <xsd:restriction base="xsd:string">
@@ -567,10 +573,11 @@
 
     <xsd:complexType name="messenger_bus">
         <xsd:sequence>
+            <xsd:element name="default-middleware" type="default_middleware_elem" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="middleware" type="messenger_middleware" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="required"/>
-        <xsd:attribute name="default-middleware" type="default_middleware"/>
+        <xsd:attribute name="default-middleware" type="default_middleware_attr"/>
     </xsd:complexType>
 
     <xsd:complexType name="messenger_middleware">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -383,19 +383,19 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(
             [
                 'existing_bus' => [
-                    'default_middleware' => true,
+                    'default_middleware' => ['enabled' => true, 'allow_no_handlers' => false, 'allow_no_senders' => true],
                     'middleware' => [
                         ['id' => 'existing_bus.middleware', 'arguments' => []],
                     ],
                 ],
                 'common_bus' => [
-                    'default_middleware' => false,
+                    'default_middleware' => ['enabled' => false, 'allow_no_handlers' => false, 'allow_no_senders' => true],
                     'middleware' => [
                         ['id' => 'common_bus.new_middleware', 'arguments' => []],
                     ],
                 ],
                 'new_bus' => [
-                    'default_middleware' => true,
+                    'default_middleware' => ['enabled' => true, 'allow_no_handlers' => false, 'allow_no_senders' => true],
                     'middleware' => [
                         ['id' => 'new_bus.middleware', 'arguments' => []],
                     ],
@@ -607,7 +607,7 @@ class ConfigurationTest extends TestCase
                     ],
                 ],
                 'default_bus' => null,
-                'buses' => ['messenger.bus.default' => ['default_middleware' => true, 'middleware' => []]],
+                'buses' => ['messenger.bus.default' => ['default_middleware' => ['enabled' => true, 'allow_no_handlers' => false, 'allow_no_senders' => true], 'middleware' => []]],
                 'reset_on_message' => true,
             ],
             'disallow_search_engine_index' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1013,8 +1013,8 @@ abstract class FrameworkExtensionTest extends TestCase
             ['id' => 'reject_redelivered_message_middleware'],
             ['id' => 'dispatch_after_current_bus'],
             ['id' => 'failed_message_processing_middleware'],
-            ['id' => 'send_message'],
-            ['id' => 'handle_message'],
+            ['id' => 'send_message', 'arguments' => [true]],
+            ['id' => 'handle_message', 'arguments' => [false]],
         ], $container->getParameter('messenger.bus.commands.middleware'));
         $this->assertTrue($container->has('messenger.bus.events'));
         $this->assertSame([], $container->getDefinition('messenger.bus.events')->getArgument(0));
@@ -1024,8 +1024,8 @@ abstract class FrameworkExtensionTest extends TestCase
             ['id' => 'dispatch_after_current_bus'],
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
-            ['id' => 'send_message'],
-            ['id' => 'handle_message'],
+            ['id' => 'send_message', 'arguments' => [true]],
+            ['id' => 'handle_message', 'arguments' => [false]],
         ], $container->getParameter('messenger.bus.events.middleware'));
         $this->assertTrue($container->has('messenger.bus.queries'));
         $this->assertSame([], $container->getDefinition('messenger.bus.queries')->getArgument(0));

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `TransportNamesStamp` to change the transport while dispatching a message
  * Add support for rate limited transports by using the RateLimiter component.
  * Deprecate `MessageHandlerInterface` and `MessageSubscriberInterface`, use `#[AsMessageHandler]` instead
+ * Add new parameter `allowNoSenders` to `SendMessageMiddleware` to enable throwing when a message doesn't have a sender
 
 6.1
 ---

--- a/src/Symfony/Component/Messenger/Exception/NoSenderForMessageException.php
+++ b/src/Symfony/Component/Messenger/Exception/NoSenderForMessageException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * @author Jérémy Reynaud <jeremy@reynaud.io>
+ */
+class NoSenderForMessageException extends LogicException
+{
+}

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
+use Symfony\Component\Messenger\Exception\NoSenderForMessageException;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
@@ -30,11 +31,13 @@ class SendMessageMiddleware implements MiddlewareInterface
 
     private SendersLocatorInterface $sendersLocator;
     private ?EventDispatcherInterface $eventDispatcher;
+    private bool $allowNoSenders;
 
-    public function __construct(SendersLocatorInterface $sendersLocator, EventDispatcherInterface $eventDispatcher = null)
+    public function __construct(SendersLocatorInterface $sendersLocator, EventDispatcherInterface $eventDispatcher = null, bool $allowNoSenders = true)
     {
         $this->sendersLocator = $sendersLocator;
         $this->eventDispatcher = $eventDispatcher;
+        $this->allowNoSenders = $allowNoSenders;
         $this->logger = new NullLogger();
     }
 
@@ -63,6 +66,10 @@ class SendMessageMiddleware implements MiddlewareInterface
 
                 $this->logger->info('Sending message {class} with {alias} sender using {sender}', $context + ['alias' => $alias, 'sender' => $sender::class]);
                 $envelope = $sender->send($envelope->with(new SentStamp($sender::class, \is_string($alias) ? $alias : null)));
+            }
+
+            if (!$this->allowNoSenders && !$sender) {
+                throw new NoSenderForMessageException(sprintf('No sender for message "%s".', $context['class']));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/17383 <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Hello,

For my first contribution to the Symfony community I would like to propose this feature.
On my projects, sometimes I forget to update the messenger.yaml file and I don't have a routing for my new message. If you don't set the entry on the `routing` section, the message will be dispatch like if you use sync://.

In order to don't forget to add the entry, I've update the `SendMessageMiddleware` middleware to throw an exception.

For the documentation, I never work with rst file, so if someone would help me, i will very appreciate.

Thanks.
