### PR TITLE
[DependencyInjection] Allow using BackedEnum in Target attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Target.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Target.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Attribute;
 
+use BackedEnum;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
@@ -23,9 +24,9 @@ final class Target
 {
     public string $name;
 
-    public function __construct(string $name)
+    public function __construct(string|BackedEnum $name)
     {
-        $this->name = lcfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name))));
+        $this->name = lcfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name instanceof BackedEnum ? $name->value : $name))));
     }
 
     public static function parseName(\ReflectionParameter $parameter): string

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\FooVariadic;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\WithEnumTarget;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Component\ExpressionLanguage\Expression;
@@ -1104,6 +1105,20 @@ class AutowirePassTest extends TestCase
         (new AutowirePass())->process($container);
 
         $this->assertSame(BarInterface::class.' $imageStorage', (string) $container->getDefinition('with_target')->getArgument(0));
+    }
+
+    public function testArgumentWithEnumTarget()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(BarInterface::class, BarInterface::class);
+        $container->register(BarInterface::class.' $bar', BarInterface::class);
+        $container->register('with_target', WithEnumTarget::class)
+            ->setAutowired(true);
+
+        (new AutowirePass())->process($container);
+
+        $this->assertSame(BarInterface::class.' $bar', (string) $container->getDefinition('with_target')->getArgument(0));
     }
 
     public function testDecorationWithServiceAndAliasedInterface()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooBackedEnum.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooBackedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Stringable;
+
+enum FooBackedEnum: string
+{
+    case BAR = 'bar';
+    case FOO = 'foo';
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WithEnumTarget.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WithEnumTarget.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Target;
+
+class WithEnumTarget
+{
+    public function __construct(
+        #[Target(FooBackedEnum::BAR)]
+        BarInterface $bar
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features / 4.4, 5.4 or 6.0 for bug fixes <!-- see below -->
| Bug fix?      |no
| New feature?  | yes
| Deprecations? |no 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This adds support for using backed enums on the Target attribute. 

In our code base, we want to do something like this:

```php
enum GraphQLSchema: string {
  case PUBLIC = 'public';
  case INTERNAL = 'internal';
  // other schemas
}

public function __construct(
  #[Target(GraphQLSchema::PUBLIC)]
  private Schema $schema
) {}
```

Ideally, more attributes would support using enums but that's another discussion / PR.