### PR TITLE
[Serializer] Added missing __call to TraceableEncoder

### DIFF
--- a/src/Symfony/Component/Serializer/Debug/TraceableEncoder.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableEncoder.php
@@ -121,4 +121,12 @@ class TraceableEncoder implements EncoderInterface, DecoderInterface, Serializer
     {
         return !$this->encoder instanceof NormalizationAwareEncoder;
     }
+
+    /**
+     * Proxies all method calls to the original encoder.
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        return $this->encoder->{$method}(...$arguments);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       |  none
| License       | MIT
| Doc PR        | none

Added missing `__call` method to the new TraceableEncoder.