### PR TITLE
[Console]  Fix missing negative variation of negatable options in shell completion

### DIFF
--- a/src/Symfony/Component/Console/Completion/Output/BashCompletionOutput.php
+++ b/src/Symfony/Component/Console/Completion/Output/BashCompletionOutput.php
@@ -24,6 +24,9 @@ class BashCompletionOutput implements CompletionOutputInterface
         $values = $suggestions->getValueSuggestions();
         foreach ($suggestions->getOptionSuggestions() as $option) {
             $values[] = '--'.$option->getName();
+            if ($option->isNegatable()) {
+                $values[] = '--no-'.$option->getName();
+            }
         }
         $output->writeln(implode("\n", $values));
     }

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -119,9 +119,9 @@ class CompleteCommandTest extends TestCase
 
     public function provideCompleteCommandInputDefinitionInputs()
     {
-        yield 'definition' => [['bin/console', 'hello', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-interaction']];
+        yield 'definition' => [['bin/console', 'hello', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction']];
         yield 'custom' => [['bin/console', 'hello'], ['Fabien', 'Robin', 'Wouter']];
-        yield 'definition-aliased' => [['bin/console', 'ahoy', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-interaction']];
+        yield 'definition-aliased' => [['bin/console', 'ahoy', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction']];
         yield 'custom-aliased' => [['bin/console', 'ahoy'], ['Fabien', 'Robin', 'Wouter']];
     }
 

--- a/src/Symfony/Component/Console/Tests/Completion/Output/BashCompletionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Completion/Output/BashCompletionOutputTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Completion\Output;
+
+use Symfony\Component\Console\Completion\Output\BashCompletionOutput;
+use Symfony\Component\Console\Completion\Output\CompletionOutputInterface;
+
+class BashCompletionOutputTest extends CompletionOutputTestCase
+{
+    public function getCompletionOutput(): CompletionOutputInterface
+    {
+        return new BashCompletionOutput();
+    }
+
+    public function getExpectedOptionsOutput(): string
+    {
+        return "--option1\n--negatable\n--no-negatable".\PHP_EOL;
+    }
+
+    public function getExpectedValuesOutput(): string
+    {
+        return "Green\nRed\nYellow".\PHP_EOL;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Completion/Output/CompletionOutputTestCase.php
+++ b/src/Symfony/Component/Console/Tests/Completion/Output/CompletionOutputTestCase.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Completion\Output;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Output\CompletionOutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\StreamOutput;
+
+abstract class CompletionOutputTestCase extends TestCase
+{
+    abstract public function getCompletionOutput(): CompletionOutputInterface;
+
+    abstract public function getExpectedOptionsOutput(): string;
+
+    abstract public function getExpectedValuesOutput(): string;
+
+    public function testOptionsOutput()
+    {
+        $options = [
+            new InputOption('option1', 'o', InputOption::VALUE_NONE),
+            new InputOption('negatable', null, InputOption::VALUE_NEGATABLE),
+        ];
+        $suggestions = new CompletionSuggestions();
+        $suggestions->suggestOptions($options);
+        $stream = fopen('php://memory', 'rw+');
+        $this->getCompletionOutput()->write($suggestions, new StreamOutput($stream));
+        fseek($stream, 0);
+        $this->assertEquals($this->getExpectedOptionsOutput(), stream_get_contents($stream));
+    }
+
+    public function testValuesOutput()
+    {
+        $suggestions = new CompletionSuggestions();
+        $suggestions->suggestValues(['Green', 'Red', 'Yellow']);
+        $stream = fopen('php://memory', 'rw+');
+        $this->getCompletionOutput()->write($suggestions, new StreamOutput($stream));
+        fseek($stream, 0);
+        $this->assertEquals($this->getExpectedValuesOutput(), stream_get_contents($stream));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Add negation of [negatable options](https://symfony.com/blog/new-in-symfony-5-3-negatable-command-options) in bash completion output.

2nd PR for Fish, targeting branch 6.1: #46387 