### PR TITLE
[Mime] Add null check for EmailHeaderSame

### DIFF
--- a/src/Symfony/Component/Mime/Test/Constraint/EmailHeaderSame.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailHeaderSame.php
@@ -55,12 +55,14 @@ final class EmailHeaderSame extends Constraint
      */
     protected function failureDescription($message): string
     {
-        return sprintf('the Email %s (value is %s)', $this->toString(), $this->getHeaderValue($message));
+        return sprintf('the Email %s (value is %s)', $this->toString(), $this->getHeaderValue($message) ?? 'null');
     }
 
-    private function getHeaderValue($message): string
+    private function getHeaderValue($message): ?string
     {
-        $header = $message->getHeaders()->get($this->headerName);
+        if (null === $header = $message->getHeaders()->get($this->headerName)) {
+            return null;
+        }
 
         return $header instanceof UnstructuredHeader ? $header->getValue() : $header->getBodyAsString();
     }

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mime\Tests;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -19,6 +20,7 @@ use Symfony\Component\Mime\Part\Multipart\AlternativePart;
 use Symfony\Component\Mime\Part\Multipart\MixedPart;
 use Symfony\Component\Mime\Part\Multipart\RelatedPart;
 use Symfony\Component\Mime\Part\TextPart;
+use Symfony\Component\Mime\Test\Constraint\EmailHeaderSame;
 
 class EmailTest extends TestCase
 {
@@ -383,5 +385,15 @@ class EmailTest extends TestCase
         $n = unserialize(serialize($e));
         $this->assertEquals($expected->getHeaders(), $n->getHeaders());
         $this->assertEquals($e->getBody(), $n->getBody());
+    }
+
+    public function testMissingHeaderDoesNotThrowError()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Email has header "foo" with value "bar" (value is null).');
+
+        $e = new Email();
+        $emailHeaderSame = new EmailHeaderSame('foo', 'bar');
+        $emailHeaderSame->evaluate($e);
     }
 }


### PR DESCRIPTION
When asserting that an email header matches some text and the header
does not exist on the message, an `Error` was being thrown because the
method `getBodyAsString()` was being called on a `null` object.  This
commit allows a missing header and will show the user that the header's
value is `null`.

Issue #44190

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #44190 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->