### PR TITLE
[Notifier] Allow symfony/mercure 0.6 in Mercure bridge

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "ext-json": "*",
-        "symfony/mercure": "^0.5.2",
+        "symfony/mercure": "^0.5.2|^0.6",
         "symfony/notifier": "^5.3|^6.0",
         "symfony/service-contracts": "^1.10|^2|^3"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes https://github.com/symfony/symfony/issues/46270
| License       | MIT
| Doc PR        | -

Nothing to do in the root composer.json.