### PR TITLE
[Security] Allow disabling redirect on logout

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `allowed_time_drift` option to the OIDC token handler configuration
+ * Allow disabling the redirection on successful logout by passing `null` to the `target` option
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -453,9 +453,11 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 'logout_path' => $firewall['logout']['path'],
             ]);
 
-            $container->setDefinition('security.logout.listener.default.'.$id, new ChildDefinition('security.logout.listener.default'))
-                ->replaceArgument(1, $firewall['logout']['target'])
-                ->addTag('kernel.event_subscriber', ['dispatcher' => $firewallEventDispatcherId]);
+            if (null !== $firewall['logout']['target']) {
+                $container->setDefinition('security.logout.listener.default.'.$id, new ChildDefinition('security.logout.listener.default'))
+                    ->replaceArgument(1, $firewall['logout']['target'])
+                    ->addTag('kernel.event_subscriber', ['dispatcher' => $firewallEventDispatcherId]);
+            }
 
             // add CSRF provider
             if ($firewall['logout']['enable_csrf']) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -932,6 +932,25 @@ class SecurityExtensionTest extends TestCase
         $this->assertContains('custom_firewall_listener_id', $firewallListeners);
     }
 
+    public function testDisableLogoutTarget()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'main' => [
+                    'logout' => [
+                        'target' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertFalse($container->hasDefinition('security.logout.listener.default.main'));
+    }
+
     public function testClearSiteDataLogoutListenerEnabled()
     {
         $container = $this->getRawContainer();

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/password-hasher": "^7.4|^8.0",
         "symfony/security-core": "^7.4|^8.0",
         "symfony/security-csrf": "^7.4|^8.0",
-        "symfony/security-http": "^8.1",
+        "symfony/security-http": "^8.2",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -79,13 +79,11 @@ class LogoutListener extends AbstractListener
         $logoutEvent = new LogoutEvent($request, $this->tokenStorage->getToken());
         $this->eventDispatcher->dispatch($logoutEvent);
 
-        if (!$response = $logoutEvent->getResponse()) {
-            throw new \RuntimeException('No logout listener set the Response, make sure at least the DefaultLogoutListener is registered.');
-        }
-
         $this->tokenStorage->setToken(null);
 
-        $event->setResponse($response);
+        if ($response = $logoutEvent->getResponse()) {
+            $event->setResponse($response);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -126,13 +126,14 @@ class LogoutListenerTest extends TestCase
 
     public function testNoResponseSet()
     {
-        $listener = $this->getListener();
+        $listener = new LogoutListener($this->tokenStorage, new HttpUtils(), $this->eventDispatcher);
         $request = Request::create('/logout');
-
-        $this->expectException(\RuntimeException::class);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $this->assertTrue($listener->supports($request));
-        $listener->authenticate(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener->authenticate($event);
+
+        $this->assertNull($event->getResponse());
     }
 
     #[DataProvider('provideInvalidCsrfTokens')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature   | yes
| Deprecations  | no
| License       | MIT
| Doc PR        |

When using JSON authentication, customizing the success response can be done easily in the corresponding controller, but customizing the logout success is more tiresome and requires to create a listener for it (while still requiring to create a route for it to work).

This PR propose to add the possibility to disable the redirect on successful logout and let the request fallback to the defined route in this case.

This allow customizing both login and logout response in the same place like this:
```yaml
security:
    firewalls:
        main:
            json_login:
                check_path: auth_login
            logout:
                path: auth_logout
                target: ~
```

```php
class AuthController extends AbstractController
{
    #[Route("/login", name: "auth_login")]
    public function login(): Response
    {
        return $this->json($this->getUser());
    }

    #[Route("/logout", name: "auth_logout")]
    public function logout(): Response
    {
        return $this->json(null);
    }
}
```

It means I had to remove the Exception in case no logout listener set a response but I don't think it should be considered a BC break since it's an error case that is removed and the corresponding exception was just the base `RuntimeException` and thus wasn't specifically catchable.

The only downside is that other logout listeners can't modify the response anymore because it doesn't exists in the event but since this is an opt-in feature I don't think it's a problem.