### PR TITLE
[WebProfilerBundle] Update the icon of the Serializer profiler panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
@@ -4,7 +4,7 @@
 
 {% block menu %}
     <span class="label {{ not collector.handledCount ? 'disabled' }}">
-        <span class="icon">{{ include('@WebProfiler/Icon/validator.svg') }}</span>
+        <span class="icon">{{ include('@WebProfiler/Icon/serializer.svg') }}</span>
         <strong>Serializer</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/serializer.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/serializer.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="21" y1="17" x2="3" y2="17" />
+  <path d="M18 4l3 3l-3 3" />
+  <path d="M18 20l3 -3l-3 -3" />
+  <line x1="21" y1="7" x2="3" y2="7" />
+</svg>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In the PR that added the Serializer profiler panel, the new icon was left as a pending thing. See https://github.com/symfony/symfony/pull/45656#discussion_r840733803

This PR adds the new icon and it looks like this:

<img width="264" alt="icon-serializer" src="https://user-images.githubusercontent.com/73419/166722845-a9852079-1436-44a9-9421-399e2e9d312e.png">

Two comments:

(1) The icon style doesn't 100% match the style of the other icons. Don't worry about that. We plan to update all icons for Symfony 6.2 and they all will use that style.

(2) I know the icon might not be super clear and I'm open to better suggestions for this icon ... but it seems that it's impossible to conceptualize the "serializer" concept in an icon. See the biggest icon libraries in the world:

* Iconfinder: it has nothing about that: https://www.iconfinder.com/search?q=serializer
* The Noun Project: it has an icon of a triangle. It looks totally random to me: https://thenounproject.com/search/icons/?iconspage=1&q=serializer

So, I did this: I looked for "serializer" in Google Images (https://www.google.com/search?q=serializer&tbm=isch) and found that most images are block diagrams with lots of horizontal arrows. That's why I opted for the "two horizontal arrows" icon.
