### PR TITLE
[FrameworkBundle] Fix BC break in abstract config commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\StyleInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
@@ -60,7 +59,7 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
     /**
      * @return ExtensionInterface
      */
-    protected function findExtension($name, ContainerBuilder $container)
+    protected function findExtension($name)
     {
         $bundles = $this->initializeBundles();
         $minScore = \INF;
@@ -81,6 +80,8 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
                 $minScore = $distance;
             }
         }
+
+        $container = $this->getContainerBuilder();
 
         if ($container->hasExtension($name)) {
             return $container->getExtension($name);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -79,9 +79,9 @@ EOF
             return 0;
         }
 
-        $container = $this->compileContainer();
-        $extension = $this->findExtension($name, $container);
+        $extension = $this->findExtension($name);
         $extensionAlias = $extension->getAlias();
+        $container = $this->compileContainer();
 
         $config = $container->resolveEnvPlaceholders(
             $container->getParameterBag()->resolveValue(

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -89,10 +89,9 @@ EOF
             return 0;
         }
 
-        $container = $this->getContainerBuilder();
-        $extension = $this->findExtension($name, $container);
+        $extension = $this->findExtension($name);
 
-        $configuration = $extension->getConfiguration([], $container);
+        $configuration = $extension->getConfiguration([], $this->getContainerBuilder());
 
         $this->validateConfiguration($extension, $configuration);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixes https://github.com/symfony/symfony/pull/46412

This revert also the unnecessary changes made in ConfigDebugCommand and ConfigDumpReferenceCommand classes