### PR TITLE
 [WebProfilerBundle] Bump http-kernel requirement to ^6.1 

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "symfony/config": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
-        "symfony/http-kernel": "^5.4|^6.0",
+        "symfony/http-kernel": "^6.1",
         "symfony/routing": "^5.4|^6.0",
         "symfony/twig-bundle": "^5.4|^6.0",
         "twig/twig": "^2.13|^3.0.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      |  yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | 

Since https://github.com/symfony/symfony/pull/44483, WebProfilerBundle requires `\Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector::hasXdebugInfo`, but this feature was added to http-kernel in very same PR. Hence profiler at the moment does not work with http-kernel < 6.1 (when twig strict variables are enabled, which is a default)