### PR TITLE
[HttpKernel] New bundle path convention when `AbstractBundle` is used

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/AbstractBundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/AbstractBundle.php
@@ -47,4 +47,18 @@ abstract class AbstractBundle extends Bundle implements ConfigurableExtensionInt
 
         return $this->extension ??= new BundleExtension($this, $this->extensionAlias);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath(): string
+    {
+        if (null === $this->path) {
+            $reflected = new \ReflectionObject($this);
+            // assume the modern directory structure by default
+            $this->path = \dirname($reflected->getFileName(), 2);
+        }
+
+        return $this->path;
+    }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `Profiler::isEnabled()` so collaborating collector services may elect to omit themselves
  * Add the `UidValueResolver` argument value resolver
  * Add `AbstractBundle` class for DI configuration/definition on a single file
+ * Update the path of a bundle placed in the `src/` directory to the parent directory when `AbstractBundle` is used
 
 6.0
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16801

Addressing this comment https://github.com/symfony/symfony-docs/pull/16801#discussion_r870915569

Since Symfony 6.1 when any bundle starts using the new `AbstractBundle` and the bundle is placed in the `src/` directory we automatically update this path to the parent directory, so we don't have to do it manually to use [the modern bundle directory structure](https://symfony.com/doc/current/bundles/best_practices.html#directory-structure).

As far as I can see, there is no BC break on this proposal as this is a new class introduced in 6.1 and you have to update your code to make this happen. I will add a note about this subject in the doc too.