### PR TITLE
[Console] Fix fish completion script

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.fish
+++ b/src/Symfony/Component/Console/Resources/completion.fish
@@ -7,7 +7,7 @@
 
 function _sf_{{ COMMAND_NAME }}
     set sf_cmd (commandline -o)
-    set c (math (count (commandline -oc))) - 1)
+    set c (count (commandline -oc))
 
     set completecmd "$sf_cmd[1]" "_complete" "-sfish" "-S{{ VERSION }}"
 

--- a/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTest.php
@@ -48,6 +48,9 @@ abstract class AbstractDescriptorTest extends TestCase
     /** @dataProvider getDescribeApplicationTestData */
     public function testDescribeApplication(Application $application, $expectedDescription)
     {
+        // the "completion" command has dynamic help information depending on the shell
+        $application->find('completion')->setHelp('');
+
         $this->assertDescription($expectedDescription, $application);
     }
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -120,7 +120,7 @@
                 "completion [--debug] [--] [<shell>]"
             ],
             "description": "Dump the shell completion script",
-            "help": "The <info>completion</> command dumps the shell completion script required\nto use shell autocompletion (currently only bash completion is supported).\n\n<comment>Static installation\n-------------------</>\n\nDump the script to a global completion file and restart your shell:\n\n    <info>%%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%</>\n\nOr dump the script to a local file and source it:\n\n    <info>%%PHP_SELF%% completion bash > completion.sh</>\n\n    <comment># source the file whenever you use the project</>\n    <info>source completion.sh</>\n\n    <comment># or add this line at the end of your \"~/.bashrc\" file:</>\n    <info>source /path/to/completion.sh</>\n\n<comment>Dynamic installation\n--------------------</>\n\nAdd this to the end of your shell configuration file (e.g. <info>\"~/.bashrc\"</>):\n\n    <info>eval \"$(%%PHP_SELF_FULL%% completion bash)\"</>",
+            "help": "Dump the shell completion script",
             "definition": {
                 "arguments": {
                     "shell": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
@@ -14,32 +14,7 @@ Dump the shell completion script
 
 * `completion [--debug] [--] [<shell>]`
 
-The completion command dumps the shell completion script required
-to use shell autocompletion (currently only bash completion is supported).
-
-Static installation
--------------------
-
-Dump the script to a global completion file and restart your shell:
-
-    %%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%
-
-Or dump the script to a local file and source it:
-
-    %%PHP_SELF%% completion bash > completion.sh
-
-    # source the file whenever you use the project
-    source completion.sh
-
-    # or add this line at the end of your "~/.bashrc" file:
-    source /path/to/completion.sh
-
-Dynamic installation
---------------------
-
-Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
-
-    eval "$(%%PHP_SELF_FULL%% completion bash)"
+Dump the shell completion script
 
 ### Arguments
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -53,32 +53,7 @@
         <usage>completion [--debug] [--] [&lt;shell&gt;]</usage>
       </usages>
       <description>Dump the shell completion script</description>
-      <help>The &lt;info&gt;completion&lt;/&gt; command dumps the shell completion script required
- to use shell autocompletion (currently only bash completion is supported).
- 
- &lt;comment&gt;Static installation
- -------------------&lt;/&gt;
- 
- Dump the script to a global completion file and restart your shell:
- 
-     &lt;info&gt;%%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%&lt;/&gt;
- 
- Or dump the script to a local file and source it:
- 
-     &lt;info&gt;%%PHP_SELF%% completion bash &gt; completion.sh&lt;/&gt;
- 
-     &lt;comment&gt;# source the file whenever you use the project&lt;/&gt;
-     &lt;info&gt;source completion.sh&lt;/&gt;
- 
-     &lt;comment&gt;# or add this line at the end of your "~/.bashrc" file:&lt;/&gt;
-     &lt;info&gt;source /path/to/completion.sh&lt;/&gt;
- 
- &lt;comment&gt;Dynamic installation
- --------------------&lt;/&gt;
- 
- Add this to the end of your shell configuration file (e.g. &lt;info&gt;"~/.bashrc"&lt;/&gt;):
- 
-     &lt;info&gt;eval "$(%%PHP_SELF_FULL%% completion bash)"&lt;/&gt;</help>
+      <help>Dump the shell completion script</help>
       <arguments>
         <argument name="shell" is_required="0" is_array="0">
           <description>The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -124,7 +124,7 @@
                 "completion [--debug] [--] [<shell>]"
             ],
             "description": "Dump the shell completion script",
-            "help": "The <info>completion</> command dumps the shell completion script required\nto use shell autocompletion (currently only bash completion is supported).\n\n<comment>Static installation\n-------------------</>\n\nDump the script to a global completion file and restart your shell:\n\n    <info>%%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%</>\n\nOr dump the script to a local file and source it:\n\n    <info>%%PHP_SELF%% completion bash > completion.sh</>\n\n    <comment># source the file whenever you use the project</>\n    <info>source completion.sh</>\n\n    <comment># or add this line at the end of your \"~/.bashrc\" file:</>\n    <info>source /path/to/completion.sh</>\n\n<comment>Dynamic installation\n--------------------</>\n\nAdd this to the end of your shell configuration file (e.g. <info>\"~/.bashrc\"</>):\n\n    <info>eval \"$(%%PHP_SELF_FULL%% completion bash)\"</>",
+            "help": "Dump the shell completion script",
             "definition": {
                 "arguments": {
                     "shell": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -27,32 +27,7 @@ Dump the shell completion script
 
 * `completion [--debug] [--] [<shell>]`
 
-The completion command dumps the shell completion script required
-to use shell autocompletion (currently only bash completion is supported).
-
-Static installation
--------------------
-
-Dump the script to a global completion file and restart your shell:
-
-    %%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%
-
-Or dump the script to a local file and source it:
-
-    %%PHP_SELF%% completion bash > completion.sh
-
-    # source the file whenever you use the project
-    source completion.sh
-
-    # or add this line at the end of your "~/.bashrc" file:
-    source /path/to/completion.sh
-
-Dynamic installation
---------------------
-
-Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
-
-    eval "$(%%PHP_SELF_FULL%% completion bash)"
+Dump the shell completion script
 
 ### Arguments
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -53,32 +53,7 @@
         <usage>completion [--debug] [--] [&lt;shell&gt;]</usage>
       </usages>
       <description>Dump the shell completion script</description>
-      <help>The &lt;info&gt;completion&lt;/&gt; command dumps the shell completion script required
- to use shell autocompletion (currently only bash completion is supported).
- 
- &lt;comment&gt;Static installation
- -------------------&lt;/&gt;
- 
- Dump the script to a global completion file and restart your shell:
- 
-     &lt;info&gt;%%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%&lt;/&gt;
- 
- Or dump the script to a local file and source it:
- 
-     &lt;info&gt;%%PHP_SELF%% completion bash &gt; completion.sh&lt;/&gt;
- 
-     &lt;comment&gt;# source the file whenever you use the project&lt;/&gt;
-     &lt;info&gt;source completion.sh&lt;/&gt;
- 
-     &lt;comment&gt;# or add this line at the end of your "~/.bashrc" file:&lt;/&gt;
-     &lt;info&gt;source /path/to/completion.sh&lt;/&gt;
- 
- &lt;comment&gt;Dynamic installation
- --------------------&lt;/&gt;
- 
- Add this to the end of your shell configuration file (e.g. &lt;info&gt;"~/.bashrc"&lt;/&gt;):
- 
-     &lt;info&gt;eval "$(%%PHP_SELF_FULL%% completion bash)"&lt;/&gt;</help>
+      <help>Dump the shell completion script</help>
       <arguments>
         <argument name="shell" is_required="0" is_array="0">
           <description>The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
@@ -18,32 +18,7 @@ Dump the shell completion script
 
 * `completion [--debug] [--] [<shell>]`
 
-The completion command dumps the shell completion script required
-to use shell autocompletion (currently only bash completion is supported).
-
-Static installation
--------------------
-
-Dump the script to a global completion file and restart your shell:
-
-    %%PHP_SELF%% completion bash | sudo tee /etc/bash_completion.d/%%COMMAND_NAME%%
-
-Or dump the script to a local file and source it:
-
-    %%PHP_SELF%% completion bash > completion.sh
-
-    # source the file whenever you use the project
-    source completion.sh
-
-    # or add this line at the end of your "~/.bashrc" file:
-    source /path/to/completion.sh
-
-Dynamic installation
---------------------
-
-Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
-
-    eval "$(%%PHP_SELF_FULL%% completion bash)"
+Dump the shell completion script
 
 ### Arguments
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

While trying out the fish completion support, I discovered a syntax error in the fish script. After fixing it, I realized the cursor calculation was wrong in the fish script. I've tested these changes using Fish 3.4.1 and the Symfony demo app.

Meanwhile, I improved the help of the `completion` command to account for the fish shell support. I had to find the PR that introduced this feature in order to get installation instructions (these are now part of the help - just like with bash).