### PR TITLE
[Routing] fix router base url when default uri has trailing slash

### DIFF
--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -98,7 +98,7 @@ class RequestContext
      */
     public function setBaseUrl(string $baseUrl)
     {
-        $this->baseUrl = $baseUrl;
+        $this->baseUrl = rtrim($baseUrl, '/');
 
         return $this;
     }

--- a/src/Symfony/Component/Routing/Tests/RequestContextTest.php
+++ b/src/Symfony/Component/Routing/Tests/RequestContextTest.php
@@ -40,6 +40,51 @@ class RequestContextTest extends TestCase
         $this->assertEquals('bar=foobar', $requestContext->getQueryString());
     }
 
+    public function testFromUriWithBaseUrl()
+    {
+        $requestContext = RequestContext::fromUri('https://test.com:444/index.php');
+
+        $this->assertSame('GET', $requestContext->getMethod());
+        $this->assertSame('https', $requestContext->getScheme());
+        $this->assertSame('test.com', $requestContext->getHost());
+        $this->assertSame('/index.php', $requestContext->getBaseUrl());
+        $this->assertSame('/', $requestContext->getPathInfo());
+        $this->assertSame(80, $requestContext->getHttpPort());
+        $this->assertSame(444, $requestContext->getHttpsPort());
+    }
+
+    public function testFromUriWithTrailingSlash()
+    {
+        $requestContext = RequestContext::fromUri('http://test.com:8080/');
+
+        $this->assertSame('http', $requestContext->getScheme());
+        $this->assertSame('test.com', $requestContext->getHost());
+        $this->assertSame(8080, $requestContext->getHttpPort());
+        $this->assertSame(443, $requestContext->getHttpsPort());
+        $this->assertSame('', $requestContext->getBaseUrl());
+        $this->assertSame('/', $requestContext->getPathInfo());
+    }
+
+    public function testFromUriWithoutTrailingSlash()
+    {
+        $requestContext = RequestContext::fromUri('https://test.com');
+
+        $this->assertSame('https', $requestContext->getScheme());
+        $this->assertSame('test.com', $requestContext->getHost());
+        $this->assertSame('', $requestContext->getBaseUrl());
+        $this->assertSame('/', $requestContext->getPathInfo());
+    }
+
+    public function testFromUriBeingEmpty()
+    {
+        $requestContext = RequestContext::fromUri('');
+
+        $this->assertSame('http', $requestContext->getScheme());
+        $this->assertSame('localhost', $requestContext->getHost());
+        $this->assertSame('', $requestContext->getBaseUrl());
+        $this->assertSame('/', $requestContext->getPathInfo());
+    }
+
     public function testFromRequest()
     {
         $request = Request::create('https://test.com:444/foo?bar=baz');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

When the router default uri (feature #36651) has a trailing slash, the generated URLs are wrong. E.g.

```yaml
framework:
    router:
        default_uri: 'https://example.org/' # this is equivalent URI to 'https://example.org'
 ```

Generating any absolute URL given this base path currently resulted in double slashes, e.g. `https://example.org//mypage` 
because the base url is set to `/` and the path info defaults to `/` as well. This is not correct and will result in a 404.

The most consistent fix with the rest of symfony is to always rtrim the trailing slashes from the base url.
This is already done in the HttpFoundation Request class see https://github.com/symfony/symfony/blob/674ad07a684fe1274ae49d9f4b6294ede3b47b92/src/Symfony/Component/HttpFoundation/Request.php#L849
So I think it makes sense to enforce this also on the requestcontext so it is also the case when it does not go through the fromRequest but via fromUri in the CLI.
