### PR TITLE
[Security] [LoginLink] Set custom lifetime for login link

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -21,6 +21,7 @@ Security
    prevent [session storage flooding](https://symfony.com/blog/cve-2016-4423-large-username-storage-in-session)
  * Deprecate the `Symfony\Component\Security\Core\Security` class and service, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
  * Passing empty username or password parameter when using `JsonLoginAuthenticator` is not supported anymore
+ * Add `$lifetime` parameter to `LoginLinkHandlerInterface::createLoginLink()`
 
 Validator
 ---------

--- a/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
@@ -38,9 +38,9 @@ class FirewallAwareLoginLinkHandler implements LoginLinkHandlerInterface
         $this->requestStack = $requestStack;
     }
 
-    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails
+    public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null): LoginLinkDetails
     {
-        return $this->getForFirewall()->createLoginLink($user, $request);
+        return $this->getForFirewall()->createLoginLink($user, $request, $lifetime);
     }
 
     public function consumeLoginLink(Request $request): UserInterface

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add maximum username length enforcement of 4096 characters in `UserBadge`
  * Add `#[IsGranted()]`
  * Deprecate empty username or password when using when using `JsonLoginAuthenticator`
+ * Set custom lifetime for login link
+ * Add `$lifetime` parameter to `LoginLinkHandlerInterface::createLoginLink()`
 
 6.0
 ---

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -44,9 +44,9 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         ], $options);
     }
 
-    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails
+    public function createLoginLink(UserInterface $user, Request $request = null, int $lifetime = null): LoginLinkDetails
     {
-        $expires = time() + $this->options['lifetime'];
+        $expires = time() + ($lifetime ?: $this->options['lifetime']);
         $expiresAt = new \DateTimeImmutable('@'.$expires);
 
         $parameters = [

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -23,8 +23,10 @@ interface LoginLinkHandlerInterface
 {
     /**
      * Generate a link that can be used to authenticate as the given user.
+     *
+     * @param int $lifetime
      */
-    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails;
+    public function createLoginLink(UserInterface $user, Request $request = null /*, int $lifetime = null */): LoginLinkDetails;
 
     /**
      * Validates if this request contains a login link and returns the associated User.

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -24,7 +24,7 @@ interface LoginLinkHandlerInterface
     /**
      * Generate a link that can be used to authenticate as the given user.
      *
-     * @param int $lifetime
+     * @param int|null $lifetime When not null, the argument overrides any default lifetime previously set
      */
     public function createLoginLink(UserInterface $user, Request $request = null /*, int $lifetime = null */): LoginLinkDetails;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #46561
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This adds a new parameter `$lifetime` to `LoginLinkHandlerInterface::createLoginLink()` and its default implementation `LoginLinkHandler`. This allows setting an lifetime for each login link individually compared to the static and shared `lifetime` configuration option.