### PR TITLE
[Messenger] add missing log context when sending to failure transport

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -60,8 +60,10 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
             new RedeliveryStamp(0)
         );
 
+        $message = $envelope->getMessage();
         $this->logger?->info('Rejected message {class} will be sent to the failure transport {transport}.', [
-            'class' => \get_class($envelope->getMessage()),
+            'message' => $message,
+            'class' => \get_class($message),
             'transport' => \get_class($failureSender),
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

## Why?
Logs generated by `SendFailedMessageToFailureTransportListener::onMessageFailed` do not include the message in the context, unlike those generated by `SendFailedMessageForRetryListener::onMessageFailed`.

## Before
```
INFO      [messenger] Rejected message App\Message\MyCustomMessage will be sent to the failure transport Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport.
 [
   "class" => "App\Message\MyCustomMessage",
   "transport" => "Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport"
 ]
 [
   "request_id" => false,
   "uid" => "537143b"
 ]
```

## After
```
INFO      [messenger] Rejected message App\Message\MyCustomMessage will be sent to the failure transport Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport.
 [
   "message" => App\Message\MyCustomMessage {
     -foo: true
     -bar: false
   },
   "class" => "App\Message\MyCustomMessage",
   "transport" => "Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport"
 ]
 [
   "request_id" => false,
   "uid" => "537143b"
 ]
```