### PR TITLE
Mark PHP 8.2 CI as experimental

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
           - php: '8.1'
             mode: low-deps
           - php: '8.2'
-            #mode: experimental
+            mode: experimental
       fail-fast: false
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

PHP 8.2 is still in active development (only expected to be released in 7 months time). Imho, we should keep the 8.2 job as experimental, to avoid noisy PR check failures due to upstream changes (e.g. over the weekend, a change in PHP 8.2 caused all new PRs to have a failing check).