### PR TITLE
Fix dumping enums on PHP 8.2

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -150,6 +150,10 @@ abstract class Descriptor implements DescriptorInterface
      */
     protected function formatValue($value): string
     {
+        if ($value instanceof \UnitEnum) {
+            return ltrim(var_export($value, true), '\\');
+        }
+
         if (\is_object($value)) {
             return sprintf('object(%s)', \get_class($value));
         }
@@ -158,7 +162,7 @@ abstract class Descriptor implements DescriptorInterface
             return $value;
         }
 
-        return preg_replace("/\n\s*/s", '', var_export($value, true));
+        return preg_replace("/\n\s*/s", '', ltrim(var_export($value, true)), '\\');
     }
 
     /**
@@ -169,7 +173,7 @@ abstract class Descriptor implements DescriptorInterface
     protected function formatParameter($value): string
     {
         if ($value instanceof \UnitEnum) {
-            return var_export($value, true);
+            return ltrim(var_export($value, true), '\\');
         }
 
         // Recursively search for enum values, so we can replace it
@@ -177,7 +181,7 @@ abstract class Descriptor implements DescriptorInterface
         if (\is_array($value)) {
             array_walk_recursive($value, static function (&$value) {
                 if ($value instanceof \UnitEnum) {
-                    $value = var_export($value, true);
+                    $value = ltrim(var_export($value, true), '\\');
                 }
             });
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -162,7 +162,7 @@ class JsonDescriptor extends Descriptor
         // before json_encode (which will not display anything for \UnitEnum otherwise)
         array_walk_recursive($data, static function (&$value) {
             if ($value instanceof \UnitEnum) {
-                $value = var_export($value, true);
+                $value = ltrim(var_export($value, true), '\\');
             }
         });
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -343,7 +343,7 @@ class TextDescriptor extends Descriptor
                 } elseif ($argument instanceof Definition) {
                     $argumentsInformation[] = 'Inlined Service';
                 } elseif ($argument instanceof \UnitEnum) {
-                    $argumentsInformation[] = var_export($argument, true);
+                    $argumentsInformation[] = ltrim(var_export($argument, true), '\\');
                 } else {
                     $argumentsInformation[] = \is_array($argument) ? sprintf('Array (%d element(s))', \count($argument)) : $argument;
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -388,7 +388,7 @@ class XmlDescriptor extends Descriptor
                 }
             } elseif ($argument instanceof \UnitEnum) {
                 $argumentXML->setAttribute('type', 'constant');
-                $argumentXML->appendChild(new \DOMText(var_export($argument, true)));
+                $argumentXML->appendChild(new \DOMText(ltrim(var_export($argument, true), '\\')));
             } else {
                 $argumentXML->appendChild(new \DOMText($argument));
             }

--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -195,12 +195,13 @@ class Exporter
     public static function export($value, $indent = '')
     {
         switch (true) {
-            case \is_int($value) || \is_float($value) || $value instanceof \UnitEnum: return var_export($value, true);
+            case \is_int($value) || \is_float($value): return var_export($value, true);
             case [] === $value: return '[]';
             case false === $value: return 'false';
             case true === $value: return 'true';
             case null === $value: return 'null';
             case '' === $value: return "''";
+            case $value instanceof \UnitEnum: return ltrim(var_export($value, true), '\\');
         }
 
         if ($value instanceof Reference) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follows https://github.com/php/php-src/pull/8233
Makes the CI green again on PHP 8.2.
Replaces #46160