### PR TITLE
[Contracts/Service] Add generics to ServiceProviderInterface

### DIFF
--- a/src/Symfony/Contracts/Service/ServiceProviderInterface.php
+++ b/src/Symfony/Contracts/Service/ServiceProviderInterface.php
@@ -18,9 +18,23 @@ use Psr\Container\ContainerInterface;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Mateusz Sip <mateusz.sip@gmail.com>
+ *
+ * @template T of mixed
  */
 interface ServiceProviderInterface extends ContainerInterface
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @return T
+     */
+    public function get(string $id): mixed;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has(string $id): bool;
+
     /**
      * Returns an associative array of service types keyed by the identifiers provided by the current container.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Should allow using `ServiceProviderInterface<MyInterface>` and have autocompletion when doing `$provider->get->...`.

Submitted upstream as https://github.com/php-fig/container/pull/44