### PR TITLE
[DomCrawler] Failing test for Crawler emojis handling regression

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -379,6 +379,13 @@ abstract class AbstractCrawlerTest extends TestCase
         $this->assertSame('my value', $this->createTestCrawler(null)->filterXPath('//ol')->html('my value'));
     }
 
+    public function testEmojis()
+    {
+        $crawler = $this->createCrawler('<body><p>Hey 👋</p></body>');
+
+        $this->assertSame('<body><p>Hey 👋</p></body>', $crawler->html());
+    }
+
     public function testExtract()
     {
         $crawler = $this->createTestCrawler()->filterXPath('//ul[1]/li');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

since 4.4.39, 5.4.6 and 6.0.6.

This is the minimal reproducer for an issue we encountered on our blog while upgrading to 5.4.6 (this probably goes beyond emojis issues).
Our contents are parsed from markdown files, converted to HTML, then read using the Crawler to performs some checks and modifications. But since the upgrades, emojis included in the original content were wrongly encoded:

```diff
-'<body><p>Hey 👋</p></body>'
+'<body><p>Hey ð</p></body>'
```

These changes are the culprit: https://github.com/symfony/symfony/pull/45532/files#diff-940b51ffa31dedac17aa49cd8e04e44aa8b3747782c7f9f27457b0510587c05d

However, I'm unsure this is an actual regression, or somehow a misuse of the Crawler, since adding:

```html
<head>
    <meta charset="UTF-8"/>
</head>
```

in the test case would fix it?