### PR TITLE
[Serializer] Add option to nullify empty XML tags

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Deprecate supporting denormalization for `AbstractUid` in `UidNormalizer`, use one of `AbstractUid` child class instead
  * Deprecate denormalizing to an abstract class in `UidNormalizer`
  * Add support for `can*()` methods to `ObjectNormalizer`
+ * Add `XmlEncoder::NULLIFY_EMPTY_TAGS` context option
 
 6.0
 ---

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -132,4 +132,12 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     {
         return $this->with(XmlEncoder::VERSION, $version);
     }
+
+    /**
+     * Configures whether to decode empty tags to null.
+     */
+    public function withNullifyEmptyTags(?bool $nullifyEmptyTags): static
+    {
+        return $this->with(XmlEncoder::NULLIFY_EMPTY_TAGS, $nullifyEmptyTags);
+    }
 }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -52,6 +52,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     public const STANDALONE = 'xml_standalone';
     public const TYPE_CAST_ATTRIBUTES = 'xml_type_cast_attributes';
     public const VERSION = 'xml_version';
+    public const NULLIFY_EMPTY_TAGS = 'nullify_empty_tags';
 
     private $defaultContext = [
         self::AS_COLLECTION => false,
@@ -61,6 +62,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::REMOVE_EMPTY_TAGS => false,
         self::ROOT_NODE_NAME => 'response',
         self::TYPE_CAST_ATTRIBUTES => true,
+        self::NULLIFY_EMPTY_TAGS => false,
     ];
 
     public function __construct(array $defaultContext = [])
@@ -244,11 +246,14 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     /**
      * Parse the input DOMNode into an array or a string.
      */
-    private function parseXml(\DOMNode $node, array $context = []): array|string
+    private function parseXml(\DOMNode $node, array $context = []): array|string|null
     {
         $data = $this->parseXmlAttributes($node, $context);
 
         $value = $this->parseXmlValue($node, $context);
+
+        $nullifyEmptyTags = (bool) ($context[self::NULLIFY_EMPTY_TAGS] ?? $this->defaultContext[self::NULLIFY_EMPTY_TAGS]);
+        $value = $nullifyEmptyTags && '' === $value ? null : $value;
 
         if (!\count($data)) {
             return $value;

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
@@ -46,6 +46,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             ->withStandalone($values[XmlEncoder::STANDALONE])
             ->withTypeCastAttributes($values[XmlEncoder::TYPE_CAST_ATTRIBUTES])
             ->withVersion($values[XmlEncoder::VERSION])
+            ->withNullifyEmptyTags($values[XmlEncoder::NULLIFY_EMPTY_TAGS])
             ->toArray();
 
         $this->assertSame($values, $context);
@@ -68,6 +69,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::STANDALONE => false,
             XmlEncoder::TYPE_CAST_ATTRIBUTES => true,
             XmlEncoder::VERSION => '1.0',
+            XmlEncoder::NULLIFY_EMPTY_TAGS => false,
         ]];
 
         yield 'With null values' => [[
@@ -82,6 +84,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::STANDALONE => null,
             XmlEncoder::TYPE_CAST_ATTRIBUTES => null,
             XmlEncoder::VERSION => null,
+            XmlEncoder::NULLIFY_EMPTY_TAGS => null,
         ]];
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -898,6 +898,33 @@ XML;
         $this->assertEquals($expected, $encoder->encode($data, 'xml'));
     }
 
+    public function testDecodeEmptyTags()
+    {
+        $encoder = new XmlEncoder([
+            XmlEncoder::NULLIFY_EMPTY_TAGS => true,
+        ]);
+
+        $source = <<<XML
+<?xml version="1.0"?>
+<document>
+    <empty_node_1 foo="bar"/>
+    <empty_node_2></empty_node_2>
+    <not_empty_node> </not_empty_node>
+</document>
+XML;
+
+        $expected = [
+            'empty_node_1' => [
+                '@foo' => 'bar',
+                '#' => null,
+            ],
+            'empty_node_2' => null,
+            'not_empty_node' => ' ',
+        ];
+
+        $this->assertSame($expected, $encoder->decode($source, 'xml'));
+    }
+
     private function createXmlEncoderWithEnvelopeNormalizer(): XmlEncoder
     {
         $normalizers = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16791

Some web services for some reason use empty XML tags to indicate absence of an element instead of omiting such tags. At the moment empty tags are decoded into empty strings, which, in case of deserialization, get denormalized into empty objects instead of null. This would provide an easy solution. I seem to be not the only one with such a problem:
https://stackoverflow.com/questions/68137366/how-can-i-deserialize-empty-xml-elements-to-null-instead-of-empty-strings-using
https://stackoverflow.com/questions/40488545/jmsserializer-deserializing-empty-datetime-xml-element-into-php-null-object
https://stackoverflow.com/questions/55714538/php-xml-to-array-how-to-get-rid-of-empty-tags
