### PR TITLE
[RateLimiter][Security] Improve performance of login/request rate limiter

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -17,14 +17,24 @@ use Symfony\Component\RateLimiter\Policy\NoLimiter;
 use Symfony\Component\RateLimiter\RateLimit;
 
 /**
- * An implementation of RequestRateLimiterInterface that
+ * An implementation of PeekableRequestRateLimiterInterface that
  * fits most use-cases.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-abstract class AbstractRequestRateLimiter implements RequestRateLimiterInterface
+abstract class AbstractRequestRateLimiter implements PeekableRequestRateLimiterInterface
 {
     public function consume(Request $request): RateLimit
+    {
+        return $this->doConsume($request, 1);
+    }
+
+    public function peek(Request $request): RateLimit
+    {
+        return $this->doConsume($request, 0);
+    }
+
+    private function doConsume(Request $request, int $tokens)
     {
         $limiters = $this->getLimiters($request);
         if (0 === \count($limiters)) {
@@ -33,7 +43,7 @@ abstract class AbstractRequestRateLimiter implements RequestRateLimiterInterface
 
         $minimalRateLimit = null;
         foreach ($limiters as $limiter) {
-            $rateLimit = $limiter->consume(1);
+            $rateLimit = $limiter->consume($tokens);
 
             if (null === $minimalRateLimit || $rateLimit->getRemainingTokens() < $minimalRateLimit->getRemainingTokens()) {
                 $minimalRateLimit = $rateLimit;

--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -34,7 +34,7 @@ abstract class AbstractRequestRateLimiter implements PeekableRequestRateLimiterI
         return $this->doConsume($request, 0);
     }
 
-    private function doConsume(Request $request, int $tokens)
+    private function doConsume(Request $request, int $tokens): RateLimit
     {
         $limiters = $this->getLimiters($request);
         if (0 === \count($limiters)) {

--- a/src/Symfony/Component/HttpFoundation/RateLimiter/PeekableRequestRateLimiterInterface.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/PeekableRequestRateLimiterInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RateLimiter;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\RateLimit;
+
+/**
+ * A request limiter which allows peeking ahead.
+ *
+ * This is valuable to reduce the cache backend load in scenarios
+ * like a login when we only want to consume a token on login failure,
+ * and where the majority of requests will be successful and thus not
+ * need to consume a token.
+ *
+ * This way we can peek ahead before allowing the request through, and
+ * only consume if the request failed (1 backend op). This is compared
+ * to always consuming and then resetting the limit if the request
+ * is successful (2 backend ops).
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface PeekableRequestRateLimiterInterface extends RequestRateLimiterInterface
+{
+    public function peek(Request $request): RateLimit;
+}

--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -75,7 +75,10 @@ final class FixedWindowLimiter implements LimiterInterface
 
                 $reservation = new Reservation($now + $waitDuration, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
             }
-            $this->storage->save($window);
+
+            if (0 < $tokens) {
+                $this->storage->save($window);
+            }
         } finally {
             $this->lock->release();
         }

--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -59,13 +59,14 @@ final class FixedWindowLimiter implements LimiterInterface
 
             $now = microtime(true);
             $availableTokens = $window->getAvailableTokens($now);
-            $waitDuration = $window->calculateTimeForTokens(max(1, $tokens));
 
-            if ($availableTokens >= $tokens) {
+            if ($availableTokens >= max(1, $tokens)) {
                 $window->add($tokens, $now);
 
-                $reservation = new Reservation($now, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), true, $this->limit));
+                $reservation = new Reservation($now, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now)), true, $this->limit));
             } else {
+                $waitDuration = $window->calculateTimeForTokens(max(1, $tokens));
+
                 if (null !== $maxTime && $waitDuration > $maxTime) {
                     // process needs to wait longer than set interval
                     throw new MaxWaitDurationExceededException(sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -74,7 +74,10 @@ final class SlidingWindowLimiter implements LimiterInterface
             }
 
             $window->add($tokens);
-            $this->storage->save($window);
+
+            if (0 < $tokens) {
+                $this->storage->save($window);
+            }
 
             return new RateLimit($this->getAvailableTokens($window->getHitCount()), $window->getRetryAfter(), true, $this->limit);
         } finally {

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -92,7 +92,9 @@ final class TokenBucketLimiter implements LimiterInterface
                 $reservation = new Reservation($now + $waitDuration, new RateLimit(0, \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->maxBurst));
             }
 
-            $this->storage->save($bucket);
+            if (0 < $tokens) {
+                $this->storage->save($bucket);
+            }
         } finally {
             $this->lock->release();
         }

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -67,16 +67,17 @@ final class TokenBucketLimiter implements LimiterInterface
 
             $now = microtime(true);
             $availableTokens = $bucket->getAvailableTokens($now);
-            $remainingTokens = $tokens - $availableTokens;
-            $waitDuration = $this->rate->calculateTimeForTokens(max(1, $remainingTokens));
 
-            if ($availableTokens >= $tokens) {
+            if ($availableTokens >= max(1, $tokens)) {
                 // tokens are now available, update bucket
                 $bucket->setTokens($availableTokens - $tokens);
                 $bucket->setTimer($now);
 
-                $reservation = new Reservation($now, new RateLimit($bucket->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), true, $this->maxBurst));
+                $reservation = new Reservation($now, new RateLimit($bucket->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now)), true, $this->maxBurst));
             } else {
+                $remainingTokens = $tokens - $availableTokens;
+                $waitDuration = $this->rate->calculateTimeForTokens($remainingTokens);
+
                 if (null !== $maxTime && $waitDuration > $maxTime) {
                     // process needs to wait longer than set interval
                     $rateLimit = new RateLimit($availableTokens, \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->maxBurst);

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -108,6 +108,20 @@ class FixedWindowLimiterTest extends TestCase
         $this->assertSame(100, $window->getAvailableTokens($serverOneClock));
     }
 
+    public function testPeekConsume()
+    {
+        $limiter = $this->createLimiter();
+
+        $limiter->consume(9);
+
+        // peek by consuming 0 tokens twice (making sure peeking doesn't claim a token)
+        for ($i = 0; $i < 2; ++$i) {
+            $rateLimit = $limiter->consume(0);
+            $this->assertSame(10, $rateLimit->getLimit());
+            $this->assertTrue($rateLimit->isAccepted());
+        }
+    }
+
     public function provideConsumeOutsideInterval(): \Generator
     {
         yield ['PT15S'];

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -76,6 +76,19 @@ class SlidingWindowLimiterTest extends TestCase
         $this->createLimiter()->reserve();
     }
 
+    public function testPeekConsume()
+    {
+        $limiter = $this->createLimiter();
+
+        $limiter->consume(9);
+
+        for ($i = 0; $i < 2; ++$i) {
+            $rateLimit = $limiter->consume(0);
+            $this->assertTrue($rateLimit->isAccepted());
+            $this->assertSame(10, $rateLimit->getLimit());
+        }
+    }
+
     private function createLimiter(): SlidingWindowLimiter
     {
         return new SlidingWindowLimiter('test', 10, new \DateInterval('PT12S'), $this->storage);

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -128,6 +128,19 @@ class TokenBucketLimiterTest extends TestCase
         $this->assertSame(100, $bucket->getAvailableTokens($serverOneClock));
     }
 
+    public function testPeekConsume()
+    {
+        $limiter = $this->createLimiter();
+
+        $limiter->consume(9);
+
+        for ($i = 0; $i < 2; ++$i) {
+            $rateLimit = $limiter->consume(0);
+            $this->assertTrue($rateLimit->isAccepted());
+            $this->assertSame(10, $rateLimit->getLimit());
+        }
+    }
+
     private function createLimiter($initialTokens = 10, Rate $rate = null)
     {
         return new TokenBucketLimiter('test', $initialTokens, $rate ?? Rate::perSecond(10), $this->storage);

--- a/src/Symfony/Component/Security/Http/EventListener/LoginThrottlingListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/LoginThrottlingListener.php
@@ -12,11 +12,13 @@
 namespace Symfony\Component\Security\Http\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RateLimiter\PeekableRequestRateLimiterInterface;
 use Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
@@ -44,21 +46,41 @@ final class LoginThrottlingListener implements EventSubscriberInterface
         $request = $this->requestStack->getMainRequest();
         $request->attributes->set(SecurityRequestAttributes::LAST_USERNAME, $passport->getBadge(UserBadge::class)->getUserIdentifier());
 
-        $limit = $this->limiter->consume($request);
-        if (!$limit->isAccepted()) {
-            throw new TooManyLoginAttemptsAuthenticationException(ceil(($limit->getRetryAfter()->getTimestamp() - time()) / 60));
+        if ($this->limiter instanceof PeekableRequestRateLimiterInterface) {
+            $limit = $this->limiter->peek($request);
+            // Checking isAccepted here is not enough as peek consumes 0 token, it will
+            // be accepted even if there are 0 tokens remaining to be consumed. We check both
+            // anyway for safety in case third party implementations behave unexpectedly.
+            if (!$limit->isAccepted() || 0 === $limit->getRemainingTokens()) {
+                throw new TooManyLoginAttemptsAuthenticationException(ceil(($limit->getRetryAfter()->getTimestamp() - time()) / 60));
+            }
+        } else {
+            $limit = $this->limiter->consume($request);
+            if (!$limit->isAccepted()) {
+                throw new TooManyLoginAttemptsAuthenticationException(ceil(($limit->getRetryAfter()->getTimestamp() - time()) / 60));
+            }
         }
     }
 
     public function onSuccessfulLogin(LoginSuccessEvent $event): void
     {
-        $this->limiter->reset($event->getRequest());
+        if (!$this->limiter instanceof PeekableRequestRateLimiterInterface) {
+            $this->limiter->reset($event->getRequest());
+        }
+    }
+
+    public function onFailedLogin(LoginFailureEvent $event): void
+    {
+        if ($this->limiter instanceof PeekableRequestRateLimiterInterface) {
+            $this->limiter->consume($event->getRequest());
+        }
     }
 
     public static function getSubscribedEvents(): array
     {
         return [
             CheckPassportEvent::class => ['checkPassport', 2080],
+            LoginFailureEvent::class => 'onFailedLogin',
             LoginSuccessEvent::class => 'onSuccessfulLogin',
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40371 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The login rate limiter currently works this way:

- consume 1 token on auth start (this READ + WRITES to cache backend / rate limiter storage), if this fails we fail the request as it exceeds the rate limit
- if auth succeeded, clear the rate limit (this WRITES again)]
- if auth failed, nothing further happens as we already consumed

So the happy path which is the most common (login succeeds) looks something like that on redis, as there are two rate limiter (global per IP and local per username+IP combo):

```
step1

1650362918.653657 [3 127.0.0.1:41584] "MGET" "lIoZODSNyI:921c2aa99364ab8bbb0e4525c4297aa71c61d2c6"
1650362918.654027 [3 127.0.0.1:41584] "MGET" "lIoZODSNyI:921c2aa99364ab8bbb0e4525c4297aa71c61d2c6"
1650362918.654294 [3 127.0.0.1:41584] "SETEX" "lIoZODSNyI:921c2aa99364ab8bbb0e4525c4297aa71c61d2c6" "119" "\x00\x00\x00\x02\x172Symfony\\Component\\RateLimiter\\Policy\\SlidingWindow\x14\x01\x11\"\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00<login_per_ip-127.0.0.1\x0cA\xd8\x97\xa2\x98\xa9\xd8\xcf"
1650362918.654651 [3 127.0.0.1:41584] "MGET" "lIoZODSNyI:d97b05c8178d81ea0e2009445cb6465d5fcffa39"
1650362918.654877 [3 127.0.0.1:41584] "MGET" "lIoZODSNyI:d97b05c8178d81ea0e2009445cb6465d5fcffa39"
1650362918.655146 [3 127.0.0.1:41584] "SETEX" "lIoZODSNyI:d97b05c8178d81ea0e2009445cb6465d5fcffa39" "119" "\x00\x00\x00\x02\x172Symfony\\Component\\RateLimiter\\Policy\\SlidingWindow\x14\x01\x11\xcc\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00<login_per_ip_username-bd9913b290c5ecb5ebc0b925f736c15043ed9f214aa0bd9d980db7b9573b1a5f49943dc9a9fcccd22c9c0a630176ba7163df6cd32073cbe495fe94f7569c307a4b187e4917613982efbbe7ad2c3df785-127.0.0.1\x0cA\xd8\x97\xa2\x98\xa9\xe7\xb4"

step 2

1650362918.691968 [3 127.0.0.1:41584] "UNLINK" "lIoZODSNyI:921c2aa99364ab8bbb0e4525c4297aa71c61d2c6"
1650362918.692171 [3 127.0.0.1:41584] "UNLINK" "lIoZODSNyI:d97b05c8178d81ea0e2009445cb6465d5fcffa39"
```

This workflow is fine for form logins, but when rate limiting an API authenticator which works with a token, you end up doing a login on every request, so in that case it's less than optimal. This PR aims to improve that by changing the workflow to the following:

- peek at token storage by consuming 0 tokens (https://github.com/symfony/symfony/commit/4c2d67087d46ccbe10ec73adcc95e2d256375ede allows doing this without writing to the cache to keep it to a simple READ from cache backend), if there are no tokens left available we fail the request as it is exceeding the rate limit
- if auth success, nothing further happens
- if auth fails, we then consume 1 token (which READ + WRITES to the cache)

Thanks to this, the happy path is much leaner on the cache backend:

```
1650374176.991495 [3 127.0.0.1:41926] "MGET" "lIoZODSNyI:921c2aa99364ab8bbb0e4525c4297aa71c61d2c6"
1650374176.991774 [3 127.0.0.1:41926] "MGET" "lIoZODSNyI:d97b05c8178d81ea0e2009445cb6465d5fcffa39"
```

And the login failed path consumes a token still of course so it looks a lot like the previous step1 but with an additional READ (that's the only trade-off this PR makes perf wise as far as I can tell).

```
1650373275.322053 [3 127.0.0.1:41906] "MGET" "lIoZODSNyI:921c2aa99364ab8bbb0e4525c4297aa71c61d2c6"
1650373275.322431 [3 127.0.0.1:41906] "MGET" "lIoZODSNyI:a4df4a2604acb8d5003ba9789f3af4727f50fee5"
1650373275.344146 [3 127.0.0.1:41906] "MGET" "lIoZODSNyI:921c2aa99364ab8bbb0e4525c4297aa71c61d2c6"
1650373275.344402 [3 127.0.0.1:41906] "MGET" "lIoZODSNyI:921c2aa99364ab8bbb0e4525c4297aa71c61d2c6"
1650373275.344666 [3 127.0.0.1:41906] "SETEX" "lIoZODSNyI:921c2aa99364ab8bbb0e4525c4297aa71c61d2c6" "62" "\x00\x00\x00\x02\x172Symfony\\Component\\RateLimiter\\Policy\\SlidingWindow\x14\x01\x11\"\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00<login_per_ip-127.0.0.1\x0cA\xd8\x97\xac\xa7l1<"
1650373275.344966 [3 127.0.0.1:41906] "MGET" "lIoZODSNyI:a4df4a2604acb8d5003ba9789f3af4727f50fee5"
1650373275.345157 [3 127.0.0.1:41906] "MGET" "lIoZODSNyI:a4df4a2604acb8d5003ba9789f3af4727f50fee5"
1650373275.345378 [3 127.0.0.1:41906] "SETEX" "lIoZODSNyI:a4df4a2604acb8d5003ba9789f3af4727f50fee5" "62" "\x00\x00\x00\x02\x172Symfony\\Component\\RateLimiter\\Policy\\SlidingWindow\x14\x01\x11\xcd\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00<login_per_ip_username-bd9913b290c5ecb5ebc0b925f736c15043ed9f214aa0bd9d980db7b9573b1a5f49943dc9a9fcccd22c9c0a630176ba7163df6cd32073cbe495fe94f7569c307a4b187e4917613982efbbe7ad2c3df785z-127.0.0.1\x0cA\xd8\x97\xac\xa7l>\xc0"
```

