### PR TITLE
Fix double authentication via RememberMe resulting in wrong RememberMe cookie being set in client

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -75,6 +75,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
 
         if ($this->tokenVerifier) {
             $isTokenValid = $this->tokenVerifier->verifyToken($persistentToken, $tokenValue);
+            $tokenValue = $persistentToken->getTokenValue();
         } else {
             $isTokenValid = hash_equals($persistentToken->getTokenValue(), $tokenValue);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | There has not yet an issue opened for this.
| License       | MIT
| Doc PR        | n.a.

In the RememberMe feature we have noticed that with a custom tokenVerifier it is possible to verify an old token. That works as expected but leads to the problematic issue that it will still result in the old token being integrated into the cookie that is sent back to the client.

So the flow is as follows:

* Customer sends a request "A" with `rem`-cookie with token "tokenA"
* The user is authenticated via the token "tokenA", the token is refreshed with "tokenB".
* Customer sends a request "B" with `rem`-cookie with token "tokenA"
* Set-Cookie is sent back to the customer in response to request "A" with Remember-Me token "tokenB"
* The user is authenticated via the token "tokenA" via a custom verifier. The last token was created less than 60 seconds ago, so let's not refresh the token but resend the current token.
* Set-Cookie is sent back to the customer in response to request "B" with Remember-Me token "tokenA"
* Remember-Me token "tokenA" overwrites the previously received token "tokenB" in the client.
* Customer sends a request "C" with `rem`-cookie with "tokenA"
* The user is not authenticated any more as the custom.verifier no longer accepts old token "tokenA" and "tokenA" doesn't match the persisted token "tokenB". The `rem`-cookie is overwritten with `deleted`.

This PR will pass the persisted token (in the example "tokenB") in request "B" instead of the provided token (in the example "tokenA") and therefore not causing an overwrite of the Remember-Me cookie with a wrong value and a continuing functionality also when authentication-requests are sent within one minute of one another. 

How that can happen? By using double clicks for example in certain setups where then two authenticating requests are sent right after one another...