### PR TITLE
[CssSelector] [HashParser] Added parsing support for dotted hashes

### DIFF
--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
@@ -40,7 +40,7 @@ class HashParser implements ParserInterface
         //     1 => string 'test' (length=4)
         //     2 => string 'input' (length=5)
         //     3 => string 'ab6bd_field' (length=11)
-        if (preg_match('/^(?:([a-z]++)\|)?+([\w-]++|\*)?+#([\w-]++)$/i', trim($source), $matches)) {
+        if (preg_match('/^(?:([a-z]++)\|)?+([\w-]++|\*)?+#([\w.-]++)$/i', trim($source), $matches)) {
             return [
                 new SelectorNode(new HashNode(new ElementNode($matches[1] ?: null, $matches[2] ?: null), $matches[3])),
             ];

--- a/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/HashParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/HashParserTest.php
@@ -36,10 +36,15 @@ class HashParserTest extends TestCase
     {
         return [
             ['#testid', 'Hash[Element[*]#testid]'],
+            ['#test.id', 'Hash[Element[*]#test.id]'],
             ['testel#testid', 'Hash[Element[testel]#testid]'],
+            ['testel#test.id', 'Hash[Element[testel]#test.id]'],
             ['testns|#testid', 'Hash[Element[testns|*]#testid]'],
+            ['testns|#test.id', 'Hash[Element[testns|*]#test.id]'],
             ['testns|*#testid', 'Hash[Element[testns|*]#testid]'],
+            ['testns|*#test.id', 'Hash[Element[testns|*]#test.id]'],
             ['testns|testel#testid', 'Hash[Element[testns|testel]#testid]'],
+            ['testns|testel#test.id', 'Hash[Element[testns|testel]#test.id]'],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        |  Added parsing support for dotted hashes in the `CssSelector` component.
