### PR TITLE
[Security] Fix division by zero

### DIFF
--- a/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
@@ -134,6 +134,9 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
             return $value;
         }
         $key = base64_decode(strtr($parts[1], '-_', '+/'));
+        if ('' === $key || false === $key) {
+            return $value;
+        }
         $value = base64_decode(strtr($parts[2], '-_', '+/'));
 
         return $this->xor($value, $key);

--- a/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
@@ -193,6 +193,26 @@ class CsrfTokenManagerTest extends TestCase
         $this->assertFalse($manager->isTokenValid(new CsrfToken('token_id', 'FOOBAR')));
     }
 
+    public function testTokenShouldNotTriggerDivisionByZero()
+    {
+        [$generator, $storage] = $this->getGeneratorAndStorage();
+        $manager = new CsrfTokenManager($generator, $storage);
+
+        // Scenario: the token that was returned is abc.def.ghi, and gets modified in the browser to abc..ghi
+
+        $storage->expects($this->once())
+            ->method('hasToken')
+            ->with('https-token_id')
+            ->willReturn(true);
+
+        $storage->expects($this->once())
+            ->method('getToken')
+            ->with('https-token_id')
+            ->willReturn('def');
+
+        $this->assertFalse($manager->isTokenValid(new CsrfToken('token_id', 'abc..ghi')));
+    }
+
     /**
      * @dataProvider getManagerGeneratorAndStorage
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Given: CSRF token abc.def.ghi was returned
When: I change the value of this token in my browser to abc..ghi
Then: the key becomes '' and the xor that is called in denormalize results in a division by zero and http 500
