### PR TITLE
[Form] Fix handling of null values in ChoiceType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -121,6 +121,13 @@ class ChoiceType extends AbstractType
                     $data = (array) (string) $data;
                 }
 
+                // Remove null values
+                foreach ($data as $key => $value) {
+                    if (null === $value) {
+                        unset($data[$key]);
+                    }
+                }
+
                 // A map from submitted values to integers
                 $valueMap = array_flip($data);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -2200,4 +2200,17 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->assertSame('20', $view['choice_two']->vars['choices'][1]->value);
         $this->assertSame('30', $view['choice_two']->vars['choices'][2]->value);
     }
+
+    public function testArrayFlipDoesNotThrowErrorOnNullInput()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'multiple' => true,
+            'expanded' => true,
+            'choices' => ['test'],
+        ]);
+
+        $form->submit([null]);
+
+        $this->assertSame([], $form->getData());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no

Hi there :wave:

We're facing an issue where the array_flip performed in the ChoiceType throws a warning because the choices submitted contains null values.

![errorexception-with-null-values](https://user-images.githubusercontent.com/1224811/171820671-eb3be50d-8538-4e91-b7e9-52d042d31505.png)

I'm not completely sure if it's the right way to fix it but I'm open to any feedbacks.

