### PR TITLE
[WebProfilerBundle] Fix AJAX requests info are truncated in the WDT

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -324,7 +324,7 @@ div.sf-toolbar .sf-toolbar-block a:hover {
 .sf-toolbar-block.hover .sf-toolbar-info {
     display: block;
     padding: 10px;
-    max-width: 480px;
+    max-width: 525px;
     max-height: 480px;
     word-wrap: break-word;
     overflow: hidden;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45741?, replaces #46495 ?
| License       | MIT
| Doc PR        | n/a

At some point (I guess during the WDT redesign, #15160), something changed making the AJAX request table in the WDT just a little bit larger.
This causes the requests to be truncated when the URL is too long:
<img width="824" alt="Screenshot 2022-05-30 at 10 21 51" src="https://user-images.githubusercontent.com/870118/171017432-8eeec54d-1342-427d-b885-a590db978458.png">

This PR fixes this by increasing the max-width of the WDT info panel to 525px:
<img width="866" alt="Screenshot 2022-05-30 at 10 22 20" src="https://user-images.githubusercontent.com/870118/171018191-9370c1e0-9ecb-487f-ad1c-300b831ae2d6.png">

We could reduce the width of the request table to fit in, but 525px seems reasonable enough nowadays and provides more information about the URL.
