### PR TITLE
[Serializer] Fine-tune `ContextBuilder::withContext()`

### DIFF
--- a/src/Symfony/Component/Serializer/Context/ContextBuilderInterface.php
+++ b/src/Symfony/Component/Serializer/Context/ContextBuilderInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context;
+
+/**
+ * Common interface for context builders.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+interface ContextBuilderInterface
+{
+    /**
+     * @param self|array<string, mixed> $context
+     */
+    public function withContext(self|array $context): static;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/src/Symfony/Component/Serializer/Context/ContextBuilderTrait.php
+++ b/src/Symfony/Component/Serializer/Context/ContextBuilderTrait.php
@@ -30,10 +30,14 @@ trait ContextBuilderTrait
     }
 
     /**
-     * @param array<string, mixed> $context
+     * @param ContextBuilderInterface|array<string, mixed> $context
      */
-    public function withContext(array $context): static
+    public function withContext(ContextBuilderInterface|array $context): static
     {
+        if ($context instanceof ContextBuilderInterface) {
+            $context = $context->toArray();
+        }
+
         $instance = new static();
         $instance->context = array_merge($this->context, $context);
 

--- a/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Encoder;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
@@ -20,7 +21,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class CsvEncoderContextBuilder
+final class CsvEncoderContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Encoder/JsonEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/JsonEncoderContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Encoder;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
@@ -20,7 +21,7 @@ use Symfony\Component\Serializer\Encoder\JsonEncode;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class JsonEncoderContextBuilder
+final class JsonEncoderContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Encoder;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 
@@ -19,7 +20,7 @@ use Symfony\Component\Serializer\Encoder\XmlEncoder;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class XmlEncoderContextBuilder
+final class XmlEncoderContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Encoder/YamlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/YamlEncoderContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Encoder;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Encoder\YamlEncoder;
 
@@ -19,7 +20,7 @@ use Symfony\Component\Serializer\Encoder\YamlEncoder;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class YamlEncoderContextBuilder
+final class YamlEncoderContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Normalizer;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
@@ -20,7 +21,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-abstract class AbstractNormalizerContextBuilder
+abstract class AbstractNormalizerContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Normalizer/ConstraintViolationListNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/ConstraintViolationListNormalizerContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Normalizer;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
 
@@ -19,7 +20,7 @@ use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class ConstraintViolationListNormalizerContextBuilder
+final class ConstraintViolationListNormalizerContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Normalizer/DateIntervalNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/DateIntervalNormalizerContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Normalizer;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
 
@@ -19,7 +20,7 @@ use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class DateIntervalNormalizerContextBuilder
+final class DateIntervalNormalizerContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Normalizer;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
@@ -20,7 +21,7 @@ use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class DateTimeNormalizerContextBuilder
+final class DateTimeNormalizerContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Normalizer/FormErrorNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/FormErrorNormalizerContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Normalizer;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Normalizer\FormErrorNormalizer;
 
@@ -19,7 +20,7 @@ use Symfony\Component\Serializer\Normalizer\FormErrorNormalizer;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class FormErrorNormalizerContextBuilder
+final class FormErrorNormalizerContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Normalizer/ProblemNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/ProblemNormalizerContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Normalizer;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Normalizer\ProblemNormalizer;
 
@@ -19,7 +20,7 @@ use Symfony\Component\Serializer\Normalizer\ProblemNormalizer;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class ProblemNormalizerContextBuilder
+final class ProblemNormalizerContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Normalizer/UidNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/UidNormalizerContextBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Context\Normalizer;
 
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\UidNormalizer;
@@ -20,7 +21,7 @@ use Symfony\Component\Serializer\Normalizer\UidNormalizer;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class UidNormalizerContextBuilder
+final class UidNormalizerContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/Normalizer/UnwrappingDenormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/UnwrappingDenormalizerContextBuilder.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Context\Normalizer;
 
 use Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException;
 use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
@@ -22,7 +23,7 @@ use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class UnwrappingDenormalizerContextBuilder
+final class UnwrappingDenormalizerContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Context/SerializerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/SerializerContextBuilder.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Serializer;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class SerializerContextBuilder
+final class SerializerContextBuilder implements ContextBuilderInterface
 {
     use ContextBuilderTrait;
 

--- a/src/Symfony/Component/Serializer/Tests/Context/ContextBuilderTraitTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/ContextBuilderTraitTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Context;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
 use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 
 /**
@@ -21,13 +22,17 @@ class ContextBuilderTraitTest extends TestCase
 {
     public function testWithContext()
     {
-        $contextBuilder = new class() {
+        $contextBuilder = new class() implements ContextBuilderInterface {
             use ContextBuilderTrait;
         };
 
         $context = $contextBuilder->withContext(['foo' => 'bar'])->toArray();
 
         $this->assertSame(['foo' => 'bar'], $context);
+
+        $withContextBuilderObject = $contextBuilder->withContext($contextBuilder->withContext(['foo' => 'bar']))->toArray();
+
+        $this->assertSame(['foo' => 'bar'], $withContextBuilderObject);
     }
 
     public function testWith()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes, small DX improvement
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16753

Allows to skip calling `toArray()` on the context builder when it is passed to `withContext()`:

```php
$contextBuilder = (new CsvEncoderContextBuilder())
  ->withContext($contextBuilder)
  ->withDelimiter('-')
```

instead of 
```php
$contextBuilder = (new CsvEncoderContextBuilder())
  ->withContext($contextBuilder->toArray())
  ->withDelimiter('-')
```

Allowing to do the same when passing the context to `serialize()` would require to revisit the SerializerInterface, which we can consider for 6.2.
/cc @mtarld 