### PR TITLE
[Ldap] Fix LDAP connection options

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -29,6 +29,12 @@ class Connection extends AbstractConnection
     private const LDAP_INVALID_CREDENTIALS = 0x31;
     private const LDAP_TIMEOUT = 0x55;
     private const LDAP_ALREADY_EXISTS = 0x44;
+    private const PRECONNECT_OPTIONS = [
+        ConnectionOptions::DEBUG_LEVEL,
+        ConnectionOptions::X_TLS_CACERTDIR,
+        ConnectionOptions::X_TLS_CACERTFILE,
+        ConnectionOptions::X_TLS_REQUIRE_CERT,
+    ];
 
     /** @var bool */
     private $bound = false;
@@ -147,10 +153,18 @@ class Connection extends AbstractConnection
             return;
         }
 
+        foreach ($this->config['options'] as $name => $value) {
+            if (\in_array(ConnectionOptions::getOption($name), self::PRECONNECT_OPTIONS, true)) {
+                $this->setOption($name, $value);
+            }
+        }
+
         $this->connection = ldap_connect($this->config['connection_string']);
 
         foreach ($this->config['options'] as $name => $value) {
-            $this->setOption($name, $value);
+            if (!\in_array(ConnectionOptions::getOption($name), self::PRECONNECT_OPTIONS, true)) {
+                $this->setOption($name, $value);
+            }
         }
 
         if (false === $this->connection) {

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/ConnectionOptions.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/ConnectionOptions.php
@@ -40,6 +40,7 @@ final class ConnectionOptions
     public const DEBUG_LEVEL = 0x5001;
     public const TIMEOUT = 0x5002;
     public const NETWORK_TIMEOUT = 0x5005;
+    public const X_TLS_CACERTFILE = 0x6002;
     public const X_TLS_CACERTDIR = 0x6003;
     public const X_TLS_CERTFILE = 0x6004;
     public const X_TLS_CRL_ALL = 0x02;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

This PR adds support for the [`LDAP_OPT_X_TLS_CACERTFILE`](https://www.php.net/manual/de/ldap.constants.php#constant.ldap-opt-x-tls-cacertfile) option in order to specify a CA file which should be used. It is available since the same PHP version [as the other options](https://www.php.net/manual/de/function.ldap-set-option.php) and may just have been forgotten.

Furthermore the connection options need to be applied at different stages in order to be effective.

Connection options are tagged to be preconnect-options and are executed before `ldap_connect`, all other options continue to be applied between `ldap_connect` and `ldap_bind`.

Be aware that [there is no LDAP documentation](https://www.openldap.org/software/man.cgi?query=ldap_get_option&apropos=0&sektion=0&manpath=OpenLDAP+2.6-Release&arch=default&format=html) about which option is global and thus not requiring a connection and which needs one.

The preconnect options from this PR come from trial-and-error testing and mailing list entries at OpenLDAP.

Maybe also relevant:
- https://bugs.php.net/bug.php?id=73558
- https://bugs.php.net/bug.php?id=78029