### PR TITLE
[Routing] Add `Requirement::POSITIVE_INT` for common ids and pagination

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add `Requirement::POSITIVE_INT` for common ids and pagination
+
 6.1
 ---
 

--- a/src/Symfony/Component/Routing/Requirement/Requirement.php
+++ b/src/Symfony/Component/Routing/Requirement/Requirement.php
@@ -20,6 +20,7 @@ enum Requirement
     public const CATCH_ALL = '.+';
     public const DATE_YMD = '[0-9]{4}-(?:0[1-9]|1[012])-(?:0[1-9]|[12][0-9]|(?<!02-)3[01])'; // YYYY-MM-DD
     public const DIGITS = '[0-9]+';
+    public const POSITIVE_INT = '[1-9][0-9]*';
     public const UID_BASE32 = '[0-9A-HJKMNP-TV-Z]{26}';
     public const UID_BASE58 = '[1-9A-HJ-NP-Za-km-z]{22}';
     public const UID_RFC4122 = '[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}';

--- a/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
+++ b/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
@@ -109,6 +109,7 @@ class RequirementTest extends TestCase
 
     /**
      * @testWith    ["0"]
+     *              ["012"]
      *              ["1"]
      *              ["42"]
      *              ["42198"]
@@ -132,6 +133,36 @@ class RequirementTest extends TestCase
     {
         $this->assertDoesNotMatchRegularExpression(
             (new Route('/{digits}', [], ['digits' => Requirement::DIGITS]))->compile()->getRegex(),
+            '/'.$digits,
+        );
+    }
+
+    /**
+     * @testWith    ["1"]
+     *              ["42"]
+     *              ["42198"]
+     *              ["999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"]
+     */
+    public function testPositiveIntOK(string $digits)
+    {
+        $this->assertMatchesRegularExpression(
+            (new Route('/{digits}', [], ['digits' => Requirement::POSITIVE_INT]))->compile()->getRegex(),
+            '/'.$digits,
+        );
+    }
+
+    /**
+     * @testWith    [""]
+     *              ["0"]
+     *              ["045"]
+     *              ["foo"]
+     *              ["-1"]
+     *              ["3.14"]
+     */
+    public function testPositiveIntKO(string $digits)
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            (new Route('/{digits}', [], ['digits' => Requirement::POSITIVE_INT]))->compile()->getRegex(),
             '/'.$digits,
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45528
| License       | MIT
| Doc PR        | ~

I targeted 6.1 because it's not yet released, should I rebase onto 6.2?

ping @fancyweb :)