### PR TITLE
[Contracts] remove static cache from `ServiceSubscriberTrait`

### DIFF
--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -29,12 +29,6 @@ trait ServiceSubscriberTrait
      */
     public static function getSubscribedServices(): array
     {
-        static $services;
-
-        if (null !== $services) {
-            return $services;
-        }
-
         $services = method_exists(get_parent_class(self::class) ?: '', __FUNCTION__) ? parent::getSubscribedServices() : [];
 
         foreach ((new \ReflectionClass(self::class))->getMethods() as $method) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

I found an edge case when using this trait on a class that extends a parent class that implements `getSubscribedServices()`. The issue occurs if the parent _dynamically_ determines the return value of `getSubscribedServices()` based on something in the child class (in my case, using reflection). It's fine if only one class extends this parent but when multiple do, only the first class registered in the container has the proper services. The next classes have the same as the first because of the static variable.
