### PR TITLE
[BrowserKit] Accept status code 201 as redirect

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -410,7 +410,7 @@ abstract class Client
 
         $status = $this->internalResponse->getStatusCode();
 
-        if ($status >= 300 && $status < 400) {
+        if (($status >= 300 && $status < 400) || $status === 201) {
             $this->redirect = $this->internalResponse->getHeader('Location');
         } else {
             $this->redirect = null;

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -430,16 +430,16 @@ class AbstractBrowserTest extends TestCase
         $client->setNextResponse(new Response('', 201, ['Location' => 'http://www.example.com/redirected']));
         $client->request('GET', 'http://www.example.com/foo/foobar');
 
-        $this->assertSame('http://www.example.com/foo/foobar', $client->getRequest()->getUri(), '->followRedirect() does not follow redirect if HTTP Code is not 30x');
+        $this->assertSame('http://www.example.com/redirected', $client->getRequest()->getUri(), '->followRedirect() automatically follows redirects if followRedirects is true');
 
         $client = $this->getBrowser();
-        $client->setNextResponse(new Response('', 201, ['Location' => 'http://www.example.com/redirected']));
+        $client->setNextResponse(new Response('', 400, ['Location' => 'http://www.example.com/redirected']));
         $client->followRedirects(false);
         $client->request('GET', 'http://www.example.com/foo/foobar');
 
         try {
             $client->followRedirect();
-            $this->fail('->followRedirect() throws a \LogicException if the request did not respond with 30x HTTP Code');
+            $this->fail('->followRedirect() throws a \LogicException if the request did not respond with 30x or 201 HTTP Code');
         } catch (\Exception $e) {
             $this->assertInstanceOf(\LogicException::class, $e, '->followRedirect() throws a \LogicException if the request did not respond with 30x HTTP Code');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Status code 201 is currently not recognized as a possible redirect and thus calling `followRedirect()` fails, which checks the redirect:
https://github.com/symfony/symfony/blob/527e085868b1f36f0fed275a003cb0e362973cbe/src/Symfony/Component/BrowserKit/AbstractBrowser.php#L531-L535

Response gets it right and accepts 201 as redirect: 
https://github.com/symfony/symfony/blob/527e085868b1f36f0fed275a003cb0e362973cbe/src/Symfony/Component/HttpFoundation/Response.php#L1235-L1238

See e.g. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201 for further infos about the status code.

I am currently experiencing it on 6.1. Seems like a bugfix to me, but with possible BC breaks. Not sure if 4.4 is the correct target.