### PR TITLE
[Messenger] Add new `messenger:count` command that return a list of transports with their "to be processed" message count.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -108,6 +108,7 @@ use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFac
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
+use Symfony\Component\Messenger\Command\StatsCommand;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
@@ -503,6 +504,7 @@ class FrameworkExtension extends Extension
             $this->registerMessengerConfiguration($config['messenger'], $container, $loader, $config['validation']);
         } else {
             $container->removeDefinition('console.command.messenger_consume_messages');
+            $container->removeDefinition('console.command.messenger_stats');
             $container->removeDefinition('console.command.messenger_debug');
             $container->removeDefinition('console.command.messenger_stop_workers');
             $container->removeDefinition('console.command.messenger_setup_transports');
@@ -1964,6 +1966,10 @@ class FrameworkExtension extends Extension
     {
         if (!interface_exists(MessageBusInterface::class)) {
             throw new LogicException('Messenger support cannot be enabled as the Messenger component is not installed. Try running "composer require symfony/messenger".');
+        }
+
+        if (!class_exists(StatsCommand::class)) {
+            $container->removeDefinition('console.command.messenger_stats');
         }
 
         $loader->load('messenger.php');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -42,6 +42,7 @@ use Symfony\Bundle\FrameworkBundle\EventListener\SuggestMissingPackageSubscriber
 use Symfony\Component\Console\EventListener\ErrorListener;
 use Symfony\Component\Dotenv\Command\DebugCommand as DotenvDebugCommand;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
+use Symfony\Component\Messenger\Command\StatsCommand;
 use Symfony\Component\Messenger\Command\DebugCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesRemoveCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
@@ -206,6 +207,13 @@ return static function (ContainerConfigurator $container) {
             ])
             ->tag('console.command')
 
+        ->set('console.command.messenger_stats', StatsCommand::class)
+            ->args([
+                service('messenger.receiver_locator'),
+                abstract_arg('Receivers names'),
+            ])
+            ->tag('console.command')
+
         ->set('console.command.router_debug', RouterDebugCommand::class)
             ->args([
                 service('router'),
@@ -334,5 +342,5 @@ return static function (ContainerConfigurator $container) {
                 service('secrets.local_vault')->ignoreOnInvalid(),
             ])
             ->tag('console.command')
-    ;
+        ;
 };

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Add new `messenger:stats` command that return a list of transports with their "to be processed" message count.
+
 6.1
 ---
 

--- a/src/Symfony/Component/Messenger/Command/StatsCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StatsCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Command;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+
+/**
+ * @author Kévin Thérage <therage.kevin@gmail.com>
+ */
+#[AsCommand(name: 'messenger:stats', description: 'Show the message count for one or more transports')]
+class StatsCommand extends Command
+{
+    private ContainerInterface $transportLocator;
+    private array $transportNames;
+
+    public function __construct(ContainerInterface $transportLocator, array $transportNames = [])
+    {
+        $this->transportLocator = $transportLocator;
+        $this->transportNames = $transportNames;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->addArgument('transport_names', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'List of transports\' names')
+            ->setHelp(<<<EOF
+The <info>%command.name%</info> command counts the messages for all the transports:
+
+    <info>php %command.full_name%</info>
+
+Or specific transports only:
+
+    <info>php %command.full_name% <transportNames></info>
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
+
+        $transportNames = $this->transportNames;
+        if ($input->getArgument('transport_names')) {
+            $transportNames = $input->getArgument('transport_names');
+        }
+
+        $outputTable = [];
+        $uncountableTransports = [];
+        foreach ($transportNames as $transportName) {
+            if (!$this->transportLocator->has($transportName)) {
+                $io->warning(sprintf('The "%s" transport does not exist.', $transportName));
+
+                continue;
+            }
+            $transport = $this->transportLocator->get($transportName);
+            if (!$transport instanceof MessageCountAwareInterface) {
+                $uncountableTransports[] = $transportName;
+
+                continue;
+            }
+            $outputTable[] = [$transportName, $transport->getMessageCount()];
+        }
+
+        $io->table(['Transport', 'Count'], $outputTable);
+
+        if ($uncountableTransports) {
+            $io->note(sprintf('Unable to get message count for the following transports: "%s".', implode('", "', $uncountableTransports)));
+        }
+
+        return 0;
+    }
+}

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -311,6 +311,11 @@ class MessengerPass implements CompilerPassInterface
                 ->replaceArgument(1, array_values($receiverNames));
         }
 
+        if ($container->hasDefinition('console.command.messenger_stats')) {
+            $container->getDefinition('console.command.messenger_stats')
+                ->replaceArgument(1, array_values($receiverNames));
+        }
+
         $container->getDefinition('messenger.receiver_locator')->replaceArgument(0, $receiverMapping);
 
         $failureTransportsLocator = ServiceLocatorTagPass::register($container, $failureTransportsMap);

--- a/src/Symfony/Component/Messenger/Tests/Command/StatsCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/StatsCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Messenger\Command\StatsCommand;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * @author Kévin Thérage <therage.kevin@gmail.com>
+ */
+class StatsCommandTest extends TestCase
+{
+    private StatsCommand $command;
+
+    public function setUp(): void
+    {
+        $messageCountableTransport = $this->createMock(MessageCountAwareInterface::class);
+        $messageCountableTransport->method('getMessageCount')->willReturn(6);
+
+        $simpleTransport = $this->createMock(TransportInterface::class);
+
+        // mock a service locator
+        /** @var MockObject&ServiceLocator $serviceLocator */
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator
+            ->method('get')
+            ->willReturnCallback(function (string $transportName) use ($messageCountableTransport, $simpleTransport) {
+                if (\in_array($transportName, ['message_countable', 'another_message_countable'], true)) {
+                    return $messageCountableTransport;
+                }
+
+                return $simpleTransport;
+            });
+        $serviceLocator
+            ->method('has')
+            ->willReturnCallback(function (string $transportName) {
+                return \in_array($transportName, ['message_countable', 'simple', 'another_message_countable'], true);
+            })
+        ;
+
+        $this->command = new StatsCommand($serviceLocator, [
+            'message_countable',
+            'simple',
+            'another_message_countable',
+            'unexisting'
+        ]);
+    }
+
+    public function testWithoutArgument(): void
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('[WARNING] The "unexisting" transport does not exist.', $display);
+        $this->assertStringContainsString('message_countable           6', $display);
+        $this->assertStringContainsString('another_message_countable   6', $display);
+        $this->assertStringContainsString('! [NOTE] Unable to get message count for the following transports: "simple".', $display);
+    }
+
+    public function testWithOneExistingMessageCountableTransport(): void
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute(['transport_names' => ['message_countable']]);
+        $display = $tester->getDisplay();
+
+        $this->assertStringNotContainsString('[WARNING] The "unexisting" transport does not exist.', $display);
+        $this->assertStringContainsString('message_countable   6', $display);
+        $this->assertStringNotContainsString('another_message_countable', $display);
+        $this->assertStringNotContainsString(' ! [NOTE] Unable to get message count for the following transports: "simple".', $display);
+    }
+
+    public function testWithMultipleExistingMessageCountableTransport(): void
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute(['transport_names' => ['message_countable', 'another_message_countable']]);
+        $display = $tester->getDisplay();
+
+        $this->assertStringNotContainsString('[WARNING] The "unexisting" transport does not exist.', $display);
+        $this->assertStringContainsString('message_countable           6', $display);
+        $this->assertStringContainsString('another_message_countable   6', $display);
+        $this->assertStringNotContainsString('! [NOTE] Unable to get message count for the following transports: "simple".', $display);
+    }
+
+    public function testWithNotMessageCountableTransport(): void
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute(['transport_names' => ['simple']]);
+        $display = $tester->getDisplay();
+
+        $this->assertStringNotContainsString('[WARNING] The "unexisting" transport does not exist.', $display);
+        $this->assertStringNotContainsString('message_countable', $display);
+        $this->assertStringNotContainsString('another_message_countable', $display);
+        $this->assertStringContainsString('! [NOTE] Unable to get message count for the following transports: "simple".', $display);
+    }
+
+    public function testWithNotExistingTransport(): void
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute(['transport_names' => ['unexisting']]);
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('[WARNING] The "unexisting" transport does not exist.', $display);
+        $this->assertStringNotContainsString('message_countable', $display);
+        $this->assertStringNotContainsString('another_message_countable', $display);
+        $this->assertStringNotContainsString('! [NOTE] Unable to get message count for the following transports: "simple".', $display);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | Todo

### Why ?

I worked on a project that didn't had insights on how many messages were present in "queues" (because of some hosting quirks) and to have this information we've developed a command that aims to make it possible via the Symfony's console.
After a visio call with an ex-colleague on another Symfony project, it turns out that he was verry interested to have this command in Symfony.
I've also discused with @Jean-Beru that literraly pushed me too open that PR.

So here I am.

### What does it does ?

This quite simple, like for the `setup-transport` command it takes in input all configured transports' receivers and **Only if they implement `Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface`** it gets the message count and prints it out in a pretty little table.

### Limitation

This command won't work if the configured transport's receiver does not implement `Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface`

### A small demo ?

https://user-images.githubusercontent.com/35264408/171853603-6807f0d1-a251-4180-b34b-80d3a3c49b92.mp4
