### PR TITLE
[Console] Revert syntax errors

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -357,7 +357,7 @@ class Command
                 }
             }
         } else {
-            $code = $code(...);
+            $code = \Closure::fromCallable($code);
         }
 
         $this->code = $code;

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -182,7 +182,7 @@ class Question
             throw new LogicException('A hidden question cannot use the autocompleter.');
         }
 
-        $this->autocompleterCallback = null === $callback ? null : $callback(...);
+        $this->autocompleterCallback = null === $callback || $callback instanceof \Closure ? $callback : \Closure::fromCallable($callback);
 
         return $this;
     }
@@ -194,7 +194,7 @@ class Question
      */
     public function setValidator(callable $validator = null): static
     {
-        $this->validator = null === $validator ? null : $validator(...);
+        $this->validator = null === $validator || $validator instanceof \Closure ? $validator : \Closure::fromCallable($validator);
 
         return $this;
     }
@@ -246,7 +246,7 @@ class Question
      */
     public function setNormalizer(callable $normalizer): static
     {
-        $this->normalizer = $normalizer(...);
+        $this->normalizer = $normalizer instanceof \Closure ? $normalizer : \Closure::fromCallable($normalizer);
 
         return $this;
     }

--- a/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
+++ b/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
@@ -34,7 +34,7 @@ final class SignalRegistry
 
         $this->signalHandlers[$signal][] = $signalHandler;
 
-        pcntl_signal($signal, $this->handle(...));
+        pcntl_signal($signal, [$this, 'handle']);
     }
 
     public static function isSupported(): bool

--- a/src/Symfony/Component/Console/Tests/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/JsonDescriptorTest.php
@@ -27,13 +27,13 @@ class JsonDescriptorTest extends AbstractDescriptorTest
 
     protected function normalizeOutput($output)
     {
-        return array_map($this->normalizeOutputRecursively(...), json_decode($output, true));
+        return array_map([$this, 'normalizeOutputRecursively'], json_decode($output, true));
     }
 
     private function normalizeOutputRecursively($output)
     {
         if (\is_array($output)) {
-            return array_map($this->normalizeOutputRecursively(...), $output);
+            return array_map([$this, 'normalizeOutputRecursively'], $output);
         }
 
         if (null === $output) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features / 4.4, 5.4 or 6.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | not applicable, see below
| License       | MIT
| Doc PR        | not applicable

This PR reverts syntax errors from [b0217c6](https://github.com/symfony/symfony/commit/b0217c600f078d58d6c3bd9895d6a015d1f24c14) for the console. For example doctrine/orm `2.13.x-dev` breaks under some circumstances (e.g. if `SignalRegistry` is needed). 

Maybe @nicolas-grekas knows more about it.