### PR TITLE
Introduce FlashBagAwareSessionInterface

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/FlashBagAwareSessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/FlashBagAwareSessionInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session;
+
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+
+/**
+ * Interface for session with a flashbag.
+ */
+interface FlashBagAwareSessionInterface extends SessionInterface
+{
+    public function getFlashBag(): FlashBagInterface;
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -30,7 +30,7 @@ class_exists(SessionBagProxy::class);
  *
  * @implements \IteratorAggregate<string, mixed>
  */
-class Session implements SessionInterface, \IteratorAggregate, \Countable
+class Session implements FlashBagAwareSessionInterface, \IteratorAggregate, \Countable
 {
     protected $storage;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #41765
| License       | MIT
| Doc PR        | symfony/symfony-docs#... Not needed

This solve https://github.com/symfony/symfony/issues/41765

People will be able to write
```
$session = $request->getSession();
if ($session instanceof FlashBagAwareSessionInterface) {
     $session->addFlashBag(...);
}
```

This is better than a `instanceof Session` check (which is not working with decoration).