### PR TITLE
Hide sensitive information with `SensitiveParameter` attribute

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -35,5 +35,11 @@
                 <referencedClass name="UnitEnum"/>
             </errorLevel>
         </UndefinedDocblockClass>
+        <UndefinedAttributeClass>
+            <errorLevel type="suppress">
+                <!-- These classes have been added in PHP 8.2 -->
+                <referencedClass name="SensitiveParameter"/>
+            </errorLevel>
+        </UndefinedAttributeClass>
     </issueHandlers>
 </psalm>

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -87,7 +87,7 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
     /**
      * {@inheritdoc}
      */
-    public function updateToken(string $series, string $tokenValue, \DateTime $lastUsed)
+    public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed)
     {
         $sql = 'UPDATE rememberme_token SET value=:value, lastUsed=:lastUsed WHERE series=:series';
         $paramValues = [
@@ -140,7 +140,7 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
     /**
      * {@inheritdoc}
      */
-    public function verifyToken(PersistentTokenInterface $token, string $tokenValue): bool
+    public function verifyToken(PersistentTokenInterface $token, #[\SensitiveParameter] string $tokenValue): bool
     {
         // Check if the token value matches the current persisted token
         if (hash_equals($token->getTokenValue(), $tokenValue)) {
@@ -177,7 +177,7 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
     /**
      * {@inheritdoc}
      */
-    public function updateExistingToken(PersistentTokenInterface $token, string $tokenValue, \DateTimeInterface $lastUsed): void
+    public function updateExistingToken(PersistentTokenInterface $token, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed): void
     {
         if (!$token instanceof PersistentToken) {
             return;

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -374,7 +374,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
      * @param string      $id    The id used when generating the token
      * @param string|null $token The actual token sent with the request that should be validated
      */
-    protected function isCsrfTokenValid(string $id, ?string $token): bool
+    protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
     {
         if (!$this->container->has('security.csrf.token_manager')) {
             throw new \LogicException('CSRF protection is not enabled in your application. Enable it with the "csrf_protection" key in "config/packages/framework.yaml".');

--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -32,7 +32,7 @@ class HttpOptions
     /**
      * @return $this
      */
-    public function setAuthBasic(string $user, string $password = ''): static
+    public function setAuthBasic(string $user, #[\SensitiveParameter] string $password = ''): static
     {
         $this->options['auth_basic'] = $user;
 
@@ -46,7 +46,7 @@ class HttpOptions
     /**
      * @return $this
      */
-    public function setAuthBearer(string $token): static
+    public function setAuthBearer(#[\SensitiveParameter] string $token): static
     {
         $this->options['auth_bearer'] = $token;
 

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -27,7 +27,7 @@ class UriSigner
      * @param string $secret    A secret
      * @param string $parameter Query string parameter to use
      */
-    public function __construct(string $secret, string $parameter = '_hash')
+    public function __construct(#[\SensitiveParameter] string $secret, string $parameter = '_hash')
     {
         $this->secret = $secret;
         $this->parameter = $parameter;

--- a/src/Symfony/Component/Ldap/Adapter/ConnectionInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/ConnectionInterface.php
@@ -32,5 +32,5 @@ interface ConnectionInterface
      * @throws ConnectionTimeoutException  When the connection can't be created because of an LDAP_TIMEOUT error
      * @throws InvalidCredentialsException When the connection can't be created because of an LDAP_INVALID_CREDENTIALS error
      */
-    public function bind(string $dn = null, string $password = null);
+    public function bind(string $dn = null, #[\SensitiveParameter] string $password = null);
 }

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -69,7 +69,7 @@ class Connection extends AbstractConnection
      *
      * @param string $password WARNING: When the LDAP server allows unauthenticated binds, a blank $password will always be valid
      */
-    public function bind(string $dn = null, string $password = null)
+    public function bind(string $dn = null, #[\SensitiveParameter] string $password = null)
     {
         if (!$this->connection) {
             $this->connect();

--- a/src/Symfony/Component/Ldap/Ldap.php
+++ b/src/Symfony/Component/Ldap/Ldap.php
@@ -32,7 +32,7 @@ final class Ldap implements LdapInterface
     /**
      * {@inheritdoc}
      */
-    public function bind(string $dn = null, string $password = null)
+    public function bind(string $dn = null, #[\SensitiveParameter] string $password = null)
     {
         $this->adapter->getConnection()->bind($dn, $password);
     }

--- a/src/Symfony/Component/Ldap/LdapInterface.php
+++ b/src/Symfony/Component/Ldap/LdapInterface.php
@@ -30,7 +30,7 @@ interface LdapInterface
      *
      * @throws ConnectionException if dn / password could not be bound
      */
-    public function bind(string $dn = null, string $password = null);
+    public function bind(string $dn = null, #[\SensitiveParameter] string $password = null);
 
     /**
      * Queries a ldap server for entries matching the given criteria.

--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -29,7 +29,7 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
     private array $roles;
     private array $extraFields;
 
-    public function __construct(Entry $entry, string $username, ?string $password, array $roles = [], array $extraFields = [])
+    public function __construct(Entry $entry, string $username, #[\SensitiveParameter] ?string $password, array $roles = [], array $extraFields = [])
     {
         if (!$username) {
             throw new \InvalidArgumentException('The username cannot be empty.');
@@ -97,7 +97,7 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
         return $this->extraFields;
     }
 
-    public function setPassword(string $password)
+    public function setPassword(#[\SensitiveParameter] string $password)
     {
         $this->password = $password;
     }

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -43,7 +43,7 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
     private ?string $passwordAttribute;
     private array $extraFields;
 
-    public function __construct(LdapInterface $ldap, string $baseDn, string $searchDn = null, string $searchPassword = null, array $defaultRoles = [], string $uidKey = null, string $filter = null, string $passwordAttribute = null, array $extraFields = [])
+    public function __construct(LdapInterface $ldap, string $baseDn, string $searchDn = null, #[\SensitiveParameter] string $searchPassword = null, array $defaultRoles = [], string $uidKey = null, string $filter = null, string $passwordAttribute = null, array $extraFields = [])
     {
         if (null === $uidKey) {
             $uidKey = 'sAMAccountName';

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
@@ -28,7 +28,7 @@ class SesSmtpTransport extends EsmtpTransport
     /**
      * @param string|null $region Amazon SES region
      */
-    public function __construct(string $username, string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct(sprintf('email-smtp.%s.amazonaws.com', $region ?: 'eu-west-1'), 465, true, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
@@ -20,7 +20,7 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class GmailSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('smtp.gmail.com', 465, true, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillSmtpTransport.php
@@ -22,7 +22,7 @@ class MandrillSmtpTransport extends EsmtpTransport
 {
     use MandrillHeadersTrait;
 
-    public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('smtp.mandrillapp.com', 587, false, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
@@ -22,7 +22,7 @@ class MailgunSmtpTransport extends EsmtpTransport
 {
     use MailgunHeadersTrait;
 
-    public function __construct(string $username, string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', 465, true, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetSmtpTransport.php
@@ -17,7 +17,7 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 
 class MailjetSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('in-v3.mailjet.com', 465, true, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueSmtpTransport.php
@@ -20,7 +20,7 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 final class SendinblueSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('smtp-relay.sendinblue.com', 465, true, $dispatcher, $logger);
 

--- a/src/Symfony/Component/Mailer/Transport/Dsn.php
+++ b/src/Symfony/Component/Mailer/Transport/Dsn.php
@@ -25,7 +25,7 @@ final class Dsn
     private ?int $port;
     private array $options;
 
-    public function __construct(string $scheme, string $host, string $user = null, string $password = null, int $port = null, array $options = [])
+    public function __construct(string $scheme, string $host, string $user = null, #[\SensitiveParameter] string $password = null, int $port = null, array $options = [])
     {
         $this->scheme = $scheme;
         $this->host = $host;

--- a/src/Symfony/Component/Mailer/Transport/Smtp/Auth/CramMd5Authenticator.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Auth/CramMd5Authenticator.php
@@ -41,7 +41,7 @@ class CramMd5Authenticator implements AuthenticatorInterface
     /**
      * Generates a CRAM-MD5 response from a server challenge.
      */
-    private function getResponse(string $secret, string $challenge): string
+    private function getResponse(#[\SensitiveParameter] string $secret, string $challenge): string
     {
         if (\strlen($secret) > 64) {
             $secret = pack('H32', md5($secret));

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -83,7 +83,7 @@ class EsmtpTransport extends SmtpTransport
     /**
      * @return $this
      */
-    public function setPassword(string $password): static
+    public function setPassword(#[\SensitiveParameter] string $password): static
     {
         $this->password = $password;
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
@@ -34,7 +34,7 @@ final class DiscordTransport extends AbstractTransport
     private string $token;
     private string $webhookId;
 
-    public function __construct(string $token, string $webhookId, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $token, string $webhookId, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->webhookId = $webhookId;

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
@@ -32,7 +32,7 @@ final class EsendexTransport extends AbstractTransport
     private string $accountReference;
     private string $from;
 
-    public function __construct(string $email, string $password, string $accountReference, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $email, #[\SensitiveParameter] string $password, string $accountReference, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->email = $email;
         $this->password = $password;

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -31,7 +31,7 @@ final class FirebaseTransport extends AbstractTransport
 
     private string $token;
 
-    public function __construct(string $token, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $token, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->client = $client;

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
@@ -32,7 +32,7 @@ final class FreeMobileTransport extends AbstractTransport
     private string $password;
     private string $phone;
 
-    public function __construct(string $login, string $password, string $phone, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $login, #[\SensitiveParameter] string $password, string $phone, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->login = $login;
         $this->password = $password;

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/GitterTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/GitterTransport.php
@@ -31,7 +31,7 @@ final class GitterTransport extends AbstractTransport
     private string $token;
     private string $roomId;
 
-    public function __construct(string $token, string $roomId, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $token, string $roomId, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->roomId = $roomId;

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
@@ -44,7 +44,7 @@ final class GoogleChatTransport extends AbstractTransport
      *                                 Subsequent messages with the same thread identifier will be posted into the same thread.
      *                                 {@see https://developers.google.com/hangouts/chat/reference/rest/v1/spaces.messages/create#query-parameters}
      */
-    public function __construct(string $space, string $accessKey, string $accessToken, string $threadKey = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $space, string $accessKey, #[\SensitiveParameter] string $accessToken, string $threadKey = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->space = $space;
         $this->accessKey = $accessKey;

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
@@ -32,7 +32,7 @@ final class IqsmsTransport extends AbstractTransport
     private string $password;
     private string $from;
 
-    public function __construct(string $login, string $password, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $login, #[\SensitiveParameter] string $password, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->login = $login;
         $this->password = $password;

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
@@ -32,7 +32,7 @@ class KazInfoTehTransport extends AbstractTransport
     private string $password;
     private string $sender;
 
-    public function __construct(string $username, string $password, string $sender, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, string $sender, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->username = $username;
         $this->password = $password;

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
@@ -75,7 +75,7 @@ final class LightSmsTransport extends AbstractTransport
         999 => 'Unknown Error',
     ];
 
-    public function __construct(string $login, string $password, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $login, #[\SensitiveParameter] string $password, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->login = $login;
         $this->password = $password;

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
@@ -30,7 +30,7 @@ final class MattermostTransport extends AbstractTransport
     private string $channel;
     private ?string $path;
 
-    public function __construct(string $token, string $channel, string $path = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $token, string $channel, string $path = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->channel = $channel;

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
@@ -31,7 +31,7 @@ final class MessageBirdTransport extends AbstractTransport
     private string $token;
     private string $from;
 
-    public function __construct(string $token, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $token, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->from = $from;

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
@@ -32,7 +32,7 @@ final class RocketChatTransport extends AbstractTransport
     private string $accessToken;
     private ?string $chatChannel;
 
-    public function __construct(string $accessToken, string $chatChannel = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $accessToken, string $chatChannel = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->accessToken = $accessToken;
         $this->chatChannel = $chatChannel;

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
@@ -34,7 +34,7 @@ final class SendberryTransport extends AbstractTransport
     private string $authKey;
     private string $from;
 
-    public function __construct(string $username, string $password, string $authKey, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, string $authKey, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->username = $username;
         $this->password = $password;

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -33,7 +33,7 @@ final class SlackTransport extends AbstractTransport
     private string $accessToken;
     private ?string $chatChannel;
 
-    public function __construct(string $accessToken, string $channel = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $accessToken, string $channel = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         if (!preg_match('/^xox(b-|p-|a-2)/', $accessToken)) {
             throw new InvalidArgumentException('A valid Slack token needs to start with "xoxb-", "xoxp-" or "xoxa-2". See https://api.slack.com/authentication/token-types for further information.');

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
@@ -33,7 +33,7 @@ final class SmsFactorTransport extends AbstractTransport
     private ?string $sender;
     private ?SmsFactorPushType $pushType;
 
-    public function __construct(string $tokenApi, ?string $sender, ?SmsFactorPushType $pushType, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $tokenApi, ?string $sender, ?SmsFactorPushType $pushType, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->tokenApi = $tokenApi;
         $this->sender = $sender;

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
@@ -34,7 +34,7 @@ final class SmscTransport extends AbstractTransport
     private ?string $password;
     private string $from;
 
-    public function __construct(?string $username, ?string $password, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(?string $username, #[\SensitiveParameter] ?string $password, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->login = $username;
         $this->password = $password;

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
@@ -36,7 +36,7 @@ final class SpotHitTransport extends AbstractTransport
     private string $token;
     private ?string $from;
 
-    public function __construct(string $token, string $from = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $token, string $from = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->from = $from;

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -36,7 +36,7 @@ final class TelegramTransport extends AbstractTransport
     private string $token;
     private ?string $chatChannel;
 
-    public function __construct(string $token, string $channel = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $token, string $channel = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->chatChannel = $channel;

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
@@ -31,7 +31,7 @@ final class ZulipTransport extends AbstractTransport
     private string $token;
     private string $channel;
 
-    public function __construct(string $email, string $token, string $channel, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $email, #[\SensitiveParameter] string $token, string $channel, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->email = $email;
         $this->token = $token;

--- a/src/Symfony/Component/PasswordHasher/CHANGELOG.md
+++ b/src/Symfony/Component/PasswordHasher/CHANGELOG.md
@@ -1,3 +1,11 @@
+CHANGELOG
+=========
+
+6.2
+---
+
+ * Use `SensitiveParameter` attribute to redact sensitive values in back traces
+
 5.3
 ---
 

--- a/src/Symfony/Component/PasswordHasher/Hasher/CheckPasswordLengthTrait.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/CheckPasswordLengthTrait.php
@@ -18,7 +18,7 @@ use Symfony\Component\PasswordHasher\PasswordHasherInterface;
  */
 trait CheckPasswordLengthTrait
 {
-    private function isPasswordTooLong(string $password): bool
+    private function isPasswordTooLong(#[\SensitiveParameter] string $password): bool
     {
         return PasswordHasherInterface::MAX_PASSWORD_LENGTH < \strlen($password);
     }

--- a/src/Symfony/Component/PasswordHasher/Hasher/MessageDigestPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/MessageDigestPasswordHasher.php
@@ -48,7 +48,7 @@ class MessageDigestPasswordHasher implements LegacyPasswordHasherInterface
         $this->iterations = $iterations;
     }
 
-    public function hash(string $plainPassword, string $salt = null): string
+    public function hash(#[\SensitiveParameter] string $plainPassword, string $salt = null): string
     {
         if ($this->isPasswordTooLong($plainPassword)) {
             throw new InvalidPasswordException();
@@ -69,7 +69,7 @@ class MessageDigestPasswordHasher implements LegacyPasswordHasherInterface
         return $this->encodeHashAsBase64 ? base64_encode($digest) : bin2hex($digest);
     }
 
-    public function verify(string $hashedPassword, string $plainPassword, string $salt = null): bool
+    public function verify(string $hashedPassword, #[\SensitiveParameter] string $plainPassword, string $salt = null): bool
     {
         if (\strlen($hashedPassword) !== $this->hashLength || str_contains($hashedPassword, '$')) {
             return false;
@@ -83,7 +83,7 @@ class MessageDigestPasswordHasher implements LegacyPasswordHasherInterface
         return false;
     }
 
-    private function mergePasswordAndSalt(string $password, ?string $salt): string
+    private function mergePasswordAndSalt(#[\SensitiveParameter] string $password, ?string $salt): string
     {
         if (!$salt) {
             return $password;

--- a/src/Symfony/Component/PasswordHasher/Hasher/MigratingPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/MigratingPasswordHasher.php
@@ -33,12 +33,12 @@ final class MigratingPasswordHasher implements PasswordHasherInterface
         $this->extraHashers = $extraHashers;
     }
 
-    public function hash(string $plainPassword, string $salt = null): string
+    public function hash(#[\SensitiveParameter] string $plainPassword, string $salt = null): string
     {
         return $this->bestHasher->hash($plainPassword, $salt);
     }
 
-    public function verify(string $hashedPassword, string $plainPassword, string $salt = null): bool
+    public function verify(string $hashedPassword, #[\SensitiveParameter] string $plainPassword, string $salt = null): bool
     {
         if ($this->bestHasher->verify($hashedPassword, $plainPassword, $salt)) {
             return true;

--- a/src/Symfony/Component/PasswordHasher/Hasher/NativePasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/NativePasswordHasher.php
@@ -71,7 +71,7 @@ final class NativePasswordHasher implements PasswordHasherInterface
         ];
     }
 
-    public function hash(string $plainPassword): string
+    public function hash(#[\SensitiveParameter] string $plainPassword): string
     {
         if ($this->isPasswordTooLong($plainPassword)) {
             throw new InvalidPasswordException();
@@ -84,7 +84,7 @@ final class NativePasswordHasher implements PasswordHasherInterface
         return password_hash($plainPassword, $this->algorithm, $this->options);
     }
 
-    public function verify(string $hashedPassword, string $plainPassword): bool
+    public function verify(string $hashedPassword, #[\SensitiveParameter] string $plainPassword): bool
     {
         if ('' === $plainPassword || $this->isPasswordTooLong($plainPassword)) {
             return false;

--- a/src/Symfony/Component/PasswordHasher/Hasher/Pbkdf2PasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/Pbkdf2PasswordHasher.php
@@ -59,7 +59,7 @@ final class Pbkdf2PasswordHasher implements LegacyPasswordHasherInterface
         $this->iterations = $iterations;
     }
 
-    public function hash(string $plainPassword, string $salt = null): string
+    public function hash(#[\SensitiveParameter] string $plainPassword, string $salt = null): string
     {
         if ($this->isPasswordTooLong($plainPassword)) {
             throw new InvalidPasswordException();
@@ -74,7 +74,7 @@ final class Pbkdf2PasswordHasher implements LegacyPasswordHasherInterface
         return $this->encodeHashAsBase64 ? base64_encode($digest) : bin2hex($digest);
     }
 
-    public function verify(string $hashedPassword, string $plainPassword, string $salt = null): bool
+    public function verify(string $hashedPassword, #[\SensitiveParameter] string $plainPassword, string $salt = null): bool
     {
         if (\strlen($hashedPassword) !== $this->encodedLength || str_contains($hashedPassword, '$')) {
             return false;

--- a/src/Symfony/Component/PasswordHasher/Hasher/PlaintextPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PlaintextPasswordHasher.php
@@ -38,7 +38,7 @@ class PlaintextPasswordHasher implements LegacyPasswordHasherInterface
     /**
      * {@inheritdoc}
      */
-    public function hash(string $plainPassword, string $salt = null): string
+    public function hash(#[\SensitiveParameter] string $plainPassword, string $salt = null): string
     {
         if ($this->isPasswordTooLong($plainPassword)) {
             throw new InvalidPasswordException();
@@ -47,7 +47,7 @@ class PlaintextPasswordHasher implements LegacyPasswordHasherInterface
         return $this->mergePasswordAndSalt($plainPassword, $salt);
     }
 
-    public function verify(string $hashedPassword, string $plainPassword, string $salt = null): bool
+    public function verify(string $hashedPassword, #[\SensitiveParameter] string $plainPassword, string $salt = null): bool
     {
         if ($this->isPasswordTooLong($plainPassword)) {
             return false;
@@ -67,7 +67,7 @@ class PlaintextPasswordHasher implements LegacyPasswordHasherInterface
         return false;
     }
 
-    private function mergePasswordAndSalt(string $password, ?string $salt): string
+    private function mergePasswordAndSalt(#[\SensitiveParameter] string $password, ?string $salt): string
     {
         if (empty($salt)) {
             return $password;

--- a/src/Symfony/Component/PasswordHasher/Hasher/SodiumPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/SodiumPasswordHasher.php
@@ -52,7 +52,7 @@ final class SodiumPasswordHasher implements PasswordHasherInterface
         return version_compare(\extension_loaded('sodium') ? \SODIUM_LIBRARY_VERSION : phpversion('libsodium'), '1.0.14', '>=');
     }
 
-    public function hash(string $plainPassword): string
+    public function hash(#[\SensitiveParameter] string $plainPassword): string
     {
         if ($this->isPasswordTooLong($plainPassword)) {
             throw new InvalidPasswordException();
@@ -69,7 +69,7 @@ final class SodiumPasswordHasher implements PasswordHasherInterface
         throw new LogicException('Libsodium is not available. You should either install the sodium extension or use a different password hasher.');
     }
 
-    public function verify(string $hashedPassword, string $plainPassword): bool
+    public function verify(string $hashedPassword, #[\SensitiveParameter] string $plainPassword): bool
     {
         if ('' === $plainPassword) {
             return false;

--- a/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
@@ -30,7 +30,7 @@ class UserPasswordHasher implements UserPasswordHasherInterface
         $this->hasherFactory = $hasherFactory;
     }
 
-    public function hashPassword(PasswordAuthenticatedUserInterface $user, string $plainPassword): string
+    public function hashPassword(PasswordAuthenticatedUserInterface $user, #[\SensitiveParameter] string $plainPassword): string
     {
         $salt = null;
         if ($user instanceof LegacyPasswordAuthenticatedUserInterface) {
@@ -42,7 +42,7 @@ class UserPasswordHasher implements UserPasswordHasherInterface
         return $hasher->hash($plainPassword, $salt);
     }
 
-    public function isPasswordValid(PasswordAuthenticatedUserInterface $user, string $plainPassword): bool
+    public function isPasswordValid(PasswordAuthenticatedUserInterface $user, #[\SensitiveParameter] string $plainPassword): bool
     {
         $salt = null;
         if ($user instanceof LegacyPasswordAuthenticatedUserInterface) {

--- a/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasherInterface.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasherInterface.php
@@ -23,12 +23,12 @@ interface UserPasswordHasherInterface
     /**
      * Hashes the plain password for the given user.
      */
-    public function hashPassword(PasswordAuthenticatedUserInterface $user, string $plainPassword): string;
+    public function hashPassword(PasswordAuthenticatedUserInterface $user, #[\SensitiveParameter] string $plainPassword): string;
 
     /**
      * Checks if the plaintext password matches the user's password.
      */
-    public function isPasswordValid(PasswordAuthenticatedUserInterface $user, string $plainPassword): bool;
+    public function isPasswordValid(PasswordAuthenticatedUserInterface $user, #[\SensitiveParameter] string $plainPassword): bool;
 
     /**
      * Checks if an encoded password would benefit from rehashing.

--- a/src/Symfony/Component/PasswordHasher/LegacyPasswordHasherInterface.php
+++ b/src/Symfony/Component/PasswordHasher/LegacyPasswordHasherInterface.php
@@ -27,10 +27,10 @@ interface LegacyPasswordHasherInterface extends PasswordHasherInterface
      *
      * @throws InvalidPasswordException If the plain password is invalid, e.g. excessively long
      */
-    public function hash(string $plainPassword, string $salt = null): string;
+    public function hash(#[\SensitiveParameter] string $plainPassword, string $salt = null): string;
 
     /**
      * Checks that a plain password and a salt match a password hash.
      */
-    public function verify(string $hashedPassword, string $plainPassword, string $salt = null): bool;
+    public function verify(string $hashedPassword, #[\SensitiveParameter] string $plainPassword, string $salt = null): bool;
 }

--- a/src/Symfony/Component/PasswordHasher/PasswordHasherInterface.php
+++ b/src/Symfony/Component/PasswordHasher/PasswordHasherInterface.php
@@ -29,12 +29,12 @@ interface PasswordHasherInterface
      *
      * @throws InvalidPasswordException When the plain password is invalid, e.g. excessively long
      */
-    public function hash(string $plainPassword): string;
+    public function hash(#[\SensitiveParameter] string $plainPassword): string;
 
     /**
      * Verifies a plain password against a hash.
      */
-    public function verify(string $hashedPassword, string $plainPassword): bool;
+    public function verify(string $hashedPassword, #[\SensitiveParameter] string $plainPassword): bool;
 
     /**
      * Checks if a password hash would benefit from rehashing.

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/CacheTokenVerifier.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/CacheTokenVerifier.php
@@ -38,7 +38,7 @@ class CacheTokenVerifier implements TokenVerifierInterface
     /**
      * {@inheritdoc}
      */
-    public function verifyToken(PersistentTokenInterface $token, string $tokenValue): bool
+    public function verifyToken(PersistentTokenInterface $token, #[\SensitiveParameter] string $tokenValue): bool
     {
         if (hash_equals($token->getTokenValue(), $tokenValue)) {
             return true;
@@ -58,7 +58,7 @@ class CacheTokenVerifier implements TokenVerifierInterface
     /**
      * {@inheritdoc}
      */
-    public function updateExistingToken(PersistentTokenInterface $token, string $tokenValue, \DateTimeInterface $lastUsed): void
+    public function updateExistingToken(PersistentTokenInterface $token, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed): void
     {
         // When a token gets updated, persist the outdated token for $outdatedTokenTtl seconds so we can
         // still accept it as valid in verifyToken

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
@@ -37,7 +37,7 @@ class InMemoryTokenProvider implements TokenProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function updateToken(string $series, string $tokenValue, \DateTime $lastUsed)
+    public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed)
     {
         if (!isset($this->tokens[$series])) {
             throw new TokenNotFoundException('No token found.');

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
@@ -24,7 +24,7 @@ final class PersistentToken implements PersistentTokenInterface
     private string $tokenValue;
     private \DateTime $lastUsed;
 
-    public function __construct(string $class, string $userIdentifier, string $series, string $tokenValue, \DateTime $lastUsed)
+    public function __construct(string $class, string $userIdentifier, string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed)
     {
         if (empty($class)) {
             throw new \InvalidArgumentException('$class must not be empty.');

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
@@ -39,7 +39,7 @@ interface TokenProviderInterface
      *
      * @throws TokenNotFoundException if the token is not found
      */
-    public function updateToken(string $series, string $tokenValue, \DateTime $lastUsed);
+    public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed);
 
     /**
      * Creates a new token.

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenVerifierInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenVerifierInterface.php
@@ -23,10 +23,10 @@ interface TokenVerifierInterface
      *
      * Do not forget to implement token comparisons using hash_equals for a secure implementation.
      */
-    public function verifyToken(PersistentTokenInterface $token, string $tokenValue): bool;
+    public function verifyToken(PersistentTokenInterface $token, #[\SensitiveParameter] string $tokenValue): bool;
 
     /**
      * Updates an existing token with a new token value and lastUsed time.
      */
-    public function updateExistingToken(PersistentTokenInterface $token, string $tokenValue, \DateTimeInterface $lastUsed): void;
+    public function updateExistingToken(PersistentTokenInterface $token, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed): void;
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -28,7 +28,7 @@ class RememberMeToken extends AbstractToken
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(UserInterface $user, string $firewallName, string $secret)
+    public function __construct(UserInterface $user, string $firewallName, #[\SensitiveParameter] string $secret)
     {
         parent::__construct($user->getRoles());
 

--- a/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
+++ b/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
@@ -35,7 +35,7 @@ class SignatureHasher
      * @param ExpiredSignatureStorage|null $expiredSignaturesStorage if provided, secures a sequence of hashes that are expired
      * @param int|null                     $maxUses                  used together with $expiredSignatureStorage to allow a maximum usage of a hash
      */
-    public function __construct(PropertyAccessorInterface $propertyAccessor, array $signatureProperties, string $secret, ExpiredSignatureStorage $expiredSignaturesStorage = null, int $maxUses = null)
+    public function __construct(PropertyAccessorInterface $propertyAccessor, array $signatureProperties, #[\SensitiveParameter] string $secret, ExpiredSignatureStorage $expiredSignaturesStorage = null, int $maxUses = null)
     {
         $this->propertyAccessor = $propertyAccessor;
         $this->signatureProperties = $signatureProperties;

--- a/src/Symfony/Component/Security/Csrf/CsrfToken.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfToken.php
@@ -21,7 +21,7 @@ class CsrfToken
     private string $id;
     private string $value;
 
-    public function __construct(string $id, ?string $value)
+    public function __construct(string $id, #[\SensitiveParameter] ?string $value)
     {
         $this->id = $id;
         $this->value = $value ?? '';

--- a/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
@@ -85,7 +85,7 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function refreshToken(string $tokenId): CsrfToken
+    public function refreshToken(#[\SensitiveParameter] string $tokenId): CsrfToken
     {
         $namespacedId = $this->getNamespace().$tokenId;
         $value = $this->generator->generateToken();

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Credentials/PasswordCredentials.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Credentials/PasswordCredentials.php
@@ -28,7 +28,7 @@ class PasswordCredentials implements CredentialsInterface
     private ?string $password = null;
     private bool $resolved = false;
 
-    public function __construct(string $password)
+    public function __construct(#[\SensitiveParameter] string $password)
     {
         $this->password = $password;
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -49,7 +49,7 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
     private string $cookieName;
     private ?LoggerInterface $logger;
 
-    public function __construct(RememberMeHandlerInterface $rememberMeHandler, string $secret, TokenStorageInterface $tokenStorage, string $cookieName, LoggerInterface $logger = null)
+    public function __construct(RememberMeHandlerInterface $rememberMeHandler, #[\SensitiveParameter] string $secret, TokenStorageInterface $tokenStorage, string $cookieName, LoggerInterface $logger = null)
     {
         $this->rememberMeHandler = $rememberMeHandler;
         $this->secret = $secret;

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -36,7 +36,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
     private ?TokenVerifierInterface $tokenVerifier;
     private string $secret;
 
-    public function __construct(TokenProviderInterface $tokenProvider, string $secret, UserProviderInterface $userProvider, RequestStack $requestStack, array $options, LoggerInterface $logger = null, TokenVerifierInterface $tokenVerifier = null)
+    public function __construct(TokenProviderInterface $tokenProvider, #[\SensitiveParameter] string $secret, UserProviderInterface $userProvider, RequestStack $requestStack, array $options, LoggerInterface $logger = null, TokenVerifierInterface $tokenVerifier = null)
     {
         parent::__construct($userProvider, $requestStack, $options, $logger);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

New feature for PHP 8.2: [Redact parameters in back traces](https://stitcher.io/blog/new-in-php-82#redact-parameters-in-back-traces-rfc)

This could be a "minor" change, but I think it should be highlighted to be fully functional. The annotation is required in all calling functions otherwise the argument value is displayed. 