### PR TITLE
[SecurityBundle] Configure Voter priority via getDefaultPriority

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add the `Security` helper class
  * Deprecate the `Symfony\Component\Security\Core\Security` service alias, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
  * Add `Security::getFirewallConfig()` to help to get the firewall configuration associated to the Request
+ * Priority of the services tagged with `security.voter` is configurable via `getDefaultPriority`
 
 6.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -38,7 +39,7 @@ class AddSecurityVotersPass implements CompilerPassInterface
             return;
         }
 
-        $voters = $this->findAndSortTaggedServices('security.voter', $container);
+        $voters = $this->findAndSortTaggedServices(new TaggedIteratorArgument('security.voter'), $container);
         if (!$voters) {
             throw new LogicException('No security voters found. You need to tag at least one with "security.voter".');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #43074
| License       | MIT
| Doc PR        | Will do if PR gets approval

The issue describes well the missing feature. Solution is based on https://github.com/symfony/symfony/issues/43074#issuecomment-998045430 As mentioned in https://github.com/symfony/symfony/issues/43074#issuecomment-1050070069 it can be solved with PHP attributes already. If this became obsolete, feel free to close it.