### PR TITLE
[Form] fix populating single widget time view data with different timezones

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -47,12 +47,14 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
      * @param string|null $inputTimezone  The name of the input timezone
      * @param string|null $outputTimezone The name of the output timezone
      * @param string      $format         The date format
+     * @param string|null $parseFormat    The parse format when different from $format
      */
-    public function __construct(string $inputTimezone = null, string $outputTimezone = null, string $format = 'Y-m-d H:i:s')
+    public function __construct(string $inputTimezone = null, string $outputTimezone = null, string $format = 'Y-m-d H:i:s', string $parseFormat = null)
     {
         parent::__construct($inputTimezone, $outputTimezone);
 
-        $this->generateFormat = $this->parseFormat = $format;
+        $this->generateFormat = $format;
+        $this->parseFormat = $parseFormat ?? $format;
 
         // See https://php.net/datetime.createfromformat
         // The character "|" in the format makes sure that the parts of a date

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -73,8 +73,10 @@ class TimeType extends AbstractType
                 }
             });
 
+            $parseFormat = null;
+
             if (null !== $options['reference_date']) {
-                $format = 'Y-m-d '.$format;
+                $parseFormat = 'Y-m-d '.$format;
 
                 $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($options) {
                     $data = $event->getData();
@@ -85,7 +87,7 @@ class TimeType extends AbstractType
                 });
             }
 
-            $builder->addViewTransformer(new DateTimeToStringTransformer($options['model_timezone'], $options['view_timezone'], $format));
+            $builder->addViewTransformer(new DateTimeToStringTransformer($options['model_timezone'], $options['view_timezone'], $format, $parseFormat));
         } else {
             $hourOptions = $minuteOptions = $secondOptions = [
                 'error_bubbling' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -279,6 +279,76 @@ class TimeTypeTest extends BaseTypeTest
         $this->assertEquals('03:04:00', $form->getViewData());
     }
 
+    public function testPreSetDataDifferentTimezones()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'Europe/Berlin',
+            'input' => 'datetime',
+            'with_seconds' => true,
+            'reference_date' => new \DateTimeImmutable('2019-01-01', new \DateTimeZone('UTC')),
+        ]);
+        $form->setData(new \DateTime('2022-01-01 15:09:10', new \DateTimeZone('UTC')));
+
+        $this->assertSame('15:09:10', $form->getData()->format('H:i:s'));
+        $this->assertSame([
+            'hour' => '16',
+            'minute' => '9',
+            'second' => '10',
+        ], $form->getViewData());
+    }
+
+    public function testPreSetDataDifferentTimezonesDuringDaylightSavingTime()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'Europe/Berlin',
+            'input' => 'datetime',
+            'with_seconds' => true,
+            'reference_date' => new \DateTimeImmutable('2019-07-12', new \DateTimeZone('UTC')),
+        ]);
+        $form->setData(new \DateTime('2022-04-29 15:09:10', new \DateTimeZone('UTC')));
+
+        $this->assertSame('15:09:10', $form->getData()->format('H:i:s'));
+        $this->assertSame([
+            'hour' => '17',
+            'minute' => '9',
+            'second' => '10',
+        ], $form->getViewData());
+    }
+
+    public function testPreSetDataDifferentTimezonesUsingSingleTextWidget()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'Europe/Berlin',
+            'input' => 'datetime',
+            'with_seconds' => true,
+            'reference_date' => new \DateTimeImmutable('2019-01-01', new \DateTimeZone('UTC')),
+            'widget' => 'single_text',
+        ]);
+        $form->setData(new \DateTime('2022-01-01 15:09:10', new \DateTimeZone('UTC')));
+
+        $this->assertSame('15:09:10', $form->getData()->format('H:i:s'));
+        $this->assertSame('16:09:10', $form->getViewData());
+    }
+
+    public function testPreSetDataDifferentTimezonesDuringDaylightSavingTimeUsingSingleTextWidget()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'Europe/Berlin',
+            'input' => 'datetime',
+            'with_seconds' => true,
+            'reference_date' => new \DateTimeImmutable('2019-07-12', new \DateTimeZone('UTC')),
+            'widget' => 'single_text',
+        ]);
+        $form->setData(new \DateTime('2022-04-29 15:09:10', new \DateTimeZone('UTC')));
+
+        $this->assertSame('15:09:10', $form->getData()->format('H:i:s'));
+        $this->assertSame('17:09:10', $form->getViewData());
+    }
+
     public function testSubmitDifferentTimezones()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46137
| License       | MIT
| Doc PR        | 