### PR TITLE
[Security] Add a `ChainUserChecker` to allow calling multiple user checkers for a firewall

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -44,6 +45,7 @@ use Symfony\Component\Security\Core\Authorization\Strategy\ConsensusStrategy;
 use Symfony\Component\Security\Core\Authorization\Strategy\PriorityStrategy;
 use Symfony\Component\Security\Core\Authorization\Strategy\UnanimousStrategy;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\User\ChainUserChecker;
 use Symfony\Component\Security\Core\User\ChainUserProvider;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -384,6 +386,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 $id => new ServiceClosureArgument(new Reference($firewallEventDispatcherId)),
             ]))
         ;
+
+        // Register Firewall-specific chained user checker
+        $container->register('security.user_checker.chain.'.$id, ChainUserChecker::class)
+            ->addArgument(new TaggedIteratorArgument('security.user_checker.'.$id));
 
         // Register listeners
         $listeners = [];

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Deprecate the `Security` class, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
  * Change the signature of `TokenStorageInterface::setToken()` to `setToken(?TokenInterface $token)`
  * Deprecate calling `TokenStorage::setToken()` without arguments
+ * Add a `ChainUserChecker` to allow calling multiple user checkers for a firewall
 
 6.0
 ---

--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserCheckerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\User;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\User\ChainUserChecker;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class ChainUserCheckerTest extends TestCase
+{
+    public function testForwardsPreAuthToAllUserCheckers()
+    {
+        $user = $this->createMock(UserInterface::class);
+
+        $checker1 = $this->createMock(UserCheckerInterface::class);
+        $checker1->expects($this->once())
+            ->method('checkPreAuth')
+            ->with($user);
+
+        $checker2 = $this->createMock(UserCheckerInterface::class);
+        $checker2->expects($this->once())
+            ->method('checkPreAuth')
+            ->with($user);
+
+        $checker3 = $this->createMock(UserCheckerInterface::class);
+        $checker3->expects($this->once())
+            ->method('checkPreAuth')
+            ->with($user);
+
+        (new ChainUserChecker([$checker1, $checker2, $checker3]))->checkPreAuth($user);
+    }
+
+    public function testForwardsPostAuthToAllUserCheckers()
+    {
+        $user = $this->createMock(UserInterface::class);
+
+        $checker1 = $this->createMock(UserCheckerInterface::class);
+        $checker1->expects($this->once())
+            ->method('checkPostAuth')
+            ->with($user);
+
+        $checker2 = $this->createMock(UserCheckerInterface::class);
+        $checker2->expects($this->once())
+            ->method('checkPostAuth')
+            ->with($user);
+
+        $checker3 = $this->createMock(UserCheckerInterface::class);
+        $checker3->expects($this->once())
+            ->method('checkPostAuth')
+            ->with($user);
+
+        (new ChainUserChecker([$checker1, $checker2, $checker3]))->checkPostAuth($user);
+    }
+}

--- a/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\User;
+
+final class ChainUserChecker implements UserCheckerInterface
+{
+    /**
+     * @param iterable<UserCheckerInterface> $checkers
+     */
+    public function __construct(private readonly iterable $checkers)
+    {
+    }
+
+    public function checkPreAuth(UserInterface $user): void
+    {
+        foreach ($this->checkers as $checker) {
+            $checker->checkPreAuth($user);
+        }
+    }
+
+    public function checkPostAuth(UserInterface $user): void
+    {
+        foreach ($this->checkers as $checker) {
+            $checker->checkPostAuth($user);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

I had a case in one of my apps where I have some shared logic for user checkers across multiple firewalls (API and traditional web login) while also needing extra logic for the API.  Instead of duplicating the checker for each firewall or using a decorator, I thought a chained user checker would be nice to have and that it might be useful to users of the framework.

This will add a `ChainUserChecker` class to the `security-core` component, and the SecurityBundle will create a `security.user_checker.chain.<firewall>` service for each firewall.  User checkers can then be tagged with a `security.user_checker.<firewall>` tag for each firewall the checker applies to, and users would set this chain service as the user checker for their firewall.

```php
<?php

namespace App\Security\User;

use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
use Symfony\Component\Security\Core\User\UserCheckerInterface;

#[Autoconfigure(tags: [['security.user_checker.main' => ['priority' => 10]]])]
#[Autoconfigure(tags: [['security.user_checker.api' => ['priority' => 10]]])]
final class DisabledAccountUserChecker implements UserCheckerInterface {}

#[Autoconfigure(tags: [['security.user_checker.api' => ['priority' => 5]]])]
final class ApiAccessAllowedUserChecker implements UserCheckerInterface {}
```