### PR TITLE
fix query explanation table width restrictions

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -1234,7 +1234,10 @@ tr.log-status-silenced {
 }
 .sql-explain {
     overflow-x: auto;
-    max-width: 920px;
+    max-width: 888px;
+}
+.width-full .sql-explain {
+    max-width: min-content;
 }
 .sql-explain table td, .sql-explain table tr {
     word-break: normal;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

max width for query explanation table was too wide for Normal page width
max width for query explanation table was too narrow for Full-page
