### PR TITLE
[HtmlSanitizer] Fix default configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/html_sanitizer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/html_sanitizer.php
@@ -18,7 +18,7 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('html_sanitizer.config.default', HtmlSanitizerConfig::class)
-            ->call('allowSafeElements')
+            ->call('allowSafeElements', [], true)
 
         ->set('html_sanitizer.sanitizer.default', HtmlSanitizer::class)
             ->args([service('html_sanitizer.config.default')])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer.php
@@ -4,7 +4,7 @@ $container->loadFromExtension('framework', [
     'http_method_override' => false,
     'html_sanitizer' => [
         'sanitizers' => [
-            'default' => [
+            'custom' => [
                 'allow_safe_elements' => true,
                 'allow_static_elements' => true,
                 'allow_elements' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/html_sanitizer_default_config.php
@@ -1,0 +1,5 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'http_method_override' => false,
+    'html_sanitizer' => null]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer.xml
@@ -7,7 +7,7 @@
 
     <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false">
         <html-sanitizer>
-            <sanitizer name="default"
+            <sanitizer name="custom"
                 allow-safe-elements="true"
                 allow-static-elements="true"
                 force-https-urls="true"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/html_sanitizer_default_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <config xmlns="http://symfony.com/schema/dic/symfony" http-method-override="false">
+        <html-sanitizer />
+    </config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer.yml
@@ -2,7 +2,7 @@ framework:
     http_method_override: false
     html_sanitizer:
         sanitizers:
-            default:
+            custom:
                 allow_safe_elements: true
                 allow_static_elements: true
                 allow_elements:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/html_sanitizer_default_config.yml
@@ -1,0 +1,3 @@
+framework:
+    http_method_override: false
+    html_sanitizer: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -2050,16 +2050,14 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('html_sanitizer');
 
         // html_sanitizer service
-        $this->assertTrue($container->hasAlias('html_sanitizer'), '->registerHtmlSanitizerConfiguration() loads html_sanitizer.php');
-        $this->assertSame('html_sanitizer.sanitizer.default', (string) $container->getAlias('html_sanitizer'));
-        $this->assertSame(HtmlSanitizer::class, $container->getDefinition('html_sanitizer.sanitizer.default')->getClass());
-        $this->assertCount(1, $args = $container->getDefinition('html_sanitizer.sanitizer.default')->getArguments());
-        $this->assertSame('html_sanitizer.config.default', (string) $args[0]);
+        $this->assertSame(HtmlSanitizer::class, $container->getDefinition('html_sanitizer.sanitizer.custom')->getClass());
+        $this->assertCount(1, $args = $container->getDefinition('html_sanitizer.sanitizer.custom')->getArguments());
+        $this->assertSame('html_sanitizer.config.custom', (string) $args[0]);
 
         // config
-        $this->assertTrue($container->hasDefinition('html_sanitizer.config.default'), '->registerHtmlSanitizerConfiguration() loads custom sanitizer');
-        $this->assertSame(HtmlSanitizerConfig::class, $container->getDefinition('html_sanitizer.config.default')->getClass());
-        $this->assertCount(23, $calls = $container->getDefinition('html_sanitizer.config.default')->getMethodCalls());
+        $this->assertTrue($container->hasDefinition('html_sanitizer.config.custom'), '->registerHtmlSanitizerConfiguration() loads custom sanitizer');
+        $this->assertSame(HtmlSanitizerConfig::class, $container->getDefinition('html_sanitizer.config.custom')->getClass());
+        $this->assertCount(23, $calls = $container->getDefinition('html_sanitizer.config.custom')->getMethodCalls());
         $this->assertSame(
             [
                 ['allowSafeElements', [], true],
@@ -2102,6 +2100,30 @@ abstract class FrameworkExtensionTest extends TestCase
 
         // Named alias
         $this->assertSame('html_sanitizer.sanitizer.all.sanitizer', (string) $container->getAlias(HtmlSanitizerInterface::class.' $allSanitizer'));
+        $this->assertFalse($container->hasAlias(HtmlSanitizerInterface::class.' $default'));
+    }
+
+    public function testHtmlSanitizerDefaultConfig()
+    {
+        $container = $this->createContainerFromFile('html_sanitizer_default_config');
+
+        // html_sanitizer service
+        $this->assertTrue($container->hasAlias('html_sanitizer'), '->registerHtmlSanitizerConfiguration() loads default_config');
+        $this->assertSame('html_sanitizer.sanitizer.default', (string) $container->getAlias('html_sanitizer'));
+        $this->assertSame(HtmlSanitizer::class, $container->getDefinition('html_sanitizer.sanitizer.default')->getClass());
+        $this->assertCount(1, $args = $container->getDefinition('html_sanitizer.sanitizer.default')->getArguments());
+        $this->assertSame('html_sanitizer.config.default', (string) $args[0]);
+
+        // config
+        $this->assertTrue($container->hasDefinition('html_sanitizer.config.default'), '->registerHtmlSanitizerConfiguration() loads custom sanitizer');
+        $this->assertSame(HtmlSanitizerConfig::class, $container->getDefinition('html_sanitizer.config.default')->getClass());
+        $this->assertCount(1, $calls = $container->getDefinition('html_sanitizer.config.default')->getMethodCalls());
+        $this->assertSame(
+            ['allowSafeElements', [], true],
+            $calls[0]
+        );
+
+        // Named alias
         $this->assertFalse($container->hasAlias(HtmlSanitizerInterface::class.' $default'));
 
         // Default alias


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #46648 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

Fix `html_sanitizer.config.default` configuration (see related issue)
