### PR TITLE
[Form] Add approriate description to CollectionToArrayTransformer::reverseTransform docblock

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
@@ -24,8 +24,6 @@ class CollectionToArrayTransformer implements DataTransformerInterface
     /**
      * Transforms a collection into an array.
      *
-     * @return mixed An array of entities
-     *
      * @throws TransformationFailedException
      */
     public function transform($collection)
@@ -48,11 +46,9 @@ class CollectionToArrayTransformer implements DataTransformerInterface
     }
 
     /**
-     * Transforms choice keys into entities.
+     * Transforms an array into a collection.
      *
-     * @param mixed $array An array of entities
-     *
-     * @return Collection A collection of entities
+     * @return Collection
      */
     public function reverseTransform($array)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | N/A

It seems that during creation of CollectionToArrayTransformer, the source code of another class was used as base, and the documentation for one of the methods was not changed according with the function of the new class.

Not sure which branch this should be applied to, since its not a new feature, and technically not a bug fix but a documentation fix.