### PR TITLE
[Serializer][WebProfilerBundle] Show serializer collector info in toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
@@ -2,6 +2,65 @@
 
 {% import _self as helper %}
 
+{% block toolbar %}
+    {% if collector.handledCount > 0 or collector.calls|length %}
+        {% set icon %}
+            {{ source('@WebProfiler/Icon/serializer.svg') }}
+            <span class="sf-toolbar-value">
+                {{ collector.handledCount }}
+            </span>
+        {% endset %}
+
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                <b>Total calls</b>
+                <span class="sf-toolbar-status">{{ collector.handledCount }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Total time</b>
+                <span>
+                    {{ '%.2f'|format(collector.totalTime * 1000) }} <span class="unit">ms</span>
+                </span>
+            </div>
+
+            <div class="detailed-metrics">
+                <div>
+                    <div class="sf-toolbar-info-piece">
+                        <b>Serialize</b>
+                        <span class="sf-toolbar-status">{{ collector.data.serialize|length }}</span>
+                    </div>
+                    <div class="sf-toolbar-info-piece">
+                        <b>Deserialize</b>
+                        <span class="sf-toolbar-status">{{ collector.data.deserialize|length }}</span>
+                    </div>
+                </div>
+                <div>
+                    <div class="sf-toolbar-info-piece">
+                        <b>Encode</b>
+                        <span class="sf-toolbar-status">{{ collector.data.encode|length }}</span>
+                    </div>
+                    <div class="sf-toolbar-info-piece">
+                        <b>Decode</b>
+                        <span class="sf-toolbar-status">{{ collector.data.decode|length }}</span>
+                    </div>
+                </div>
+                <div>
+                    <div class="sf-toolbar-info-piece">
+                        <b>Normalize</b>
+                        <span class="sf-toolbar-status">{{ collector.data.normalize|length }}</span>
+                    </div>
+                    <div class="sf-toolbar-info-piece">
+                        <b>Denormalize</b>
+                        <span class="sf-toolbar-status">{{ collector.data.denormalize|length }}</span>
+                    </div>
+                </div>
+            </div>
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}
+    {% endif %}
+{% endblock %}
+
 {% block menu %}
     <span class="label {{ not collector.handledCount ? 'disabled' }}">
         <span class="icon">{{ include('@WebProfiler/Icon/serializer.svg') }}</span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -425,6 +425,13 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     display: none;
 }
 
+.sf-toolbar-block-serializer .detailed-metrics {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-gap: 15px;
+    margin-top: 15px;
+}
+
 /* Responsive Design */
 .sf-toolbar-icon .sf-toolbar-label,
 .sf-toolbar-icon .sf-toolbar-value {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

![Capture d’écran 2022-06-03 à 10 22 41](https://user-images.githubusercontent.com/2211145/171817937-448c1017-bbf5-4293-9547-f258541845d4.png)

The numbers themselves are, most of the time, not much important, but knowing the serializer was called and which methods at a glance is helpful and allows to link directly to the Serializer panel.