### PR TITLE
[Mailer] Added scheduling to API transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/README.md
@@ -18,6 +18,9 @@ With API, you can use custom headers.
 ```php
 $params = ['param1' => 'foo', 'param2' => 'bar'];
 $json = json_encode(['"custom_header_1' => 'custom_value_1']);
+$scheduledAt = (new \DateTime())
+   ->sub(new \DateInterval(sprintf('PT%dM', 5)))
+   ->format(\DateTimeInterface::ATOM);
 
 $email = new Email();
 $email
@@ -27,6 +30,7 @@ $email
     ->add(new TagHeader('TagInHeaders2'))
     ->addTextHeader('sender.ip', '1.2.3.4')
     ->addTextHeader('templateId', 1)
+    ->addTextHeader('scheduledAt', $scheduledAt)
     ->addParameterizedHeader('params', 'params', $params)
     ->addTextHeader('foo', 'bar')
 ;
@@ -35,6 +39,7 @@ $email
 This example allow you to set :
 
  * templateId
+ * scheduledAt
  * params
  * tags
  * headers

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
@@ -56,12 +56,16 @@ class SendinblueApiTransportTest extends TestCase
     {
         $params = ['param1' => 'foo', 'param2' => 'bar'];
         $json = json_encode(['"custom_header_1' => 'custom_value_1']);
+        $scheduledAt = (new \DateTime())
+            ->sub(new \DateInterval(sprintf('PT%dM', 5)))
+            ->format(\DateTimeInterface::ATOM);
 
         $email = new Email();
         $email->getHeaders()
             ->add(new MetadataHeader('custom', $json))
             ->add(new TagHeader('TagInHeaders'))
             ->addTextHeader('templateId', 1)
+            ->addTextHeader('scheduledAt', $scheduledAt)
             ->addParameterizedHeader('params', 'params', $params)
             ->addTextHeader('foo', 'bar')
         ;
@@ -78,6 +82,8 @@ class SendinblueApiTransportTest extends TestCase
         $this->assertEquals('TagInHeaders', current($payload['tags']));
         $this->assertArrayHasKey('templateId', $payload);
         $this->assertEquals(1, $payload['templateId']);
+        $this->assertArrayHasKey('scheduledAt', $payload);
+        $this->assertEquals($scheduledAt, $payload['scheduledAt']);
         $this->assertArrayHasKey('params', $payload);
         $this->assertEquals('foo', $payload['params']['param1']);
         $this->assertEquals('bar', $payload['params']['param2']);

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Transport/SendinblueApiTransport.php
@@ -156,6 +156,11 @@ final class SendinblueApiTransport extends AbstractApiTransport
 
                 continue;
             }
+            if ('scheduledat' === $name) {
+                $headersAndTags[$header->getName()] = $header->getValue();
+
+                continue;
+            }
             if ('params' === $name) {
                 $headersAndTags[$header->getName()] = $header->getParameters();
 


### PR DESCRIPTION
Added scheduling to API transport, according to Sendinblue documentation: https://developers.sendinblue.com/reference/sendtransacemail
