### PR TITLE
[Console] Fix deprecation when description is null

### DIFF
--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -124,7 +124,7 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 if (!$r->isSubclassOf(Command::class)) {
                     throw new InvalidArgumentException(sprintf('The service "%s" tagged "%s" must be a subclass of "%s".', $id, $this->commandTag, Command::class));
                 }
-                $description = str_replace('%', '%%', $class::getDefaultDescription());
+                $description = str_replace('%', '%%', $class::getDefaultDescription() ?? '');
             }
 
             if ($description) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixes `str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated` when `getDefaultDescription()` returns `null`, caused by #46574.