### PR TITLE
[DependencyInjection] Fix "proxy" tag: resolve its parameters and pass it to child definitions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
@@ -187,6 +187,12 @@ class ResolveChildDefinitionsPass extends AbstractRecursivePass
         // and it's not legal on an instanceof
         $def->setAutoconfigured($definition->isAutoconfigured());
 
+        if (!$def->hasTag('proxy')) {
+            foreach ($parentDef->getTag('proxy') as $v) {
+                $def->addTag('proxy', $v);
+            }
+        }
+
         return $def;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -85,6 +85,11 @@ class ResolveParameterPlaceHoldersPass extends AbstractRecursivePass
             if (isset($changes['file'])) {
                 $value->setFile($this->bag->resolveValue($value->getFile()));
             }
+            $tags = $value->getTags();
+            if (isset($tags['proxy'])) {
+                $tags['proxy'] = $this->bag->resolveValue($tags['proxy']);
+                $value->setTags($tags);
+            }
         }
 
         $value = parent::processValue($value, $isRoot);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -118,6 +118,31 @@ class ResolveChildDefinitionsPassTest extends TestCase
         $this->assertEquals([], $def->getTags());
     }
 
+    public function testProcessCopiesTagsProxy()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('parent')
+            ->addTag('proxy', ['a' => 'b'])
+        ;
+
+        $container
+            ->setDefinition('child1', new ChildDefinition('parent'))
+        ;
+        $container
+            ->setDefinition('child2', (new ChildDefinition('parent'))->addTag('proxy', ['c' => 'd']))
+        ;
+
+        $this->process($container);
+
+        $def = $container->getDefinition('child1');
+        $this->assertSame(['proxy' => [['a' => 'b']]], $def->getTags());
+
+        $def = $container->getDefinition('child2');
+        $this->assertSame(['proxy' => [['c' => 'd']]], $def->getTags());
+    }
+
     public function testProcessDoesNotCopyDecoratedService()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -97,6 +97,20 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
         $this->assertCount(1, $definition->getErrors());
     }
 
+    public function testOnlyProxyTagIsResolved()
+    {
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('a_param', 'here_you_go');
+        $definition = $containerBuilder->register('def');
+        $definition->addTag('foo', ['bar' => '%a_param%']);
+        $definition->addTag('proxy', ['interface' => '%a_param%']);
+
+        $pass = new ResolveParameterPlaceHoldersPass(true, false);
+        $pass->process($containerBuilder);
+
+        $this->assertSame(['foo' => [['bar' => '%a_param%']], 'proxy' => [['interface' => 'here_you_go']]], $definition->getTags());
+    }
+
     private function createContainerBuilder(): ContainerBuilder
     {
         $containerBuilder = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Forgotten in https://github.com/symfony/symfony/pull/27697

"proxy" tags are special: they must follow like the "lazy" attribute of definitions.