### PR TITLE
[DoctrineBridge] Treat firstResult === 0 like null

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -50,7 +50,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
      */
     public function getEntitiesByIds($identifier, array $values)
     {
-        if (null !== $this->queryBuilder->getMaxResults() || null !== $this->queryBuilder->getFirstResult()) {
+        if (null !== $this->queryBuilder->getMaxResults() || 0 < (int) $this->queryBuilder->getFirstResult()) {
             // an offset or a limit would apply on results including the where clause with submitted id values
             // that could make invalid choices valid
             $choices = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Doctrine ORM has changed its default value for the `firstResult` property of `Query` and `QueryBuilder` instances from `null` to `0`. Both values should be considered equal: Setting no offset or setting the offset to zero should yield the same results.

This new default however confuses our `ORMQueryBuilderLoader` because it checks for `null` only. This PR intends to fix that.