### PR TITLE
[Finder] Add methods to sort by extension & size 

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -425,6 +425,22 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Sorts files and directories by extension.
+     *
+     * This can be slow as all the matching files and directories must be retrieved for comparison.
+     *
+     * @return $this
+     *
+     * @see SortableIterator
+     */
+    public function sortByExtension(): static
+    {
+        $this->sort = Iterator\SortableIterator::SORT_BY_EXTENSION;
+
+        return $this;
+    }
+
+    /**
      * Sorts files and directories by name.
      *
      * This can be slow as all the matching files and directories must be retrieved for comparison.
@@ -452,6 +468,22 @@ class Finder implements \IteratorAggregate, \Countable
     public function sortByCaseInsensitiveName(bool $useNaturalSort = false): static
     {
         $this->sort = $useNaturalSort ? Iterator\SortableIterator::SORT_BY_NAME_NATURAL_CASE_INSENSITIVE : Iterator\SortableIterator::SORT_BY_NAME_CASE_INSENSITIVE;
+
+        return $this;
+    }
+
+    /**
+     * Sorts files and directories by size.
+     *
+     * This can be slow as all the matching files and directories must be retrieved for comparison.
+     *
+     * @return $this
+     *
+     * @see SortableIterator
+     */
+    public function sortBySize(): static
+    {
+        $this->sort = Iterator\SortableIterator::SORT_BY_SIZE;
 
         return $this;
     }

--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -29,6 +29,8 @@ class SortableIterator implements \IteratorAggregate
     public const SORT_BY_NAME_NATURAL = 6;
     public const SORT_BY_NAME_CASE_INSENSITIVE = 7;
     public const SORT_BY_NAME_NATURAL_CASE_INSENSITIVE = 8;
+    public const SORT_BY_EXTENSION = 9;
+    public const SORT_BY_SIZE = 10;
 
     /** @var \Traversable<string, \SplFileInfo> */
     private \Traversable $iterator;
@@ -82,6 +84,14 @@ class SortableIterator implements \IteratorAggregate
         } elseif (self::SORT_BY_MODIFIED_TIME === $sort) {
             $this->sort = static function (\SplFileInfo $a, \SplFileInfo $b) use ($order) {
                 return $order * ($a->getMTime() - $b->getMTime());
+            };
+        } elseif (self::SORT_BY_EXTENSION === $sort) {
+            $this->sort = static function (\SplFileInfo $a, \SplFileInfo $b) use ($order) {
+                return $order * strnatcmp($a->getExtension(), $b->getExtension());
+            };
+        } elseif (self::SORT_BY_SIZE === $sort) {
+            $this->sort = static function (\SplFileInfo $a, \SplFileInfo $b) use ($order) {
+                return $order * ($a->getSize() - $b->getSize());
             };
         } elseif (self::SORT_BY_NONE === $sort) {
             $this->sort = $order;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

The Finder component had functionality to filter by extension and size but no sortBy*() methods to sort by extension or size (e.g. for a media manager in a CMS). This adds sortByExtension() + sortBySize(). Performance is the same as with e.g. sortByType() (depending on # of files/directories).

Likely requires changes to "/src/Symfony/Component/Finder/CHANGELOG.md" + https://symfony.com/doc/current/components/finder.html#sorting-results if accepted.