### PR TITLE
[HttpClient] Fixes max_duration not being respected

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncContext.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncContext.php
@@ -159,6 +159,14 @@ final class AsyncContext
                 $onProgress($dlNow, $dlSize, $thisInfo + $info);
             };
         }
+        
+        if ($maxDuration = $options['max_duration'] ?? false) {
+            $totalElapsed = 0;
+            foreach ($this->info['previous_info'] as $req) {
+                $totalElapsed += $req['total_time'];
+            }
+            $options['timeout'] = ceil($maxDuration - $totalElapsed);
+        }
 
         return $this->response = $this->client->request($method, $url, ['buffer' => false] + $options);
     }


### PR DESCRIPTION
As reported on #46316, when a request gets a successful response in further attempts, the max_duration is not respected and the request may take longer than the value specified here.

My way to solve the issue was by reducing the timeout option in future requests, making it smaller in every attempt. By doing so, the total time of a $client->request will never be much longer than max_duration. Perhaps a second or two maybe, due to the waiting time between requests, but not as much as the timeout.

| Q             | A
| ------------- | ---
| Branch?       | Noticed on 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46316
| License       | MIT
