### PR TITLE
[Console] Add SymfonyStyle::hr() method to render horizontal rulers

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * added `SymfonyStyle::hr() to render horizontal rulers`
+
 6.1
 ---
 

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -411,6 +411,13 @@ class SymfonyStyle extends OutputStyle
         return (new Table($output))->setStyle($style);
     }
 
+    public function hr(string $word = '─', string $format = '%s'): void
+    {
+        $line_width = (new Terminal())->getWidth() ?: self::MAX_LINE_LENGTH;
+        $line = str_repeat($word, $line_width / mb_strlen($word));
+        $this->output->writeln(sprintf($format, $line));
+    }
+
     private function getProgressBar(): ProgressBar
     {
         return $this->progressBar


### PR DESCRIPTION
  | Q             | A
  | ------------- | ---
  | Branch?       | 6.2
  | Bug fix?      | no
  | New feature?  | yes
  | Deprecations? | no
  | License       | MIT
  
This allows to render full width horizontal rulers that can be helpful when inspecting long output in PHP scripts.
Bash implementation can be found here:  https://github.com/LuRsT/hr

