### PR TITLE
[Security] Do not use First Class Callable Syntax for listeners

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -85,7 +85,7 @@ class ContextListener extends AbstractListener
     public function authenticate(RequestEvent $event)
     {
         if (!$this->registered && null !== $this->dispatcher && $event->isMainRequest()) {
-            $this->dispatcher->addListener(KernelEvents::RESPONSE, $this->onKernelResponse(...));
+            $this->dispatcher->addListener(KernelEvents::RESPONSE, [$this, 'onKernelResponse']);
             $this->registered = true;
         }
 
@@ -162,7 +162,7 @@ class ContextListener extends AbstractListener
             return;
         }
 
-        $this->dispatcher?->removeListener(KernelEvents::RESPONSE, $this->onKernelResponse(...));
+        $this->dispatcher?->removeListener(KernelEvents::RESPONSE, [$this, 'onKernelResponse']);
         $this->registered = false;
         $session = $request->getSession();
         $sessionId = $session->getId();

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -75,7 +75,7 @@ class ExceptionListener
      */
     public function register(EventDispatcherInterface $dispatcher)
     {
-        $dispatcher->addListener(KernelEvents::EXCEPTION, $this->onKernelException(...), 1);
+        $dispatcher->addListener(KernelEvents::EXCEPTION, [$this, 'onKernelException'], 1);
     }
 
     /**
@@ -83,7 +83,7 @@ class ExceptionListener
      */
     public function unregister(EventDispatcherInterface $dispatcher)
     {
-        $dispatcher->removeListener(KernelEvents::EXCEPTION, $this->onKernelException(...));
+        $dispatcher->removeListener(KernelEvents::EXCEPTION, [$this, 'onKernelException']);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -177,6 +178,18 @@ class ExceptionListenerTest extends TestCase
 
         $this->assertEquals('Invalid CSRF.', $event->getThrowable()->getMessage());
         $this->assertEquals(403, $event->getThrowable()->getStatusCode());
+    }
+
+    public function testUnregister()
+    {
+        $listener = $this->createExceptionListener();
+        $dispatcher = new EventDispatcher();
+
+        $listener->register($dispatcher);
+        $this->assertNotEmpty($dispatcher->getListeners());
+
+        $listener->unregister($dispatcher);
+        $this->assertEmpty($dispatcher->getListeners());
     }
 
     public function getAccessDeniedExceptionProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR fixes usage of First Class Callable Syntax for registering listeners which are intended to be unregistered later.

I'm targeting 6.1 branch because the issue was introduced only in this branch via https://github.com/symfony/symfony/commit/b0217c600f078d58d6c3bd9895d6a015d1f24c14

The reason of this change is clear from the following example:
```php
<?php

class Foo {
    public function bar() {}
}

$foo = new Foo();
var_dump($foo->bar(...) === $foo->bar(...)); // false
var_dump([$foo, 'bar'] === [$foo, 'bar']);   // true
```

In other words, it's not safe to use First Class Callable Syntax in the cases when we need to refer to the same function to remove it from somewhere, because each `method(...)` returns a new function.