### PR TITLE
[HttpClient][WebProfilerBundle] Catch errors when encoding body for c…

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -194,7 +194,11 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
             $dataArg[] = '--data '.escapeshellarg(json_encode($json, \JSON_PRETTY_PRINT));
         } elseif ($body = $trace['options']['body'] ?? null) {
             if (\is_string($body)) {
-                $dataArg[] = '--data '.escapeshellarg($body);
+                try {
+                    $dataArg[] = '--data '.escapeshellarg($body);
+                } catch (\ValueError $e) {
+                    return null;
+                }
             } elseif (\is_array($body)) {
                 foreach ($body as $key => $value) {
                     $dataArg[] = '--data '.escapeshellarg("$key=$value");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

In Symfony 6.1 a [button to copy a request as a cURL command](https://github.com/symfony/symfony/pull/43931) was introduced for the profiler.

But if I post a binary file containing null characters using the curl-http-client the `HttpClientDataCollector` throws an error.
```
Warning: Uncaught ValueError: escapeshellarg(): Argument #1 ($arg) must not contain any null bytes
```

My solution is to catch the `ValueError` in this situation and to return `null` as the resulting curl command. Returning `null` seems to be the standard handling for unexpectad values in this data collector.