### PR TITLE
[Console] Better required argument check in InputArgument

### DIFF
--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -92,7 +92,7 @@ class InputArgument
      */
     public function setDefault($default = null)
     {
-        if (self::REQUIRED === $this->mode && null !== $default) {
+        if ($this->isRequired() && null !== $default) {
             throw new LogicException('Cannot set a default value except for InputArgument::OPTIONAL mode.');
         }
 

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -88,6 +88,14 @@ class InputArgumentTest extends TestCase
         $argument->setDefault('default');
     }
 
+    public function testSetDefaultWithRequiredArrayArgument()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot set a default value except for InputArgument::OPTIONAL mode.');
+        $argument = new InputArgument('foo', InputArgument::REQUIRED | InputArgument::IS_ARRAY);
+        $argument->setDefault([]);
+    }
+
     public function testSetDefaultWithArrayArgument()
     {
         $this->expectException(\LogicException::class);


### PR DESCRIPTION
Use better check for required arguments in InputArgument when setting default value,
to correctly account for combining multiple mode options

| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

In the current implementation, when combining multiple argument modes, e.g. `REQUIRED` and `IS_ARRAY`, it is possible to also pass a default value, while this should raise an exception.

This fix uses the `isRequired` method (which does a bitwise comparison) instead of a full equality match, to always reject a default value if the argument is required.

Note: I am not sure if this is considered a bugfix or something that could be considered breaking backwards compatibility, as some configurations (e.g. combining the `REQUIRED` and `IS_ARRAY` modes and still passing a default value) that previously worked will break due to this.