### PR TITLE
[PhpUnitBridge] Fix reading variable after it's reset

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -255,6 +255,15 @@ class SymfonyTestsListenerTrait
             $this->error = null;
         }
 
+        if (!$this->runsInSeparateProcess && -2 < $this->state && ($test instanceof \PHPUnit_Framework_TestCase || $test instanceof TestCase)) {
+            if (\in_array('time-sensitive', $groups, true)) {
+                ClockMock::withClockMock(false);
+            }
+            if (\in_array('dns-sensitive', $groups, true)) {
+                DnsMock::withMockedHosts([]);
+            }
+        }
+
         if ($this->runsInSeparateProcess) {
             $deprecations = file_get_contents($this->runsInSeparateProcess);
             unlink($this->runsInSeparateProcess);
@@ -289,14 +298,6 @@ class SymfonyTestsListenerTrait
 
             $this->expectedDeprecations = $this->gatheredDeprecations = [];
             $this->previousErrorHandler = null;
-        }
-        if (!$this->runsInSeparateProcess && -2 < $this->state && ($test instanceof \PHPUnit_Framework_TestCase || $test instanceof TestCase)) {
-            if (\in_array('time-sensitive', $groups, true)) {
-                ClockMock::withClockMock(false);
-            }
-            if (\in_array('dns-sensitive', $groups, true)) {
-                DnsMock::withMockedHosts([]);
-            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I've noticed that the `$runsInSeparateProcess` property is reset to `false` on line 271:

https://github.com/symfony/symfony/blob/989fea0ade90711ea3ebb196486659de4cbf9fb9/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php#L258-L272

but, is than used on line 293:

https://github.com/symfony/symfony/blob/989fea0ade90711ea3ebb196486659de4cbf9fb9/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php#L293-L300

Since the value is always `false` at this point the condition seems redundant. This doesn't really break anything as far as I can tell, but I don't think it was meant to work like this.
