### PR TITLE
[HttpFoundation] Test invalid cookie regeneration

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
@@ -54,10 +54,12 @@ ob_start();
 class TestSessionHandler extends AbstractSessionHandler
 {
     private $data;
+    private ?string $sessionId;
 
-    public function __construct($data = '')
+    public function __construct($data = '', $sessionId = null)
     {
         $this->data = $data;
+        $this->sessionId = $sessionId;
     }
 
     public function open(string $path, string $name): bool
@@ -130,7 +132,12 @@ class TestSessionHandler extends AbstractSessionHandler
 
     protected function doRead($sessionId): string
     {
-        echo __FUNCTION__.': ', $this->data, "\n";
+        if (isset($this->sessionId) && $sessionId !== $this->sessionId) {
+            echo __FUNCTION__ . ": invalid sessionId\n";
+
+            return '';
+        }
+        echo __FUNCTION__ . ': ', $this->data, "\n";
 
         return $this->data;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/invalid_regenerate.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/invalid_regenerate.expected
@@ -1,0 +1,17 @@
+open
+validateId
+read
+doRead: invalid sessionId
+read
+$_SESSION is not empty
+
+write
+doWrite: _symfony_flashes|a:1:{s:3:"foo";a:1:{i:0;s:3:"bar";}}
+close
+Array
+(
+    [0] => Content-Type: text/plain; charset=utf-8
+    [1] => Cache-Control: max-age=0, private, must-revalidate
+    [2] => Set-Cookie: sid=random_session_id; path=/; secure; HttpOnly
+)
+shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/invalid_regenerate.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/invalid_regenerate.php
@@ -1,0 +1,20 @@
+<?php
+
+require __DIR__.'/common.inc';
+
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+
+$storage = new NativeSessionStorage();
+// Change sessionId so the test value looks invalid.
+$storage->setSaveHandler(new TestSessionHandler('', 'abc123'));
+$flash = new FlashBag();
+$storage->registerBag($flash);
+$storage->start();
+
+// Add something to the session, so it isn't pruned.
+$flash->add('foo', 'bar');
+echo empty($_SESSION) ? '$_SESSION is empty' : '$_SESSION is not empty';
+echo "\n";
+
+ob_start(function ($buffer) { return preg_replace('~_sf2_meta.*$~m', '', str_replace(session_id(), 'random_session_id', $buffer)); });


### PR DESCRIPTION
Asserts that validateId logic in AbstractSesssionHandler correctly protects against session fixation attempts by regenerating the session id.

Just some free test coverage. No fixes or features or any of that.

| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT

