### PR TITLE
[Intl] Fix the IntlDateFormatter::formatObject signature

### DIFF
--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -243,7 +243,7 @@ abstract class IntlDateFormatter
      *
      * @throws MethodNotImplementedException
      */
-    public function formatObject($object, $format = null, $locale = null)
+    public static function formatObject($object, $format = null, $locale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | :hole: 

I was calling `IntlDateFormatter::formatObject` in my user-land code and got this error from PHPStan:

```
Static call to instance method Symfony\Component\Intl\DateFormatter\IntlDateFormatter::formatObject().  
```

The Intl component `formatObject` method signature is indeed non-static, but the PHP Intl signature is.

Reference: https://www.php.net/manual/en/intldateformatter.formatobject.php

So I think the component should respect PHP method signature.
