### PR TITLE
[Serializer] Allow to add groups to SerializedName annotation/attribute

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -108,6 +108,11 @@ Translation
  * Deprecate `PhpExtractor` in favor of `PhpAstExtractor`
  * Add `PhpAstExtractor` (requires [nikic/php-parser](https://github.com/nikic/php-parser) to be installed)
 
+Serializer
+----------
+
+ * Add argument `$groups` to `AttributeMetadata::setSerializedName()` and `AttributeMetadata::getSerializedName()`
+
 Validator
 ---------
 

--- a/src/Symfony/Component/Serializer/Annotation/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedName.php
@@ -22,18 +22,35 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  *
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 final class SerializedName
 {
-    public function __construct(private string $serializedName)
+    /**
+     * @var string[]
+     */
+    private array $groups;
+
+    /**
+     * @param string|string[] $groups
+     */
+    public function __construct(private string $serializedName, string|array $groups = [])
     {
+        $this->groups = (array) $groups;
         if ('' === $serializedName) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', self::class));
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', static::class));
         }
     }
 
     public function getSerializedName(): string
     {
         return $this->serializedName;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getGroups(): array
+    {
+        return $this->groups;
     }
 }

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
  * Change the signature of `ClassMetadataInterface::setClassDiscriminatorMapping()` to `setClassDiscriminatorMapping(?ClassDiscriminatorMapping)`
  * Add option YamlEncoder::YAML_INDENTATION to YamlEncoder constructor options to configure additional indentation for each level of nesting. This allows configuring indentation in the service configuration.
  * Add `SerializedPath` annotation to flatten nested attributes
+ * Add serialized name group support
+ * Add argument `$groups` to `AttributeMetadata::setSerializedName()` and `AttributeMetadata::getSerializedName()`
 
 6.1
 ---

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -52,14 +52,32 @@ interface AttributeMetadataInterface
     public function getMaxDepth(): ?int;
 
     /**
-     * Sets the serialization name for this attribute.
+     * Sets the serialization names for given groups.
+     *
+     * @param array<string, string|null> $serializedNames
      */
-    public function setSerializedName(?string $serializedName);
+    public function setSerializedNames(array $serializedNames): void;
 
     /**
-     * Gets the serialization name for this attribute.
+     * Set a serialization name for given groups.
+     *
+     * @param string[] $groups
      */
-    public function getSerializedName(): ?string;
+    public function setSerializedName(?string $serializedName/* , array $groups = [] */);
+
+    /**
+     * Gets the serialization name for given groups.
+     *
+     * @param string[] $groups
+     */
+    public function getSerializedName(/* array $groups = [] */): ?string;
+
+    /**
+     * Gets all the serialization names per group ("*" being the default serialization name).
+     *
+     * @return array<string, string|null>
+     */
+    public function getSerializedNames(): array;
 
     public function setSerializedPath(?PropertyPath $serializedPath): void;
 

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
@@ -47,7 +47,7 @@ EOF;
                 $attributesMetadata[$attributeMetadata->getName()] = [
                     $attributeMetadata->getGroups(),
                     $attributeMetadata->getMaxDepth(),
-                    $attributeMetadata->getSerializedName(),
+                    $attributeMetadata->getSerializedNames(),
                     $attributeMetadata->getSerializedPath(),
                 ];
             }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -82,7 +82,7 @@ class AnnotationLoader implements LoaderInterface
                     } elseif ($annotation instanceof MaxDepth) {
                         $attributesMetadata[$property->name]->setMaxDepth($annotation->getMaxDepth());
                     } elseif ($annotation instanceof SerializedName) {
-                        $attributesMetadata[$property->name]->setSerializedName($annotation->getSerializedName());
+                        $attributesMetadata[$property->name]->setSerializedName($annotation->getSerializedName(), $annotation->getGroups());
                     } elseif ($annotation instanceof SerializedPath) {
                         $attributesMetadata[$property->name]->setSerializedPath($annotation->getSerializedPath());
                     } elseif ($annotation instanceof Ignore) {
@@ -137,7 +137,7 @@ class AnnotationLoader implements LoaderInterface
                         throw new MappingException(sprintf('SerializedName on "%s::%s()" cannot be added. SerializedName can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
                     }
 
-                    $attributeMetadata->setSerializedName($annotation->getSerializedName());
+                    $attributeMetadata->setSerializedName($annotation->getSerializedName(), $annotation->getGroups());
                 } elseif ($annotation instanceof SerializedPath) {
                     if (!$accessorOrMutator) {
                         throw new MappingException(sprintf('SerializedPath on "%s::%s()" cannot be added. SerializedPath can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -67,7 +67,13 @@ class XmlFileLoader extends FileLoader
                 }
 
                 if (isset($attribute['serialized-name'])) {
-                    $attributeMetadata->setSerializedName((string) $attribute['serialized-name']);
+                    $attributeMetadata->setSerializedName((string) $attribute['serialized-name'], []);
+                }
+
+                foreach ($attribute->serialized_name as $node) {
+                    $serializedName = (string) $node['name'];
+                    $groups = (array) $node->group;
+                    $attributeMetadata->setSerializedName('' === $serializedName ? null : $serializedName, $groups);
                 }
 
                 if (isset($attribute['serialized-path'])) {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -86,11 +86,24 @@ class YamlFileLoader extends FileLoader
                 }
 
                 if (isset($data['serialized_name'])) {
-                    if (!\is_string($data['serialized_name']) || '' === $data['serialized_name']) {
-                        throw new MappingException(sprintf('The "serialized_name" value must be a non-empty string in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
-                    }
+                    $serializedNames = $data['serialized_name'];
 
-                    $attributeMetadata->setSerializedName($data['serialized_name']);
+                    if (\is_string($serializedNames)) {
+                        if ('' === $serializedNames) {
+                            throw new MappingException(sprintf('The "serialized_name" value must be a non-empty string in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                        }
+                        $attributeMetadata->setSerializedName($serializedNames, []);
+                    } elseif (\is_array($serializedNames)) {
+                        foreach ($serializedNames as $serializedName => $groups) {
+                            if (!\is_string($serializedName) || !$serializedName) {
+                                throw new MappingException(sprintf('The key for "serialized_name" array must be a non-empty string in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                            }
+
+                            $attributeMetadata->setSerializedName($serializedName, (array) $groups);
+                        }
+                    } else {
+                        throw new MappingException(sprintf('The "serialized_name" value must be a non-empty string or an array of serialized name/groups in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                    }
                 }
 
                 if (isset($data['serialized_path'])) {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
@@ -54,6 +54,19 @@
         <xsd:attribute name="class" type="xsd:string" use="required" />
     </xsd:complexType>
 
+    <xsd:complexType name="serialized-name">
+        <xsd:sequence minOccurs="0">
+            <xsd:element name="group" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="name">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1" />
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
+    </xsd:complexType>
+
     <xsd:complexType name="attribute">
         <xsd:annotation>
             <xsd:documentation><![CDATA[
@@ -65,6 +78,7 @@
             <xsd:element name="context" type="context" maxOccurs="unbounded" />
             <xsd:element name="normalization_context" type="context" maxOccurs="unbounded" />
             <xsd:element name="denormalization_context" type="context" maxOccurs="unbounded" />
+            <xsd:element name="serialized_name" type="serialized-name" maxOccurs="unbounded" />
         </xsd:choice>
         <xsd:attribute name="name" type="xsd:string" use="required" />
         <xsd:attribute name="max-depth">

--- a/src/Symfony/Component/Serializer/Tests/Annotation/SerializedNameTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/SerializedNameTest.php
@@ -31,6 +31,21 @@ class SerializedNameTest extends TestCase
     public function testSerializedNameParameters()
     {
         $maxDepth = new SerializedName('foo');
-        $this->assertEquals('foo', $maxDepth->getSerializedName());
+        $this->assertSame('foo', $maxDepth->getSerializedName());
+        $this->assertSame([], $maxDepth->getGroups());
+    }
+
+    public function testSerializedNameParametersWithArrayGroups()
+    {
+        $maxDepth = new SerializedName('foo', ['bar', 'baz']);
+        $this->assertSame('foo', $maxDepth->getSerializedName());
+        $this->assertSame(['bar', 'baz'], $maxDepth->getGroups());
+    }
+
+    public function testSerializedNameParametersWithStringGroup()
+    {
+        $maxDepth = new SerializedName('foo', 'bar');
+        $this->assertSame('foo', $maxDepth->getSerializedName());
+        $this->assertSame(['bar'], $maxDepth->getGroups());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/SerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/SerializedNameDummy.php
@@ -33,6 +33,13 @@ class SerializedNameDummy
     public $child;
 
     /**
+     * @SerializedName("nameOne")
+     * @SerializedName("nameTwo", groups={"a", "b"})
+     * @SerializedName("nameThree", groups="c")
+     */
+    public $corge;
+
+    /**
      * @SerializedName("qux")
      */
     public function getBar()

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedNameDummy.php
@@ -30,6 +30,11 @@ class SerializedNameDummy
      */
     public $child;
 
+    #[SerializedName('nameOne')]
+    #[SerializedName('nameTwo', ['a', 'b'])]
+    #[SerializedName('nameThree', ['c'])]
+    public $corge;
+
     #[SerializedName('qux')]
     public function getBar()
     {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -23,6 +23,15 @@
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy">
         <attribute name="foo" serialized-name="baz" />
         <attribute name="bar" serialized-name="qux" />
+        <attribute name="quux" serialized-name="nameDefault">
+            <serialized_name name="nameOne">
+                <group>groupA</group>
+                <group>groupB</group>
+            </serialized_name>
+            <serialized_name name="nameTwo">
+                <group>groupC</group>
+            </serialized_name>
+        </attribute>
     </class>
 
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy">

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -16,6 +16,10 @@
       serialized_name: 'baz'
     bar:
       serialized_name: 'qux'
+    quux:
+      serialized_name:
+        nameOne: ['groupA', 'groupB']
+        nameTwo: 'groupC'
 'Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy':
   attributes:
     three:

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serializer.class.metadata.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serializer.class.metadata.php
@@ -5,10 +5,10 @@
 return [
     'Symfony\Component\Serializer\Tests\Fixtures\Dummy' => [
         [
-            'foo' => [[], null, null],
-            'bar' => [[], null, null],
-            'baz' => [[], null, null],
-            'qux' => [[], null, null],
+            'foo' => [[], null, []],
+            'bar' => [[], null, []],
+            'baz' => [[], null, []],
+            'qux' => [[], null, []],
         ],
         null,
     ],

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
@@ -62,10 +62,10 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         $this->assertArrayHasKey(Dummy::class, $compiledMetadata);
         $this->assertEquals([
             [
-                'foo' => [[], null, null, null],
-                'bar' => [[], null, null, null],
-                'baz' => [[], null, null, null],
-                'qux' => [[], null, null, null],
+                'foo' => [[], null, [], null],
+                'bar' => [[], null, [], null],
+                'baz' => [[], null, [], null],
+                'qux' => [[], null, [], null],
             ],
             null,
         ], $compiledMetadata[Dummy::class]);
@@ -73,9 +73,9 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         $this->assertArrayHasKey(MaxDepthDummy::class, $compiledMetadata);
         $this->assertEquals([
             [
-                'foo' => [[], 2, null, null],
-                'bar' => [[], 3, null, null],
-                'child' => [[], null, null, null],
+                'foo' => [[], 2, [], null],
+                'bar' => [[], 3, [], null],
+                'child' => [[], null, [], null],
             ],
             null,
         ], $compiledMetadata[MaxDepthDummy::class]);
@@ -83,10 +83,16 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         $this->assertArrayHasKey(SerializedNameDummy::class, $compiledMetadata);
         $this->assertEquals([
             [
-                'foo' => [[], null, 'baz', null],
-                'bar' => [[], null, 'qux', null],
-                'quux' => [[], null, null, null],
-                'child' => [[], null, null, null],
+                'foo' => [[], null, ['*' => 'baz'], null],
+                'bar' => [[], null, ['*' => 'qux'], null],
+                'quux' => [[], null, [], null],
+                'child' => [[], null, [], null],
+                'corge' => [[], null, [
+                    'a' => 'nameTwo',
+                    'b' => 'nameTwo',
+                    'c' => 'nameThree',
+                    '*' => 'nameOne',
+                ], null],
             ],
             null,
         ], $compiledMetadata[SerializedNameDummy::class]);
@@ -94,8 +100,8 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         $this->assertArrayHasKey(SerializedPathDummy::class, $compiledMetadata);
         $this->assertEquals([
             [
-                'three' => [[], null, null, '[one][two]'],
-                'seven' => [[], null, null, '[three][four]'],
+                'three' => [[], null, [], '[one][two]'],
+                'seven' => [[], null, [], '[three][four]'],
             ],
             null,
         ], $compiledMetadata[SerializedPathDummy::class]);

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -89,8 +89,15 @@ abstract class AnnotationLoaderTest extends TestCase
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
+
         $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+        $this->assertEquals([
+            'a' => 'nameTwo',
+            'b' => 'nameTwo',
+            'c' => 'nameThree',
+            '*' => 'nameOne',
+        ], $attributesMetadata['corge']->getSerializedNames());
     }
 
     public function testLoadSerializedPath()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -82,6 +82,10 @@ class XmlFileLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+
+        $this->assertEquals('nameDefault', $attributesMetadata['quux']->getSerializedName());
+        $this->assertEquals('nameOne', $attributesMetadata['quux']->getSerializedName(['groupB']));
+        $this->assertEquals('nameTwo', $attributesMetadata['quux']->getSerializedName(['groupC']));
     }
 
     public function testSerializedPath()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -96,6 +96,10 @@ class YamlFileLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+
+        $this->assertEquals('nameOne', $attributesMetadata['quux']->getSerializedName(['groupA']));
+        $this->assertEquals('nameOne', $attributesMetadata['quux']->getSerializedName(['groupB']));
+        $this->assertEquals('nameTwo', $attributesMetadata['quux']->getSerializedName(['groupC']));
     }
 
     public function testSerializedPath()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #30483
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR allow to configure serialization groups for annotation `SerializedName`. Inspired by PR https://github.com/symfony/symfony/pull/37903.

Before we can only define `#[SerializedName('nameOne')]`. Now, name can be different depending of group

## Attributes

```php
#[SerializedName('nameOne')]             <-- Applied when no groups are provided or when group no match
#[SerializedName('nameTwo', ['a', 'b'])] <-- Applied if group is a or b
#[SerializedName('nameThree', ['c'])]    <-- Applied if group is c
public $foo;
```

## Annotations

```php
/**
 * @SerializedName("nameOne")
 * @SerializedName("nameTwo", groups={"a", "b"})
 * @SerializedName("nameThree", groups="c")
 */
public $foo;
```
## YAML

```yaml
attributes:
  foo:
    serialized_names:
      nameOne: ['a', 'b']
      nameTwo: 'c'
```

## XML

```xml
<attribute name="foo">
    <serialized_name name="nameOne">
        <group>a</group>
        <group>b</group>
    </serialized_name>
    <serialized_name name="nameTwo">
        <group>c</group>
    </serialized_name>
</attribute>
```