### PR TITLE
[Console] Fix enabled check of lazy commands

### DIFF
--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -131,7 +131,7 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 $definition->addMethodCall('setDescription', [$description]);
 
                 $container->register('.'.$id.'.lazy', LazyCommand::class)
-                    ->setArguments([$commandName, $aliases, $description, $isHidden, new ServiceClosureArgument($lazyCommandRefs[$id])]);
+                    ->setArguments([$commandName, $aliases, $description, $isHidden, new ServiceClosureArgument($lazyCommandRefs[$id]), null]);
 
                 $lazyCommandRefs[$id] = new Reference('.'.$id.'.lazy');
             }

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -146,9 +146,9 @@ class AddConsoleCommandPassTest extends TestCase
         $this->assertSame(['cmdalias'], $command->getAliases());
         $this->assertSame('Just testing', $command->getDescription());
         $this->assertTrue($command->isHidden());
-        $this->assertTrue($command->isEnabled());
         $this->assertSame($initCounter, DescribedCommand::$initCounter);
 
+        $this->assertTrue($command->isEnabled());
         $this->assertSame('', $command->getHelp());
         $this->assertSame(1 + $initCounter, DescribedCommand::$initCounter);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #46237 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This fixes the checking of `Command::isEnabled` for lazy commands. As it turns out, this was already considered in the initial implentation, the LazyCommand was just not properly setup in `AddConsoleCommandPass`. This fixes this issue.
