### PR TITLE
[HttpKernel] Revert "bug #46327  Allow ErrorHandler ^5.0 to be used"

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "symfony/error-handler": "^4.4|^5.0",
+        "symfony/error-handler": "^4.4",
         "symfony/event-dispatcher": "^4.4",
         "symfony/http-client-contracts": "^1.1|^2",
         "symfony/http-foundation": "^4.4.30|^5.3.7",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This reverts commit 1e317ccd651085920e4eb4a68f3eb4aaef066ed9, reversing
changes made to 129a2710e6c884bdbed77eb18760904455633ce7.

As discussed in #46327