### PR TITLE
[Console] Fixes "Incorrectly nested style tag found" error when using multi-line header content

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
@@ -8,9 +8,9 @@
  ----------------- --------------------------------- 
   Service ID        .service_2                       
   Class             Full\Qualified\Class2            
-[39;49m  Tags              tag1 ([39;49m[32mattr1[39m[39;49m: val1, [39;49m[32mattr2[39m[39;49m: val2)[39;49m[39;49m  [39;49m
-[39;49m                    [39;49m[39;49mtag1 ([39;49m[32mattr3[39m[39;49m: val3)[39;49m[39;49m               [39;49m
-[39;49m                    [39;49mtag2                             
+  Tags              tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
+                    tag1 ([32mattr3[39m: val3)               
+                    tag2                             
   Calls             setMailer                        
   Public            no                               
   Synthetic         yes                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
@@ -3,9 +3,9 @@
  ----------------- --------------------------------- 
   Service ID        -                                
   Class             Full\Qualified\Class2            
-[39;49m  Tags              tag1 ([39;49m[32mattr1[39m[39;49m: val1, [39;49m[32mattr2[39m[39;49m: val2)[39;49m[39;49m  [39;49m
-[39;49m                    [39;49m[39;49mtag1 ([39;49m[32mattr3[39m[39;49m: val3)[39;49m[39;49m               [39;49m
-[39;49m                    [39;49mtag2                             
+  Tags              tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
+                    tag1 ([32mattr3[39m: val3)               
+                    tag2                             
   Calls             setMailer                        
   Public            no                               
   Synthetic         yes                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
@@ -13,12 +13,12 @@
   Autoconfigured   no                           
   Factory Class    Full\Qualified\FactoryClass  
   Factory Method   get                          
-[39;49m  Arguments        Service(.definition_2)[39;49m[39;49m       [39;49m
-[39;49m                   [39;49m[39;49m%parameter%[39;49m[39;49m                  [39;49m
-[39;49m                   [39;49m[39;49mInlined Service[39;49m[39;49m              [39;49m
-[39;49m                   [39;49m[39;49mArray (3 element(s))[39;49m[39;49m         [39;49m
-[39;49m                   [39;49m[39;49mIterator (2 element(s))[39;49m[39;49m      [39;49m
-[39;49m                   [39;49m[39;49m- Service(definition_1)[39;49m[39;49m      [39;49m
-[39;49m                   [39;49m- Service(.definition_2)     
+  Arguments        Service(.definition_2)       
+                   %parameter%                  
+                   Inlined Service              
+                   Array (3 element(s))         
+                   Iterator (2 element(s))      
+                   - Service(definition_1)      
+                   - Service(.definition_2)     
  ---------------- -----------------------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
@@ -3,9 +3,9 @@
  ----------------- --------------------------------- 
   Service ID        -                                
   Class             Full\Qualified\Class2            
-[39;49m  Tags              tag1 ([39;49m[32mattr1[39m[39;49m: val1, [39;49m[32mattr2[39m[39;49m: val2)[39;49m[39;49m  [39;49m
-[39;49m                    [39;49m[39;49mtag1 ([39;49m[32mattr3[39m[39;49m: val3)[39;49m[39;49m               [39;49m
-[39;49m                    [39;49mtag2                             
+  Tags              tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
+                    tag1 ([32mattr3[39m: val3)               
+                    tag2                             
   Calls             setMailer                        
   Public            no                               
   Synthetic         yes                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1.txt
@@ -11,7 +11,7 @@
 | Requirements | name: [a-z]+                                                      |
 | Class        | Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub |
 | Defaults     | name: Joseph                                                      |
-[39;49m| Options      | compiler_class: Symfony\Component\Routing\RouteCompiler[39;49m[39;49m           |[39;49m
-[39;49m|              | [39;49m[39;49mopt1: val1[39;49m[39;49m                                                        |[39;49m
-[39;49m|              | [39;49mopt2: val2                                                        |
+| Options      | compiler_class: Symfony\Component\Routing\RouteCompiler           |
+|              | opt1: val1                                                        |
+|              | opt2: val2                                                        |
 +--------------+-------------------------------------------------------------------+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2.txt
@@ -11,8 +11,8 @@
 | Requirements | NO CUSTOM                                                         |
 | Class        | Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub |
 | Defaults     | NONE                                                              |
-[39;49m| Options      | compiler_class: Symfony\Component\Routing\RouteCompiler[39;49m[39;49m           |[39;49m
-[39;49m|              | [39;49m[39;49mopt1: val1[39;49m[39;49m                                                        |[39;49m
-[39;49m|              | [39;49mopt2: val2                                                        |
+| Options      | compiler_class: Symfony\Component\Routing\RouteCompiler           |
+|              | opt1: val1                                                        |
+|              | opt2: val2                                                        |
 | Condition    | context.getMethod() in ['GET', 'HEAD', 'POST']                    |
 +--------------+-------------------------------------------------------------------+

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -37,7 +37,7 @@
         "paragonie/sodium_compat": "^1.8",
         "symfony/asset": "^3.4|^4.0|^5.0",
         "symfony/browser-kit": "^4.3|^5.0",
-        "symfony/console": "^4.4.21|^5.0",
+        "symfony/console": "^4.4.42|^5.4.9",
         "symfony/css-selector": "^3.4|^4.0|^5.0",
         "symfony/dom-crawler": "^4.4.30|^5.3.7",
         "symfony/dotenv": "^4.3.6|^5.0",

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -586,7 +586,7 @@ class Table
                 }
                 $escaped = implode("\n", array_map([OutputFormatter::class, 'escapeTrailingBackslash'], explode("\n", $cell)));
                 $cell = $cell instanceof TableCell ? new TableCell($escaped, ['colspan' => $cell->getColspan()]) : $escaped;
-                $lines = explode("\n", str_replace("\n", "<fg=default;bg=default>\n</>", $cell));
+                $lines = explode("\n", str_replace("\n", "<fg=default;bg=default></>\n", $cell));
                 foreach ($lines as $lineKey => $line) {
                     if ($colspan > 1) {
                         $line = new TableCell($line, ['colspan' => $colspan]);

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -615,8 +615,8 @@ TABLE
                 'default',
                 <<<'TABLE'
 +-------+------------+
-[39;49m| [39;49m[37;41mDont break[39;49m[39;49m         |[39;49m
-[39;49m| [39;49m[37;41mhere[39;49m               |
+[37;41m| [39;49m[37;41mDont break[39;49m[37;41m         |[39;49m
+[37;41m| here[39;49m               |
 +-------+------------+
 [39;49m| foo   | [39;49m[37;41mDont break[39;49m[39;49m |[39;49m
 [39;49m| bar   | [39;49m[37;41mhere[39;49m       |
@@ -1077,6 +1077,26 @@ TABLE;
 | 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
 | 80-902734-1-6 | And Then There Were None | Agatha Christie  |
 +---------------+--------- Page 1/2 -------+------------------+
+
+TABLE
+                ,
+                true,
+           ],
+            'header contains multiple lines' => [
+                'Multiline'."\n".'header'."\n".'here',
+                'footer',
+                'default',
+                <<<'TABLE'
++---------------+--- Multiline
+header
+here +------------------+
+| ISBN          | Title                    | Author           |
++---------------+--------------------------+------------------+
+| 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
+| 9971-5-0210-0 | A Tale of Two Cities     | Charles Dickens  |
+| 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
+| 80-902734-1-6 | And Then There Were None | Agatha Christie  |
++---------------+---------- footer --------+------------------+
 
 TABLE
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

This is intended to fix a bug identified as a result of usage in a separate package (https://github.com/hotmeteor/spectator/issues/69 and https://github.com/hotmeteor/spectator/issues/90).

When a multi-line string is provided in the headers the Table helper produces content that cannot be rendered correctly.

in `src/Symfony/Component/Console/Helper/Table.php` there's a line` $lines = explode("\n", str_replace("\n", "<fg=default;bg=default>\n</>", $cell))` the exact line version varies between package versions, but this hasn't changed since 2017.

What this seems to do when you pass a multi line terminal string is wrap the newlines in a default style tag, presumably to try to force a reset. 

But what happens in the headers is that it splits it so that each line after the first starts with the close tag and ends with the open, resulting in the incorrect nesting error.  All this does is shift the newline character to after the reset style tag.  A side-effect of this is that it appears to now pad out the content of the `compact` and `borderless` styles in a manner which (to me) appears to be the intended output i.e. spaces padded out to the full table width.
