### PR TITLE
[MonologBridge] Fix LevelName being removed in Monolog 3.0

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
@@ -17,7 +17,6 @@ use Monolog\Handler\AbstractHandler;
 use Monolog\Handler\FormattableHandlerTrait;
 use Monolog\Handler\ProcessableHandlerTrait;
 use Monolog\Level;
-use Monolog\LevelName;
 use Monolog\Logger;
 use Monolog\LogRecord;
 use Symfony\Component\HttpClient\HttpClient;
@@ -61,7 +60,7 @@ class ElasticsearchLogstashHandler extends AbstractHandler
      */
     private \SplObjectStorage $responses;
 
-    public function __construct(string $endpoint = 'http://127.0.0.1:9200', string $index = 'monolog', HttpClientInterface $client = null, string|int|Level|LevelName $level = Logger::DEBUG, bool $bubble = true)
+    public function __construct(string $endpoint = 'http://127.0.0.1:9200', string $index = 'monolog', HttpClientInterface $client = null, string|int|Level $level = Logger::DEBUG, bool $bubble = true)
     {
         if (!interface_exists(HttpClientInterface::class)) {
             throw new \LogicException(sprintf('The "%s" handler needs an HTTP client. Try running "composer require symfony/http-client".', __CLASS__));

--- a/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
@@ -16,7 +16,6 @@ use Monolog\Formatter\HtmlFormatter;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Level;
-use Monolog\LevelName;
 use Monolog\Logger;
 use Monolog\LogRecord;
 use Symfony\Component\Mailer\MailerInterface;
@@ -34,7 +33,7 @@ class MailerHandler extends AbstractProcessingHandler
     private MailerInterface $mailer;
     private \Closure|Email $messageTemplate;
 
-    public function __construct(MailerInterface $mailer, callable|Email $messageTemplate, string|int|Level|LevelName $level = Logger::DEBUG, bool $bubble = true)
+    public function __construct(MailerInterface $mailer, callable|Email $messageTemplate, string|int|Level $level = Logger::DEBUG, bool $bubble = true)
     {
         parent::__construct($level, $bubble);
 

--- a/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Handler;
 
 use Monolog\Handler\AbstractHandler;
+use Monolog\Level;
 use Monolog\Logger;
 use Monolog\LogRecord;
 use Symfony\Component\Notifier\Notification\Notification;
@@ -31,7 +32,7 @@ class NotifierHandler extends AbstractHandler
 
     private NotifierInterface $notifier;
 
-    public function __construct(NotifierInterface $notifier, string|int|Level|LevelName $level = Logger::ERROR, bool $bubble = true)
+    public function __construct(NotifierInterface $notifier, string|int|Level $level = Logger::ERROR, bool $bubble = true)
     {
         $this->notifier = $notifier;
 

--- a/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
@@ -15,7 +15,6 @@ use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Handler\FormattableHandlerTrait;
 use Monolog\Level;
-use Monolog\LevelName;
 use Monolog\Logger;
 use Monolog\LogRecord;
 use Symfony\Bridge\Monolog\Formatter\VarDumperFormatter;
@@ -77,7 +76,7 @@ trait ServerLogHandlerTrait
      */
     private $socket;
 
-    public function __construct(string $host, string|int|Level|LevelName $level = Logger::DEBUG, bool $bubble = true, array $context = [])
+    public function __construct(string $host, string|int|Level $level = Logger::DEBUG, bool $bubble = true, array $context = [])
     {
         parent::__construct($level, $bubble);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

A couple last fixes as follow-up to #46153 now that the Monolog 3.0.0 release is out.
