### PR TITLE
Bootstrap 4 fieldset for row errors

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
@@ -49,6 +49,7 @@ col-sm-2
             <div class="{{ block('form_group_class') }}">
                 {{- form_widget(form, widget_attr) -}}
                 {{- form_help(form) -}}
+                {{- form_errors(form) -}}
             </div>
         </div>
 {##}</fieldset>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #28086
| License       | MIT
| Doc PR        | 

When using bootstrap_4_horizontal_layout.html and ChoiceType on a form with expanded and multiple options, the checkbox list is rendered, but no errors are displayed. My changes only affect bootstrap version 4. Bootstrap 5 already has these changes.