### PR TITLE
[Serializer] Forget partially collected traces

### DIFF
--- a/src/Symfony/Component/Serializer/DataCollector/SerializerDataCollector.php
+++ b/src/Symfony/Component/Serializer/DataCollector/SerializerDataCollector.php
@@ -179,6 +179,10 @@ class SerializerDataCollector extends DataCollector implements LateDataCollector
         ];
 
         foreach ($this->collected as $collected) {
+            if (!isset($collected['data'])) {
+                continue;
+            }
+
             $data = [
                 'data' => $this->cloneVar($collected['data']),
                 'dataType' => get_debug_type($collected['data']),

--- a/src/Symfony/Component/Serializer/Tests/DataCollector/SerializerDataCollectorTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DataCollector/SerializerDataCollectorTest.php
@@ -276,6 +276,27 @@ class SerializerDataCollectorTest extends TestCase
         $this->assertSame([], $dataCollector->getData());
     }
 
+    public function testDoNotCollectPartialTraces()
+    {
+        $dataCollector = new SerializerDataCollector();
+
+        $dataCollector->collectNormalization('traceIdOne', DateTimeNormalizer::class, 1.0);
+        $dataCollector->collectDenormalization('traceIdTwo', DateTimeNormalizer::class, 1.0);
+        $dataCollector->collectEncoding('traceIdThree', CsvEncoder::class, 10.0);
+        $dataCollector->collectDecoding('traceIdFour', JsonEncoder::class, 1.0);
+
+        $dataCollector->lateCollect();
+
+        $data = $dataCollector->getData();
+
+        $this->assertSame([], $data['serialize']);
+        $this->assertSame([], $data['deserialize']);
+        $this->assertSame([], $data['normalize']);
+        $this->assertSame([], $data['denormalize']);
+        $this->assertSame([], $data['encode']);
+        $this->assertSame([], $data['decode']);
+    }
+
     /**
      * Cast cloned vars to be able to test nested values.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46522 
| License       | MIT

If serialization fails whereas a nested normalizer has already succeeded, a trace will be created but is still partially filled.
But these traces aren't useful and might be omitted.

Therefore, as discussed in #46522, this change will simply make the `SerializerDataColelctor::lateCollect` method ignore partial traces.
