### PR TITLE
[DependencyInjection] add `#[Exclude]` in order to not register as a service

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Exclude.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Exclude.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to tell class, method or function should not be registered as a service.
+ *
+ * @author Antoine Lamirault <lamiraultantoine@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
+class Exclude
+{
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Add `#[Exclude]` attribute to tell class, method or function should not be registered as a service
+
 6.1
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\FileLoader as BaseFileLoader;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Config\Resource\GlobResource;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
 use Symfony\Component\DependencyInjection\Attribute\When;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\RegisterAutoconfigureAttributesPass;
@@ -109,17 +110,24 @@ abstract class FileLoader extends BaseFileLoader
         $serializedPrototype = serialize($prototype);
 
         foreach ($classes as $class => $errorMessage) {
-            if (null === $errorMessage && $autoconfigureAttributes && $this->env) {
+            if (null === $errorMessage && $autoconfigureAttributes) {
                 $r = $this->container->getReflectionClass($class);
-                $attribute = null;
-                foreach ($r->getAttributes(When::class) as $attribute) {
-                    if ($this->env === $attribute->newInstance()->env) {
-                        $attribute = null;
-                        break;
-                    }
-                }
-                if (null !== $attribute) {
+
+                if (!empty($r->getAttributes(Exclude::class))) {
                     continue;
+                }
+
+                if ($this->env) {
+                    $attribute = null;
+                    foreach ($r->getAttributes(When::class) as $attribute) {
+                        if ($this->env === $attribute->newInstance()->env) {
+                            $attribute = null;
+                            break;
+                        }
+                    }
+                    if (null !== $attribute) {
+                        continue;
+                    }
                 }
             }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Builder\ConfigBuilderGenerator;
 use Symfony\Component\Config\Builder\ConfigBuilderGeneratorInterface;
 use Symfony\Component\Config\Builder\ConfigBuilderInterface;
 use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
 use Symfony\Component\DependencyInjection\Attribute\When;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -99,6 +100,10 @@ class PhpFileLoader extends FileLoader
         $arguments = [];
         $configBuilders = [];
         $r = new \ReflectionFunction($callback);
+
+        if (!empty($r->getAttributes(Exclude::class))) {
+            return;
+        }
 
         $attribute = null;
         foreach ($r->getAttributes(When::class) as $attribute) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ExcludedDummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ExcludedDummy.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+#[Exclude]
+class ExcludedDummy
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/exclude.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/exclude.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+return #[Exclude] function () {
+    throw new RuntimeException('This code should not be run.');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\ExcludedDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\BadClasses\MissingParent;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\FooInterface;
@@ -270,6 +271,19 @@ class FileLoaderTest extends TestCase
         );
 
         $this->assertSame($expected, $container->has(Foo::class));
+    }
+
+    public function testNotRegisterClassesWithExclude()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'), 'prod');
+        $loader->registerClasses(
+            (new Definition())->setAutoconfigured(true),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\\',
+            '{ExcludedDummy.php}'
+        );
+
+        $this->assertFalse($container->has(ExcludedDummy::class));
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -184,4 +184,13 @@ class PhpFileLoaderTest extends TestCase
 
         $loader->load($fixtures.'/config/when_env.php');
     }
+
+    public function testExclude()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator(), 'dev', new ConfigBuilderGenerator(sys_get_temp_dir()));
+
+        $loader->load($fixtures.'/config/exclude.php');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #46643
| License       | MIT
| Doc PR        | TODO


This PR allow to use `#[Exclude]` attribute (as suggested by @AlikDex) when we don't want a class/method/function as service.
It can be useful in some cases and avoid use `#[When(env: 'never')]` for bad reason and improve DX.

TODO:

- [ ] PR symfony doc
