### PR TITLE
[Ldap] Deprecate '{username}' parameter use in favour of '{user_identifier}' in LDAP configuration

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -14,10 +14,15 @@ HttpFoundation
 
  * Deprecate `Request::getContentType()`, use `Request::getContentTypeFormat()` instead
 
-Mailer
---------
+Ldap
+----
 
-* Deprecate the `OhMySMTP` transport, use `MailPace` instead
+ * Deprecate `{username}` parameter use in favour of `{user_identifier}`
+
+Mailer
+------
+
+ * Deprecate the `OhMySMTP` transport, use `MailPace` instead
 
 Security
 --------

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Deprecate `{username}` parameter use in favour of `{user_identifier}`
+
 6.1
 ---
 

--- a/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
+++ b/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
@@ -83,17 +83,17 @@ class CheckLdapCredentialsListener implements EventSubscriberInterface
                 } else {
                     throw new LogicException('Using the "query_string" config without using a "search_dn" and a "search_password" is not supported.');
                 }
-                $username = $ldap->escape($user->getUserIdentifier(), '', LdapInterface::ESCAPE_FILTER);
-                $query = str_replace('{username}', $username, $ldapBadge->getQueryString());
+                $identifier = $ldap->escape($user->getUserIdentifier(), '', LdapInterface::ESCAPE_FILTER);
+                $query = str_replace('{user_identifier}', $identifier, $ldapBadge->getQueryString());
                 $result = $ldap->query($ldapBadge->getDnString(), $query)->execute();
                 if (1 !== $result->count()) {
-                    throw new BadCredentialsException('The presented username is invalid.');
+                    throw new BadCredentialsException('The presented user identifier is invalid.');
                 }
 
                 $dn = $result[0]->getDn();
             } else {
-                $username = $ldap->escape($user->getUserIdentifier(), '', LdapInterface::ESCAPE_DN);
-                $dn = str_replace('{username}', $username, $ldapBadge->getDnString());
+                $identifier = $ldap->escape($user->getUserIdentifier(), '', LdapInterface::ESCAPE_DN);
+                $dn = str_replace('{user_identifier}', $identifier, $ldapBadge->getDnString());
             }
 
             $ldap->bind($dn, $presentedPassword);

--- a/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
+++ b/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
@@ -42,7 +42,7 @@ class LdapAuthenticator implements AuthenticationEntryPointInterface, Interactiv
     private string $searchPassword;
     private string $queryString;
 
-    public function __construct(AuthenticatorInterface $authenticator, string $ldapServiceId, string $dnString = '{username}', string $searchDn = '', string $searchPassword = '', string $queryString = '')
+    public function __construct(AuthenticatorInterface $authenticator, string $ldapServiceId, string $dnString = '{user_identifier}', string $searchDn = '', string $searchPassword = '', string $queryString = '')
     {
         $this->authenticator = $authenticator;
         $this->ldapServiceId = $ldapServiceId;

--- a/src/Symfony/Component/Ldap/Security/LdapBadge.php
+++ b/src/Symfony/Component/Ldap/Security/LdapBadge.php
@@ -31,12 +31,20 @@ class LdapBadge implements BadgeInterface
     private string $searchPassword;
     private ?string $queryString;
 
-    public function __construct(string $ldapServiceId, string $dnString = '{username}', string $searchDn = '', string $searchPassword = '', string $queryString = null)
+    public function __construct(string $ldapServiceId, string $dnString = '{user_identifier}', string $searchDn = '', string $searchPassword = '', string $queryString = null)
     {
         $this->ldapServiceId = $ldapServiceId;
+        $dnString = str_replace('{username}', '{user_identifier}', $dnString, $replaceCount);
+        if ($replaceCount > 0) {
+            trigger_deprecation('symfony/ldap', '6.2', 'Using "{username}" parameter in LDAP configuration is deprecated, consider using "{user_identifier}" instead.');
+        }
         $this->dnString = $dnString;
         $this->searchDn = $searchDn;
         $this->searchPassword = $searchPassword;
+        $queryString = str_replace('{username}', '{user_identifier}', $queryString ?? '', $replaceCount);
+        if ($replaceCount > 0) {
+            trigger_deprecation('symfony/ldap', '6.2', 'Using "{username}" parameter in LDAP configuration is deprecated, consider using "{user_identifier}" instead.');
+        }
         $this->queryString = $queryString;
     }
 

--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -24,19 +24,19 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface
 {
     private Entry $entry;
-    private string $username;
+    private string $identifier;
     private ?string $password;
     private array $roles;
     private array $extraFields;
 
-    public function __construct(Entry $entry, string $username, #[\SensitiveParameter] ?string $password, array $roles = [], array $extraFields = [])
+    public function __construct(Entry $entry, string $identifier, #[\SensitiveParameter] ?string $password, array $roles = [], array $extraFields = [])
     {
-        if (!$username) {
+        if (!$identifier) {
             throw new \InvalidArgumentException('The username cannot be empty.');
         }
 
         $this->entry = $entry;
-        $this->username = $username;
+        $this->identifier = $identifier;
         $this->password = $password;
         $this->roles = $roles;
         $this->extraFields = $extraFields;
@@ -81,7 +81,7 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
 
     public function getUserIdentifier(): string
     {
-        return $this->username;
+        return $this->identifier;
     }
 
     /**

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -81,7 +81,11 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
         }
 
         $identifier = $this->ldap->escape($identifier, '', LdapInterface::ESCAPE_FILTER);
-        $query = str_replace(['{username}', '{user_identifier}'], $identifier, $this->defaultSearch);
+        $query = str_replace('{username}', '{user_identifier}', $this->defaultSearch, $replaceCount);
+        if ($replaceCount > 0) {
+            trigger_deprecation('symfony/ldap', '6.2', 'Using "{username}" parameter in LDAP configuration is deprecated, consider using "{user_identifier}" instead.');
+        }
+        $query = str_replace('{user_identifier}', $identifier, $query);
         $search = $this->ldap->query($this->baseDn, $query, ['filter' => 0 == \count($this->extraFields) ? '*' : $this->extraFields]);
 
         $entries = $search->execute();

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException;
  */
 class LdapUserProviderTest extends TestCase
 {
-    public function testLoadUserByUsernameFailsIfCantConnectToLdap()
+    public function testLoadUserByIdentifierFailsIfCantConnectToLdap()
     {
         $this->expectException(ConnectionException::class);
 
@@ -42,7 +42,7 @@ class LdapUserProviderTest extends TestCase
         $provider->loadUserByIdentifier('foo');
     }
 
-    public function testLoadUserByUsernameFailsIfNoLdapEntries()
+    public function testLoadUserByIdentifierFailsIfNoLdapEntries()
     {
         $this->expectException(UserNotFoundException::class);
 
@@ -74,7 +74,7 @@ class LdapUserProviderTest extends TestCase
         $provider->loadUserByIdentifier('foo');
     }
 
-    public function testLoadUserByUsernameFailsIfMoreThanOneLdapEntry()
+    public function testLoadUserByIdentifierFailsIfMoreThanOneLdapEntry()
     {
         $this->expectException(UserNotFoundException::class);
 
@@ -106,7 +106,7 @@ class LdapUserProviderTest extends TestCase
         $provider->loadUserByIdentifier('foo');
     }
 
-    public function testLoadUserByUsernameFailsIfMoreThanOneLdapPasswordsInEntry()
+    public function testLoadUserByIdentifierFailsIfMoreThanOneLdapPasswordsInEntry()
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -143,11 +143,11 @@ class LdapUserProviderTest extends TestCase
             ->willReturn($query)
         ;
 
-        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword');
+        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={user_identifier})', 'userpassword');
         $this->assertInstanceOf(LdapUser::class, $provider->loadUserByIdentifier('foo'));
     }
 
-    public function testLoadUserByUsernameShouldNotFailIfEntryHasNoUidKeyAttribute()
+    public function testLoadUserByIdentifierShouldNotFailIfEntryHasNoUidKeyAttribute()
     {
         $result = $this->createMock(CollectionInterface::class);
         $query = $this->createMock(QueryInterface::class);
@@ -179,11 +179,11 @@ class LdapUserProviderTest extends TestCase
             ->willReturn($query)
         ;
 
-        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})');
+        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={user_identifier})');
         $this->assertInstanceOf(LdapUser::class, $provider->loadUserByIdentifier('foo'));
     }
 
-    public function testLoadUserByUsernameFailsIfEntryHasNoPasswordAttribute()
+    public function testLoadUserByIdentifierFailsIfEntryHasNoPasswordAttribute()
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -217,11 +217,11 @@ class LdapUserProviderTest extends TestCase
             ->willReturn($query)
         ;
 
-        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword');
+        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={user_identifier})', 'userpassword');
         $this->assertInstanceOf(LdapUser::class, $provider->loadUserByIdentifier('foo'));
     }
 
-    public function testLoadUserByUsernameIsSuccessfulWithoutPasswordAttribute()
+    public function testLoadUserByIdentifierIsSuccessfulWithoutPasswordAttribute()
     {
         $result = $this->createMock(CollectionInterface::class);
         $query = $this->createMock(QueryInterface::class);
@@ -257,7 +257,7 @@ class LdapUserProviderTest extends TestCase
         $this->assertInstanceOf(LdapUser::class, $provider->loadUserByIdentifier('foo'));
     }
 
-    public function testLoadUserByUsernameIsSuccessfulWithoutPasswordAttributeAndWrongCase()
+    public function testLoadUserByIdentifierIsSuccessfulWithoutPasswordAttributeAndWrongCase()
     {
         $result = $this->createMock(CollectionInterface::class);
         $query = $this->createMock(QueryInterface::class);
@@ -293,7 +293,7 @@ class LdapUserProviderTest extends TestCase
         $this->assertSame('foo', $provider->loadUserByIdentifier('Foo')->getUserIdentifier());
     }
 
-    public function testLoadUserByUsernameIsSuccessfulWithPasswordAttribute()
+    public function testLoadUserByIdentifierIsSuccessfulWithPasswordAttribute()
     {
         $result = $this->createMock(CollectionInterface::class);
         $query = $this->createMock(QueryInterface::class);
@@ -329,14 +329,14 @@ class LdapUserProviderTest extends TestCase
             ->willReturn($query)
         ;
 
-        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword', ['email']);
+        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={user_identifier})', 'userpassword', ['email']);
         $this->assertInstanceOf(LdapUser::class, $provider->loadUserByIdentifier('foo'));
     }
 
     public function testRefreshUserShouldReturnUserWithSameProperties()
     {
         $ldap = $this->createMock(LdapInterface::class);
-        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword', ['email']);
+        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={user_identifier})', 'userpassword', ['email']);
 
         $user = new LdapUser(new Entry('foo'), 'foo', 'bar', ['ROLE_DUMMY'], ['email' => 'foo@symfony.com']);
 

--- a/src/Symfony/Component/Ldap/composer.json
+++ b/src/Symfony/Component/Ldap/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.1",
         "ext-ldap": "*",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/options-resolver": "^5.4|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR aims to fix a missing forward compatibility as done in src/Symfony/Component/Ldap/Security/LdapUserProvider.php at line 80 when authenticating with LDAP and using the following configuration : 
```yaml
security:
// ...
    firewalls:œ
    // ...
        main:
            form_login_ldap:
                // ...
                query_string: '(whatever={user_identifier})'
                dn_string: 'uid={user_identifier},dc=example,dc=com'
```
instead of :
```yaml
security:
// ...
    firewalls:
    // ...
        main:
            form_login_ldap:
                // ...
                query_string: '(whatever={username})'
                dn_string: 'uid={username},dc=example,dc=com'
```

maybe related to : https://github.com/symfony/symfony/pull/40403