### PR TITLE
[Notifier] Fix extensibility of `Notification` class

### DIFF
--- a/src/Symfony/Component/Notifier/Notification/Notification.php
+++ b/src/Symfony/Component/Notifier/Notification/Notification.php
@@ -50,11 +50,14 @@ class Notification
         $this->channels = $channels;
     }
 
+    /**
+     * @return static
+     */
     public static function fromThrowable(\Throwable $exception, array $channels = []): self
     {
         $parts = explode('\\', \get_class($exception));
 
-        $notification = new self(sprintf('%s: %s', array_pop($parts), $exception->getMessage()), $channels);
+        $notification = new static(sprintf('%s: %s', array_pop($parts), $exception->getMessage()), $channels);
         if (class_exists(FlattenException::class)) {
             $notification->exception = $exception instanceof FlattenException ? $exception : FlattenException::createFromThrowable($exception);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | ???
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Without using static it kills the extensibility of the `Notification` class as the `exception` and `exceptionAsString` properties are private and other methods such as `EmailMessage::fromNotification` use that to customize the message to send to channels.
