### PR TITLE
[HttpKernel] Handle previously converted `DateTime` arguments

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
@@ -40,6 +40,12 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface
     {
         $value = $request->attributes->get($argument->getName());
 
+        if ($value instanceof \DateTimeInterface) {
+            yield $value;
+
+            return;
+        }
+
         if ($argument->isNullable() && !$value) {
             yield null;
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
@@ -113,6 +113,21 @@ class DateTimeValueResolverTest extends TestCase
         $this->assertNull($results[0]);
     }
 
+    public function testPreviouslyConvertedAttribute()
+    {
+        $resolver = new DateTimeValueResolver();
+
+        $argument = new ArgumentMetadata('dummy', \DateTime::class, false, false, null, true);
+        $request = self::requestWithAttributes(['dummy' => $datetime = new \DateTime()]);
+
+        /** @var \Generator $results */
+        $results = $resolver->resolve($request, $argument);
+        $results = iterator_to_array($results);
+
+        $this->assertCount(1, $results);
+        $this->assertSame($datetime, $results[0]);
+    }
+
     public function testCustomClass()
     {
         date_default_timezone_set('UTC');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix sensiolabs/SensioFrameworkExtraBundle#770
| License       | MIT
| Doc PR        | N/A

I'm not sure I like this fix, but given the order of operations between the param converters in SensioFrameworkExtraBundle and the controller argument resolvers in the HttpKernel component, this is probably going to cause the least number of headaches for users when upgrading.  And in some ways, this is the same problem as #40333 but in reverse.

Because the param converters are triggered on the `kernel.controller` event, they will handle converting values before the controller argument resolvers are fired.  This means that a typehinted `DateTimeInterface` will potentially be handled twice (once by the param converter, once by the argument resolver).  To avoid the `TypeError` noted in the issue, a practical fix is to gracefully handle a previously converted value in this resolver.  As the other options aren't great (removing services from the container or turning off the param converters in full, which has other side effects), this is probably the most practical fix.