### PR TITLE
[Mailer] Fix Error Handling for OhMySMTP Bridge

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/OhMySmtp/Tests/Transport/OhMySmtpApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/OhMySmtp/Tests/Transport/OhMySmtpApiTransportTest.php
@@ -101,7 +101,7 @@ final class OhMySmtpApiTransportTest extends TestCase
     public function testSendThrowsForErrorResponse()
     {
         $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
-            return new MockResponse(json_encode(['Message' => 'i\'m a teapot', 'ErrorCode' => 418]), [
+            return new MockResponse(json_encode(['error' => 'i\'m a teapot']), [
                 'http_code' => 418,
                 'response_headers' => [
                     'content-type' => 'application/json',
@@ -118,7 +118,31 @@ final class OhMySmtpApiTransportTest extends TestCase
             ->text('Hello There!');
 
         $this->expectException(HttpTransportException::class);
-        $this->expectExceptionMessage('Unable to send an email: i\'m a teapot (code 418).');
+        $this->expectExceptionMessage('Unable to send an email: {"error":"i\'m a teapot"}');
+        $transport->send($mail);
+    }
+
+    public function testSendThrowsForMultipleErrorResponses()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
+            return new MockResponse(json_encode(['errors' => ["to" => "undefined field" ]]), [
+                'http_code' => 418,
+                'response_headers' => [
+                    'content-type' => 'application/json',
+                ],
+            ]);
+        });
+        $transport = new OhMySmtpApiTransport('KEY', $client);
+        $transport->setPort(8984);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send an email: {"errors":{"to":"undefined field"}}');
         $transport->send($mail);
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/OhMySmtp/Transport/OhMySmtpApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/OhMySmtp/Transport/OhMySmtpApiTransport.php
@@ -67,7 +67,7 @@ final class OhMySmtpApiTransport extends AbstractApiTransport
         }
 
         if (200 !== $statusCode) {
-            throw new HttpTransportException('Unable to send an email: '.$result['Message'].sprintf(' (code %d).', $result['ErrorCode']), $response);
+            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false), $response);
         }
 
         $sentMessage->setMessageId($result['id']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The OhMySMTP Bridge does not handle errors correctly, and throws up an `Undefined array key "Message"` error when an API error is encountered (e.g. an invalid API key or Internal Server Error). This PR fixes this by showing the full error response.