### PR TITLE
[VarDumper] Show the file that generates the dump in command line

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -34,6 +34,7 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
     protected $decimalPoint = '.';
     protected $indentPad = '  ';
     protected $flags;
+    protected array $backtrace = [];
 
     private string $charset = '';
 
@@ -193,5 +194,10 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
         }
 
         return iconv('CP850', 'UTF-8', $s);
+    }
+
+    public function setBacktrace(array $backtrace): void
+    {
+        $this->backtrace = $backtrace;
     }
 }

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Dumper;
 
 use Symfony\Component\VarDumper\Cloner\Cursor;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
@@ -84,6 +85,17 @@ class CliDumper extends AbstractDumper
         }
 
         $this->displayOptions['fileLinkFormat'] = ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format') ?: 'file://%f#L%l';
+    }
+
+    public function dump(Data $data, $output = null): ?string
+    {
+        if (!empty($this->backtrace)) {
+            $calledIn = $this->backtrace[0];
+            $this->line = sprintf("\033[%sm{$calledIn['file']}:{$calledIn['line']}\033[m", $this->styles['note']);
+            $this->dumpLine(0);
+        }
+
+        return parent::dump($data, $output);
     }
 
     /**

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -978,6 +978,11 @@ EOHTML
 
         return false;
     }
+
+    public function setBacktrace(array $backtrace): void
+    {
+        // Disabled for HtmlDumper
+    }
 }
 
 function esc(string $str)

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -17,7 +17,7 @@ if (!function_exists('dump')) {
      */
     function dump(mixed $var, mixed ...$moreVars): mixed
     {
-        VarDumper::dump($var);
+        VarDumper::dump($var, debug_backtrace());
 
         foreach ($moreVars as $v) {
             VarDumper::dump($v);

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -37,10 +37,10 @@ class VarDumper
      */
     private static $handler;
 
-    public static function dump(mixed $var)
+    public static function dump(mixed $var, array $backtrace = null)
     {
         if (null === self::$handler) {
-            self::register();
+            self::register($backtrace ?? []);
         }
 
         return (self::$handler)($var);
@@ -60,7 +60,7 @@ class VarDumper
         return $prevHandler;
     }
 
-    private static function register(): void
+    private static function register(array $backtrace): void
     {
         $cloner = new VarCloner();
         $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
@@ -82,6 +82,8 @@ class VarDumper
             default:
                 $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) ? new CliDumper() : new HtmlDumper();
         }
+
+        $dumper->setBacktrace($backtrace);
 
         if (!$dumper instanceof ServerDumper) {
             $dumper = new ContextualizedDumper($dumper, [new SourceContextProvider()]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #46148 
| License       | MIT
| Doc PR        | 

When `dump()` is called from a Command line context, show the position (file and line) where it is done before showing the content of the data we wanted to dump.
This is especially useful when there are a lot of dumps in the code.

| Code | Result |
| --- | --- |
| ![Screenshot: a simple Command that dumps "Hello, World!" and returns 0](https://user-images.githubusercontent.com/7600265/167638184-57bf1d78-dc7b-4112-ab64-5385045a5142.png) | ![Screenshot: execution result of the command, showing the "Hello, World" dumped message along with the position of the dump that provoked it](https://user-images.githubusercontent.com/7600265/167638636-f443d410-0f0d-4031-8897-81a8a578943f.png)


Still a work in progress, I'd like a first review to know if I'm on a good path or not, since the VarDumper's code is not the most obvious to understand.
Also, I'd like some help to know how exactly I could test this.

Thanks :)

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
