### PR TITLE
[BrowserKit] Make it easier to use a custom child request in AbstractBrowser

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -356,7 +356,8 @@ abstract class AbstractBrowser
 
         $server['HTTPS'] = 'https' == parse_url($uri, \PHP_URL_SCHEME);
 
-        $this->internalRequest = new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
+        $requestFqcn = $this->getRequestClass();
+        $this->internalRequest = new $requestFqcn($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
 
         $this->request = $this->filterRequest($this->internalRequest);
 
@@ -398,6 +399,14 @@ abstract class AbstractBrowser
         }
 
         return $this->crawler;
+    }
+
+    /**
+     * @return class-string<Request>
+     */
+    protected function getRequestClass(): string
+    {
+        return Request::class;
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -356,8 +356,7 @@ abstract class AbstractBrowser
 
         $server['HTTPS'] = 'https' == parse_url($uri, \PHP_URL_SCHEME);
 
-        $requestFqcn = $this->getRequestClass();
-        $this->internalRequest = new $requestFqcn($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
+        $this->internalRequest = $this->createRequest($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
 
         $this->request = $this->filterRequest($this->internalRequest);
 
@@ -401,12 +400,9 @@ abstract class AbstractBrowser
         return $this->crawler;
     }
 
-    /**
-     * @return class-string<Request>
-     */
-    protected function getRequestClass(): string
+    protected function createRequest(string $uri, string $method, array $parameters, array $files, array $cookies, array $server, string $content = null): Request
     {
-        return Request::class;
+        return new Request($uri, $method, $parameters, $files, $cookies, $server, $content);
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `toArray` method to `Response`
+ * Add protected `getRequestClass` method to `AbstractBrowser`
 
 5.3
 ---

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Add `toArray` method to `Response`
- * Add protected `getRequestClass` method to `AbstractBrowser`
+ * Add protected `createRequest` method to `AbstractBrowser`
 
 5.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1, feature
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | (no needed I suppose?)
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

It should not concern most of the devs as we usually don't extends the `Request` object but if we do, we need to override the `AbstractBrowser#request` method to use a `Request` subclass, I think it could be handy to have a method to create the Request ~~get the fully qualified class name of the request (similarly to what exists in the Kernel with `getContainerClass`)~~ to be able to override it with ease. What do you think?