### PR TITLE
Fix getting class constraints on debug command

### DIFF
--- a/src/Symfony/Component/Validator/Command/DebugCommand.php
+++ b/src/Symfony/Component/Validator/Command/DebugCommand.php
@@ -90,7 +90,19 @@ EOF
         $rows = [];
         $dump = new Dumper($output);
 
-        foreach ($this->getConstrainedPropertiesData($class) as $propertyName => $constraintsData) {
+        /** @var ClassMetadataInterface $classMetadata */
+        $classMetadata = $this->validator->getMetadataFor($class);
+
+        foreach ($this->getClassConstraintsData($classMetadata) as $data) {
+            $rows[] = [
+                '-',
+                $data['class'],
+                implode(', ', $data['groups']),
+                $dump($data['options']),
+            ];
+        }
+
+        foreach ($this->getConstrainedPropertiesData($classMetadata) as $propertyName => $constraintsData) {
             foreach ($constraintsData as $data) {
                 $rows[] = [
                     $propertyName,
@@ -121,12 +133,20 @@ EOF
         $table->render();
     }
 
-    private function getConstrainedPropertiesData(string $class): array
+    private function getClassConstraintsData(ClassMetadataInterface $classMetadata): iterable
+    {
+        foreach ($classMetadata->getConstraints() as $constraint) {
+            yield [
+                'class' => \get_class($constraint),
+                'groups' => $constraint->groups,
+                'options' => $this->getConstraintOptions($constraint),
+            ];
+        }
+    }
+
+    private function getConstrainedPropertiesData(ClassMetadataInterface $classMetadata): array
     {
         $data = [];
-
-        /** @var ClassMetadataInterface $classMetadata */
-        $classMetadata = $this->validator->getMetadataFor($class);
 
         foreach ($classMetadata->getConstrainedProperties() as $constrainedProperty) {
             $data[$constrainedProperty] = $this->getPropertyData($classMetadata, $constrainedProperty);

--- a/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Validator\Command\DebugCommand;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
@@ -37,6 +38,11 @@ class DebugCommandTest extends TestCase
             ->method('getMetadataFor')
             ->with(DummyClassOne::class)
             ->willReturn($classMetadata);
+
+        $classMetadata
+            ->expects($this->once())
+            ->method('getConstraints')
+            ->willReturn([new Expression('1 + 1 = 2')]);
 
         $classMetadata
             ->expects($this->once())
@@ -68,22 +74,28 @@ class DebugCommandTest extends TestCase
 Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 -----------------------------------------------------
 
-+---------------+--------------------------------------------------+---------+------------------------------------------------------------+
-| Property      | Name                                             | Groups  | Options                                                    |
-+---------------+--------------------------------------------------+---------+------------------------------------------------------------+
-| firstArgument | Symfony\Component\Validator\Constraints\NotBlank | Default | [                                                          |
-|               |                                                  |         |   "allowNull" => false,                                    |
-|               |                                                  |         |   "message" => "This value should not be blank.",          |
-|               |                                                  |         |   "normalizer" => null,                                    |
-|               |                                                  |         |   "payload" => null                                        |
-|               |                                                  |         | ]                                                          |
-| firstArgument | Symfony\Component\Validator\Constraints\Email    | Default | [                                                          |
-|               |                                                  |         |   "message" => "This value is not a valid email address.", |
-|               |                                                  |         |   "mode" => null,                                          |
-|               |                                                  |         |   "normalizer" => null,                                    |
-|               |                                                  |         |   "payload" => null                                        |
-|               |                                                  |         | ]                                                          |
-+---------------+--------------------------------------------------+---------+------------------------------------------------------------+
++---------------+----------------------------------------------------+---------+------------------------------------------------------------+
+| Property      | Name                                               | Groups  | Options                                                    |
++---------------+----------------------------------------------------+---------+------------------------------------------------------------+
+| -             | Symfony\Component\Validator\Constraints\Expression | Default | [                                                          |
+|               |                                                    |         |   "expression" => "1 + 1 = 2",                             |
+|               |                                                    |         |   "message" => "This value is not valid.",                 |
+|               |                                                    |         |   "payload" => null,                                       |
+|               |                                                    |         |   "values" => []                                           |
+|               |                                                    |         | ]                                                          |
+| firstArgument | Symfony\Component\Validator\Constraints\NotBlank   | Default | [                                                          |
+|               |                                                    |         |   "allowNull" => false,                                    |
+|               |                                                    |         |   "message" => "This value should not be blank.",          |
+|               |                                                    |         |   "normalizer" => null,                                    |
+|               |                                                    |         |   "payload" => null                                        |
+|               |                                                    |         | ]                                                          |
+| firstArgument | Symfony\Component\Validator\Constraints\Email      | Default | [                                                          |
+|               |                                                    |         |   "message" => "This value is not a valid email address.", |
+|               |                                                    |         |   "mode" => null,                                          |
+|               |                                                    |         |   "normalizer" => null,                                    |
+|               |                                                    |         |   "payload" => null                                        |
+|               |                                                    |         | ]                                                          |
++---------------+----------------------------------------------------+---------+------------------------------------------------------------+
 
 TXT
             , $tester->getDisplay(true)
@@ -109,6 +121,11 @@ TXT
             ]);
 
         $classMetadata
+            ->expects($this->exactly(2))
+            ->method('getConstraints')
+            ->willReturn([new Expression('1 + 1 = 2')]);
+
+        $classMetadata
             ->method('getPropertyMetadata')
             ->with('firstArgument')
             ->willReturn([
@@ -129,42 +146,54 @@ TXT
 Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 -----------------------------------------------------
 
-+---------------+--------------------------------------------------+---------+------------------------------------------------------------+
-| Property      | Name                                             | Groups  | Options                                                    |
-+---------------+--------------------------------------------------+---------+------------------------------------------------------------+
-| firstArgument | Symfony\Component\Validator\Constraints\NotBlank | Default | [                                                          |
-|               |                                                  |         |   "allowNull" => false,                                    |
-|               |                                                  |         |   "message" => "This value should not be blank.",          |
-|               |                                                  |         |   "normalizer" => null,                                    |
-|               |                                                  |         |   "payload" => null                                        |
-|               |                                                  |         | ]                                                          |
-| firstArgument | Symfony\Component\Validator\Constraints\Email    | Default | [                                                          |
-|               |                                                  |         |   "message" => "This value is not a valid email address.", |
-|               |                                                  |         |   "mode" => null,                                          |
-|               |                                                  |         |   "normalizer" => null,                                    |
-|               |                                                  |         |   "payload" => null                                        |
-|               |                                                  |         | ]                                                          |
-+---------------+--------------------------------------------------+---------+------------------------------------------------------------+
++---------------+----------------------------------------------------+---------+------------------------------------------------------------+
+| Property      | Name                                               | Groups  | Options                                                    |
++---------------+----------------------------------------------------+---------+------------------------------------------------------------+
+| -             | Symfony\Component\Validator\Constraints\Expression | Default | [                                                          |
+|               |                                                    |         |   "expression" => "1 + 1 = 2",                             |
+|               |                                                    |         |   "message" => "This value is not valid.",                 |
+|               |                                                    |         |   "payload" => null,                                       |
+|               |                                                    |         |   "values" => []                                           |
+|               |                                                    |         | ]                                                          |
+| firstArgument | Symfony\Component\Validator\Constraints\NotBlank   | Default | [                                                          |
+|               |                                                    |         |   "allowNull" => false,                                    |
+|               |                                                    |         |   "message" => "This value should not be blank.",          |
+|               |                                                    |         |   "normalizer" => null,                                    |
+|               |                                                    |         |   "payload" => null                                        |
+|               |                                                    |         | ]                                                          |
+| firstArgument | Symfony\Component\Validator\Constraints\Email      | Default | [                                                          |
+|               |                                                    |         |   "message" => "This value is not a valid email address.", |
+|               |                                                    |         |   "mode" => null,                                          |
+|               |                                                    |         |   "normalizer" => null,                                    |
+|               |                                                    |         |   "payload" => null                                        |
+|               |                                                    |         | ]                                                          |
++---------------+----------------------------------------------------+---------+------------------------------------------------------------+
 
 Symfony\Component\Validator\Tests\Dummy\DummyClassTwo
 -----------------------------------------------------
 
-+---------------+--------------------------------------------------+---------+------------------------------------------------------------+
-| Property      | Name                                             | Groups  | Options                                                    |
-+---------------+--------------------------------------------------+---------+------------------------------------------------------------+
-| firstArgument | Symfony\Component\Validator\Constraints\NotBlank | Default | [                                                          |
-|               |                                                  |         |   "allowNull" => false,                                    |
-|               |                                                  |         |   "message" => "This value should not be blank.",          |
-|               |                                                  |         |   "normalizer" => null,                                    |
-|               |                                                  |         |   "payload" => null                                        |
-|               |                                                  |         | ]                                                          |
-| firstArgument | Symfony\Component\Validator\Constraints\Email    | Default | [                                                          |
-|               |                                                  |         |   "message" => "This value is not a valid email address.", |
-|               |                                                  |         |   "mode" => null,                                          |
-|               |                                                  |         |   "normalizer" => null,                                    |
-|               |                                                  |         |   "payload" => null                                        |
-|               |                                                  |         | ]                                                          |
-+---------------+--------------------------------------------------+---------+------------------------------------------------------------+
++---------------+----------------------------------------------------+---------+------------------------------------------------------------+
+| Property      | Name                                               | Groups  | Options                                                    |
++---------------+----------------------------------------------------+---------+------------------------------------------------------------+
+| -             | Symfony\Component\Validator\Constraints\Expression | Default | [                                                          |
+|               |                                                    |         |   "expression" => "1 + 1 = 2",                             |
+|               |                                                    |         |   "message" => "This value is not valid.",                 |
+|               |                                                    |         |   "payload" => null,                                       |
+|               |                                                    |         |   "values" => []                                           |
+|               |                                                    |         | ]                                                          |
+| firstArgument | Symfony\Component\Validator\Constraints\NotBlank   | Default | [                                                          |
+|               |                                                    |         |   "allowNull" => false,                                    |
+|               |                                                    |         |   "message" => "This value should not be blank.",          |
+|               |                                                    |         |   "normalizer" => null,                                    |
+|               |                                                    |         |   "payload" => null                                        |
+|               |                                                    |         | ]                                                          |
+| firstArgument | Symfony\Component\Validator\Constraints\Email      | Default | [                                                          |
+|               |                                                    |         |   "message" => "This value is not a valid email address.", |
+|               |                                                    |         |   "mode" => null,                                          |
+|               |                                                    |         |   "normalizer" => null,                                    |
+|               |                                                    |         |   "payload" => null                                        |
+|               |                                                    |         | ]                                                          |
++---------------+----------------------------------------------------+---------+------------------------------------------------------------+
 
 TXT
             , $tester->getDisplay(true)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Partially #46544 
| License       | MIT
| Doc PR        | 
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Currently, Symfony `debug:validator` command does not show constraints that are configured on the class. It only shows constraints of class properties.

So with this fix, we add class constraints on the output tables. `-` symbol is used on the `Property`column to show that the constraint is not linked to a property.

Before
<img width="1253" alt="before" src="https://user-images.githubusercontent.com/8329789/172346784-04b23d69-3443-4cef-9619-c9417a6fccc1.png">

After
<img width="1518" alt="after" src="https://user-images.githubusercontent.com/8329789/172346181-4febe7ff-1e49-4fa2-bf98-aa08d495f52d.png">

