### PR TITLE
[DoctrineBridge] Add `NAME` const for UID types

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add `NAME` constant to `UlidType` and `UuidType`
+
 6.0
 ---
 

--- a/src/Symfony/Bridge/Doctrine/Types/UlidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/UlidType.php
@@ -15,9 +15,11 @@ use Symfony\Component\Uid\Ulid;
 
 final class UlidType extends AbstractUidType
 {
+    public const NAME = 'ulid';
+
     public function getName(): string
     {
-        return 'ulid';
+        return self::NAME;
     }
 
     protected function getUidClass(): string

--- a/src/Symfony/Bridge/Doctrine/Types/UuidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/UuidType.php
@@ -15,9 +15,11 @@ use Symfony\Component\Uid\Uuid;
 
 final class UuidType extends AbstractUidType
 {
+    public const NAME = 'uuid';
+
     public function getName(): string
     {
-        return 'uuid';
+        return self::NAME;
     }
 
     protected function getUidClass(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | symfony/symfony-docs#16866

This allows to refer to the constant instead of an "arbitrary" string. For example:

```php
#[ORM\Column(type: UuidType::NAME)]
private $foo;
```

Doctrine [already does it this way][1] in its documentation.

The name of the constant is taken from the already existing `Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineFooType` class, where a constant with a similar purpose already exists (albeit this one is `private`). Another possibility would be `UlidType::ULID` and `UuidType::UUID` as shown in Doctrine's [Custom Mapping Types][2] documentation.

[1]: https://www.doctrine-project.org/projects/doctrine-orm/en/2.11/reference/basic-mapping.html
[2]: https://www.doctrine-project.org/projects/doctrine-orm/en/2.11/cookbook/custom-mapping-types.html