### PR TITLE
[Mailer] `max_per_second` option configurable via DSN

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -117,6 +117,14 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport->setMaxPerSecond(2.0);
+
+        yield [
+            new Dsn('smtps', 'example.com', '', '', 465, ['max_per_second' => '2']),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
         $transport->setRestartThreshold(10, 1);
 
         yield [

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -52,6 +52,10 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
             $transport->setLocalDomain($localDomain);
         }
 
+        if (null !== ($maxPerSecond = $dsn->getOption('max_per_second'))) {
+            $transport->setMaxPerSecond((float) $maxPerSecond);
+        }
+
         if (null !== ($restartThreshold = $dsn->getOption('restart_threshold'))) {
             $transport->setRestartThreshold((int) $restartThreshold, (int) $dsn->getOption('restart_threshold_sleep', 0));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#16800

This option is available since 5.1, but it was impossible to configure it by dsn.