### PR TITLE
[DependencyInjection] Add Enum Env Var Processor

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1722,7 +1722,7 @@ class FrameworkExtension extends Extension
         }
 
         if ($config['decryption_env_var']) {
-            if (!preg_match('/^(?:[-.\w]*+:)*+\w++$/', $config['decryption_env_var'])) {
+            if (!preg_match('/^(?:[-.\w\\\\]*+:)*+\w++$/', $config['decryption_env_var'])) {
                 throw new InvalidArgumentException(sprintf('Invalid value "%s" set as "decryption_env_var": only "word" characters are allowed.', $config['decryption_env_var']));
             }
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add argument `&$asGhostObject` to LazyProxy's `DumperInterface` to allow using ghost objects for lazy loading services
+ * Add `enum` env var processor
 
 6.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterEnvVarProcessorsPass implements CompilerPassInterface
 {
-    private const ALLOWED_TYPES = ['array', 'bool', 'float', 'int', 'string'];
+    private const ALLOWED_TYPES = ['array', 'bool', 'float', 'int', 'string', \BackedEnum::class];
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1539,7 +1539,7 @@ EOF;
             $export = $this->exportParameters([$value], '', 12, $hasEnum);
             $export = explode('0 => ', substr(rtrim($export, " ]\n"), 2, -1), 2);
 
-            if ($hasEnum || preg_match("/\\\$this->(?:getEnv\('(?:[-.\w]*+:)*+\w++'\)|targetDir\.'')/", $export[1])) {
+            if ($hasEnum || preg_match("/\\\$this->(?:getEnv\('(?:[-.\w\\\\]*+:)*+\w++'\)|targetDir\.'')/", $export[1])) {
                 $dynamicPhp[$key] = sprintf('%s%s => %s,', $export[0], $this->export($key), $export[1]);
             } else {
                 $php[] = sprintf('%s%s => %s,', $export[0], $this->export($key), $export[1]);
@@ -1952,7 +1952,7 @@ EOF;
                 return $dumpedValue;
             }
 
-            if (!preg_match("/\\\$this->(?:getEnv\('(?:[-.\w]*+:)*+\w++'\)|targetDir\.'')/", $dumpedValue)) {
+            if (!preg_match("/\\\$this->(?:getEnv\('(?:[-.\w\\\\]*+:)*+\w++'\)|targetDir\.'')/", $dumpedValue)) {
                 return sprintf('$this->parameters[%s]', $this->doExport($name));
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/EnvConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/EnvConfigurator.php
@@ -221,4 +221,16 @@ class EnvConfigurator extends ParamConfigurator
 
         return $this;
     }
+
+    /**
+     * @param class-string<\BackedEnum> $backedEnumClassName
+     *
+     * @return $this
+     */
+    public function enum(string $backedEnumClassName): static
+    {
+        array_unshift($this->stack, 'enum', $backedEnumClassName);
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -44,7 +44,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
                     return $placeholder; // return first result
                 }
             }
-            if (!preg_match('/^(?:[-.\w]*+:)*+\w++$/', $env)) {
+            if (!preg_match('/^(?:[-.\w\\\\]*+:)*+\w++$/', $env)) {
                 throw new InvalidArgumentException(sprintf('Invalid %s name: only "word" characters are allowed.', $name));
             }
             if ($this->has($name) && null !== ($defaultValue = parent::get($name)) && !\is_string($defaultValue)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -48,6 +48,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'string' => ['string'],
             'trim' => ['string'],
             'require' => ['bool', 'int', 'float', 'string', 'array'],
+            'enum' => [\BackedEnum::class],
         ];
 
         $this->assertSame($expected, $container->getParameterBag()->getProvidedTypes());
@@ -65,7 +66,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
     public function testBadProcessor()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid type "foo" returned by "Symfony\Component\DependencyInjection\Tests\Compiler\BadProcessor::getProvidedTypes()", expected one of "array", "bool", "float", "int", "string".');
+        $this->expectExceptionMessage('Invalid type "foo" returned by "Symfony\Component\DependencyInjection\Tests\Compiler\BadProcessor::getProvidedTypes()", expected one of "array", "bool", "float", "int", "string", "BackedEnum".');
         $container = new ContainerBuilder();
         $container->register('foo', BadProcessor::class)->addTag('container.env_var_processor');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/IntBackedEnum.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/IntBackedEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+enum IntBackedEnum: int
+{
+    case Nine = 9;
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StringBackedEnum.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StringBackedEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+enum StringBackedEnum: string
+{
+    case Bar = 'bar';
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/EnvConfiguratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/EnvConfiguratorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Loader\Configurator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Loader\Configurator\EnvConfigurator;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\StringBackedEnum;
 
 final class EnvConfiguratorTest extends TestCase
 {
@@ -24,7 +25,7 @@ final class EnvConfiguratorTest extends TestCase
         $this->assertSame($expected, (string) $envConfigurator);
     }
 
-    public function provide()
+    public function provide(): iterable
     {
         yield ['%env(FOO)%', new EnvConfigurator('FOO')];
         yield ['%env(string:FOO)%', new EnvConfigurator('string:FOO')];
@@ -32,5 +33,6 @@ final class EnvConfiguratorTest extends TestCase
         yield ['%env(key:path:url:FOO)%', (new EnvConfigurator('FOO'))->url()->key('path')];
         yield ['%env(default:fallback:bar:arg1:FOO)%', (new EnvConfigurator('FOO'))->custom('bar', 'arg1')->default('fallback')];
         yield ['%env(my_processor:my_argument:FOO)%', (new EnvConfigurator('FOO'))->myProcessor('my_argument')];
+        yield ['%env(enum:'.StringBackedEnum::class.':FOO)%', (new EnvConfigurator('FOO'))->enum(StringBackedEnum::class)];
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -14,14 +14,24 @@ namespace Symfony\Component\DependencyInjection\Tests\ParameterBag;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Loader\Configurator\EnvConfigurator;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\StringBackedEnum;
 
 class EnvPlaceholderParameterBagTest extends TestCase
 {
+    public function testEnumEnvVarProcessorPassesRegex()
+    {
+        $bag = new EnvPlaceholderParameterBag();
+        $name = \trim((new EnvConfigurator('FOO'))->enum(StringBackedEnum::class), '%');
+        $this->assertIsString($bag->get($name));
+    }
+
     public function testGetThrowsInvalidArgumentExceptionIfEnvNameContainsNonWordCharacters()
     {
-        $this->expectException(InvalidArgumentException::class);
         $bag = new EnvPlaceholderParameterBag();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid env(%foo%) name: only "word" characters are allowed.');
         $bag->get('env(%foo%)');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | waiting on approval of feature

Add the ability to transform env variables into \BackedEnums.

For example, you could now autowire an enum from an environment variable:
```php
<?php

use Symfony\Component\DependencyInjection\Attribute\Autowire;

enum AppEnv: string {
   case Test = 'test';
   case Dev = 'dev';
   case Stage = 'stage';
   case Prod = 'prod';
}

class Foo {
    public function __construct(
        #[Autowire('%env(enum:'.AppEnv::class.':APP_ENV)%')]
        private AppEnv $appEnv,
    ) {}
}
```