### PR TITLE
Feature/46497: Adding Failing Test For Quiet Config [PhPUnitBridge]

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/quiet_not_working.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/quiet_not_working.phpt
@@ -40,19 +40,8 @@ trigger_deprecation('foo/bar', '2.0', 'func is deprecated, use new instead.');
 --EXPECTF--
 Remaining self deprecation notices (1)
 
-  1x: Since App 3.0: selfDeprecation is deprecated, use selfDeprecation_new instead.
-    1x in AppService::selfDeprecation from App\Services
-
 Remaining direct deprecation notices (1)
-
-  1x: Since acme/lib 3.0: deprecatedApi is deprecated, use deprecatedApi_new instead.
-    1x in AppService::directDeprecation from App\Services
 
 Remaining indirect deprecation notices (1)
 
-  1x: Since bar/lib 3.0: deprecatedApi is deprecated, use deprecatedApi_new instead.
-    1x in AppService::indirectDeprecation from App\Services
-
 Other deprecation notices (1)
-
-  1x: Since foo/bar 2.0: func is deprecated, use new instead.

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/quiet_not_working.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/quiet_not_working.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Test DeprecationErrorHandler with quiet output (not working)
+--FILE--
+<?php
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'quiet[]=self&quiet[]=direct&quiet[]=indirect&quiet[]=other');
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+eval(<<<'EOPHP'
+namespace PHPUnit\Util;
+
+class Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+EOPHP
+);
+
+require __DIR__.'/fake_vendor/autoload.php';
+
+(new \App\Services\AppService())->selfDeprecation(true);
+(new \App\Services\AppService())->directDeprecation(true);
+(new \App\Services\AppService())->indirectDeprecation(true);
+trigger_deprecation('foo/bar', '2.0', 'func is deprecated, use new instead.');
+?>
+--EXPECTF--
+Remaining self deprecation notices (1)
+
+  1x: Since App 3.0: selfDeprecation is deprecated, use selfDeprecation_new instead.
+    1x in AppService::selfDeprecation from App\Services
+
+Remaining direct deprecation notices (1)
+
+  1x: Since acme/lib 3.0: deprecatedApi is deprecated, use deprecatedApi_new instead.
+    1x in AppService::directDeprecation from App\Services
+
+Remaining indirect deprecation notices (1)
+
+  1x: Since bar/lib 3.0: deprecatedApi is deprecated, use deprecatedApi_new instead.
+    1x in AppService::indirectDeprecation from App\Services
+
+Other deprecation notices (1)
+
+  1x: Since foo/bar 2.0: func is deprecated, use new instead.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features / 4.4, 5.4, 6.0 or 6.1 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #46497 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

## Summary

Setting *any* `quiet` option is getting ignored. This PR provides a failing test for https://github.com/symfony/symfony/issues/46497.

`quiet[]=self&quiet[]=direct&quiet[]=indirect&quiet[]=other`

Expected output:

```
Remaining self deprecation notices (1)

Remaining direct deprecation notices (1)

Remaining indirect deprecation notices (1)

Other deprecation notices (1)
```

Actual output:
```
Remaining self deprecation notices (1)

  1x: Since App 3.0: selfDeprecation is deprecated, use selfDeprecation_new instead.
    1x in AppService::selfDeprecation from App\Services

Remaining direct deprecation notices (1)

  1x: Since acme/lib 3.0: deprecatedApi is deprecated, use deprecatedApi_new instead.
    1x in AppService::directDeprecation from App\Services

Remaining indirect deprecation notices (1)

  1x: Since bar/lib 3.0: deprecatedApi is deprecated, use deprecatedApi_new instead.
    1x in AppService::indirectDeprecation from App\Services

Other deprecation notices (1)

  1x: Since foo/bar 2.0: func is deprecated, use new instead.
```