### PR TITLE
[HttpKernel] Fix missing null type in `ErrorListener::__construct()`

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
@@ -35,7 +35,7 @@ class ErrorListener implements EventSubscriberInterface
     protected $debug;
     protected $exceptionsMapping;
 
-    public function __construct(string|object|array $controller, LoggerInterface $logger = null, bool $debug = false, array $exceptionsMapping = [])
+    public function __construct(string|object|array|null $controller, LoggerInterface $logger = null, bool $debug = false, array $exceptionsMapping = [])
     {
         $this->controller = $controller;
         $this->logger = $logger;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46375
| License       | MIT
| Doc PR        | -