### PR TITLE
[HttpCache] Do not call terminate() on cache hit

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -78,6 +78,11 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *                            the cache can serve a stale response when an error is encountered (default: 60).
      *                            This setting is overridden by the stale-if-error HTTP Cache-Control extension
      *                            (see RFC 5861).
+     *
+     *   * terminate_on_cache_hit Specifies if the kernel.terminate event should be dispatched even when the cache
+     *                            was hit (default: true).
+     *                            Unless your application needs to process events on cache hits, it is recommended
+     *                            to set this to false to avoid having to bootstrap the Symfony framework on a cache hit.
      */
     public function __construct(HttpKernelInterface $kernel, StoreInterface $store, SurrogateInterface $surrogate = null, array $options = [])
     {
@@ -98,6 +103,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             'stale_if_error' => 60,
             'trace_level' => 'none',
             'trace_header' => 'X-Symfony-Cache',
+            'terminate_on_cache_hit' => true,
         ], $options);
 
         if (!isset($options['trace_level'])) {
@@ -238,6 +244,15 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      */
     public function terminate(Request $request, Response $response)
     {
+        // Do not call any listeners in case of a cache hit.
+        // This ensures identical behavior as if you had a separate
+        // reverse caching proxy such as Varnish and the like.
+        if ($this->options['terminate_on_cache_hit']) {
+            trigger_deprecation('symfony/http-kernel', '6.2', 'Setting "terminate_on_cache_hit" to "true" is deprecated and will be changed to "false" in Symfony 7.0.');
+        } elseif (\in_array('fresh', $this->traces[$this->getTraceKey($request)] ?? [], true)) {
+            return;
+        }
+
         if ($this->getKernel() instanceof TerminableInterface) {
             $this->getKernel()->terminate($request, $response);
         }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpCache\Esi;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
@@ -124,6 +125,10 @@ class HttpCacheTestCase extends TestCase
             $this->cacheConfig['debug'] = true;
         }
 
+        if (!isset($this->cacheConfig['terminate_on_cache_hit'])) {
+            $this->cacheConfig['terminate_on_cache_hit'] = false;
+        }
+
         $this->esi = $esi ? new Esi() : null;
         $this->cache = new HttpCache($this->kernel, $this->store, $this->esi, $this->cacheConfig);
         $this->request = Request::create($uri, $method, [], $cookies, [], $server);
@@ -145,9 +150,9 @@ class HttpCacheTestCase extends TestCase
     }
 
     // A basic response with 200 status code and a tiny body.
-    public function setNextResponse($statusCode = 200, array $headers = [], $body = 'Hello World', \Closure $customizer = null)
+    public function setNextResponse($statusCode = 200, array $headers = [], $body = 'Hello World', \Closure $customizer = null, EventDispatcher $eventDispatcher = null)
     {
-        $this->kernel = new TestHttpKernel($body, $statusCode, $headers, $customizer);
+        $this->kernel = new TestHttpKernel($body, $statusCode, $headers, $customizer, $eventDispatcher);
     }
 
     public function setNextResponses($responses)

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
@@ -29,14 +29,14 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface, 
     protected $catch = false;
     protected $backendRequest;
 
-    public function __construct($body, $status, $headers, \Closure $customizer = null)
+    public function __construct($body, $status, $headers, \Closure $customizer = null, EventDispatcher $eventDispatcher = null)
     {
         $this->body = $body;
         $this->status = $status;
         $this->headers = $headers;
         $this->customizer = $customizer;
 
-        parent::__construct(new EventDispatcher(), $this, null, $this, true);
+        parent::__construct($eventDispatcher ?? new EventDispatcher(), $this, null, $this, true);
     }
 
     public function assert(\Closure $callback)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently, `HttpCache` always calls the `kernel.terminate` events, even if the response is coming from cache.
Why is this a problem?

`kernel.terminate` events are used to do things after the response has been sent to the visitor. At least that happens if you have support for `fastcgi_finish_request()`.
For Contao for example, we use this to dispatch a message to update the search index but you can imagine a lot of stuff being done there, like sending e-mails etc. According [to the docs](https://symfony.com/doc/current/components/http_kernel.html#8-the-kernel-terminate-event), it says "perform some heavy action".

This means that currently, the system is basically always booted even when the response is coming from `HttpCache` because dispatching the `TerminateEvent` causes the container to be booted etc. which makes the system slower than it needs to be. 

We don't need to update the search index when the response is coming from the cache because it already is up to date. And there are no e-mails or other "heavy actions" to perform because by definition, nothing could've happened as the system was not booted (or should not have been).

Also, imagine if you used a "real" reverse proxy like Varnish. There's no call to the back end either when there's a cache hit so it's actually an inconsistency. You cannot "perform some heavy action" there either. If you wanted to, it would have to be implemented in the proxy itself. So Varnish would need to trigger that heavy action. HttpCache should behave just the same.
You could e.g. use the `EventDispatchingHttpCache` from https://github.com/FriendsOfSymfony/FOSHttpCache, if you need something like that.