### PR TITLE
[HtmlSanitizer] Fix node renderer handling of self-closing (void) elements

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -237,16 +237,21 @@ class HtmlSanitizerAllTest extends TestCase
             ],
             [
                 '<BODY BACKGROUND="javascript:alert(\'XSS\')">',
-                '<body />',
+                '<body></body>',
             ],
             [
                 '<BGSOUND SRC="javascript:alert(\'XSS\');">',
-                '<bgsound />',
+                '<bgsound></bgsound>',
             ],
             [
                 '<BR SIZE="&{alert(\'XSS\')}">',
                 '<br size="&amp;{alert(&#039;XSS&#039;)}" />',
             ],
+            [
+                '<BR></br>',
+                '<br /><br />',
+            ],
+
             [
                 '<OBJECT TYPE="text/x-scriptlet" DATA="http://xss.rocks/scriptlet.html"></OBJECT>',
                 '',
@@ -445,6 +450,11 @@ class HtmlSanitizerAllTest extends TestCase
                 '<i>Lorem ipsum</i>',
                 '<i>Lorem ipsum</i>',
             ],
+            [
+                '<i></i>',
+                '<i></i>',
+            ],
+
             [
                 '<li>Lorem ipsum</li>',
                 '<li>Lorem ipsum</li>',

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
@@ -20,6 +20,25 @@ use Symfony\Component\HtmlSanitizer\TextSanitizer\StringSanitizer;
  */
 final class Node implements NodeInterface
 {
+    // HTML5 elements which are self-closing
+    private const VOID_ELEMENTS = [
+        'area' => true,
+        'base' => true,
+        'br' => true,
+        'col' => true,
+        'embed' => true,
+        'hr' => true,
+        'img' => true,
+        'input' => true,
+        'keygen' => true,
+        'link' => true,
+        'meta' => true,
+        'param' => true,
+        'source' => true,
+        'track' => true,
+        'wbr' => true,
+    ];
+
     private NodeInterface $parent;
     private string $tagName;
     private array $attributes = [];
@@ -56,7 +75,7 @@ final class Node implements NodeInterface
 
     public function render(): string
     {
-        if (!$this->children) {
+        if (isset(self::VOID_ELEMENTS[$this->tagName])) {
             return '<'.$this->tagName.$this->renderAttributes().' />';
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46258 
| License       | MIT
| Doc PR        | n/a

When sanitizing an HTML string, the node renderer previously interpreted all empty (no children) nodes as being self-closing or void tags. This would result in invalid HTML being rendered in the result. This patch adds the list of valid void HTML5 elements and checks when a no-children node is encountered to see if the tag that is generated should be rendered as self-closing or not.