### PR TITLE
Update sponsors of components v6.1

### DIFF
--- a/src/Symfony/Component/Console/README.md
+++ b/src/Symfony/Component/Console/README.md
@@ -4,18 +4,6 @@ Console Component
 The Console component eases the creation of beautiful and testable command line
 interfaces.
 
-Sponsor
--------
-
-The Console component for Symfony 5.4/6.0 is [backed][1] by [Les-Tilleuls.coop][2].
-
-Les-Tilleuls.coop is a team of 50+ Symfony experts who can help you design, develop and
-fix your projects. We provide a wide range of professional services including development,
-consulting, coaching, training and audits. We also are highly skilled in JS, Go and DevOps.
-We are a worker cooperative!
-
-Help Symfony by [sponsoring][3] its development!
-
 Resources
 ---------
 
@@ -30,7 +18,3 @@ Credits
 
 `Resources/bin/hiddeninput.exe` is a third party binary provided within this
 component. Find sources and license at https://github.com/Seldaek/hidden-input.
-
-[1]: https://symfony.com/backers
-[2]: https://les-tilleuls.coop
-[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/HttpClient/README.md
+++ b/src/Symfony/Component/HttpClient/README.md
@@ -3,16 +3,6 @@ HttpClient component
 
 The HttpClient component provides powerful methods to fetch HTTP resources synchronously or asynchronously.
 
-Sponsor
--------
-
-The Httpclient component for Symfony 5.4/6.0 is [backed][1] by [Klaxoon][2].
-
-Klaxoon is a platform that empowers organizations to run effective and
-productive workshops easily in a hybrid environment. Anytime, Anywhere.
-
-Help Symfony by [sponsoring][3] its development!
-
 Resources
 ---------
 
@@ -21,7 +11,3 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
-
-[1]: https://symfony.com/backers
-[2]: https://klaxoon.com
-[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/HttpFoundation/README.md
+++ b/src/Symfony/Component/HttpFoundation/README.md
@@ -4,16 +4,6 @@ HttpFoundation Component
 The HttpFoundation component defines an object-oriented layer for the HTTP
 specification.
 
-Sponsor
--------
-
-The HttpFoundation component for Symfony 5.4/6.0 is [backed][1] by [Laravel][2].
-
-Laravel is a PHP web development framework that is passionate about maximum developer
-happiness. Laravel is built using a variety of bespoke and Symfony based components.
-
-Help Symfony by [sponsoring][3] its development!
-
 Resources
 ---------
 
@@ -22,7 +12,3 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
-
-[1]: https://symfony.com/backers
-[2]: https://laravel.com/
-[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/HttpKernel/README.md
+++ b/src/Symfony/Component/HttpKernel/README.md
@@ -5,18 +5,6 @@ The HttpKernel component provides a structured process for converting a Request
 into a Response by making use of the EventDispatcher component. It's flexible
 enough to create full-stack frameworks, micro-frameworks or advanced CMS systems like Drupal.
 
-Sponsor
--------
-
-The HttpKernel component for Symfony 5.4/6.0 is [backed][1] by [Les-Tilleuls.coop][2].
-
-Les-Tilleuls.coop is a team of 50+ Symfony experts who can help you design, develop and
-fix your projects. We provide a wide range of professional services including development,
-consulting, coaching, training and audits. We also are highly skilled in JS, Go and DevOps.
-We are a worker cooperative!
-
-Help Symfony by [sponsoring][3] its development!
-
 Resources
 ---------
 
@@ -25,7 +13,3 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
-
-[1]: https://symfony.com/backers
-[2]: https://les-tilleuls.coop
-[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Messenger/README.md
+++ b/src/Symfony/Component/Messenger/README.md
@@ -7,7 +7,7 @@ other applications or via message queues.
 Sponsor
 -------
 
-The Messenger component for Symfony 5.4/6.0 is [backed][1] by [SensioLabs][2].
+The Messenger component for Symfony 6.1 is [backed][1] by [SensioLabs][2].
 
 As the creator of Symfony, SensioLabs supports companies using Symfony, with an
 offering encompassing consultancy, expertise, services, training, and technical

--- a/src/Symfony/Component/Notifier/README.md
+++ b/src/Symfony/Component/Notifier/README.md
@@ -6,7 +6,7 @@ The Notifier component sends notifications via one or more channels (email, SMS,
 Sponsor
 -------
 
-The Notifier component for Symfony 5.4/6.0 is [backed][1] by [Mercure.rocks][2].
+The Notifier component for Symfony 6.1 is [backed][1] by [Mercure.rocks][2].
 
 Create real-time experiences in minutes! Mercure.rocks provides a realtime API service
 that is tightly integrated with Symfony: create UIs that update in live with UX Turbo,

--- a/src/Symfony/Component/Process/README.md
+++ b/src/Symfony/Component/Process/README.md
@@ -6,7 +6,7 @@ The Process component executes commands in sub-processes.
 Sponsor
 -------
 
-The Process component for Symfony 5.4/6.0 is [backed][1] by [SensioLabs][2].
+The Process component for Symfony 6.1 is [backed][1] by [SensioLabs][2].
 
 As the creator of Symfony, SensioLabs supports companies using Symfony, with an
 offering encompassing consultancy, expertise, services, training, and technical

--- a/src/Symfony/Component/Security/Core/README.md
+++ b/src/Symfony/Component/Security/Core/README.md
@@ -41,7 +41,7 @@ if (!$accessDecisionManager->decide($token, ['ROLE_ADMIN'])) {
 Sponsor
 -------
 
-The Security component for Symfony 5.4/6.0 is [backed][1] by [SymfonyCasts][2].
+The Security component for Symfony 6.1 is [backed][1] by [SymfonyCasts][2].
 
 Learn Symfony faster by watching real projects being built and actively coding
 along with them. SymfonyCasts bridges that learning gap, bringing you video

--- a/src/Symfony/Component/Security/Csrf/README.md
+++ b/src/Symfony/Component/Security/Csrf/README.md
@@ -7,7 +7,7 @@ The Security CSRF (cross-site request forgery) component provides a class
 Sponsor
 -------
 
-The Security component for Symfony 5.4/6.0 is [backed][1] by [SymfonyCasts][2].
+The Security component for Symfony 6.1 is [backed][1] by [SymfonyCasts][2].
 
 Learn Symfony faster by watching real projects being built and actively coding
 along with them. SymfonyCasts bridges that learning gap, bringing you video

--- a/src/Symfony/Component/Security/Http/README.md
+++ b/src/Symfony/Component/Security/Http/README.md
@@ -15,7 +15,7 @@ $ composer require symfony/security-http
 Sponsor
 -------
 
-The Security component for Symfony 5.4/6.0 is [backed][1] by [SymfonyCasts][2].
+The Security component for Symfony 6.1 is [backed][1] by [SymfonyCasts][2].
 
 Learn Symfony faster by watching real projects being built and actively coding
 along with them. SymfonyCasts bridges that learning gap, bringing you video

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/README.md
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/README.md
@@ -23,7 +23,7 @@ where:
 Sponsor
 -------
 
-This bridge for Symfony 5.4/6.0 is [backed][1] by [Crowdin][2].
+This bridge for Symfony 6.1 is [backed][1] by [Crowdin][2].
 
 Crowdin is a cloud-based localization management software helping teams to go global and stay agile.
 

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/README.md
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/README.md
@@ -19,16 +19,6 @@ Go to the Project Settings in Lokalise to find the Project ID.
 
 [Generate an API key on Lokalise](https://app.lokalise.com/api2docs/curl/#resource-authentication)
 
-Sponsor
--------
-
-This bridge for Symfony 5.4/6.0 is [backed][1] by [Lokalise][2].
-
-Lokalise is a continuous localization and translation management platform. It integrates
-into your development workflow so you can ship localized products, faster.
-
-Help Symfony by [sponsoring][3] its development!
-
 Resources
 ---------
 
@@ -36,7 +26,3 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
-
-[1]: https://symfony.com/backers
-[2]: https://lokalise.com
-[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Translation/README.md
+++ b/src/Symfony/Component/Translation/README.md
@@ -26,12 +26,11 @@ echo $translator->trans('Hello World!'); // outputs « Bonjour ! »
 Sponsor
 -------
 
-The Translation component for Symfony 5.4/6.0 is [backed][1] by:
+The Translation component for Symfony 6.1 is [backed][1] by:
 
  * [Crowdin][2], a cloud-based localization management software helping teams to go global and stay agile.
- * [Lokalise][3], a continuous localization and translation management platform that integrates into your development workflow so you can ship localized products, faster.
 
-Help Symfony by [sponsoring][4] its development!
+Help Symfony by [sponsoring][3] its development!
 
 Resources
 ---------
@@ -44,5 +43,4 @@ Resources
 
 [1]: https://symfony.com/backers
 [2]: https://crowdin.com
-[3]: https://lokalise.com
-[4]: https://symfony.com/sponsor
+[3]: https://symfony.com/sponsor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Many thanks to the (re)new(ed) sponsors for 6.1!
- SensioLabs for `Process` and `Messenger` :love_letter: /cc @Jean-Beru @hadriengem
- SymfonyCasts for `Security/*` :love_you_gesture: /cc @weaverryan
- Crowdin for the Crowdin bridge of the `Translation` component :earth_africa: /cc @andrii-bodnar
- Mercure.rocks for the `Notifier` component :cupid: /cc @dunglas 
- Endava for the `test-pack` pack :heavy_check_mark: /cc @Endava

Many thanks for having sponsored 5.4/6.0 to:
- Les-Tilleuls.coop for `Console` and `HttpKernel` :green_heart: /cc @dunglas @GregoireHebert 
- Klaxoon for `HttpClient` :spider_web: /cc @f2r 
- Laravel for `HttpFoundation` :hugs: /cc @taylorotwell 
- Lokalise for the Lokalise bridge of the `Translation` component :star: /cc @beinarovic @nickustinov

To anyone reading, please reach me [via this form](https://symfony.com/support?product=SFB#products) to add your company (back) in the list for 6.1 or later!
