### PR TITLE
[Filesystem] Safeguard (sym)link calls

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -318,6 +318,8 @@ class Filesystem
      */
     public function symlink($originDir, $targetDir, $copyOnWindows = false)
     {
+        self::assertFunctionExists('symlink');
+
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $originDir = strtr($originDir, '/', '\\');
             $targetDir = strtr($targetDir, '/', '\\');
@@ -354,6 +356,8 @@ class Filesystem
      */
     public function hardlink($originFile, $targetFiles)
     {
+        self::assertFunctionExists('link');
+
         if (!$this->exists($originFile)) {
             throw new FileNotFoundException(null, 0, null, $originFile);
         }
@@ -737,13 +741,22 @@ class Filesystem
         return 2 === \count($components) ? [$components[0], $components[1]] : [null, $components[0]];
     }
 
+    private static function assertFunctionExists(string $func): void
+    {
+        if (!\function_exists($func)) {
+            throw new IOException(sprintf('Unable to perform filesystem operation because the "%s()" function has been disabled.', $func));
+        }
+    }
+
     /**
      * @param mixed ...$args
      *
      * @return mixed
      */
-    private static function box(callable $func, ...$args)
+    private static function box(string $func, ...$args)
     {
+        self::assertFunctionExists($func);
+
         self::$lastError = null;
         set_error_handler(__CLASS__.'::handleError');
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #46402
| License       | MIT
| Doc PR        | N/A

This PR let's link and symlink operations fail if the corresponding PHP functions are unavailable, e.g. because they have been disabled. Without the patch, the user receives a cryptic `TypeError` in such cases.

I'm not really sure, if I can write tests for this scenario because we cannot disable those functions at runtime, can we?