### PR TITLE
[DoctrineBridge] Restore PHP8 features for Doctrine debug middlewares

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -29,22 +29,20 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class DoctrineDataCollector extends DataCollector
 {
-    private ManagerRegistry $registry;
     private array $connections;
     private array $managers;
-    private ?DebugDataHolder $debugDataHolder;
 
     /**
      * @var array<string, DebugStack>
      */
     private array $loggers = [];
 
-    public function __construct(ManagerRegistry $registry, DebugDataHolder $debugDataHolder = null)
-    {
-        $this->registry = $registry;
+    public function __construct(
+        private ManagerRegistry $registry,
+        private ?DebugDataHolder $debugDataHolder = null,
+    ) {
         $this->connections = $registry->getConnectionNames();
         $this->managers = $registry->getManagerNames();
-        $this->debugDataHolder = $debugDataHolder;
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Connection.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Connection.php
@@ -24,18 +24,15 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 final class Connection extends AbstractConnectionMiddleware
 {
-    private $nestingLevel = 0;
-    private $debugDataHolder;
-    private $stopwatch;
-    private $connectionName;
+    private int $nestingLevel = 0;
 
-    public function __construct(ConnectionInterface $connection, DebugDataHolder $debugDataHolder, ?Stopwatch $stopwatch, string $connectionName)
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        private DebugDataHolder $debugDataHolder,
+        private ?Stopwatch $stopwatch,
+        private string $connectionName,
+    ) {
         parent::__construct($connection);
-
-        $this->debugDataHolder = $debugDataHolder;
-        $this->stopwatch = $stopwatch;
-        $this->connectionName = $connectionName;
     }
 
     public function prepare(string $sql): DriverStatement
@@ -44,7 +41,7 @@ final class Connection extends AbstractConnectionMiddleware
             parent::prepare($sql),
             $this->debugDataHolder,
             $this->connectionName,
-            $sql
+            $sql,
         );
     }
 
@@ -52,20 +49,14 @@ final class Connection extends AbstractConnectionMiddleware
     {
         $this->debugDataHolder->addQuery($this->connectionName, $query = new Query($sql));
 
-        if (null !== $this->stopwatch) {
-            $this->stopwatch->start('doctrine', 'doctrine');
-        }
-
+        $this->stopwatch?->start('doctrine', 'doctrine');
         $query->start();
 
         try {
             $result = parent::query($sql);
         } finally {
             $query->stop();
-
-            if (null !== $this->stopwatch) {
-                $this->stopwatch->stop('doctrine');
-            }
+            $this->stopwatch?->stop('doctrine');
         }
 
         return $result;
@@ -75,20 +66,14 @@ final class Connection extends AbstractConnectionMiddleware
     {
         $this->debugDataHolder->addQuery($this->connectionName, $query = new Query($sql));
 
-        if (null !== $this->stopwatch) {
-            $this->stopwatch->start('doctrine', 'doctrine');
-        }
-
+        $this->stopwatch?->start('doctrine', 'doctrine');
         $query->start();
 
         try {
             $affectedRows = parent::exec($sql);
         } finally {
             $query->stop();
-
-            if (null !== $this->stopwatch) {
-                $this->stopwatch->stop('doctrine');
-            }
+            $this->stopwatch?->stop('doctrine');
         }
 
         return $affectedRows;
@@ -101,24 +86,14 @@ final class Connection extends AbstractConnectionMiddleware
             $this->debugDataHolder->addQuery($this->connectionName, $query = new Query('"START TRANSACTION"'));
         }
 
-        if (null !== $this->stopwatch) {
-            $this->stopwatch->start('doctrine', 'doctrine');
-        }
-
-        if (null !== $query) {
-            $query->start();
-        }
+        $this->stopwatch?->start('doctrine', 'doctrine');
+        $query?->start();
 
         try {
             $ret = parent::beginTransaction();
         } finally {
-            if (null !== $query) {
-                $query->stop();
-            }
-
-            if (null !== $this->stopwatch) {
-                $this->stopwatch->stop('doctrine');
-            }
+            $query?->stop();
+            $this->stopwatch?->stop('doctrine');
         }
 
         return $ret;
@@ -131,24 +106,14 @@ final class Connection extends AbstractConnectionMiddleware
             $this->debugDataHolder->addQuery($this->connectionName, $query = new Query('"COMMIT"'));
         }
 
-        if (null !== $this->stopwatch) {
-            $this->stopwatch->start('doctrine', 'doctrine');
-        }
-
-        if (null !== $query) {
-            $query->start();
-        }
+        $this->stopwatch?->start('doctrine', 'doctrine');
+        $query?->start();
 
         try {
             $ret = parent::commit();
         } finally {
-            if (null !== $query) {
-                $query->stop();
-            }
-
-            if (null !== $this->stopwatch) {
-                $this->stopwatch->stop('doctrine');
-            }
+            $query?->stop();
+            $this->stopwatch?->stop('doctrine');
         }
 
         return $ret;
@@ -161,24 +126,14 @@ final class Connection extends AbstractConnectionMiddleware
             $this->debugDataHolder->addQuery($this->connectionName, $query = new Query('"ROLLBACK"'));
         }
 
-        if (null !== $this->stopwatch) {
-            $this->stopwatch->start('doctrine', 'doctrine');
-        }
-
-        if (null !== $query) {
-            $query->start();
-        }
+        $this->stopwatch?->start('doctrine', 'doctrine');
+        $query?->start();
 
         try {
             $ret = parent::rollBack();
         } finally {
-            if (null !== $query) {
-                $query->stop();
-            }
-
-            if (null !== $this->stopwatch) {
-                $this->stopwatch->stop('doctrine');
-            }
+            $query?->stop();
+            $this->stopwatch?->stop('doctrine');
         }
 
         return $ret;

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/DebugDataHolder.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/DebugDataHolder.php
@@ -16,7 +16,7 @@ namespace Symfony\Bridge\Doctrine\Middleware\Debug;
  */
 class DebugDataHolder
 {
-    private $data = [];
+    private array $data = [];
 
     public function addQuery(string $connectionName, Query $query): void
     {

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Driver.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Driver.php
@@ -22,17 +22,13 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 final class Driver extends AbstractDriverMiddleware
 {
-    private $debugDataHolder;
-    private $stopwatch;
-    private $connectionName;
-
-    public function __construct(DriverInterface $driver, DebugDataHolder $debugDataHolder, ?Stopwatch $stopwatch, string $connectionName)
-    {
+    public function __construct(
+        DriverInterface $driver,
+        private DebugDataHolder $debugDataHolder,
+        private ?Stopwatch $stopwatch,
+        private string $connectionName,
+    ) {
         parent::__construct($driver);
-
-        $this->debugDataHolder = $debugDataHolder;
-        $this->stopwatch = $stopwatch;
-        $this->connectionName = $connectionName;
     }
 
     public function connect(array $params): Connection
@@ -41,7 +37,7 @@ final class Driver extends AbstractDriverMiddleware
             parent::connect($params),
             $this->debugDataHolder,
             $this->stopwatch,
-            $this->connectionName
+            $this->connectionName,
         );
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Middleware.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Middleware.php
@@ -22,15 +22,11 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 final class Middleware implements MiddlewareInterface
 {
-    private $debugDataHolder;
-    private $stopwatch;
-    private $connectionName;
-
-    public function __construct(DebugDataHolder $debugDataHolder, ?Stopwatch $stopwatch, string $connectionName = 'default')
-    {
-        $this->debugDataHolder = $debugDataHolder;
-        $this->stopwatch = $stopwatch;
-        $this->connectionName = $connectionName;
+    public function __construct(
+        private DebugDataHolder $debugDataHolder,
+        private ?Stopwatch $stopwatch,
+        private string $connectionName = 'default',
+    ) {
     }
 
     public function wrap(DriverInterface $driver): DriverInterface

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
@@ -20,17 +20,15 @@ use Doctrine\DBAL\ParameterType;
  */
 class Query
 {
-    private $params = [];
-    private $types = [];
+    private array $params = [];
+    private array $types = [];
 
-    private $start;
-    private $duration;
+    private ?float $start = null;
+    private ?float $duration = null;
 
-    private $sql;
-
-    public function __construct(string $sql)
-    {
-        $this->sql = $sql;
+    public function __construct(
+        private string $sql,
+    ) {
     }
 
     public function start(): void
@@ -45,11 +43,7 @@ class Query
         }
     }
 
-    /**
-     * @param string|int                 $param
-     * @param string|int|float|bool|null $variable
-     */
-    public function setParam($param, &$variable, int $type): void
+    public function setParam(string|int $param, null|string|int|float|bool &$variable, int $type): void
     {
         // Numeric indexes start at 0 in profiler
         $idx = \is_int($param) ? $param - 1 : $param;
@@ -58,11 +52,7 @@ class Query
         $this->types[$idx] = $type;
     }
 
-    /**
-     * @param string|int                 $param
-     * @param string|int|float|bool|null $value
-     */
-    public function setValue($param, $value, int $type): void
+    public function setValue(string|int $param, null|string|int|float|bool $value, int $type): void
     {
         // Numeric indexes start at 0 in profiler
         $idx = \is_int($param) ? $param - 1 : $param;

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Statement.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Statement.php
@@ -23,16 +23,16 @@ use Doctrine\DBAL\ParameterType;
  */
 final class Statement extends AbstractStatementMiddleware
 {
-    private $debugDataHolder;
-    private $connectionName;
-    private $query;
+    private Query $query;
 
-    public function __construct(StatementInterface $statement, DebugDataHolder $debugDataHolder, string $connectionName, string $sql)
-    {
+    public function __construct(
+        StatementInterface $statement,
+        private DebugDataHolder $debugDataHolder,
+        private string $connectionName,
+        string $sql,
+    ) {
         parent::__construct($statement);
 
-        $this->debugDataHolder = $debugDataHolder;
-        $this->connectionName = $connectionName;
         $this->query = new Query($sql);
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
@@ -16,7 +16,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 use Symfony\Bridge\Doctrine\Middleware\Debug\Middleware;
@@ -28,9 +28,9 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 class MiddlewareTest extends TestCase
 {
-    private $debugDataHolder;
-    private $conn;
-    private $stopwatch;
+    private DebugDataHolder $debugDataHolder;
+    private Connection $conn;
+    private ?Stopwatch $stopwatch;
 
     protected function setUp(): void
     {
@@ -63,22 +63,17 @@ CREATE TABLE products (
 	price REAL NOT NULL,
 	stock INTEGER NOT NULL
 );
-EOT
-        );
+EOT);
     }
 
     public function provideExecuteMethod(): array
     {
         return [
             'executeStatement' => [
-                static function (object $target, ...$args) {
-                    return $target->executeStatement(...$args);
-                },
+                static fn (Statement|Connection $target, mixed ...$args) => $target->executeStatement(...$args),
             ],
             'executeQuery' => [
-                static function (object $target, ...$args): Result {
-                    return $target->executeQuery(...$args);
-                },
+                static fn (Statement|Connection $target, mixed ...$args) => $target->executeQuery(...$args),
             ],
         ];
     }
@@ -156,18 +151,8 @@ EOT
     public function provideEndTransactionMethod(): array
     {
         return [
-            'commit' => [
-                static function (Connection $conn): bool {
-                    return $conn->commit();
-                },
-                '"COMMIT"',
-            ],
-            'rollback' => [
-                static function (Connection $conn): bool {
-                    return $conn->rollBack();
-                },
-                '"ROLLBACK"',
-            ],
+            'commit' => [static fn (Connection $conn) => $conn->commit(), '"COMMIT"'],
+            'rollback' => [static fn (Connection $conn) => $conn->rollBack(), '"ROLLBACK"'],
         ];
     }
 
@@ -207,20 +192,12 @@ EOT
     {
         return [
             'commit and exec' => [
-                static function (Connection $conn, string $sql) {
-                    return $conn->executeStatement($sql);
-                },
-                static function (Connection $conn): bool {
-                    return $conn->commit();
-                },
+                static fn (Connection $conn, string $sql) => $conn->executeStatement($sql),
+                static fn (Connection $conn) => $conn->commit(),
             ],
             'rollback and query' => [
-                static function (Connection $conn, string $sql): Result {
-                    return $conn->executeQuery($sql);
-                },
-                static function (Connection $conn): bool {
-                    return $conn->rollBack();
-                },
+                static fn (Connection $conn, string $sql) => $conn->executeQuery($sql),
+                static fn (Connection $conn) => $conn->rollBack(),
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

 To merge #45491 in 5.4, the code has been changed to be 7.2 compliant. This PR restores the original code for Symfony versions that support php >= 8.0 (see https://github.com/symfony/symfony/pull/45491#issuecomment-1075221498).