### PR TITLE
[DoctrineBridge] Don't reinit managers when they are proxied as ghost objects

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
+++ b/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine;
 
 use Doctrine\Persistence\AbstractManagerRegistry;
+use ProxyManager\Proxy\GhostObjectInterface;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
 use Symfony\Component\DependencyInjection\Container;
@@ -19,7 +20,7 @@ use Symfony\Component\DependencyInjection\Container;
 /**
  * References Doctrine connections and entity/document managers.
  *
- * @author  Lukas Kahwe Smith <smith@pooteeweet.org>
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
 abstract class ManagerRegistry extends AbstractManagerRegistry
 {
@@ -52,6 +53,9 @@ abstract class ManagerRegistry extends AbstractManagerRegistry
 
         if (!$manager instanceof LazyLoadingInterface) {
             throw new \LogicException('Resetting a non-lazy manager service is not supported. '.(interface_exists(LazyLoadingInterface::class) && class_exists(RuntimeInstantiator::class) ? sprintf('Declare the "%s" service as lazy.', $name) : 'Try running "composer require symfony/proxy-manager-bridge".'));
+        }
+        if ($manager instanceof GhostObjectInterface) {
+            throw new \LogicException('Resetting a lazy-ghost-object manager service is not supported.');
         }
         $manager->setProxyInitializer(\Closure::bind(
             function (&$wrappedInstance, LazyLoadingInterface $manager) use ($name) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Paving the way to https://github.com/symfony/symfony/issues/35345

Interface `GhostObjectInterface` extends `LazyLoadingInterface` but breaks LSP because `setProxyInitializer()` takes another kind of closure as argument.

This won't solve https://github.com/symfony/symfony/issues/35216 since resetting a closed entity manager won't happen anymore if we start to use ghost object proxies. But at least this code won't explode.

/cc @ostrolucky any idea what we could put inside the added "if" to solve #35216? Would you be up to submit a PR doing that, branch 6.2 I guess since that'd be a new feature?