### PR TITLE
[WebProfilerBundle] Fix spelling of curl

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
@@ -96,7 +96,7 @@
                                         {% endif %}
                                         {% if trace.curlCommand is not null %}
                                             <th>
-                                                <button class="btn btn-sm hidden label" title="Copy as cURL" data-clipboard-text="{{ trace.curlCommand }}">cURL</button>
+                                                <button class="btn btn-sm hidden label" title="Copy as curl" data-clipboard-text="{{ trace.curlCommand }}">curl</button>
                                             </th>
                                         {% endif %}
                                     </tr>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

the CLU is spelled `curl`
the project is spelled `cURL`

Some references:

* https://curl.se/
* https://github.com/curl/curl
* https://twitter.com/bagder/status/1524674023224922112
