### PR TITLE
[EventDispatcher] Fix removing listeners when using first-class callable syntax

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -75,7 +75,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     {
         if (isset($this->wrappedListeners[$eventName])) {
             foreach ($this->wrappedListeners[$eventName] as $index => $wrappedListener) {
-                if ($wrappedListener->getWrappedListener() === $listener) {
+                if ($wrappedListener->getWrappedListener() === $listener || ($listener instanceof \Closure && $wrappedListener->getWrappedListener() == $listener)) {
                     $listener = $wrappedListener;
                     unset($this->wrappedListeners[$eventName][$index]);
                     break;
@@ -110,8 +110,8 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         // we might have wrapped listeners for the event (if called while dispatching)
         // in that case get the priority by wrapper
         if (isset($this->wrappedListeners[$eventName])) {
-            foreach ($this->wrappedListeners[$eventName] as $index => $wrappedListener) {
-                if ($wrappedListener->getWrappedListener() === $listener) {
+            foreach ($this->wrappedListeners[$eventName] as $wrappedListener) {
+                if ($wrappedListener->getWrappedListener() === $listener || ($listener instanceof \Closure && $wrappedListener->getWrappedListener() == $listener)) {
                     return $this->dispatcher->getListenerPriority($eventName, $wrappedListener);
                 }
             }

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -122,7 +122,7 @@ class EventDispatcher implements EventDispatcherInterface
                     $v[0] = $v[0]();
                     $v[1] = $v[1] ?? '__invoke';
                 }
-                if ($v === $listener) {
+                if ($v === $listener || ($listener instanceof \Closure && $v == $listener)) {
                     return $priority;
                 }
             }
@@ -178,7 +178,7 @@ class EventDispatcher implements EventDispatcherInterface
                     $v[0] = $v[0]();
                     $v[1] = $v[1] ?? '__invoke';
                 }
-                if ($v === $listener) {
+                if ($v === $listener || ($listener instanceof \Closure && $v == $listener)) {
                     unset($listeners[$k], $this->sorted[$eventName], $this->optimized[$eventName]);
                 }
             }

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -422,6 +422,35 @@ class EventDispatcherTest extends TestCase
     }
 
     /**
+     * @requires PHP 8.1
+     */
+    public function testNamedClosures()
+    {
+        $listener = new TestEventListener();
+
+        $callback1 = \Closure::fromCallable($listener);
+        $callback2 = \Closure::fromCallable($listener);
+        $callback3 = \Closure::fromCallable(new TestEventListener());
+
+        $this->assertNotSame($callback1, $callback2);
+        $this->assertNotSame($callback1, $callback3);
+        $this->assertNotSame($callback2, $callback3);
+        $this->assertTrue($callback1 == $callback2);
+        $this->assertFalse($callback1 == $callback3);
+
+        $this->dispatcher->addListener('foo', $callback1, 3);
+        $this->dispatcher->addListener('foo', $callback2, 2);
+        $this->dispatcher->addListener('foo', $callback3, 1);
+
+        $this->assertSame(3, $this->dispatcher->getListenerPriority('foo', $callback1));
+        $this->assertSame(3, $this->dispatcher->getListenerPriority('foo', $callback2));
+
+        $this->dispatcher->removeListener('foo', $callback1);
+
+        $this->assertSame(['foo' => [$callback3]], $this->dispatcher->getListeners());
+    }
+
+    /**
      * @group legacy
      * @expectedDeprecation Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as the first argument is deprecated since Symfony 4.3, pass it as the second argument and provide the event object as the first argument instead.
      */

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -342,6 +342,30 @@ class ContextListenerTest extends TestCase
         $this->assertSame($usageIndex, $session->getUsageIndex());
     }
 
+    public function testOnKernelResponseRemoveListener()
+    {
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken('test1', 'pass1', 'phpunit', ['ROLE_USER']));
+
+        $request = new Request();
+        $request->attributes->set('_security_firewall_run', '_security_session');
+
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $dispatcher = new EventDispatcher();
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+
+        $listener = new ContextListener($tokenStorage, [], 'session', null, $dispatcher, null, \Closure::fromCallable([$tokenStorage, 'getToken']));
+        $this->assertEmpty($dispatcher->getListeners());
+
+        $listener(new RequestEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+        $this->assertNotEmpty($dispatcher->getListeners());
+
+        $listener->onKernelResponse(new ResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST, new Response()));
+        $this->assertEmpty($dispatcher->getListeners());
+    }
+
     protected function runSessionOnKernelResponse($newToken, $original = null)
     {
         $session = new Session(new MockArraySessionStorage());

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -168,6 +169,18 @@ class ExceptionListenerTest extends TestCase
 
         $this->assertEquals('Invalid CSRF.', $event->getThrowable()->getMessage());
         $this->assertEquals(403, $event->getThrowable()->getStatusCode());
+    }
+
+    public function testUnregister()
+    {
+        $listener = $this->createExceptionListener();
+        $dispatcher = new EventDispatcher();
+
+        $listener->register($dispatcher);
+        $this->assertNotEmpty($dispatcher->getListeners());
+
+        $listener->unregister($dispatcher);
+        $this->assertEmpty($dispatcher->getListeners());
     }
 
     public function getAccessDeniedExceptionProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46260
| License       | MIT
| Doc PR        | -

Closures should be compared using non-strict comparison to account for the first-class callable syntax.
See https://github.com/php/php-src/blob/9a90bd705483004c2ef408ee9e9bb0902beade3f/Zend/zend_closures.c#L387-L423