### PR TITLE
[FrameworkBundle] update docblock to not expose the internal class

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -14,7 +14,7 @@ index d68ae4c8b3..8e980a9e70 100644
       * @return TestContainer
       */
 -    protected static function getContainer(): ContainerInterface
-+    protected static function getContainer(): TestContainer
++    protected static function getContainer(): Container
      {
          if (!static::$booted) {
 diff --git a/src/Symfony/Component/BrowserKit/AbstractBrowser.php b/src/Symfony/Component/BrowserKit/AbstractBrowser.php

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -83,7 +84,7 @@ abstract class KernelTestCase extends TestCase
      *
      * Using this method is the best way to get a container from your test code.
      *
-     * @return TestContainer
+     * @return Container
      */
     protected static function getContainer(): ContainerInterface
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46483
| License       | MIT
| Doc PR        | 

The change was introduced in #44695 motivated by the idea to be able to use the `getServiceIds()` and `getRemovedIds()` methods which are Symfony-specific methods. Exposing the `TestContainer` has the drawback of static analysis tools complaining about making use of internal classes. Since the interesting methods are part of the base `Container` class which is not internal I propose to change the docblock to return an instance of this class instead.
