### PR TITLE
[Security] Fix legacy impersonation system

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -94,7 +94,10 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
         }
 
         if ($token instanceof SwitchUserToken) {
-            $authenticatedToken = new SwitchUserToken($user, $token->getCredentials(), $this->providerKey, $user->getRoles(), $token->getOriginalToken());
+            $roles = $user->getRoles();
+            $roles[] = 'ROLE_PREVIOUS_ADMIN';
+
+            $authenticatedToken = new SwitchUserToken($user, $token->getCredentials(), $this->providerKey, $roles, $token->getOriginalToken());
         } else {
             $authenticatedToken = new UsernamePasswordToken($user, $token->getCredentials(), $this->providerKey, $user->getRoles());
         }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -225,6 +225,7 @@ class UserAuthenticationProviderTest extends TestCase
         $this->assertSame($originalToken, $authToken->getOriginalToken());
         $this->assertSame($user, $authToken->getUser());
         $this->assertContains('ROLE_FOO', $authToken->getRoleNames());
+        $this->assertContains('ROLE_PREVIOUS_ADMIN', $authToken->getRoleNames());
         $this->assertEquals('foo', $authToken->getCredentials());
         $this->assertEquals(['foo' => 'bar'], $authToken->getAttributes(), '->authenticate() copies token attributes');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

When using the legacy authentication system with a user class not
implementing `EquatableInterface` (for instance, the default when using
Sylius) a bug prevents the impersonation system from working properly.

The switch is done correctly, but then the user is disconnected on the
next request because `SecurityContext::hasUserChanged()` compares the
roles of the token in session with the roles of the temporary token, and they
aren't equal.

`ROLE_PREVIOUS_ADMIN` is added in
`SwitchUserListener::attemptSwitchUser()`, but then removed if the
legacy system is still enabled in `UserAuthenticationProvider`.

It looks like this bug has been introduced while deprecating support for
role classes: https://github.com/symfony/symfony/commit/d64372df8c8d63e124d14de5c08fcbbb4674a12e#diff-914ec544d4f7b26fda540aea3d7bc57cc5057d76bfb9ad72047d77739e3bb5a3L115

This patch fixes the issue (tested on a real Sylius project).

