### PR TITLE
[SecurityBundle] Add service alias for legacy Security helper

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `Security` helper class
+ * Deprecate the `Symfony\Component\Security\Core\Security` service alias, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
 
 6.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -34,6 +34,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\RoleHierarchyVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\RoleVoter;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+use Symfony\Component\Security\Core\Security as LegacySecurity;
 use Symfony\Component\Security\Core\User\ChainUserProvider;
 use Symfony\Component\Security\Core\User\InMemoryUserChecker;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
@@ -81,6 +82,8 @@ return static function (ContainerConfigurator $container) {
                 'security.authorization_checker' => service('security.authorization_checker'),
             ])])
         ->alias(Security::class, 'security.helper')
+        ->alias(LegacySecurity::class, 'security.helper')
+            ->deprecate('symfony/security-bundle', '6.2', 'The "%alias_id%" service alias is deprecated, use "'.Security::class.'" instead.')
 
         ->set('security.user_value_resolver', UserValueResolver::class)
             ->args([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

The service alias for `Symfony\Component\Security\Core\Security` was removed in #46094 which causes existing code to break when upgrading to 6.2, eg:

```php
use Symfony\Component\Security\Core\Security;

class HomeController extends AbstractController
{
    public function __construct(private Security $security)
    {
    }
}
```
results in:
![image](https://user-images.githubusercontent.com/2445045/172196153-dbcacf0e-0632-40ad-87a2-bbe7774cc698.png)
