### PR TITLE
[Config] Allow scalar configuration in PHP Configuration

### DIFF
--- a/src/Symfony/Component/Config/Builder/ClassBuilder.php
+++ b/src/Symfony/Component/Config/Builder/ClassBuilder.php
@@ -68,7 +68,7 @@ class ClassBuilder
             }
             $require .= sprintf('require_once __DIR__.\DIRECTORY_SEPARATOR.\'%s\';', implode('\'.\DIRECTORY_SEPARATOR.\'', $path))."\n";
         }
-        $use = '';
+        $use = $require ? "\n" : '';
         foreach (array_keys($this->use) as $statement) {
             $use .= sprintf('use %s;', $statement)."\n";
         }
@@ -81,7 +81,7 @@ class ClassBuilder
         foreach ($this->methods as $method) {
             $lines = explode("\n", $method->getContent());
             foreach ($lines as $line) {
-                $body .= '    '.$line."\n";
+                $body .= ($line ? '    '.$line : '')."\n";
             }
         }
 
@@ -89,9 +89,7 @@ class ClassBuilder
 
 namespace NAMESPACE;
 
-REQUIRE
-USE
-
+REQUIREUSE
 /**
  * This class is automatically generated to help in creating a config.
  */

--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -435,8 +435,7 @@ public function NAME(): array
 
         $class->addMethod('__construct', '
 public function __construct(array $value = [])
-{
-'.$body.'
+{'.$body.'
 }');
     }
 

--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -136,14 +136,39 @@ public function NAME(): string
         $class->addRequire($childClass);
         $this->classes[] = $childClass;
 
-        $property = $class->addProperty($node->getName(), $childClass->getFqcn());
-        $body = '
+        $hasNormalizationClosures = $this->hasNormalizationClosures($node);
+        $property = $class->addProperty(
+            $node->getName(),
+            $this->getType($childClass->getFqcn(), $hasNormalizationClosures)
+        );
+        $body = $hasNormalizationClosures ? '
+/**
+ * @return CLASS|$this
+ */
+public function NAME($value = [])
+{
+    if (!\is_array($value)) {
+        $this->_usedProperties[\'PROPERTY\'] = true;
+        $this->PROPERTY = $value;
+
+        return $this;
+    }
+
+    if (!$this->PROPERTY instanceof CLASS) {
+        $this->_usedProperties[\'PROPERTY\'] = true;
+        $this->PROPERTY = new CLASS($value);
+    } elseif (0 < \func_num_args()) {
+        throw new InvalidConfigurationException(\'The node created by "NAME()" has already been initialized. You cannot pass values the second time you call NAME().\');
+    }
+
+    return $this->PROPERTY;
+}' : '
 public function NAME(array $value = []): CLASS
 {
     if (null === $this->PROPERTY) {
         $this->_usedProperties[\'PROPERTY\'] = true;
         $this->PROPERTY = new CLASS($value);
-    } elseif ([] !== $value) {
+    } elseif (0 < \func_num_args()) {
         throw new InvalidConfigurationException(\'The node created by "NAME()" has already been initialized. You cannot pass values the second time you call NAME().\');
     }
 
@@ -227,10 +252,29 @@ public function NAME(string $VAR, $VALUE): self
         }
         $class->addRequire($childClass);
         $this->classes[] = $childClass;
-        $property = $class->addProperty($node->getName(), $childClass->getFqcn().'[]');
+
+        $hasNormalizationClosures = $this->hasNormalizationClosures($node) || $this->hasNormalizationClosures($prototype);
+        $property = $class->addProperty(
+            $node->getName(),
+            $this->getType($childClass->getFqcn().'[]', $hasNormalizationClosures)
+        );
 
         if (null === $key = $node->getKeyAttribute()) {
-            $body = '
+            $body = $hasNormalizationClosures ? '
+/**
+ * @return CLASS|$this
+ */
+public function NAME($value = [])
+{
+    $this->_usedProperties[\'PROPERTY\'] = true;
+    if (!\is_array($value)) {
+        $this->PROPERTY[] = $value;
+
+        return $this;
+    }
+
+    return $this->PROPERTY[] = new CLASS($value);
+}' : '
 public function NAME(array $value = []): CLASS
 {
     $this->_usedProperties[\'PROPERTY\'] = true;
@@ -239,19 +283,38 @@ public function NAME(array $value = []): CLASS
 }';
             $class->addMethod($methodName, $body, ['PROPERTY' => $property->getName(), 'CLASS' => $childClass->getFqcn()]);
         } else {
-            $body = '
+            $body = $hasNormalizationClosures ? '
+/**
+ * @return CLASS|$this
+ */
+public function NAME(string $VAR, $VALUE = [])
+{
+    if (!\is_array($VALUE)) {
+        $this->_usedProperties[\'PROPERTY\'] = true;
+        $this->PROPERTY[$VAR] = $VALUE;
+
+        return $this;
+    }
+
+    if (!isset($this->PROPERTY[$VAR]) || !$this->PROPERTY[$VAR] instanceof CLASS) {
+        $this->_usedProperties[\'PROPERTY\'] = true;
+        $this->PROPERTY[$VAR] = new CLASS($VALUE);
+    } elseif (1 < \func_num_args()) {
+        throw new InvalidConfigurationException(\'The node created by "NAME()" has already been initialized. You cannot pass values the second time you call NAME().\');
+    }
+
+    return $this->PROPERTY[$VAR];
+}' : '
 public function NAME(string $VAR, array $VALUE = []): CLASS
 {
     if (!isset($this->PROPERTY[$VAR])) {
         $this->_usedProperties[\'PROPERTY\'] = true;
-
-        return $this->PROPERTY[$VAR] = new CLASS($VALUE);
-    }
-    if ([] === $VALUE) {
-        return $this->PROPERTY[$VAR];
+        $this->PROPERTY[$VAR] = new CLASS($VALUE);
+    } elseif (1 < \func_num_args()) {
+        throw new InvalidConfigurationException(\'The node created by "NAME()" has already been initialized. You cannot pass values the second time you call NAME().\');
     }
 
-    throw new InvalidConfigurationException(\'The node created by "NAME()" has already been initialized. You cannot pass values the second time you call NAME().\');
+    return $this->PROPERTY[$VAR];
 }';
             $class->addUse(InvalidConfigurationException::class);
             $class->addMethod($methodName, $body, ['PROPERTY' => $property->getName(), 'CLASS' => $childClass->getFqcn(), 'VAR' => '' === $key ? 'key' : $key, 'VALUE' => 'value' === $key ? 'data' : 'value']);
@@ -375,16 +438,22 @@ public function NAME($value): self
             $code = '$this->PROPERTY';
             if (null !== $p->getType()) {
                 if ($p->isArray()) {
-                    $code = 'array_map(function ($v) { return $v->toArray(); }, $this->PROPERTY)';
+                    $code = $p->areScalarsAllowed()
+                        ? 'array_map(function ($v) { return $v instanceof CLASS ? $v->toArray() : $v; }, $this->PROPERTY)'
+                        : 'array_map(function ($v) { return $v->toArray(); }, $this->PROPERTY)'
+                    ;
                 } else {
-                    $code = '$this->PROPERTY->toArray()';
+                    $code = $p->areScalarsAllowed()
+                        ? '$this->PROPERTY instanceof CLASS ? $this->PROPERTY->toArray() : $this->PROPERTY'
+                        : '$this->PROPERTY->toArray()'
+                    ;
                 }
             }
 
             $body .= strtr('
     if (isset($this->_usedProperties[\'PROPERTY\'])) {
         $output[\'ORG_NAME\'] = '.$code.';
-    }', ['PROPERTY' => $p->getName(), 'ORG_NAME' => $p->getOriginalName()]);
+    }', ['PROPERTY' => $p->getName(), 'ORG_NAME' => $p->getOriginalName(), 'CLASS' => $p->getType()]);
         }
 
         $extraKeys = $class->shouldAllowExtraKeys() ? ' + $this->_extraKeys' : '';
@@ -405,9 +474,15 @@ public function NAME(): array
             $code = '$value[\'ORG_NAME\']';
             if (null !== $p->getType()) {
                 if ($p->isArray()) {
-                    $code = 'array_map(function ($v) { return new '.$p->getType().'($v); }, $value[\'ORG_NAME\'])';
+                    $code = $p->areScalarsAllowed()
+                        ? 'array_map(function ($v) { return \is_array($v) ? new '.$p->getType().'($v) : $v; }, $value[\'ORG_NAME\'])'
+                        : 'array_map(function ($v) { return new '.$p->getType().'($v); }, $value[\'ORG_NAME\'])'
+                    ;
                 } else {
-                    $code = 'new '.$p->getType().'($value[\'ORG_NAME\'])';
+                    $code = $p->areScalarsAllowed()
+                        ? '\is_array($value[\'ORG_NAME\']) ? new '.$p->getType().'($value[\'ORG_NAME\']) : $value[\'ORG_NAME\']'
+                        : 'new '.$p->getType().'($value[\'ORG_NAME\'])'
+                    ;
                 }
             }
 
@@ -465,5 +540,22 @@ public function NAME(string $key, $value): self
     private function getSubNamespace(ClassBuilder $rootClass): string
     {
         return sprintf('%s\\%s', $rootClass->getNamespace(), substr($rootClass->getName(), 0, -6));
+    }
+
+    private function hasNormalizationClosures(NodeInterface $node): bool
+    {
+        try {
+            $r = new \ReflectionProperty($node, 'normalizationClosures');
+        } catch (\ReflectionException $e) {
+            return false;
+        }
+        $r->setAccessible(true);
+
+        return [] !== $r->getValue($node);
+    }
+
+    private function getType(string $classType, bool $hasNormalizationClosures): string
+    {
+        return $classType.($hasNormalizationClosures ? '|scalar' : '');
     }
 }

--- a/src/Symfony/Component/Config/Builder/Property.php
+++ b/src/Symfony/Component/Config/Builder/Property.php
@@ -23,6 +23,7 @@ class Property
     private $name;
     private $originalName;
     private $array = false;
+    private $scalarsAllowed = false;
     private $type = null;
     private $content;
 
@@ -46,6 +47,11 @@ class Property
     {
         $this->array = false;
         $this->type = $type;
+
+        if ('|scalar' === substr($type, -7)) {
+            $this->scalarsAllowed = true;
+            $this->type = $type = substr($type, 0, -7);
+        }
 
         if ('[]' === substr($type, -2)) {
             $this->array = true;
@@ -71,5 +77,10 @@ class Property
     public function isArray(): bool
     {
         return $this->array;
+    }
+
+    public function areScalarsAllowed(): bool
+    {
+        return $this->scalarsAllowed;
     }
 }

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Config\AddToListConfig;
 
 return static function (AddToListConfig $config) {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.output.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 return [
     'translator' => [
         'fallbacks' => ['sv', 'fr', 'es'],

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Config\Tests\Builder\Fixtures;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
@@ -2,10 +2,8 @@
 
 namespace Symfony\Config\AddToList\Messenger;
 
-
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-
 
 /**
  * This class is automatically generated to help in creating a config.
@@ -15,7 +13,7 @@ class ReceivingConfig
     private $priority;
     private $color;
     private $_usedProperties = [];
-    
+
     /**
      * @default null
      * @param ParamConfigurator|int $value
@@ -25,10 +23,10 @@ class ReceivingConfig
     {
         $this->_usedProperties['priority'] = true;
         $this->priority = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -38,30 +36,29 @@ class ReceivingConfig
     {
         $this->_usedProperties['color'] = true;
         $this->color = $value;
-    
+
         return $this;
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('priority', $value)) {
             $this->_usedProperties['priority'] = true;
             $this->priority = $value['priority'];
             unset($value['priority']);
         }
-    
+
         if (array_key_exists('color', $value)) {
             $this->_usedProperties['color'] = true;
             $this->color = $value['color'];
             unset($value['color']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -71,7 +68,7 @@ class ReceivingConfig
         if (isset($this->_usedProperties['color'])) {
             $output['color'] = $this->color;
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
@@ -2,10 +2,8 @@
 
 namespace Symfony\Config\AddToList\Messenger;
 
-
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-
 
 /**
  * This class is automatically generated to help in creating a config.
@@ -14,7 +12,7 @@ class RoutingConfig
 {
     private $senders;
     private $_usedProperties = [];
-    
+
     /**
      * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
      * @return $this
@@ -23,31 +21,30 @@ class RoutingConfig
     {
         $this->_usedProperties['senders'] = true;
         $this->senders = $value;
-    
+
         return $this;
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('senders', $value)) {
             $this->_usedProperties['senders'] = true;
             $this->senders = $value['senders'];
             unset($value['senders']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
         if (isset($this->_usedProperties['senders'])) {
             $output['senders'] = $this->senders;
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
@@ -7,7 +7,6 @@ require_once __DIR__.\DIRECTORY_SEPARATOR.'Messenger'.\DIRECTORY_SEPARATOR.'Rece
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
-
 /**
  * This class is automatically generated to help in creating a config.
  */
@@ -16,48 +15,45 @@ class MessengerConfig
     private $routing;
     private $receiving;
     private $_usedProperties = [];
-    
+
     public function routing(string $message_class, array $value = []): \Symfony\Config\AddToList\Messenger\RoutingConfig
     {
         if (!isset($this->routing[$message_class])) {
             $this->_usedProperties['routing'] = true;
-    
-            return $this->routing[$message_class] = new \Symfony\Config\AddToList\Messenger\RoutingConfig($value);
+            $this->routing[$message_class] = new \Symfony\Config\AddToList\Messenger\RoutingConfig($value);
+        } elseif (1 < \func_num_args()) {
+            throw new InvalidConfigurationException('The node created by "routing()" has already been initialized. You cannot pass values the second time you call routing().');
         }
-        if ([] === $value) {
-            return $this->routing[$message_class];
-        }
-    
-        throw new InvalidConfigurationException('The node created by "routing()" has already been initialized. You cannot pass values the second time you call routing().');
+
+        return $this->routing[$message_class];
     }
-    
+
     public function receiving(array $value = []): \Symfony\Config\AddToList\Messenger\ReceivingConfig
     {
         $this->_usedProperties['receiving'] = true;
-    
+
         return $this->receiving[] = new \Symfony\Config\AddToList\Messenger\ReceivingConfig($value);
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('routing', $value)) {
             $this->_usedProperties['routing'] = true;
             $this->routing = array_map(function ($v) { return new \Symfony\Config\AddToList\Messenger\RoutingConfig($v); }, $value['routing']);
             unset($value['routing']);
         }
-    
+
         if (array_key_exists('receiving', $value)) {
             $this->_usedProperties['receiving'] = true;
             $this->receiving = array_map(function ($v) { return new \Symfony\Config\AddToList\Messenger\ReceivingConfig($v); }, $value['receiving']);
             unset($value['receiving']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -67,7 +63,7 @@ class MessengerConfig
         if (isset($this->_usedProperties['receiving'])) {
             $output['receiving'] = array_map(function ($v) { return $v->toArray(); }, $this->receiving);
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
@@ -2,10 +2,8 @@
 
 namespace Symfony\Config\AddToList;
 
-
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-
 
 /**
  * This class is automatically generated to help in creating a config.
@@ -15,7 +13,7 @@ class TranslatorConfig
     private $fallbacks;
     private $sources;
     private $_usedProperties = [];
-    
+
     /**
      * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
      * @return $this
@@ -24,10 +22,10 @@ class TranslatorConfig
     {
         $this->_usedProperties['fallbacks'] = true;
         $this->fallbacks = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @param ParamConfigurator|mixed $value
      * @return $this
@@ -36,30 +34,29 @@ class TranslatorConfig
     {
         $this->_usedProperties['sources'] = true;
         $this->sources[$source_class] = $value;
-    
+
         return $this;
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('fallbacks', $value)) {
             $this->_usedProperties['fallbacks'] = true;
             $this->fallbacks = $value['fallbacks'];
             unset($value['fallbacks']);
         }
-    
+
         if (array_key_exists('sources', $value)) {
             $this->_usedProperties['sources'] = true;
             $this->sources = $value['sources'];
             unset($value['sources']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -69,7 +66,7 @@ class TranslatorConfig
         if (isset($this->_usedProperties['sources'])) {
             $output['sources'] = $this->sources;
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
@@ -7,7 +7,6 @@ require_once __DIR__.\DIRECTORY_SEPARATOR.'AddToList'.\DIRECTORY_SEPARATOR.'Mess
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
-
 /**
  * This class is automatically generated to help in creating a config.
  */
@@ -16,56 +15,55 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
     private $translator;
     private $messenger;
     private $_usedProperties = [];
-    
+
     public function translator(array $value = []): \Symfony\Config\AddToList\TranslatorConfig
     {
         if (null === $this->translator) {
             $this->_usedProperties['translator'] = true;
             $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value);
-        } elseif ([] !== $value) {
+        } elseif (0 < \func_num_args()) {
             throw new InvalidConfigurationException('The node created by "translator()" has already been initialized. You cannot pass values the second time you call translator().');
         }
-    
+
         return $this->translator;
     }
-    
+
     public function messenger(array $value = []): \Symfony\Config\AddToList\MessengerConfig
     {
         if (null === $this->messenger) {
             $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value);
-        } elseif ([] !== $value) {
+        } elseif (0 < \func_num_args()) {
             throw new InvalidConfigurationException('The node created by "messenger()" has already been initialized. You cannot pass values the second time you call messenger().');
         }
-    
+
         return $this->messenger;
     }
-    
+
     public function getExtensionAlias(): string
     {
         return 'add_to_list';
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('translator', $value)) {
             $this->_usedProperties['translator'] = true;
             $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value['translator']);
             unset($value['translator']);
         }
-    
+
         if (array_key_exists('messenger', $value)) {
             $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value['messenger']);
             unset($value['messenger']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -75,7 +73,7 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
         if (isset($this->_usedProperties['messenger'])) {
             $output['messenger'] = $this->messenger->toArray();
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.config.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Config\ArrayExtraKeysConfig;
 
 return static function (ArrayExtraKeysConfig $config) {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.output.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 return [
     'foo' => [
         'baz' => 'foo_baz',

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Config\Tests\Builder\Fixtures;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
@@ -2,9 +2,7 @@
 
 namespace Symfony\Config\ArrayExtraKeys;
 
-
 use Symfony\Component\Config\Loader\ParamConfigurator;
-
 
 /**
  * This class is automatically generated to help in creating a config.
@@ -15,7 +13,7 @@ class BarConfig
     private $grault;
     private $_usedProperties = [];
     private $_extraKeys;
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -25,10 +23,10 @@ class BarConfig
     {
         $this->_usedProperties['corge'] = true;
         $this->corge = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -38,29 +36,28 @@ class BarConfig
     {
         $this->_usedProperties['grault'] = true;
         $this->grault = $value;
-    
+
         return $this;
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('corge', $value)) {
             $this->_usedProperties['corge'] = true;
             $this->corge = $value['corge'];
             unset($value['corge']);
         }
-    
+
         if (array_key_exists('grault', $value)) {
             $this->_usedProperties['grault'] = true;
             $this->grault = $value['grault'];
             unset($value['grault']);
         }
-    
+
         $this->_extraKeys = $value;
-    
+
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -70,10 +67,10 @@ class BarConfig
         if (isset($this->_usedProperties['grault'])) {
             $output['grault'] = $this->grault;
         }
-    
+
         return $output + $this->_extraKeys;
     }
-    
+
     /**
      * @param ParamConfigurator|mixed $value
      * @return $this
@@ -81,7 +78,7 @@ class BarConfig
     public function set(string $key, $value): self
     {
         $this->_extraKeys[$key] = $value;
-    
+
         return $this;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BazConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BazConfig.php
@@ -2,9 +2,7 @@
 
 namespace Symfony\Config\ArrayExtraKeys;
 
-
 use Symfony\Component\Config\Loader\ParamConfigurator;
-
 
 /**
  * This class is automatically generated to help in creating a config.
@@ -12,21 +10,20 @@ use Symfony\Component\Config\Loader\ParamConfigurator;
 class BazConfig 
 {
     private $_extraKeys;
-    
+
     public function __construct(array $value = [])
     {
-    
         $this->_extraKeys = $value;
-    
+
     }
-    
+
     public function toArray(): array
     {
         $output = [];
-    
+
         return $output + $this->_extraKeys;
     }
-    
+
     /**
      * @param ParamConfigurator|mixed $value
      * @return $this
@@ -34,7 +31,7 @@ class BazConfig
     public function set(string $key, $value): self
     {
         $this->_extraKeys[$key] = $value;
-    
+
         return $this;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
@@ -2,9 +2,7 @@
 
 namespace Symfony\Config\ArrayExtraKeys;
 
-
 use Symfony\Component\Config\Loader\ParamConfigurator;
-
 
 /**
  * This class is automatically generated to help in creating a config.
@@ -15,7 +13,7 @@ class FooConfig
     private $qux;
     private $_usedProperties = [];
     private $_extraKeys;
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -25,10 +23,10 @@ class FooConfig
     {
         $this->_usedProperties['baz'] = true;
         $this->baz = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -38,29 +36,28 @@ class FooConfig
     {
         $this->_usedProperties['qux'] = true;
         $this->qux = $value;
-    
+
         return $this;
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('baz', $value)) {
             $this->_usedProperties['baz'] = true;
             $this->baz = $value['baz'];
             unset($value['baz']);
         }
-    
+
         if (array_key_exists('qux', $value)) {
             $this->_usedProperties['qux'] = true;
             $this->qux = $value['qux'];
             unset($value['qux']);
         }
-    
+
         $this->_extraKeys = $value;
-    
+
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -70,10 +67,10 @@ class FooConfig
         if (isset($this->_usedProperties['qux'])) {
             $output['qux'] = $this->qux;
         }
-    
+
         return $output + $this->_extraKeys;
     }
-    
+
     /**
      * @param ParamConfigurator|mixed $value
      * @return $this
@@ -81,7 +78,7 @@ class FooConfig
     public function set(string $key, $value): self
     {
         $this->_extraKeys[$key] = $value;
-    
+
         return $this;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
@@ -8,7 +8,6 @@ require_once __DIR__.\DIRECTORY_SEPARATOR.'ArrayExtraKeys'.\DIRECTORY_SEPARATOR.
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
-
 /**
  * This class is automatically generated to help in creating a config.
  */
@@ -18,69 +17,68 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
     private $bar;
     private $baz;
     private $_usedProperties = [];
-    
+
     public function foo(array $value = []): \Symfony\Config\ArrayExtraKeys\FooConfig
     {
         if (null === $this->foo) {
             $this->_usedProperties['foo'] = true;
             $this->foo = new \Symfony\Config\ArrayExtraKeys\FooConfig($value);
-        } elseif ([] !== $value) {
+        } elseif (0 < \func_num_args()) {
             throw new InvalidConfigurationException('The node created by "foo()" has already been initialized. You cannot pass values the second time you call foo().');
         }
-    
+
         return $this->foo;
     }
-    
+
     public function bar(array $value = []): \Symfony\Config\ArrayExtraKeys\BarConfig
     {
         $this->_usedProperties['bar'] = true;
-    
+
         return $this->bar[] = new \Symfony\Config\ArrayExtraKeys\BarConfig($value);
     }
-    
+
     public function baz(array $value = []): \Symfony\Config\ArrayExtraKeys\BazConfig
     {
         if (null === $this->baz) {
             $this->_usedProperties['baz'] = true;
             $this->baz = new \Symfony\Config\ArrayExtraKeys\BazConfig($value);
-        } elseif ([] !== $value) {
+        } elseif (0 < \func_num_args()) {
             throw new InvalidConfigurationException('The node created by "baz()" has already been initialized. You cannot pass values the second time you call baz().');
         }
-    
+
         return $this->baz;
     }
-    
+
     public function getExtensionAlias(): string
     {
         return 'array_extra_keys';
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('foo', $value)) {
             $this->_usedProperties['foo'] = true;
             $this->foo = new \Symfony\Config\ArrayExtraKeys\FooConfig($value['foo']);
             unset($value['foo']);
         }
-    
+
         if (array_key_exists('bar', $value)) {
             $this->_usedProperties['bar'] = true;
             $this->bar = array_map(function ($v) { return new \Symfony\Config\ArrayExtraKeys\BarConfig($v); }, $value['bar']);
             unset($value['bar']);
         }
-    
+
         if (array_key_exists('baz', $value)) {
             $this->_usedProperties['baz'] = true;
             $this->baz = new \Symfony\Config\ArrayExtraKeys\BazConfig($value['baz']);
             unset($value['baz']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -93,7 +91,7 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
         if (isset($this->_usedProperties['baz'])) {
             $output['baz'] = $this->baz->toArray();
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Config\NodeInitialValuesConfig;
 
 return static function (NodeInitialValuesConfig $config) {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.output.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 return [
     'some_clever_name' => [
         'first' => 'bar',

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Config\Tests\Builder\Fixtures;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
@@ -2,10 +2,8 @@
 
 namespace Symfony\Config\NodeInitialValues\Messenger;
 
-
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-
 
 /**
  * This class is automatically generated to help in creating a config.
@@ -16,7 +14,7 @@ class TransportsConfig
     private $serializer;
     private $options;
     private $_usedProperties = [];
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -26,10 +24,10 @@ class TransportsConfig
     {
         $this->_usedProperties['dsn'] = true;
         $this->dsn = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -39,10 +37,10 @@ class TransportsConfig
     {
         $this->_usedProperties['serializer'] = true;
         $this->serializer = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
      * @return $this
@@ -51,36 +49,35 @@ class TransportsConfig
     {
         $this->_usedProperties['options'] = true;
         $this->options = $value;
-    
+
         return $this;
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('dsn', $value)) {
             $this->_usedProperties['dsn'] = true;
             $this->dsn = $value['dsn'];
             unset($value['dsn']);
         }
-    
+
         if (array_key_exists('serializer', $value)) {
             $this->_usedProperties['serializer'] = true;
             $this->serializer = $value['serializer'];
             unset($value['serializer']);
         }
-    
+
         if (array_key_exists('options', $value)) {
             $this->_usedProperties['options'] = true;
             $this->options = $value['options'];
             unset($value['options']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -93,7 +90,7 @@ class TransportsConfig
         if (isset($this->_usedProperties['options'])) {
             $output['options'] = $this->options;
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
@@ -6,7 +6,6 @@ require_once __DIR__.\DIRECTORY_SEPARATOR.'Messenger'.\DIRECTORY_SEPARATOR.'Tran
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
-
 /**
  * This class is automatically generated to help in creating a config.
  */
@@ -14,42 +13,39 @@ class MessengerConfig
 {
     private $transports;
     private $_usedProperties = [];
-    
+
     public function transports(string $name, array $value = []): \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig
     {
         if (!isset($this->transports[$name])) {
             $this->_usedProperties['transports'] = true;
-    
-            return $this->transports[$name] = new \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig($value);
+            $this->transports[$name] = new \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig($value);
+        } elseif (1 < \func_num_args()) {
+            throw new InvalidConfigurationException('The node created by "transports()" has already been initialized. You cannot pass values the second time you call transports().');
         }
-        if ([] === $value) {
-            return $this->transports[$name];
-        }
-    
-        throw new InvalidConfigurationException('The node created by "transports()" has already been initialized. You cannot pass values the second time you call transports().');
+
+        return $this->transports[$name];
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('transports', $value)) {
             $this->_usedProperties['transports'] = true;
             $this->transports = array_map(function ($v) { return new \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig($v); }, $value['transports']);
             unset($value['transports']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
         if (isset($this->_usedProperties['transports'])) {
             $output['transports'] = array_map(function ($v) { return $v->toArray(); }, $this->transports);
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
@@ -2,10 +2,8 @@
 
 namespace Symfony\Config\NodeInitialValues;
 
-
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-
 
 /**
  * This class is automatically generated to help in creating a config.
@@ -16,7 +14,7 @@ class SomeCleverNameConfig
     private $second;
     private $third;
     private $_usedProperties = [];
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -26,10 +24,10 @@ class SomeCleverNameConfig
     {
         $this->_usedProperties['first'] = true;
         $this->first = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -39,10 +37,10 @@ class SomeCleverNameConfig
     {
         $this->_usedProperties['second'] = true;
         $this->second = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -52,36 +50,35 @@ class SomeCleverNameConfig
     {
         $this->_usedProperties['third'] = true;
         $this->third = $value;
-    
+
         return $this;
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('first', $value)) {
             $this->_usedProperties['first'] = true;
             $this->first = $value['first'];
             unset($value['first']);
         }
-    
+
         if (array_key_exists('second', $value)) {
             $this->_usedProperties['second'] = true;
             $this->second = $value['second'];
             unset($value['second']);
         }
-    
+
         if (array_key_exists('third', $value)) {
             $this->_usedProperties['third'] = true;
             $this->third = $value['third'];
             unset($value['third']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -94,7 +91,7 @@ class SomeCleverNameConfig
         if (isset($this->_usedProperties['third'])) {
             $output['third'] = $this->third;
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
@@ -7,7 +7,6 @@ require_once __DIR__.\DIRECTORY_SEPARATOR.'NodeInitialValues'.\DIRECTORY_SEPARAT
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
-
 /**
  * This class is automatically generated to help in creating a config.
  */
@@ -16,56 +15,55 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
     private $someCleverName;
     private $messenger;
     private $_usedProperties = [];
-    
+
     public function someCleverName(array $value = []): \Symfony\Config\NodeInitialValues\SomeCleverNameConfig
     {
         if (null === $this->someCleverName) {
             $this->_usedProperties['someCleverName'] = true;
             $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value);
-        } elseif ([] !== $value) {
+        } elseif (0 < \func_num_args()) {
             throw new InvalidConfigurationException('The node created by "someCleverName()" has already been initialized. You cannot pass values the second time you call someCleverName().');
         }
-    
+
         return $this->someCleverName;
     }
-    
+
     public function messenger(array $value = []): \Symfony\Config\NodeInitialValues\MessengerConfig
     {
         if (null === $this->messenger) {
             $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value);
-        } elseif ([] !== $value) {
+        } elseif (0 < \func_num_args()) {
             throw new InvalidConfigurationException('The node created by "messenger()" has already been initialized. You cannot pass values the second time you call messenger().');
         }
-    
+
         return $this->messenger;
     }
-    
+
     public function getExtensionAlias(): string
     {
         return 'node_initial_values';
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('some_clever_name', $value)) {
             $this->_usedProperties['someCleverName'] = true;
             $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value['some_clever_name']);
             unset($value['some_clever_name']);
         }
-    
+
         if (array_key_exists('messenger', $value)) {
             $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value['messenger']);
             unset($value['messenger']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -75,7 +73,7 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
         if (isset($this->_usedProperties['messenger'])) {
             $output['messenger'] = $this->messenger->toArray();
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.config.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Config\PlaceholdersConfig;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.output.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 return [
     'enabled' => '%env(bool:FOO_ENABLED)%',
     'favorite_float' => '%eulers_number%',

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Config\Tests\Builder\Fixtures;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.php
@@ -15,7 +15,7 @@ class Placeholders implements ConfigurationInterface
             ->children()
                 ->booleanNode('enabled')->defaultFalse()->end()
                 ->floatNode('favorite_float')->end()
-                 ->arrayNode('good_integers')
+                ->arrayNode('good_integers')
                     ->integerPrototype()->end()
                 ->end()
             ->end()

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.config.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Config\PrimitiveTypesConfig;
 
 return static function (PrimitiveTypesConfig $config) {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.output.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 return [
     'boolean_node' => true,
     'enum_node' => 'foo',

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Config\Tests\Builder\Fixtures;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
@@ -2,10 +2,8 @@
 
 namespace Symfony\Config;
 
-
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-
 
 /**
  * This class is automatically generated to help in creating a config.
@@ -19,7 +17,7 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     private $scalarNode;
     private $scalarNodeWithDefault;
     private $_usedProperties = [];
-    
+
     /**
      * @default null
      * @param ParamConfigurator|bool $value
@@ -29,10 +27,10 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     {
         $this->_usedProperties['booleanNode'] = true;
         $this->booleanNode = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|'foo'|'bar'|'baz' $value
@@ -42,10 +40,10 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     {
         $this->_usedProperties['enumNode'] = true;
         $this->enumNode = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|float $value
@@ -55,10 +53,10 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     {
         $this->_usedProperties['floatNode'] = true;
         $this->floatNode = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|int $value
@@ -68,10 +66,10 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     {
         $this->_usedProperties['integerNode'] = true;
         $this->integerNode = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
@@ -81,10 +79,10 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     {
         $this->_usedProperties['scalarNode'] = true;
         $this->scalarNode = $value;
-    
+
         return $this;
     }
-    
+
     /**
      * @default true
      * @param ParamConfigurator|mixed $value
@@ -94,59 +92,58 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     {
         $this->_usedProperties['scalarNodeWithDefault'] = true;
         $this->scalarNodeWithDefault = $value;
-    
+
         return $this;
     }
-    
+
     public function getExtensionAlias(): string
     {
         return 'primitive_types';
     }
-    
+
     public function __construct(array $value = [])
     {
-    
         if (array_key_exists('boolean_node', $value)) {
             $this->_usedProperties['booleanNode'] = true;
             $this->booleanNode = $value['boolean_node'];
             unset($value['boolean_node']);
         }
-    
+
         if (array_key_exists('enum_node', $value)) {
             $this->_usedProperties['enumNode'] = true;
             $this->enumNode = $value['enum_node'];
             unset($value['enum_node']);
         }
-    
+
         if (array_key_exists('float_node', $value)) {
             $this->_usedProperties['floatNode'] = true;
             $this->floatNode = $value['float_node'];
             unset($value['float_node']);
         }
-    
+
         if (array_key_exists('integer_node', $value)) {
             $this->_usedProperties['integerNode'] = true;
             $this->integerNode = $value['integer_node'];
             unset($value['integer_node']);
         }
-    
+
         if (array_key_exists('scalar_node', $value)) {
             $this->_usedProperties['scalarNode'] = true;
             $this->scalarNode = $value['scalar_node'];
             unset($value['scalar_node']);
         }
-    
+
         if (array_key_exists('scalar_node_with_default', $value)) {
             $this->_usedProperties['scalarNodeWithDefault'] = true;
             $this->scalarNodeWithDefault = $value['scalar_node_with_default'];
             unset($value['scalar_node_with_default']);
         }
-    
+
         if ([] !== $value) {
             throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
         }
     }
-    
+
     public function toArray(): array
     {
         $output = [];
@@ -168,7 +165,7 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
         if (isset($this->_usedProperties['scalarNodeWithDefault'])) {
             $output['scalar_node_with_default'] = $this->scalarNodeWithDefault;
         }
-    
+
         return $output;
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.config.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Config\ScalarNormalizedTypesConfig;
+
+return static function (ScalarNormalizedTypesConfig $config) {
+    $config
+        ->simpleArray('foo')
+        ->keyedArray('key', 'value')
+        ->listObject('bar')
+        ->listObject('baz')
+        ->listObject()->name('qux');
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.config.php
@@ -1,12 +1,31 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Config\ScalarNormalizedTypesConfig;
 
 return static function (ScalarNormalizedTypesConfig $config) {
     $config
         ->simpleArray('foo')
         ->keyedArray('key', 'value')
+        ->object(true)
         ->listObject('bar')
         ->listObject('baz')
         ->listObject()->name('qux');
+
+    $config
+        ->keyedListObject('Foo\\Bar', true)
+        ->keyedListObject('Foo\\Baz')->settings(['one', 'two']);
+
+    $config->nested([
+        'nested_object' => true,
+        'nested_list_object' => ['one', 'two'],
+    ]);
 };

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.output.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'simple_array' => 'foo',
+    'keyed_array' => [
+        'key' => 'value'
+    ],
+    'list_object' => [
+        'bar',
+        'baz',
+        ['name' => 'qux'],
+    ],
+];

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.output.php
@@ -1,13 +1,33 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 return [
     'simple_array' => 'foo',
     'keyed_array' => [
-        'key' => 'value'
+        'key' => 'value',
     ],
+    'object' => true,
     'list_object' => [
         'bar',
         'baz',
         ['name' => 'qux'],
+    ],
+    'keyed_list_object' => [
+        'Foo\\Bar' => true,
+        'Foo\\Baz' => [
+            'settings' => ['one', 'two'],
+        ],
+    ],
+    'nested' => [
+        'nested_object' => true,
+        'nested_list_object' => ['one', 'two'],
     ],
 ];

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Symfony\Component\Config\Tests\Builder\Fixtures;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class ScalarNormalizedTypes implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $tb = new TreeBuilder('scalar_normalized_types');
+        $rootNode = $tb->getRootNode();
+        $rootNode
+            ->children()
+                ->arrayNode('simple_array')
+                    ->beforeNormalization()->ifString()->then(function ($v) { return [$v]; })->end()
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('keyed_array')
+                    ->useAttributeAsKey('name')
+                    ->prototype('array')
+                        ->beforeNormalization()
+                            ->ifString()->then(function ($v) { return [$v]; })
+                        ->end()
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
+                ->arrayNode('list_object')
+                    ->beforeNormalization()
+                        ->always()
+                        ->then(function ($values) {
+                            //inspired by Workflow places
+                            if (isset($values[0]) && \is_string($values[0])) {
+                                return array_map(function (string $value) {
+                                    return ['name' => $value];
+                                }, $values);
+                            }
+
+                            if (isset($values[0]) && \is_array($values[0])) {
+                                return $values;
+                            }
+
+                            foreach ($values as $name => $value) {
+                                if (\is_array($value) && \array_key_exists('name', $value)) {
+                                    continue;
+                                }
+                                $value['name'] = $name;
+                                $values[$name] = $value;
+                            }
+
+                            return array_values($values);
+                        })
+                        ->end()
+                        ->isRequired()
+                        ->requiresAtLeastOneElement()
+                        ->prototype('array')
+                            ->children()
+                                ->scalarNode('name')
+                                    ->isRequired()
+                                    ->cannotBeEmpty()
+                                ->end()
+                                ->arrayNode('data')
+                                    ->normalizeKeys(false)
+                                    ->defaultValue([])
+                                    ->prototype('variable')
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $tb;
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/KeyedListObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/KeyedListObjectConfig.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Symfony\Config\ScalarNormalizedTypes;
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class KeyedListObjectConfig 
+{
+    private $enabled;
+    private $settings;
+    private $_usedProperties = [];
+
+    /**
+     * @default true
+     * @param ParamConfigurator|bool $value
+     * @return $this
+     */
+    public function enabled($value): self
+    {
+        $this->_usedProperties['enabled'] = true;
+        $this->enabled = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
+     * @return $this
+     */
+    public function settings($value): self
+    {
+        $this->_usedProperties['settings'] = true;
+        $this->settings = $value;
+
+        return $this;
+    }
+
+    public function __construct(array $value = [])
+    {
+        if (array_key_exists('enabled', $value)) {
+            $this->_usedProperties['enabled'] = true;
+            $this->enabled = $value['enabled'];
+            unset($value['enabled']);
+        }
+
+        if (array_key_exists('settings', $value)) {
+            $this->_usedProperties['settings'] = true;
+            $this->settings = $value['settings'];
+            unset($value['settings']);
+        }
+
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+
+    public function toArray(): array
+    {
+        $output = [];
+        if (isset($this->_usedProperties['enabled'])) {
+            $output['enabled'] = $this->enabled;
+        }
+        if (isset($this->_usedProperties['settings'])) {
+            $output['settings'] = $this->settings;
+        }
+
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ListObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ListObjectConfig.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Symfony\Config\ScalarNormalizedTypes;
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class ListObjectConfig 
+{
+    private $name;
+    private $data;
+    private $_usedProperties = [];
+
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function name($value): self
+    {
+        $this->_usedProperties['name'] = true;
+        $this->name = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
+     * @return $this
+     */
+    public function data($value): self
+    {
+        $this->_usedProperties['data'] = true;
+        $this->data = $value;
+
+        return $this;
+    }
+
+    public function __construct(array $value = [])
+    {
+        if (array_key_exists('name', $value)) {
+            $this->_usedProperties['name'] = true;
+            $this->name = $value['name'];
+            unset($value['name']);
+        }
+
+        if (array_key_exists('data', $value)) {
+            $this->_usedProperties['data'] = true;
+            $this->data = $value['data'];
+            unset($value['data']);
+        }
+
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+
+    public function toArray(): array
+    {
+        $output = [];
+        if (isset($this->_usedProperties['name'])) {
+            $output['name'] = $this->name;
+        }
+        if (isset($this->_usedProperties['data'])) {
+            $output['data'] = $this->data;
+        }
+
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedListObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedListObjectConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Config;
+namespace Symfony\Config\ScalarNormalizedTypes\Nested;
 
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -8,9 +8,9 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 /**
  * This class is automatically generated to help in creating a config.
  */
-class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+class NestedListObjectConfig 
 {
-    private $anyValue;
+    private $name;
     private $_usedProperties = [];
 
     /**
@@ -18,25 +18,20 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
      * @param ParamConfigurator|mixed $value
      * @return $this
      */
-    public function anyValue($value): self
+    public function name($value): self
     {
-        $this->_usedProperties['anyValue'] = true;
-        $this->anyValue = $value;
+        $this->_usedProperties['name'] = true;
+        $this->name = $value;
 
         return $this;
     }
 
-    public function getExtensionAlias(): string
-    {
-        return 'variable_type';
-    }
-
     public function __construct(array $value = [])
     {
-        if (array_key_exists('any_value', $value)) {
-            $this->_usedProperties['anyValue'] = true;
-            $this->anyValue = $value['any_value'];
-            unset($value['any_value']);
+        if (array_key_exists('name', $value)) {
+            $this->_usedProperties['name'] = true;
+            $this->name = $value['name'];
+            unset($value['name']);
         }
 
         if ([] !== $value) {
@@ -47,8 +42,8 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
     public function toArray(): array
     {
         $output = [];
-        if (isset($this->_usedProperties['anyValue'])) {
-            $output['any_value'] = $this->anyValue;
+        if (isset($this->_usedProperties['name'])) {
+            $output['name'] = $this->name;
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedObjectConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Config;
+namespace Symfony\Config\ScalarNormalizedTypes\Nested;
 
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -8,35 +8,30 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 /**
  * This class is automatically generated to help in creating a config.
  */
-class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+class NestedObjectConfig 
 {
-    private $anyValue;
+    private $enabled;
     private $_usedProperties = [];
 
     /**
      * @default null
-     * @param ParamConfigurator|mixed $value
+     * @param ParamConfigurator|bool $value
      * @return $this
      */
-    public function anyValue($value): self
+    public function enabled($value): self
     {
-        $this->_usedProperties['anyValue'] = true;
-        $this->anyValue = $value;
+        $this->_usedProperties['enabled'] = true;
+        $this->enabled = $value;
 
         return $this;
     }
 
-    public function getExtensionAlias(): string
-    {
-        return 'variable_type';
-    }
-
     public function __construct(array $value = [])
     {
-        if (array_key_exists('any_value', $value)) {
-            $this->_usedProperties['anyValue'] = true;
-            $this->anyValue = $value['any_value'];
-            unset($value['any_value']);
+        if (array_key_exists('enabled', $value)) {
+            $this->_usedProperties['enabled'] = true;
+            $this->enabled = $value['enabled'];
+            unset($value['enabled']);
         }
 
         if ([] !== $value) {
@@ -47,8 +42,8 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
     public function toArray(): array
     {
         $output = [];
-        if (isset($this->_usedProperties['anyValue'])) {
-            $output['any_value'] = $this->anyValue;
+        if (isset($this->_usedProperties['enabled'])) {
+            $output['enabled'] = $this->enabled;
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Symfony\Config\ScalarNormalizedTypes;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'Nested'.\DIRECTORY_SEPARATOR.'NestedObjectConfig.php';
+require_once __DIR__.\DIRECTORY_SEPARATOR.'Nested'.\DIRECTORY_SEPARATOR.'NestedListObjectConfig.php';
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class NestedConfig 
+{
+    private $nestedObject;
+    private $nestedListObject;
+    private $_usedProperties = [];
+
+    /**
+     * @return \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig|$this
+     */
+    public function nestedObject($value = [])
+    {
+        if (!\is_array($value)) {
+            $this->_usedProperties['nestedObject'] = true;
+            $this->nestedObject = $value;
+
+            return $this;
+        }
+
+        if (!$this->nestedObject instanceof \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig) {
+            $this->_usedProperties['nestedObject'] = true;
+            $this->nestedObject = new \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig($value);
+        } elseif (0 < \func_num_args()) {
+            throw new InvalidConfigurationException('The node created by "nestedObject()" has already been initialized. You cannot pass values the second time you call nestedObject().');
+        }
+
+        return $this->nestedObject;
+    }
+
+    /**
+     * @return \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig|$this
+     */
+    public function nestedListObject($value = [])
+    {
+        $this->_usedProperties['nestedListObject'] = true;
+        if (!\is_array($value)) {
+            $this->nestedListObject[] = $value;
+
+            return $this;
+        }
+
+        return $this->nestedListObject[] = new \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig($value);
+    }
+
+    public function __construct(array $value = [])
+    {
+        if (array_key_exists('nested_object', $value)) {
+            $this->_usedProperties['nestedObject'] = true;
+            $this->nestedObject = \is_array($value['nested_object']) ? new \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig($value['nested_object']) : $value['nested_object'];
+            unset($value['nested_object']);
+        }
+
+        if (array_key_exists('nested_list_object', $value)) {
+            $this->_usedProperties['nestedListObject'] = true;
+            $this->nestedListObject = array_map(function ($v) { return \is_array($v) ? new \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig($v) : $v; }, $value['nested_list_object']);
+            unset($value['nested_list_object']);
+        }
+
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+
+    public function toArray(): array
+    {
+        $output = [];
+        if (isset($this->_usedProperties['nestedObject'])) {
+            $output['nested_object'] = $this->nestedObject instanceof \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig ? $this->nestedObject->toArray() : $this->nestedObject;
+        }
+        if (isset($this->_usedProperties['nestedListObject'])) {
+            $output['nested_list_object'] = array_map(function ($v) { return $v instanceof \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig ? $v->toArray() : $v; }, $this->nestedListObject);
+        }
+
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ObjectConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Config;
+namespace Symfony\Config\ScalarNormalizedTypes;
 
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -8,15 +8,15 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 /**
  * This class is automatically generated to help in creating a config.
  */
-class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+class ObjectConfig 
 {
     private $enabled;
-    private $favoriteFloat;
-    private $goodIntegers;
+    private $dateFormat;
+    private $removeUsedContextFields;
     private $_usedProperties = [];
 
     /**
-     * @default false
+     * @default null
      * @param ParamConfigurator|bool $value
      * @return $this
      */
@@ -30,32 +30,28 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
 
     /**
      * @default null
-     * @param ParamConfigurator|float $value
+     * @param ParamConfigurator|mixed $value
      * @return $this
      */
-    public function favoriteFloat($value): self
+    public function dateFormat($value): self
     {
-        $this->_usedProperties['favoriteFloat'] = true;
-        $this->favoriteFloat = $value;
+        $this->_usedProperties['dateFormat'] = true;
+        $this->dateFormat = $value;
 
         return $this;
     }
 
     /**
-     * @param ParamConfigurator|list<int|ParamConfigurator> $value
+     * @default null
+     * @param ParamConfigurator|bool $value
      * @return $this
      */
-    public function goodIntegers($value): self
+    public function removeUsedContextFields($value): self
     {
-        $this->_usedProperties['goodIntegers'] = true;
-        $this->goodIntegers = $value;
+        $this->_usedProperties['removeUsedContextFields'] = true;
+        $this->removeUsedContextFields = $value;
 
         return $this;
-    }
-
-    public function getExtensionAlias(): string
-    {
-        return 'placeholders';
     }
 
     public function __construct(array $value = [])
@@ -66,16 +62,16 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
             unset($value['enabled']);
         }
 
-        if (array_key_exists('favorite_float', $value)) {
-            $this->_usedProperties['favoriteFloat'] = true;
-            $this->favoriteFloat = $value['favorite_float'];
-            unset($value['favorite_float']);
+        if (array_key_exists('date_format', $value)) {
+            $this->_usedProperties['dateFormat'] = true;
+            $this->dateFormat = $value['date_format'];
+            unset($value['date_format']);
         }
 
-        if (array_key_exists('good_integers', $value)) {
-            $this->_usedProperties['goodIntegers'] = true;
-            $this->goodIntegers = $value['good_integers'];
-            unset($value['good_integers']);
+        if (array_key_exists('remove_used_context_fields', $value)) {
+            $this->_usedProperties['removeUsedContextFields'] = true;
+            $this->removeUsedContextFields = $value['remove_used_context_fields'];
+            unset($value['remove_used_context_fields']);
         }
 
         if ([] !== $value) {
@@ -89,11 +85,11 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
         if (isset($this->_usedProperties['enabled'])) {
             $output['enabled'] = $this->enabled;
         }
-        if (isset($this->_usedProperties['favoriteFloat'])) {
-            $output['favorite_float'] = $this->favoriteFloat;
+        if (isset($this->_usedProperties['dateFormat'])) {
+            $output['date_format'] = $this->dateFormat;
         }
-        if (isset($this->_usedProperties['goodIntegers'])) {
-            $output['good_integers'] = $this->goodIntegers;
+        if (isset($this->_usedProperties['removeUsedContextFields'])) {
+            $output['remove_used_context_fields'] = $this->removeUsedContextFields;
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Symfony\Config;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'ScalarNormalizedTypes'.\DIRECTORY_SEPARATOR.'ObjectConfig.php';
+require_once __DIR__.\DIRECTORY_SEPARATOR.'ScalarNormalizedTypes'.\DIRECTORY_SEPARATOR.'ListObjectConfig.php';
+require_once __DIR__.\DIRECTORY_SEPARATOR.'ScalarNormalizedTypes'.\DIRECTORY_SEPARATOR.'KeyedListObjectConfig.php';
+require_once __DIR__.\DIRECTORY_SEPARATOR.'ScalarNormalizedTypes'.\DIRECTORY_SEPARATOR.'NestedConfig.php';
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+{
+    private $simpleArray;
+    private $keyedArray;
+    private $object;
+    private $listObject;
+    private $keyedListObject;
+    private $nested;
+    private $_usedProperties = [];
+
+    /**
+     * @param ParamConfigurator|list<mixed|ParamConfigurator> $value
+     * @return $this
+     */
+    public function simpleArray($value): self
+    {
+        $this->_usedProperties['simpleArray'] = true;
+        $this->simpleArray = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param ParamConfigurator|array $value
+     * @return $this
+     */
+    public function keyedArray(string $name, $value): self
+    {
+        $this->_usedProperties['keyedArray'] = true;
+        $this->keyedArray[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return \Symfony\Config\ScalarNormalizedTypes\ObjectConfig|$this
+     */
+    public function object($value = [])
+    {
+        if (!\is_array($value)) {
+            $this->_usedProperties['object'] = true;
+            $this->object = $value;
+
+            return $this;
+        }
+
+        if (!$this->object instanceof \Symfony\Config\ScalarNormalizedTypes\ObjectConfig) {
+            $this->_usedProperties['object'] = true;
+            $this->object = new \Symfony\Config\ScalarNormalizedTypes\ObjectConfig($value);
+        } elseif (0 < \func_num_args()) {
+            throw new InvalidConfigurationException('The node created by "object()" has already been initialized. You cannot pass values the second time you call object().');
+        }
+
+        return $this->object;
+    }
+
+    /**
+     * @return \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig|$this
+     */
+    public function listObject($value = [])
+    {
+        $this->_usedProperties['listObject'] = true;
+        if (!\is_array($value)) {
+            $this->listObject[] = $value;
+
+            return $this;
+        }
+
+        return $this->listObject[] = new \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig($value);
+    }
+
+    /**
+     * @return \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig|$this
+     */
+    public function keyedListObject(string $class, $value = [])
+    {
+        if (!\is_array($value)) {
+            $this->_usedProperties['keyedListObject'] = true;
+            $this->keyedListObject[$class] = $value;
+
+            return $this;
+        }
+
+        if (!isset($this->keyedListObject[$class]) || !$this->keyedListObject[$class] instanceof \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig) {
+            $this->_usedProperties['keyedListObject'] = true;
+            $this->keyedListObject[$class] = new \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig($value);
+        } elseif (1 < \func_num_args()) {
+            throw new InvalidConfigurationException('The node created by "keyedListObject()" has already been initialized. You cannot pass values the second time you call keyedListObject().');
+        }
+
+        return $this->keyedListObject[$class];
+    }
+
+    public function nested(array $value = []): \Symfony\Config\ScalarNormalizedTypes\NestedConfig
+    {
+        if (null === $this->nested) {
+            $this->_usedProperties['nested'] = true;
+            $this->nested = new \Symfony\Config\ScalarNormalizedTypes\NestedConfig($value);
+        } elseif (0 < \func_num_args()) {
+            throw new InvalidConfigurationException('The node created by "nested()" has already been initialized. You cannot pass values the second time you call nested().');
+        }
+
+        return $this->nested;
+    }
+
+    public function getExtensionAlias(): string
+    {
+        return 'scalar_normalized_types';
+    }
+
+    public function __construct(array $value = [])
+    {
+        if (array_key_exists('simple_array', $value)) {
+            $this->_usedProperties['simpleArray'] = true;
+            $this->simpleArray = $value['simple_array'];
+            unset($value['simple_array']);
+        }
+
+        if (array_key_exists('keyed_array', $value)) {
+            $this->_usedProperties['keyedArray'] = true;
+            $this->keyedArray = $value['keyed_array'];
+            unset($value['keyed_array']);
+        }
+
+        if (array_key_exists('object', $value)) {
+            $this->_usedProperties['object'] = true;
+            $this->object = \is_array($value['object']) ? new \Symfony\Config\ScalarNormalizedTypes\ObjectConfig($value['object']) : $value['object'];
+            unset($value['object']);
+        }
+
+        if (array_key_exists('list_object', $value)) {
+            $this->_usedProperties['listObject'] = true;
+            $this->listObject = array_map(function ($v) { return \is_array($v) ? new \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig($v) : $v; }, $value['list_object']);
+            unset($value['list_object']);
+        }
+
+        if (array_key_exists('keyed_list_object', $value)) {
+            $this->_usedProperties['keyedListObject'] = true;
+            $this->keyedListObject = array_map(function ($v) { return \is_array($v) ? new \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig($v) : $v; }, $value['keyed_list_object']);
+            unset($value['keyed_list_object']);
+        }
+
+        if (array_key_exists('nested', $value)) {
+            $this->_usedProperties['nested'] = true;
+            $this->nested = new \Symfony\Config\ScalarNormalizedTypes\NestedConfig($value['nested']);
+            unset($value['nested']);
+        }
+
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+
+    public function toArray(): array
+    {
+        $output = [];
+        if (isset($this->_usedProperties['simpleArray'])) {
+            $output['simple_array'] = $this->simpleArray;
+        }
+        if (isset($this->_usedProperties['keyedArray'])) {
+            $output['keyed_array'] = $this->keyedArray;
+        }
+        if (isset($this->_usedProperties['object'])) {
+            $output['object'] = $this->object instanceof \Symfony\Config\ScalarNormalizedTypes\ObjectConfig ? $this->object->toArray() : $this->object;
+        }
+        if (isset($this->_usedProperties['listObject'])) {
+            $output['list_object'] = array_map(function ($v) { return $v instanceof \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig ? $v->toArray() : $v; }, $this->listObject);
+        }
+        if (isset($this->_usedProperties['keyedListObject'])) {
+            $output['keyed_list_object'] = array_map(function ($v) { return $v instanceof \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig ? $v->toArray() : $v; }, $this->keyedListObject);
+        }
+        if (isset($this->_usedProperties['nested'])) {
+            $output['nested'] = $this->nested->toArray();
+        }
+
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.config.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Config\VariableTypeConfig;
 
 return static function (VariableTypeConfig $config) {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.output.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 return [
     'any_value' => 'foobar',
 ];

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Config\Tests\Builder\Fixtures;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -56,6 +56,7 @@ class GeneratedConfigTest extends TestCase
     public function fixtureNames()
     {
         $array = [
+            'ScalarNormalizedTypes' => 'scalar_normalized_types',
             'PrimitiveTypes' => 'primitive_types',
             'VariableType' => 'variable_type',
             'AddToList' => 'add_to_list',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/monolog-bundle/pull/417#issuecomment-1123294337
| License       | MIT
| Doc PR        | -

Fixes passing scalar values to array nodes that have a `beforeNormalization` hook, eg:

```php
return static function (MonologConfig $config): void {
    $config->handler('console')
        // ...
        ->processPsr3Messages()
            ->enabled(true)
    ;
};
```

can be shortened thanks to a [`beforeNormalization` hook](https://github.com/symfony/monolog-bundle/blob/a41bbcdc1105603b6d73a7d9a43a3788f8e0fb7d/DependencyInjection/Configuration.php#L453):

```php
return static function (MonologConfig $config): void {
    $config->handler('console')
        // ...
        ->processPsr3Messages(true)
    ;
};
```

I've used some of the code from https://github.com/symfony/symfony/pull/44166 by @jderusse. Since his PR is a feature it can't go on 5.4, but it still helped a lot.