### PR TITLE
[Form] [Component] Add support for an initial form value

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add a `prototype_options` option to `CollectionType`
+ * Add `init_value` option to `FormType` to set form value that has no underlying object, created event listener `InitFormValueListener`
 
 6.0
 ---

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/InitFormValueListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/InitFormValueListener.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Set an initial value on a form field that does not have an underlying object bound.
+ *
+ * @author Ross Phillipson <rosco404@gmail.com>
+ */
+class InitFormValueListener implements EventSubscriberInterface
+{
+    public function onPreSetData(FormEvent $event): void
+    {
+        $data = $event->getData() ?? $event->getForm()->getConfig()->getOption('init_value');
+
+        $event->setData($data);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [FormEvents::PRE_SET_DATA => 'onPreSetData'];
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\Extension\Core\DataAccessor\ChainAccessor;
 use Symfony\Component\Form\Extension\Core\DataAccessor\PropertyPathAccessor;
 use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
 use Symfony\Component\Form\Extension\Core\EventListener\TrimListener;
+use Symfony\Component\Form\Extension\Core\EventListener\InitFormValueListener;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -64,6 +65,10 @@ class FormType extends BaseType
 
         if ($options['trim']) {
             $builder->addEventSubscriber(new TrimListener());
+        }
+
+        if (null !== $options['init_value']) {
+            $builder->addEventSubscriber(new InitFormValueListener());
         }
 
         $builder->setIsEmptyCallback($options['is_empty_callback']);
@@ -188,6 +193,7 @@ class FormType extends BaseType
         $resolver->setDefaults([
             'data_class' => $dataClass,
             'empty_data' => $emptyData,
+            'init_value' => null,
             'trim' => true,
             'required' => true,
             'property_path' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Add support for an **_initial form value_** to be set when the form does not have an underlying object (yet) or not bound.

There are many times i see confusion over the `data` and `empty_data` properties in form types. These do not provide the expected functionality that many people think, especially new comers. It is more intuitive to have an `init_value` (initial value).

Even though this functionality can be achieved via a form listener, it should be a default feature. It can also be achieved via a placeholder, but this can differ depending on front-end CSS frameworks used that may need modifying. Again, it is more intuitive with `init_value`.

 **Example usuage:**

```
$builder
    ->add('field_name', TextType::class, array(
        'init_value' => 'Hello World!'
));
```
**TODO:**

- [ ] Modify/Update documentation if this PR gets accepted.