### PR TITLE
[Translation] Refresh local translations on PushCommand if the provider has domains

### DIFF
--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -131,16 +131,16 @@ EOF
         $force = $input->getOption('force');
         $deleteMissing = $input->getOption('delete-missing');
 
+        if (!$domains && $provider instanceof FilteringProvider) {
+            $domains = $provider->getDomains();
+        }
+
+        // Reading local translations must be done after retrieving the domains from the provider
+        // in order to manage only translations from configured domains
         $localTranslations = $this->readLocalTranslations($locales, $domains, $this->transPaths);
 
         if (!$domains) {
-            if ($provider instanceof FilteringProvider) {
-                $domains = $provider->getDomains();
-            }
-
-            if (!$domains) {
-                $domains = $this->getDomainsFromTranslatorBag($localTranslations);
-            }
+            $domains = $this->getDomainsFromTranslatorBag($localTranslations);
         }
 
         if (!$deleteMissing && $force) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Since https://github.com/symfony/symfony/pull/45171 it's possible to define targeted translation domains in configuration.

On `translation:push` without `--domains` option the command should read our configuration in order build local translations list. 
If the domain is only define in the configuration we need to refresh the local translations list to prevent full update of Provider (push all domains without filtering).

I think we should add a test but I failed to do it properly.