### PR TITLE
[Messenger] Make Redis messages countable

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -339,6 +339,27 @@ class RedisExtIntegrationTest extends TestCase
         $redis->del('messenger-rejectthenget');
     }
 
+    public function testItCountMessages()
+    {
+        $this->assertSame(0, $this->connection->getMessageCount());
+
+        $this->connection->add('{"message": "Hi"}', ['type' => DummyMessage::class]);
+        $this->connection->add('{"message": "Hi"}', ['type' => DummyMessage::class]);
+        $this->connection->add('{"message": "Hi"}', ['type' => DummyMessage::class]);
+
+        $this->assertSame(3, $this->connection->getMessageCount());
+
+        $message = $this->connection->get();
+        $this->connection->ack($message['id']);
+
+        $this->assertSame(2, $this->connection->getMessageCount());
+
+        $message = $this->connection->get();
+        $this->connection->reject($message['id']);
+
+        $this->assertSame(1, $this->connection->getMessageCount());
+    }
+
     private function getConnectionGroup(Connection $connection): string
     {
         $property = (new \ReflectionClass(Connection::class))->getProperty('group');

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Bridge\Redis\Transport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  * @author Alexander Schranz <alexander@sulu.io>
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-class RedisReceiver implements ReceiverInterface
+class RedisReceiver implements ReceiverInterface, MessageCountAwareInterface
 {
     private Connection $connection;
     private SerializerInterface $serializer;
@@ -82,6 +83,14 @@ class RedisReceiver implements ReceiverInterface
     public function reject(Envelope $envelope): void
     {
         $this->connection->reject($this->findRedisReceivedStamp($envelope)->getId());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageCount(): int
+    {
+        return $this->connection->getMessageCount();
     }
 
     private function findRedisReceivedStamp(Envelope $envelope): RedisReceivedStamp

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\Redis\Transport;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\SetupableTransportInterface;
@@ -21,7 +22,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  * @author Alexander Schranz <alexander@sulu.io>
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-class RedisTransport implements TransportInterface, SetupableTransportInterface
+class RedisTransport implements TransportInterface, SetupableTransportInterface, MessageCountAwareInterface
 {
     private SerializerInterface $serializer;
     private Connection $connection;
@@ -72,6 +73,14 @@ class RedisTransport implements TransportInterface, SetupableTransportInterface
     public function setup(): void
     {
         $this->connection->setup();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageCount(): int
+    {
+        return $this->getReceiver()->getMessageCount();
     }
 
     private function getReceiver(): RedisReceiver


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Each Messenger Transport can return the number of messages present in the queue. For example, when we use the `messenger:failed:retry` command, Messenger displays the number of messages to retry.

Actually, this count is not displayed when using `RedisTransport`. This PR adds this functionality.
