### PR TITLE
[DependencyInjection] Add helper config functions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -193,3 +193,23 @@ function closure(string|array|ReferenceConfigurator|Expression $callable): Inlin
         ->factory(['Closure', 'fromCallable'])
         ->args([$callable]);
 }
+
+if (interface_exists('Symfony\Contracts\HttpClient\HttpClientInterface')) {
+    /**
+     * Creates a reference to a scoped http client service.
+     */
+    function http_client_service(string $scopedHttpClientName): ReferenceConfigurator
+    {
+        return service(\sprintf('Symfony\Contracts\HttpClient\HttpClientInterface $%s', $scopedHttpClientName));
+    }
+}
+
+if (interface_exists('Symfony\Contracts\Cache\CacheInterface')) {
+    /**
+     * Creates a reference to a cache poll service.
+     */
+    function cache_servcie(string $cacheName): ReferenceConfigurator
+    {
+        return service(\sprintf('Symfony\Contracts\Cache\CacheInterface $%s', $cacheName));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT

Add two helper function for configuration:
- `http_client_service` - creates a reference to a scoped http client service
- `cache_servcie` - creates a reference to a cache poll service
