### PR TITLE
[MonologBridge] ensure that the $response property is initialized before being read

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 class FirePHPHandler extends BaseFirePHPHandler
 {
     private array $headers = [];
-    private Response $response;
+    private ?Response $response = null;
 
     /**
      * Adds the headers to the response once it's created.
@@ -61,7 +61,7 @@ class FirePHPHandler extends BaseFirePHPHandler
             return;
         }
 
-        if ($this->response) {
+        if (null !== $this->response) {
             $this->response->headers->set($header, $content);
         } else {
             $this->headers[$header] = $content;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46474
| License       | MIT
| Doc PR        | 