### PR TITLE
[FrameworkBundle] Lower JsonSerializableNormalizer priority

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -60,7 +60,7 @@
 
         <service id="serializer.normalizer.json_serializable" class="Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer">
             <!-- Run before serializer.normalizer.object -->
-            <tag name="serializer.normalizer" priority="-900" />
+            <tag name="serializer.normalizer" priority="-950" />
         </service>
 
         <service id="serializer.normalizer.problem" class="Symfony\Component\Serializer\Normalizer\ProblemNormalizer">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1297,7 +1297,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $tag = $definition->getTag('serializer.normalizer');
 
         $this->assertEquals(JsonSerializableNormalizer::class, $definition->getClass());
-        $this->assertEquals(-900, $tag[0]['priority']);
+        $this->assertEquals(-950, $tag[0]['priority']);
     }
 
     public function testObjectNormalizerRegistered()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

IMHO, more generic normalizers, like `ObjectNormalizer` or `JsonSerializableNormalizer` should have lower priority than other more specific normalizers, like `DateTimeNormalizer`, `ConstraintViolationListNormalizer`, etc.

My issue was with `Carbon` library, which extends php's `DateTime`.
`Carbon` classes implement `JsonSerializable` interface, so they are serialized with `JsonSerializableNormalizer`, using its internal `toJSON()` method, so I can't control which format I want them to be serialized.
I should be able to do it, as I can with `DateTime`, cause both implement `DateTimeInterface`.

That's because `JsonSerializableNormalizer` has higher priority than `DateTimeNormalizer`.


For now, my "fix" was to change priority in config like so:
```yaml
serializer.normalizer.json_serializable:
        class: Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer
        tags:
            - {name: 'serializer.normalizer', priority: -950 }
```