### PR TITLE
[Serializer][WebProfilerBundle] Fix broken toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
@@ -3,7 +3,7 @@
 {% import _self as helper %}
 
 {% block toolbar %}
-    {% if collector.handledCount > 0 or collector.calls|length %}
+    {% if collector.handledCount > 0 %}
         {% set icon %}
             {{ source('@WebProfiler/Icon/serializer.svg') }}
             <span class="sf-toolbar-value">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

It seems that #46566 broke the toolbar:

![image](https://user-images.githubusercontent.com/2445045/172192538-04220c57-57ef-4fc3-b203-db431a319b10.png)