### PR TITLE
[DependencyInjection] [POC] allow `ServiceSubscriberTrait` to autowire properties

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -246,6 +246,8 @@ class RegisterServiceSubscribersPassTest extends TestCase
             TestServiceSubscriberChild::class.'::testDefinition4' => new ServiceClosureArgument(new TypedReference(TestDefinition3::class, TestDefinition3::class)),
             TestServiceSubscriberParent::class.'::testDefinition1' => new ServiceClosureArgument(new TypedReference(TestDefinition1::class, TestDefinition1::class)),
             'custom_name' => new ServiceClosureArgument(new TypedReference(TestDefinition3::class, TestDefinition3::class, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'custom_name')),
+            'testDefinition1' => new ServiceClosureArgument(new TypedReference(TestDefinition1::class, TestDefinition1::class, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'testDefinition1')),
+            'testDefinition2' => new ServiceClosureArgument(new TypedReference(TestDefinition2::class, TestDefinition2::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'testDefinition2')),
         ];
 
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberChild.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberChild.php
@@ -11,6 +11,12 @@ class TestServiceSubscriberChild extends TestServiceSubscriberParent
     use TestServiceSubscriberTrait;
 
     #[SubscribedService]
+    private TestDefinition1 $testDefinition1;
+
+    #[SubscribedService]
+    private ?TestDefinition2 $testDefinition2;
+
+    #[SubscribedService]
     private function testDefinition2(): ?TestDefinition2
     {
         return $this->container->get(__METHOD__);

--- a/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
+++ b/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Service\ServiceSubscriberTrait;
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 final class SubscribedService
 {
     /** @var object[] */

--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -17,7 +17,9 @@ use Symfony\Contracts\Service\Attribute\SubscribedService;
 
 /**
  * Implementation of ServiceSubscriberInterface that determines subscribed services from
- * method return types. Service ids are available as "ClassName::methodName".
+ * method return types and property type-hints for methods/properties marked with the
+ * "SubscribedService" attribute. Service ids are available as "ClassName::methodName"
+ * for methods and "propertyName" for properties.
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -29,8 +31,39 @@ trait ServiceSubscriberTrait
     public static function getSubscribedServices(): array
     {
         $services = method_exists(get_parent_class(self::class) ?: '', __FUNCTION__) ? parent::getSubscribedServices() : [];
+        $refClass = new \ReflectionClass(self::class);
 
-        foreach ((new \ReflectionClass(self::class))->getMethods() as $method) {
+        foreach ($refClass->getProperties() as $property) {
+            if (self::class !== $property->getDeclaringClass()->name) {
+                continue;
+            }
+
+            if (!$attribute = $property->getAttributes(SubscribedService::class)[0] ?? null) {
+                continue;
+            }
+
+            if ($property->isStatic()) {
+                throw new \LogicException(sprintf('Cannot use "%s" on property "%s::$%s" (can only be used on non-static properties with a type).', SubscribedService::class, self::class, $property->name));
+            }
+
+            if (!$type = $property->getType()) {
+                throw new \LogicException(sprintf('Cannot use "%s" on properties without a type in "%s::%s()".', SubscribedService::class, $property->name, self::class));
+            }
+
+            /* @var SubscribedService $attribute */
+            $attribute = $attribute->newInstance();
+            $attribute->key ??= $property->name;
+            $attribute->type ??= $type instanceof \ReflectionNamedType ? $type->getName() : (string) $type;
+            $attribute->nullable = $type->allowsNull();
+
+            if ($attribute->attributes) {
+                $services[] = $attribute;
+            } else {
+                $services[$attribute->key] = ($attribute->nullable ? '?' : '').$attribute->type;
+            }
+        }
+
+        foreach ($refClass->getMethods() as $method) {
             if (self::class !== $method->getDeclaringClass()->name) {
                 continue;
             }
@@ -68,10 +101,31 @@ trait ServiceSubscriberTrait
     {
         $this->container = $container;
 
+        foreach ((new \ReflectionClass(self::class))->getProperties() as $property) {
+            if (self::class !== $property->getDeclaringClass()->name) {
+                continue;
+            }
+
+            if (!$property->getAttributes(SubscribedService::class)) {
+                continue;
+            }
+
+            unset($this->{$property->name});
+        }
+
         if (method_exists(get_parent_class(self::class) ?: '', __FUNCTION__)) {
             return parent::setContainer($container);
         }
 
         return null;
+    }
+
+    public function __get(string $name): mixed
+    {
+        // TODO: ensure cannot be called from outside of the scope of the object?
+        // TODO: what if class has a child/parent that allows this?
+        // TODO: call parent::__get()?
+
+        return $this->$name = $this->container->has($name) ? $this->container->get($name) : null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This comes from a slack discussion with @nicolas-grekas.

This PR allows `ServiceSubscriberInterface` services using the `ServiceSubscriber` trait to _autowire_ properties marked with the `SubscribedService` attribute.

```php
class MyService implements ServiceSubscriberInterface
{
    use ServiceSubscriberTrait;

    #[SubscribedService]
    private AnotherService $anotherService;

    public function someMethod()
    {
        $this->anotherService->something(); // lazily initializes the property the first time it's accessed
    }
}
```

TODO:
- [x] nullable properties?
- [ ] more tests
- [ ] changelog
