### PR TITLE
[Serializer] Fix JsonSerializableNormalizer ignores circular reference handler in $context

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
@@ -27,7 +27,7 @@ class JsonSerializableNormalizer extends AbstractNormalizer
     public function normalize($object, $format = null, array $context = [])
     {
         if ($this->isCircularReference($object, $context)) {
-            return $this->handleCircularReference($object);
+            return $this->handleCircularReference($object, $format, $context);
         }
 
         if (!$object instanceof \JsonSerializable) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/JsonSerializableCircularReferenceDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/JsonSerializableCircularReferenceDummy.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Marvin Feldmann <breyndot.echse@gmail.com>
+ */
+class JsonSerializableCircularReferenceDummy implements \JsonSerializable
+{
+    public function jsonSerialize(): array
+    {
+        return [
+            'me' => $this,
+        ];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
@@ -17,14 +17,19 @@ use Symfony\Component\Serializer\Exception\CircularReferenceException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\JsonSerializableCircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\JsonSerializableDummy;
+use Symfony\Component\Serializer\Tests\Normalizer\Features\CircularReferenceTestTrait;
 
 /**
  * @author Fred Cox <mcfedr@gmail.com>
  */
 class JsonSerializableNormalizerTest extends TestCase
 {
+    use CircularReferenceTestTrait;
+
     /**
      * @var JsonSerializableNormalizer
      */
@@ -94,6 +99,19 @@ class JsonSerializableNormalizerTest extends TestCase
         ;
 
         $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));
+    }
+
+    protected function getNormalizerForCircularReference(array $defaultContext): JsonSerializableNormalizer
+    {
+        $normalizer = new JsonSerializableNormalizer(null, null, $defaultContext);
+        new Serializer([$normalizer]);
+
+        return $normalizer;
+    }
+
+    protected function getSelfReferencingModel()
+    {
+        return new JsonSerializableCircularReferenceDummy();
     }
 
     public function testInvalidDataThrowException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

**How to reproduce this bug:**
Normalize an object using the default "_serializer_" service (will use "_serializer.normalizer.object_" normalizer / _ObjectNormalizer_)
```php
$target = new class {
    public function getMe() { return $this; }
};
$targetData = $serializer->normalize($target, null, [
    AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => static fn($v) => is_object($v) ? get_class($v) : gettype($v)
]);

// Normalized data as expected:
// $targetData === ["me" => "class@anonymous\x00 ...."];
```

Normalize an object implementing \JsonSerializable using the default "_serializer_" service (will use "_serializer.normalizer.json_serializable_" normalizer / JsonSerializableNormalizer)
```php
$target = new class implements \JsonSerializable {
    public function jsonSerialize() { return ['me' => $this]; }
};
$targetData = $serializer->normalize($target, null, [
    AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => static fn($v) => is_object($v) ? get_class($v) : gettype($v)
]);

// Same result expected as above, but an exception will be thrown instead:
// Symfony\Component\Serializer\Exception\CircularReferenceException("A circular reference has been detected when serializing the object of class "JsonSerializable@anonymous" (configured limit: 1).")
```