### PR TITLE
[ExpressionLanguage] Add support for null coalescing syntax

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.1
 ---
 
+ * Add support for null-coalescing syntax
  * Add support for null-safe syntax when parsing object's methods and properties
  * Add new operators: `contains`, `starts with` and `ends with`
  * Support lexing numbers with the numeric literal separator `_`

--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -77,6 +77,10 @@ class Lexer
                 // null-safe
                 $tokens[] = new Token(Token::PUNCTUATION_TYPE, '?.', ++$cursor);
                 ++$cursor;
+            } elseif ('?' === $expression[$cursor] && '?' === ($expression[$cursor + 1] ?? '')) {
+                // null-coalescing
+                $tokens[] = new Token(Token::PUNCTUATION_TYPE, '??', ++$cursor);
+                ++$cursor;
             } elseif (str_contains('.,?:', $expression[$cursor])) {
                 // punctuation
                 $tokens[] = new Token(Token::PUNCTUATION_TYPE, $expression[$cursor], $cursor + 1);

--- a/src/Symfony/Component/ExpressionLanguage/Node/NullCoalesceNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/NullCoalesceNode.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Node;
+
+use Symfony\Component\ExpressionLanguage\Compiler;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal
+ */
+class NullCoalesceNode extends Node
+{
+    public function __construct(Node $expr1, Node $expr2)
+    {
+        parent::__construct(['expr1' => $expr1, 'expr2' => $expr2]);
+    }
+
+    public function compile(Compiler $compiler)
+    {
+        $compiler
+            ->raw('((')
+            ->compile($this->nodes['expr1'])
+            ->raw(') ?? (')
+            ->compile($this->nodes['expr2'])
+            ->raw('))')
+        ;
+    }
+
+    public function evaluate(array $functions, array $values)
+    {
+        if ($this->nodes['expr1'] instanceof GetAttrNode) {
+            $this->nodes['expr1']->isNullCoalesce = true;
+        }
+
+        return $this->nodes['expr1']->evaluate($functions, $values) ?? $this->nodes['expr2']->evaluate($functions, $values);
+    }
+
+    public function toArray()
+    {
+        return ['(', $this->nodes['expr1'], ') ?? (', $this->nodes['expr2'], ')'];
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -176,6 +176,13 @@ class Parser
 
     protected function parseConditionalExpression(Node\Node $expr)
     {
+        while ($this->stream->current->test(Token::PUNCTUATION_TYPE, '??')) {
+            $this->stream->next();
+            $expr2 = $this->parseExpression();
+
+            $expr = new Node\NullCoalesceNode($expr, $expr2);
+        }
+
         while ($this->stream->current->test(Token::PUNCTUATION_TYPE, '?')) {
             $this->stream->next();
             if (!$this->stream->current->test(Token::PUNCTUATION_TYPE, ':')) {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -316,6 +316,44 @@ class ExpressionLanguageTest extends TestCase
     }
 
     /**
+     * @dataProvider provideNullCoalescing
+     */
+    public function testNullCoalescingEvaluate($expression, $foo)
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $this->assertSame($expressionLanguage->evaluate($expression, ['foo' => $foo]), 'default');
+    }
+
+    /**
+     * @dataProvider provideNullCoalescing
+     */
+    public function testNullCoalescingCompile($expression, $foo)
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $this->assertSame(eval(sprintf('return %s;', $expressionLanguage->compile($expression, ['foo' => 'foo']))), 'default');
+    }
+
+    public function provideNullCoalescing()
+    {
+        $foo = new class() extends \stdClass {
+            public function bar()
+            {
+                return null;
+            }
+        };
+
+        yield ['foo.bar ?? "default"', null];
+        yield ['foo.bar.baz ?? "default"', (object) ['bar' => null]];
+        yield ['foo.bar ?? foo.baz ?? "default"', null];
+        yield ['foo[0] ?? "default"', []];
+        yield ['foo["bar"] ?? "default"', ['bar' => null]];
+        yield ['foo["baz"] ?? "default"', ['bar' => null]];
+        yield ['foo["bar"]["baz"] ?? "default"', ['bar' => null]];
+        yield ['foo["bar"].baz ?? "default"', ['bar' => null]];
+        yield ['foo.bar().baz ?? "default"', $foo];
+    }
+
+    /**
      * @dataProvider getRegisterCallbacks
      */
     public function testRegisterAfterCompile($registerCallback)

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -163,6 +163,16 @@ class ParserTest extends TestCase
                 'foo?.not()',
                 ['foo'],
             ],
+            [
+                new Node\NullCoalesceNode(new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar', true), new Node\ArgumentsNode(), Node\GetAttrNode::PROPERTY_CALL), new Node\ConstantNode('default')),
+                'foo.bar ?? "default"',
+                ['foo'],
+            ],
+            [
+                new Node\NullCoalesceNode(new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar'), new Node\ArgumentsNode(), Node\GetAttrNode::ARRAY_CALL), new Node\ConstantNode('default')),
+                'foo["bar"] ?? "default"',
+                ['foo'],
+            ],
 
             // chained calls
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45411, #21691
| License       | MIT
| Doc PR        | symfony/symfony-docs#16743

This is another waited feature for the syntax of the expression-language component. The [null-coalescing](https://wiki.php.net/rfc/isset_ternary) operator ``??`` becomes a need for variant programming needs these days. 

Following my previous PR introducing the null-safe operator (#45795). I'm hereby introducing yet another essential operator to make the syntax even more complete.

The null-coalescing operator is a syntactic sugar for a common use of ternary in conjunction with ``isset()`` (in PHP) or equivalent in other languages. This is such a common use-case to the point that almost all majors programming syntax nowadays support a sort of a short-hand for that operation namely coalescing operator. Now it's time for the syntax of Expression-Language to do so!

Expressions like:

* ``foo.bar ?? 'default'``
* ``foo[3] ?? 'default'``
* ``foo.bar ?? foo['bar'] ?? 'default'``

will default to the expression in the right-hand-side of the ``??`` operator whenever the expression in the left-hand-side of it does not exist or it's ``null``. Note that this coalescing behavior can be chained and the validation logic takes decreasing priority from left to right.
