### PR TITLE
Add rate limit factory interface

### DIFF
--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -1,5 +1,8 @@
 CHANGELOG
 =========
+6.1
+---
+ * Switch to use an Interface for the `RateLimiterFactory`
 
 5.4
 ---

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -25,7 +25,7 @@ use Symfony\Component\RateLimiter\Storage\StorageInterface;
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-final class RateLimiterFactory
+final class RateLimiterFactory implements RateLimiterFactoryInterface
 {
     private array $config;
     private StorageInterface $storage;

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactoryInterface.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter;
+
+interface RateLimiterFactoryInterface
+{
+    public function create(string $key = null): LimiterInterface;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #46644
| License       | MIT
| Doc PR        | symfony/symfony-docs#16867

Adding a `RateLimitFactoryInterface` so that alternative limiters can be used, or for its use in UnitTests. Extension can be done using the decorator pattern with this PR.
