### PR TITLE
[Form] Fix same choice loader with different choice values

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
@@ -146,8 +146,7 @@ class DoctrineChoiceLoaderTest extends TestCase
         $this->assertEquals($choiceList, $loaded = $loader->loadChoiceList());
 
         // no further loads on subsequent calls
-
-        $this->assertSame($loaded, $loader->loadChoiceList());
+        $this->assertEquals($loaded, $loader->loadChoiceList());
     }
 
     public function testLoadValuesForChoices()

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1779,4 +1779,32 @@ class EntityTypeTest extends BaseTypeTest
         $this->assertEquals($collection, $form->getNormData());
         $this->assertEquals($collection, $form->getData());
     }
+
+    public function testWithSameLoaderAndDifferentChoiceValueCallbacks()
+    {
+        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $entity2 = new SingleIntIdEntity(2, 'Bar');
+        $this->persist([$entity1, $entity2]);
+
+        $view = $this->factory->create(FormTypeTest::TESTED_TYPE)
+            ->add('entity_one', self::TESTED_TYPE, [
+                'em' => 'default',
+                'class' => self::SINGLE_IDENT_CLASS,
+            ])
+            ->add('entity_two', self::TESTED_TYPE, [
+                'em' => 'default',
+                'class' => self::SINGLE_IDENT_CLASS,
+                'choice_value' => function ($choice) {
+                    return $choice ? $choice->name : '';
+                },
+            ])
+            ->createView()
+        ;
+
+        $this->assertSame('1', $view['entity_one']->vars['choices'][1]->value);
+        $this->assertSame('2', $view['entity_one']->vars['choices'][2]->value);
+
+        $this->assertSame('Foo', $view['entity_two']->vars['choices']['Foo']->value);
+        $this->assertSame('Bar', $view['entity_two']->vars['choices']['Bar']->value);
+    }
 }

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -29,7 +29,7 @@
         "symfony/stopwatch": "^3.4|^4.0|^5.0",
         "symfony/config": "^4.2|^5.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-        "symfony/form": "^4.4.11|^5.0.11",
+        "symfony/form": "^4.4.41|^5.0.11",
         "symfony/http-kernel": "^4.3.7",
         "symfony/messenger": "^4.4|^5.0",
         "symfony/property-access": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Component/Form/ChoiceList/Loader/CallbackChoiceLoader.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/CallbackChoiceLoader.php
@@ -23,11 +23,11 @@ class CallbackChoiceLoader implements ChoiceLoaderInterface
     private $callback;
 
     /**
-     * The loaded choice list.
+     * The loaded choices.
      *
-     * @var ArrayChoiceList
+     * @var array|null
      */
-    private $choiceList;
+    private $choices;
 
     /**
      * @param callable $callback The callable returning an array of choices
@@ -42,11 +42,11 @@ class CallbackChoiceLoader implements ChoiceLoaderInterface
      */
     public function loadChoiceList($value = null)
     {
-        if (null !== $this->choiceList) {
-            return $this->choiceList;
+        if (null === $this->choices) {
+            $this->choices = ($this->callback)();
         }
 
-        return $this->choiceList = new ArrayChoiceList(($this->callback)(), $value);
+        return new ArrayChoiceList($this->choices, $value);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
@@ -32,7 +32,7 @@ class LazyChoiceListTest extends TestCase
 
         $this->assertSame(['RESULT'], $list->getChoices());
         $this->assertSame(['RESULT'], $list->getChoices());
-        $this->assertSame(1, $calls);
+        $this->assertSame(2, $calls);
     }
 
     public function testGetValuesLoadsLoadedListOnFirstCall()
@@ -46,7 +46,7 @@ class LazyChoiceListTest extends TestCase
 
         $this->assertSame(['RESULT'], $list->getValues());
         $this->assertSame(['RESULT'], $list->getValues());
-        $this->assertSame(1, $calls);
+        $this->assertSame(2, $calls);
     }
 
     public function testGetStructuredValuesLoadsLoadedListOnFirstCall()
@@ -60,7 +60,7 @@ class LazyChoiceListTest extends TestCase
 
         $this->assertSame(['RESULT'], $list->getStructuredValues());
         $this->assertSame(['RESULT'], $list->getStructuredValues());
-        $this->assertSame(1, $calls);
+        $this->assertSame(2, $calls);
     }
 
     public function testGetOriginalKeysLoadsLoadedListOnFirstCall()
@@ -79,7 +79,7 @@ class LazyChoiceListTest extends TestCase
 
         $this->assertSame(['foo' => 'a', 'bar' => 'b', 'baz' => 'c'], $list->getOriginalKeys());
         $this->assertSame(['foo' => 'a', 'bar' => 'b', 'baz' => 'c'], $list->getOriginalKeys());
-        $this->assertSame(3, $calls);
+        $this->assertSame(6, $calls);
     }
 
     public function testGetChoicesForValuesForwardsCallIfListNotLoaded()
@@ -98,7 +98,7 @@ class LazyChoiceListTest extends TestCase
 
         $this->assertSame(['foo', 'bar'], $list->getChoicesForValues(['a', 'b']));
         $this->assertSame(['foo', 'bar'], $list->getChoicesForValues(['a', 'b']));
-        $this->assertSame(3, $calls);
+        $this->assertSame(6, $calls);
     }
 
     public function testGetChoicesForValuesUsesLoadedList()

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
@@ -67,11 +67,18 @@ class CallbackChoiceLoaderTest extends TestCase
         $this->assertInstanceOf(ChoiceListInterface::class, self::$loader->loadChoiceList(self::$value));
     }
 
-    public function testLoadChoiceListOnlyOnce()
+    public function testLoadChoicesOnlyOnce()
     {
-        $loadedChoiceList = self::$loader->loadChoiceList(self::$value);
+        $calls = 0;
+        $loader = new CallbackChoiceLoader(function () use (&$calls) {
+            ++$calls;
 
-        $this->assertSame($loadedChoiceList, self::$loader->loadChoiceList(self::$value));
+            return [1];
+        });
+        $loadedChoiceList = $loader->loadChoiceList();
+
+        $this->assertNotSame($loadedChoiceList, $loader->loadChoiceList());
+        $this->assertSame(1, $calls);
     }
 
     public function testLoadChoicesForValuesLoadsChoiceListOnFirstCall()

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/IntlCallbackChoiceLoaderTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/IntlCallbackChoiceLoaderTest.php
@@ -68,11 +68,19 @@ class IntlCallbackChoiceLoaderTest extends TestCase
         $this->assertInstanceOf(ChoiceListInterface::class, self::$loader->loadChoiceList(self::$value));
     }
 
-    public function testLoadChoiceListOnlyOnce()
+    public function testLoadChoicesOnlyOnce()
     {
-        $loadedChoiceList = self::$loader->loadChoiceList(self::$value);
+        $calls = 0;
+        $loader = new IntlCallbackChoiceLoader(function () use (&$calls) {
+            ++$calls;
 
-        $this->assertSame($loadedChoiceList, self::$loader->loadChoiceList(self::$value));
+            return self::$choices;
+        });
+
+        $loadedChoiceList = $loader->loadChoiceList(self::$value);
+
+        $this->assertNotSame($loadedChoiceList, $loader->loadChoiceList(self::$value));
+        $this->assertSame(1, $calls);
     }
 
     public function testLoadChoicesForValuesLoadsChoiceListOnFirstCall()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | #44655
| License       | MIT
| Doc PR        | ~

It appears that deprecating the caching in the `LazyChoiceList` (cf #18359) was a mistake. The bug went under the radar because in practice every choice field has its own loader instance.
However, optimizations made in #30994 then revealed the flaw (cf #42206) as the loaders were actually shared across many fields.
While working on a fix I ended up implementing something similar to what's proposed in #44655.

I'll send a PR for 5.4 as well.