### PR TITLE
[Form] Add prototype_options to CollectionType

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -7,6 +7,11 @@ in 5.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.4.0...v5.4.1
 
+
+* 5.4.10 (2022-06-02)
+
+ * Add a `prototype_options` option to `CollectionType`
+
 * 5.4.9 (2022-05-27)
 
  * bug #46386 [Console]  Fix missing negative variation of negatable options in shell completion (GromNaN)

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -30,7 +30,7 @@ class CollectionType extends AbstractType
             $prototypeOptions = array_replace([
                 'required' => $options['required'],
                 'label' => $options['prototype_name'].'label__',
-            ], $options['entry_options']);
+            ], array_replace($options['entry_options'], $options['prototype_options']));
 
             if (null !== $options['prototype_data']) {
                 $prototypeOptions['data'] = $options['prototype_data'];
@@ -120,6 +120,7 @@ class CollectionType extends AbstractType
             'prototype_name' => '__name__',
             'entry_type' => TextType::class,
             'entry_options' => [],
+            'prototype_options' => [],
             'delete_empty' => false,
             'invalid_message' => function (Options $options, $previousValue) {
                 return ($options['legacy_error_messages'] ?? true)
@@ -130,6 +131,7 @@ class CollectionType extends AbstractType
 
         $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);
         $resolver->setAllowedTypes('delete_empty', ['bool', 'callable']);
+        $resolver->setAllowedTypes('prototype_options', 'array');
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -515,6 +515,23 @@ class CollectionTypeTest extends BaseTypeTest
         $this->assertSame($expectedBlockPrefixes, $collectionView->vars['prototype']->vars['block_prefixes']);
     }
 
+    public function testPrototypeOptionsOverrideEntryOptions()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, [], [
+            'allow_add' => true,
+            'prototype' => true,
+            'entry_type' => TextTypeTest::TESTED_TYPE,
+            'entry_options' => [
+                'help' => null,
+            ],
+            'prototype_options' => [
+                'help' => 'foo',
+            ],
+        ]);
+
+        $this->assertSame('foo', $form->createView()->vars['prototype']->vars['help']);
+    }
+
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
         parent::testSubmitNull([], [], []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 <!-- see below -->
| Bug fix?      | no, fix for Backward compatibility
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16840

Based on https://github.com/symfony/symfony/pull/45605 for 6.1
For support EasyAdminBundle CRUD in collection for 5.4 symfony https://github.com/EasyCorp/EasyAdminBundle/pull/5210
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
