### PR TITLE
[Serializer] Add support of true built-in type (from PHP 8.2)

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -313,6 +313,7 @@ class ReflectionExtractorTest extends TestCase
     {
         yield ['nil', null];
         yield ['false', [new Type(Type::BUILTIN_TYPE_FALSE)]];
+        yield ['true', [new Type(Type::BUILTIN_TYPE_TRUE)]];
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -565,7 +565,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                     return (float) $data;
                 }
 
-                if (Type::BUILTIN_TYPE_FALSE === $builtinType && false === $data) {
+                if ((Type::BUILTIN_TYPE_FALSE === $builtinType && false === $data) || (Type::BUILTIN_TYPE_TRUE === $builtinType && true === $data)) {
                     return $data;
                 }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/TrueBuiltInDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/TrueBuiltInDummy.php
@@ -9,13 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+namespace Symfony\Component\Serializer\Tests\Fixtures;
 
-class Php82Dummy
+class TrueBuiltInDummy
 {
-    public null $nil = null;
-
-    public false $false = false;
-
     public true $true = true;
 }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -63,6 +63,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Full;
 use Symfony\Component\Serializer\Tests\Fixtures\Php80WithPromotedTypedConstructor;
 use Symfony\Component\Serializer\Tests\Fixtures\TraversableDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\TrueBuiltInDummy;
 use Symfony\Component\Serializer\Tests\Normalizer\TestDenormalizer;
 use Symfony\Component\Serializer\Tests\Normalizer\TestNormalizer;
 
@@ -793,6 +794,19 @@ class SerializerTest extends TestCase
         $actual = $serializer->deserialize('{"false":false}', FalseBuiltInDummy::class, 'json');
 
         $this->assertEquals(new FalseBuiltInDummy(), $actual);
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testTrueBuiltInTypes()
+    {
+        $extractor = new PropertyInfoExtractor([], [new ReflectionExtractor()]);
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, $extractor)], ['json' => new JsonEncoder()]);
+
+        $actual = $serializer->deserialize('{"true":true}', TrueBuiltInDummy::class, 'json');
+
+        $this->assertEquals(new TrueBuiltInDummy(), $actual);
     }
 
     private function serializerWithClassDiscriminator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

RFC: https://wiki.php.net/rfc/true-type
Pull request: https://github.com/php/php-src/pull/8326

Same as this PR to add support of `false` and `null` types: https://github.com/symfony/symfony/pull/45981