### PR TITLE
[Serializer] Allow (de)normalization of empty objects in `PropertyNormalizer`

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -102,7 +102,7 @@ class TemplatedEmailTest extends TestCase
 EOF;
 
         $extractor = new PhpDocExtractor();
-        $propertyNormalizer = new PropertyNormalizer(null, null, $extractor);
+        $propertyNormalizer = new PropertyNormalizer(null, null, $extractor, null, null, [], true);
         $serializer = new Serializer([
             new ArrayDenormalizer(),
             new MimeMessageNormalizer($propertyNormalizer),

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -138,6 +138,7 @@ return static function (ContainerConfigurator $container) {
                 service('serializer.mapping.class_discriminator_resolver')->ignoreOnInvalid(),
                 null,
                 [],
+                false,
             ])
 
         ->alias(PropertyNormalizer::class, 'serializer.normalizer.property')

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -524,7 +524,7 @@ class EmailTest extends TestCase
 EOF;
 
         $extractor = new PhpDocExtractor();
-        $propertyNormalizer = new PropertyNormalizer(null, null, $extractor);
+        $propertyNormalizer = new PropertyNormalizer(null, null, $extractor, null, null, [], true);
         $serializer = new Serializer([
             new ArrayDenormalizer(),
             new MimeMessageNormalizer($propertyNormalizer),

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -245,7 +245,7 @@ EOF;
 EOF;
 
         $extractor = new PhpDocExtractor();
-        $propertyNormalizer = new PropertyNormalizer(null, null, $extractor);
+        $propertyNormalizer = new PropertyNormalizer(null, null, $extractor, null, null, [], true);
         $serializer = new Serializer([
             new ArrayDenormalizer(),
             new MimeMessageNormalizer($propertyNormalizer),

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
 * Add support for constructor promoted properties to `Context` attribute
 * Add context option `PropertyNormalizer::NORMALIZE_VISIBILITY` with bitmask flags `PropertyNormalizer::NORMALIZE_PUBLIC`, `PropertyNormalizer::NORMALIZE_PROTECTED`, `PropertyNormalizer::NORMALIZE_PRIVATE`
 * Add method `withNormalizeVisibility` to `PropertyNormalizerContextBuilder`
+* Add `allowNormalizationOfObjectsWithoutAnyProperties` option to `PropertyNormalizer`
+* Add `allowNormalizationOfObjectsWithoutAnyGetters` option to `GetSetMethodNormalizer`
 
 6.1
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -54,6 +54,10 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
     ) {
         parent::__construct($classMetadataFactory, $nameConverter, $propertyTypeExtractor, $classDiscriminatorResolver, $objectClassResolver, $defaultContext);
         $this->allowNormalizationOfObjectsWithoutAnyGetters = $allowNormalizationOfObjectsWithoutAnyGetters;
+
+        if (\func_num_args() < 7) {
+            trigger_deprecation('symfony/serializer', '6.2', '$allowNormalizationOfObjectsWithoutAnyGetters parameter of %s() should be explicitly provided since the default value will change to `true` in symfony/serializer >=7.0', __METHOD__);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -11,6 +11,11 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
 /**
  * Converts between objects with getter and setter methods and arrays.
  *
@@ -35,6 +40,21 @@ namespace Symfony\Component\Serializer\Normalizer;
 class GetSetMethodNormalizer extends AbstractObjectNormalizer
 {
     private static $setterAccessibleCache = [];
+
+    private $allowNormalizationOfObjectsWithoutAnyGetters;
+
+    public function __construct(
+        ClassMetadataFactoryInterface $classMetadataFactory = null,
+        NameConverterInterface $nameConverter = null,
+        PropertyTypeExtractorInterface $propertyTypeExtractor = null,
+        ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null,
+        callable $objectClassResolver = null,
+        array $defaultContext = [],
+        bool $allowNormalizationOfObjectsWithoutAnyGetters = false,
+    ) {
+        parent::__construct($classMetadataFactory, $nameConverter, $propertyTypeExtractor, $classDiscriminatorResolver, $objectClassResolver, $defaultContext);
+        $this->allowNormalizationOfObjectsWithoutAnyGetters = $allowNormalizationOfObjectsWithoutAnyGetters;
+    }
 
     /**
      * {@inheritdoc}
@@ -69,6 +89,10 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
      */
     private function supports(string $class): bool
     {
+        if ($this->allowNormalizationOfObjectsWithoutAnyGetters) {
+            return true;
+        }
+
         $class = new \ReflectionClass($class);
         $methods = $class->getMethods(\ReflectionMethod::IS_PUBLIC);
         foreach ($methods as $method) {

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -56,6 +56,10 @@ class PropertyNormalizer extends AbstractObjectNormalizer
         }
 
         $this->allowNormalizationOfObjectsWithoutAnyProperties = $allowNormalizationOfObjectsWithoutAnyProperties;
+
+        if (\func_num_args() < 7) {
+            trigger_deprecation('symfony/serializer', '6.2', '$allowNormalizationOfObjectsWithoutAnyProperties parameter of %s() should be explicitly provided since the default value will change to `true` in symfony/serializer >=7.0', __METHOD__);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -45,13 +45,17 @@ class PropertyNormalizer extends AbstractObjectNormalizer
      */
     public const NORMALIZE_VISIBILITY = 'normalize_visibility';
 
-    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, callable $objectClassResolver = null, array $defaultContext = [])
+    private $allowNormalizationOfObjectsWithoutAnyProperties;
+
+    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, callable $objectClassResolver = null, array $defaultContext = [], bool $allowNormalizationOfObjectsWithoutAnyProperties = false)
     {
         parent::__construct($classMetadataFactory, $nameConverter, $propertyTypeExtractor, $classDiscriminatorResolver, $objectClassResolver, $defaultContext);
 
         if (!isset($this->defaultContext[self::NORMALIZE_VISIBILITY])) {
             $this->defaultContext[self::NORMALIZE_VISIBILITY] = self::NORMALIZE_PUBLIC | self::NORMALIZE_PROTECTED | self::NORMALIZE_PRIVATE;
         }
+
+        $this->allowNormalizationOfObjectsWithoutAnyProperties = $allowNormalizationOfObjectsWithoutAnyProperties;
     }
 
     /**
@@ -87,6 +91,10 @@ class PropertyNormalizer extends AbstractObjectNormalizer
      */
     private function supports(string $class): bool
     {
+        if ($this->allowNormalizationOfObjectsWithoutAnyProperties) {
+            return true;
+        }
+
         $class = new \ReflectionClass($class);
 
         // We look for at least one non-static property

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -205,8 +205,8 @@ class AbstractNormalizerTest extends TestCase
     {
         $extractor = new PhpDocExtractor();
 
-        yield [new PropertyNormalizer()];
-        yield [new PropertyNormalizer(null, null, $extractor)];
+        yield [new PropertyNormalizer(null, null, null, null, null, [], true)];
+        yield [new PropertyNormalizer(null, null, $extractor, null, null, [], true)];
         yield [new ObjectNormalizer()];
         yield [new ObjectNormalizer(null, null, null, $extractor)];
     }
@@ -222,7 +222,7 @@ class AbstractNormalizerTest extends TestCase
         $dummy = new IgnoreDummy();
         $dummy->ignored1 = 'hello';
 
-        $normalizer = new PropertyNormalizer($this->classMetadata);
+        $normalizer = new PropertyNormalizer($this->classMetadata, null, null, null, null, [], true);
 
         $this->assertSame([], $normalizer->normalize($dummy));
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -357,6 +357,36 @@ class GetSetMethodNormalizerTest extends TestCase
         $this->markTestSkipped('This test makes no sense with the GetSetMethodNormalizer');
     }
 
+    protected function getNormalizerAllowingObjectsWithoutGetters(): GetSetMethodNormalizer
+    {
+        return new GetSetMethodNormalizer(null, null, null, null, null, [], true);
+    }
+
+    public function testNormalizeObjectWithoutAnyProperties()
+    {
+        $normalizer = $this->getNormalizerAllowingObjectsWithoutGetters();
+        $obj = new EmptyObjectDummy();
+
+        $this->assertTrue($normalizer->supportsNormalization($obj));
+
+        $this->assertEquals(
+            [],
+            $normalizer->normalize($obj),
+        );
+    }
+
+    public function testDenormalizeObjectWithoutAnyProperties()
+    {
+        $normalizer = $this->getNormalizerAllowingObjectsWithoutGetters();
+        $obj = new EmptyObjectDummy();
+
+        $this->assertTrue($normalizer->supportsDenormalization($obj, \get_class($obj)));
+        $this->assertEquals(
+            $obj,
+            $normalizer->denormalize([], \get_class($obj)),
+        );
+    }
+
     protected function getNormalizerForIgnoredAttributes(): GetSetMethodNormalizer
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
@@ -721,4 +751,8 @@ class ObjectWithHasGetterDummy
     {
         return $this->foo;
     }
+}
+
+class EmptyObjectDummy
+{
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -294,6 +294,36 @@ class PropertyNormalizerTest extends TestCase
         return new PropertyNormalizer($classMetadataFactory);
     }
 
+    protected function getNormalizerAllowingObjectsWithoutProperties(): PropertyNormalizer
+    {
+        return new PropertyNormalizer(null, null, null, null, null, [], true);
+    }
+
+    public function testNormalizeObjectWithoutAnyProperties()
+    {
+        $normalizer = $this->getNormalizerAllowingObjectsWithoutProperties();
+        $obj = new StaticPropertyDummy();
+
+        $this->assertTrue($normalizer->supportsNormalization($obj));
+
+        $this->assertEquals(
+            [],
+            $normalizer->normalize($obj),
+        );
+    }
+
+    public function testDenormalizeObjectWithoutAnyProperties()
+    {
+        $normalizer = $this->getNormalizerAllowingObjectsWithoutProperties();
+        $obj = new StaticPropertyDummy();
+
+        $this->assertTrue($normalizer->supportsDenormalization($obj, \get_class($obj)));
+        $this->assertEquals(
+            $obj,
+            $normalizer->denormalize([], \get_class($obj)),
+        );
+    }
+
     public function testGroupsNormalizeWithNameConverter()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -77,7 +77,7 @@ class PropertyNormalizerTest extends TestCase
     private function createNormalizer(array $defaultContext = [])
     {
         $this->serializer = $this->createMock(SerializerInterface::class);
-        $this->normalizer = new PropertyNormalizer(null, null, null, null, null, $defaultContext);
+        $this->normalizer = new PropertyNormalizer(null, null, null, null, null, $defaultContext, true);
         $this->normalizer->setSerializer($this->serializer);
     }
 
@@ -234,17 +234,17 @@ class PropertyNormalizerTest extends TestCase
 
     protected function getNormalizerForCallbacks(): PropertyNormalizer
     {
-        return new PropertyNormalizer();
+        return new PropertyNormalizer(null, null, null, null, null, [], true);
     }
 
     protected function getNormalizerForCallbacksWithPropertyTypeExtractor(): PropertyNormalizer
     {
-        return new PropertyNormalizer(null, null, $this->getCallbackPropertyTypeExtractor());
+        return new PropertyNormalizer(null, null, $this->getCallbackPropertyTypeExtractor(), null, null, [], true);
     }
 
     protected function getNormalizerForCircularReference(array $defaultContext): PropertyNormalizer
     {
-        $normalizer = new PropertyNormalizer(null, null, null, null, null, $defaultContext);
+        $normalizer = new PropertyNormalizer(null, null, null, null, null, $defaultContext, true);
         new Serializer([$normalizer]);
 
         return $normalizer;
@@ -273,7 +273,7 @@ class PropertyNormalizerTest extends TestCase
     protected function getDenormalizerForConstructArguments(): PropertyNormalizer
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
-        $denormalizer = new PropertyNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+        $denormalizer = new PropertyNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory), null, null, null, [], true);
         $serializer = new Serializer([$denormalizer]);
         $denormalizer->setSerializer($serializer);
 
@@ -284,50 +284,42 @@ class PropertyNormalizerTest extends TestCase
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
 
-        return new PropertyNormalizer($classMetadataFactory);
+        return new PropertyNormalizer($classMetadataFactory, null, null, null, null, [], true);
     }
 
     protected function getDenormalizerForGroups(): PropertyNormalizer
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
 
-        return new PropertyNormalizer($classMetadataFactory);
-    }
-
-    protected function getNormalizerAllowingObjectsWithoutProperties(): PropertyNormalizer
-    {
-        return new PropertyNormalizer(null, null, null, null, null, [], true);
+        return new PropertyNormalizer($classMetadataFactory, null, null, null, null, [], true);
     }
 
     public function testNormalizeObjectWithoutAnyProperties()
     {
-        $normalizer = $this->getNormalizerAllowingObjectsWithoutProperties();
         $obj = new StaticPropertyDummy();
 
-        $this->assertTrue($normalizer->supportsNormalization($obj));
-
+        $this->assertTrue($this->normalizer->supportsNormalization($obj));
         $this->assertEquals(
             [],
-            $normalizer->normalize($obj),
+            $this->normalizer->normalize($obj),
         );
     }
 
     public function testDenormalizeObjectWithoutAnyProperties()
     {
-        $normalizer = $this->getNormalizerAllowingObjectsWithoutProperties();
         $obj = new StaticPropertyDummy();
 
-        $this->assertTrue($normalizer->supportsDenormalization($obj, \get_class($obj)));
+        $this->assertTrue($this->normalizer->supportsDenormalization($obj, \get_class($obj)));
         $this->assertEquals(
             $obj,
-            $normalizer->denormalize([], \get_class($obj)),
+            $this->normalizer->denormalize([], \get_class($obj)),
         );
     }
 
     public function testGroupsNormalizeWithNameConverter()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
-        $this->normalizer = new PropertyNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
+        $this->normalizer = new PropertyNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter(), null, null, null, [], true);
         $this->normalizer->setSerializer($this->serializer);
 
         $obj = new GroupDummy();
@@ -348,7 +340,7 @@ class PropertyNormalizerTest extends TestCase
     public function testGroupsDenormalizeWithNameConverter()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
-        $this->normalizer = new PropertyNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
+        $this->normalizer = new PropertyNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter(), null, null, null, [], true);
         $this->normalizer->setSerializer($this->serializer);
 
         $obj = new GroupDummy();
@@ -368,7 +360,7 @@ class PropertyNormalizerTest extends TestCase
 
     protected function getDenormalizerForIgnoredAttributes(): PropertyNormalizer
     {
-        $normalizer = new PropertyNormalizer();
+        $normalizer = new PropertyNormalizer(null, null, null, null, null, [], true);
         // instantiate a serializer with the normalizer to handle normalizing recursive structures
         new Serializer([$normalizer]);
 
@@ -377,7 +369,7 @@ class PropertyNormalizerTest extends TestCase
 
     protected function getNormalizerForIgnoredAttributes(): PropertyNormalizer
     {
-        $normalizer = new PropertyNormalizer();
+        $normalizer = new PropertyNormalizer(null, null, null, null, null, [], true);
         // instantiate a serializer with the normalizer to handle normalizing recursive structures
         new Serializer([$normalizer]);
 
@@ -392,7 +384,7 @@ class PropertyNormalizerTest extends TestCase
     protected function getNormalizerForMaxDepth(): PropertyNormalizer
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
-        $normalizer = new PropertyNormalizer($classMetadataFactory);
+        $normalizer = new PropertyNormalizer($classMetadataFactory, null, null, null, null, [], true);
         $serializer = new Serializer([$normalizer]);
         $normalizer->setSerializer($serializer);
 
@@ -402,7 +394,7 @@ class PropertyNormalizerTest extends TestCase
     protected function getDenormalizerForObjectToPopulate(): PropertyNormalizer
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
-        $normalizer = new PropertyNormalizer($classMetadataFactory, null, new PhpDocExtractor());
+        $normalizer = new PropertyNormalizer($classMetadataFactory, null, new PhpDocExtractor(), null, null, [], true);
         new Serializer([$normalizer]);
 
         return $normalizer;
@@ -411,7 +403,7 @@ class PropertyNormalizerTest extends TestCase
     protected function getDenormalizerForTypeEnforcement(): DenormalizerInterface
     {
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
-        $normalizer = new PropertyNormalizer(null, null, $extractor);
+        $normalizer = new PropertyNormalizer(null, null, $extractor, null, null, [], true);
         $serializer = new Serializer([new ArrayDenormalizer(), $normalizer]);
         $normalizer->setSerializer($serializer);
 
@@ -455,7 +447,8 @@ class PropertyNormalizerTest extends TestCase
 
     public function testNoStaticPropertySupport()
     {
-        $this->assertFalse($this->normalizer->supportsNormalization(new StaticPropertyDummy()));
+        $normalizer = new PropertyNormalizer(null, null, null, null, null, [], false);
+        $this->assertFalse($normalizer->supportsNormalization(new StaticPropertyDummy()));
     }
 
     public function testInheritedPropertiesSupport()
@@ -525,12 +518,12 @@ class PropertyNormalizerTest extends TestCase
 
     protected function getNormalizerForCacheableObjectAttributesTest(): AbstractObjectNormalizer
     {
-        return new PropertyNormalizer();
+        return new PropertyNormalizer(null, null, null, null, null, [], true);
     }
 
     protected function getNormalizerForSkipUninitializedValues(): NormalizerInterface
     {
-        return new PropertyNormalizer(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())));
+        return new PropertyNormalizer(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())), null, null, null, null, [], true);
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -194,7 +194,7 @@ class SerializerTest extends TestCase
 
     public function testSerialize()
     {
-        $serializer = new Serializer([new GetSetMethodNormalizer()], ['json' => new JsonEncoder()]);
+        $serializer = new Serializer([new GetSetMethodNormalizer(null, null, null, null, null, [], true)], ['json' => new JsonEncoder()]);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $result = $serializer->serialize(Model::fromArray($data), 'json');
         $this->assertEquals(json_encode($data), $result);
@@ -246,7 +246,7 @@ class SerializerTest extends TestCase
 
     public function testDeserialize()
     {
-        $serializer = new Serializer([new GetSetMethodNormalizer()], ['json' => new JsonEncoder()]);
+        $serializer = new Serializer([new GetSetMethodNormalizer(null, null, null, null, null, [], true)], ['json' => new JsonEncoder()]);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $result = $serializer->deserialize(json_encode($data), Model::class, 'json');
         $this->assertEquals($data, $result->toArray());
@@ -254,7 +254,7 @@ class SerializerTest extends TestCase
 
     public function testDeserializeUseCache()
     {
-        $serializer = new Serializer([new GetSetMethodNormalizer()], ['json' => new JsonEncoder()]);
+        $serializer = new Serializer([new GetSetMethodNormalizer(null, null, null, null, null, [], true)], ['json' => new JsonEncoder()]);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $serializer->deserialize(json_encode($data), Model::class, 'json');
         $data = ['title' => 'bar', 'numbers' => [2, 8]];
@@ -288,14 +288,14 @@ class SerializerTest extends TestCase
 
     public function testDeserializeSupported()
     {
-        $serializer = new Serializer([new GetSetMethodNormalizer()], []);
+        $serializer = new Serializer([new GetSetMethodNormalizer(null, null, null, null, null, [], true)], []);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $this->assertTrue($serializer->supportsDenormalization(json_encode($data), Model::class, 'json'));
     }
 
     public function testDeserializeNotSupported()
     {
-        $serializer = new Serializer([new GetSetMethodNormalizer()], []);
+        $serializer = new Serializer([new GetSetMethodNormalizer(null, null, null, null, null, [], false)], []);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $this->assertFalse($serializer->supportsDenormalization(json_encode($data), 'stdClass', 'json'));
     }
@@ -327,8 +327,8 @@ class SerializerTest extends TestCase
     {
         $serializer = new Serializer(
             [
-                new GetSetMethodNormalizer(),
-                new PropertyNormalizer(),
+                new GetSetMethodNormalizer(null, null, null, null, null, [], true),
+                new PropertyNormalizer(null, null, null, null, null, [], true),
                 new ObjectNormalizer(),
                 new CustomNormalizer(),
                 new ArrayDenormalizer(),
@@ -354,7 +354,7 @@ class SerializerTest extends TestCase
 
         $serializer = new Serializer(
             [
-                new GetSetMethodNormalizer(),
+                new GetSetMethodNormalizer(null, null, null, null, null, [], true),
                 new ArrayDenormalizer(),
             ],
             [
@@ -529,14 +529,14 @@ class SerializerTest extends TestCase
     public function testNormalizeTransformEmptyArrayObjectToArray()
     {
         $serializer = new Serializer(
-            [
-                new PropertyNormalizer(),
-                new ObjectNormalizer(),
-                new ArrayDenormalizer(),
-            ],
-            [
-                'json' => new JsonEncoder(),
-            ]
+          [
+              new PropertyNormalizer(null, null, null, null, null, [], true),
+              new ObjectNormalizer(),
+              new ArrayDenormalizer(),
+          ],
+          [
+              'json' => new JsonEncoder(),
+          ]
         );
 
         $object = [];
@@ -552,14 +552,14 @@ class SerializerTest extends TestCase
     public function provideObjectOrCollectionTests()
     {
         $serializer = new Serializer(
-            [
-                new PropertyNormalizer(),
-                new ObjectNormalizer(),
-                new ArrayDenormalizer(),
-            ],
-            [
-                'json' => new JsonEncoder(),
-            ]
+          [
+              new PropertyNormalizer(null, null, null, null, null, [], true),
+              new ObjectNormalizer(),
+              new ArrayDenormalizer(),
+          ],
+          [
+              'json' => new JsonEncoder(),
+          ]
         );
 
         $data = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/46280#issuecomment-1127919687
| License       | MIT
| Doc PR        | --

This PR adds optional support for the normalization of objects without properties (in the case of `PropertyNormalizer`) or objects without getters (in the case of `GetSetMethodNormalizer`). Backward compatibility is preserved since this change is disabled by default for now.

Reasoning behind this change is explained in the discussion of the linked issue (https://github.com/symfony/symfony/issues/46280)
