### PR TITLE
Modify processing of uploaded files to be compatible with PHP 8.1

### DIFF
--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -198,6 +198,8 @@ class NativeRequestHandler implements RequestHandlerInterface
             return $data;
         }
 
+        // Remove extra key added by PHP 8.1.
+        unset($data['full_path']);
         $keys = array_keys($data);
         sort($keys);
 


### PR DESCRIPTION
Remove full_path from keys before check
Keep logic the same as in src/Symfony/Component/HttpFoundation/FileBag.php

| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #46146
| License       | MIT
