### PR TITLE
[Security] Implement HttpBearerAuthenticator

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractBearerAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractBearerAuthenticator.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator;
+
+use Exception;
+use Lcobucci\JWT\Token;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\TokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\TokenPassport;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\TokenExtractor\BearerTokenExtractorInterface;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ */
+abstract class AbstractBearerAuthenticator implements AuthenticatorInterface, AuthenticationEntryPointInterface
+{
+    protected UserProviderInterface $userProvider;
+
+    protected BearerTokenExtractorInterface $tokenExtractor;
+
+    protected string $realmName;
+
+    protected string $payloadKey;
+
+    protected LoggerInterface $logger;
+
+    public function __construct(
+        UserProviderInterface $userProvider,
+        BearerTokenExtractorInterface $tokenExtractor,
+        string $realmName,
+        string $payloadKey,
+        LoggerInterface $logger = null
+    ) {
+        if (!interface_exists(Token::class)) {
+            throw new RuntimeException(sprintf('"%s" requires lcobucci/jwt, please run "composer require lcobucci/jwt" to install it.', self::class));
+        }
+
+        $this->userProvider = $userProvider;
+        $this->tokenExtractor = $tokenExtractor;
+        $this->realmName = $realmName;
+        $this->payloadKey = $payloadKey;
+        $this->logger = $logger;
+    }
+
+    public function start(Request $request, AuthenticationException $authException = null): Response
+    {
+        $response = new Response();
+        $response->headers->set('WWW-Authenticate', sprintf('Bearer realm="%s"', $this->realmName));
+        $response->setStatusCode(Response::HTTP_UNAUTHORIZED);
+
+        return $response;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        return $this->tokenExtractor->supports($request);
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        try {
+            $token = $this->getToken($this->tokenExtractor->extract($request));
+        } catch (Exception $exception) {
+            throw new AuthenticationException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+
+        $userIdentifier = $token->claims()->get($this->payloadKey);
+        if (null === $userIdentifier) {
+            throw new AuthenticationException(sprintf('Cannot retrieve key "%s" from token.', $this->payloadKey));
+        }
+
+        return new TokenPassport(
+            new TokenBadge($token, $userIdentifier, [$this->userProvider, 'loadUserByIdentifier'])
+        );
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        return new PostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles());
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        if (null !== $this->logger) {
+            $this->logger->info('Bearer authentication failed for token.', ['token' => $this->tokenExtractor->extract($request), 'exception' => $exception]);
+        }
+
+        return $this->start($request, $exception);
+    }
+
+    abstract protected function getToken(string $data): Token;
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Configuration/ConfigurationFactory.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Configuration/ConfigurationFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Configuration;
+
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Hmac\Sha384;
+use Lcobucci\JWT\Signer\Hmac\Sha512;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * todo Migrate this factory to framework bundle configuration.
+ *
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class ConfigurationFactory
+{
+    /**
+     * @var array<string, class-string<Signer>>
+     */
+    final public const SIGN_ALGORITHMS = [
+        'HS256' => Sha256::class,
+        'HS384' => Sha384::class,
+        'HS512' => Sha512::class,
+        'ES256' => Signer\Ecdsa\Sha256::class,
+        'ES384' => Signer\Ecdsa\Sha384::class,
+        'ES512' => Signer\Ecdsa\Sha512::class,
+        'RS256' => Signer\Rsa\Sha256::class,
+        'RS384' => Signer\Rsa\Sha384::class,
+        'RS512' => Signer\Rsa\Sha512::class,
+    ];
+
+    public static function createFromBase64Encoded(string $algorithm, string $key): Configuration
+    {
+        $signerClass = self::SIGN_ALGORITHMS[$algorithm];
+
+        return Configuration::forSymmetricSigner(new $signerClass(), InMemory::base64Encoded($key));
+    }
+
+    public static function createFromFile(string $algorithm, string $key): Configuration
+    {
+        $signerClass = self::SIGN_ALGORITHMS[$algorithm];
+
+        return Configuration::forSymmetricSigner(new $signerClass(), InMemory::file($key));
+    }
+
+    public static function createFromPlainText(string $algorithm, string $key): Configuration
+    {
+        $signerClass = self::SIGN_ALGORITHMS[$algorithm];
+
+        return Configuration::forSymmetricSigner(new $signerClass(), InMemory::plainText($key));
+    }
+
+    public static function createFromUri(string $algorithm, string $key, HttpClientInterface $client = null): Configuration
+    {
+        $signerClass = self::SIGN_ALGORITHMS[$algorithm];
+
+        return Configuration::forSymmetricSigner(new $signerClass(), InMemory::plainText(sprintf(<<<KEY
+-----BEGIN PUBLIC KEY-----
+%s
+-----END PUBLIC KEY-----
+KEY
+            , $client->request('GET', $key)->toArray()['public_key']
+        )));
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/HttpBearerAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/HttpBearerAuthenticator.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator;
+
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Token;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\SignedTokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\TokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\TokenExtractor\BearerTokenExtractorInterface;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class HttpBearerAuthenticator extends AbstractBearerAuthenticator
+{
+    private readonly Configuration $configuration;
+
+    public function __construct(UserProviderInterface $userProvider, BearerTokenExtractorInterface $tokenExtractor, Configuration $configuration, string $realmName, string $payloadKey, LoggerInterface $logger = null)
+    {
+        parent::__construct($userProvider, $tokenExtractor, $realmName, $payloadKey, $logger);
+
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * Override Passport to add SignedTokenBadge.
+     */
+    public function authenticate(Request $request): Passport
+    {
+        $passport = parent::authenticate($request);
+
+        return $passport->addBadge(new SignedTokenBadge($this->configuration, $passport->getBadge(TokenBadge::class)->getToken()));
+    }
+
+    protected function getToken(string $data): Token
+    {
+        return $this->configuration->parser()->parse($data);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/SignedTokenBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/SignedTokenBadge.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Passport\Badge;
+
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Token;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class SignedTokenBadge implements BadgeInterface
+{
+    private readonly Configuration $configuration;
+
+    private readonly Token $payload;
+
+    public function __construct(Configuration $configuration, Token $token)
+    {
+        $this->configuration = $configuration;
+        $this->payload = $token;
+    }
+
+    public function getConfiguration(): Configuration
+    {
+        return $this->configuration;
+    }
+
+    public function getToken(): Token
+    {
+        return $this->payload;
+    }
+
+    public function isResolved(): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/TokenBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/TokenBadge.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Passport\Badge;
+
+use Lcobucci\JWT\Token;
+use LogicException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\EventListener\TokenUserLoaderListener;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class TokenBadge extends UserBadge
+{
+    private readonly Token $payload;
+
+    private ?UserInterface $user = null;
+
+    public function __construct(Token $token, string $userIdentifier, callable $userLoader = null)
+    {
+        parent::__construct($userIdentifier, $userLoader);
+
+        $this->payload = $token;
+    }
+
+    public function getToken(): Token
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @throws AuthenticationException when the user cannot be found
+     */
+    public function getUser(): UserInterface
+    {
+        if (!isset($this->user)) {
+            if (null === $this->getUserLoader()) {
+                throw new LogicException(sprintf('No user loader is configured, did you forget to register the "%s" listener?', TokenUserLoaderListener::class));
+            }
+
+            $this->user = ($this->getUserLoader())($this->getUserIdentifier(), $this->getToken());
+            if (!$this->user instanceof UserInterface) {
+                throw new AuthenticationServiceException(sprintf('The user provider must return a UserInterface object, "%s" given.', get_debug_type($this->user)));
+            }
+        }
+
+        return $this->user;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/TokenPassport.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/TokenPassport.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Passport;
+
+use LogicException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\TokenBadge;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class TokenPassport extends SelfValidatingPassport
+{
+    public function __construct(TokenBadge $tokenBadge, array $badges = [])
+    {
+        parent::__construct($tokenBadge, $badges);
+    }
+
+    public function getUser(): UserInterface
+    {
+        if (null === $this->user) {
+            if (!$this->hasBadge(TokenBadge::class)) {
+                throw new LogicException('Cannot get the Security user, no username or TokenBadge configured for this passport.');
+            }
+
+            /* @phpstan-ignore-next-line */
+            $this->user = $this->getBadge(TokenBadge::class)->getUser();
+        }
+
+        return $this->user;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Token/TokenAwareUserProviderInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Token/TokenAwareUserProviderInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Token;
+
+use Lcobucci\JWT\Token;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * Overrides UserProviderInterface to add $token optional parameter on loadUserByIdentifier method.
+ * This is intended for HttpBearerAuthenticator.
+ *
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ */
+interface TokenAwareUserProviderInterface extends UserProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByIdentifier(string $identifier, Token $token = null): UserInterface;
+}

--- a/src/Symfony/Component/Security/Http/EventListener/TokenUserLoaderListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/TokenUserLoaderListener.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use Lcobucci\JWT\Token;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\TokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Token\TokenAwareUserProviderInterface;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class TokenUserLoaderListener implements EventSubscriberInterface
+{
+    private readonly UserProviderInterface $userProvider;
+
+    public function __construct(UserProviderInterface $userProvider)
+    {
+        $this->userProvider = $userProvider;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [CheckPassportEvent::class => ['checkPassport', 2048]];
+    }
+
+    public function checkPassport(CheckPassportEvent $event): void
+    {
+        $passport = $event->getPassport();
+        if (!$passport->hasBadge(TokenBadge::class)) {
+            return;
+        }
+
+        /** @var TokenBadge $badge */
+        $badge = $passport->getBadge(TokenBadge::class);
+        if (null !== $badge->getUserLoader()) {
+            return;
+        }
+
+        if (!$this->userProvider instanceof TokenAwareUserProviderInterface) {
+            return;
+        }
+
+        $badge->setUserLoader(function (string $identifier, ?Token $token): UserInterface {
+            /* @phpstan-ignore-next-line */
+            return $this->userProvider->loadUserByIdentifier($identifier, $token);
+        });
+    }
+}

--- a/src/Symfony/Component/Security/Http/EventListener/ValidateSignedTokenListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/ValidateSignedTokenListener.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use App\Security\Authenticator\Passport\Badge\SignedTokenBadge;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+
+/**
+ * Validate Token signature from Bearer authentication.
+ *
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class ValidateSignedTokenListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [CheckPassportEvent::class => 'checkPassport'];
+    }
+
+    public function checkPassport(CheckPassportEvent $event): void
+    {
+        $passport = $event->getPassport();
+        if (!$passport->hasBadge(SignedTokenBadge::class)) {
+            return;
+        }
+
+        /** @var SignedTokenBadge $badge */
+        $badge = $passport->getBadge(SignedTokenBadge::class);
+        $configuration = $badge->getConfiguration();
+
+        $configuration->setValidationConstraints(new SignedWith($configuration->signer(), $configuration->signingKey()));
+
+        if (!$configuration->validator()->validate($badge->getToken(), ...$configuration->validationConstraints())) {
+            throw new BadCredentialsException('The token signature is invalid.');
+        }
+    }
+}

--- a/src/Symfony/Component/Security/Http/TokenExtractor/BearerTokenExtractor.php
+++ b/src/Symfony/Component/Security/Http/TokenExtractor/BearerTokenExtractor.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\TokenExtractor;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class BearerTokenExtractor implements BearerTokenExtractorInterface
+{
+    /**
+     * @var BearerTokenExtractorInterface[]
+     */
+    private iterable $extractors;
+
+    public function __construct(iterable $extractors)
+    {
+        $this->extractors = $extractors;
+    }
+
+    public function supports(Request $request): bool
+    {
+        foreach ($this->extractors as $extractor) {
+            if ($extractor->supports($request)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function extract(Request $request): string
+    {
+        foreach ($this->extractors as $extractor) {
+            if ($extractor->supports($request)) {
+                return $extractor->extract($request);
+            }
+        }
+
+        // todo throw BearerTokenNotFoundException
+        return '';
+    }
+}

--- a/src/Symfony/Component/Security/Http/TokenExtractor/BearerTokenExtractorInterface.php
+++ b/src/Symfony/Component/Security/Http/TokenExtractor/BearerTokenExtractorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\TokenExtractor;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ */
+interface BearerTokenExtractorInterface
+{
+    public function supports(Request $request): bool;
+
+    public function extract(Request $request): string;
+}

--- a/src/Symfony/Component/Security/Http/TokenExtractor/FormBearerTokenExtractor.php
+++ b/src/Symfony/Component/Security/Http/TokenExtractor/FormBearerTokenExtractor.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\TokenExtractor;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Implementation of the RFC 6750 for token extraction from Form-Encoded Body Parameter.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6750#section-2.2
+ *
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class FormBearerTokenExtractor implements BearerTokenExtractorInterface
+{
+    public function supports(Request $request): bool
+    {
+        return str_starts_with($request->headers->get('CONTENT_TYPE', ''), 'application/x-www-form-urlencoded')
+            && !$request->isMethod(Request::METHOD_GET)
+            && !empty($request->getContent()['access_token']);
+    }
+
+    public function extract(Request $request): string
+    {
+        return $request->getContent()['access_token'];
+    }
+}

--- a/src/Symfony/Component/Security/Http/TokenExtractor/HeaderBearerTokenExtractor.php
+++ b/src/Symfony/Component/Security/Http/TokenExtractor/HeaderBearerTokenExtractor.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\TokenExtractor;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Implementation of the RFC 6750 for token extraction from Form-Encoded Body Parameter.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+ *
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class HeaderBearerTokenExtractor implements BearerTokenExtractorInterface
+{
+    public function supports(Request $request): bool
+    {
+        return $request->headers->has('AUTHORIZATION') && str_starts_with($request->headers->get('AUTHORIZATION'), 'Bearer ');
+    }
+
+    public function extract(Request $request): string
+    {
+        return substr($request->headers->get('AUTHORIZATION'), 7);
+    }
+}

--- a/src/Symfony/Component/Security/Http/TokenExtractor/QueryBearerTokenExtractor.php
+++ b/src/Symfony/Component/Security/Http/TokenExtractor/QueryBearerTokenExtractor.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\TokenExtractor;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Implementation of the RFC 6750 for token extraction from Form-Encoded Body Parameter.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6750#section-2.3
+ *
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @final
+ */
+class QueryBearerTokenExtractor implements BearerTokenExtractorInterface
+{
+    public function supports(Request $request): bool
+    {
+        return $request->query->has('access_token');
+    }
+
+    public function extract(Request $request): string
+    {
+        return $request->query->get('access_token');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45844
| License       | MIT
| Doc PR        | **TO DO**

A proposal implementation for a Bearer authenticator following [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750) with an AbstractBearerAuthenticator allowing to create its own Bearer authenticator.

This implementation is based on lcobucci/jwt, but there is a discussion about this dependency on #45844.

TODO:
- [ ] migrate ConfigurationFactory to framework-bundle configuration
- [ ] write doc
- [ ] write tests
- [ ] create abstraction layer over lcobucci/jwt