### PR TITLE
[Mailer] Fix for missing sender name in case with usage of the EnvelopeListener

### DIFF
--- a/src/Symfony/Component/Mailer/EventListener/EnvelopeListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/EnvelopeListener.php
@@ -48,7 +48,7 @@ class EnvelopeListener implements EventSubscriberInterface
             $message = $event->getMessage();
             if ($message instanceof Message) {
                 if (!$message->getHeaders()->has('Sender') && !$message->getHeaders()->has('From')) {
-                    $message->getHeaders()->addMailboxHeader('Sender', $this->sender->getAddress());
+                    $message->getHeaders()->addMailboxHeader('Sender', $this->sender);
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4, 5.4 or 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

```
$eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
$eventDispatcher->addSubscriber(
    new \Symfony\Component\Mailer\EventListener\EnvelopeListener(
        new \Symfony\Component\Mime\Address('noreply@test.com', 'TestName')
    )
);
```
