### PR TITLE
[HttpKernel] Disable session tracking while collecting profiler data

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
@@ -87,8 +89,21 @@ class ProfilerListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$profile = $this->profiler->collect($request, $event->getResponse(), $exception)) {
-            return;
+        $session = method_exists(Request::class, 'getPreferredFormat') && $request->hasPreviousSession() && $request->hasSession() ? $request->getSession() : null;
+
+        if ($session instanceof Session) {
+            $usageIndexValue = $usageIndexReference = &$session->getUsageIndex();
+            $usageIndexReference = \PHP_INT_MIN;
+        }
+
+        try {
+            if (!$profile = $this->profiler->collect($request, $event->getResponse(), $exception)) {
+                return;
+            }
+        } finally {
+            if ($session instanceof Session) {
+                $usageIndexReference = $usageIndexValue;
+            }
         }
 
         $this->profiles[$request] = $profile;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While playing with the Symfony book, I noticed that HttpCache wouldn't cache a public response because I was logged in as admin.
After inspecting the reason why, I noticed that some data collectors access the session and thus make the request private.
In this PR, the session tracking logic is disabled by using the same code that we use in the firewall, where we also ignore session tracking until authentication is actually needed by the app.