### PR TITLE
[DependencyInjection] Properly declare #[When] as allowed on functions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/When.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/When.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\DependencyInjection\Attribute;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
 class When
 {
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Caught by the  CI on PHP 8.2
Not sure why it didn't fail before, but this was missing for sure.