### PR TITLE
[Routing] Fix $requirements PHPDoc for SCA

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -30,9 +30,9 @@ class Route
     private array $schemes;
 
     /**
-     * @param string[]        $requirements
-     * @param string[]|string $methods
-     * @param string[]|string $schemes
+     * @param array<string|\Stringable> $requirements
+     * @param string[]|string           $methods
+     * @param string[]|string           $schemes
      */
     public function __construct(
         string|array $path = null,

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -37,14 +37,14 @@ class Route implements \Serializable
      *  * compiler_class: A class name able to compile this route instance (RouteCompiler by default)
      *  * utf8:           Whether UTF-8 matching is enforced ot not
      *
-     * @param string          $path         The path pattern to match
-     * @param array           $defaults     An array of default parameter values
-     * @param array           $requirements An array of requirements for parameters (regexes)
-     * @param array           $options      An array of options
-     * @param string|null     $host         The host pattern to match
-     * @param string|string[] $schemes      A required URI scheme or an array of restricted schemes
-     * @param string|string[] $methods      A required HTTP method or an array of restricted methods
-     * @param string|null     $condition    A condition that should evaluate to true for the route to match
+     * @param string                    $path         The path pattern to match
+     * @param array                     $defaults     An array of default parameter values
+     * @param array<string|\Stringable> $requirements An array of requirements for parameters (regexes)
+     * @param array                     $options      An array of options
+     * @param string|null               $host         The host pattern to match
+     * @param string|string[]           $schemes      A required URI scheme or an array of restricted schemes
+     * @param string|string[]           $methods      A required HTTP method or an array of restricted methods
+     * @param string|null               $condition    A condition that should evaluate to true for the route to match
      */
     public function __construct(string $path, array $defaults = [], array $requirements = [], array $options = [], ?string $host = '', string|array $schemes = [], string|array $methods = [], ?string $condition = '')
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

```
Parameter $requirements of attribute class Symfony\Component\Routing\Annotation\Route constructor expects array<string>, array<string, string|Symfony\Component\Routing\Requirement\EnumRequirement> given.
```

We officially support `\Stringable` since we introduced `EnumRequirement` in 6.1.

It looks like we started supporting it in 5.0 through type coercion (https://github.com/symfony/symfony/commit/614e8248c354b60ba74b18224d81139e3c67868f#diff-f82bb2cf9b0e716ac5f670438837154457d6fd24f0b99b0189c6fa3deca3ce46R535). Target 6.1 or 5.4? :thinking: 