### PR TITLE
[Asset] Ignore missing manifest.json files in non-strict mode

### DIFF
--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
@@ -58,10 +58,12 @@ class JsonManifestVersionStrategyTest extends TestCase
     /**
      * @dataProvider provideMissingStrategies
      */
-    public function testMissingManifestFileThrowsException(JsonManifestVersionStrategy $strategy)
+    public function testMissingManifestFileThrowsException(JsonManifestVersionStrategy $strategy, bool $isLocal)
     {
-        $this->expectException(RuntimeException::class);
-        $strategy->getVersion('main.js');
+        if (!$isLocal) {
+            $this->expectException(RuntimeException::class);
+        }
+        $this->assertSame('main.js', $strategy->getVersion('main.js'));
     }
 
     /**
@@ -109,9 +111,9 @@ class JsonManifestVersionStrategyTest extends TestCase
             return new MockResponse('{}', ['http_code' => 404]);
         });
 
-        yield [new JsonManifestVersionStrategy('https://cdn.example.com/'.$manifestPath, $httpClient)];
+        yield [new JsonManifestVersionStrategy('https://cdn.example.com/'.$manifestPath, $httpClient), false];
 
-        yield [new JsonManifestVersionStrategy(__DIR__.'/../fixtures/'.$manifestPath)];
+        yield [new JsonManifestVersionStrategy(__DIR__.'/../fixtures/'.$manifestPath), true];
     }
 
     public function provideStrictStrategies()

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -81,6 +81,9 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
                 }
             } else {
                 if (!is_file($this->manifestPath)) {
+                    if (!$this->strictMode) {
+                        return null;
+                    }
                     throw new RuntimeException(sprintf('Asset manifest file "%s" does not exist. Did you forget to build the assets with npm or yarn?', $this->manifestPath));
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix -
| License       | MIT
| Doc PR        | -

Something we missed in #38495 I suppose.

In its current state, the webapp-pack cannot be used without running `yarn encore dev` or similar: as soon as one uses the `{{ asset() }}` helper in a Twig file, an exception is thrown because the `manifest.json` file is missing.

Similar to https://github.com/symfony/recipes/pull/1087, we should instead ignore when this file is missing by default, in non-strict mode only of course.