### PR TITLE
[SecurityBundle] Add shortcut option to enable logout CSRF protection

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `Security::getFirewallConfig()` to help to get the firewall configuration associated to the Request
  * Add `Security::login()` to login programmatically
  * Add `Security::logout()` to logout programmatically
+ * Add `security.firewalls.logout.enable_csrf` to enable CSRF protection using the default CSRF token generator
 
 6.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -426,7 +426,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 ->addTag('kernel.event_subscriber', ['dispatcher' => $firewallEventDispatcherId]);
 
             // add CSRF provider
-            if (isset($firewall['logout']['csrf_token_generator'])) {
+            if ($firewall['logout']['enable_csrf']) {
                 $logoutListener->addArgument(new Reference($firewall['logout']['csrf_token_generator']));
             }
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -177,6 +177,7 @@
         <xsd:attribute name="csrf-parameter" type="xsd:string" />
         <xsd:attribute name="csrf-token-generator" type="xsd:string" />
         <xsd:attribute name="csrf-token-id" type="xsd:string" />
+        <xsd:attribute name="enable-csrf" type="xsd:boolean" />
         <xsd:attribute name="path" type="xsd:string" />
         <xsd:attribute name="target" type="xsd:string" />
         <xsd:attribute name="invalidate-session" type="xsd:boolean" />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -173,6 +173,7 @@ abstract class CompleteConfigurationTest extends TestCase
                     'target' => '/',
                     'invalidate_session' => true,
                     'delete_cookies' => [],
+                    'enable_csrf' => null,
                 ],
             ],
             [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -88,6 +88,55 @@ class MainConfigurationTest extends TestCase
         $this->assertEquals('a_token_id', $processedConfig['firewalls']['stub']['logout']['csrf_token_id']);
     }
 
+    public function testLogoutCsrf()
+    {
+        $config = [
+            'firewalls' => [
+                'custom_token_generator' => [
+                    'logout' => [
+                        'csrf_token_generator' => 'a_token_generator',
+                        'csrf_token_id' => 'a_token_id',
+                    ],
+                ],
+                'default_token_generator' => [
+                    'logout' => [
+                        'enable_csrf' => true,
+                        'csrf_token_id' => 'a_token_id',
+                    ],
+                ],
+                'disabled_csrf' => [
+                    'logout' => [
+                        'enable_csrf' => false,
+                    ],
+                ],
+                'empty' => [
+                    'logout' => true,
+                ],
+            ],
+        ];
+        $config = array_merge(static::$minimalConfig, $config);
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration([], []);
+        $processedConfig = $processor->processConfiguration($configuration, [$config]);
+
+        $assertions = [
+            'custom_token_generator' => [true, 'a_token_generator'],
+            'default_token_generator' => [true, 'security.csrf.token_generator'],
+            'disabled_csrf' => [false, null],
+            'empty' => [false, null],
+        ];
+        foreach ($assertions as $firewallName => [$enabled, $tokenGenerator]) {
+            $this->assertEquals($enabled, $processedConfig['firewalls'][$firewallName]['logout']['enable_csrf']);
+            if ($tokenGenerator) {
+                $this->assertEquals($tokenGenerator, $processedConfig['firewalls'][$firewallName]['logout']['csrf_token_generator']);
+                $this->assertEquals('a_token_id', $processedConfig['firewalls'][$firewallName]['logout']['csrf_token_id']);
+            } else {
+                $this->assertArrayNotHasKey('csrf_token_generator', $processedConfig['firewalls'][$firewallName]['logout']);
+            }
+        }
+    }
+
     public function testDefaultUserCheckers()
     {
         $processor = new Processor();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

In the new security system, enabling login CSRF protection was simplified to `enable_csrf: true`, but we didn't change enabling logout CSRF protection. This means that users have to set some very low level configuration options to enable logout CSRF:

```yaml
security:
  firewalls:
    main:
      logout:
        csrf_token_generator: security.csrf.token_generator
```

This PR introduced an `enable_csrf` option to make this equal to enabling login CSRF protection:

```yaml
security:
  firewalls:
    main:
      logout:
        enable_csrf: true
        # when enabled, the default token generator will be used and
        # csrf_token_generator can be used to use a custom generator
```

The feature is fully backwards compatible without BC breaks (i.e. setting a token generator automatically enables CSRF).