### PR TITLE
[Serializer] CsvEncoder : Check coherent header

### DIFF
--- a/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
@@ -138,10 +138,10 @@ final class CsvEncoderContextBuilder implements ContextBuilderInterface
     }
 
     /**
-     * Configures whether cols header are checked before encoding.
+     * Configures whether cols headers are checked before encoding.
      */
-    public function withCheckValidHeaders(?bool $checkValidHeader): static
+    public function withCheckValidHeaders(?bool $checkValidHeaders): static
     {
-        return $this->with(CsvEncoder::CHECK_VALID_HEADERS, $checkValidHeader);
+        return $this->with(CsvEncoder::CHECK_VALID_HEADERS, $checkValidHeaders);
     }
 }

--- a/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
@@ -136,4 +136,12 @@ final class CsvEncoderContextBuilder implements ContextBuilderInterface
     {
         return $this->with(CsvEncoder::OUTPUT_UTF8_BOM_KEY, $outputUtf8Bom);
     }
+
+    /**
+     * Configures whether cols header are checked before encoding.
+     */
+    public function withCheckValidHeaders(?bool $checkValidHeader): static
+    {
+        return $this->with(CsvEncoder::CHECK_VALID_HEADERS, $checkValidHeader);
+    }
 }

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -177,7 +177,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
                         && \count($cols) !== \count($expectedHeaders)
                         && \count(array_intersect($cols, $expectedHeaders)) !== \count($expectedHeaders)
                     ) {
-                        throw new NotEncodableValueException(sprintf('Expected %s headers, got %s.', implode(',', $expectedHeaders), implode(',', $cols)));
+                        throw new NotEncodableValueException(sprintf('Expected "%s" headers, got "%s".', implode(',', $expectedHeaders), implode(',', $cols)));
                     }
 
                     continue;

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -151,7 +151,6 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         $headers = null;
         $nbHeaders = 0;
         $headerCount = [];
-        $headerFile = [];
         $result = [];
 
         [$delimiter, $enclosure, $escapeChar, $keySeparator, $expectedHeaders, , , $asCollection] = $this->getCsvOptions($context);
@@ -171,14 +170,20 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
                     foreach ($cols as $col) {
                         $header = explode($keySeparator, $col);
                         $headers[] = $header;
-                        $headerFile[] = $col;
                         $headerCount[] = \count($header);
                     }
 
                     if (($context[self::CHECK_VALID_HEADERS] ?? $this->defaultContext[self::CHECK_VALID_HEADERS])
-                        && \count(array_intersect($headerFile, $expectedHeader)) !== \count($expectedHeader)
+                        && \count($cols) !== \count($expectedHeaders)
+                        && \count(array_intersect($cols, $expectedHeaders)) !== \count($expectedHeaders)
                     ) {
-                        throw new NotEncodableValueException('Invalid headers in content.');
+                        throw new NotEncodableValueException(
+                            sprintf(
+                                'Expected %s headers, got %s.',
+                                implode(',', $expectedHeaders),
+                                implode(',', $cols)
+                            )
+                        );
                     }
 
                     continue;

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -154,7 +154,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         $headerFile = [];
         $result = [];
 
-        [$delimiter, $enclosure, $escapeChar, $keySeparator, $expectedHeader, , , $asCollection] = $this->getCsvOptions($context);
+        [$delimiter, $enclosure, $escapeChar, $keySeparator, $expectedHeaders, , , $asCollection] = $this->getCsvOptions($context);
 
         while (false !== ($cols = fgetcsv($handle, 0, $delimiter, $enclosure, $escapeChar))) {
             $nbCols = \count($cols);

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -177,13 +177,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
                         && \count($cols) !== \count($expectedHeaders)
                         && \count(array_intersect($cols, $expectedHeaders)) !== \count($expectedHeaders)
                     ) {
-                        throw new NotEncodableValueException(
-                            sprintf(
-                                'Expected %s headers, got %s.',
-                                implode(',', $expectedHeaders),
-                                implode(',', $cols)
-                            )
-                        );
+                        throw new NotEncodableValueException(sprintf('Expected %s headers, got %s.', implode(',', $expectedHeaders), implode(',', $cols)));
                     }
 
                     continue;

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
@@ -46,6 +46,7 @@ class CsvEncoderContextBuilderTest extends TestCase
             ->withNoHeaders($values[CsvEncoder::NO_HEADERS_KEY])
             ->withEndOfLine($values[CsvEncoder::END_OF_LINE])
             ->withOutputUtf8Bom($values[CsvEncoder::OUTPUT_UTF8_BOM_KEY])
+            ->withCheckValidHeaders($values[CsvEncoder::CHECK_VALID_HEADERS])
             ->toArray();
 
         $this->assertSame($values, $context);
@@ -67,6 +68,7 @@ class CsvEncoderContextBuilderTest extends TestCase
             CsvEncoder::NO_HEADERS_KEY => false,
             CsvEncoder::END_OF_LINE => 'EOL',
             CsvEncoder::OUTPUT_UTF8_BOM_KEY => false,
+            CsvEncoder::CHECK_VALID_HEADERS => true,
         ]];
 
         yield 'With null values' => [[
@@ -80,6 +82,7 @@ class CsvEncoderContextBuilderTest extends TestCase
             CsvEncoder::NO_HEADERS_KEY => null,
             CsvEncoder::END_OF_LINE => null,
             CsvEncoder::OUTPUT_UTF8_BOM_KEY => null,
+            CsvEncoder::CHECK_VALID_HEADERS => null,
         ]];
     }
 
@@ -96,6 +99,7 @@ class CsvEncoderContextBuilderTest extends TestCase
             ->withNoHeaders(null)
             ->withEndOfLine(null)
             ->withOutputUtf8Bom(null)
+            ->withCheckValidHeaders(null)
             ->toArray();
 
         $this->assertSame([
@@ -109,6 +113,7 @@ class CsvEncoderContextBuilderTest extends TestCase
             CsvEncoder::NO_HEADERS_KEY => null,
             CsvEncoder::END_OF_LINE => null,
             CsvEncoder::OUTPUT_UTF8_BOM_KEY => null,
+            CsvEncoder::CHECK_VALID_HEADERS => null,
         ], $context);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -731,7 +731,7 @@ hello,"hey ho"
 CSV;
 
         $this->expectException(NotEncodableValueException::class);
-        $this->expectExceptionMessage('Expected foo,bar,baz headers, got foo,bar.');
+        $this->expectExceptionMessage('Expected "foo,bar,baz" headers, got "foo,bar".');
         $this->encoder->decode(
             $csv,
             'csv',

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -731,7 +731,7 @@ hello,"hey ho"
 CSV;
 
         $this->expectException(NotEncodableValueException::class);
-        $this->expectExceptionMessage('Invalid headers in content.');
+        $this->expectExceptionMessage('Expected foo,bar,baz headers, got foo,bar.');
         $this->encoder->decode(
             $csv,
             'csv',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR adds a new option in CsvEncoder to validate that the header in the file is valid with we expect.
By default, this option is set to false.