### PR TITLE
[HttpKernel] Adding _renderer attribute like _format in request to make Fragment (SubRequest) detectable.  

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -125,7 +125,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         }
         $setSession($subRequest, $request);
 
-        $subRequest->attributes->set('_renderer', 'inline');
+        $subRequest->attributes->set('_renderer', $this->getName());
 
         if ($request->get('_format')) {
             $subRequest->attributes->set('_format', $request->get('_format'));

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -125,6 +125,8 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         }
         $setSession($subRequest, $request);
 
+        $subRequest->attributes->set('_renderer', 'inline');
+
         if ($request->get('_format')) {
             $subRequest->attributes->set('_format', $request->get('_format'));
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -35,6 +35,7 @@ class InlineFragmentRendererTest extends TestCase
     {
         $request = Request::create('/');
         $request->attributes->replace(['_renderer' => 'inline']);
+
         return $request;
     }
 


### PR DESCRIPTION
https://github.com/symfony/webpack-encore-bundle/pull/115#issuecomment-1105093641

| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features / 4.4, 5.4 or 6.0 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I have attached a _renderer attribute when subrequest render as inline request by fragment as want to solve the issue which broken by https://github.com/symfony/webpack-encore-bundle/pull/115#issuecomment-1105093641 PR which is a helper for rendering multiple files or mails and want to reset the assets but its breaking the render(controller(..)) and any other embed feature due to that. 

This is my first PR. sorry if its not good enough. 