### PR TITLE
[HttpClient] Warning: Array to string conversion

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -197,7 +197,11 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
                 $dataArg[] = '--data '.escapeshellarg($body);
             } elseif (\is_array($body)) {
                 foreach ($body as $key => $value) {
-                    $dataArg[] = '--data '.escapeshellarg("$key=$value");
+                    if (\is_array($value)) {
+                        $dataArg[] = '--data '.urldecode(http_build_query($value));
+                    } else {
+                        $dataArg[] = '--data '.escapeshellarg("$key=$value");
+                    }
                 }
             } else {
                 return null;


### PR DESCRIPTION
Hi everybody !

When you try to send multidimensional arrays, you get the error "Warning: Array to string conversion".
I don't know if it the best way to fix it... but works for me.

Thanks for reading me :)


| Q             | A
| ------------- | ---
| Branch?       | 6.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
