### PR TITLE
[Serializer] Added missing __call to TraceableNormalizer and TraceableSerializer

### DIFF
--- a/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
@@ -150,4 +150,12 @@ class TraceableNormalizer implements NormalizerInterface, DenormalizerInterface,
     {
         return $this->normalizer instanceof CacheableSupportsMethodInterface && $this->normalizer->hasCacheableSupportsMethod();
     }
+
+    /**
+     * Proxies all method calls to the original normalizer.
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        return $this->normalizer->{$method}(...$arguments);
+    }
 }

--- a/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
@@ -165,4 +165,12 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
     {
         return $this->serializer->supportsDecoding($format, $context);
     }
+
+    /**
+     * Proxies all method calls to the original serializer.
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        return $this->serializer->{$method}(...$arguments);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       |  symfony/maker-bundle#1252 
| License       | MIT
| Doc PR        | none

Added missing `__call` method to the new TraceableNormalizer and TraceableSerializer.
This method was forgotten and breaks custom normalizers that have public methods outside of the NormalizerInterface.

This approach is already being used for TreaceableAuthenticator, TraceableEventDispatcher, LoggingTranslator etc...