### PR TITLE
Fix "Notice: Undefined index: headers" in messenger with Oracle

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -409,7 +409,7 @@ class ConnectionTest extends TestCase
 
         yield 'Oracle' => [
             new OraclePlatform(),
-            'SELECT w.* FROM messenger_messages w WHERE w.id IN(SELECT a.id FROM (SELECT m.* FROM messenger_messages m WHERE (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) AND (m.queue_name = ?) ORDER BY available_at ASC) a WHERE ROWNUM <= 1) FOR UPDATE',
+            'SELECT w.id AS "id", w.body AS "body", w.headers AS "headers", w.queue_name AS "queue_name", w.created_at AS "created_at", w.available_at AS "available_at", w.delivered_at AS "delivered_at" FROM messenger_messages w WHERE w.id IN(SELECT a.id FROM (SELECT m.* FROM messenger_messages m WHERE (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) AND (m.queue_name = ?) ORDER BY available_at ASC) a WHERE ROWNUM <= 1) FOR UPDATE',
         ];
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -193,7 +193,11 @@ class Connection
                 $sql = str_replace('SELECT a.* FROM', 'SELECT a.id FROM', $sql);
 
                 $wrappedQuery = $this->driverConnection->createQueryBuilder()
-                    ->select('w.*')
+                    ->select(
+                        'w.id AS "id", w.body AS "body", w.headers AS "headers", w.queue_name AS "queue_name", '.
+                        'w.created_at AS "created_at", w.available_at AS "available_at", '.
+                        'w.delivered_at AS "delivered_at"'
+                    )
                     ->from($this->configuration['table_name'], 'w')
                     ->where('w.id IN('.$sql.')');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/44988
| License       | MIT
| Doc PR        | no

When using messenger with Oracle. The following exception happens:

```
In Connection.php line 453:
                                    
  [ErrorException]                  
  Notice: Undefined index: headers  
                                    
Exception trace:
  at /var/www/app/vendor/symfony/doctrine-messenger/Transport/Connection.php:453
 Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection->decodeEnvelopeHeaders()
```

The reason for this exception is because most Oracle databases use all caps table and field names. This is not a problem for updating and saving but when messenger tries to get the messages it will result in a response with all caps field names.

By selecting the was we do `SELECT table.foo as "foo"` we force the result to be lowercase even when the actual field is all caps.