### PR TITLE
[HttpKernel] Fix a PHP 8.1 deprecation notice in HttpCache

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -718,7 +718,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             $timeout = $this->options['stale_while_revalidate'];
         }
 
-        return abs($entry->getTtl()) < $timeout;
+        return abs($entry->getTtl() ?? 0) < $timeout;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

PHP 8.1 may trigger a deprecation notice `PHP Deprecated:  abs(): Passing null to parameter #1 ($num) of type int|float is deprecated in .../symfony/http-kernel/HttpCache/HttpCache.php on line 721`

The reason is that `$entry->getTtl()` may return `null` for cache entries where no freshness information is present.

I think we would err on the safe side by not using stale-while-revalidate behaviour in this case.