### PR TITLE
[PropertyInfo] Ignore empty doc-block for promoted properties in PhpStanExtractor

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -227,7 +227,11 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
             $constructor = new \ReflectionMethod($class, '__construct');
             $rawDocNode = $constructor->getDocComment();
             $source = self::MUTATOR;
-        } elseif (null === $rawDocNode = $reflectionProperty->getDocComment() ?: null) {
+        } else {
+            $rawDocNode = $reflectionProperty->getDocComment();
+        }
+
+        if (!$rawDocNode) {
             return null;
         }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80PromotedDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\RootDummy\RootDummyItem;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
@@ -439,15 +440,16 @@ class PhpStanExtractorTest extends TestCase
     /**
      * @dataProvider php80TypesProvider
      */
-    public function testExtractPhp80Type($property, array $type = null)
+    public function testExtractPhp80Type(string $class, $property, array $type = null)
     {
-        $this->assertEquals($type, $this->extractor->getTypes(Php80Dummy::class, $property, []));
+        $this->assertEquals($type, $this->extractor->getTypes($class, $property, []));
     }
 
     public function php80TypesProvider()
     {
         return [
-            ['promotedAndMutated', [new Type(Type::BUILTIN_TYPE_STRING)]],
+            [Php80Dummy::class, 'promotedAndMutated', [new Type(Type::BUILTIN_TYPE_STRING)]],
+            [Php80PromotedDummy::class, 'promoted', null],
         ];
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80PromotedDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80PromotedDummy.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class Php80PromotedDummy
+{
+    public function __construct(private string $promoted)
+    {
+    }
+
+    public function getPromoted(): string
+    {
+        return $this->promoted;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fix processing empty doc-block for promoted properties (introduced in #46056)

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
