### PR TITLE
[Serializer] Get attributeContext after converting name

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -359,11 +359,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $resolvedClass = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
 
         foreach ($normalizedData as $attribute => $value) {
-            $attributeContext = $this->getAttributeDenormalizationContext($resolvedClass, $attribute, $context);
-
             if ($this->nameConverter) {
-                $attribute = $this->nameConverter->denormalize($attribute, $resolvedClass, $format, $attributeContext);
+                $attribute = $this->nameConverter->denormalize($attribute, $resolvedClass, $format, $context);
             }
+
+            $attributeContext = $this->getAttributeDenormalizationContext($resolvedClass, $attribute, $context);
 
             if ((false !== $allowedAttributes && !\in_array($attribute, $allowedAttributes)) || !$this->isAllowedAttribute($resolvedClass, $attribute, $format, $context)) {
                 if (!($context[self::ALLOW_EXTRA_ATTRIBUTES] ?? $this->defaultContext[self::ALLOW_EXTRA_ATTRIBUTES])) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Annotation\Context;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -70,6 +71,17 @@ trait ContextMetadataTestTrait
         ]);
         self::assertEquals('2011-07-28', $dummy->date->format('Y-m-d'), 'a specific denormalization context is used for this group');
     }
+
+    public function testContextDenormalizeWithNameConverter()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter(), null, new PhpDocExtractor());
+        new Serializer([new DateTimeNormalizer(), $normalizer]);
+
+        /** @var ContextMetadataNamingDummy $dummy */
+        $dummy = $normalizer->denormalize(['created_at' => '28/07/2011'], ContextMetadataNamingDummy::class);
+        self::assertEquals('2011-07-28', $dummy->createdAt->format('Y-m-d'));
+    }
 }
 
 class ContextMetadataDummy
@@ -89,4 +101,14 @@ class ContextMetadataDummy
      * )
      */
     public $date;
+}
+
+class ContextMetadataNamingDummy
+{
+    /**
+     * @var \DateTime
+     *
+     * @Context({ DateTimeNormalizer::FORMAT_KEY = "d/m/Y" })
+     */
+    public $createdAt;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Property specific denormalization context doesn't work when property name in the array being denormalized is different from property name in the class.
To reproduce:

```php
// composer require symfony/serializer:"5.4.*" doctrine/annotations symfony/property-access
<?php
require_once __DIR__.'/vendor/autoload.php';

use Doctrine\Common\Annotations\AnnotationReader;
use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
use Symfony\Component\Serializer\Annotation\Context;
use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
use Symfony\Component\Serializer\Serializer;

class Item
{
    /**
     * @Context({ DateTimeNormalizer::FORMAT_KEY = "d/m/Y" })
     */
    public \DateTime $createdAt;
}

$classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
$objectNormalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter(), null, new ReflectionExtractor());
$normalizers = [new DateTimeNormalizer(), $objectNormalizer];
new Serializer($normalizers, []);

// outputs 2011-07-28
echo ($objectNormalizer->denormalize(['createdAt' => '28/07/2011'], Item::class))->createdAt->format('Y-m-d') . PHP_EOL;

// crashes because 'created_at' !== 'createdAt'
echo ($objectNormalizer->denormalize(['created_at' => '28/07/2011'], Item::class))->createdAt->format('Y-m-d') . PHP_EOL;
```

Theoretically this could introduce breaking changes to people who use property specific context in their custom name converters, but due to this bug that context reaches the name converter only when the source name already matches the property name, so in that case no name converting is needed anyway and the context is useless.

Moreover, I'm not sure if 'deserialization_path' changing from source name to the converted name is an issue, if it is I can modify my PR to preserve the original functionality.
