### PR TITLE
[Security] Enforce maximum username length in UserBadge

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -1,6 +1,12 @@
 UPGRADE FROM 6.1 to 6.2
 =======================
 
+Security
+--------
+
+ * Add maximum username length enforcement of 4096 characters in `UserBadge` to
+   prevent [session storage flooding](https://symfony.com/blog/cve-2016-4423-large-username-storage-in-session)
+
 Validator
 ---------
 

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/UserBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/UserBadge.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Authenticator\Passport\Badge;
 
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\EventListener\UserProviderListener;
@@ -27,6 +28,8 @@ use Symfony\Component\Security\Http\EventListener\UserProviderListener;
  */
 class UserBadge implements BadgeInterface
 {
+    public const MAX_USERNAME_LENGTH = 4096;
+
     private string $userIdentifier;
     /** @var callable|null */
     private $userLoader;
@@ -47,6 +50,10 @@ class UserBadge implements BadgeInterface
      */
     public function __construct(string $userIdentifier, callable $userLoader = null)
     {
+        if (\strlen($userIdentifier) > self::MAX_USERNAME_LENGTH) {
+            throw new BadCredentialsException('Username too long.');
+        }
+
         $this->userIdentifier = $userIdentifier;
         $this->userLoader = $userLoader;
     }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add maximum username length enforcement of 4096 characters in `UserBadge`
+
 6.0
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In 2016, a CVE release was made to harden all build-in authenticators for session storage flooding attacks: https://symfony.com/blog/cve-2016-4423-large-username-storage-in-session With the new security system, we can extend the hardening to all authenticators by enforcing the maximum user length in the `UserBadge`.

I believe we can do this as a "bugfix" in 6.2 directly, based on this reasoning from the blog post: "To avoid any BC break, the limit is set to 4096 characters, which should be more than enough for normal usages." For full stability safety, I think it's better to not do this on 5.4.