### PR TITLE
[Console] Add support for resuming a ProgressBar

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add method `__toString()` to `InputInterface`
  * Deprecate `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead
  * Add suggested values for arguments and options in input definition, for input completion
+ * Add `$resumeAt` parameter to `ProgressBar#start()`, so that one can easily 'resume' progress on longer tasks, and still get accurate `getEstimate()` and `getRemaining()` results.
 
 6.0
 ---

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -66,6 +66,69 @@ class ProgressBarTest extends TestCase
         );
     }
 
+    public function testResumeNoMax()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
+        $bar->start(null, 15);
+        $bar->advance();
+
+        rewind($output->getStream());
+
+        $this->assertEquals(
+            '   15 [--------------->------------]'.
+            $this->generateOutput('   16 [---------------->-----------]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testResumeWithMax()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 5000, 0);
+        $bar->start(null, 1000);
+
+        rewind($output->getStream());
+
+        $this->assertEquals(
+            ' 1000/5000 [=====>----------------------]  20%',
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testRegularTimeEstimation()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 1_200, 0);
+        $bar->start();
+
+        $bar->advance();
+        $bar->advance();
+
+        sleep(1);
+
+        $this->assertEquals(
+            600.0,
+            $bar->getEstimated()
+        );
+    }
+
+    public function testResumedTimeEstimation()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 1_200, 0);
+        $bar->start(null, 599);
+        $bar->advance();
+
+        sleep(1);
+
+        $this->assertEquals(
+            1_200.0,
+            $bar->getEstimated()
+        );
+
+        $this->assertEquals(
+            600.0,
+            $bar->getRemaining()
+        );
+    }
+
     public function testAdvanceWithStep()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);


### PR DESCRIPTION
Add an `(int) $resumeAt` argument for `ProgressBar#start()`, so that the progress bar is initialized at a specific progress level, with a new property so that `getEstimated()` and `getRemaining()` report the right number.

| Q             | A
| ------------- | ---
| Branch?       | 6.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

As pointed out on a recently posted [SO question](https://stackoverflow.com/q/72097256/1426539)), when working on a longish task one may want to create a progress bar for a _resumed_ task.

Calling `advance()` works to increase the progress bar counter, but the results of `getRemaining()` and `getEstimated()` will be "broken", since whatever steps one "skipped" will be considered to have taken 0 seconds. For a longer running task, the estimation will be **very** inaccurate, and will remain so for a long while. Using the example code from the linked question:

```php
$itemCount = 1_000_000;
$startItem = 150_000;

$progressBar = new ProgressBar($output, $itemCount);
$progressBar->setFormat(
    $progressBar->getFormatDefinition(ProgressBar::FORMAT_DEBUG)
);

$progressBar->start();

if ($startItem !== 0) {
    // unfortunately taken into account in ETA calculation
    $progressBar->advance($startItem);
}

for ($i = $startItem; $i < $itemCount; $i++) {
    usleep(50_000);
    $progressBar->advance();
}
```

This will output this to begin with:

```none
150038/1000000 [====>-----------------------]  15% 2 secs/13 secs 20.0 MiB
```

The estimated time will keep growing as the tasks progresses, but the estimation won't be remotely useful for a long while.

This PR adds a `$resumeAt` parameter to `ProgresBar#start()`, so that's possible to write:

```php
$bar = new ProgressBar($output, 1_200_000, 0);
$bar->start(null, 300_000);
```

And calls to `$bar->getEstimated()` and `$bar->getRemaining()` will return sane results (and calling the initial `->advance()` would be no longer necessary).

### TODO:

- [ ] submit changes to the documentation (if the PR is well received)

