### PR TITLE
[Messenger] move resetting services at worker stopped into listener

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Messenger\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
@@ -34,10 +36,16 @@ class ResetServicesListener implements EventSubscriberInterface
         }
     }
 
+    public function resetServicesAtStop(WorkerStoppedEvent $event): void
+    {
+        $this->servicesResetter->reset();
+    }
+
     public static function getSubscribedEvents(): array
     {
         return [
             WorkerRunningEvent::class => ['resetServices', -1024],
+            WorkerStoppedEvent::class => ['resetServicesAtStop', -1024],
         ];
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/EventListener/ResetServicesListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/ResetServicesListenerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\Worker;
 
@@ -37,5 +38,16 @@ class ResetServicesListenerTest extends TestCase
 
         $resetListener = new ResetServicesListener($servicesResetter);
         $resetListener->resetServices($event);
+    }
+
+    public function testResetServicesAtStop()
+    {
+        $servicesResetter = $this->createMock(ServicesResetter::class);
+        $servicesResetter->expects($this->once())->method('reset');
+
+        $event = new WorkerStoppedEvent($this->createMock(Worker::class));
+
+        $resetListener = new ResetServicesListener($servicesResetter);
+        $resetListener->resetServicesAtStop($event);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Tests;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
@@ -21,6 +22,7 @@ use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
+use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\Exception\RuntimeException;
 use Symfony\Component\Messenger\Handler\Acknowledger;
@@ -103,13 +105,48 @@ class WorkerTest extends TestCase
     {
         $resettableReceiver = new ResettableDummyReceiver([]);
 
-        $bus = $this->createMock(MessageBusInterface::class);
         $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new ResetServicesListener(new ServicesResetter(new \ArrayIterator([$resettableReceiver]), ['reset'])));
 
+        $bus = $this->createMock(MessageBusInterface::class);
         $worker = new Worker([$resettableReceiver], $bus, $dispatcher);
         $worker->stop();
         $worker->run();
         $this->assertTrue($resettableReceiver->hasBeenReset());
+    }
+
+    public function testWorkerResetsTransportsIfResetServicesListenerIsCalled()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $resettableReceiver = new ResettableDummyReceiver([[$envelope]]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new ResetServicesListener(new ServicesResetter(new \ArrayIterator([$resettableReceiver]), ['reset'])));
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) {
+            $event->getWorker()->stop();
+        });
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $worker = new Worker([$resettableReceiver], $bus, $dispatcher);
+        $worker->run();
+        $this->assertTrue($resettableReceiver->hasBeenReset());
+    }
+
+    public function testWorkerDoesNotResetTransportsIfResetServicesListenerIsNotCalled()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $resettableReceiver = new ResettableDummyReceiver([[$envelope]]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) {
+            $event->getWorker()->stop();
+        });
+
+        $worker = new Worker([$resettableReceiver], $bus, $dispatcher);
+        $worker->run();
+        $this->assertFalse($resettableReceiver->hasBeenReset());
     }
 
     public function testWorkerDoesNotSendNullMessagesToTheBus()

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -136,7 +136,6 @@ class Worker
 
         $this->flush(true);
         $this->dispatchEvent(new WorkerStoppedEvent($this));
-        $this->resetReceiverConnections();
     }
 
     private function handleMessage(Envelope $envelope, string $transportName): void
@@ -258,15 +257,6 @@ class Worker
     public function getMetadata(): WorkerMetadata
     {
         return $this->metadata;
-    }
-
-    private function resetReceiverConnections(): void
-    {
-        foreach ($this->receivers as $receiver) {
-            if ($receiver instanceof ResetInterface) {
-                $receiver->reset();
-            }
-        }
     }
 
     private function dispatchEvent(object $event): void


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46349
| License       | MIT

This PR tries to fix an issue about "--no-reset" introduced by a [previous fix](https://github.com/symfony/symfony/commit/a4c8f4e48c3b639c6d19d21324adee850a2686fe).
Instead of resetting the resettable receivers after the WorkerStoppedEvent dispatch, the ResetServicesListener subscribes to it and resets the resettable services.
It allows --no-reset to work again because this option decides the ResetServicesListener to be added or not.




