### PR TITLE
[Mime] Check that the path is a file in the DataPart::fromPath

### DIFF
--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -61,7 +61,7 @@ class DataPart extends TextPart
             $contentType = self::$mimeTypes->getMimeTypes($ext)[0] ?? 'application/octet-stream';
         }
 
-        if (false === is_readable($path)) {
+        if (!is_file($path) || !is_readable($path)) {
             throw new InvalidArgumentException(sprintf('Path "%s" is not readable.', $path));
         }
 

--- a/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Mime\Tests\Part;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\IdentificationHeader;
 use Symfony\Component\Mime\Header\ParameterizedHeader;
@@ -125,6 +126,12 @@ class DataPartTest extends TestCase
             new UnstructuredHeader('Content-Transfer-Encoding', 'base64'),
             new ParameterizedHeader('Content-Disposition', 'attachment', ['name' => 'photo.gif', 'filename' => 'photo.gif'])
         ), $p->getPreparedHeaders());
+    }
+
+    public function testFromPathWithNotAFile()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        DataPart::fromPath(__DIR__.'/../Fixtures/mimetypes/');
     }
 
     public function testHasContentId()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

The directory can also be readable. Fix to the [PR](https://github.com/symfony/symfony/pull/36304).

Found it while working on another fix related to this method.