### PR TITLE
[Serializer] Add `COLLECT_EXTRA_ATTRIBUTES_ERRORS` and full deserialization path

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -127,6 +127,8 @@ Serializer
 ----------
 
  * Deprecate datetime constructor as a fallback, in version 9.0 a `Symfony\Component\Serializer\Exception\NotNormalizableValueException` will be thrown when a date could not be parsed using the default format
+ * Change the signature of `PartialDenormalizationException::__construct($data, array $errors)` to `__construct(mixed $data, array $notNormalizableErrors, array $extraAttributesErrors = [])`
+ * Deprecate `PartialDenormalizationException::getErrors()`, use `getNotNormalizableValueErrors()` instead
 
 Uid
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -133,7 +133,8 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                     $payload = $payloadMapper($request, $argument->metadata, $argument);
                 } catch (PartialDenormalizationException $e) {
                     $trans = $this->translator ? $this->translator->trans(...) : static fn ($m, $p) => strtr($m, $p);
-                    foreach ($e->getErrors() as $error) {
+                    $errors = method_exists($e, 'getNotNormalizableValueErrors') ? $e->getNotNormalizableValueErrors() : $e->getErrors();
+                    foreach ($errors as $error) {
                         $parameters = [];
                         $template = 'This value was of an unexpected type.';
                         if ($expectedTypes = $error->getExpectedTypes()) {
@@ -173,7 +174,8 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 try {
                     $payload = $payloadMapper($request, $argument->metadata, $argument);
                 } catch (PartialDenormalizationException $e) {
-                    throw HttpException::fromStatusCode($validationFailedCode, implode("\n", array_map(static fn ($e) => $e->getMessage(), $e->getErrors())), $e);
+                    $errors = method_exists($e, 'getNotNormalizableValueErrors') ? $e->getNotNormalizableValueErrors() : $e->getErrors();
+                    throw HttpException::fromStatusCode($validationFailedCode, implode("\n", array_map(static fn ($e) => $e->getMessage(), $errors)), $e);
                 } catch (SerializerInvalidArgumentException $e) {
                     throw HttpException::fromStatusCode($validationFailedCode, $e->getMessage(), $e);
                 }

--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `PropertyPath::append()`
+
 7.0
 ---
 

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -202,4 +202,33 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
 
         return $this->isNullSafe[$index];
     }
+
+    /**
+     * Utility method for dealing with property paths.
+     * For more extensive functionality, use instances of this class.
+     *
+     * Appends a path to a given property path.
+     *
+     * If the base path is empty, the appended path will be returned unchanged.
+     * If the base path is not empty, and the appended path starts with a
+     * squared opening bracket ("["), the concatenation of the two paths is
+     * returned. Otherwise, the concatenation of the two paths is returned,
+     * separated by a dot (".").
+     */
+    public static function append(string $basePath, string $subPath): string
+    {
+        if ('' === $subPath) {
+            return $basePath;
+        }
+
+        if ('[' === $subPath[0]) {
+            return $basePath.$subPath;
+        }
+
+        if ('' === $basePath) {
+            return $subPath;
+        }
+
+        return $basePath.'.'.$subPath;
+    }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
@@ -203,4 +203,22 @@ class PropertyPathTest extends TestCase
 
         $propertyPath->isIndex(-1);
     }
+
+    #[DataProvider('provideAppendPaths')]
+    public function testAppend(string $basePath, string $subPath, string $expectedPath, string $message)
+    {
+        $this->assertSame($expectedPath, PropertyPath::append($basePath, $subPath), $message);
+    }
+
+    public static function provideAppendPaths()
+    {
+        return [
+            ['foo', '', 'foo', 'It returns the basePath if subPath is empty'],
+            ['', 'bar', 'bar', 'It returns the subPath if basePath is empty'],
+            ['foo', 'bar', 'foo.bar', 'It append the subPath to the basePath'],
+            ['foo', '[bar]', 'foo[bar]', 'It does not include the dot separator if subPath uses the array notation'],
+            ['0', 'bar', '0.bar', 'Leading zeros are kept.'],
+            ['0', '1', '0.1', 'Leading zeros are kept on subPath too.'],
+        ];
+    }
 }

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Improve `NotNormalizableValueException` exception messages in `BackedEnumNormalizer` to contain more useful information
  * Trigger a deprecation when a date could not be parsed using the default format
  * Add `AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION` for scalar type transformation
+ * Add `COLLECT_EXTRA_ATTRIBUTES_ERRORS` option to `Serializer` to collect extra-attributes errors during denormalization
+ * Deprecate `PartialDenormalizationException::getErrors()`, use `getNotNormalizableValueErrors()` instead
 
 8.0
 ---

--- a/src/Symfony/Component/Serializer/Context/SerializerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/SerializerContextBuilder.php
@@ -36,4 +36,9 @@ final class SerializerContextBuilder implements ContextBuilderInterface
     {
         return $this->with(DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS, $collectDenormalizationErrors);
     }
+
+    public function withCollectExtraAttributesErrors(?bool $collectExtraAttributesErrors): static
+    {
+        return $this->with(DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS, $collectExtraAttributesErrors);
+    }
 }

--- a/src/Symfony/Component/Serializer/Exception/PartialDenormalizationException.php
+++ b/src/Symfony/Component/Serializer/Exception/PartialDenormalizationException.php
@@ -16,13 +16,24 @@ namespace Symfony\Component\Serializer\Exception;
  */
 class PartialDenormalizationException extends UnexpectedValueException
 {
+    private ?ExtraAttributesException $extraAttributesError = null;
+
     /**
-     * @param NotNormalizableValueException[] $errors
+     * @param NotNormalizableValueException[] $notNormalizableErrors
+     * @param ExtraAttributesException[]      $extraAttributesErrors
      */
     public function __construct(
         private mixed $data,
-        private array $errors,
+        private array $notNormalizableErrors,
+        array $extraAttributesErrors = [],
     ) {
+        $extraAttributes = [];
+        foreach ($extraAttributesErrors as $error) {
+            $extraAttributes = array_merge($extraAttributes, $error->getExtraAttributes());
+        }
+        if ($extraAttributes) {
+            $this->extraAttributesError = new ExtraAttributesException($extraAttributes);
+        }
     }
 
     public function getData(): mixed
@@ -31,10 +42,25 @@ class PartialDenormalizationException extends UnexpectedValueException
     }
 
     /**
-     * @return NotNormalizableValueException[]
+     * @deprecated since Symfony 8.1, use getNotNormalizableValueErrors() instead
      */
     public function getErrors(): array
     {
-        return $this->errors;
+        trigger_deprecation('symfony/serializer', '8.1', 'The "%s()" method is deprecated, use "%s::getNotNormalizableValueErrors()" instead.', __METHOD__, self::class);
+
+        return $this->getNotNormalizableValueErrors();
+    }
+
+    /**
+     * @return NotNormalizableValueException[]
+     */
+    public function getNotNormalizableValueErrors(): array
+    {
+        return $this->notNormalizableErrors;
+    }
+
+    public function getExtraAttributesError(): ?ExtraAttributesException
+    {
+        return $this->extraAttributesError;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -593,7 +594,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      */
     protected function getAttributeDenormalizationContext(string $class, string $attribute, array $context): array
     {
-        $context['deserialization_path'] = ($context['deserialization_path'] ?? false) ? $context['deserialization_path'].'.'.$attribute : $attribute;
+        $context['deserialization_path'] = PropertyPath::append($context['deserialization_path'] ?? '', $attribute);
 
         if (null === $metadata = $this->getAttributeMetadata($class, $attribute)) {
             return $context;

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -15,6 +15,7 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -421,7 +422,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         if ($extraAttributes) {
-            throw new ExtraAttributesException($extraAttributes);
+            $extraAttributeException = new ExtraAttributesException(array_map(static fn (string $extraAttribute) => PropertyPath::append($context['deserialization_path'] ?? '', $extraAttribute), $extraAttributes));
+            if (!isset($context['extra_attributes_exceptions'])) {
+                throw $extraAttributeException;
+            }
+            $context['extra_attributes_exceptions'][] = $extraAttributeException;
         }
 
         return $object;

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -24,7 +24,15 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
  */
 interface DenormalizerInterface
 {
+    /**
+     * Whether to collect all denormalization errors or to stop at first error.
+     */
     public const COLLECT_DENORMALIZATION_ERRORS = 'collect_denormalization_errors';
+
+    /**
+     * Whether to collect all extra attributes errors or to stop at first nested error.
+     */
+    public const COLLECT_EXTRA_ATTRIBUTES_ERRORS = 'collect_extra_attributes_errors';
 
     /**
      * Denormalizes data back into an object of the given class.

--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -81,7 +81,7 @@ class ProblemNormalizer implements NormalizerInterface, SerializerAwareInterface
                                 '{{ type }}' => implode('|', $e->getExpectedTypes() ?? ['?']),
                             ],
                         ] + ($debug || $e->canUseMessageForUser() ? ['hint' => $e->getMessage()] : []),
-                        $exception->getErrors()
+                        $exception->getNotNormalizableValueErrors()
                     ),
                 ];
                 $error['detail'] = implode("\n", array_map(static fn ($e) => $e['propertyPath'].': '.$e['title'], $error['violations']));

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -194,6 +194,10 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
             throw new LogicException('Passing a value for "not_normalizable_value_exceptions" context key is not allowed.');
         }
 
+        if (isset($context[DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS], $context['extra_attributes_exceptions'])) {
+            throw new LogicException('Passing a value for "extra_attributes_exceptions" context key is not allowed.');
+        }
+
         $normalizer = $this->getDenormalizer($data, $type, $format, $context);
 
         // Check for a denormalizer first, e.g. the data is wrapped
@@ -213,31 +217,40 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
             throw new NotNormalizableValueException(\sprintf('Could not denormalize object of type "%s", no supporting normalizer found.', $type));
         }
 
-        if ((isset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]) || isset($this->defaultContext[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS])) && !isset($context['not_normalizable_value_exceptions'])) {
+        $collectNotNormalizable = (isset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]) || isset($this->defaultContext[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS])) && !isset($context['not_normalizable_value_exceptions']);
+        $collectExtraAttributes = ($context[DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS] ?? $this->defaultContext[DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS] ?? false) && !isset($context['extra_attributes_exceptions']);
+
+        $notNormalizableErrors = [];
+        $extraAttributesExceptions = [];
+
+        if ($collectNotNormalizable) {
             unset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]);
-            $context['not_normalizable_value_exceptions'] = [];
-            $errors = &$context['not_normalizable_value_exceptions'];
-            $denormalized = $normalizer->denormalize($data, $type, $format, $context);
-
-            if ($errors) {
-                // merge errors so that one path has only one error
-                $uniqueErrors = [];
-                foreach ($errors as $error) {
-                    if (null === $error->getPath()) {
-                        $uniqueErrors[] = $error;
-                        continue;
-                    }
-
-                    $uniqueErrors[$error->getPath()] ??= $error;
-                }
-
-                throw new PartialDenormalizationException($denormalized, array_values($uniqueErrors));
-            }
-
-            return $denormalized;
+            $context['not_normalizable_value_exceptions'] = &$notNormalizableErrors;
         }
 
-        return $normalizer->denormalize($data, $type, $format, $context);
+        if ($collectExtraAttributes) {
+            unset($context[DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS]);
+            $context['extra_attributes_exceptions'] = &$extraAttributesExceptions;
+        }
+
+        $denormalized = $normalizer->denormalize($data, $type, $format, $context);
+
+        if ($notNormalizableErrors || $extraAttributesExceptions) {
+            // merge errors so that one path has only one error
+            $uniqueErrors = [];
+            foreach ($notNormalizableErrors as $error) {
+                if (null === $error->getPath()) {
+                    $uniqueErrors[] = $error;
+                    continue;
+                }
+
+                $uniqueErrors[$error->getPath()] ??= $error;
+            }
+
+            throw new PartialDenormalizationException($denormalized, array_values($uniqueErrors), $extraAttributesExceptions);
+        }
+
+        return $denormalized;
     }
 
     public function getSupportedTypes(?string $format): array

--- a/src/Symfony/Component/Serializer/Tests/Context/SerializerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/SerializerContextBuilderTest.php
@@ -38,6 +38,7 @@ class SerializerContextBuilderTest extends TestCase
         $context = $this->contextBuilder
             ->withEmptyArrayAsObject($values[Serializer::EMPTY_ARRAY_AS_OBJECT])
             ->withCollectDenormalizationErrors($values[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS])
+            ->withCollectExtraAttributesErrors($values[DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS])
             ->toArray();
 
         $this->assertSame($values, $context);
@@ -51,11 +52,13 @@ class SerializerContextBuilderTest extends TestCase
         yield 'With values' => [[
             Serializer::EMPTY_ARRAY_AS_OBJECT => true,
             DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => false,
+            DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS => false,
         ]];
 
         yield 'With null values' => [[
             Serializer::EMPTY_ARRAY_AS_OBJECT => null,
             DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => null,
+            DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS => null,
         ]];
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
@@ -34,6 +34,7 @@ final class Php74Full
     public TestFoo $nestedObject;
     /** @var Php74Full[] */
     public $anotherCollection;
+    public TestFoo $nestedObject2;
 }
 
 final class Php74FullWithConstructor

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -528,8 +528,8 @@ class ObjectNormalizerTest extends TestCase
 
             $this->fail(\sprintf('Expected a "%s".', PartialDenormalizationException::class));
         } catch (PartialDenormalizationException $e) {
-            $this->assertCount(1, $e->getErrors());
-            $error = $e->getErrors()[0];
+            $this->assertCount(1, $e->getNotNormalizableValueErrors());
+            $error = $e->getNotNormalizableValueErrors()[0];
             $this->assertInstanceOf(NotNormalizableValueException::class, $error);
             $this->assertSame('name', $error->getPath());
             $this->assertSame('array', $error->getCurrentType());

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -620,8 +620,8 @@ class PropertyNormalizerTest extends TestCase
 
             $this->fail(\sprintf('Expected a "%s".', PartialDenormalizationException::class));
         } catch (PartialDenormalizationException $e) {
-            $this->assertCount(1, $e->getErrors());
-            $error = $e->getErrors()[0];
+            $this->assertCount(1, $e->getNotNormalizableValueErrors());
+            $error = $e->getNotNormalizableValueErrors()[0];
             $this->assertInstanceOf(NotNormalizableValueException::class, $error);
             $this->assertSame('name', $error->getPath());
             $this->assertSame('array', $error->getCurrentType());

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -989,6 +989,7 @@ class SerializerTest extends TestCase
             $this->assertInstanceOf(PartialDenormalizationException::class, $th);
         }
 
+        /** @var PartialDenormalizationException $th */
         $this->assertInstanceOf(Php74Full::class, $th->getData());
 
         $exceptionsAsArray = array_map(static fn (NotNormalizableValueException $e): array => [
@@ -997,7 +998,7 @@ class SerializerTest extends TestCase
             'path' => $e->getPath(),
             'useMessageForUser' => $e->canUseMessageForUser(),
             'message' => $e->getMessage(),
-        ], $th->getErrors());
+        ], $th->getNotNormalizableValueErrors());
 
         $expected = [
             [
@@ -1199,6 +1200,7 @@ class SerializerTest extends TestCase
             $this->assertInstanceOf(PartialDenormalizationException::class, $th);
         }
 
+        /** @var PartialDenormalizationException $th */
         $this->assertCount(2, $th->getData());
         $this->assertInstanceOf(Php74Full::class, $th->getData()[0]);
         $this->assertInstanceOf(Php74Full::class, $th->getData()[1]);
@@ -1209,7 +1211,7 @@ class SerializerTest extends TestCase
             'path' => $e->getPath(),
             'useMessageForUser' => $e->canUseMessageForUser(),
             'message' => $e->getMessage(),
-        ], $th->getErrors());
+        ], $th->getNotNormalizableValueErrors());
 
         $expected = [
             [
@@ -1264,7 +1266,7 @@ class SerializerTest extends TestCase
             'path' => $e->getPath(),
             'useMessageForUser' => $e->canUseMessageForUser(),
             'message' => $e->getMessage(),
-        ], $th->getErrors());
+        ], $th->getNotNormalizableValueErrors());
 
         $expected = [
             [
@@ -1299,6 +1301,200 @@ class SerializerTest extends TestCase
         $this->assertSame($expected, $exceptionsAsArray);
     }
 
+    public function testNoCollectExtraAttributesErrors()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $json = '
+        {
+            "extra1": true,
+            "collection": [
+                {
+                    "extra2": true
+                },
+                {
+                    "extra3": true
+                }
+            ],
+            "nestedObject2": {
+                "extra4": true
+            }
+        }';
+
+        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+
+        $serializer = new Serializer(
+            [
+                new ArrayDenormalizer(),
+                new DateTimeNormalizer(),
+                new DateTimeZoneNormalizer(),
+                new DataUriNormalizer(),
+                new UidNormalizer(),
+                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, $classMetadataFactory ? new ClassDiscriminatorFromClassMetadata($classMetadataFactory) : null),
+            ],
+            ['json' => new JsonEncoder()]
+        );
+
+        try {
+            $serializer->deserialize($json, Php74Full::class, 'json', [
+                AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
+                DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS => false,
+            ]);
+
+            $this->fail();
+        } catch (\Throwable $th) {
+            $this->assertInstanceOf(ExtraAttributesException::class, $th);
+        }
+
+        /** @var ExtraAttributesException $th */
+        $exceptionAsArray = [
+            'extraAttributes' => $th->getExtraAttributes(),
+        ];
+
+        $expected = [
+            'extraAttributes' => [
+                'collection[0].extra2',
+            ],
+        ];
+
+        $this->assertSame($expected, $exceptionAsArray);
+    }
+
+    public function testCollectExtraAttributesErrors()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $json = '
+        {
+            "extra1": true,
+            "collection": [
+                {
+                    "extra2": true
+                },
+                {
+                    "extra3": true
+                }
+            ],
+            "nestedObject2": {
+                "extra4": true
+            }
+        }';
+
+        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+
+        $serializer = new Serializer(
+            [
+                new ArrayDenormalizer(),
+                new DateTimeNormalizer(),
+                new DateTimeZoneNormalizer(),
+                new DataUriNormalizer(),
+                new UidNormalizer(),
+                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, $classMetadataFactory ? new ClassDiscriminatorFromClassMetadata($classMetadataFactory) : null),
+            ],
+            ['json' => new JsonEncoder()]
+        );
+
+        try {
+            $serializer->deserialize($json, Php74Full::class, 'json', [
+                AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
+                DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS => true,
+            ]);
+
+            $this->fail();
+        } catch (\Throwable $th) {
+            $this->assertInstanceOf(PartialDenormalizationException::class, $th);
+            /** @var PartialDenormalizationException $th */
+            $this->assertInstanceOf(ExtraAttributesException::class, $extraAttributeError = $th->getExtraAttributesError());
+        }
+
+        $this->assertInstanceOf(Php74Full::class, $th->getData());
+
+        $exceptionAsArray = [
+            'extraAttributes' => $extraAttributeError->getExtraAttributes(),
+        ];
+
+        $expected = [
+            'extraAttributes' => [
+                'collection[0].extra2',
+                'collection[1].extra3',
+                'nestedObject2.extra4',
+                'extra1',
+            ],
+        ];
+
+        $this->assertSame($expected, $exceptionAsArray);
+    }
+
+    public function testCollectDenormalizationAndExtraAttributesErrors()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $json = '
+        {
+            "string": null,
+            "extra1": true
+        }';
+
+        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+
+        $serializer = new Serializer(
+            [
+                new ArrayDenormalizer(),
+                new DateTimeNormalizer(),
+                new DateTimeZoneNormalizer(),
+                new DataUriNormalizer(),
+                new UidNormalizer(),
+                new ObjectNormalizer($classMetadataFactory, null, null, $extractor, $classMetadataFactory ? new ClassDiscriminatorFromClassMetadata($classMetadataFactory) : null),
+            ],
+            ['json' => new JsonEncoder()]
+        );
+
+        try {
+            $serializer->deserialize($json, Php74Full::class, 'json', [
+                AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
+                DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+                DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS => true,
+            ]);
+
+            $this->fail();
+        } catch (\Throwable $th) {
+            $this->assertInstanceOf(PartialDenormalizationException::class, $th);
+            /** @var PartialDenormalizationException $th */
+            $this->assertInstanceOf(ExtraAttributesException::class, $extraAttributeError = $th->getExtraAttributesError());
+        }
+
+        $this->assertInstanceOf(Php74Full::class, $th->getData());
+
+        $extraAttributesExceptionAsArray = [
+            'extraAttributes' => $extraAttributeError->getExtraAttributes(),
+        ];
+
+        $expectedExtraAttributesException = [
+            'extraAttributes' => [
+                'extra1',
+            ],
+        ];
+
+        $this->assertSame($expectedExtraAttributesException, $extraAttributesExceptionAsArray);
+
+        $exceptionsAsArray = array_map(static fn (NotNormalizableValueException $e): array => [
+            'currentType' => $e->getCurrentType(),
+            'expectedTypes' => $e->getExpectedTypes(),
+            'path' => $e->getPath(),
+            'useMessageForUser' => $e->canUseMessageForUser(),
+            'message' => $e->getMessage(),
+        ], $th->getNotNormalizableValueErrors());
+
+        $expectedExceptions = [[
+            'currentType' => 'null',
+            'expectedTypes' => [
+                'string',
+            ],
+            'path' => 'string',
+            'useMessageForUser' => false,
+            'message' => 'The type of the "string" attribute for class "Symfony\\Component\\Serializer\\Tests\\Fixtures\\Php74Full" must be one of "string" ("null" given).',
+        ]];
+
+        $this->assertSame($expectedExceptions, $exceptionsAsArray);
+    }
+
     #[DataProvider('provideCollectDenormalizationErrors')]
     public function testCollectDenormalizationErrorsWithConstructor(?ClassMetadataFactory $classMetadataFactory)
     {
@@ -1323,6 +1519,7 @@ class SerializerTest extends TestCase
             $this->assertInstanceOf(PartialDenormalizationException::class, $th);
         }
 
+        /** @var PartialDenormalizationException $th */
         $this->assertInstanceOf(Php80WithPromotedTypedConstructor::class, $th->getData());
 
         $exceptionsAsArray = array_map(static fn (NotNormalizableValueException $e): array => [
@@ -1331,7 +1528,7 @@ class SerializerTest extends TestCase
             'path' => $e->getPath(),
             'useMessageForUser' => $e->canUseMessageForUser(),
             'message' => $e->getMessage(),
-        ], $th->getErrors());
+        ], $th->getNotNormalizableValueErrors());
 
         $expected = [
             [
@@ -1399,7 +1596,7 @@ class SerializerTest extends TestCase
             'path' => $e->getPath(),
             'useMessageForUser' => $e->canUseMessageForUser(),
             'message' => $e->getMessage(),
-        ], $th->getErrors());
+        ], $th->getNotNormalizableValueErrors());
 
         $expected = [
             [
@@ -1453,7 +1650,7 @@ class SerializerTest extends TestCase
             'path' => $e->getPath(),
             'useMessageForUser' => $e->canUseMessageForUser(),
             'message' => $e->getMessage(),
-        ], $th->getErrors());
+        ], $th->getNotNormalizableValueErrors());
 
         $expected = [
             [
@@ -1501,7 +1698,7 @@ class SerializerTest extends TestCase
             'currentType' => $e->getCurrentType(),
             'useMessageForUser' => $e->canUseMessageForUser(),
             'message' => $e->getMessage(),
-        ], $th->getErrors());
+        ], $th->getNotNormalizableValueErrors());
 
         $expected = [
             [
@@ -1540,7 +1737,7 @@ class SerializerTest extends TestCase
             'currentType' => $e->getCurrentType(),
             'useMessageForUser' => $e->canUseMessageForUser(),
             'message' => $e->getMessage(),
-        ], $e->getErrors());
+        ], $e->getNotNormalizableValueErrors());
 
         $expected = [
             [
@@ -1574,7 +1771,7 @@ class SerializerTest extends TestCase
                 'path' => $error->getPath(),
                 'useMessageForUser' => $error->canUseMessageForUser(),
                 'message' => $error->getMessage(),
-            ], $e->getErrors());
+            ], $e->getNotNormalizableValueErrors());
 
             $this->assertSame([
                 [
@@ -1620,7 +1817,7 @@ class SerializerTest extends TestCase
             self::fail(\sprintf('Failed asserting that exception of type "%s" is thrown.', PartialDenormalizationException::class));
         } catch (PartialDenormalizationException $e) {
             $capturedFromTypeError = array_values(array_filter(
-                $e->getErrors(),
+                $e->getNotNormalizableValueErrors(),
                 static fn (NotNormalizableValueException $error): bool => $error->getPrevious() instanceof \TypeError,
             ));
             self::assertCount(1, $capturedFromTypeError, 'Constructor TypeError must be captured exactly once as a NotNormalizableValueException.');
@@ -1762,7 +1959,7 @@ class SerializerTest extends TestCase
             'path' => $e->getPath(),
             'useMessageForUser' => $e->canUseMessageForUser(),
             'message' => $e->getMessage(),
-        ], $th->getErrors());
+        ], $th->getNotNormalizableValueErrors());
 
         $expected = [
             [
@@ -1832,8 +2029,8 @@ class SerializerTest extends TestCase
             $serializer->denormalize($data, DummyEntityWithStringAndDateTime::class);
             $this->fail('Expected PartialDenormalizationException was not thrown');
         } catch (PartialDenormalizationException $e) {
-            $this->assertIsArray($e->getErrors());
-            $this->assertCount(2, $e->getErrors(), 'Expected two denormalization errors');
+            $this->assertIsArray($e->getNotNormalizableValueErrors());
+            $this->assertCount(2, $e->getNotNormalizableValueErrors(), 'Expected two denormalization errors');
 
             $exceptionsAsArray = array_map(static fn (NotNormalizableValueException $ex): array => [
                 'currentType' => $ex->getCurrentType(),
@@ -1841,7 +2038,7 @@ class SerializerTest extends TestCase
                 'path' => $ex->getPath(),
                 'useMessageForUser' => $ex->canUseMessageForUser(),
                 'message' => $ex->getMessage(),
-            ], $e->getErrors());
+            ], $e->getNotNormalizableValueErrors());
 
             $expected = [
                 [

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -35,7 +35,7 @@
         "symfony/http-kernel": "^7.4|^8.0",
         "symfony/messenger": "^7.4|^8.0",
         "symfony/mime": "^7.4|^8.0",
-        "symfony/property-access": "^7.4.9|^8.0.9",
+        "symfony/property-access": "^8.1",
         "symfony/property-info": "^7.4|^8.0",
         "symfony/translation-contracts": "^2.5|^3",
         "symfony/type-info": "^7.4|^8.0",
@@ -48,7 +48,7 @@
     "conflict": {
         "phpdocumentor/reflection-docblock": "<5.2|>=7",
         "phpdocumentor/type-resolver": "<1.5.1",
-        "symfony/property-access": "<7.4.9|>=8.0,<8.0.9",
+        "symfony/property-access": "<8.1",
         "symfony/property-info": "<7.4",
         "symfony/type-info": "<7.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes/no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #46283, Fix #46284
| License       | MIT
| Doc PR        | symfony/symfony-docs#16872

The `PartialDenormalizationException` is used as unexpected extra attributes are, IMO, part of the denormalization exception.
This enables executing:

```php
  try {
       $dto = $serializer->deserialize($request->getContent(), MyDto::class, 'json', [
            DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
            DenormalizerInterface::COLLECT_EXTRA_ATTRIBUTES_ERRORS => true,
            DenormalizerInterface::ALLOW_EXTRA_ATTRIBUTES => false,
        ]);
    } catch (PartialDenormalizationException $e) {
        $violations = new ConstraintViolationList();
        /** @var NotNormalizableValueException */
        foreach ($e->getErrors() as $exception) {
            $message = sprintf('The type must be one of "%s" ("%s" given).', implode(', ', $exception->getExpectedTypes()), $exception->getCurrentType());
            $parameters = [];
            if ($exception->canUseMessageForUser()) {
                $parameters['hint'] = $exception->getMessage();
            }
            $violations->add(new ConstraintViolation($message, '', $parameters, null, $exception->getPath(), null));
        };
        if (null !== $extraAttributesException = $e->getExtraAttributesError()) {
            foreach ($extraAttributesException->getExtraAttributes() as $extraAttribute) {
                $violations->add(new ConstraintViolation('This attribute is not allowed.', '', [], null, $extraAttribute, null));
            };
        }

        return $this->json($violations, 400);
    }
```