### PR TITLE
Fix choice filter error when loading mix of grouped and non-grouped choices

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/Loader/FilterChoiceLoaderDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/FilterChoiceLoaderDecorator.php
@@ -36,10 +36,17 @@ class FilterChoiceLoaderDecorator extends AbstractChoiceLoader
         }
 
         foreach ($structuredValues as $group => $values) {
-            if ($values && $filtered = array_filter($list->getChoicesForValues($values), $this->filter)) {
-                $choices[$group] = $filtered;
+            if (is_array($values)) {
+                if ($values && $filtered = array_filter($list->getChoicesForValues($values), $this->filter)) {
+                    $choices[$group] = $filtered;
+                }
+                continue;
+                // filter empty groups
             }
-            // filter empty groups
+
+            if ($filtered = array_filter($list->getChoicesForValues([$values]), $this->filter)) {
+                $choices[$group] = $filtered[0];
+            }
         }
 
         return $choices ?? [];

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/FilterChoiceLoaderDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/FilterChoiceLoaderDecoratorTest.php
@@ -47,6 +47,29 @@ class FilterChoiceLoaderDecoratorTest extends TestCase
         ]), $loader->loadChoiceList());
     }
 
+    public function testLoadChoiceListMixedWithGroupedAndNonGroupedChoices()
+    {
+        $filter = function ($choice) {
+            return 0 === $choice % 2;
+        };
+
+        $choices = array_merge(range(1, 9), ['grouped' => range(10, 40, 5)]);
+        $loader = new FilterChoiceLoaderDecorator(new ArrayChoiceLoader($choices), $filter);
+
+        $this->assertEquals(new ArrayChoiceList([
+            1 => 2,
+            3 => 4,
+            5 => 6,
+            7 => 8,
+            'grouped' => [
+                0 => 10,
+                2 => 20,
+                4 => 30,
+                6 => 40,
+            ],
+        ]), $loader->loadChoiceList());
+    }
+
     public function testLoadValuesForChoices()
     {
         $evenValues = [1 => '2', 3 => '4'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

**How to reproduce this bug:**
```php
$choiceType = $builder->create('test', ChoiceType::class, [
    'choice_loader' => new CallbackChoiceLoader(fn() => [
        'Foo',
        'Optgroup' => [
            'Bar',
            'Baz',
        ],
    ]),
    'choice_filter' => fn() => true,
]);
$choiceType->getForm()->createView();
```
**TypeError:**
```
Argument 1 passed to Symfony\Component\Form\ChoiceList\ArrayChoiceList::getChoicesForValues() must be of the type array, string given, called in ~/symfony/form/ChoiceList/Loader/FilterChoiceLoaderDecorator.php on line 39
```