### PR TITLE
[FrameworkBundle][HtmlSanitizer] Fix calling `allowStaticElements` when setting `allow_all_static_elements: true`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2149,7 +2149,7 @@ class Configuration implements ConfigurationInterface
                                         ->info('Allows "safe" elements and attributes.')
                                         ->defaultFalse()
                                     ->end()
-                                    ->booleanNode('allow_all_static_elements')
+                                    ->booleanNode('allow_static_elements')
                                         ->info('Allows all static elements and attributes from the W3C Sanitizer API standard.')
                                         ->defaultFalse()
                                     ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2682,8 +2682,8 @@ class FrameworkExtension extends Extension
                 $def->addMethodCall('allowSafeElements', [], true);
             }
 
-            if ($sanitizerConfig['allow_all_static_elements']) {
-                $def->addMethodCall('allowAllStaticElements', [], true);
+            if ($sanitizerConfig['allow_static_elements']) {
+                $def->addMethodCall('allowStaticElements', [], true);
             }
 
             // Configures elements

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -845,7 +845,7 @@
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="required" />
         <xsd:attribute name="allow-safe-elements" type="xsd:boolean" />
-        <xsd:attribute name="allow-all-static-elements" type="xsd:boolean" />
+        <xsd:attribute name="allow-static-elements" type="xsd:boolean" />
         <xsd:attribute name="force-https-urls" type="xsd:boolean" />
         <xsd:attribute name="allow-relative-links" type="xsd:boolean" />
         <xsd:attribute name="allow-relative-medias" type="xsd:boolean" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer.php
@@ -6,7 +6,7 @@ $container->loadFromExtension('framework', [
         'sanitizers' => [
             'default' => [
                 'allow_safe_elements' => true,
-                'allow_all_static_elements' => true,
+                'allow_static_elements' => true,
                 'allow_elements' => [
                     'iframe' => 'src',
                     'custom-tag' => ['data-attr', 'data-attr-1'],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer.xml
@@ -9,7 +9,7 @@
         <html-sanitizer>
             <sanitizer name="default"
                 allow-safe-elements="true"
-                allow-all-static-elements="true"
+                allow-static-elements="true"
                 force-https-urls="true"
                 allow-relative-links="true"
                 allow-relative-medias="true"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer.yml
@@ -4,7 +4,7 @@ framework:
         sanitizers:
             default:
                 allow_safe_elements: true
-                allow_all_static_elements: true
+                allow_static_elements: true
                 allow_elements:
                     iframe: 'src'
                     custom-tag: ['data-attr', 'data-attr-1']

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -2045,7 +2045,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(
             [
                 ['allowSafeElements', [], true],
-                ['allowAllStaticElements', [], true],
+                ['allowStaticElements', [], true],
                 ['allowElement', ['iframe', 'src'], true],
                 ['allowElement', ['custom-tag', ['data-attr', 'data-attr-1']], true],
                 ['allowElement', ['custom-tag-2', '*'], true],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | [symfony/symfony-docs#... <!-- required for new features -->](https://github.com/symfony/symfony-docs/pull/16838)

```
Symfony\Component\ErrorHandler\Error\UndefinedMethodError {#21964
  #message: """
    Attempted to call an undefined method named "allowAllStaticElements" of class "Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig".\n
    Did you mean to call e.g. "allowSafeElements" or "allowStaticElements"?
    """
  #code: 0
  #file: "./var/cache/dev/ContainerXJ5lfcV/getHtmlSanitizer_Sanitizer_PostContent_SanitizerService.php"
  #line: 25
  trace: {
    ./var/cache/dev/ContainerXJ5lfcV/getHtmlSanitizer_Sanitizer_PostContent_SanitizerService.php:25 {
      ContainerXJ5lfcV\getHtmlSanitizer_Sanitizer_PostContent_SanitizerService::do($container, $lazyLoad = true)
      › $a = new \Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig();
      › $a = $a->allowAllStaticElements();
      › $a = $a->forceHttpsUrls(false);
    }
    ./var/cache/dev/ContainerXJ5lfcV/App_KernelDevDebugContainer.php:981 { …}
    ./var/cache/dev/ContainerXJ5lfcV/getTestCommandService.php:23 { …}
    ./var/cache/dev/ContainerXJ5lfcV/App_KernelDevDebugContainer.php:981 { …}
    ./vendor/symfony/dependency-injection/Container.php:383 { …}
    ./vendor/symfony/dependency-injection/Argument/ServiceLocator.php:43 { …}
    ./vendor/symfony/console/CommandLoader/ContainerCommandLoader.php:46 { …}
    ./vendor/symfony/console/Application.php:570 { …}
    ./vendor/symfony/console/Application.php:657 { …}
    ./vendor/symfony/framework-bundle/Console/Application.php:114 { …}
    ./vendor/symfony/console/Application.php:259 { …}
    ./vendor/symfony/framework-bundle/Console/Application.php:80 { …}
    ./vendor/symfony/console/Application.php:171 { …}
    ./vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:54 { …}
    ./vendor/autoload_runtime.php:29 { …}
    ./bin/console:15 { …}
  }
}
```