### PR TITLE
[WebProfilerBundle] Fix tests about web profiler icons

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Resources/IconTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Resources/IconTest.php
@@ -20,7 +20,7 @@ class IconTest extends TestCase
      */
     public function testIconFileContents($iconFilePath)
     {
-        $this->assertMatchesRegularExpression('~<svg xmlns="http://www.w3.org/2000/svg" width="\d+" height="\d+" viewBox="0 0 \d+ \d+">.*</svg>~s', file_get_contents($iconFilePath), sprintf('The SVG metadata of the %s icon is different than expected (use the same as the other icons).', $iconFilePath));
+        $this->assertMatchesRegularExpression('~<svg xmlns="http://www.w3.org/2000/svg" width="\d+" height="\d+" viewBox="0 0 \d+ \d+"[^>]*+>.*</svg>~s', file_get_contents($iconFilePath), sprintf('The SVG metadata of the %s icon is different than expected (use the same as the other icons).', $iconFilePath));
     }
 
     public function provideIconFilePaths()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The new icon added in #46252 broke tests. This PR fixes them.
