### PR TITLE
[Stopwatch] Remove non-printable characters from section names

### DIFF
--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -141,6 +141,7 @@ class Section
     public function isEventStarted($name)
     {
         $sanitizedName = $this->sanitizeName($name);
+
         return isset($this->events[$sanitizedName]) && $this->events[$sanitizedName]->isStarted();
     }
 
@@ -175,6 +176,7 @@ class Section
     public function lap($name)
     {
         $sanitizedName = $this->sanitizeName($name);
+
         return $this->stopEvent($sanitizedName)->start();
     }
 
@@ -208,14 +210,14 @@ class Section
     }
 
     /**
-     *
-     * Removes all non printable characters from events
+     * Removes all non printable characters from events.
      *
      * @param string $name
+     *
      * @return string
      */
     private function sanitizeName($name)
     {
-        return preg_replace( '/[^[:print:]]/', '',$name);
+        return preg_replace('/[^[:print:]]/', '', $name);
     }
 }

--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -123,11 +123,12 @@ class Section
      */
     public function startEvent($name, $category)
     {
-        if (!isset($this->events[$name])) {
-            $this->events[$name] = new StopwatchEvent($this->origin ?: microtime(true) * 1000, $category, $this->morePrecision);
+        $sanitizedName = $this->sanitizeName($name);
+        if (!isset($this->events[$sanitizedName])) {
+            $this->events[$sanitizedName] = new StopwatchEvent($this->origin ?: microtime(true) * 1000, $category, $this->morePrecision);
         }
 
-        return $this->events[$name]->start();
+        return $this->events[$sanitizedName]->start();
     }
 
     /**
@@ -139,7 +140,8 @@ class Section
      */
     public function isEventStarted($name)
     {
-        return isset($this->events[$name]) && $this->events[$name]->isStarted();
+        $sanitizedName = $this->sanitizeName($name);
+        return isset($this->events[$sanitizedName]) && $this->events[$sanitizedName]->isStarted();
     }
 
     /**
@@ -153,11 +155,12 @@ class Section
      */
     public function stopEvent($name)
     {
-        if (!isset($this->events[$name])) {
-            throw new \LogicException(sprintf('Event "%s" is not started.', $name));
+        $sanitizedName = $this->sanitizeName($name);
+        if (!isset($this->events[$sanitizedName])) {
+            throw new \LogicException(sprintf('Event "%s" is not started.', $sanitizedName));
         }
 
-        return $this->events[$name]->stop();
+        return $this->events[$sanitizedName]->stop();
     }
 
     /**
@@ -171,7 +174,8 @@ class Section
      */
     public function lap($name)
     {
-        return $this->stopEvent($name)->start();
+        $sanitizedName = $this->sanitizeName($name);
+        return $this->stopEvent($sanitizedName)->start();
     }
 
     /**
@@ -185,11 +189,12 @@ class Section
      */
     public function getEvent($name)
     {
-        if (!isset($this->events[$name])) {
-            throw new \LogicException(sprintf('Event "%s" is not known.', $name));
+        $sanitizedName = $this->sanitizeName($name);
+        if (!isset($this->events[$sanitizedName])) {
+            throw new \LogicException(sprintf('Event "%s" is not known.', $sanitizedName));
         }
 
-        return $this->events[$name];
+        return $this->events[$sanitizedName];
     }
 
     /**
@@ -200,5 +205,17 @@ class Section
     public function getEvents()
     {
         return $this->events;
+    }
+
+    /**
+     *
+     * Removes all non printable characters from events
+     *
+     * @param string $name
+     * @return string
+     */
+    private function sanitizeName($name)
+    {
+        return preg_replace( '/[^[:print:]]/', '',$name);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #46250 
| License       | MIT
| Doc PR        | n/a


Fix Performance tab from breaking when fed with non printable characters by removing them.
(I think in 5.4 `StopwatchEvent` also takes $name as parameter so that also needs to be replaced with `$sanitizedName`)