### PR TITLE
[HttpKernel] Allow ErrorHandler ^5.0 to be used in HttpKernel 4.4

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "symfony/error-handler": "^4.4",
+        "symfony/error-handler": "^4.4|^5.0",
         "symfony/event-dispatcher": "^4.4",
         "symfony/http-client-contracts": "^1.1|^2",
         "symfony/http-foundation": "^4.4.30|^5.3.7",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I wonder what prevents us from allowing HttpKernel ^4.4 to be used with ErrorHandler ^5.0?

ErrorHandler 5.4 (IIRC) adds the incredibly helpful feature ❤️‍🔥 to emit deprecation notices for missing return type hints. This is valuable when trying to migrate larger codebases to make use of type hints.

Symfony 4.4 is the current LTS, and this PR would allow people to switch to ErrorHandler 5.4 while the rest of the code can still use Symfony 4.4 components.
