### PR TITLE
[HttpClient] Migrate PHPUnit configuration to new format

### DIFF
--- a/src/Symfony/Component/HttpClient/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpClient/phpunit.xml.dist
@@ -18,13 +18,13 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

This PR fixes the deprecation note from PHPUnit about outdated configuration settings:
```
src/Symfony/Component/HttpClient                                              5s
+ /home/runner/work/symfony/symfony/phpunit --exclude-group tty,benchmark,intl-data,integration src/Symfony/Component/HttpClient

PHPUnit 9.5.20 #StandWithUkraine
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
Testing /home/runner/work/symfony/symfony/src/Symfony/Component/HttpClient
......SS.....

Error: KO src/Symfony/Component/HttpClient
