### PR TITLE
[Messenger] Do not log the message object itself

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -56,7 +56,6 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
         $message = $envelope->getMessage();
         $context = [
-            'message' => $message,
             'class' => \get_class($message),
         ];
 

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -53,7 +53,6 @@ class HandleMessageMiddleware implements MiddlewareInterface
         $message = $envelope->getMessage();
 
         $context = [
-            'message' => $message,
             'class' => \get_class($message),
         ];
 

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -46,7 +46,6 @@ class SendMessageMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         $context = [
-            'message' => $envelope->getMessage(),
             'class' => \get_class($envelope->getMessage()),
         ];
 

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -208,7 +208,6 @@ class Worker
             if (null !== $this->logger) {
                 $message = $envelope->getMessage();
                 $context = [
-                    'message' => $message,
                     'class' => \get_class($message),
                 ];
                 $this->logger->info('{class} was handled successfully (acknowledging to transport).', $context);


### PR DESCRIPTION
In order to avoid the leak of sensitive data (e.g. credentials) or the overflow of third-party services.

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This is a follow-up of #46450 where we had a discussion with @Nyholm about the problems related to the logging of the message object. I'm targeting the `5.4` branch as we see this change as a (security ?) fix rather than a new feature.