### PR TITLE
Allow passing null in twig_is_selected_choice

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -188,7 +188,7 @@ final class FormExtension extends AbstractExtension
  *
  * @see ChoiceView::isSelected()
  */
-function twig_is_selected_choice(ChoiceView $choice, string|array $selectedValue): bool
+function twig_is_selected_choice(ChoiceView $choice, string|array|null $selectedValue): bool
 {
     if (\is_array($selectedValue)) {
         return \in_array($choice->value, $selectedValue, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0 and >
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

In the cached file of my application, generated by Symfony I can see the following code fragment:
```php
if (( !((array_key_exists("render_preferred_choices", $context)) ? (_twig_default_filter((isset($context["render_preferred_choices"]) || 
array_key_exists("render_preferred_choices", $context) ? $context["render_preferred_choices"] : (function () { throw new 
RuntimeError('Variable "render_preferred_choices" does not exist.', 88, $this->source); })()), false)) : (false)) && Symfony\Bridge
\Twig\Extension\twig_is_selected_choice($context["choice"], (isset($context["value"]) || array_key_exists("value", $context) ? 
$context["value"] : (function () { throw new RuntimeError('Variable "value" does not exist.', 88, $this->source); })())))) {
                    echo " selected=\"selected\"";
                }
```

The 2nd Arg passed when calling ``twig_is_selected_choice`` is the result of ``(isset($context["value"]) || array_key_exists("value", $context) ? $context["value"]``. So in case ``$context['value'] = null``, we pass ``null`` as 2nd arg of ``twig_is_selected_choice``.

As a result in some case, when I submit form with empty (null) value, I got the following error:
```
Symfony\Bridge\Twig\Extension\twig_is_selected_choice(): Argument #2 ($selectedValue) must be of type array|string, null given, called in ...\var\cache\dev\twig\01\01615438ee40292438687b29025d08a9.php on line 534
```

