### PR TITLE
[HttpKernel] Fix BackedEnumValueResolver already resolved enum value

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/BackedEnumValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/BackedEnumValueResolver.php
@@ -51,6 +51,12 @@ class BackedEnumValueResolver implements ArgumentValueResolverInterface
             return;
         }
 
+        if ($value instanceof \BackedEnum) {
+            yield $value;
+
+            return;
+        }
+
         if (!\is_int($value) && !\is_string($value)) {
             throw new \LogicException(sprintf('Could not resolve the "%s $%s" controller argument: expecting an int or string, got %s.', $argument->getType(), $argument->getName(), get_debug_type($value)));
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/BackedEnumValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/BackedEnumValueResolverTest.php
@@ -95,6 +95,12 @@ class BackedEnumValueResolverTest extends TestCase
             ),
             [null],
         ];
+
+        yield 'already resolved attribute value' => [
+            self::createRequest(['suit' => Suit::Hearts]),
+            self::createArgumentMetadata('suit', Suit::class),
+            [Suit::Hearts],
+        ];
     }
 
     public function testResolveThrowsNotFoundOnInvalidValue()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46585
| License       | MIT
| Doc PR        |

Fix #46585