### PR TITLE
[FrameworkBundle] Fix dumping extension config without bundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -79,9 +79,9 @@ EOF
             return 0;
         }
 
-        $extension = $this->findExtension($name);
-        $extensionAlias = $extension->getAlias();
         $container = $this->compileContainer();
+        $extension = $this->findExtension($name, $container);
+        $extensionAlias = $extension->getAlias();
 
         $config = $container->resolveEnvPlaceholders(
             $container->getParameterBag()->resolveValue(

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -89,9 +89,10 @@ EOF
             return 0;
         }
 
-        $extension = $this->findExtension($name);
+        $container = $this->getContainerBuilder();
+        $extension = $this->findExtension($name, $container);
 
-        $configuration = $extension->getConfiguration([], $this->getContainerBuilder());
+        $configuration = $extension->getConfiguration([], $container);
 
         $this->validateConfiguration($extension, $configuration);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -68,6 +68,15 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString(sprintf("dsn: 'file:%s/profiler'", $kernelCacheDir), $tester->getDisplay());
     }
 
+    public function testDumpExtensionConfigWithoutBundle()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(['name' => 'test_dump']);
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertStringContainsString('enabled: true', $tester->getDisplay());
+    }
+
     public function testDumpUndefinedBundleOption()
     {
         $tester = $this->createCommandTester();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -40,6 +40,15 @@ class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString('    custom:', $tester->getDisplay());
     }
 
+    public function testDumpExtensionConfigWithoutBundle()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(['name' => 'test_dump']);
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertStringContainsString('enabled:              true', $tester->getDisplay());
+    }
+
     public function testDumpAtPath()
     {
         $tester = $this->createCommandTester();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Extension/TestDumpExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Extension/TestDumpExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Extension;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+class TestDumpExtension extends Extension implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('test_dump');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->booleanNode('enabled')->defaultTrue()->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+
+    public function load(array $configs, ContainerBuilder $container)
+    {
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return $this;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\app;
 
 use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Extension\TestDumpExtension;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -78,6 +79,7 @@ class AppKernel extends Kernel
     protected function build(ContainerBuilder $container)
     {
         $container->register('logger', NullLogger::class);
+        $container->registerExtension(new TestDumpExtension());
     }
 
     public function __sleep(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Either the `debug:config` or `config:dump-reference` commands allow to pass the bundle name or the extension alias as first argument. However, when we register an extension without a bundle (i.e. it's directly registered in the kernel class or the kernel class implements `ExtensionInterface`), these commands cannot dump the configuration related to this extension.

This PR fixes the issue, so both commands will look at the extensions list regardless of whether it belongs to a bundle.