### PR TITLE
[Mailer] Add mailgun multi domain support

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -37,20 +37,20 @@ class MailgunApiTransportTest extends TestCase
     {
         return [
             [
-                new MailgunApiTransport('ACCESS_KEY', 'DOMAIN'),
-                'mailgun+api://api.mailgun.net?domain=DOMAIN',
+                new MailgunApiTransport('ACCESS_KEY'),
+                'mailgun+api://api.mailgun.net',
             ],
             [
-                new MailgunApiTransport('ACCESS_KEY', 'DOMAIN', 'us-east-1'),
-                'mailgun+api://api.us-east-1.mailgun.net?domain=DOMAIN',
+                new MailgunApiTransport('ACCESS_KEY', 'us-east-1'),
+                'mailgun+api://api.us-east-1.mailgun.net',
             ],
             [
-                (new MailgunApiTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com'),
-                'mailgun+api://example.com?domain=DOMAIN',
+                (new MailgunApiTransport('ACCESS_KEY'))->setHost('example.com'),
+                'mailgun+api://example.com',
             ],
             [
-                (new MailgunApiTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com')->setPort(99),
-                'mailgun+api://example.com:99?domain=DOMAIN',
+                (new MailgunApiTransport('ACCESS_KEY'))->setHost('example.com')->setPort(99),
+                'mailgun+api://example.com:99',
             ],
         ];
     }
@@ -71,7 +71,7 @@ class MailgunApiTransportTest extends TestCase
         $email->getHeaders()->addTextHeader('amp-html', 'amp-html-value');
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $transport = new MailgunApiTransport('ACCESS_KEY');
         $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
@@ -107,7 +107,7 @@ class MailgunApiTransportTest extends TestCase
 
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $transport = new MailgunApiTransport('ACCESS_KEY');
         $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
@@ -119,7 +119,7 @@ class MailgunApiTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.us-east-1.mailgun.net:8984/v3/symfony/messages', $url);
+            $this->assertSame('https://api.us-east-1.mailgun.net:8984/v3/symfony.com/messages', $url);
             $this->assertStringContainsString('Basic YXBpOkFDQ0VTU19LRVk=', $options['headers'][2] ?? $options['request_headers'][1]);
 
             $content = '';
@@ -136,7 +136,7 @@ class MailgunApiTransportTest extends TestCase
                 'http_code' => 200,
             ]);
         });
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us-east-1', $client);
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'us-east-1', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -165,7 +165,7 @@ class MailgunApiTransportTest extends TestCase
                 'http_code' => 200,
             ]);
         });
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us-east-1', $client);
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'us-east-1', $client);
 
         $mail = new Email();
         $mail->subject('Hello!')
@@ -186,7 +186,7 @@ class MailgunApiTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.mailgun.net:8984/v3/symfony/messages', $url);
+            $this->assertSame('https://api.mailgun.net:8984/v3/symfony.com/messages', $url);
             $this->assertStringContainsStringIgnoringCase('Authorization: Basic YXBpOkFDQ0VTU19LRVk=', $options['headers'][2] ?? $options['request_headers'][1]);
 
             return new MockResponse(json_encode(['message' => 'i\'m a teapot']), [
@@ -196,7 +196,7 @@ class MailgunApiTransportTest extends TestCase
                 ],
             ]);
         });
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us', $client);
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'us', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -214,7 +214,7 @@ class MailgunApiTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.mailgun.net:8984/v3/symfony/messages', $url);
+            $this->assertSame('https://api.mailgun.net:8984/v3/symfony.com/messages', $url);
             $this->assertStringContainsStringIgnoringCase('Authorization: Basic YXBpOkFDQ0VTU19LRVk=', $options['headers'][2] ?? $options['request_headers'][1]);
 
             // NOTE: Mailgun API does this even if "Accept" request header value is "application/json".
@@ -225,7 +225,7 @@ class MailgunApiTransportTest extends TestCase
                 ],
             ]);
         });
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us', $client);
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'us', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -251,7 +251,7 @@ class MailgunApiTransportTest extends TestCase
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $transport = new MailgunApiTransport('ACCESS_KEY');
         $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
         $payload = $method->invoke($transport, $email, $envelope);
         $this->assertArrayHasKey('h:X-Mailgun-Variables', $payload);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
@@ -36,20 +36,20 @@ class MailgunHttpTransportTest extends TestCase
     {
         return [
             [
-                new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN'),
-                'mailgun+https://api.mailgun.net?domain=DOMAIN',
+                new MailgunHttpTransport('ACCESS_KEY'),
+                'mailgun+https://api.mailgun.net',
             ],
             [
-                new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN', 'us-east-1'),
-                'mailgun+https://api.us-east-1.mailgun.net?domain=DOMAIN',
+                new MailgunHttpTransport('ACCESS_KEY', 'us-east-1'),
+                'mailgun+https://api.us-east-1.mailgun.net',
             ],
             [
-                (new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com'),
-                'mailgun+https://example.com?domain=DOMAIN',
+                (new MailgunHttpTransport('ACCESS_KEY'))->setHost('example.com'),
+                'mailgun+https://example.com',
             ],
             [
-                (new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com')->setPort(99),
-                'mailgun+https://example.com:99?domain=DOMAIN',
+                (new MailgunHttpTransport('ACCESS_KEY'))->setHost('example.com')->setPort(99),
+                'mailgun+https://example.com:99',
             ],
         ];
     }
@@ -58,7 +58,7 @@ class MailgunHttpTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.us-east-1.mailgun.net:8984/v3/symfony/messages.mime', $url);
+            $this->assertSame('https://api.us-east-1.mailgun.net:8984/v3/symfony.com/messages.mime', $url);
             $this->assertStringContainsString('Basic YXBpOkFDQ0VTU19LRVk=', $options['headers'][2] ?? $options['request_headers'][1]);
 
             $content = '';
@@ -75,7 +75,7 @@ class MailgunHttpTransportTest extends TestCase
                 'http_code' => 200,
             ]);
         });
-        $transport = new MailgunHttpTransport('ACCESS_KEY', 'symfony', 'us-east-1', $client);
+        $transport = new MailgunHttpTransport('ACCESS_KEY', 'us-east-1', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -93,7 +93,7 @@ class MailgunHttpTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.mailgun.net:8984/v3/symfony/messages.mime', $url);
+            $this->assertSame('https://api.mailgun.net:8984/v3/symfony.com/messages.mime', $url);
             $this->assertStringContainsString('Basic YXBpOkFDQ0VTU19LRVk=', $options['headers'][2] ?? $options['request_headers'][1]);
 
             return new MockResponse(json_encode(['message' => 'i\'m a teapot']), [
@@ -103,7 +103,7 @@ class MailgunHttpTransportTest extends TestCase
                 ],
             ]);
         });
-        $transport = new MailgunHttpTransport('ACCESS_KEY', 'symfony', 'us', $client);
+        $transport = new MailgunHttpTransport('ACCESS_KEY', 'us', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -126,7 +126,7 @@ class MailgunHttpTransportTest extends TestCase
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
 
-        $transport = new MailgunHttpTransport('key', 'domain');
+        $transport = new MailgunHttpTransport('key');
         $method = new \ReflectionMethod(MailgunHttpTransport::class, 'addMailgunHeaders');
         $method->invoke($transport, $email);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
@@ -67,32 +67,32 @@ class MailgunTransportFactoryTest extends TransportFactoryTestCase
 
         yield [
             new Dsn('mailgun+api', 'default', self::USER, self::PASSWORD),
-            new MailgunApiTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger),
+            new MailgunApiTransport(self::USER, null, $client, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('mailgun+api', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu']),
-            new MailgunApiTransport(self::USER, self::PASSWORD, 'eu', $client, $dispatcher, $logger),
+            new MailgunApiTransport(self::USER, 'eu', $client, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('mailgun+api', 'example.com', self::USER, self::PASSWORD, 8080),
-            (new MailgunApiTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new MailgunApiTransport(self::USER, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('mailgun', 'default', self::USER, self::PASSWORD),
-            new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger),
+            new MailgunHttpTransport(self::USER, null, $client, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('mailgun+https', 'default', self::USER, self::PASSWORD),
-            new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger),
+            new MailgunHttpTransport(self::USER, null, $client, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('mailgun+https', 'example.com', self::USER, self::PASSWORD, 8080),
-            (new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new MailgunHttpTransport(self::USER, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunTransportFactory.php
@@ -31,11 +31,11 @@ final class MailgunTransportFactory extends AbstractTransportFactory
         $port = $dsn->getPort();
 
         if ('mailgun+api' === $scheme) {
-            return (new MailgunApiTransport($user, $password, $region, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
+            return (new MailgunApiTransport($user, $region, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
         }
 
         if ('mailgun+https' === $scheme || 'mailgun' === $scheme) {
-            return (new MailgunHttpTransport($user, $password, $region, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
+            return (new MailgunHttpTransport($user, $region, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
         }
 
         if ('mailgun+smtp' === $scheme || 'mailgun+smtps' === $scheme) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes (sort of)
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->


This changes make it possible to use the Mailer over multiple sender domains.

As the domain is must be based of the sender address otherwise Mailgun won't accept the Email. it doesn't make sense to hardcode the domain in the configuration.


### Before

```php
$transport = new MailgunHttpTransport('ACCESS_KEY', 'symfony', 'us', $client);
$transport->send(mailFrom("info@symfony.com")
```
would fail as domains are not correct: `symfony.com !== symfony`

### Now
```php
$transport = new MailgunHttpTransport('ACCESS_KEY', 'us', $client);
$transport->send(mailFrom("info@symfony.com")
```

Will send via the symfony.com domain. no domain setup necessary.


### Security concern (minor)

As before sending mails from `@other.domain` would fail at Mailgun side per default. 

now if you have multiple domains in Mailgun and you let the user fill in the the Sender/From address. It would allow a malicious user to send from any of your domains setup in Mailgun.

As letting the user decide the Sender address without any validation is very bad practise anyways i don't think this would be an issue.


### Backwards compatibility

As using the `MailgunTransportFactory` to create new mailers is advised and used in all documentation, here is nothing is changed.

The mailer constructors have backwards compatibilty breaks in their constructors though. Should i rever this and just not use the domain variable?