### PR TITLE
[DoctrineBridge] add generic service to reset object managers

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ClearObjectManagers.php
+++ b/src/Symfony/Bridge/Doctrine/ClearObjectManagers.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ClearObjectManagers implements ResetInterface
+{
+    public function __construct(private ManagerRegistry $managerRegistry)
+    {
+    }
+
+    public function reset(): void
+    {
+        foreach ($this->managerRegistry->getManagers() as $manager) {
+            $manager->clear();
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 (6.2)
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

I might be off-base here but shouldn't the object manager's be reset between requests? Now that messenger supports resetting services, this could replace the `DoctrineClearEntityManagerWorkerSubscriber`.

Ran into an issue (https://github.com/zenstruck/messenger-test/issues/43) where the em is cleared when processing messenger messages in tests. This was not desired and there is no way to disable. Another solution would be to make `DoctrineClearEntityManagerWorkerSubscriber` _configurable_ in doctrine-bundle (https://github.com/doctrine/DoctrineBundle/pull/1043).

I wanted to first check if there should be a more generic _resetter_.

**TODO:**
- [ ] update changelog
- [ ] deprecate `DoctrineClearEntityManagerWorkerSubscriber`?
- [ ] add doctrine-bundle PR
