### PR TITLE
[HttpKernel] Ignore autowiring errors on controllers unless argument's type is an interface

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
@@ -108,8 +108,6 @@ class ServiceValueResolverTest extends TestCase
 
     public function testErrorIsTruncated()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot autowire argument $dummy of "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyController::index()": it references class "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyService" but no such service exists.');
         $container = new ContainerBuilder();
         $container->addCompilerPass(new RegisterControllerArgumentLocatorsPass());
 
@@ -119,7 +117,10 @@ class ServiceValueResolverTest extends TestCase
         $container->compile();
 
         $request = $this->requestWithAttributes(['_controller' => [DummyController::class, 'index']]);
-        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+        $argument = new ArgumentMetadata('dummy', DummyServiceInterface::class, false, false, null);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot autowire argument $dummy of "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyController::index()": it references interface "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyServiceInterface" but no such service exists.');
         $container->get('argument_resolver.service')->resolve($request, $argument)->current();
     }
 
@@ -145,13 +146,17 @@ class ServiceValueResolverTest extends TestCase
     }
 }
 
+interface DummyServiceInterface
+{
+}
+
 class DummyService
 {
 }
 
 class DummyController
 {
-    public function index(DummyService $dummy)
+    public function index(DummyServiceInterface $dummy)
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -141,7 +141,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $this->assertSame(ServiceLocator::class, $locator->getClass());
         $this->assertFalse($locator->isPublic());
 
-        $expected = ['bar' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'bar'))];
+        $expected = ['bar' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'bar'))];
         $this->assertEquals($expected, $locator->getArgument(0));
     }
 
@@ -437,8 +437,8 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $expected = [
             'apiKey' => new ServiceClosureArgument(new Reference('the_api_key')),
-            'service1' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'imageStorage')),
-            'service2' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'service2')),
+            'service1' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'imageStorage')),
+            'service2' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'service2')),
         ];
         $this->assertEquals($expected, $locator->getArgument(0));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While inspecting the dumped container of the demo app, I noticed that it contains so-called "errored" services.
Those come from controllers' arguments: when computing the service locator for the argument resolver, entities found as type hints are obviously not found by the autowiring logic since they're not services.

When this happens, we register an errored service in case this entity-class is fetched from the service argument resolver. The issue is that in order to compute the related error messages (to be maybe thrown at runtime), the autowiring logic needs to inspect all services for alternatives. This is a heavy process that is useless in this situation.

This PR proposes to simply skip computing those error messages when an argument is type-hinted with *a class*. In practice, this means that some error messages might become less informative. To alleviate this drawback, we keep computing those error messages in case an argument references *an interface*.

On the demo app, this removes any errored definitions from the dumped container. This should improve the dumping compilation time a bit (not measurable on the demo app though.)