### PR TITLE
[HttpClient] Fix json encode flags usage in copy-as-curl generation

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -194,7 +194,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
         $dataArg = [];
 
         if ($json = $trace['options']['json'] ?? null) {
-            $dataArg[] = '--data '.escapeshellarg(json_encode($json, \JSON_PRETTY_PRINT));
+            $dataArg[] = '--data '.escapeshellarg(self::jsonEncode($json));
         } elseif ($body = $trace['options']['body'] ?? null) {
             if (\is_string($body)) {
                 try {

--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -307,6 +307,8 @@ class HttpClientDataCollectorTest extends TestCase
                         'json' => [
                             'foo' => [
                                 'bar' => 'baz',
+                                'qux' => [1.10, 1.0],
+                                'fred' => ['<foo>',"'bar'",'"baz"','&blong&'],
                             ],
                         ],
                     ],
@@ -317,14 +319,10 @@ class HttpClientDataCollectorTest extends TestCase
   --url %1$shttp://localhost:8057/json%1$s \\
   --header %1$sContent-Type: application/json%1$s \\
   --header %1$sAccept: */*%1$s \\
-  --header %1$sContent-Length: 21%1$s \\
+  --header %1$sContent-Length: 120%1$s \\
   --header %1$sAccept-Encoding: gzip%1$s \\
   --header %1$sUser-Agent: Symfony HttpClient/Native%1$s \\
-  --data %1$s{
-    "foo": {
-        "bar": "baz"
-    }
-}%1$s',
+  --data %1$s{"foo":{"bar":"baz","qux":[1.1,1.0],"fred":["\u003Cfoo\u003E","\u0027bar\u0027","\u0022baz\u0022","\u0026blong\u0026"]}}%1$s',
             ];
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

The `json_encode($json, \JSON_PRETTY_PRINT)` call to generate the cURL version of a HTTP Request in HttpClientDataCollector didn't use the `self::jsonEncode` method available.

The main issue with that is the usage of `\JSON_PRETTY_PRINT`, which is overwrites all other flags in `self::jsonEncode` method, especially `\JSON_PRESERVE_ZERO_FRACTION`.

So I have added a test for it:

```
1) Symfony\Component\HttpClient\Tests\DataCollector\HttpClientDataCollectorTest::testItGeneratesCurlCommandsAsExpected with data set "POST with json" (array('POST', 'http://localhost:8057/js
on', array(array(array('baz', array(1.1, 1.0))))), 'curl \\n  --compressed \\n  -...n}%1$s')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
         "bar": "baz",\n
         "qux": [\n
             1.1,\n
-            1.0\n
+            1\n
         ]\n
     }\n
 }''
```

After the changes, this test pass :white_check_mark: 

I've added test for all other flags, to be sure that they are used. It could lead to less readable JSON (with hex values) displayed in Profiler, but it's more accurate to debug.

EDIT: removing `\JSON_PRETTY_PRINT` solve the problem too, and we don't need to pretty-print the JSON in curl command, it allows to run the *exact* same request.