### PR TITLE
[Security] Centralize max username length enforcement

### DIFF
--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -46,9 +46,7 @@ class Security implements AuthorizationCheckerInterface
     public const LAST_USERNAME = '_security.last_username';
 
     /**
-     * @deprecated since Symfony 6.2, use \Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface::MAX_USERNAME_LENGTH instead
-     *
-     *  In 7.0, move this constant to the NewSecurityHelper class and make it reference AuthenticatorInterface:MAX_USERNAME_LENGTH.
+     * @deprecated since Symfony 6.2, use \Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge::MAX_USERNAME_LENGTH instead
      */
     public const MAX_USERNAME_LENGTH = 4096;
 

--- a/src/Symfony/Component/Security/Http/Authenticator/AuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AuthenticatorInterface.php
@@ -26,8 +26,6 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
  */
 interface AuthenticatorInterface
 {
-    public const MAX_USERNAME_LENGTH = 4096;
-
     /**
      * Does the authenticator support the given Request?
      *

--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -132,10 +132,6 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
 
         $credentials['username'] = trim($credentials['username']);
 
-        if (\strlen($credentials['username']) > self::MAX_USERNAME_LENGTH) {
-            throw new BadCredentialsException('Invalid username.');
-        }
-
         $request->getSession()->set(SecurityRequestAttributes::LAST_USERNAME, $credentials['username']);
 
         return $credentials;

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -149,10 +149,6 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             if (!\is_string($credentials['username'])) {
                 throw new BadRequestHttpException(sprintf('The key "%s" must be a string.', $this->options['username_path']));
             }
-
-            if (\strlen($credentials['username']) > self::MAX_USERNAME_LENGTH) {
-                throw new BadCredentialsException('Invalid username.');
-            }
         } catch (AccessException $e) {
             throw new BadRequestHttpException(sprintf('The key "%s" must be provided.', $this->options['username_path']), $e);
         }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -19,10 +19,10 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\FormLoginAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PasswordUpgradeBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Tests\Authenticator\Fixtures\PasswordUpgraderProvider;
 
@@ -50,7 +50,7 @@ class FormLoginAuthenticatorTest extends TestCase
             $this->expectNotToPerformAssertions();
         } else {
             $this->expectException(BadCredentialsException::class);
-            $this->expectExceptionMessage('Invalid username.');
+            $this->expectExceptionMessage('Username too long.');
         }
 
         $request = Request::create('/login_check', 'POST', ['_username' => $username, '_password' => 's$cr$t']);
@@ -62,8 +62,8 @@ class FormLoginAuthenticatorTest extends TestCase
 
     public function provideUsernamesForLength()
     {
-        yield [str_repeat('x', AuthenticatorInterface::MAX_USERNAME_LENGTH + 1), false];
-        yield [str_repeat('x', AuthenticatorInterface::MAX_USERNAME_LENGTH - 1), true];
+        yield [str_repeat('x', UserBadge::MAX_USERNAME_LENGTH + 1), false];
+        yield [str_repeat('x', UserBadge::MAX_USERNAME_LENGTH - 1), true];
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\JsonLoginAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Translation\Loader\ArrayLoader;
@@ -121,9 +122,9 @@ class JsonLoginAuthenticatorTest extends TestCase
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '{"username": "dunglas", "password": 1}');
         yield [$request, 'The key "password" must be a string.'];
 
-        $username = str_repeat('x', AuthenticatorInterface::MAX_USERNAME_LENGTH + 1);
-        $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], sprintf('{"username": "%s", "password": 1}', $username));
-        yield [$request, 'Invalid username.', BadCredentialsException::class];
+        $username = str_repeat('x', UserBadge::MAX_USERNAME_LENGTH + 1);
+        $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], sprintf('{"username": "%s", "password": "foo"}', $username));
+        yield [$request, 'Username too long.', BadCredentialsException::class];
     }
 
     public function testAuthenticationFailureWithoutTranslator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Cleans up the max username length enforcement across the board. Authenticators do not need to check it on their own since #46584.