### PR TITLE
[ExpressionLanguage] Fix null-safe chaining

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -24,6 +24,8 @@ class GetAttrNode extends Node
     public const METHOD_CALL = 2;
     public const ARRAY_CALL = 3;
 
+    private bool $isShortCircuited = false;
+
     public function __construct(Node $node, Node $attribute, ArrayNode $arguments, int $type)
     {
         parent::__construct(
@@ -70,9 +72,16 @@ class GetAttrNode extends Node
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
                 $obj = $this->nodes['node']->evaluate($functions, $values);
+
                 if (null === $obj && $this->nodes['attribute']->isNullSafe) {
+                    $this->isShortCircuited = true;
+
                     return null;
                 }
+                if (null === $obj && $this->isShortCircuited()) {
+                    return null;
+                }
+
                 if (!\is_object($obj)) {
                     throw new \RuntimeException(sprintf('Unable to get property "%s" of non-object "%s".', $this->nodes['attribute']->dump(), $this->nodes['node']->dump()));
                 }
@@ -83,9 +92,16 @@ class GetAttrNode extends Node
 
             case self::METHOD_CALL:
                 $obj = $this->nodes['node']->evaluate($functions, $values);
+
                 if (null === $obj && $this->nodes['attribute']->isNullSafe) {
+                    $this->isShortCircuited = true;
+
                     return null;
                 }
+                if (null === $obj && $this->isShortCircuited()) {
+                    return null;
+                }
+
                 if (!\is_object($obj)) {
                     throw new \RuntimeException(sprintf('Unable to call method "%s" of non-object "%s".', $this->nodes['attribute']->dump(), $this->nodes['node']->dump()));
                 }
@@ -97,12 +113,24 @@ class GetAttrNode extends Node
 
             case self::ARRAY_CALL:
                 $array = $this->nodes['node']->evaluate($functions, $values);
+
+                if (null === $array && $this->isShortCircuited()) {
+                    return null;
+                }
+
                 if (!\is_array($array) && !$array instanceof \ArrayAccess) {
                     throw new \RuntimeException(sprintf('Unable to get an item of non-array "%s".', $this->nodes['node']->dump()));
                 }
 
                 return $array[$this->nodes['attribute']->evaluate($functions, $values)];
         }
+    }
+
+    private function isShortCircuited(): bool
+    {
+        return $this->isShortCircuited
+            || ($this->nodes['node'] instanceof self && $this->nodes['node']->isShortCircuited())
+        ;
     }
 
     public function toArray()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the null-safe operator in the expression language doesn't behave the same as in PHP. According to the [RFC](https://wiki.php.net/rfc/nullsafe_operator):
> When the evaluation of one element in the chain fails the execution of the entire chain is aborted and the entire chain evaluates to null. 

For example, in PHP the following expressions will [return `null`](https://3v4l.org/lZ65Q):
```php
$foo = null;
$foo?->bar['baz'];
$foo?->bar['baz']['qux'];
$foo?->bar['baz']['qux']->quux;
$foo?->bar['baz']['qux']->quux();
```

This, however, is not the case with the null-safe operator in the expression language where the evaluation for such cases fails.

Not sure if this qualifies as a bug fix or a feature, so please let me know. 