### PR TITLE
[Config] Add conditional types to conditional builders

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -143,7 +143,11 @@ public function NAME(): string
         );
         $body = $hasNormalizationClosures ? '
 /**
+ * @template T
+ * @psalm-param T $value
+ *
  * @return CLASS|$this
+ * @psalm-return (T is array ? CLASS : static)
  */
 public function NAME($value = [])
 {
@@ -262,7 +266,11 @@ public function NAME(string $VAR, $VALUE): self
         if (null === $key = $node->getKeyAttribute()) {
             $body = $hasNormalizationClosures ? '
 /**
+ * @template T
+ * @psalm-param T $value
+ *
  * @return CLASS|$this
+ * @psalm-return (T is array ? CLASS : static)
  */
 public function NAME($value = [])
 {
@@ -285,7 +293,11 @@ public function NAME(array $value = []): CLASS
         } else {
             $body = $hasNormalizationClosures ? '
 /**
+ * @template T
+ * @psalm-param T $value
+ *
  * @return CLASS|$this
+ * @psalm-return (T is array ? CLASS : static)
  */
 public function NAME(string $VAR, $VALUE = [])
 {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
@@ -10,14 +10,18 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 /**
  * This class is automatically generated to help in creating a config.
  */
-class NestedConfig 
+class NestedConfig
 {
     private $nestedObject;
     private $nestedListObject;
     private $_usedProperties = [];
 
     /**
+     * @template T
+     * @psalm-param T $value
+     *
      * @return \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig|$this
+     * @psalm-return (T is array ? \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig : static)
      */
     public function nestedObject($value = [])
     {
@@ -39,7 +43,11 @@ class NestedConfig
     }
 
     /**
+     * @template T
+     * @psalm-param T $value
+     *
      * @return \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig|$this
+     * @psalm-return (T is array ? \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig : static)
      */
     public function nestedListObject($value = [])
     {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
@@ -48,7 +48,11 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     }
 
     /**
+     * @template T
+     * @psalm-param T $value
+     *
      * @return \Symfony\Config\ScalarNormalizedTypes\ObjectConfig|$this
+     * @psalm-return (T is array ? \Symfony\Config\ScalarNormalizedTypes\ObjectConfig : static)
      */
     public function object($value = [])
     {
@@ -70,7 +74,11 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     }
 
     /**
+     * @template T
+     * @psalm-param T $value
+     *
      * @return \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig|$this
+     * @psalm-return (T is array ? \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig : static)
      */
     public function listObject($value = [])
     {
@@ -85,7 +93,11 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     }
 
     /**
+     * @template T
+     * @psalm-param T $value
+     *
      * @return \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig|$this
+     * @psalm-return (T is array ? \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig : static)
      */
     public function keyedListObject(string $class, $value = [])
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46546 
| License       | MIT
| Doc PR        | -

On second thought, one of the main benefits of using the new PHP config builders in application code is the ability to use PHP community tooling to autocomplete and validate the configuration. In this light, I think it makes sense to add the correct PHPdocs to make Psalm and PHPstan understand the config builders.

On top of that, as these config classes are live generated, this is not something that can be easily stubbed in the special PHPstan and Psalm Symfony plugins.