### PR TITLE
[MonologBridge] Add support for Monolog 3

### DIFF
--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add support for Monolog 3
+
 6.0
 ---
 

--- a/src/Symfony/Bridge/Monolog/Formatter/CompatibilityFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/CompatibilityFormatter.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Formatter;
+
+use Monolog\Logger;
+use Monolog\LogRecord;
+
+if (Logger::API >= 3) {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityFormatter
+    {
+        abstract private function doFormat(array|LogRecord $record): mixed;
+
+        /**
+         * {@inheritdoc}
+         */
+        public function format(LogRecord $record): mixed
+        {
+            return $this->doFormat($record);
+        }
+    }
+} else {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityFormatter
+    {
+        abstract private function doFormat(array|LogRecord $record): mixed;
+
+        /**
+         * {@inheritdoc}
+         */
+        public function format(array $record): mixed
+        {
+            return $this->doFormat($record);
+        }
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Monolog\Formatter;
 
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\Stub;
@@ -24,9 +25,13 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
  *
  * @author Tobias Schultze <http://tobion.de>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @final since Symfony 6.1
  */
 class ConsoleFormatter implements FormatterInterface
 {
+    use CompatibilityFormatter;
+
     public const SIMPLE_FORMAT = "%datetime% %start_tag%%level_name%%end_tag% <comment>[%channel%]</> %message%%context%%extra%\n";
     public const SIMPLE_DATE = 'H:i:s';
 
@@ -98,11 +103,11 @@ class ConsoleFormatter implements FormatterInterface
         return $records;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function format(array $record): mixed
+    private function doFormat(array|LogRecord $record): mixed
     {
+        if ($record instanceof LogRecord) {
+            $record = $record->toArray();
+        }
         $record = $this->replacePlaceHolder($record);
 
         if (!$this->options['ignore_empty_context_and_extra'] || !empty($record['context'])) {

--- a/src/Symfony/Bridge/Monolog/Formatter/VarDumperFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/VarDumperFormatter.php
@@ -12,13 +12,18 @@
 namespace Symfony\Bridge\Monolog\Formatter;
 
 use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @final since Symfony 6.1
  */
 class VarDumperFormatter implements FormatterInterface
 {
+    use CompatibilityFormatter;
+
     private VarCloner $cloner;
 
     public function __construct(VarCloner $cloner = null)
@@ -26,11 +31,12 @@ class VarDumperFormatter implements FormatterInterface
         $this->cloner = $cloner ?? new VarCloner();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function format(array $record): mixed
+    private function doFormat(array|LogRecord $record): mixed
     {
+        if ($record instanceof LogRecord) {
+            $record = $record->toArray();
+        }
+
         $record['context'] = $this->cloner->cloneVar($record['context']);
         $record['extra'] = $this->cloner->cloneVar($record['extra']);
 

--- a/src/Symfony/Bridge/Monolog/Handler/CompatibilityHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/CompatibilityHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Handler;
+
+use Monolog\Logger;
+use Monolog\LogRecord;
+
+if (Logger::API >= 3) {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityHandler
+    {
+        abstract private function doHandle(array|LogRecord $record): bool;
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(LogRecord $record): bool
+        {
+            return $this->doHandle($record);
+        }
+    }
+} else {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityHandler
+    {
+        abstract private function doHandle(array|LogRecord $record): bool;
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(array $record): bool
+        {
+            return $this->doHandle($record);
+        }
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Handler/CompatibilityProcessingHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/CompatibilityProcessingHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Handler;
+
+use Monolog\Logger;
+use Monolog\LogRecord;
+
+if (Logger::API >= 3) {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityProcessingHandler
+    {
+        abstract private function doWrite(array|LogRecord $record): void;
+
+        /**
+         * {@inheritdoc}
+         */
+        protected function write(LogRecord $record): void
+        {
+            $this->doWrite($record);
+        }
+    }
+} else {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityProcessingHandler
+    {
+        abstract private function doWrite(array|LogRecord $record): void;
+
+        /**
+         * {@inheritdoc}
+         */
+        protected function write(array $record): void
+        {
+            $this->doWrite($record);
+        }
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -15,6 +15,7 @@ use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -23,6 +24,48 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
+
+if (Logger::API >= 3) {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityIsHandlingHandler
+    {
+        abstract private function doIsHandling(array|LogRecord $record): bool;
+
+        /**
+         * {@inheritdoc}
+         */
+        public function isHandling(LogRecord $record): bool
+        {
+            return $this->doIsHandling($record);
+        }
+    }
+} else {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityIsHandlingHandler
+    {
+        abstract private function doIsHandling(array|LogRecord $record): bool;
+
+        /**
+         * {@inheritdoc}
+         */
+        public function isHandling(array $record): bool
+        {
+            return $this->doIsHandling($record);
+        }
+    }
+}
 
 /**
  * Writes logs to the console output depending on its verbosity setting.
@@ -40,9 +83,15 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
  * This mapping can be customized with the $verbosityLevelMap constructor parameter.
  *
  * @author Tobias Schultze <http://tobion.de>
+ *
+ * @final since Symfony 6.1
  */
 class ConsoleHandler extends AbstractProcessingHandler implements EventSubscriberInterface
 {
+    use CompatibilityHandler;
+    use CompatibilityIsHandlingHandler;
+    use CompatibilityProcessingHandler;
+
     private ?OutputInterface $output;
     private array $verbosityLevelMap = [
         OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
@@ -75,7 +124,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     /**
      * {@inheritdoc}
      */
-    public function isHandling(array $record): bool
+    private function doIsHandling(array|LogRecord $record): bool
     {
         return $this->updateLevel() && parent::isHandling($record);
     }
@@ -83,7 +132,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     /**
      * {@inheritdoc}
      */
-    public function handle(array $record): bool
+    private function doHandle(array|LogRecord $record): bool
     {
         // we have to update the logging level each time because the verbosity of the
         // console output might have changed in the meantime (it is not immutable)
@@ -141,10 +190,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function write(array $record): void
+    private function doWrite(array|LogRecord $record): void
     {
         // at this point we've determined for sure that we want to output the record, so use the output's own verbosity
         $this->output->write((string) $record['formatted'], false, $this->output->getVerbosity());

--- a/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
@@ -16,7 +16,10 @@ use Monolog\Formatter\LogstashFormatter;
 use Monolog\Handler\AbstractHandler;
 use Monolog\Handler\FormattableHandlerTrait;
 use Monolog\Handler\ProcessableHandlerTrait;
+use Monolog\Level;
+use Monolog\LevelName;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -39,9 +42,13 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * stack is recommended.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @final since Symfony 6.1
  */
 class ElasticsearchLogstashHandler extends AbstractHandler
 {
+    use CompatibilityHandler;
+
     use FormattableHandlerTrait;
     use ProcessableHandlerTrait;
 
@@ -54,7 +61,7 @@ class ElasticsearchLogstashHandler extends AbstractHandler
      */
     private \SplObjectStorage $responses;
 
-    public function __construct(string $endpoint = 'http://127.0.0.1:9200', string $index = 'monolog', HttpClientInterface $client = null, string|int $level = Logger::DEBUG, bool $bubble = true)
+    public function __construct(string $endpoint = 'http://127.0.0.1:9200', string $index = 'monolog', HttpClientInterface $client = null, string|int|Level|LevelName $level = Logger::DEBUG, bool $bubble = true)
     {
         if (!interface_exists(HttpClientInterface::class)) {
             throw new \LogicException(sprintf('The "%s" handler needs an HTTP client. Try running "composer require symfony/http-client".', __CLASS__));
@@ -67,7 +74,7 @@ class ElasticsearchLogstashHandler extends AbstractHandler
         $this->responses = new \SplObjectStorage();
     }
 
-    public function handle(array $record): bool
+    private function doHandle(array|LogRecord $record): bool
     {
         if (!$this->isHandling($record)) {
             return false;

--- a/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/HttpCodeActivationStrategy.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/HttpCodeActivationStrategy.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Handler\FingersCrossed;
 
 use Monolog\Handler\FingersCrossed\ActivationStrategyInterface;
+use Monolog\LogRecord;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -41,7 +42,7 @@ final class HttpCodeActivationStrategy implements ActivationStrategyInterface
         }
     }
 
-    public function isHandlerActivated(array $record): bool
+    public function isHandlerActivated(array|LogRecord $record): bool
     {
         $isActivated = $this->inner->isHandlerActivated($record);
 

--- a/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/NotFoundActivationStrategy.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/NotFoundActivationStrategy.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Handler\FingersCrossed;
 
 use Monolog\Handler\FingersCrossed\ActivationStrategyInterface;
+use Monolog\LogRecord;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -34,7 +35,7 @@ final class NotFoundActivationStrategy implements ActivationStrategyInterface
         $this->exclude = '{('.implode('|', $excludedUrls).')}i';
     }
 
-    public function isHandlerActivated(array $record): bool
+    public function isHandlerActivated(array|LogRecord $record): bool
     {
         $isActivated = $this->inner->isHandlerActivated($record);
 

--- a/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Monolog\Handler;
 
 use Monolog\Handler\AbstractHandler;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\Notifier\NotifierInterface;
@@ -21,19 +22,23 @@ use Symfony\Component\Notifier\NotifierInterface;
  * Uses Notifier as a log handler.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 6.1
  */
 class NotifierHandler extends AbstractHandler
 {
+    use CompatibilityHandler;
+
     private NotifierInterface $notifier;
 
-    public function __construct(NotifierInterface $notifier, string|int $level = Logger::ERROR, bool $bubble = true)
+    public function __construct(NotifierInterface $notifier, string|int|Level|LevelName $level = Logger::ERROR, bool $bubble = true)
     {
         $this->notifier = $notifier;
 
         parent::__construct(Logger::toMonologLevel($level) < Logger::ERROR ? Logger::ERROR : $level, $bubble);
     }
 
-    public function handle(array $record): bool
+    private function doHandle(array|LogRecord $record): bool
     {
         if (!$this->isHandling($record)) {
             return false;

--- a/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
@@ -14,12 +14,20 @@ namespace Symfony\Bridge\Monolog\Handler;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Handler\FormattableHandlerTrait;
+use Monolog\Level;
+use Monolog\LevelName;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Symfony\Bridge\Monolog\Formatter\VarDumperFormatter;
 
 if (trait_exists(FormattableHandlerTrait::class)) {
+    /**
+     * @final since Symfony 6.1
+     */
     class ServerLogHandler extends AbstractProcessingHandler
     {
+        use CompatibilityHandler;
+        use CompatibilityProcessingHandler;
         use ServerLogHandlerTrait;
 
         /**
@@ -31,8 +39,13 @@ if (trait_exists(FormattableHandlerTrait::class)) {
         }
     }
 } else {
+    /**
+     * @final since Symfony 6.1
+     */
     class ServerLogHandler extends AbstractProcessingHandler
     {
+        use CompatibilityHandler;
+        use CompatibilityProcessingHandler;
         use ServerLogHandlerTrait;
 
         /**
@@ -47,6 +60,8 @@ if (trait_exists(FormattableHandlerTrait::class)) {
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @internal since Symfony 6.1
  */
 trait ServerLogHandlerTrait
 {
@@ -62,7 +77,7 @@ trait ServerLogHandlerTrait
      */
     private $socket;
 
-    public function __construct(string $host, string|int $level = Logger::DEBUG, bool $bubble = true, array $context = [])
+    public function __construct(string $host, string|int|Level|LevelName $level = Logger::DEBUG, bool $bubble = true, array $context = [])
     {
         parent::__construct($level, $bubble);
 
@@ -74,10 +89,7 @@ trait ServerLogHandlerTrait
         $this->context = stream_context_create($context);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function handle(array $record): bool
+    private function doHandle(array|LogRecord $record): bool
     {
         if (!$this->isHandling($record)) {
             return false;
@@ -96,7 +108,7 @@ trait ServerLogHandlerTrait
         return parent::handle($record);
     }
 
-    protected function write(array $record): void
+    private function doWrite(array|LogRecord $record): void
     {
         $recordFormatted = $this->formatRecord($record);
 
@@ -139,7 +151,7 @@ trait ServerLogHandlerTrait
         return $socket;
     }
 
-    private function formatRecord(array $record): string
+    private function formatRecord(array|LogRecord $record): string
     {
         $recordFormatted = $record['formatted'];
 

--- a/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Monolog\Processor;
 
+use Monolog\LogRecord;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -19,9 +20,13 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  *
  * @author Dany Maillard <danymaillard93b@gmail.com>
  * @author Igor Timoshenko <igor.timoshenko@i.ua>
+ *
+ * @internal since Symfony 6.1
  */
 abstract class AbstractTokenProcessor
 {
+    use CompatibilityProcessor;
+
     /**
      * @var TokenStorageInterface
      */
@@ -36,7 +41,7 @@ abstract class AbstractTokenProcessor
 
     abstract protected function getToken(): ?TokenInterface;
 
-    public function __invoke(array $record): array
+    private function doInvoke(array|LogRecord $record): array|LogRecord
     {
         $record['extra'][$this->getKey()] = null;
 

--- a/src/Symfony/Bridge/Monolog/Processor/CompatibilityProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/CompatibilityProcessor.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Processor;
+
+use Monolog\Logger;
+use Monolog\LogRecord;
+
+if (Logger::API >= 3) {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityProcessor
+    {
+        abstract private function doInvoke(array|LogRecord $record): array|LogRecord;
+
+        public function __invoke(LogRecord $record): LogRecord
+        {
+            return $this->doInvoke($record);
+        }
+    }
+} else {
+    /**
+     * The base class for compatibility between Monolog 3 LogRecord and Monolog 1/2 array records.
+     *
+     * @author Jordi Boggiano <j.boggiano@seld.be>
+     *
+     * @internal
+     */
+    trait CompatibilityProcessor
+    {
+        abstract private function doInvoke(array|LogRecord $record): array|LogRecord;
+
+        public function __invoke(array $record): array
+        {
+            return $this->doInvoke($record);
+        }
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Processor/ConsoleCommandProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/ConsoleCommandProcessor.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Monolog\Processor;
 
+use Monolog\LogRecord;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -20,9 +21,13 @@ use Symfony\Contracts\Service\ResetInterface;
  * Adds the current console command information to the log entry.
  *
  * @author Piotr Stankowski <git@trakos.pl>
+ *
+ * @final since Symfony 6.1
  */
 class ConsoleCommandProcessor implements EventSubscriberInterface, ResetInterface
 {
+    use CompatibilityProcessor;
+
     private array $commandData;
     private bool $includeArguments;
     private bool $includeOptions;
@@ -33,13 +38,13 @@ class ConsoleCommandProcessor implements EventSubscriberInterface, ResetInterfac
         $this->includeOptions = $includeOptions;
     }
 
-    public function __invoke(array $records)
+    private function doInvoke(array|LogRecord $record): array|LogRecord
     {
-        if (isset($this->commandData) && !isset($records['extra']['command'])) {
-            $records['extra']['command'] = $this->commandData;
+        if (isset($this->commandData) && !isset($record['extra']['command'])) {
+            $record['extra']['command'] = $this->commandData;
         }
 
-        return $records;
+        return $record;
     }
 
     public function reset()

--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Processor;
 
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
@@ -19,6 +20,8 @@ use Symfony\Contracts\Service\ResetInterface;
 
 class DebugProcessor implements DebugLoggerInterface, ResetInterface
 {
+    use CompatibilityProcessor;
+
     private array $records = [];
     private array $errorCount = [];
     private ?RequestStack $requestStack;
@@ -28,7 +31,7 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
         $this->requestStack = $requestStack;
     }
 
-    public function __invoke(array $record)
+    private function doInvoke(array|LogRecord $record): array|LogRecord
     {
         $hash = $this->requestStack && ($request = $this->requestStack->getCurrentRequest()) ? spl_object_hash($request) : '';
 

--- a/src/Symfony/Bridge/Monolog/Processor/RouteProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/RouteProcessor.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Monolog\Processor;
 
+use Monolog\LogRecord;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -35,13 +36,13 @@ class RouteProcessor implements EventSubscriberInterface, ResetInterface
         $this->reset();
     }
 
-    public function __invoke(array $records): array
+    public function __invoke(array|LogRecord $record): array|LogRecord
     {
-        if ($this->routeData && !isset($records['extra']['requests'])) {
-            $records['extra']['requests'] = array_values($this->routeData);
+        if ($this->routeData && !isset($record['extra']['requests'])) {
+            $record['extra']['requests'] = array_values($this->routeData);
         }
 
-        return $records;
+        return $record;
     }
 
     public function reset()

--- a/src/Symfony/Bridge/Monolog/Processor/SwitchUserTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/SwitchUserTokenProcessor.php
@@ -18,6 +18,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * Adds the original security token to the log entry.
  *
  * @author Igor Timoshenko <igor.timoshenko@i.ua>
+ *
+ * @final since Symfony 6.1
  */
 class SwitchUserTokenProcessor extends AbstractTokenProcessor
 {

--- a/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
@@ -18,6 +18,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  *
  * @author Dany Maillard <danymaillard93b@gmail.com>
  * @author Igor Timoshenko <igor.timoshenko@i.ua>
+ *
+ * @final since Symfony 6.1
  */
 class TokenProcessor extends AbstractTokenProcessor
 {

--- a/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
@@ -12,15 +12,17 @@
 namespace Symfony\Bridge\Monolog\Tests\Formatter;
 
 use Monolog\Logger;
+use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 
 class ConsoleFormatterTest extends TestCase
 {
     /**
      * @dataProvider providerFormatTests
      */
-    public function testFormat(array $record, $expectedMessage)
+    public function testFormat(array|LogRecord $record, $expectedMessage)
     {
         $formatter = new ConsoleFormatter();
         self::assertSame($expectedMessage, $formatter->format($record));
@@ -28,25 +30,20 @@ class ConsoleFormatterTest extends TestCase
 
     public function providerFormatTests(): array
     {
-        $currentDateTime = new \DateTime();
+        $currentDateTime = new \DateTimeImmutable();
 
-        return [
+        $tests = [
             'record with DateTime object in datetime field' => [
-                'record' => [
-                    'message' => 'test',
-                    'context' => [],
-                    'level' => Logger::WARNING,
-                    'level_name' => Logger::getLevelName(Logger::WARNING),
-                    'channel' => 'test',
-                    'datetime' => $currentDateTime,
-                    'extra' => [],
-                ],
+                'record' => RecordFactory::create(datetime: $currentDateTime),
                 'expectedMessage' => sprintf(
                     "%s <fg=cyan>WARNING  </> <comment>[test]</> test\n",
                     $currentDateTime->format(ConsoleFormatter::SIMPLE_DATE)
                 ),
             ],
-            'record with string in datetime field' => [
+        ];
+
+        if (Logger::API < 3) {
+            $tests['record with string in datetime field'] = [
                 'record' => [
                     'message' => 'test',
                     'context' => [],
@@ -57,7 +54,9 @@ class ConsoleFormatterTest extends TestCase
                     'extra' => [],
                 ],
                 'expectedMessage' => "2019-01-01T00:42:00+00:00 <fg=cyan>WARNING  </> <comment>[test]</> test\n",
-            ],
-        ];
+            ];
+        }
+
+        return $tests;
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -15,6 +15,7 @@ use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
 use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -41,7 +42,7 @@ class ConsoleHandlerTest extends TestCase
     public function testIsHandling()
     {
         $handler = new ConsoleHandler();
-        $this->assertFalse($handler->isHandling([]), '->isHandling returns false when no output is set');
+        $this->assertFalse($handler->isHandling(RecordFactory::create()), '->isHandling returns false when no output is set');
     }
 
     /**
@@ -56,7 +57,7 @@ class ConsoleHandlerTest extends TestCase
             ->willReturn($verbosity)
         ;
         $handler = new ConsoleHandler($output, true, $map);
-        $this->assertSame($isHandling, $handler->isHandling(['level' => $level]),
+        $this->assertSame($isHandling, $handler->isHandling(RecordFactory::create($level)),
             '->isHandling returns correct value depending on console verbosity and log level'
         );
 
@@ -77,15 +78,7 @@ class ConsoleHandlerTest extends TestCase
             ->with($log, false);
         $handler = new ConsoleHandler($realOutput, true, $map);
 
-        $infoRecord = [
-            'message' => 'My info message',
-            'context' => [],
-            'level' => $level,
-            'level_name' => Logger::getLevelName($level),
-            'channel' => 'app',
-            'datetime' => new \DateTime('2013-05-29 16:21:54'),
-            'extra' => [],
-        ];
+        $infoRecord = RecordFactory::create($level, 'My info message', 'app', datetime: new \DateTimeImmutable('2013-05-29 16:21:54'));
         $this->assertFalse($handler->handle($infoRecord), 'The handler finished handling the log.');
     }
 
@@ -123,10 +116,10 @@ class ConsoleHandlerTest extends TestCase
             )
         ;
         $handler = new ConsoleHandler($output);
-        $this->assertFalse($handler->isHandling(['level' => Logger::NOTICE]),
+        $this->assertFalse($handler->isHandling(RecordFactory::create(Logger::NOTICE)),
             'when verbosity is set to quiet, the handler does not handle the log'
         );
-        $this->assertTrue($handler->isHandling(['level' => Logger::NOTICE]),
+        $this->assertTrue($handler->isHandling(RecordFactory::create(Logger::NOTICE)),
             'since the verbosity of the output increased externally, the handler is now handling the log'
         );
     }
@@ -157,15 +150,7 @@ class ConsoleHandlerTest extends TestCase
         $handler = new ConsoleHandler(null, false);
         $handler->setOutput($output);
 
-        $infoRecord = [
-            'message' => 'My info message',
-            'context' => [],
-            'level' => Logger::INFO,
-            'level_name' => Logger::getLevelName(Logger::INFO),
-            'channel' => 'app',
-            'datetime' => new \DateTime('2013-05-29 16:21:54'),
-            'extra' => [],
-        ];
+        $infoRecord = RecordFactory::create(Logger::INFO, 'My info message', 'app', datetime: new \DateTimeImmutable('2013-05-29 16:21:54'));
 
         $this->assertTrue($handler->handle($infoRecord), 'The handler finished handling the log as bubble is false.');
     }

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/HttpCodeActivationStrategyTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/HttpCodeActivationStrategyTest.php
@@ -15,6 +15,7 @@ use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -58,16 +59,16 @@ class HttpCodeActivationStrategyTest extends TestCase
     public function isActivatedProvider(): array
     {
         return [
-            ['/test',  ['level' => Logger::ERROR], true],
-            ['/400',   ['level' => Logger::ERROR, 'context' => $this->getContextException(400)], true],
-            ['/400/a', ['level' => Logger::ERROR, 'context' => $this->getContextException(400)], false],
-            ['/400/b', ['level' => Logger::ERROR, 'context' => $this->getContextException(400)], false],
-            ['/400/c', ['level' => Logger::ERROR, 'context' => $this->getContextException(400)], true],
-            ['/401',   ['level' => Logger::ERROR, 'context' => $this->getContextException(401)], true],
-            ['/403',   ['level' => Logger::ERROR, 'context' => $this->getContextException(403)], false],
-            ['/404',   ['level' => Logger::ERROR, 'context' => $this->getContextException(404)], false],
-            ['/405',   ['level' => Logger::ERROR, 'context' => $this->getContextException(405)], false],
-            ['/500',   ['level' => Logger::ERROR, 'context' => $this->getContextException(500)], true],
+            ['/test',  RecordFactory::create(Logger::ERROR), true],
+            ['/400',   RecordFactory::create(Logger::ERROR, context: $this->getContextException(400)), true],
+            ['/400/a', RecordFactory::create(Logger::ERROR, context: $this->getContextException(400)), false],
+            ['/400/b', RecordFactory::create(Logger::ERROR, context: $this->getContextException(400)), false],
+            ['/400/c', RecordFactory::create(Logger::ERROR, context: $this->getContextException(400)), true],
+            ['/401',   RecordFactory::create(Logger::ERROR, context: $this->getContextException(401)), true],
+            ['/403',   RecordFactory::create(Logger::ERROR, context: $this->getContextException(403)), false],
+            ['/404',   RecordFactory::create(Logger::ERROR, context: $this->getContextException(404)), false],
+            ['/405',   RecordFactory::create(Logger::ERROR, context: $this->getContextException(405)), false],
+            ['/500',   RecordFactory::create(Logger::ERROR, context: $this->getContextException(500)), true],
         ];
     }
 

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
@@ -13,8 +13,10 @@ namespace Symfony\Bridge\Monolog\Tests\Handler\FingersCrossed;
 
 use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -24,7 +26,7 @@ class NotFoundActivationStrategyTest extends TestCase
     /**
      * @dataProvider isActivatedProvider
      */
-    public function testIsActivated(string $url, array $record, bool $expected)
+    public function testIsActivated(string $url, array|LogRecord $record, bool $expected)
     {
         $requestStack = new RequestStack();
         $requestStack->push(Request::create($url));
@@ -37,15 +39,15 @@ class NotFoundActivationStrategyTest extends TestCase
     public function isActivatedProvider(): array
     {
         return [
-            ['/test',      ['level' => Logger::DEBUG], false],
-            ['/foo',       ['level' => Logger::DEBUG, 'context' => $this->getContextException(404)], false],
-            ['/baz/bar',   ['level' => Logger::ERROR, 'context' => $this->getContextException(404)], false],
-            ['/foo',       ['level' => Logger::ERROR, 'context' => $this->getContextException(404)], false],
-            ['/foo',       ['level' => Logger::ERROR, 'context' => $this->getContextException(500)], true],
+            ['/test',      RecordFactory::create(Logger::DEBUG), false],
+            ['/foo',       RecordFactory::create(Logger::DEBUG, context: $this->getContextException(404)), false],
+            ['/baz/bar',   RecordFactory::create(Logger::ERROR, context: $this->getContextException(404)), false],
+            ['/foo',       RecordFactory::create(Logger::ERROR, context: $this->getContextException(404)), false],
+            ['/foo',       RecordFactory::create(Logger::ERROR, context: $this->getContextException(500)), true],
 
-            ['/test',      ['level' => Logger::ERROR], true],
-            ['/baz',       ['level' => Logger::ERROR, 'context' => $this->getContextException(404)], true],
-            ['/baz',       ['level' => Logger::ERROR, 'context' => $this->getContextException(500)], true],
+            ['/test',      RecordFactory::create(Logger::ERROR), true],
+            ['/baz',       RecordFactory::create(Logger::ERROR, context: $this->getContextException(404)), true],
+            ['/baz',       RecordFactory::create(Logger::ERROR, context: $this->getContextException(500)), true],
         ];
     }
 

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
@@ -13,10 +13,12 @@ namespace Symfony\Bridge\Monolog\Tests\Handler;
 
 use Monolog\Formatter\HtmlFormatter;
 use Monolog\Formatter\LineFormatter;
+use Monolog\LogRecord;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\MailerHandler;
 use Symfony\Bridge\Monolog\Logger;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 
@@ -91,17 +93,9 @@ class MailerHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::WARNING, 'message'));
     }
 
-    protected function getRecord($level = Logger::WARNING, $message = 'test', $context = []): array
+    protected function getRecord($level = Logger::WARNING, $message = 'test', $context = []): array|LogRecord
     {
-        return [
-            'message' => $message,
-            'context' => $context,
-            'level' => $level,
-            'level_name' => Logger::getLevelName($level),
-            'channel' => 'test',
-            'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
-            'extra' => [],
-        ];
+        return RecordFactory::create($level, $message, context: $context);
     }
 
     protected function getMultipleRecords(): array

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ServerLogHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ServerLogHandlerTest.php
@@ -17,6 +17,7 @@ use Monolog\Processor\ProcessIdProcessor;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Formatter\VarDumperFormatter;
 use Symfony\Bridge\Monolog\Handler\ServerLogHandler;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
@@ -37,7 +38,7 @@ class ServerLogHandlerTest extends TestCase
     public function testIsHandling()
     {
         $handler = new ServerLogHandler('tcp://127.0.0.1:9999', Logger::INFO);
-        $this->assertFalse($handler->isHandling(['level' => Logger::DEBUG]), '->isHandling returns false when no output is set');
+        $this->assertFalse($handler->isHandling(RecordFactory::create(Logger::DEBUG)), '->isHandling returns false when no output is set');
     }
 
     public function testGetFormatter()
@@ -54,15 +55,7 @@ class ServerLogHandlerTest extends TestCase
         $handler = new ServerLogHandler($host, Logger::INFO, false);
         $handler->pushProcessor(new ProcessIdProcessor());
 
-        $infoRecord = [
-            'message' => 'My info message',
-            'context' => [],
-            'level' => Logger::INFO,
-            'level_name' => Logger::getLevelName(Logger::INFO),
-            'channel' => 'app',
-            'datetime' => new \DateTime('2013-05-29 16:21:54'),
-            'extra' => [],
-        ];
+        $infoRecord = RecordFactory::create(Logger::INFO, 'My info message', 'app', datetime: new \DateTimeImmutable('2013-05-29 16:21:54'));
 
         $socket = stream_socket_server($host, $errno, $errstr);
         $this->assertIsResource($socket, sprintf('Server start failed on "%s": %s %s.', $host, $errstr, $errno));

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/ConsoleCommandProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/ConsoleCommandProcessorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Monolog\Tests\Processor;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\ConsoleCommandProcessor;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,7 +30,7 @@ class ConsoleCommandProcessorTest extends TestCase
         $processor = new ConsoleCommandProcessor();
         $processor->addCommandData($this->getConsoleEvent());
 
-        $record = $processor(['extra' => []]);
+        $record = $processor(RecordFactory::create());
 
         $this->assertArrayHasKey('command', $record['extra']);
         $this->assertEquals(
@@ -43,7 +44,7 @@ class ConsoleCommandProcessorTest extends TestCase
         $processor = new ConsoleCommandProcessor(true, true);
         $processor->addCommandData($this->getConsoleEvent());
 
-        $record = $processor(['extra' => []]);
+        $record = $processor(RecordFactory::create());
 
         $this->assertArrayHasKey('command', $record['extra']);
         $this->assertEquals(
@@ -56,8 +57,8 @@ class ConsoleCommandProcessorTest extends TestCase
     {
         $processor = new ConsoleCommandProcessor(true, true);
 
-        $record = $processor(['extra' => []]);
-        $this->assertEquals(['extra' => []], $record);
+        $record = $processor(RecordFactory::create());
+        $this->assertEquals([], $record['extra']);
     }
 
     private function getConsoleEvent(): ConsoleEvent

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
@@ -12,59 +12,35 @@
 namespace Symfony\Bridge\Monolog\Tests\Processor;
 
 use Monolog\Logger;
+use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class DebugProcessorTest extends TestCase
 {
-    /**
-     * @dataProvider providerDatetimeFormatTests
-     */
-    public function testDatetimeFormat(array $record, $expectedTimestamp)
+    public function testDatetimeFormat()
     {
+        $record = RecordFactory::create(datetime: new \DateTimeImmutable('2019-01-01T00:01:00+00:00'));
         $processor = new DebugProcessor();
         $processor($record);
 
         $records = $processor->getLogs();
         self::assertCount(1, $records);
-        self::assertSame($expectedTimestamp, $records[0]['timestamp']);
+        self::assertSame(1546300860, $records[0]['timestamp']);
     }
 
-    public function providerDatetimeFormatTests(): array
+    public function testDatetimeRfc3339Format()
     {
-        $record = $this->getRecord();
-
-        return [
-            [array_merge($record, ['datetime' => new \DateTime('2019-01-01T00:01:00+00:00')]), 1546300860],
-            [array_merge($record, ['datetime' => '2019-01-01T00:01:00+00:00']), 1546300860],
-            [array_merge($record, ['datetime' => 'foo']), false],
-        ];
-    }
-
-    /**
-     * @dataProvider providerDatetimeRfc3339FormatTests
-     */
-    public function testDatetimeRfc3339Format(array $record, $expectedTimestamp)
-    {
+        $record = RecordFactory::create(datetime: new \DateTimeImmutable('2019-01-01T00:01:00+00:00'));
         $processor = new DebugProcessor();
         $processor($record);
 
         $records = $processor->getLogs();
         self::assertCount(1, $records);
-        self::assertSame($expectedTimestamp, $records[0]['timestamp_rfc3339']);
-    }
-
-    public function providerDatetimeRfc3339FormatTests(): array
-    {
-        $record = $this->getRecord();
-
-        return [
-            [array_merge($record, ['datetime' => new \DateTime('2019-01-01T00:01:00+00:00')]), '2019-01-01T00:01:00.000+00:00'],
-            [array_merge($record, ['datetime' => '2019-01-01T00:01:00+00:00']), '2019-01-01T00:01:00.000+00:00'],
-            [array_merge($record, ['datetime' => 'foo']), false],
-        ];
+        self::assertSame('2019-01-01T00:01:00.000+00:00', $records[0]['timestamp_rfc3339']);
     }
 
     public function testDebugProcessor()
@@ -123,16 +99,8 @@ class DebugProcessorTest extends TestCase
         $this->assertEquals(0, $debugProcessorChild->countErrors());
     }
 
-    private function getRecord($level = Logger::WARNING, $message = 'test'): array
+    private function getRecord($level = Logger::WARNING, $message = 'test'): array|LogRecord
     {
-        return [
-            'message' => $message,
-            'context' => [],
-            'level' => $level,
-            'level_name' => Logger::getLevelName($level),
-            'channel' => 'test',
-            'datetime' => new \DateTime(),
-            'extra' => [],
-        ];
+        return RecordFactory::create($level, $message);
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/SwitchUserTokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/SwitchUserTokenProcessorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Monolog\Tests\Processor;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\SwitchUserTokenProcessor;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -33,7 +34,7 @@ class SwitchUserTokenProcessorTest extends TestCase
         $tokenStorage->method('getToken')->willReturn($switchUserToken);
 
         $processor = new SwitchUserTokenProcessor($tokenStorage);
-        $record = ['extra' => []];
+        $record = RecordFactory::create();
         $record = $processor($record);
 
         $expected = [

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Monolog\Tests\Processor;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
@@ -31,7 +32,7 @@ class TokenProcessorTest extends TestCase
         $tokenStorage->method('getToken')->willReturn($token);
 
         $processor = new TokenProcessor($tokenStorage);
-        $record = ['extra' => []];
+        $record = RecordFactory::create();
         $record = $processor($record);
 
         $this->assertArrayHasKey('token', $record['extra']);

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\Bridge\Monolog\Tests\Processor;
 
 use Monolog\Logger;
+use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\WebProcessor;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -94,17 +96,9 @@ class WebProcessorTest extends TestCase
         return [$event, $server];
     }
 
-    private function getRecord(int $level = Logger::WARNING, string $message = 'test'): array
+    private function getRecord(int $level = Logger::WARNING, string $message = 'test'): array|LogRecord
     {
-        return [
-            'message' => $message,
-            'context' => [],
-            'level' => $level,
-            'level_name' => Logger::getLevelName($level),
-            'channel' => 'test',
-            'datetime' => new \DateTime(),
-            'extra' => [],
-        ];
+        return RecordFactory::create($level, $message);
     }
 
     private function isExtraFieldsSupported()

--- a/src/Symfony/Bridge/Monolog/Tests/RecordFactory.php
+++ b/src/Symfony/Bridge/Monolog/Tests/RecordFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests;
+
+use Monolog\Logger;
+use Monolog\LogRecord;
+
+class RecordFactory
+{
+    public static function create(int|string $level = 'warning', string|\Stringable $message = 'test', string $channel = 'test', array $context = [], \DateTimeImmutable $datetime = new \DateTimeImmutable(), array $extra = []): LogRecord|array
+    {
+        $level = Logger::toMonologLevel($level);
+
+        if (Logger::API >= 3) {
+            return new LogRecord(
+                message: (string) $message,
+                context: $context,
+                level: $level,
+                channel: $channel,
+                datetime: $datetime,
+                extra: $extra,
+            );
+        }
+
+        return [
+            'message' => $message,
+            'context' => $context,
+            'level' => $level,
+            'level_name' => Logger::getLevelName($level),
+            'channel' => $channel,
+            // Monolog 1 had no support for DateTimeImmutable
+            'datetime' => Logger::API >= 2 ? $datetime : \DateTime::createFromImmutable($datetime),
+            'extra' => $extra,
+        ];
+    }
+}

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "monolog/monolog": "^1.25.1|^2",
+        "monolog/monolog": "^1.25.1|^2|^3",
         "symfony/service-contracts": "^1.1|^2|^3",
         "symfony/http-kernel": "^5.4|^6.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Adds support for the upcoming version of Monolog. I mostly wanted to do this before releasing it to ensure it is possible to integrate with it and Monolog 2 using the same codebase with only minimal amounts of version-based forks. 

I think the result is pretty good, so I will try and keep pushing for a beta release soon. I still need to add a SymfonyMailerHandler to replace the SwiftMailerHandler which got axed though.

To try it with Monolog 3 one needs to switch the requirement to `^3@dev` for now, but I did that locally and all tests pass with v3.