### PR TITLE
[Mime] Allow url as a path in the DataPart::fromPath

### DIFF
--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -61,13 +61,20 @@ class DataPart extends TextPart
             $contentType = self::$mimeTypes->getMimeTypes($ext)[0] ?? 'application/octet-stream';
         }
 
-        if (!is_file($path) || !is_readable($path)) {
+        if ((is_file($path) && !is_readable($path)) || is_dir($path)) {
             throw new InvalidArgumentException(sprintf('Path "%s" is not readable.', $path));
         }
 
         if (false === $handle = @fopen($path, 'r', false)) {
             throw new InvalidArgumentException(sprintf('Unable to open path "%s".', $path));
         }
+
+        if (!is_file($path)) {
+            $cache = fopen('php://temp', 'r+');
+            stream_copy_to_stream($handle, $cache);
+            $handle = $cache;
+        }
+
         $p = new self($handle, $name ?: basename($path), $contentType);
         $p->handle = $handle;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

While switching from the Swift Mailer to the Symfony Mailer I encounter a bug `Symfony\Component\Mime\Exception\InvalidArgumentException`. 
Steps to reproduce:
1. I have created an email with an attachment that is a remote file and saw `An exception has been thrown during the rendering of a template`. 
2. Also when I have visited tab E-mails in the Symfony Profiler, saw the same Symfony Exception page

DataPart can't be created from url,  even if `fopen` can open url. 
Apparently, before Symfony [4.4.11](https://github.com/symfony/symfony/pull/36304) this worked with URLs. At least in the context of email with attachments. 
PHP doesn't support rewind on non-local streams, so calling multiple times method `getBody` from `TextPart` would return an empty string. So in another context, it worked partially.


Additional notes:
1. Network example based on [this](https://github.com/symfony/symfony/blob/60ce5a3dfbd90fad60cd39fcb3d7bf7888a48659/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php#L165)
2. Base64Encoder chunk split base64 encoded string so I only check the first line
