### PR TITLE
[HttpClient] Add missing HttpOptions::setMaxDuration()

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -200,6 +200,16 @@ class HttpOptions
     /**
      * @return $this
      */
+    public function setMaxDuration(float $maxDuration)
+    {
+        $this->options['max_duration'] = $maxDuration;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function bindTo(string $bindto)
     {
         $this->options['bindto'] = $bindto;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | no

Forgotten in #32807