### PR TITLE
Add "negate" option to Expression constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate the "loose" e-mail validation mode, use "html5" instead
+ * Add the `negate` option to the `Expression` constraint, to inverse the logic of the violation's creation
 
 6.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -40,6 +40,7 @@ class Expression extends Constraint
     public $message = 'This value is not valid.';
     public $expression;
     public $values = [];
+    public bool $negate = true;
 
     public function __construct(
         string|ExpressionObject|array|null $expression,
@@ -47,7 +48,8 @@ class Expression extends Constraint
         array $values = null,
         array $groups = null,
         mixed $payload = null,
-        array $options = []
+        array $options = [],
+        bool $negate = null,
     ) {
         if (!class_exists(ExpressionLanguage::class)) {
             throw new LogicException(sprintf('The "symfony/expression-language" component is required to use the "%s" constraint.', __CLASS__));
@@ -63,6 +65,7 @@ class Expression extends Constraint
 
         $this->message = $message ?? $this->message;
         $this->values = $values ?? $this->values;
+        $this->negate = $negate ?? $this->negate;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -42,7 +42,7 @@ class ExpressionValidator extends ConstraintValidator
         $variables['value'] = $value;
         $variables['this'] = $this->context->getObject();
 
-        if (!$this->getExpressionLanguage()->evaluate($constraint->expression, $variables)) {
+        if ($constraint->negate xor $this->getExpressionLanguage()->evaluate($constraint->expression, $variables)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING))
                 ->setCode(Expression::EXPRESSION_FAILED_ERROR)

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionTest.php
@@ -26,17 +26,20 @@ class ExpressionTest extends TestCase
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertSame('value == "1"', $aConstraint->expression);
         self::assertSame([], $aConstraint->values);
+        self::assertTrue($aConstraint->negate);
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();
         self::assertSame('value == "1"', $bConstraint->expression);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'ExpressionDummy'], $bConstraint->groups);
+        self::assertTrue($bConstraint->negate);
 
         [$cConstraint] = $metadata->properties['c']->getConstraints();
         self::assertSame('value == someVariable', $cConstraint->expression);
         self::assertSame(['someVariable' => 42], $cConstraint->values);
         self::assertSame(['foo'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
+        self::assertFalse($cConstraint->negate);
     }
 }
 
@@ -45,9 +48,9 @@ class ExpressionDummy
     #[Expression('value == "1"')]
     private $a;
 
-    #[Expression(expression: 'value == "1"', message: 'myMessage')]
+    #[Expression(expression: 'value == "1"', message: 'myMessage', negate: true)]
     private $b;
 
-    #[Expression(expression: 'value == someVariable', values: ['someVariable' => 42], groups: ['foo'], payload: 'some attached data')]
+    #[Expression(expression: 'value == someVariable', values: ['someVariable' => 42], groups: ['foo'], payload: 'some attached data', negate: false)]
     private $c;
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -285,4 +285,23 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
         $this->assertNoViolation();
     }
+
+    public function testViolationOnPass()
+    {
+        $constraint = new Expression([
+            'expression' => 'value + custom != 2',
+            'values' => [
+                'custom' => 1,
+            ],
+            'negate' => false,
+        ]);
+
+        $this->validator->validate(2, $constraint);
+
+        $this->buildViolation('This value is not valid.')
+            ->atPath('property.path')
+            ->setParameter('{{ value }}', 2)
+            ->setCode(Expression::EXPRESSION_FAILED_ERROR)
+            ->assertRaised();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16852

Using `Expression` constraint is tedious because the written expression is the opposite of the error message. Adding `negate` option (naming ?) as `Regex::$match` allow us to write condition in phase with the wording.
