### PR TITLE
[Console] A getter function to returns only given input options

### DIFF
--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -144,6 +144,14 @@ abstract class Input implements InputInterface, StreamableInputInterface
     /**
      * {@inheritdoc}
      */
+    public function getNonDefualtOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getOption(string $name): mixed
     {
         if ($this->definition->hasNegation($name)) {

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -144,7 +144,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
     /**
      * {@inheritdoc}
      */
-    public function getNonDefualtOptions(): array
+    public function getNonDefaultOptions(): array
     {
         return $this->options;
     }

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -108,6 +108,13 @@ interface InputInterface
     public function getOptions(): array;
 
     /**
+     * Returns all the given options without adding any default values.
+     *
+     * @return array<string|bool|int|float|array|null>
+     */
+    public function getNonDefualtOptions(): array;
+
+    /**
      * Returns the option value for a given option name.
      *
      * @return mixed

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -112,7 +112,7 @@ interface InputInterface
      *
      * @return array<string|bool|int|float|array|null>
      */
-    public function getNonDefualtOptions(): array;
+    public function getNonDefaultOptions(): array;
 
     /**
      * Returns the option value for a given option name.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add a getter function to returns only given options, not any other additional defualt values.

