### PR TITLE
[PropertyInfo] Fix resolution of partially docblock covered constructors

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -239,6 +239,10 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
         $phpDocNode = $this->phpDocParser->parse($tokens);
         $tokens->consumeTokenType(Lexer::TOKEN_END);
 
+        if (self::MUTATOR === $source && !$this->filterDocBlockParams($phpDocNode, $property)) {
+            return null;
+        }
+
         return [$phpDocNode, $source, $reflectionProperty->class];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTestDoc.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTestDoc.php
@@ -449,6 +449,7 @@ class PhpStanExtractorTest extends TestCase
     {
         return [
             [Php80Dummy::class, 'promotedAndMutated', [new Type(Type::BUILTIN_TYPE_STRING)]],
+            [Php80Dummy::class, 'promoted', null],
             [Php80PromotedDummy::class, 'promoted', null],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46383
| License       | MIT
| Doc PR        | -

This fixes a regression in 6.1