### PR TITLE
[Serializer] Fix denormalization union types with constructor

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -20,6 +20,7 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
@@ -395,6 +396,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      * @return mixed
      *
      * @throws NotNormalizableValueException
+     * @throws ExtraAttributesException
+     * @throws MissingConstructorArgumentsException
      * @throws LogicException
      */
     private function validateAndDenormalize(string $currentClass, string $attribute, $data, ?string $format, array $context)
@@ -406,6 +409,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $expectedTypes = [];
         $isUnionType = \count($types) > 1;
         $extraAttributesException = null;
+        $missingConstructorArgumentException = null;
         foreach ($types as $type) {
             if (null === $data && $type->isNullable()) {
                 return null;
@@ -503,11 +507,23 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 if (!$extraAttributesException) {
                     $extraAttributesException = $e;
                 }
+            } catch (MissingConstructorArgumentsException $e) {
+                if (!$isUnionType) {
+                    throw $e;
+                }
+
+                if (!$missingConstructorArgumentException) {
+                    $missingConstructorArgumentException = $e;
+                }
             }
         }
 
         if ($extraAttributesException) {
             throw $extraAttributesException;
+        }
+
+        if ($missingConstructorArgumentException) {
+            throw $missingConstructorArgumentException;
         }
 
         if ($context[self::DISABLE_TYPE_ENFORCEMENT] ?? $this->defaultContext[self::DISABLE_TYPE_ENFORCEMENT] ?? false) {

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -586,20 +586,26 @@ class SerializerTest extends TestCase
             ['json' => new JsonEncoder()]
         );
 
-        $actual = $serializer->deserialize('{ "v": { "a": 0 }}', DummyUnionWithAAndB::class, 'json', [
+        $actual = $serializer->deserialize('{ "v": { "a": 0 }}', DummyUnionWithAAndCAndB::class, 'json', [
             AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
         ]);
 
-        $this->assertEquals(new DummyUnionWithAAndB(new DummyATypeForUnion()), $actual);
+        $this->assertEquals(new DummyUnionWithAAndCAndB(new DummyATypeForUnion()), $actual);
 
-        $actual = $serializer->deserialize('{ "v": { "b": 1 }}', DummyUnionWithAAndB::class, 'json', [
+        $actual = $serializer->deserialize('{ "v": { "b": 1 }}', DummyUnionWithAAndCAndB::class, 'json', [
             AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
         ]);
 
-        $this->assertEquals(new DummyUnionWithAAndB(new DummyBTypeForUnion()), $actual);
+        $this->assertEquals(new DummyUnionWithAAndCAndB(new DummyBTypeForUnion()), $actual);
+
+        $actual = $serializer->deserialize('{ "v": { "c": 3 }}', DummyUnionWithAAndCAndB::class, 'json', [
+            AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
+        ]);
+
+        $this->assertEquals(new DummyUnionWithAAndCAndB(new DummyCTypeForUnion(3)), $actual);
 
         $this->expectException(ExtraAttributesException::class);
-        $serializer->deserialize('{ "v": { "b": 1, "c": "i am not allowed" }}', DummyUnionWithAAndB::class, 'json', [
+        $serializer->deserialize('{ "v": { "b": 1, "d": "i am not allowed" }}', DummyUnionWithAAndCAndB::class, 'json', [
             AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
         ]);
     }
@@ -719,13 +725,23 @@ class DummyBTypeForUnion
     public $b = 1;
 }
 
-class DummyUnionWithAAndB
+class DummyCTypeForUnion
 {
-    /** @var DummyATypeForUnion|DummyBTypeForUnion */
+    public $c = 2;
+
+    public function __construct($c)
+    {
+        $this->c = $c;
+    }
+}
+
+class DummyUnionWithAAndCAndB
+{
+    /** @var DummyATypeForUnion|DummyCTypeForUnion|DummyBTypeForUnion */
     public $v;
 
     /**
-     * @param DummyATypeForUnion|DummyBTypeForUnion $v
+     * @param DummyATypeForUnion|DummyCTypeForUnion|DummyBTypeForUnion $v
      */
     public function __construct($v)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/46396
| License       | MIT

Fix bug when deserialize union types with constructor. Before that, `MissingConstructorArgumentsException` was thrown even if another type matched.

Is similar to https://github.com/symfony/symfony/pull/45861