### PR TITLE
[Serializer][WebProfilerBundle] Collect & show caller source code

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
@@ -11,34 +11,36 @@
 
 {% block panel %}
     <h2>Serializer</h2>
-    {% if not collector.handledCount %}
-        <div class="empty">
-            <p>Nothing was handled by the serializer for this request.</p>
-        </div>
-    {% else %}
-        <div class="metrics">
-            <div class="metric">
-                <span class="value">{{ collector.handledCount }}</span>
-                <span class="label">Handled</span>
+    <div class="sf-serializer sf-reset">
+        {% if not collector.handledCount %}
+            <div class="empty">
+                <p>Nothing was handled by the serializer for this request.</p>
+            </div>
+        {% else %}
+            <div class="metrics">
+                <div class="metric">
+                    <span class="value">{{ collector.handledCount }}</span>
+                    <span class="label">Handled</span>
+                </div>
+
+                <div class="metric">
+                    <span class="value">{{ '%.2f'|format(collector.totalTime * 1000) }} <span class="unit">ms</span></span>
+                    <span class="label">Total time</span>
+                </div>
             </div>
 
-            <div class="metric">
-                <span class="value">{{ '%.2f'|format(collector.totalTime * 1000) }} <span class="unit">ms</span></span>
-                <span class="label">Total time</span>
+            <div class="sf-tabs">
+                {{ helper.render_serialize_tab(collector.data, true) }}
+                {{ helper.render_serialize_tab(collector.data, false) }}
+
+                {{ helper.render_normalize_tab(collector.data, true) }}
+                {{ helper.render_normalize_tab(collector.data, false) }}
+
+                {{ helper.render_encode_tab(collector.data, true) }}
+                {{ helper.render_encode_tab(collector.data, false) }}
             </div>
-        </div>
-
-        <div class="sf-tabs">
-            {{ helper.render_serialize_tab(collector.data, true) }}
-            {{ helper.render_serialize_tab(collector.data, false) }}
-
-            {{ helper.render_normalize_tab(collector.data, true) }}
-            {{ helper.render_normalize_tab(collector.data, false) }}
-
-            {{ helper.render_encode_tab(collector.data, true) }}
-            {{ helper.render_encode_tab(collector.data, false) }}
-        </div>
-    {% endif %}
+        {% endif %}
+    </div>
 {% endblock %}
 
 {% macro render_serialize_tab(collectorData, serialize) %}
@@ -61,6 +63,7 @@
                             <th>Normalizer</th>
                             <th>Encoder</th>
                             <th>Time</th>
+                            <th>Caller</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -71,6 +74,7 @@
                                 <td>{{ helper.render_normalizer_cell(item, loop.index, cellPrefix) }}</td>
                                 <td>{{ helper.render_encoder_cell(item, loop.index, cellPrefix) }}</td>
                                 <td>{{ helper.render_time_cell(item) }}</td>
+                                <td>{{ helper.render_caller_cell(item, loop.index, cellPrefix) }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>
@@ -78,6 +82,36 @@
             {% endif %}
         </div>
     </div>
+{% endmacro %}
+
+{% macro render_caller_cell(item, index, method) %}
+    {% if item.caller is defined %}
+        <span class="metadata">
+            {% set caller = item.caller %}
+            {% if caller.line %}
+                {% set link = caller.file|file_link(caller.line) %}
+                {% if link %}
+                    <a href="{{ link }}" title="{{ caller.file }}">{{ caller.name }}</a>
+                {% else %}
+                    <abbr title="{{ caller.file }}">{{ caller.name }}</abbr>
+                {% endif %}
+            {% else %}
+                {{ caller.name }}
+            {% endif %}
+            line <a class="text-small sf-toggle" data-toggle-selector="#sf-trace-{{ method }}-{{ index }}">{{ caller.line }}</a>
+        </span>
+
+        <div class="sf-serializer-compact hidden" id="sf-trace-{{ method }}-{{ index }}">
+            <div class="trace">
+                {{ caller.file|file_excerpt(caller.line)|replace({
+                    '#DD0000': 'var(--highlight-string)',
+                    '#007700': 'var(--highlight-keyword)',
+                    '#0000BB': 'var(--highlight-default)',
+                    '#FF8000': 'var(--highlight-comment)'
+                })|raw }}
+            </div>
+        </div>
+    {% endif %}
 {% endmacro %}
 
 {% macro render_normalize_tab(collectorData, normalize) %}
@@ -99,6 +133,7 @@
                             <th>Context</th>
                             <th>Normalizer</th>
                             <th>Time</th>
+                            <th>Caller</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -108,6 +143,7 @@
                                 <td>{{ helper.render_context_cell(item, loop.index, cellPrefix) }}</td>
                                 <td>{{ helper.render_normalizer_cell(item, loop.index, cellPrefix) }}</td>
                                 <td>{{ helper.render_time_cell(item) }}</td>
+                                <td>{{ helper.render_caller_cell(item, loop.index, cellPrefix) }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>
@@ -136,6 +172,7 @@
                             <th>Context</th>
                             <th>Encoder</th>
                             <th>Time</th>
+                            <th>Caller</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -145,6 +182,7 @@
                                 <td>{{ helper.render_context_cell(item, loop.index, cellPrefix) }}</td>
                                 <td>{{ helper.render_encoder_cell(item, loop.index, cellPrefix) }}</td>
                                 <td>{{ helper.render_time_cell(item) }}</td>
+                                <td>{{ helper.render_caller_cell(item, loop.index, cellPrefix) }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>
@@ -188,7 +226,9 @@
 {% macro render_normalizer_cell(item, index, method) %}
     {% set nested_normalizers_id = 'nested-normalizers-' ~ method ~ '-' ~ index %}
 
-    <span class="nowrap"><a href="{{ item.normalizer.file|file_link(item.normalizer.line) }}" title="{{ item.normalizer.file }}">{{ item.normalizer.class }}</a> ({{ '%.2f'|format(item.normalizer.time * 1000) }} ms)</span>
+    {% if item.normalizer is defined %}
+        <span class="nowrap"><a href="{{ item.normalizer.file|file_link(item.normalizer.line) }}" title="{{ item.normalizer.file }}">{{ item.normalizer.class }}</a> ({{ '%.2f'|format(item.normalizer.time * 1000) }} ms)</span>
+    {% endif %}
 
     {% if item.normalization|length > 1 %}
         <div>
@@ -207,7 +247,9 @@
 {% macro render_encoder_cell(item, index, method) %}
     {% set nested_encoders_id = 'nested-encoders-' ~ method ~ '-' ~ index %}
 
-    <span class="nowrap"><a href="{{ item.encoder.file|file_link(item.encoder.line) }}" title="{{ item.encoder.file }}">{{ item.encoder.class }}</a> ({{ '%.2f'|format(item.encoder.time * 1000) }} ms)</span>
+    {% if item.encoder is defined %}
+        <span class="nowrap"><a href="{{ item.encoder.file|file_link(item.encoder.line) }}" title="{{ item.encoder.file }}">{{ item.encoder.class }}</a> ({{ '%.2f'|format(item.encoder.time * 1000) }} ms)</span>
+    {% endif %}
 
     {% if item.encoding|length > 1 %}
         <div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -51,6 +51,7 @@
     --highlight-default: #222222;
     --highlight-keyword: #a71d5d;
     --highlight-string: #183691;
+    --highlight-selected-line: rgba(255, 255, 153, 0.5);
     --base-0: #fff;
     --base-1: #f5f5f5;
     --base-2: #e0e0e0;
@@ -104,6 +105,7 @@
     --highlight-default: var(--base-6);
     --highlight-keyword: #ff413c;
     --highlight-string: #70a6fd;
+    --highlight-selected-line: rgba(14, 14, 14, 0.5);
     --base-0: #2e3136;
     --base-1: #444;
     --base-2: #666;
@@ -1296,7 +1298,7 @@ tr.log-status-silenced {
     padding: 0;
 }
 #collector-content .sf-validator .trace li.selected {
-    background: rgba(255, 255, 153, 0.5);
+    background: var(--highlight-selected-line);
 }
 
 {# Serializer panel
@@ -1321,15 +1323,15 @@ tr.log-status-silenced {
     padding: 0;
 }
 #collector-content .sf-serializer .trace li.selected {
-    background: rgba(255, 255, 153, 0.5);
+    background: var(--highlight-selected-line);
 }
 
 {# Messenger panel
    ========================================================================= #}
 
 #collector-content .message-bus .trace {
-    border: 1px solid #DDD;
-    background: #FFF;
+    border: var(--border);
+    background: var(--base-0);
     padding: 10px;
     margin: 0.5em 0;
     overflow: auto;
@@ -1342,7 +1344,7 @@ tr.log-status-silenced {
     padding: 0;
 }
 #collector-content .message-bus .trace li.selected {
-    background: rgba(255, 255, 153, 0.5);
+    background: var(--highlight-selected-line);
 }
 
 {# Dump panel

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -1299,6 +1299,31 @@ tr.log-status-silenced {
     background: rgba(255, 255, 153, 0.5);
 }
 
+{# Serializer panel
+   ========================================================================= #}
+
+#collector-content .sf-serializer {
+    margin-bottom: 2em;
+}
+
+#collector-content .sf-serializer .trace {
+    border: var(--border);
+    background: var(--base-0);
+    padding: 10px;
+    margin: 0.5em 0;
+    overflow: auto;
+}
+#collector-content .sf-serializer .trace {
+    font-size: 12px;
+}
+#collector-content .sf-serializer .trace li {
+    margin-bottom: 0;
+    padding: 0;
+}
+#collector-content .sf-serializer .trace li.selected {
+    background: rgba(255, 255, 153, 0.5);
+}
+
 {# Messenger panel
    ========================================================================= #}
 

--- a/src/Symfony/Component/Serializer/DataCollector/SerializerDataCollector.php
+++ b/src/Symfony/Component/Serializer/DataCollector/SerializerDataCollector.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\Serializer\Debug\TraceableSerializer;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
@@ -70,68 +71,68 @@ class SerializerDataCollector extends DataCollector implements LateDataCollector
         return $totalTime;
     }
 
-    public function collectSerialize(string $traceId, mixed $data, string $format, array $context, float $time): void
+    public function collectSerialize(string $traceId, mixed $data, string $format, array $context, float $time, array $caller): void
     {
         unset($context[TraceableSerializer::DEBUG_TRACE_ID]);
 
         $this->collected[$traceId] = array_merge(
             $this->collected[$traceId] ?? [],
-            compact('data', 'format', 'context', 'time'),
+            compact('data', 'format', 'context', 'time', 'caller'),
             ['method' => 'serialize'],
         );
     }
 
-    public function collectDeserialize(string $traceId, mixed $data, string $type, string $format, array $context, float $time): void
+    public function collectDeserialize(string $traceId, mixed $data, string $type, string $format, array $context, float $time, array $caller): void
     {
         unset($context[TraceableSerializer::DEBUG_TRACE_ID]);
 
         $this->collected[$traceId] = array_merge(
             $this->collected[$traceId] ?? [],
-            compact('data', 'format', 'type', 'context', 'time'),
+            compact('data', 'format', 'type', 'context', 'time', 'caller'),
             ['method' => 'deserialize'],
         );
     }
 
-    public function collectNormalize(string $traceId, mixed $data, ?string $format, array $context, float $time): void
+    public function collectNormalize(string $traceId, mixed $data, ?string $format, array $context, float $time, array $caller): void
     {
         unset($context[TraceableSerializer::DEBUG_TRACE_ID]);
 
         $this->collected[$traceId] = array_merge(
             $this->collected[$traceId] ?? [],
-            compact('data', 'format', 'context', 'time'),
+            compact('data', 'format', 'context', 'time', 'caller'),
             ['method' => 'normalize'],
         );
     }
 
-    public function collectDenormalize(string $traceId, mixed $data, string $type, ?string $format, array $context, float $time): void
+    public function collectDenormalize(string $traceId, mixed $data, string $type, ?string $format, array $context, float $time, array $caller): void
     {
         unset($context[TraceableSerializer::DEBUG_TRACE_ID]);
 
         $this->collected[$traceId] = array_merge(
             $this->collected[$traceId] ?? [],
-            compact('data', 'format', 'type', 'context', 'time'),
+            compact('data', 'format', 'type', 'context', 'time', 'caller'),
             ['method' => 'denormalize'],
         );
     }
 
-    public function collectEncode(string $traceId, mixed $data, ?string $format, array $context, float $time): void
+    public function collectEncode(string $traceId, mixed $data, ?string $format, array $context, float $time, array $caller): void
     {
         unset($context[TraceableSerializer::DEBUG_TRACE_ID]);
 
         $this->collected[$traceId] = array_merge(
             $this->collected[$traceId] ?? [],
-            compact('data', 'format', 'context', 'time'),
+            compact('data', 'format', 'context', 'time', 'caller'),
             ['method' => 'encode'],
         );
     }
 
-    public function collectDecode(string $traceId, mixed $data, ?string $format, array $context, float $time): void
+    public function collectDecode(string $traceId, mixed $data, ?string $format, array $context, float $time, array $caller): void
     {
         unset($context[TraceableSerializer::DEBUG_TRACE_ID]);
 
         $this->collected[$traceId] = array_merge(
             $this->collected[$traceId] ?? [],
-            compact('data', 'format', 'context', 'time'),
+            compact('data', 'format', 'context', 'time', 'caller'),
             ['method' => 'decode'],
         );
     }
@@ -192,6 +193,7 @@ class SerializerDataCollector extends DataCollector implements LateDataCollector
                 'context' => $this->cloneVar($collected['context']),
                 'normalization' => [],
                 'encoding' => [],
+                'caller' => $collected['caller'] ?? null,
             ];
 
             if (isset($collected['normalization'])) {

--- a/src/Symfony/Component/Serializer/Tests/DataCollector/SerializerDataCollectorTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DataCollector/SerializerDataCollectorTest.php
@@ -24,8 +24,9 @@ class SerializerDataCollectorTest extends TestCase
     {
         $dataCollector = new SerializerDataCollector();
 
-        $dataCollector->collectSerialize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0);
-        $dataCollector->collectDeserialize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 1.0);
+        $caller = ['name' => 'Foo.php', 'file' => 'src/Foo.php', 'line' => 123];
+        $dataCollector->collectSerialize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0, $caller);
+        $dataCollector->collectDeserialize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 1.0, $caller);
 
         $dataCollector->lateCollect();
         $collectedData = $this->castCollectedData($dataCollector->getData());
@@ -39,6 +40,7 @@ class SerializerDataCollectorTest extends TestCase
             'context' => ['foo' => 'bar'],
             'normalization' => [],
             'encoding' => [],
+            'caller' => $caller,
         ]], $collectedData['serialize']);
 
         $this->assertSame([[
@@ -50,6 +52,7 @@ class SerializerDataCollectorTest extends TestCase
             'context' => ['foo' => 'bar'],
             'normalization' => [],
             'encoding' => [],
+            'caller' => $caller,
         ]], $collectedData['deserialize']);
     }
 
@@ -57,8 +60,9 @@ class SerializerDataCollectorTest extends TestCase
     {
         $dataCollector = new SerializerDataCollector();
 
-        $dataCollector->collectNormalize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0);
-        $dataCollector->collectDenormalize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 1.0);
+        $caller = ['name' => 'Foo.php', 'file' => 'src/Foo.php', 'line' => 123];
+        $dataCollector->collectNormalize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0, $caller);
+        $dataCollector->collectDenormalize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 1.0, $caller);
 
         $dataCollector->lateCollect();
         $collectedData = $this->castCollectedData($dataCollector->getData());
@@ -72,6 +76,7 @@ class SerializerDataCollectorTest extends TestCase
             'context' => ['foo' => 'bar'],
             'normalization' => [],
             'encoding' => [],
+            'caller' => $caller,
         ]], $collectedData['normalize']);
 
         $this->assertSame([[
@@ -83,6 +88,7 @@ class SerializerDataCollectorTest extends TestCase
             'context' => ['foo' => 'bar'],
             'normalization' => [],
             'encoding' => [],
+            'caller' => $caller,
         ]], $collectedData['denormalize']);
     }
 
@@ -90,8 +96,9 @@ class SerializerDataCollectorTest extends TestCase
     {
         $dataCollector = new SerializerDataCollector();
 
-        $dataCollector->collectEncode('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0);
-        $dataCollector->collectDecode('traceIdTwo', 'data', 'format', ['foo' => 'bar'], 1.0);
+        $caller = ['name' => 'Foo.php', 'file' => 'src/Foo.php', 'line' => 123];
+        $dataCollector->collectEncode('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0, $caller);
+        $dataCollector->collectDecode('traceIdTwo', 'data', 'format', ['foo' => 'bar'], 1.0, $caller);
 
         $dataCollector->lateCollect();
         $collectedData = $this->castCollectedData($dataCollector->getData());
@@ -105,6 +112,7 @@ class SerializerDataCollectorTest extends TestCase
             'context' => ['foo' => 'bar'],
             'normalization' => [],
             'encoding' => [],
+            'caller' => $caller,
         ]], $collectedData['encode']);
 
         $this->assertSame([[
@@ -116,6 +124,7 @@ class SerializerDataCollectorTest extends TestCase
             'context' => ['foo' => 'bar'],
             'normalization' => [],
             'encoding' => [],
+            'caller' => $caller,
         ]], $collectedData['decode']);
     }
 
@@ -123,8 +132,9 @@ class SerializerDataCollectorTest extends TestCase
     {
         $dataCollector = new SerializerDataCollector();
 
-        $dataCollector->collectNormalize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 20.0);
-        $dataCollector->collectDenormalize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 20.0);
+        $caller = ['name' => 'Foo.php', 'file' => 'src/Foo.php', 'line' => 123];
+        $dataCollector->collectNormalize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 20.0, $caller);
+        $dataCollector->collectDenormalize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 20.0, $caller);
 
         $dataCollector->collectNormalization('traceIdOne', DateTimeNormalizer::class, 1.0);
         $dataCollector->collectNormalization('traceIdOne', DateTimeNormalizer::class, 2.0);
@@ -178,8 +188,9 @@ class SerializerDataCollectorTest extends TestCase
     {
         $dataCollector = new SerializerDataCollector();
 
-        $dataCollector->collectEncode('traceIdOne', 'data', 'format', ['foo' => 'bar'], 20.0);
-        $dataCollector->collectDecode('traceIdTwo', 'data', 'format', ['foo' => 'bar'], 20.0);
+        $caller = ['name' => 'Foo.php', 'file' => 'src/Foo.php', 'line' => 123];
+        $dataCollector->collectEncode('traceIdOne', 'data', 'format', ['foo' => 'bar'], 20.0, $caller);
+        $dataCollector->collectDecode('traceIdTwo', 'data', 'format', ['foo' => 'bar'], 20.0, $caller);
 
         $dataCollector->collectEncoding('traceIdOne', JsonEncoder::class, 1.0);
         $dataCollector->collectEncoding('traceIdOne', JsonEncoder::class, 2.0);
@@ -233,13 +244,14 @@ class SerializerDataCollectorTest extends TestCase
     {
         $dataCollector = new SerializerDataCollector();
 
-        $dataCollector->collectSerialize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0);
-        $dataCollector->collectDeserialize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 1.0);
-        $dataCollector->collectNormalize('traceIdThree', 'data', 'format', ['foo' => 'bar'], 20.0);
-        $dataCollector->collectDenormalize('traceIdFour', 'data', 'type', 'format', ['foo' => 'bar'], 20.0);
-        $dataCollector->collectEncode('traceIdFive', 'data', 'format', ['foo' => 'bar'], 20.0);
-        $dataCollector->collectDecode('traceIdSix', 'data', 'format', ['foo' => 'bar'], 20.0);
-        $dataCollector->collectSerialize('traceIdSeven', 'data', 'format', ['foo' => 'bar'], 1.0);
+        $caller = ['name' => 'Foo.php', 'file' => 'src/Foo.php', 'line' => 123];
+        $dataCollector->collectSerialize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0, $caller);
+        $dataCollector->collectDeserialize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 1.0, $caller);
+        $dataCollector->collectNormalize('traceIdThree', 'data', 'format', ['foo' => 'bar'], 20.0, $caller);
+        $dataCollector->collectDenormalize('traceIdFour', 'data', 'type', 'format', ['foo' => 'bar'], 20.0, $caller);
+        $dataCollector->collectEncode('traceIdFive', 'data', 'format', ['foo' => 'bar'], 20.0, $caller);
+        $dataCollector->collectDecode('traceIdSix', 'data', 'format', ['foo' => 'bar'], 20.0, $caller);
+        $dataCollector->collectSerialize('traceIdSeven', 'data', 'format', ['foo' => 'bar'], 1.0, $caller);
 
         $dataCollector->lateCollect();
 
@@ -250,13 +262,15 @@ class SerializerDataCollectorTest extends TestCase
     {
         $dataCollector = new SerializerDataCollector();
 
-        $dataCollector->collectSerialize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0);
-        $dataCollector->collectDeserialize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 2.0);
-        $dataCollector->collectNormalize('traceIdThree', 'data', 'format', ['foo' => 'bar'], 3.0);
-        $dataCollector->collectDenormalize('traceIdFour', 'data', 'type', 'format', ['foo' => 'bar'], 4.0);
-        $dataCollector->collectEncode('traceIdFive', 'data', 'format', ['foo' => 'bar'], 5.0);
-        $dataCollector->collectDecode('traceIdSix', 'data', 'format', ['foo' => 'bar'], 6.0);
-        $dataCollector->collectSerialize('traceIdSeven', 'data', 'format', ['foo' => 'bar'], 7.0);
+        $caller = ['name' => 'Foo.php', 'file' => 'src/Foo.php', 'line' => 123];
+
+        $dataCollector->collectSerialize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0, $caller);
+        $dataCollector->collectDeserialize('traceIdTwo', 'data', 'type', 'format', ['foo' => 'bar'], 2.0, $caller);
+        $dataCollector->collectNormalize('traceIdThree', 'data', 'format', ['foo' => 'bar'], 3.0, $caller);
+        $dataCollector->collectDenormalize('traceIdFour', 'data', 'type', 'format', ['foo' => 'bar'], 4.0, $caller);
+        $dataCollector->collectEncode('traceIdFive', 'data', 'format', ['foo' => 'bar'], 5.0, $caller);
+        $dataCollector->collectDecode('traceIdSix', 'data', 'format', ['foo' => 'bar'], 6.0, $caller);
+        $dataCollector->collectSerialize('traceIdSeven', 'data', 'format', ['foo' => 'bar'], 7.0, $caller);
 
         $dataCollector->lateCollect();
 
@@ -267,7 +281,8 @@ class SerializerDataCollectorTest extends TestCase
     {
         $dataCollector = new SerializerDataCollector();
 
-        $dataCollector->collectSerialize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0);
+        $caller = ['name' => 'Foo.php', 'file' => 'src/Foo.php', 'line' => 123];
+        $dataCollector->collectSerialize('traceIdOne', 'data', 'format', ['foo' => 'bar'], 1.0, $caller);
         $dataCollector->lateCollect();
 
         $this->assertNotSame([], $dataCollector->getData());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

As for the Messenger and Validator panels, knowing from which code was called the Serializer's methods and jumping to it in one click is useful to get a better understanding of each collected rows and their context.

![Capture d’écran 2022-06-03 à 09 32 00](https://user-images.githubusercontent.com/2211145/171818770-5be7e8a6-d35e-47d4-92e1-f170375ffe41.png)

![Capture d’écran 2022-06-03 à 09 46 43](https://user-images.githubusercontent.com/2211145/171818809-47f562e5-0356-41db-ac6a-3fbd52bf3651.png)

![Capture d’écran 2022-06-03 à 10 34 26](https://user-images.githubusercontent.com/2211145/171819170-cfc39261-a7e7-412f-8fdc-07ee1771d5ee.png)

--- 

the second commit relates to https://github.com/symfony/symfony/pull/46565