### PR TITLE
[Validator] add Password constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Password.php
+++ b/src/Symfony/Component/Validator/Constraints/Password.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @author Jérémy Reynaud <jeremy@reynaud.io>
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Password extends Constraint
+{
+    public const MIN_ERROR = '520975d5-94e6-416b-8571-4ae99a3ceb12';
+    public const MIXED_CASE_ERROR = '9d15ccfa-4981-46f0-bf4a-e38bc916f7bd';
+    public const LETTERS_ERROR = 'b58d02f0-233e-4a3c-9939-5084a678aa83';
+    public const NUMBERS_ERROR = 'b8721890-6e05-49db-8625-5039f3d99928';
+    public const SYMBOLS_ERROR = '17923814-85cc-43df-ab66-e37d2e80397b';
+
+    public function __construct(
+        array $options = null,
+
+        /** The minimum size of the password. */
+        public int $min = 12,
+        public string $minMessage = 'The password value is too short. It should have {{ min }} characters or more.',
+
+        /** If the password requires at least one uppercase and one lowercase letter. */
+        public bool $mixedCase = false,
+        public string $mixedCaseMessage = 'The password must contain at least one uppercase and one lowercase letter.',
+
+        /** If the password requires at least one letter. */
+        public bool $letters = false,
+        public string $lettersMessage = 'The password must contain at least one letter.',
+
+        /** If the password requires at least one number. */
+        public bool $numbers = false,
+        public string $numbersMessage = 'The password must contain at least one number.',
+
+        /** If the password requires at least one symbol. */
+        public bool $symbols = false,
+        public string $symbolsMessage = 'The password must contain at least one symbol.',
+
+        array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct($options, $groups, $payload);
+    }
+
+    public function validatedBy(): string
+    {
+        return PasswordValidator::class;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/PasswordValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordValidator.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @author Jérémy Reynaud <jeremy@reynaud.io>
+ */
+class PasswordValidator extends ConstraintValidator
+{
+    /** {@inheritDoc} */
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof Password) {
+            throw new UnexpectedTypeException($constraint, Password::class);
+        }
+
+        $value = (string) $value;
+
+        if ($constraint->min > mb_strlen($value)) {
+            $this->context
+                ->buildViolation($constraint->minMessage)
+                ->setParameter('{{ min }}', (string) $constraint->min)
+                ->setInvalidValue($value)
+                ->setCode(Password::MIN_ERROR)
+                ->addViolation()
+            ;
+        }
+
+        if ($constraint->mixedCase && 1 !== preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value)) {
+            $this->context
+                ->buildViolation($constraint->mixedCaseMessage)
+                ->setInvalidValue($value)
+                ->setCode(Password::MIXED_CASE_ERROR)
+                ->addViolation()
+            ;
+        }
+
+        if ($constraint->letters && 1 !== preg_match('/\pL/u', $value)) {
+            $this->context
+                ->buildViolation($constraint->lettersMessage)
+                ->setInvalidValue($value)
+                ->setCode(Password::LETTERS_ERROR)
+                ->addViolation()
+            ;
+        }
+
+        if ($constraint->symbols && 1 !== preg_match('/\p{Z}|\p{S}|\p{P}/u', $value)) {
+            $this->context
+                ->buildViolation($constraint->symbolsMessage)
+                ->setInvalidValue($value)
+                ->setCode(Password::SYMBOLS_ERROR)
+                ->addViolation()
+            ;
+        }
+
+        if ($constraint->numbers && 1 !== preg_match('/\pN/u', $value)) {
+            $this->context
+                ->buildViolation($constraint->numbersMessage)
+                ->setInvalidValue($value)
+                ->setCode(Password::NUMBERS_ERROR)
+                ->addViolation()
+            ;
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Password;
+use Symfony\Component\Validator\Constraints\PasswordValidator;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @author Jérémy Reynaud <jeremy@reynaud.io>
+ */
+class PasswordTest extends TestCase
+{
+    public function testValidatedByStandardValidator()
+    {
+        $constraint = new Password();
+
+        static::assertSame(PasswordValidator::class, $constraint->validatedBy());
+    }
+
+    public function testDefaultValues()
+    {
+        $constraint = new Password();
+
+        static::assertSame(12, $constraint->min);
+        static::assertFalse($constraint->mixedCase);
+        static::assertFalse($constraint->letters);
+        static::assertFalse($constraint->numbers);
+        static::assertFalse($constraint->symbols);
+    }
+
+    public function testAttributes()
+    {
+        $constraint = new Password();
+
+        $metadata = new ClassMetadata(PasswordDummy::class);
+        static::assertTrue((new AnnotationLoader())->loadClassMetadata($metadata));
+
+        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        static::assertSame($constraint->min, $aConstraint->min);
+        static::assertFalse($aConstraint->mixedCase);
+        static::assertFalse($aConstraint->letters);
+        static::assertFalse($aConstraint->numbers);
+        static::assertFalse($aConstraint->symbols);
+
+        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        static::assertSame(8, $bConstraint->min);
+        static::assertSame('myMessage', $bConstraint->minMessage);
+        static::assertSame(['Default', 'PasswordDummy'], $bConstraint->groups);
+
+        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        static::assertTrue($cConstraint->letters);
+        static::assertSame('myMessage', $cConstraint->lettersMessage);
+        static::assertSame(['my_group'], $cConstraint->groups);
+    }
+}
+
+class PasswordDummy
+{
+    #[Password]
+    private $a;
+
+    #[Password(min: 8, minMessage: 'myMessage')]
+    private $b;
+
+    #[Password(letters: true, lettersMessage: 'myMessage', groups: ['my_group'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordValidatorTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Password;
+use Symfony\Component\Validator\Constraints\PasswordValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @author Jérémy Reynaud <jeremy@reynaud.io>
+ */
+class PasswordValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): PasswordValidator
+    {
+        return new PasswordValidator();
+    }
+
+    /** @dataProvider invalidPasswordProvider */
+    public function testInvalidPassword(?string $value, Password $contraint, array $violations)
+    {
+        $this->validator->validate($value, $contraint);
+
+        $assert = $this;
+        $assertMethod = 'buildViolation';
+
+        foreach ($violations as $code => $violation) {
+            if (Password::MIN_ERROR === $code) {
+                $assert = $assert->$assertMethod($contraint->minMessage)
+                    ->setParameter('{{ min }}', $contraint->min)
+                    ->setCode(Password::MIN_ERROR)
+                    ->setInvalidValue($value)
+                ;
+            } else {
+                $assert = $assert->$assertMethod($violation)
+                    ->setCode($code)
+                    ->setInvalidValue($value)
+                ;
+            }
+
+            $assertMethod = 'buildNextViolation';
+        }
+
+        $assert->assertRaised();
+    }
+
+    public function invalidPasswordProvider(): \Generator
+    {
+        $passwordConstraint = new Password();
+
+        yield [
+            null,
+            new Password(),
+            [
+                Password::MIN_ERROR => $passwordConstraint->minMessage,
+            ],
+        ];
+
+        yield [
+            '',
+            new Password(
+                mixedCase: true,
+                numbers: true,
+                symbols: true,
+            ),
+            [
+                Password::MIN_ERROR => $passwordConstraint->minMessage,
+                Password::MIXED_CASE_ERROR => $passwordConstraint->mixedCaseMessage,
+                Password::SYMBOLS_ERROR => $passwordConstraint->symbolsMessage,
+                Password::NUMBERS_ERROR => $passwordConstraint->numbersMessage,
+            ],
+        ];
+
+        yield [
+            'test',
+            new Password(
+                mixedCase: true,
+                numbers: true,
+                symbols: true,
+            ),
+            [
+                Password::MIN_ERROR => $passwordConstraint->minMessage,
+                Password::MIXED_CASE_ERROR => $passwordConstraint->mixedCaseMessage,
+                Password::SYMBOLS_ERROR => $passwordConstraint->symbolsMessage,
+                Password::NUMBERS_ERROR => $passwordConstraint->numbersMessage,
+            ],
+        ];
+
+        yield [
+            '0000',
+            new Password(
+                mixedCase: true,
+                numbers: true,
+                symbols: true,
+            ),
+            [
+                Password::MIN_ERROR => $passwordConstraint->minMessage,
+                Password::MIXED_CASE_ERROR => $passwordConstraint->mixedCaseMessage,
+                Password::SYMBOLS_ERROR => $passwordConstraint->symbolsMessage,
+            ],
+        ];
+
+        yield [
+            'azertyuiop000',
+            new Password(
+                mixedCase: true,
+                numbers: true,
+                symbols: true,
+            ),
+            [
+                Password::MIXED_CASE_ERROR => $passwordConstraint->mixedCaseMessage,
+                Password::SYMBOLS_ERROR => $passwordConstraint->symbolsMessage,
+            ],
+        ];
+    }
+
+    /** @dataProvider validPasswordProvider */
+    public function testValidPassword(string $value, Password $contraint)
+    {
+        $this->validator->validate($value, $contraint);
+        $this->assertNoViolation();
+    }
+
+    public function validPasswordProvider(): \Generator
+    {
+        yield ['azertyuiop', new Password(min: 10)];
+        yield ['Azertyuiop000@', new Password(mixedCase: true, numbers: true, symbols: true)];
+        yield ['LaSa5KE2udBb3=$$6#?8', new Password(mixedCase: true, numbers: true, symbols: true)];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Hello,

In order to comply with the recommendations of the CNIL, I propose this little password check.

I did not update the CHANGELOG.md because you're in feature freeze. I will be update and rebase when you release Symfony 6.1 and when you'll create the branch for 6.2.

Thanks.
