### PR TITLE
[ErrorHandler][HttpKernel] Add favicon to welcome and error pages

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Resources/views/error.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/error.html.php
@@ -4,6 +4,7 @@
     <meta charset="<?= $this->charset; ?>" />
     <meta name="robots" content="noindex,nofollow,noarchive" />
     <title>An Error Occurred: <?= $statusText; ?></title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>❌</text></svg>">
     <style><?= $this->include('assets/css/error.css'); ?></style>
 </head>
 <body>

--- a/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
+++ b/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="robots" content="noindex,nofollow,noarchive,nosnippet,noodp,notranslate,noimageindex" />
     <title>Welcome to Symfony!</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>👋</text></svg>">
     <style>
         <?php $hue = random_int(0, 360); ?>
         <?php $darkColor = static function (float $alpha = 1) use ($hue) { return "hsla($hue, 20%, 45%, $alpha)"; }; ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Similar to https://github.com/symfony/recipes/pull/1023, saves some spammy http requests when displaying those pages.