### PR TITLE
[String] Fix ansi escape sequences regex

### DIFF
--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -492,7 +492,7 @@ abstract class AbstractUnicodeString extends AbstractString
         foreach (explode("\n", $s) as $s) {
             if ($ignoreAnsiDecoration) {
                 $s = preg_replace('/(?:\x1B(?:
-                    \[ [\x30-\x3F]*+ [\x20-\x2F]*+ [0x40-\x7E]
+                    \[ [\x30-\x3F]*+ [\x20-\x2F]*+ [\x40-\x7E]
                     | [P\]X^_] .*? \x1B\\\\
                     | [\x41-\x7E]
                 )|[\p{Cc}\x7F]++)/xu', '', $s);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

It doesn't change much but I think it's a mistake.
`0x40-\x7E` means one character among `0`, `x` and `4` or one character from `0` to `~` (ascii range) but what is intended is one character from `@` to `~` (ascii range).