### PR TITLE
Fix global state pollution between tests run with ApplicationTester

### DIFF
--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -54,17 +54,37 @@ class ApplicationTester
      */
     public function run(array $input, $options = [])
     {
-        $this->input = new ArrayInput($input);
-        if (isset($options['interactive'])) {
-            $this->input->setInteractive($options['interactive']);
+        $prevShellVerbosity = getenv('SHELL_VERBOSITY');
+
+        try {
+            $this->input = new ArrayInput($input);
+            if (isset($options['interactive'])) {
+                $this->input->setInteractive($options['interactive']);
+            }
+
+            if ($this->inputs) {
+                $this->input->setStream(self::createStream($this->inputs));
+            }
+
+            $this->initOutput($options);
+
+            return $this->statusCode = $this->application->run($this->input, $this->output);
+        } finally {
+            // SHELL_VERBOSITY is set by Application::configureIO so we need to unset/reset it
+            // to its previous value to avoid one test's verbosity to spread to the following tests
+            if (false === $prevShellVerbosity) {
+                if (\function_exists('putenv')) {
+                    @putenv('SHELL_VERBOSITY');
+                }
+                unset($_ENV['SHELL_VERBOSITY']);
+                unset($_SERVER['SHELL_VERBOSITY']);
+            } else {
+                if (\function_exists('putenv')) {
+                    @putenv('SHELL_VERBOSITY='.$prevShellVerbosity);
+                }
+                $_ENV['SHELL_VERBOSITY'] = $prevShellVerbosity;
+                $_SERVER['SHELL_VERBOSITY'] = $prevShellVerbosity;
+            }
         }
-
-        if ($this->inputs) {
-            $this->input->setStream(self::createStream($this->inputs));
-        }
-
-        $this->initOutput($options);
-
-        return $this->statusCode = $this->application->run($this->input, $this->output);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

If you run a test with ApplicationTester which includes -v or similar flag, then https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Console/Application.php#L985-L989 leaves the env in a dirty state, and all tests following also use -v.