### PR TITLE
[DoctrineBridge] Add missing break

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -199,6 +199,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                         case self::$useDeprecatedConstants ? DBALType::SIMPLE_ARRAY : Types::SIMPLE_ARRAY:
                             return [new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true, new Type(Type::BUILTIN_TYPE_INT), $enumType ?? new Type(Type::BUILTIN_TYPE_STRING))];
                     }
+                    break;
                 case Type::BUILTIN_TYPE_INT:
                 case Type::BUILTIN_TYPE_STRING:
                     if ($enumType) {


### PR DESCRIPTION
~~This PR only adds the "no break" comment as requested on my last PR:~~ 
This PR only adds the missing break as requested on my last PR: https://github.com/symfony/symfony/pull/46676#discussion_r901094459

I hope it's fine to not include the describing table. ~~The missing break is on purpose, so here is no real code change.~~ The missing break should not have caused any side effects.

I have not changed any tests here, because both cases are already tested by these two lines:
https://github.com/symfony/symfony/blob/7fc7acb1e4448762f438af03cadb2ce54e3918e0/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php#L186-L187