### PR TITLE
[HttpFoundation] Update "[Session] Overwrite invalid session id" to only validate when files session storage is used

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -153,7 +153,7 @@ class NativeSessionStorage implements SessionStorageInterface
         }
 
         $sessionId = $_COOKIE[session_name()] ?? null;
-        if ($sessionId && !preg_match('/^[a-zA-Z0-9,-]{22,}$/', $sessionId)) {
+        if ($sessionId && $this->saveHandler instanceof AbstractProxy && 'files' === $this->saveHandler->getSaveHandlerName() && !preg_match('/^[a-zA-Z0-9,-]{22,}$/', $sessionId)) {
             // the session ID in the header is invalid, create a new one
             session_id(session_create_id());
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -294,12 +294,31 @@ class NativeSessionStorageTest extends TestCase
         $this->assertEquals($storage->getBag('flashes'), $bag);
     }
 
-    public function testRegenerateInvalidSessionId()
+    public function testRegenerateInvalidSessionIdForNativeFileSessionHandler()
     {
         $_COOKIE[session_name()] = '&~[';
-        $started = (new NativeSessionStorage())->start();
+        session_id('&~[');
+        $storage = new NativeSessionStorage([], new NativeFileSessionHandler());
+        $started = $storage->start();
 
         $this->assertTrue($started);
         $this->assertMatchesRegularExpression('/^[a-zA-Z0-9,-]{22,}$/', session_id());
+        $storage->save();
+
+        $_COOKIE[session_name()] = '&~[';
+        session_id('&~[');
+        $storage = new NativeSessionStorage([], new SessionHandlerProxy(new NativeFileSessionHandler()));
+        $started = $storage->start();
+
+        $this->assertTrue($started);
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9,-]{22,}$/', session_id());
+        $storage->save();
+
+        $_COOKIE[session_name()] = '&~[';
+        session_id('&~[');
+        $storage = new NativeSessionStorage([], new NullSessionHandler());
+        $started = $storage->start();
+        $this->assertTrue($started);
+        $this->assertSame('&~[', session_id());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes #46249
| License       | MIT
| Doc PR        | -

#46249 restricts the allowed characters in a session ID. Unfortunately this broke at least two open source projects the use the Symfony component. See https://github.com/nelmio/NelmioSecurityBundle/issues/312 and https://www.drupal.org/project/drupal/issues/3285696

I think the change is not quite correct. It assumes that the valid characters in a session ID is consistent across all session handlers. It is not. See https://www.php.net/manual/en/function.session-id.php it says:

>Depending on the session handler, not all characters are allowed within the session id. For example, the file session handler only allows characters in the range a-z A-Z 0-9 , (comma) and - (minus)!

So we've limited the characters to the file session handler but we might not be using that.

