### PR TITLE
[HttpClient] "debug" is missing if a request failed to even start

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -171,6 +171,10 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
 
     private function getCurlCommand(array $trace): ?string
     {
+        if (!isset($trace['info']['debug'])) {
+            return null;
+        }
+
         $debug = explode("\n", $trace['info']['debug']);
         $url = $trace['url'];
         $command = ['curl', '--compressed'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | none
| Tickets       | none
| License       | MIT
| Doc PR        | not needed

If you do something really silly - like `$client->request('/foo')` (where no `base_uri` is configured), HttpClient correctly explodes with:

> Invalid URL: scheme is missing in "/SymfonyCasts/vinyl-mixes/main/mixes.json". Did you forget to add "http(s)://"?

However, in this situation, there will be no `debug` key in `$trace`. And so, currently on 6.1, instead of the above error, you see:

> Warning: Undefined array key "debug"

Let me know if any changes are needed.

Thanks!