### PR TITLE
[Console] Suppress unhandled error in some specific use-cases.

### DIFF
--- a/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
+++ b/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
@@ -41,7 +41,7 @@ final class DumpCompletionCommand extends Command
     {
         $fullCommand = $_SERVER['PHP_SELF'];
         $commandName = basename($fullCommand);
-        $fullCommand = realpath($fullCommand) ?: $fullCommand;
+        $fullCommand = @realpath($fullCommand) ?: $fullCommand;
 
         $this
             ->setHelp(<<<EOH


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

If the package is used not in console with open_basedir enabled, since 5.4 it fails with unhandled php error here:
(https://github.com/symfony/console/blob/06974380c667d7d8e3cd0f24bf51f816a71ca6c6/Command/DumpCompletionCommand.php#L44) because of trying to call realpath("/") and, of course, it's not allowed.

It's a very specific use-case for Symfony, but can happen if it's used as dependency, e.g. in Laravel. I've described it in details here: https://github.com/laravel/framework/issues/42171

I think that the best would be just suppress the error in that case.
