### PR TITLE
[DependencyInjection] Fix resolving parameters found in #[Autowire]

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -263,6 +263,7 @@ class AutowirePass extends AbstractRecursivePass
 
                     if (Autowire::class === $attribute->getName()) {
                         $value = $attribute->newInstance()->value;
+                        $value = $this->container->getParameterBag()->resolveValue($value);
 
                         if ($value instanceof Reference && $parameter->allowsNull()) {
                             $value = new Reference($value, ContainerInterface::NULL_ON_INVALID_REFERENCE);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1145,7 +1145,7 @@ class AutowirePassTest extends TestCase
         $this->assertCount(8, $definition->getArguments());
         $this->assertEquals(new Reference('some.id'), $definition->getArgument(0));
         $this->assertEquals(new Expression("parameter('some.parameter')"), $definition->getArgument(1));
-        $this->assertSame('%some.parameter%/bar', $definition->getArgument(2));
+        $this->assertSame('foo/bar', $definition->getArgument(2));
         $this->assertEquals(new Reference('some.id'), $definition->getArgument(3));
         $this->assertEquals(new Expression("parameter('some.parameter')"), $definition->getArgument(4));
         $this->assertSame('bar', $definition->getArgument(5));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As reported by @schodemeiss at https://symfony.com/blog/new-in-symfony-6-1-service-autowiring-attributes#comment-24967