### PR TITLE
[PropertyInfo] Add failing test case for multi phpdoc covered promoted properties

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -467,6 +467,7 @@ class PhpStanExtractorTest extends TestCase
         return [
             [Php80Dummy::class, 'promotedAndMutated', [new Type(Type::BUILTIN_TYPE_STRING)]],
             [Php80Dummy::class, 'promoted', null],
+            [Php80Dummy::class, 'collection', [new Type(Type::BUILTIN_TYPE_ARRAY, collection: true, collectionValueType: new Type(Type::BUILTIN_TYPE_STRING))]],
             [Php80PromotedDummy::class, 'promoted', null],
         ];
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
@@ -17,8 +17,9 @@ class Php80Dummy
 
     /**
      * @param string $promotedAndMutated
+     * @param array<string> $collection
      */
-    public function __construct(private mixed $promoted, private mixed $promotedAndMutated)
+    public function __construct(private mixed $promoted, private mixed $promotedAndMutated, private array $collection)
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This failing test case demonstrates that https://github.com/symfony/symfony/pull/46056 causes yet another regression and even originally introduced functionality doesn't work properly.

Can you take a look @simPod ?