### PR TITLE
[DependencyInjection] Autowire tagged iterators using doc blocks

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Autowire tagged iterators (needs `phpdocumentor/reflection-docblock`)
+
 6.1
 ---
 
@@ -14,7 +19,6 @@ CHANGELOG
  * Add argument type `closure` to help passing closures to services
  * Deprecate `ReferenceSetArgumentTrait`
  * Add `AbstractExtension` class for DI configuration/definition on a single file
- * Autowire tagged iterators (needs `phpdocumentor/reflection-docblock`)
 
 6.0
 ---

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add argument type `closure` to help passing closures to services
  * Deprecate `ReferenceSetArgumentTrait`
  * Add `AbstractExtension` class for DI configuration/definition on a single file
+ * Autowire tagged iterators (needs `phpdocumentor/reflection-docblock`)
 
 6.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -338,7 +338,7 @@ class AutowirePass extends AbstractRecursivePass
                         --$index;
                         break;
                     }
-                    $type = ProxyHelper::getTypeHint($reflectionMethod, $parameter );
+                    $type = ProxyHelper::getTypeHint($reflectionMethod, $parameter);
                     $type = $type ? sprintf('is type-hinted "%s"', ltrim($type, '\\')) : 'has no type-hint';
 
                     throw new AutowiringFailedException($this->currentId, sprintf('Cannot autowire service "%s": argument "$%s" of method "%s()" %s, you should configure its value explicitly.', $this->currentId, $parameter->name, $class !== $this->currentId ? $class.'::'.$method : $method, $type));

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -15,6 +15,7 @@ use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\ContextFactory;
+use phpDocumentor\Reflection\Types\Iterable_;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -314,7 +315,7 @@ class AutowirePass extends AbstractRecursivePass
                         if (
                             !$param instanceof Param
                             || !($phpDocType = $param->getType())
-                            || !$phpDocType instanceof Array_
+                            || !$phpDocType instanceof Iterable_
                             || $parameter->getName() !== $param->getVariableName()
                             || !($fqsen = $phpDocType->getValueType()->getFqsen()?->__toString())
                             || !($child = $this->container->getAutoconfiguredInstanceof()[ltrim($fqsen, '\\')] ?? null)

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1188,11 +1188,11 @@ class AutowirePassTest extends TestCase
         $this->assertSame(2, $container->getDefinition(AsDecoratorBaz::class)->getArgument(0)->getInvalidBehavior());
     }
 
-    public function testTaggedIterator(): void
+    public function testTaggedIterator()
     {
         $container = new ContainerBuilder();
         $container->register(A::class);
-        $container->register(APrime::class);
+        $container->register(ABis::class);
         $container->register(TaggedIterator::class)->setAutowired(true);
 
         $container->registerForAutoconfiguration(AInterface::class)->addTag('a');

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -30,7 +30,7 @@ class A implements AInterface
     }
 }
 
-class APrime implements AInterface
+class ABis implements AInterface
 {
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -420,7 +420,7 @@ final class ElsaAction
 class TaggedIterator
 {
     /**
-     * @param AInterface[] $aCollection
+     * @param iterable<AInterface> $aCollection
      */
     public function __construct(iterable $aCollection) {
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -30,6 +30,10 @@ class A implements AInterface
     }
 }
 
+class APrime implements AInterface
+{
+}
+
 class B extends A
 {
 }
@@ -410,5 +414,14 @@ final class ElsaAction
 {
     public function __construct(NotExisting $notExisting)
     {
+    }
+}
+
+class TaggedIterator
+{
+    /**
+     * @param AInterface[] $aCollection
+     */
+    public function __construct(iterable $aCollection) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -24,7 +24,8 @@
     "require-dev": {
         "symfony/yaml": "^5.4|^6.0",
         "symfony/config": "^6.1",
-        "symfony/expression-language": "^5.4|^6.0"
+        "symfony/expression-language": "^5.4|^6.0",
+        "phpdocumentor/reflection-docblock": "^5.3"
     },
     "suggest": {
         "symfony/yaml": "",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This patch allows the Dependency Injection component to autowire basic tagged iterators:

```php
namespace App;

use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;

#[AutoconfigureTag]
interface RoomInterface
{
    public function getBeds(): int;
}

class Hospital
{
    /** @param iterable<RoomInterface> $rooms */
    public function __construct(private iterable $rooms) {}
}
```

(edited: simplified example removing the need for a YAML config)

Tadam! This just works 🎉

This follows [discussions](https://twitter.com/dunglas/status/1519552863915196419?s=20&t=lk_w-0sEO-89XIp1MVt2CA) about @GregoireHebert's article ["Inject a tagged iterator in a more natural way"](https://knot.gheb.dev/blog/sf-inject-tagged-iterator/).

This patch has the following limitations:

* `phpdocumentor/reflection-docblock` must be installed
* Advanced cases aren't supported (union types, multiple tags...), use the new `#[TaggedIterator]` to handle these cases