### PR TITLE
[Serializer] Fix ignore attribute in Xml files

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -72,7 +72,7 @@ class XmlFileLoader extends FileLoader
                 }
 
                 if (isset($attribute['ignore'])) {
-                    $attributeMetadata->setIgnore((bool) $attribute['ignore']);
+                    $attributeMetadata->setIgnore(XmlUtils::phpize($attribute['ignore']));
                 }
 
                 foreach ($attribute->context as $node) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -37,6 +37,7 @@
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy">
         <attribute name="ignored1" ignore="true" />
         <attribute name="ignored2" ignore="true" />
+        <attribute name="notIgnored" ignore="false" />
     </class>
 
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\ContextDummyParent">

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -107,6 +107,7 @@ class XmlFileLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertTrue($attributesMetadata['ignored1']->isIgnored());
         $this->assertTrue($attributesMetadata['ignored2']->isIgnored());
+        $this->assertFalse($attributesMetadata['notIgnored']->isIgnored());
     }
 
     protected function getLoaderForContextMapping(): LoaderInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46463
| License       | MIT

Before this PR `foo` was ignored. Now it is not.

```xml
<class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy">
    <attribute name="foo" ignore="false" />
</class>
```
Instead of cast we now use `XmlUtils::phpize` like others XmlLoaders.