### PR TITLE
[Messenger] Be able to start a worker for multiple queues with custom consumption priorities

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `SerializedMessageStamp` to avoid serializing a message when a retry occurs
  * Automatically resolve handled message type when method different from `__invoke` is used as handler
  * Allow `#[AsMessageHandler]` attribute on methods
+ * Customization of the receivers priorities thanks to a specification in the command argument `bin/console messenger:consume async_redis^2 async_doctrine^1`
 
 6.0
 ---

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -156,7 +156,8 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $receivers = [];
-        foreach ($receiverNames = $input->getArgument('receivers') as $receiverName) {
+        $receiverNames = $this->reorderReceivers($input->getArgument('receivers'));
+        foreach ($receiverNames as $receiverName) {
             if (!$this->receiverLocator->has($receiverName)) {
                 $message = sprintf('The receiver "%s" does not exist.', $receiverName);
                 if ($this->receiverNames) {
@@ -261,5 +262,27 @@ EOF
         }
 
         return $max;
+    }
+
+    private function reorderReceivers(array $receiversArgument): array
+    {
+        $receiverPriorities = [];
+        $receiverDefault = [];
+
+        foreach ($receiversArgument as $receiverInput) {
+            $split = explode('^', $receiverInput);
+            if (count($split) === 2) {
+                $receiverPriorities[intval($split[1])][] = $split[0];
+            } else {
+                $receiverDefault[] = $receiverInput;
+            }
+        }
+
+        ksort($receiverPriorities);
+        $receiverPriorities = array_reduce($receiverPriorities, function ($carry, $array) {
+            return array_merge($carry, $array);
+        }, []);
+
+        return array_merge($receiverPriorities, $receiverDefault);
     }
 }

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -272,7 +272,7 @@ EOF
         foreach ($receiversArgument as $receiverInput) {
             $split = explode('^', $receiverInput);
             if (2 === \count($split)) {
-                $receiverPriorities[(int)($split[1])][] = $split[0];
+                $receiverPriorities[(int) ($split[1])][] = $split[0];
             } else {
                 $receiverDefault[] = $receiverInput;
             }

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -271,8 +271,8 @@ EOF
 
         foreach ($receiversArgument as $receiverInput) {
             $split = explode('^', $receiverInput);
-            if (count($split) === 2) {
-                $receiverPriorities[intval($split[1])][] = $split[0];
+            if (2 === \count($split)) {
+                $receiverPriorities[(int)($split[1])][] = $split[0];
             } else {
                 $receiverDefault[] = $receiverInput;
             }

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -165,6 +165,38 @@ class ConsumeMessagesCommandTest extends TestCase
         $this->assertSame($expectedSuggestions, $suggestions);
     }
 
+    public function testBasicRunWithPriority()
+    {
+        $envelope = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
+
+        $receiver = $this->createMock(ReceiverInterface::class);
+        $receiver->expects($this->once())->method('get')->willReturn([$envelope]);
+
+        $receiverLocator = $this->createMock(ContainerInterface::class);
+        $receiverLocator->expects($this->once())->method('has')->with('dummy-receiver')->willReturn(true);
+        $receiverLocator->expects($this->once())->method('get')->with('dummy-receiver')->willReturn($receiver);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch');
+
+        $busLocator = $this->createMock(ContainerInterface::class);
+        $busLocator->expects($this->once())->method('has')->with('dummy-bus')->willReturn(true);
+        $busLocator->expects($this->once())->method('get')->with('dummy-bus')->willReturn($bus);
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
+
+        $application = new Application();
+        $application->add($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+        $tester->execute([
+            'receivers' => ['dummy-receiver^1'],
+            '--limit' => 1,
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
+    }
+
     public function provideCompletionSuggestions()
     {
         yield 'receiver' => [[''], ['async', 'async_high', 'failed']];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch ?       | 6.1
| Bug fix ?      | no
| New feature ?  | yes
| Deprecations ? | no 
| Tickets       | https://github.com/symfony/symfony/issues/45882
| License       | MIT
| Doc PR        | 


This feature in the first part of the issue https://github.com/symfony/symfony/issues/45882.

Thanks to this feature, we no longer have to order receivers the command argument, but we can simply set their priority in the argument as follows  : 

`bin/console messenger:consume async_lower^3 async_high^1 async_med^2`
is equivalent to 
`bin/console messenger:consume order async_high async_med, async_low` 
This is very convenient when you have a lot of receivers.

When the PR https://github.com/symfony/symfony/pull/44294 well be ready, we will be able to create a `mixed` strategy to allow some receivers to have the same priority, and run them with turn by turn