### PR TITLE
Change github pull request template from 6.1 to 6.2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 | Q             | A
 | ------------- | ---
-| Branch?       | 6.1 for features / 4.4, 5.4 or 6.0 for bug fixes <!-- see below -->
+| Branch?       | 6.2 for features / 4.4, 5.4 or 6.1 for bug fixes <!-- see below -->
 | Bug fix?      | yes/no
 | New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
 | Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        |

Symfony 6.1 will be release soon. I think all new features PR must be target on new branch 6.2.
(Maybe too soon ?)