### PR TITLE
[Workflow] Add a nice exception message when unexpected data is passed to Marking

### DIFF
--- a/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
@@ -70,6 +70,8 @@ final class MethodMarkingStore implements MarkingStoreInterface
 
         if ($this->singleState) {
             $marking = [(string) $marking => 1];
+        } elseif (!is_array($marking)) {
+            throw new LogicException(sprintf('The method "%s::%s()" did not return an array and the Workflow\'s Marking store is instantiated with $singleState=false.', get_debug_type($subject), $method));
         }
 
         return new Marking($marking);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

During my Workshop during Symfony online, one of my attendees got an exception message they didn't really undersand. 
They ran 
```php
$this->workflow->apply($subject, 'foobar');
```
But got the error `Marking::__construct() expects array, string passed`. 

Their issue was that `$subject->getPlaces()` returned a string. It was pretty hard to figure out from that exception message, so I thought we could improve. 