### PR TITLE
[Security] Add an easier way to get the current firewall configuration

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add the `Security` helper class
  * Deprecate the `Symfony\Component\Security\Core\Security` service alias, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
+ * Add `Security::getFirewallConfig()` to help to get the firewall configuration associated to the Request
 
 6.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -80,6 +80,7 @@ return static function (ContainerConfigurator $container) {
             ->args([service_locator([
                 'security.token_storage' => service('security.token_storage'),
                 'security.authorization_checker' => service('security.authorization_checker'),
+                'security.firewall.map' => service('security.firewall.map'),
             ])])
         ->alias(Security::class, 'security.helper')
         ->alias(LegacySecurity::class, 'security.helper')

--- a/src/Symfony/Bundle/SecurityBundle/Security/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/Security.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Security;
 
 use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Security as LegacySecurity;
 
 /**
@@ -21,8 +22,13 @@ use Symfony\Component\Security\Core\Security as LegacySecurity;
  */
 class Security extends LegacySecurity
 {
-    public function __construct(ContainerInterface $container)
+    public function __construct(private ContainerInterface $container)
     {
         parent::__construct($container, false);
+    }
+
+    public function getFirewallConfig(Request $request): ?FirewallConfig
+    {
+        return $this->container->get('security.firewall.map')->getFirewallConfig($request);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\SecuredPageBundle\Security\Core\User\ArrayUserProvider;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -33,6 +35,8 @@ class SecurityTest extends AbstractWebTestCase
         $security = $container->get('functional_test.security.helper');
         $this->assertTrue($security->isGranted('ROLE_USER'));
         $this->assertSame($token, $security->getToken());
+        $this->assertInstanceOf(FirewallConfig::class, $firewallConfig = $security->getFirewallConfig(new Request()));
+        $this->assertSame('default', $firewallConfig->getName());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #46015 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Added a new method `Security#getFirewallConfig($request)` to easily get the firewall configuration associated to the `Request`.

The firewall name can be accessed through `$security->getFirewallConfig($request)?->getName()`. 