### PR TITLE
[FrameworkBundle] fix wiring of annotations.cached_reader

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAnnotationsCachedReaderPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAnnotationsCachedReaderPass.php
@@ -29,7 +29,6 @@ class AddAnnotationsCachedReaderPass implements CompilerPassInterface
         // "annotation_reader" at build time don't get any cache
         foreach ($container->findTaggedServiceIds('annotations.cached_reader') as $id => $tags) {
             $reader = $container->getDefinition($id);
-            $reader->setPublic(false);
             $properties = $reader->getProperties();
 
             if (isset($properties['cacheProviderBackup'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -28,6 +28,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'cache.pool.clearer',
         'config_cache.resource_checker',
         'console.command',
+        'container.do_not_inline',
         'container.env_var_loader',
         'container.env_var_processor',
         'container.hot_path',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -469,6 +469,8 @@ class FrameworkExtension extends Extension
             ->addTag('routing.route_loader');
 
         $container->setParameter('container.behavior_describing_tags', [
+            'annotations.cached_reader',
+            'container.do_not_inline',
             'container.service_locator',
             'container.service_subscriber',
             'kernel.event_subscriber',
@@ -1463,11 +1465,9 @@ class FrameworkExtension extends Extension
 
             $container
                 ->getDefinition('annotations.cached_reader')
-                ->setPublic(true) // set to false in AddAnnotationsCachedReaderPass
                 ->replaceArgument(2, $config['debug'])
                 // reference the cache provider without using it until AddAnnotationsCachedReaderPass runs
                 ->addArgument(new ServiceClosureArgument(new Reference($cacheService)))
-                ->addTag('annotations.cached_reader')
             ;
 
             $container->setAlias('annotation_reader', 'annotations.cached_reader')->setPrivate(true);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -31,6 +31,8 @@
                 </service>
             </argument>
             <argument /><!-- Debug-Flag -->
+            <tag name="annotations.cached_reader" />
+            <tag name="container.do_not_inline" />
         </service>
 
         <service id="annotations.filesystem_cache_adapter" class="Symfony\Component\Cache\Adapter\FilesystemAdapter">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1699,6 +1699,8 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertTrue($container->hasParameter('container.behavior_describing_tags'));
         $this->assertEquals([
+            'annotations.cached_reader',
+            'container.do_not_inline',
             'container.service_locator',
             'container.service_subscriber',
             'kernel.event_subscriber',

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -40,6 +40,10 @@ class DecoratorServicePass implements CompilerPassInterface
         }
         $decoratingDefinitions = [];
 
+        $tagsToKeep = $container->hasParameter('container.behavior_describing_tags')
+            ? $container->getParameter('container.behavior_describing_tags')
+            : ['container.do_not_inline', 'container.service_locator', 'container.service_subscriber'];
+
         foreach ($definitions as [$id, $definition]) {
             $decoratedService = $definition->getDecoratedService();
             [$inner, $renamedId] = $decoratedService;
@@ -89,8 +93,8 @@ class DecoratorServicePass implements CompilerPassInterface
                 $decoratingTags = $decoratingDefinition->getTags();
                 $resetTags = [];
 
-                // container.service_locator and container.service_subscriber have special logic and they must not be transferred out to decorators
-                foreach (['container.service_locator', 'container.service_subscriber'] as $containerTag) {
+                // Behavior-describing tags must not be transferred out to decorators
+                foreach ($tagsToKeep as $containerTag) {
                     if (isset($decoratingTags[$containerTag])) {
                         $resetTags[$containerTag] = $decoratingTags[$containerTag];
                         unset($decoratingTags[$containerTag]);

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -177,7 +177,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
      */
     private function isInlineableDefinition(string $id, Definition $definition): bool
     {
-        if ($definition->hasErrors() || $definition->isDeprecated() || $definition->isLazy() || $definition->isSynthetic()) {
+        if ($definition->hasErrors() || $definition->isDeprecated() || $definition->isLazy() || $definition->isSynthetic() || $definition->hasTag('container.do_not_inline')) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46202
| License       | MIT
| Doc PR        | -

Also fixes https://github.com/symfony/symfony/pull/26088#issuecomment-379265902

Instead of trying to hack the compilation of the container to prevent it from inlining `annotations.cached_reader`, this PR relies on an `container.do_not_inline` tag that just does that, prevent inlining so that removing passes can reliably fetch the corresponding services from the container by id or by tag.