### PR TITLE
[HttpClient] Fix Copy as curl with base uri

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -301,7 +301,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
         }
 
-        return $pushedResponse ?? new CurlResponse($this->multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $host, $port), CurlClientState::$curlVersion['version_number']);
+        return $pushedResponse ?? new CurlResponse($this->multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $host, $port), CurlClientState::$curlVersion['version_number'], $url);
     }
 
     /**

--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -178,8 +178,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
             return null;
         }
 
-        $debug = explode("\n", $trace['info']['debug']);
-        $url = self::mergeQueryString($trace['url'], $trace['options']['query'] ?? [], true);
+        $url = $trace['info']['original_url'] ?? $trace['info']['url'] ?? $trace['url'];
         $command = ['curl', '--compressed'];
 
         if (isset($trace['options']['resolve'])) {
@@ -199,7 +198,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
             if (\is_string($body)) {
                 try {
                     $dataArg[] = '--data '.escapeshellarg($body);
-                } catch (\ValueError $e) {
+                } catch (\ValueError) {
                     return null;
                 }
             } elseif (\is_array($body)) {
@@ -214,7 +213,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
 
         $dataArg = empty($dataArg) ? null : implode(' ', $dataArg);
 
-        foreach ($debug as $line) {
+        foreach (explode("\n", $trace['info']['debug']) as $line) {
             $line = substr($line, 0, -1);
 
             if (str_starts_with('< ', $line)) {

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -80,6 +80,7 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
         $info['http_method'] = $request->getMethod();
         $info['start_time'] = null;
         $info['redirect_url'] = null;
+        $info['original_url'] = $info['url'];
         $info['redirect_time'] = 0.0;
         $info['redirect_count'] = 0;
         $info['size_upload'] = 0.0;

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -43,7 +43,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
     /**
      * @internal
      */
-    public function __construct(CurlClientState $multi, \CurlHandle|string $ch, array $options = null, LoggerInterface $logger = null, string $method = 'GET', callable $resolveRedirect = null, int $curlVersion = null)
+    public function __construct(CurlClientState $multi, \CurlHandle|string $ch, array $options = null, LoggerInterface $logger = null, string $method = 'GET', callable $resolveRedirect = null, int $curlVersion = null, string $originalUrl = null)
     {
         $this->multi = $multi;
 
@@ -69,6 +69,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
         $this->info['user_data'] = $options['user_data'] ?? null;
         $this->info['max_duration'] = $options['max_duration'] ?? null;
         $this->info['start_time'] = $this->info['start_time'] ?? microtime(true);
+        $this->info['original_url'] = $originalUrl ?? $this->info['url'] ?? curl_getinfo($ch, \CURLINFO_EFFECTIVE_URL);
         $info = &$this->info;
         $headers = &$this->headers;
         $debugBuffer = $this->debugBuffer;

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -142,6 +142,7 @@ class MockResponse implements ResponseInterface, StreamableInterface
         $response->info['user_data'] = $options['user_data'] ?? null;
         $response->info['max_duration'] = $options['max_duration'] ?? null;
         $response->info['url'] = $url;
+        $response->info['original_url'] = $url;
 
         if ($mock instanceof self) {
             $mock->requestOptions = $response->requestOptions;

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -66,6 +66,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
         // Temporary resource to dechunk the response stream
         $this->buffer = fopen('php://temp', 'w+');
 
+        $info['original_url'] = implode('', $info['url']);
         $info['user_data'] = $options['user_data'];
         $info['max_duration'] = $options['max_duration'];
         ++$multi->responseCount;

--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -196,6 +196,22 @@ class HttpClientDataCollectorTest extends TestCase
   --header %1$sAccept-Encoding: gzip%1$s \\
   --header %1$sUser-Agent: Symfony HttpClient/Native%1$s',
         ];
+        yield 'GET with base uri' => [
+            [
+                'method' => 'GET',
+                'url' => '1',
+                'options' => [
+                    'base_uri' => 'http://localhost:8057/json/',
+                ],
+            ],
+            'curl \\
+  --compressed \\
+  --request GET \\
+  --url %1$shttp://localhost:8057/json/1%1$s \\
+  --header %1$sAccept: */*%1$s \\
+  --header %1$sAccept-Encoding: gzip%1$s \\
+  --header %1$sUser-Agent: Symfony HttpClient/Native%1$s',
+        ];
         yield 'GET with resolve' => [
             [
                 'method' => 'GET',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/46583#issuecomment-1151693901
| License       | MIT
| Doc PR        | -

Fixes Copy as curl when `base_uri` is used.