### PR TITLE
[DependencyInjection] Add void return type to CompilerPassInterface

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CompilerPassInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CompilerPassInterface.php
@@ -22,6 +22,8 @@ interface CompilerPassInterface
 {
     /**
      * You can modify the container here before it is dumped to PHP code.
+     *
+     * @return void
      */
     public function process(ContainerBuilder $container);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add void return type to CompilerPassInterface.