### PR TITLE
[Mime] Throw exception when body in Email attach method is not ok

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -272,12 +272,16 @@ class Email extends Message
     }
 
     /**
-     * @param resource|string $body
+     * @param resource|string|null $body
      *
      * @return $this
      */
     public function text($body, string $charset = 'utf-8')
     {
+        if (null !== $body && !\is_string($body) && !\is_resource($body)) {
+            throw new \TypeError(sprintf('The body must be a string, a resource or null (got "%s").', get_debug_type($body)));
+        }
+
         $this->text = $body;
         $this->textCharset = $charset;
 
@@ -304,6 +308,10 @@ class Email extends Message
      */
     public function html($body, string $charset = 'utf-8')
     {
+        if (null !== $body && !\is_string($body) && !\is_resource($body)) {
+            throw new \TypeError(sprintf('The body must be a string, a resource or null (got "%s").', get_debug_type($body)));
+        }
+
         $this->html = $body;
         $this->htmlCharset = $charset;
 
@@ -330,6 +338,10 @@ class Email extends Message
      */
     public function attach($body, string $name = null, string $contentType = null)
     {
+        if (!\is_string($body) && !\is_resource($body)) {
+            throw new \TypeError(sprintf('The body must be a string or a resource (got "%s").', get_debug_type($body)));
+        }
+
         $this->attachments[] = ['body' => $body, 'name' => $name, 'content-type' => $contentType, 'inline' => false];
 
         return $this;
@@ -352,6 +364,10 @@ class Email extends Message
      */
     public function embed($body, string $name = null, string $contentType = null)
     {
+        if (!\is_string($body) && !\is_resource($body)) {
+            throw new \TypeError(sprintf('The body must be a string or a resource (got "%s").', get_debug_type($body)));
+        }
+
         $this->attachments[] = ['body' => $body, 'name' => $name, 'content-type' => $contentType, 'inline' => true];
 
         return $this;
@@ -463,7 +479,7 @@ class Email extends Message
         $names = [];
         $htmlPart = null;
         $html = $this->html;
-        if (null !== $this->html) {
+        if (null !== $html) {
             if (\is_resource($html)) {
                 if (stream_get_meta_data($html)['seekable'] ?? false) {
                     rewind($html);

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -396,4 +396,66 @@ class EmailTest extends TestCase
         $emailHeaderSame = new EmailHeaderSame('foo', 'bar');
         $emailHeaderSame->evaluate($e);
     }
+
+    public function testAttachBodyExpectStringOrResource()
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('The body must be a string or a resource (got "bool").');
+
+        (new Email())->attach(false);
+    }
+
+    public function testEmbedBodyExpectStringOrResource()
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('The body must be a string or a resource (got "bool").');
+
+        (new Email())->embed(false);
+    }
+
+    public function testHtmlBodyExpectStringOrResourceOrNull()
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('The body must be a string, a resource or null (got "bool").');
+
+        (new Email())->html(false);
+    }
+
+    public function testHtmlBodyAcceptedTypes()
+    {
+        $email = new Email();
+
+        $email->html('foo');
+        $this->assertSame('foo', $email->getHtmlBody());
+
+        $email->html(null);
+        $this->assertNull($email->getHtmlBody());
+
+        $contents = file_get_contents(__DIR__.'/Fixtures/mimetypes/test', 'r');
+        $email->html($contents);
+        $this->assertSame($contents, $email->getHtmlBody());
+    }
+
+    public function testTextBodyExpectStringOrResourceOrNull()
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('The body must be a string, a resource or null (got "bool").');
+
+        (new Email())->text(false);
+    }
+
+    public function testTextBodyAcceptedTypes()
+    {
+        $email = new Email();
+
+        $email->text('foo');
+        $this->assertSame('foo', $email->getTextBody());
+
+        $email->text(null);
+        $this->assertNull($email->getTextBody());
+
+        $contents = file_get_contents(__DIR__.'/Fixtures/mimetypes/test', 'r');
+        $email->text($contents);
+        $this->assertSame($contents, $email->getTextBody());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45350
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

As proposed in #45350, throw exception when calling `(new Email())->attach($badBodyType);` when type is not supported