### PR TITLE
[Dotenv] - refactor(dotenv): improvements for php 8.1 support

### DIFF
--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -36,14 +36,8 @@ final class DebugCommand extends Command
      */
     protected static $defaultDescription = 'Lists all dotenv files with variables and values';
 
-    private readonly string $kernelEnvironment;
-    private readonly string $projectDirectory;
-
-    public function __construct(string $kernelEnvironment, string $projectDirectory)
+    public function __construct(private string $kernelEnvironment, private string $projectDirectory)
     {
-        $this->kernelEnvironment = $kernelEnvironment;
-        $this->projectDirectory = $projectDirectory;
-
         parent::__construct();
     }
 

--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -29,21 +29,15 @@ use Symfony\Component\Dotenv\Dotenv;
 #[AsCommand(name: 'dotenv:dump', description: 'Compiles .env files to .env.local.php')]
 final class DotenvDumpCommand extends Command
 {
-    private readonly string $projectDir;
-    private readonly string|null $defaultEnv;
-
-    public function __construct(string $projectDir, string $defaultEnv = null)
+    public function __construct(private string $projectDir, private ?string $defaultEnv = null)
     {
-        $this->projectDir = $projectDir;
-        $this->defaultEnv = $defaultEnv;
-
         parent::__construct();
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function configure(): void
+    protected function configure()
     {
         $this
             ->setDefinition([

--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -29,8 +29,8 @@ use Symfony\Component\Dotenv\Dotenv;
 #[AsCommand(name: 'dotenv:dump', description: 'Compiles .env files to .env.local.php')]
 final class DotenvDumpCommand extends Command
 {
-    private string $projectDir;
-    private string|null $defaultEnv;
+    private readonly string $projectDir;
+    private readonly string|null $defaultEnv;
 
     public function __construct(string $projectDir, string $defaultEnv = null)
     {
@@ -43,7 +43,7 @@ final class DotenvDumpCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -429,7 +429,7 @@ final class Dotenv
             )
         /x';
 
-        return preg_replace_callback($regex, function ($matches) use ($loadedVars): ?string {
+        return preg_replace_callback($regex, function ($matches) use ($loadedVars) {
             if ('\\' === $matches[1]) {
                 return substr($matches[0], 1);
             }
@@ -484,7 +484,7 @@ final class Dotenv
             (?P<closing_brace>\})?             # optional closing brace
         /x';
 
-        return preg_replace_callback($regex, function ($matches) use ($loadedVars): ?string {
+        return preg_replace_callback($regex, function ($matches) use ($loadedVars) {
             // odd number of backslashes means the $ character is escaped
             if (1 === \strlen($matches['backslashes']) % 2) {
                 return substr($matches[0], 1);

--- a/src/Symfony/Component/Dotenv/Exception/FormatException.php
+++ b/src/Symfony/Component/Dotenv/Exception/FormatException.php
@@ -18,12 +18,8 @@ namespace Symfony\Component\Dotenv\Exception;
  */
 final class FormatException extends \LogicException implements ExceptionInterface
 {
-    private readonly FormatExceptionContext $context;
-
-    public function __construct(string $message, FormatExceptionContext $context, int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message, private FormatExceptionContext $context, int $code = 0, \Throwable $previous = null)
     {
-        $this->context = $context;
-
         parent::__construct(sprintf("%s in \"%s\" at line %d.\n%s", $message, $context->getPath(), $context->getLineno(), $context->getDetails()), $code, $previous);
     }
 

--- a/src/Symfony/Component/Dotenv/Exception/FormatException.php
+++ b/src/Symfony/Component/Dotenv/Exception/FormatException.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Dotenv\Exception;
  */
 final class FormatException extends \LogicException implements ExceptionInterface
 {
-    private FormatExceptionContext $context;
+    private readonly FormatExceptionContext $context;
 
     public function __construct(string $message, FormatExceptionContext $context, int $code = 0, \Throwable $previous = null)
     {

--- a/src/Symfony/Component/Dotenv/Exception/FormatExceptionContext.php
+++ b/src/Symfony/Component/Dotenv/Exception/FormatExceptionContext.php
@@ -16,17 +16,8 @@ namespace Symfony\Component\Dotenv\Exception;
  */
 final class FormatExceptionContext
 {
-    private readonly string $data;
-    private readonly string $path;
-    private readonly int $lineno;
-    private readonly int $cursor;
-
-    public function __construct(string $data, string $path, int $lineno, int $cursor)
+    public function __construct(private string $data, private string $path, private int $lineno, private int $cursor)
     {
-        $this->data = $data;
-        $this->path = $path;
-        $this->lineno = $lineno;
-        $this->cursor = $cursor;
     }
 
     public function getPath(): string

--- a/src/Symfony/Component/Dotenv/Exception/FormatExceptionContext.php
+++ b/src/Symfony/Component/Dotenv/Exception/FormatExceptionContext.php
@@ -16,10 +16,10 @@ namespace Symfony\Component\Dotenv\Exception;
  */
 final class FormatExceptionContext
 {
-    private string $data;
-    private string $path;
-    private int $lineno;
-    private int $cursor;
+    private readonly string $data;
+    private readonly string $path;
+    private readonly int $lineno;
+    private readonly int $cursor;
 
     public function __construct(string $data, string $path, int $lineno, int $cursor)
     {

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -21,7 +21,7 @@ class DotenvTest extends TestCase
     /**
      * @dataProvider getEnvDataWithFormatErrors
      */
-    public function testParseWithFormatError($data, $error)
+    public function testParseWithFormatError(string $data, $error)
     {
         $dotenv = new Dotenv();
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -21,7 +21,7 @@ class DotenvTest extends TestCase
     /**
      * @dataProvider getEnvDataWithFormatErrors
      */
-    public function testParseWithFormatError(string $data, $error)
+    public function testParseWithFormatError(string $data, string $error)
     {
         $dotenv = new Dotenv();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

Hi 👋🏻 

As discussed in the discussion https://github.com/symfony/symfony/discussions/46593, here's the first "improvement PR" about applying Rector automated rules to Symfony source code, the main goal is to enforce the usage of PHP `8.1` features / improvements.

To see the impact, I decided to apply them to `DotEnv` (which is central in Sf now but relatively small compared to components like `Form` or `DependencyInjection`).

So, what's inside? 

First, readonly attributes are now available, small improvements on types (return types added on private method, AFAIK, private methods are not concerned about BC breaks but it could reverted if needed) and extra conditions (that can turned into ternaries), short syntax functions (along with static usage).

Again, this first PR is small as the component is relatively easy to improve and quite small, a lot of things could be discussed if you wish. 

Thanks again for the feedback and have a great day 🙂 