### PR TITLE
[Console] Fix aliases handling in command name completion

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -363,9 +363,18 @@ class Application implements ResetInterface
             CompletionInput::TYPE_ARGUMENT_VALUE === $input->getCompletionType()
             && 'command' === $input->getCompletionName()
         ) {
-            $suggestions->suggestValues(array_filter(array_map(function (Command $command) {
-                return $command->isHidden() ? null : $command->getName();
-            }, $this->all())));
+            $commandNames = [];
+            foreach ($this->all() as $name => $command) {
+                // skip hidden commands and aliased commands as they already get added below
+                if ($command->isHidden() || $command->getName() !== $name) {
+                    continue;
+                }
+                $commandNames[] = $command->getName();
+                foreach ($command->getAliases() as $name) {
+                    $commandNames[] = $name;
+                }
+            }
+            $suggestions->suggestValues(array_filter($commandNames));
 
             return;
         }

--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -105,11 +105,12 @@ final class CompleteCommand extends Command
             } elseif (
                 $completionInput->mustSuggestArgumentValuesFor('command')
                 && $command->getName() !== $completionInput->getCompletionValue()
+                && !\in_array($completionInput->getCompletionValue(), $command->getAliases(), true)
             ) {
                 $this->log('  No command found, completing using the Application class.');
 
                 // expand shortcut names ("cache:cl<TAB>") into their full name ("cache:clear")
-                $suggestions->suggestValue($command->getName());
+                $suggestions->suggestValues(array_filter(array_merge([$command->getName()], $command->getAliases())));
             } else {
                 $command->mergeApplicationDefinition();
                 $completionInput->bind($command->getDefinition());

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -102,9 +102,10 @@ class CompleteCommandTest extends TestCase
 
     public function provideCompleteCommandNameInputs()
     {
-        yield 'empty' => [['bin/console'], ['help', 'list', 'completion', 'hello']];
-        yield 'partial' => [['bin/console', 'he'], ['help', 'list', 'completion', 'hello']];
-        yield 'complete-shortcut-name' => [['bin/console', 'hell'], ['hello']];
+        yield 'empty' => [['bin/console'], ['help', 'list', 'completion', 'hello', 'ahoy']];
+        yield 'partial' => [['bin/console', 'he'], ['help', 'list', 'completion', 'hello', 'ahoy']];
+        yield 'complete-shortcut-name' => [['bin/console', 'hell'], ['hello', 'ahoy']];
+        yield 'complete-aliases' => [['bin/console', 'ah'], ['hello', 'ahoy']];
     }
 
     /**
@@ -120,6 +121,8 @@ class CompleteCommandTest extends TestCase
     {
         yield 'definition' => [['bin/console', 'hello', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-interaction']];
         yield 'custom' => [['bin/console', 'hello'], ['Fabien', 'Robin', 'Wouter']];
+        yield 'definition-aliased' => [['bin/console', 'ahoy', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-interaction']];
+        yield 'custom-aliased' => [['bin/console', 'ahoy'], ['Fabien', 'Robin', 'Wouter']];
     }
 
     private function execute(array $input)
@@ -134,6 +137,7 @@ class CompleteCommandTest_HelloCommand extends Command
     public function configure(): void
     {
         $this->setName('hello')
+             ->setAliases(['ahoy'])
              ->addArgument('name', InputArgument::REQUIRED)
          ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

While working on https://github.com/composer/composer/pull/10320 I noticed that command aliases like `composer why` did not autocomplete and then even if typed manually the args/options did not autocomplete if using the alias. This PR fixes it.