### PR TITLE
[DependencyInjection] Rename `#[InnerService]` to `#[MapDecorated]`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/MapDecorated.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/MapDecorated.php
@@ -12,6 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Attribute;
 
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class InnerService
+class MapDecorated
 {
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 6.1
 ---
 
+ * Add `#[MapDecorated]` attribute telling to which parameter the decorated service should be mapped in a decorator
+ * Add `#[AsDecorator]` attribute to make a service decorates another
  * Add `$exclude` to `TaggedIterator` and `TaggedLocator` attributes
  * Add `$exclude` to `tagged_iterator` and `tagged_locator` configurator
  * Add an `env` function to the expression language provider

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\Attribute\InnerService;
+use Symfony\Component\DependencyInjection\Attribute\MapDecorated;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
 use Symfony\Component\DependencyInjection\Attribute\Target;
@@ -273,8 +273,9 @@ class AutowirePass extends AbstractRecursivePass
                         break;
                     }
 
-                    if (InnerService::class === $attribute->getName()) {
-                        $arguments[$index] = new Reference($this->currentId.'.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE);
+                    if (MapDecorated::class === $attribute->getName()) {
+                        $definition = $this->container->getDefinition($this->currentId);
+                        $arguments[$index] = new Reference($definition->innerServiceId ?? $this->currentId.'.inner', $definition->decorationOnInvalid ?? ContainerInterface::NULL_ON_INVALID_REFERENCE);
 
                         break;
                     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\Attribute\InnerService;
+use Symfony\Component\DependencyInjection\Attribute\MapDecorated;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -65,7 +65,7 @@ class AsDecoratorFoo implements AsDecoratorInterface
 #[AsDecorator(decorates: AsDecoratorFoo::class, priority: 10)]
 class AsDecoratorBar10 implements AsDecoratorInterface
 {
-    public function __construct(string $arg1, #[InnerService] AsDecoratorInterface $inner)
+    public function __construct(string $arg1, #[MapDecorated] AsDecoratorInterface $inner)
     {
     }
 }
@@ -73,7 +73,7 @@ class AsDecoratorBar10 implements AsDecoratorInterface
 #[AsDecorator(decorates: AsDecoratorFoo::class, priority: 20)]
 class AsDecoratorBar20 implements AsDecoratorInterface
 {
-    public function __construct(string $arg1, #[InnerService] AsDecoratorInterface $inner)
+    public function __construct(string $arg1, #[MapDecorated] AsDecoratorInterface $inner)
     {
     }
 }
@@ -81,7 +81,7 @@ class AsDecoratorBar20 implements AsDecoratorInterface
 #[AsDecorator(decorates: \NonExistent::class, onInvalid: ContainerInterface::NULL_ON_INVALID_REFERENCE)]
 class AsDecoratorBaz implements AsDecoratorInterface
 {
-    public function __construct(#[InnerService] AsDecoratorInterface $inner = null)
+    public function __construct(#[MapDecorated] AsDecoratorInterface $inner = null)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no but tweaks one #45834 
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When talking about the decorator pattern outside of Symfony, the term `inner` is pretty much (if not totally) inexistent. Worse, it makes the concept harder to explain. Take "there is a decorator and a decorated object" vs "there is a decorator and an inner object": using the later form, one has to explain both what is the decorator and what is the inner. While using the former, explaining what the decorator makes it obvious what the decorated is.

I propose to take the addition of this attribute as an opportunity to start making this special term go away.
 
Also I removed the `Service` suffix. It is tempting to keep it for explicitness, but it feels kinda redundant and AFAIK no other core attribute has such redundant suffix, maybe because their namespace is enough to indicate their target.