### PR TITLE
[Mailer] README, missing import in example

### DIFF
--- a/src/Symfony/Component/Mailer/README.md
+++ b/src/Symfony/Component/Mailer/README.md
@@ -13,6 +13,7 @@ $ composer require symfony/mailer
 ```php
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mime\Email;
 
 $transport = Transport::fromDsn('smtp://localhost');
 $mailer = new Mailer($transport);


### PR DESCRIPTION
Fix the README’s code example from having a missing PHP import.
Indeed, the first example had `use Symfony\Component\Mime\Email; ` missing.

Finally, I targeted `v4.4` because I believe this one should be fixed in all maintained versions.

| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
