### PR TITLE
[Mailer] Restore X-Transport after failure

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Transports.php
+++ b/src/Symfony/Component/Mailer/Transport/Transports.php
@@ -59,7 +59,13 @@ final class Transports implements TransportInterface
             throw new InvalidArgumentException(sprintf('The "%s" transport does not exist (available transports: "%s").', $transport, implode('", "', array_keys($this->transports))));
         }
 
-        return $this->transports[$transport]->send($message, $envelope);
+        try {
+            return $this->transports[$transport]->send($message, $envelope);
+        } catch (\Throwable $e) {
+            $headers->addTextHeader('X-Transport', $transport);
+
+            throw $e;
+        }
     }
 
     public function __toString(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44741
| License       | MIT
| Doc PR        |

Restores X-Transport header for retries after failure.
