### PR TITLE
Release v4.4.43

### DIFF
--- a/CHANGELOG-4.4.md
+++ b/CHANGELOG-4.4.md
@@ -7,6 +7,28 @@ in 4.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.4.0...v4.4.1
 
+* 4.4.43 (2022-06-26)
+
+ * bug #46765 [Serializer] Fix denormalization union types with constructor (Gwemox)
+ * bug #46769 [HttpKernel] Fix a PHP 8.1 deprecation notice in HttpCache (mpdude)
+ * bug #46747 Fix global state pollution between tests run with ApplicationTester (Seldaek)
+ * bug #46730 [Intl] Fix the IntlDateFormatter::formatObject signature (damienalexandre)
+ * bug #46668 [FrameworkBundle] Lower JsonSerializableNormalizer priority (aprat84)
+ * bug #46678 [HttpFoundation] Update "[Session] Overwrite invalid session id" to only validate when files session storage is used (alexpott)
+ * bug #45861 [Serializer] Try all possible denormalization route with union types when ALLOW_EXTRA_ATTRIBUTES=false (T-bond)
+ * bug #46676 [DoctrineBridge] Extend type guessing on enum fields (Gigino Chianese)
+ * bug #46699 [Cache] Respect $save option in all adapters (jrjohnson)
+ * bug #46697 [HttpKernel] Disable session tracking while collecting profiler data (nicolas-grekas)
+ * bug #46684 [MonologBridge] Fixed support of elasticsearch 7.+ in ElasticsearchLogstashHandler (lyrixx)
+ * bug #46368 [Mailer] Fix for missing sender name in case with usage of the EnvelopeListener (bobahvas)
+ * bug #46548 [Mime] Allow url as a path in the DataPart::fromPath (wkania)
+ * bug #46594 [FrameworkBundle] Fix XML cache config (HeahDude)
+ * bug #46595 [Console] Escape  in command name & description from getDefaultName() (ogizanagi)
+ * bug #46565 [WebProfilerBundle] Fix dark theme selected line highlight color & reuse css vars (ogizanagi)
+ * bug #46535 [Mime] Check that the path is a file in the DataPart::fromPath (wkania)
+ * bug #46543 [Cache] do not pass null to strlen() (xabbuh)
+ * bug #46478 [Contracts] remove static cache from `ServiceSubscriberTrait` (kbond)
+
 * 4.4.42 (2022-05-27)
 
  * bug #46448 [DependencyInjection] Fix "proxy" tag: resolve its parameters and pass it to child definitions (nicolas-grekas)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,390 +6,497 @@ Symfony is the result of the work of many people who made the code better.
 The Symfony Connect username in parenthesis allows to get more information
  - Fabien Potencier (fabpot)
  - Nicolas Grekas (nicolas-grekas)
- - Christian Flothmann (xabbuh)
- - Bernhard Schussek (bschussek)
  - Alexander M. Turek (derrabus)
+ - Christian Flothmann (xabbuh)
  - Robin Chalas (chalas_r)
+ - Bernhard Schussek (bschussek)
  - Tobias Schultze (tobion)
- - Christophe Coevoet (stof)
- - Jordi Boggiano (seldaek)
- - Grégoire Pineau (lyrixx)
- - Maxime Steinhausser (ogizanagi)
- - Kévin Dunglas (dunglas)
- - Victor Berchet (victor)
- - Jérémy DERUSSÉ (jderusse)
  - Thomas Calvet (fancyweb)
- - Roland Franssen (ro0)
+ - Jérémy DERUSSÉ (jderusse)
+ - Grégoire Pineau (lyrixx)
  - Wouter de Jong (wouterj)
- - Johannes S (johannes)
- - Ryan Weaver (weaverryan)
- - Kris Wallsmith (kriswallsmith)
- - Jakub Zalas (jakubzalas)
- - Javier Eguiluz (javier.eguiluz)
- - Yonel Ceruto (yonelceruto)
+ - Maxime Steinhausser (ogizanagi)
+ - Christophe Coevoet (stof)
+ - Kévin Dunglas (dunglas)
+ - Jordi Boggiano (seldaek)
+ - Roland Franssen (ro0)
+ - Victor Berchet (victor)
  - Tobias Nyholm (tobias)
- - Hugo Hamon (hhamon)
- - Samuel ROZE (sroze)
+ - Yonel Ceruto (yonelceruto)
  - Oskar Stark (oskarstark)
+ - Ryan Weaver (weaverryan)
+ - Javier Eguiluz (javier.eguiluz)
+ - Johannes S (johannes)
+ - Jakub Zalas (jakubzalas)
+ - Kris Wallsmith (kriswallsmith)
+ - Hugo Hamon (hhamon)
+ - Hamza Amrouche (simperfit)
+ - Samuel ROZE (sroze)
  - Pascal Borreli (pborreli)
  - Romain Neutron
  - Joseph Bielawski (stloyd)
+ - Jules Pietri (heah)
  - Drak (drak)
  - Abdellatif Ait boudad (aitboudad)
  - Lukas Kahwe Smith (lsmith)
- - Hamza Amrouche (simperfit)
+ - Jan Schädlich (jschaedl)
  - Martin Hasoň (hason)
  - Jeremy Mikola (jmikola)
+ - Jérôme Tamarelle (gromnan)
  - Jean-François Simon (jfsimon)
  - Benjamin Eberlei (beberlei)
- - Igor Wiedler
- - Jules Pietri
- - Jan Schädlich (jschaedl)
  - Kevin Bond (kbond)
- - Jonathan Wage (jwage)
- - Jérôme Tamarelle (gromnan)
+ - Igor Wiedler
  - Valentin Udaltsov (vudaltsov)
+ - Vasilij Duško (staff)
  - Matthias Pigulla (mpdude)
- - Alexandre Salomé (alexandresalome)
+ - Laurent VOULLEMIER (lvo)
+ - Pierre du Plessis (pierredup)
  - Grégoire Paris (greg0ire)
+ - Jonathan Wage (jwage)
+ - Antoine Makdessi (amakdessi)
+ - HypeMC (hypemc)
+ - Gabriel Ostrolucký (gadelat)
+ - David Maicher (dmaicher)
+ - Titouan Galopin (tgalopin)
+ - Alexandre Salomé (alexandresalome)
  - William DURAND
  - ornicar
+ - Alexander Schranz (alexander-schranz)
  - Dany Maillard (maidmaid)
  - Eriksen Costa
  - Diego Saint Esteben (dosten)
  - stealth35 ‏ (stealth35)
  - Alexander Mols (asm89)
- - Pierre du Plessis (pierredup)
+ - Gábor Egyed (1ed)
  - Francis Besset (francisbesset)
+ - Vasilij Dusko | CREATION
  - Bulat Shakirzyanov (avalanche123)
+ - Mathieu Santostefano (welcomattic)
  - Iltar van der Berg
- - David Maicher (dmaicher)
- - Gabriel Ostrolucký (gadelat)
+ - Alexandre Daubois (alexandre-daubois)
  - Miha Vrhovnik (mvrhov)
  - Saša Stamenković (umpirsky)
- - Titouan Galopin (tgalopin)
- - Gábor Egyed (1ed)
  - Mathieu Piot (mpiot)
+ - Guilhem N (guilhemn)
+ - Alex Pott
+ - Vladimir Reznichenko (kalessil)
  - Sarah Khalil (saro0h)
  - Konstantin Kudryashov (everzet)
- - Guilhem N (guilhemn)
  - Bilal Amarni (bamarni)
  - Eriksen Costa
  - Florin Patan (florinpatan)
- - Vladimir Reznichenko (kalessil)
  - Peter Rehm (rpet)
- - Vasilij Duško (staff)
+ - Tomas Norkūnas (norkunas)
  - Henrik Bjørnskov (henrikbjorn)
- - Antoine Makdessi (amakdessi)
- - Laurent VOULLEMIER (lvo)
+ - Vincent Langlet (deviling)
+ - Konstantin Myakshin (koc)
  - Andrej Hudec (pulzarraider)
- - Christian Raue
- - Eric Clemmons (ericclemmons)
- - Michel Weimerskirch (mweimerskirch)
- - Issei Murasawa (issei_m)
+ - Julien Falque (julienfalque)
+ - Massimiliano Arione (garak)
  - Douglas Greenshields (shieldo)
+ - Christian Raue
+ - David Buchmann (dbu)
+ - Graham Campbell (graham)
+ - Michel Weimerskirch (mweimerskirch)
+ - Eric Clemmons (ericclemmons)
+ - Issei Murasawa (issei_m)
+ - Fran Moreno (franmomu)
  - Jáchym Toušek (enumag)
- - Alexander Schranz (alexander-schranz)
+ - Malte Schlüter (maltemaltesich)
+ - Vasilij Dusko
+ - Mathias Arlaud (mtarld)
  - Denis (yethee)
  - Arnout Boks (aboks)
  - Charles Sarrazin (csarrazi)
- - David Buchmann (dbu)
+ - Przemysław Bogusz (przemyslaw-bogusz)
  - Henrik Westphal (snc)
  - Dariusz Górecki (canni)
+ - Maxime Helias (maxhelias)
  - Ener-Getick
- - Alex Pott
- - Fran Moreno (franmomu)
- - Graham Campbell (graham)
- - HypeMC (hypemc)
+ - Sebastiaan Stok (sstok)
+ - Ruud Kamphuis (ruudk)
+ - Jérôme Vasseur (jvasseur)
+ - Ion Bazan (ionbazan)
  - Lee McDermott
  - Brandon Turner
  - Luis Cordova (cordoval)
  - Daniel Holmes (dholmes)
  - Toni Uebernickel (havvg)
  - Bart van den Burg (burgov)
- - Vasilij Dusko | CREATION
  - Jordan Alliot (jalliot)
- - Mathieu Santostefano (welcomattic)
  - John Wards (johnwards)
  - Dariusz Ruminski
- - Konstantin Myakshin (koc)
+ - Lars Strojny (lstrojny)
+ - Smaine Milianni (ismail1432)
  - Antoine Hérault (herzult)
- - Alexandre Daubois (alexandre-daubois)
- - Julien Falque (julienfalque)
  - Konstantin.Myakshin
+ - Arman Hosseini (arman)
+ - Yanick Witschi (toflar)
  - Arnaud Le Blanc (arnaud-lb)
- - Sebastiaan Stok (sstok)
  - Maxime STEINHAUSSER
- - Massimiliano Arione (garak)
+ - Peter Kokot (maastermedia)
+ - Saif Eddin Gmati (azjezz)
+ - Ahmed TAILOULOUTE (ahmedtai)
+ - Simon Berger
  - Tim Nagel (merk)
+ - Andreas Braun
+ - Teoh Han Hui (teohhanhui)
+ - YaFou
+ - Gary PEGEOT (gary-p)
  - Chris Wilkinson (thewilkybarkid)
- - Jérôme Vasseur (jvasseur)
+ - Rokas Mikalkėnas (rokasm)
  - Brice BERNARD (brikou)
- - Jules Pietri
- - Tomas Norkūnas (norkunas)
+ - Roman Martinuk (a2a4)
+ - Gregor Harlan (gharlan)
+ - Baptiste Clavié (talus)
+ - Adrien Brault (adrienbrault)
  - Michal Piotrowski
  - marc.weistroff
- - Peter Kokot (maastermedia)
- - Lars Strojny (lstrojny)
  - lenar
- - Włodzimierz Gajda (gajdaw)
- - Adrien Brault (adrienbrault)
- - Jacob Dreesen (jdreesen)
  - Théo FIDRY
+ - jeremyFreeAgent (jeremyfreeagent)
+ - Włodzimierz Gajda (gajdaw)
+ - Christian Scheb
+ - Guillaume (guill)
+ - Mathieu Lechat (mat_the_cat)
+ - Jesse Rushlow (geeshoe)
+ - Jacob Dreesen (jdreesen)
+ - Joel Wurtz (brouznouf)
+ - Michael Babker (mbabker)
+ - Olivier Dolbeau (odolbeau)
  - Florian Voutzinos (florianv)
- - Teoh Han Hui (teohhanhui)
- - Przemysław Bogusz (przemyslaw-bogusz)
+ - zairig imad (zairigimad)
  - Colin Frei
  - Javier Spagnoletti (phansys)
- - Vincent Langlet (deviling)
+ - Tugdual Saunier (tucksaun)
  - excelwebzone
+ - Jérôme Parmentier (lctrs)
  - HeahDude
- - Joel Wurtz (brouznouf)
+ - Richard van Laak (rvanlaak)
  - Paráda József (paradajozsef)
- - Baptiste Clavié (talus)
+ - Alessandro Lai (jean85)
  - Alexander Schwenn (xelaris)
  - Fabien Pennequin (fabienpennequin)
  - Gordon Franke (gimler)
- - Malte Schlüter (maltemaltesich)
- - Ruud Kamphuis (ruudk)
- - Vasilij Dusko
- - Yanick Witschi (toflar)
- - Daniel Wehner (dawehner)
- - Tugdual Saunier (tucksaun)
- - Mathias Arlaud (mtarld)
- - Robert Schönthal (digitalkaoz)
- - Eric GELOEN (gelo)
- - Gary PEGEOT (gary-p)
+ - Jeroen Spee (jeroens)
+ - Christopher Hertel (chertel)
  - Gabriel Caruso
+ - Anthony GRASSIOT (antograssiot)
+ - Jan Rosier (rosier)
+ - Daniel Wehner (dawehner)
+ - Hugo Monteiro (monteiro)
+ - Baptiste Leduc (korbeil)
+ - Marco Pivetta (ocramius)
+ - Robert Schönthal (digitalkaoz)
+ - Võ Xuân Tiến (tienvx)
+ - fd6130 (fdtvui)
+ - Tigran Azatyan (tigranazatyan)
+ - Eric GELOEN (gelo)
+ - Matthieu Napoli (mnapoli)
+ - Tomáš Votruba (tomas_votruba)
  - Joshua Thijssen
  - Stefano Sala (stefano.sala)
- - Mathieu Lechat (mat_the_cat)
- - Maxime Helias (maxhelias)
+ - Alessandro Chitolina (alekitto)
+ - Valentine Boineau (valentineboineau)
+ - Jeroen Noten (jeroennoten)
+ - Gocha Ossinkine (ossinkine)
+ - Andreas Möller (localheinz)
  - OGAWA Katsuhiro (fivestar)
  - Jhonny Lidfors (jhonne)
- - jeremyFreeAgent (jeremyfreeagent)
+ - Martin Hujer (martinhujer)
+ - Wouter J
+ - Timo Bakx (timobakx)
  - Juti Noppornpitak (shiroyuki)
- - Gregor Harlan (gharlan)
- - Smaine Milianni (ismail1432)
+ - Joe Bennett (kralos)
  - Anthony MARTIN
+ - Colin O&#039;Dell (colinodell)
  - Sebastian Hörl (blogsh)
- - Tigran Azatyan (tigranazatyan)
- - Ion Bazan (ionbazan)
+ - Ben Davies (bendavies)
+ - François-Xavier de Guillebon (de-gui_f)
  - Daniel Gomes (danielcsgomes)
+ - Michael Käfer (michael_kaefer)
  - Hidenori Goto (hidenorigoto)
+ - Albert Casademont (acasademont)
  - Arnaud Kleinpeter (nanocom)
  - Guilherme Blanco (guilhermeblanco)
+ - Chi-teck
+ - Guilliam Xavier
+ - Nate Wiebe (natewiebe13)
+ - Hugo Alliaume (kocal)
+ - Michael Voříšek
  - SpacePossum
- - Richard van Laak (rvanlaak)
- - Andreas Braun
+ - Antoine Lamirault
  - Pablo Godel (pgodel)
- - Tomáš Votruba (tomas_votruba)
- - François-Xavier de Guillebon (de-gui_f)
- - Alessandro Chitolina (alekitto)
- - Rafael Dohms (rdohms)
- - jwdeitch
- - Saif Eddin Gmati (azjezz)
- - Jérôme Parmentier (lctrs)
- - Ahmed TAILOULOUTE (ahmedtai)
- - Michael Babker (mbabker)
- - Jérémy Derussé
- - Matthieu Napoli (mnapoli)
- - Arman Hosseini (arman)
- - Sokolov Evgeniy (ewgraf)
- - Rokas Mikalkėnas (rokasm)
+ - Romaric Drigon (romaricdrigon)
  - Andréia Bohner (andreia)
+ - Jannik Zschiesche
+ - Rafael Dohms (rdohms)
+ - George Mponos (gmponos)
+ - Aleksandar Jakovljevic (ajakov)
+ - jwdeitch
+ - Jurica Vlahoviček (vjurica)
+ - David Prévot
+ - Antonio Pauletich (x-coder264)
+ - Vincent Touzet (vincenttouzet)
+ - Fabien Bourigault (fbourigault)
+ - Farhad Safarov (safarov)
+ - Jérémy Derussé
+ - Nicolas Philippe (nikophil)
+ - Andreas Schempp (aschempp)
+ - mcfedr (mcfedr)
+ - Denis Brumann (dbrumann)
+ - Maciej Malarz (malarzm)
+ - Soner Sayakci
+ - Artem Lopata
+ - Sokolov Evgeniy (ewgraf)
+ - Stadly
+ - Justin Hileman (bobthecow)
  - Niels Keurentjes (curry684)
  - Vyacheslav Pavlov
- - Albert Casademont (acasademont)
- - George Mponos (gmponos)
+ - Dāvis Zālītis (k0d3r1s)
  - Richard Shank (iampersistent)
- - Marco Pivetta (ocramius)
- - Vincent Touzet (vincenttouzet)
- - Simon Berger
- - Olivier Dolbeau (odolbeau)
+ - Andre Rømcke (andrerom)
+ - Dmitrii Poddubnyi (karser)
+ - soyuka
  - Rouven Weßling (realityking)
- - YaFou
+ - Zmey
  - Clemens Tolboom
  - Oleg Voronkovich
  - Helmer Aaviksoo
+ - Michał (bambucha15)
+ - Remon van de Kamp
+ - Ben Hakim
+ - Sylvain Fabre (sylfabre)
+ - Filippo Tessarotto (slamdunk)
  - 77web
+ - Bohan Yang (brentybh)
+ - Bastien Jaillot (bastnic)
+ - W0rma
  - Matthieu Ouellette-Vachon (maoueh)
+ - Lynn van der Berg (kjarli)
  - Michał Pipa (michal.pipa)
  - Dawid Nowak
- - Jannik Zschiesche
- - Roman Martinuk (a2a4)
  - Amal Raghav (kertz)
  - Jonathan Ingram
+ - Fritz Michael Gschwantner (fritzmg)
  - Artur Kotyrba
- - Wouter J
  - Tyson Andre
+ - Thomas Landauer (thomas-landauer)
  - GDIBass
  - Samuel NELA (snela)
+ - dFayet
+ - Karoly Gossler (connorhu)
  - Vincent AUBERT (vincent)
- - Fabien Bourigault (fbourigault)
- - zairig imad (zairigimad)
- - Colin O&#039;Dell (colinodell)
- - Ben Davies (bendavies)
+ - Sebastien Morel (plopix)
+ - Sergey (upyx)
+ - Yoann RENARD (yrenard)
+ - BoShurik
+ - Timothée Barray (tyx)
  - James Halsall (jaitsu)
- - Christian Scheb
- - Guillaume (guill)
+ - Hubert Lenoir (hubert_lenoir)
  - Florent Mata (fmata)
- - Christopher Hertel (chertel)
  - Mikael Pajunen
  - Warnar Boekkooi (boekkooi)
- - Justin Hileman (bobthecow)
- - Alessandro Lai (jean85)
- - Anthony GRASSIOT (antograssiot)
+ - Marco Petersen (ocrampete16)
+ - Benjamin Leveque (benji07)
  - Dmitrii Chekaliuk (lazyhammer)
  - Clément JOBEILI (dator)
+ - Vilius Grigaliūnas
  - Tom Van Looy (tvlooy)
  - Marek Štípek (maryo)
- - Jesse Rushlow (geeshoe)
+ - Patrick Landolt (scube)
+ - François Pluchino (francoispluchino)
  - Daniel Espendiller
  - Arnaud PETITPAS (apetitpa)
  - Dorian Villet (gnutix)
- - Martin Hujer (martinhujer)
+ - Alexey Kopytko (sanmai)
  - Sergey Linnik (linniksa)
  - Richard Miller
+ - Leo Feyer (leofeyer)
  - Mario A. Alvarez Garcia (nomack84)
  - Thomas Rabaix (rande)
  - D (denderello)
+ - Jonathan Scheiber (jmsche)
  - DQNEO
- - David Prévot
- - Andre Rømcke (andrerom)
- - Jeroen Spee (jeroens)
- - Andreas Schempp (aschempp)
+ - Andrii Bodnar
+ - Artem (artemgenvald)
+ - ivan
+ - Sergey Belyshkin (sbelyshkin)
+ - Urinbayev Shakhobiddin (shokhaa)
+ - Ahmed Raafat
+ - Philippe Segatori
+ - Thibaut Cheymol (tcheymol)
+ - Julien Pauli
+ - Islam Israfilov (islam93)
+ - Oleg Andreyev (oleg.andreyev)
+ - Thomas Lallement (raziel057)
+ - Daniel Gorgan
+ - Hendrik Luup (hluup)
+ - Martin Herndl (herndlm)
  - Ruben Gonzalez (rubenrua)
  - Benjamin Dulau (dbenjamin)
- - mcfedr (mcfedr)
- - Remon van de Kamp
+ - Pavel Kirpitsov (pavel-kirpichyov)
  - Mathieu Lemoine (lemoinem)
  - Christian Schmidt
  - Andreas Hucks (meandmymonkey)
- - Jan Rosier (rosier)
  - Noel Guilbert (noel)
- - Stadly
+ - Hamza Makraz (makraz)
+ - Loick Piera (pyrech)
+ - Vitalii Ekert (comrade42)
+ - Clara van Miert
+ - Alexander Menshchikov
  - Stepan Anchugov (kix)
  - bronze1man
  - sun (sun)
+ - Alan Poulain (alanpoulain)
  - Larry Garfield (crell)
- - Michael Käfer (michael_kaefer)
- - Andreas Möller (localheinz)
- - Leo Feyer (leofeyer)
+ - Fabien Villepinte
+ - SiD (plbsid)
+ - Thomas Bisignani (toma)
+ - Edi Modrić (emodric)
  - Philipp Wahala (hifi)
  - Nikolay Labinskiy (e-moe)
+ - Warxcell (warxcell)
  - Martin Schuhfuß (usefulthink)
  - apetitpa
+ - Vladyslav Loboda
  - Pierre Minnieur (pminnieur)
+ - Kyle
  - Dominique Bongiraud
- - Hugo Monteiro (monteiro)
- - Baptiste Leduc (korbeil)
- - Timo Bakx (timobakx)
- - Dmitrii Poddubnyi (karser)
- - Julien Pauli
+ - Hidde Wieringa (hiddewie)
+ - Christopher Davis (chrisguitarguy)
  - Florian Lonqueu-Brochard (florianlb)
- - Joe Bennett (kralos)
  - Leszek Prabucki (l3l0)
+ - Emanuele Panzeri (thepanz)
+ - Matthew Smeets
  - François Zaninotto (fzaninotto)
  - Dustin Whittle (dustinwhittle)
  - jeff
  - John Kary (johnkary)
- - Võ Xuân Tiến (tienvx)
- - fd6130 (fdtvui)
- - Maciej Malarz (malarzm)
+ - smoench
  - Michele Orselli (orso)
- - Denis Brumann (dbrumann)
  - Sven Paulus (subsven)
+ - Daniel STANCU
+ - Markus Fasselt (digilist)
  - Maxime Veber (nek-)
- - Valentine Boineau (valentineboineau)
+ - Marcin Sikoń (marphi)
+ - Martin Auswöger
+ - Sullivan SENECHAL (soullivaneuh)
  - Rui Marinho (ruimarinho)
- - Patrick Landolt (scube)
- - Filippo Tessarotto (slamdunk)
- - Jeroen Noten (jeroennoten)
+ - Marc Weistroff (futurecat)
+ - Dimitri Gritsajuk (ottaviano)
  - Possum
  - Jérémie Augustin (jaugustin)
- - Edi Modrić (emodric)
  - Pascal Montoya
  - Julien Brochet
- - Gocha Ossinkine (ossinkine)
- - François Pluchino (francoispluchino)
+ - Michaël Perrin (michael.perrin)
+ - Wojciech Kania
  - Tristan Darricau (tristandsensio)
+ - Fabien S (bafs)
  - Victor Bocharsky (bocharsky_bw)
+ - Sébastien Alfaiate (seb33300)
  - henrikbjorn
- - Fritz Michael Gschwantner (fritzmg)
+ - Alex Bowers
  - Marcel Beerta (mazen)
- - Chi-teck
+ - Phil Taylor (prazgod)
+ - flack (flack)
+ - Craig Duncan (duncan3dc)
  - Mantis Development
- - Guilliam Xavier
- - Hidde Wieringa (hiddewie)
- - dFayet
- - Antonio Pauletich (x-coder264)
+ - Pablo Lozano (arkadis)
+ - quentin neyrat (qneyrat)
+ - Antonio Jose Cerezo (ajcerezo)
+ - Marcin Szepczynski (czepol)
+ - Lescot Edouard (idetox)
  - Rob Frawley 2nd (robfrawley)
+ - Mohammad Emran Hasan (phpfour)
+ - Dmitriy Mamontov (mamontovdmitriy)
  - Nikita Konstantinov (unkind)
  - Michael Lee (zerustech)
  - Dariusz
- - soyuka
- - Farhad Safarov (safarov)
- - Nate Wiebe (natewiebe13)
- - Hugo Alliaume (kocal)
- - Michael Voříšek
  - Francois Zaninotto
+ - Laurent Masforné (heisenberg)
+ - Claude Khedhiri (ck-developer)
  - Daniel Tschinder
  - Christian Schmidt
  - Alexander Kotynia (olden)
+ - Toni Rudolf (toooni)
  - Elnur Abdurrakhimov (elnur)
+ - Iker Ibarguren (ikerib)
  - Manuel Reinhard (sprain)
- - Nicolas Philippe (nikophil)
+ - Johann Pardanaud
+ - Indra Gunawan (indragunawan)
+ - Tim Goudriaan (codedmonkey)
+ - Harm van Tilborg (hvt)
+ - Baptiste Lafontaine (magnetik)
+ - Dries Vints
  - Adam Prager (padam87)
+ - Judicaël RUFFIEUX (axanagor)
  - Benoît Burnichon (bburnichon)
  - maxime.steinhausser
+ - simon chrzanowski (simonch)
+ - Andrew M-Y (andr)
+ - Krasimir Bosilkov (kbosilkov)
+ - Marcin Michalski (marcinmichalski)
  - Roman Ring (inori)
  - Xavier Montaña Carreras (xmontana)
- - Timothée Barray (tyx)
- - Romaric Drigon (romaricdrigon)
- - Sylvain Fabre (sylfabre)
- - Soner Sayakci
+ - Tarmo Leppänen (tarlepp)
+ - AnneKir
+ - Bob van de Vijver (bobvandevijver)
+ - Tobias Weichart
+ - Miro Michalicka
+ - M. Vondano
  - Xavier Perez
  - Arjen Brouwer (arjenjb)
- - Artem Lopata
+ - Tavo Nieves J (tavoniievez)
+ - Lukáš Holeczy (holicz)
+ - Arjen van der Meijden
  - Patrick McDougle (patrick-mcdougle)
- - Marc Weistroff (futurecat)
+ - Jerzy (jlekowski)
  - Danny Berger (dpb587)
+ - Marek Zajac
  - Alif Rachmawadi
  - Anton Chernikov (anton_ch1989)
  - Pierre-Yves Lebecq (pylebecq)
- - Benjamin Leveque (benji07)
+ - Alireza Mirsepassi (alirezamirsepassi)
  - Jordan Samouh (jordansamouh)
- - Sullivan SENECHAL (soullivaneuh)
- - Loick Piera (pyrech)
+ - Koen Reiniers (koenre)
+ - Nathan Dench (ndenc2)
+ - Gijs van Lammeren
+ - Matthew Grasmick
+ - David Badura (davidbadura)
  - Uwe Jäger (uwej711)
- - Dāvis Zālītis (k0d3r1s)
- - Lynn van der Berg (kjarli)
- - Michaël Perrin (michael.perrin)
  - Eugene Leonovich (rybakit)
  - Joseph Rouff (rouffj)
  - Félix Labrecque (woodspire)
  - GordonsLondon
+ - Roman Anasal
  - Jan Sorgalla (jsor)
+ - Piotr Kugla (piku235)
  - Ray
  - Philipp Cordes (corphi)
  - Chekote
- - Aleksandar Jakovljevic (ajakov)
+ - bhavin (bhavin4u)
+ - Pavel Popov (metaer)
  - Thomas Adam
- - Thomas Landauer (thomas-landauer)
+ - R. Achmad Dadang Nur Hidayanto (dadangnh)
+ - Stefan Kruppa
+ - Petr Duda (petrduda)
+ - Marcos Rezende (rezende79)
  - jdhoek
- - Jurica Vlahoviček (vjurica)
+ - Ivan Kurnosov
+ - Dieter
  - Bob den Otter (bopp)
+ - Johan Vlaar (johjohan)
  - Thomas Schulz (king2500)
+ - Benjamin Morel
+ - Bernd Stellwag
  - Frank de Jonge
- - Jules Pietri
- - Sebastien Morel (plopix)
- - Christopher Davis (chrisguitarguy)
- - Karoly Gossler (connorhu)
+ - Chris Tanaskoski
+ - julien57
+ - Ben Ramsey (ramsey)
  - Matthieu Auger (matthieuauger)
  - Josip Kruslin (jkruslin)
- - Thomas Lallement (raziel057)
- - Sergey (upyx)
  - Giorgio Premi
  - renanbr
  - Sébastien Lavoie (lavoiesl)
@@ -398,782 +505,1159 @@ The Symfony Connect username in parenthesis allows to get more information
  - Beau Simensen (simensen)
  - Robert Kiss (kepten)
  - Zan Baldwin (zanbaldwin)
+ - Alexis Lefebvre
  - Antonio J. García Lagar (ajgarlag)
  - Alexandre Quercia (alquerci)
  - Marcos Sánchez
- - BoShurik
- - Zmey
+ - Jérôme Tanghe (deuchnord)
  - Kim Hemsø Rasmussen (kimhemsoe)
- - Oleg Andreyev (oleg.andreyev)
+ - Dane Powell
  - jaugustin
+ - Dmytro Borysovskyi (dmytr0)
+ - Mathias STRASSER (roukmoute)
  - Pascal Luna (skalpa)
  - Wouter Van Hecke
- - Baptiste Lafontaine (magnetik)
- - Iker Ibarguren (ikerib)
- - Indra Gunawan (indragunawan)
  - Peter Kruithof (pkruithof)
- - Antoine Lamirault
  - Michael Holm (hollo)
- - Arjen van der Meijden
+ - Giso Stallenberg (gisostallenberg)
  - Blanchon Vincent (blanchonvincent)
- - Michał (bambucha15)
  - Christian Schmidt
- - Marcin Sikoń (marphi)
- - Ben Hakim
- - Marco Petersen (ocrampete16)
- - Bohan Yang (brentybh)
- - Bastien Jaillot (bastnic)
- - Vilius Grigaliūnas
- - David Badura (davidbadura)
- - Alan Poulain (alanpoulain)
+ - Gonzalo Vilaseca (gonzalovilaseca)
+ - Vadim Borodavko (javer)
+ - Haralan Dobrev (hkdobrev)
+ - Soufian EZ ZANTAR (soezz)
+ - Jan van Thoor (janvt)
+ - Martin Kirilov (wucdbm)
  - Chris Smith (cs278)
- - Thomas Bisignani (toma)
  - Florian Klein (docteurklein)
- - W0rma
+ - Damien Alexandre (damienalexandre)
+ - Bilge
+ - Rhodri Pugh (rodnaph)
  - Manuel Kiessling (manuelkiessling)
- - Alexey Kopytko (sanmai)
+ - Patrick Reimers (preimers)
+ - Anatoly Pashin (b1rdex)
+ - Pol Dellaiera (drupol)
  - Atsuhiro KUBO (iteman)
  - rudy onfroy (ronfroy)
  - Serkan Yildiz (srknyldz)
+ - Jeroen Thora (bolle)
  - Andrew Moore (finewolf)
  - Bertrand Zuchuat (garfield-fr)
  - Marc Morera (mmoreram)
- - Sébastien Alfaiate (seb33300)
+ - Quynh Xuan Nguyen (seriquynh)
  - Gabor Toth (tgabi333)
  - realmfoo
  - Thomas Tourlourat (armetiz)
  - Andrey Esaulov (andremaha)
+ - Simon Podlipsky (simpod)
  - Grégoire Passault (gregwar)
  - Jerzy Zawadzki (jzawadzki)
  - Ismael Ambrosi (iambrosi)
- - Craig Duncan (duncan3dc)
+ - Saif Eddin G
  - Emmanuel BORGES (eborges78)
  - Aurelijus Valeiša (aurelijus)
+ - Evert Harmeling (evertharmeling)
  - Jan Decavele (jandc)
  - Gustavo Piltcher
+ - Grenier Kévin (mcsky_biig)
  - Stepan Tanasiychuk (stfalcon)
- - Ivan Kurnosov
  - Tiago Ribeiro (fixe)
  - Raul Fraile (raulfraile)
  - Adrian Rudnik (kreischweide)
  - Pavel Batanov (scaytrase)
  - Francesc Rosàs (frosas)
  - Bongiraud Dominique
- - Kyle
  - janschoenherr
+ - Marko Kaznovac (kaznovac)
  - Emanuele Gaspari (inmarelibero)
  - Dariusz Rumiński
- - Andrii Bodnar
- - Artem (artemgenvald)
+ - Romain Monteil (ker0x)
+ - Terje Bråten
+ - Gennadi Janzen
+ - James Hemery
+ - Egor Taranov
+ - Philippe Segatori
+ - Loïc Frémont (loic425)
+ - Adrian Nguyen (vuphuong87)
+ - benjaminmal
  - Thierry T (lepiaf)
  - Lorenz Schori
+ - Andrey Sevastianov
+ - Oleksandr Barabolia (oleksandrbarabolia)
+ - Khoo Yong Jun
+ - Christin Gruber (christingruber)
  - Jeremy Livingston (jeremylivingston)
- - ivan
- - Urinbayev Shakhobiddin (shokhaa)
- - Ahmed Raafat
- - Philippe Segatori
- - Thibaut Cheymol (tcheymol)
+ - Julien Turby
+ - scyzoryck
+ - Greg Anderson
+ - Tri Pham (phamuyentri)
+ - marie
+ - Erkhembayar Gantulga (erheme318)
+ - Fractal Zombie
+ - Gunnstein Lye (glye)
+ - Kévin THERAGE (kevin_therage)
+ - Noémi Salaün (noemi-salaun)
+ - Michel Hunziker
+ - Krystian Marcisz (simivar)
+ - Matthias Krauser (mkrauser)
  - Erin Millard
+ - Lorenzo Millucci (lmillucci)
+ - Jérôme Tamarelle (jtamarelle-prismamedia)
+ - Emil Masiakowski
+ - Alexandre Parent
+ - DT Inier (gam6itko)
  - Matthew Lewinski (lewinski)
  - Magnus Nordlander (magnusnordlander)
- - Islam Israfilov (islam93)
  - Ricard Clau (ricardclau)
+ - Dmitrii Tarasov (dtarasov)
+ - Philipp Kolesnikov
+ - Maxim Dovydenok (shiftby)
+ - Carlos Pereira De Amorim (epitre)
+ - Rodrigo Aguilera
  - Roumen Damianoff
+ - Vladimir Varlamov (iamvar)
  - Thomas Royer (cydonia7)
+ - Gildas Quéméner (gquemener)
  - Nicolas LEFEVRE (nicoweb)
- - Emanuele Panzeri (thepanz)
+ - Martins Sipenko
+ - Guilherme Augusto Henschel
+ - Mardari Dorel (dorumd)
+ - Pierrick VIGNAND (pierrick)
  - Mateusz Sip (mateusz_sip)
+ - Andy Palmer (andyexeter)
+ - Marko H. Tamminen (gzumba)
  - Francesco Levorato
+ - Ippei Sumida (ippey_s)
+ - DerManoMann
+ - David Molineus
+ - Desjardins Jérôme (jewome62)
  - Vitaliy Zakharov (zakharovvi)
  - Tobias Sjösten (tobiassjosten)
  - Gyula Sallai (salla)
- - Bob van de Vijver (bobvandevijver)
- - Hendrik Luup (hluup)
+ - Benjamin Cremer (bcremer)
+ - rtek
  - Inal DJAFAR (inalgnu)
  - Christian Gärtner (dagardner)
- - Martin Herndl (herndlm)
- - Dmytro Borysovskyi (dmytr0)
+ - Adrien Jourdier (eclairia)
+ - Ivan Grigoriev (greedyivan)
  - Tomasz Kowalczyk (thunderer)
- - Johann Pardanaud
- - Pavel Kirpitsov (pavel-kirpichyov)
+ - Erik Saunier (snickers)
+ - Kevin SCHNEKENBURGER
+ - Fabien Salles (blacked)
  - Artur Eshenbrener
- - Harm van Tilborg (hvt)
+ - Ahmed Ashraf (ahmedash95)
+ - Gert Wijnalda (cinamo)
+ - Luca Saba (lucasaba)
  - Thomas Perez (scullwm)
- - Yoann RENARD (yrenard)
- - smoench
+ - Thomas P
+ - Kristijan Kanalaš (kristijan_kanalas_infostud)
  - Felix Labrecque
  - Yaroslav Kiliba
+ - “Filip
+ - Simon Watiau (simonwatiau)
+ - Ruben Jacobs (rubenj)
+ - William Arslett
+ - Arkadius Stefanski (arkadius)
+ - Jérémy M (th3mouk)
  - Terje Bråten
- - Gonzalo Vilaseca (gonzalovilaseca)
- - Markus Fasselt (digilist)
- - Tim Goudriaan (codedmonkey)
- - Tarmo Leppänen (tarlepp)
- - Martin Auswöger
+ - Pierre Rineau
+ - Renan Gonçalves (renan_saddam)
+ - Raulnet
+ - Tomasz Kusy
  - Jakub Kucharovic (jkucharovic)
- - Daniel STANCU
  - Kristen Gilden
- - Hubert Lenoir (hubert_lenoir)
  - Robbert Klarenbeek (robbertkl)
- - Hamza Makraz (makraz)
  - Eric Masoero (eric-masoero)
- - Vitalii Ekert (comrade42)
- - Clara van Miert
- - Haralan Dobrev (hkdobrev)
+ - Michael Lutz
+ - Michel Roca (mroca)
+ - Reedy
  - hossein zolfi (ocean)
- - Alexander Menshchikov
  - Clément Gautier (clementgautier)
- - Damien Alexandre (damienalexandre)
+ - Jelle Raaijmakers (gmta)
+ - Roberto Nygaard
+ - Joshua Nye
+ - Dalibor Karlović
+ - Randy Geraads
  - Sanpi (sanpi)
  - Eduardo Gulias (egulias)
+ - Andreas Leathley (iquito)
+ - Nathanael Noblet (gnat)
  - giulio de donato (liuggio)
+ - Mohamed Gamal
+ - Eric COURTIAL
+ - Xesxen
  - ShinDarth
+ - Arun Philip
  - Stéphane PY (steph_py)
+ - Cătălin Dan (dancatalin)
  - Philipp Kräutli (pkraeutli)
- - Rhodri Pugh (rodnaph)
+ - Carl Casbolt (carlcasbolt)
+ - battye
  - Grzegorz (Greg) Zdanowski (kiler129)
- - Dimitri Gritsajuk (ottaviano)
  - Kirill chEbba Chebunin
- - Pol Dellaiera (drupol)
+ - kylekatarnls (kylekatarnls)
+ - Steve Grunwell
  - 
  - Alex (aik099)
- - Fabien Villepinte
- - SiD (plbsid)
+ - Axel Guckelsberger (guite)
  - Greg Thornton (xdissent)
- - Alex Bowers
- - Quynh Xuan Nguyen (seriquynh)
+ - BENOIT POLASZEK (bpolaszek)
+ - Shaharia Azam
+ - Gerben Oolbekkink
+ - Alexandre Parent
+ - Thibault Richard (t-richard)
+ - Oleksii Zhurbytskyi
+ - Guillaume Verstraete
+ - vladimir.panivko
+ - Jason Tan (jt2k)
+ - Jérémy REYNAUD (babeuloula)
  - Costin Bereveanu (schniper)
+ - kick-the-bucket
  - Marek Kalnik (marekkalnik)
+ - Jeremiasz Major
  - Vyacheslav Salakhutdinov (megazoll)
+ - Trevor North
  - Maksym Slesarenko (maksym_slesarenko)
  - Hassan Amouhzi
- - Warxcell (warxcell)
- - Daniel Gorgan
+ - Antonin CLAUZIER (0x346e3730)
+ - Andrei C. (moldman)
  - Tamas Szijarto
+ - stlrnz
+ - Adrien Wilmet (adrienfr)
+ - Yannick Ihmels (ihmels)
+ - Alex Bacart
+ - hugovms
  - Michele Locati
  - Pavel Volokitin (pvolok)
+ - DemigodCode
  - Arthur de Moulins (4rthem)
  - Matthias Althaus (althaus)
- - Saif Eddin G
+ - Maximilian Bösing
+ - Leevi Graham (leevigraham)
  - Endre Fejes
+ - Carlos Buenosvinos (carlosbuenosvinos)
+ - Jake (jakesoft)
  - Tobias Naumann (tna)
+ - Greg ORIOL
+ - Bahman Mehrdad (bahman)
  - Daniel Beyer
- - flack (flack)
+ - Manuel Alejandro Paz Cetina
+ - Youssef Benhssaien (moghreb)
+ - Mario Ramundo (rammar)
+ - Ivan
  - Shein Alexey
- - Phil Taylor (prazgod)
+ - Nico Haase
+ - Jacek Jędrzejewski (jacek.jedrzejewski)
+ - Stefan Kruppa
+ - Shahriar56
+ - Dhananjay Goratela
+ - Kien Nguyen
  - Joe Lencioni
+ - arai
+ - Mouad ZIANI (mouadziani)
  - Daniel Tschinder
  - Diego Agulló (aeoris)
+ - Tomasz Ignatiuk
+ - Joachim Løvgaard (loevgaard)
  - vladimir.reznichenko
+ - Shakhobiddin
  - Kai
  - Lee Rowlands
  - Maximilian Reichel (phramz)
+ - siganushka (siganushka)
  - Alain Hippolyte (aloneh)
- - Grenier Kévin (mcsky_biig)
  - Karoly Negyesi (chx)
  - Xavier HAUSHERR
+ - Loïc Beurlet
+ - Ana Raro
+ - Ana Raro
+ - Tom Klingenberg
+ - Florian Wolfsjaeger (flowolf)
+ - Ivan Sarastov (isarastov)
+ - Jordi Sala Morales (jsala)
  - Albert Jessurum (ajessu)
+ - Samuele Lilli (doncallisto)
+ - Peter Bowyer (pbowyer)
  - Romain Pierre
  - Laszlo Korte
- - Jonathan Scheiber (jmsche)
+ - Gabrielle Langer
  - Alessandro Desantis
  - hubert lecorche (hlecorche)
- - Vladyslav Loboda
+ - bogdan
+ - mmokhi
+ - Daniel Tiringer
+ - Andrew Codispoti
+ - Lctrs
+ - Joppe De Cuyper (joppedc)
  - Marc Morales Valldepérez (kuert)
  - Vadim Kharitonov (vadim)
  - Oscar Cubo Medina (ocubom)
  - Karel Souffriau
+ - Andrii Dembitskyi
  - Christophe L. (christophelau)
+ - Daniël Brekelmans (dbrekelmans)
+ - Simon Heimberg (simon_heimberg)
+ - Morten Wulff (wulff)
+ - Sander Toonen (xatoo)
  - Anthon Pang (robocoder)
  - Julien Galenski (ruian)
+ - Rimas Kudelis
  - Ben Scott (bpscott)
- - Marko Kaznovac (kaznovac)
- - Pablo Lozano (arkadis)
+ - Andrii Dembitskyi
+ - Pavol Tuka
+ - Paulo Ribeiro (paulo)
+ - Marc Laporte
+ - Michał Jusięga
+ - Dmitriy Derepko
+ - Sebastian Paczkowski (sebpacz)
+ - Dragos Protung (dragosprotung)
+ - Thiago Cordeiro (thiagocordeiro)
+ - Julien Maulny
  - Brian King
- - quentin neyrat (qneyrat)
- - Chris Tanaskoski
  - Steffen Roßkamp
  - Alexandru Furculita (afurculita)
  - Michel Salib (michelsalib)
  - Valentin Jonovs
  - geoffrey
+ - Bastien DURAND (deamon)
+ - Jon Gotlin (jongotlin)
  - Jeanmonod David (jeanmonod)
+ - Daniel González (daniel.gonzalez)
+ - Renan (renanbr)
  - Webnet team (webnet)
- - Ben Ramsey (ramsey)
  - Berny Cantos (xphere81)
- - Antonio Jose Cerezo (ajcerezo)
- - Marcin Szepczynski (czepol)
- - Lescot Edouard (idetox)
- - Mohammad Emran Hasan (phpfour)
- - Dmitriy Mamontov (mamontovdmitriy)
+ - Mátyás Somfai (smatyas)
  - Jan Schumann
  - Niklas Fiekas
  - Mark Challoner (markchalloner)
  - Markus Bachmann (baachi)
- - Kévin THERAGE (kevin_therage)
- - Gunnstein Lye (glye)
- - Erkhembayar Gantulga (erheme318)
- - Alexis Lefebvre
- - Greg Anderson
+ - Roger Guasch (rogerguasch)
+ - Luis Tacón (lutacon)
+ - Andrii Popov (andrii-popov)
  - lancergr
- - Tri Pham (phamuyentri)
  - Ivan Nikolaev (destillat)
- - Gildas Quéméner (gquemener)
- - Laurent Masforné (heisenberg)
- - Claude Khedhiri (ck-developer)
- - Desjardins Jérôme (jewome62)
+ - Xavier Leune (xleune)
+ - Ben Roberts (benr77)
+ - Joost van Driel (j92)
+ - ampaze
  - Arturs Vonda
- - Matthew Smeets
- - Toni Rudolf (toooni)
+ - Xavier Briand (xavierbriand)
  - Asmir Mustafic (goetas)
  - vagrant
- - Benjamin Cremer (bcremer)
  - Asier Illarramendi (doup)
  - AKeeman (akeeman)
  - Martijn Cuppens
  - Restless-ET
  - Vlad Gregurco (vgregurco)
  - Boris Vujicic (boris.vujicic)
- - Dries Vints
- - Judicaël RUFFIEUX (axanagor)
  - Chris Sedlmayr (catchamonkey)
- - DerManoMann
- - Jérôme Tanghe (deuchnord)
- - Mathias STRASSER (roukmoute)
- - simon chrzanowski (simonch)
+ - mondrake (mondrake)
  - Kamil Kokot (pamil)
  - Seb Koelen
  - Christoph Mewes (xrstf)
- - Andrew M-Y (andr)
- - Krasimir Bosilkov (kbosilkov)
- - Marcin Michalski (marcinmichalski)
  - Vitaliy Tverdokhlib (vitaliytv)
  - Ariel Ferrandini (aferrandini)
+ - Niklas Keller
  - Dirk Pahl (dirkaholic)
  - Cédric Lombardot (cedriclombardot)
- - Dane Powell
- - Arkadius Stefanski (arkadius)
  - Jonas Flodén (flojon)
- - AnneKir
- - Tobias Weichart
- - Miro Michalicka
- - M. Vondano
+ - Stefan Gehrig (sgehrig)
+ - Adrien Lucas (adrienlucas)
  - Dominik Zogg
- - Tavo Nieves J (tavoniievez)
+ - Kai Dederichs
  - Luc Vieillescazes (iamluc)
- - Lukáš Holeczy (holicz)
- - Erik Saunier (snickers)
+ - Thomas Nunninger
  - François Dume (franek)
- - Jerzy (jlekowski)
- - Raulnet
- - Giso Stallenberg (gisostallenberg)
  - Rob Bast
  - Roberto Espinoza (respinoza)
- - Pierre Rineau
- - Soufian EZ ZANTAR (soezz)
- - Marek Zajac
  - Adam Harvey
- - Cătălin Dan (dancatalin)
  - ilyes kooli (skafandri)
  - Anton Bakai
- - battye
  - Sam Fleming (sam_fleming)
  - Alex Bakhturin
- - Patrick Reimers (preimers)
  - Brayden Williams (redstar504)
  - insekticid
- - Jérémy M (th3mouk)
+ - Trent Steel (trsteel88)
+ - Vitaliy Ryaboy (vitaliy)
  - boombatower
- - Alireza Mirsepassi (alirezamirsepassi)
+ - Douglas Hammond (wizhippo)
  - Jérôme Macias (jeromemacias)
  - Andrey Astakhov (aast)
  - ReenExe
  - Fabian Lange (codingfabian)
  - Yoshio HANAWA
- - Jan van Thoor (janvt)
- - Joshua Nye
- - Martin Kirilov (wucdbm)
- - Koen Reiniers (koenre)
- - Nathan Dench (ndenc2)
- - Gijs van Lammeren
+ - Toon Verwerft (veewee)
+ - Gert de Pagter
  - Sebastian Bergmann
- - Matthew Grasmick
  - Miroslav Šustek (sustmi)
  - Pablo Díez (pablodip)
+ - Damien Fa
  - Kevin McBride
  - Sergio Santoro
+ - James Gilliland (neclimdul)
  - Philipp Rieber (bicpi)
+ - Dennis Væversted (srnzitcom)
  - Manuel de Ruiter (manuel)
- - Nathanael Noblet (gnat)
  - nikos.sotiropoulos
- - BENOIT POLASZEK (bpolaszek)
  - Eduardo Oliveira (entering)
- - Oleksii Zhurbytskyi
- - Bilge
  - Eugene Wissner
  - Ricardo Oliveira (ricardolotr)
  - Roy Van Ginneken (rvanginneken)
  - ondrowan
  - Barry vd. Heuvel (barryvdh)
+ - Jon Dufresne
  - Chad Sikorra (chadsikorra)
- - Fabien S (bafs)
  - Evan S Kaufman (evanskaufman)
+ - Jonathan Sui Lioung Lee Slew (jlslew)
  - mcben
  - Jérôme Vieilledent (lolautruche)
- - Roman Anasal
  - Filip Procházka (fprochazka)
- - Jeroen Thora (bolle)
+ - stoccc
  - Markus Lanthaler (lanthaler)
+ - Xav` (xavismeh)
  - Remi Collet
- - Piotr Kugla (piku235)
+ - Mathieu Rochette (mathroc)
  - Vicent Soria Durá (vicentgodella)
  - Michael Moravec
- - Leevi Graham (leevigraham)
  - Anthony Ferrara
+ - Christian Gripp (core23)
+ - Marcel Hernandez
  - Ioan Negulescu
- - Greg ORIOL
  - Jakub Škvára (jskvara)
  - Andrew Udvare (audvare)
  - alexpods
+ - Dennis Langen (nijusan)
  - Adam Szaraniec
  - Dariusz Ruminski
  - Romain Gautier (mykiwi)
+ - Cyril Pascal (paxal)
  - Matthieu Bontemps
  - Erik Trapman
  - De Cock Xavier (xdecock)
- - Evert Harmeling (evertharmeling)
  - Nicolas Dewez (nicolas_dewez)
+ - Quentin Dreyer
  - Scott Arciszewski
  - Xavier HAUSHERR
+ - Achilles Kaloeridis (achilles)
  - Norbert Orzechowicz (norzechowicz)
+ - Robert-Jan de Dreu
  - Fabrice Bernhard (fabriceb)
  - Matthijs van den Bos (matthijs)
- - bhavin (bhavin4u)
  - Jaik Dean (jaikdean)
  - Krzysztof Piasecki (krzysztek)
- - Pavel Popov (metaer)
  - Lenard Palko
  - Nils Adermann (naderman)
- - Tom Klingenberg
  - Gábor Fási
- - R. Achmad Dadang Nur Hidayanto (dadangnh)
  - Nate (frickenate)
- - Stefan Kruppa
- - Jacek Jędrzejewski (jacek.jedrzejewski)
- - Stefan Kruppa
  - sasezaki
+ - Kristof Van Cauwenbergh (kristofvc)
  - Dawid Pakuła (zulusx)
+ - Marco Lipparini (liarco)
  - Florian Rey (nervo)
  - Rodrigo Borrego Bernabé (rodrigobb)
  - John Bafford (jbafford)
  - Emanuele Iannone
- - Petr Duda (petrduda)
- - Marcos Rezende (rezende79)
+ - Ondrej Machulda (ondram)
  - Denis Gorbachev (starfall)
  - Martin Morávek (keeo)
  - Kevin Saliou (kbsali)
+ - Matthieu Mota (matthieumota)
  - Steven Surowiec (steves)
  - Shawn Iwinski
- - Dieter
- - Samuele Lilli (doncallisto)
  - Gawain Lynch (gawain)
- - Wojciech Kania
- - mmokhi
  - Ryan
  - Alexander Deruwe (aderuwe)
  - Dave Hulbert (dave1010)
+ - Konstantin Grachev (grachevko)
  - Ivan Rey (ivanrey)
  - M. (mbontemps)
  - Marcin Chyłek (songoq)
  - Ned Schwartz
+ - Anderson Müller
  - Ziumin
+ - Matthias Schmidt
  - Lenar Lõhmus
- - Sander Toonen (xatoo)
  - Zach Badgett (zachbadgett)
  - Loïc Faugeron
  - Aurélien Fredouelle
  - Pavel Campr (pcampr)
- - Andrii Dembitskyi
  - Forfarle (forfarle)
  - Johnny Robeson (johnny)
+ - Kai Eichinger (kai_eichinger)
+ - Kuba Werłos (kuba)
+ - Philipp Keck
  - Disquedur
- - Benjamin Morel
+ - Markus S. (staabm)
  - Geoffrey Tran (geoff)
+ - Elan Ruusamäe (glen)
+ - Nicolas de Marqué (nicola)
+ - a.dmitryuk
  - Jannik Zschiesche
- - Bernd Stellwag
  - Jan Ole Behrens (deegital)
- - Romain Monteil (ker0x)
  - Mantas Var (mvar)
- - Terje Bråten
+ - Paul Oms
+ - Yann LUCAS (drixs6o9)
  - Sebastian Krebs
+ - Htun Htun Htet (ryanhhh91)
+ - Sorin Pop (sorinpop)
  - Piotr Stankowski
- - Julien Maulny
- - Gennadi Janzen
- - James Hemery
- - julien57
- - Mátyás Somfai (smatyas)
- - Bastien DURAND (deamon)
+ - Stewart Malik
+ - Stefan Graupner (efrane)
+ - Gemorroj (gemorroj)
+ - Adrien Chinour
+ - Mihail Krasilnikov (krasilnikovm)
+ - iamvar
+ - Pierre Tondereau
+ - Joel Lusavuvu (enigma97)
+ - Alex Vo (votanlean)
+ - André Matthies
+ - Piergiuseppe Longo
+ - Kevin Auivinet
+ - Valentin Nazarov
+ - Aurélien MARTIN
+ - Malte Schlüter
+ - Jules Matsounga (hyoa)
+ - Quentin Dequippe (qdequippe)
+ - Yewhen Khoptynskyi (khoptynskyi)
+ - Jérôme Nadaud (jnadaud)
+ - Alexandre Tranchant (alexandre_t)
+ - Anthony Moutte
+ - shreyadenny
+ - Daniel Iwaniec
+ - Thomas Ferney (thomasf)
+ - Hallison Boaventura (hallisonboaventura)
+ - Mas Iting
+ - Albion Bame (abame)
+ - Ivan Nemets
  - Dmitry Simushev
+ - Grégoire Hébert (gregoirehebert)
  - alcaeus
  - Fred Cox
+ - Iliya Miroslavov Iliev (i.miroslavov)
+ - Safonov Nikita (ns3777k)
  - Simon DELICATA
  - vitaliytv
- - Egor Taranov
- - Philippe Segatori
- - Loïc Frémont (loic425)
- - Jon Gotlin (jongotlin)
- - Adrian Nguyen (vuphuong87)
- - benjaminmal
- - Andrey Sevastianov
- - Oleksandr Barabolia (oleksandrbarabolia)
- - Khoo Yong Jun
- - Christin Gruber (christingruber)
+ - Nicolas Martin (cocorambo)
+ - luffy1727
+ - LHommet Nicolas (nicolaslh)
  - Sebastian Blum
- - Daniel González (daniel.gonzalez)
- - Julien Turby
- - Renan
+ - Amirreza Shafaat (amirrezashafaat)
+ - Laurent Clouet
+ - Adoni Pavlakis (adoni)
+ - Alex Hofbauer (alexhofbauer)
+ - Maarten Nusteling (nusje2000)
+ - Ahmed EBEN HASSINE (famas23)
+ - Eduard Bulava (nonanerz)
  - Ricky Su (ricky)
- - scyzoryck
+ - Igor Timoshenko (igor.timoshenko)
+ - “teerasak”
  - Kyle Evans (kevans91)
+ - Benoit Mallo
  - Max Rath (drak3)
- - marie
+ - Giuseppe Campanelli
+ - Valentin
+ - pizzaminded
+ - Matthieu Calie (matth--)
  - Stéphane Escandell (sescandell)
- - Fractal Zombie
+ - ivan
+ - linh
+ - Oleg Krasavin (okwinza)
+ - Mario Blažek (marioblazek)
+ - Jure (zamzung)
  - James Johnston
- - Noémi Salaün (noemi-salaun)
+ - Michael Nelson
+ - Eric Krona
  - Sinan Eldem
  - Gennady Telegin
+ - Kajetan Kołtuniak (kajtii)
+ - Sander Goossens (sandergo90)
+ - Damien  Fayet (rainst0rm)
  - Alexandre Dupuy (satchette)
- - Michel Hunziker
+ - MatTheCat
  - Malte Blättermann
+ - Erfan Bahramali
  - Simeon Kolev (simeon_kolev9)
- - Joost van Driel (j92)
+ - Abdiel Carrazana (abdielcs)
+ - Arman
+ - Gabi Udrescu
+ - Adamo Crespi (aerendir)
  - Jonas Elfering
+ - Luis Pabon (luispabon)
+ - boulei_n
+ - Anna Filina (afilina)
  - Mihai Stancu
  - Nahuel Cuesta (ncuesta)
+ - Patrick Luca Fazzi (ap3ir0n)
  - Chris Boden (cboden)
  - EStyles (insidestyles)
  - Christophe Villeger (seragan)
- - Krystian Marcisz (simivar)
- - Matthias Krauser (mkrauser)
+ - Bruno Rodrigues de Araujo (brunosinister)
  - Julien Fredon
- - Xavier Leune (xleune)
+ - Jacek Wilczyński (jacekwilczynski)
  - Hany el-Kerdany
  - Wang Jingyu
  - Åsmund Garfors
  - Maxime Douailin
  - Jean Pasdeloup
+ - Laurent Moreau
  - Michael Hirschler (mvhirsch)
- - Lorenzo Millucci (lmillucci)
  - Javier López (loalf)
+ - tamar peled
  - Reinier Kip
- - Jérôme Tamarelle (jtamarelle-prismamedia)
  - Geoffrey Brier (geoffrey-brier)
- - Alexandre Parent
- - Roger Guasch (rogerguasch)
- - DT Inier (gam6itko)
+ - Christophe Meneses (c77men)
  - Vladimir Tsykun
+ - Andrei O
  - Dustin Dobervich (dustin10)
- - Luis Tacón (lutacon)
- - Dmitrii Tarasov (dtarasov)
+ - Alejandro Diaz Torres
+ - Karl Shea
  - dantleech
- - Philipp Kolesnikov
- - Maxim Dovydenok (shiftby)
+ - Valentin
  - Sebastian Marek (proofek)
- - Carlos Pereira De Amorim (epitre)
+ - Łukasz Chruściel (lchrusciel)
+ - Jan Vernieuwe (vernija)
  - zenmate
- - Andrii Popov (andrii-popov)
+ - j.schmitt
+ - Georgi Georgiev
  - David Fuhr
- - Rodrigo Aguilera
- - Vladimir Varlamov (iamvar)
+ - Evgeny Anisiforov
+ - TristanPouliquen
+ - mwos
  - Aurimas Niekis (gcds)
- - Martins Sipenko
- - Guilherme Augusto Henschel
+ - Volker Killesreiter (ol0lll)
+ - Vedran Mihočinec (v-m-i)
+ - creiner
+ - RevZer0 (rav)
+ - remieuronews
+ - Marek Binkowski
  - Rostyslav Kinash
+ - Andrey Lebedev (alebedev)
+ - Cristoforo Cervino (cristoforocervino)
  - Dennis Fridrich (dfridrich)
- - Mardari Dorel (dorumd)
+ - Yoann MOROCUTTI
  - Daisuke Ohata
  - Vincent Simonin
- - Pierrick VIGNAND (pierrick)
+ - Alexander Onatskiy
+ - Philipp Fritsche
+ - tarlepp
  - Alex Bogomazov (alebo)
+ - Claus Due (namelesscoder)
  - aaa2000 (aaa2000)
- - Andy Palmer (andyexeter)
+ - Guillaume Aveline
+ - Alexandru Patranescu
+ - Arkadiusz Rzadkowolski (flies)
+ - Oksana Kozlova (oksanakozlova)
+ - Quentin Moreau (sheitak)
  - Stefan Warman (warmans)
+ - Bert Ramakers
+ - Angelov Dejan (angelov)
  - Tristan Maindron (tmaindron)
  - Behnoush Norouzali (behnoush)
- - Marko H. Tamminen (gzumba)
+ - Marc Duboc (icemad)
  - Wesley Lancel
- - Xavier Briand (xavierbriand)
  - Ke WANG (yktd26)
+ - Timothée BARRAY
+ - Nilmar Sanchez Muguercia
  - Ivo Bathke (ivoba)
- - Ippei Sumida (ippey_s)
- - David Molineus
  - Strate
  - Anton A. Sumin
+ - Atthaphon Urairat
+ - Jon Green (jontjs)
+ - Mickaël Isaert (misaert)
  - Israel J. Carberry
+ - Julius Kiekbusch
  - Miquel Rodríguez Telep (mrtorrent)
- - Stefan Gehrig (sgehrig)
  - Sergey Kolodyazhnyy (skolodyazhnyy)
  - umpirski
+ - Benjamin
  - Quentin de Longraye (quentinus95)
  - Chris Heng (gigablah)
+ - Oleksii Svitiashchuk
+ - Tristan Bessoussa (sf_tristanb)
  - Richard Bradley
+ - Nathanaël Martel (nathanaelmartel)
+ - Nicolas Jourdan (nicolasjc)
  - Ulumuddin Cahyadi Yunus (joenoez)
- - rtek
- - Adrien Jourdier (eclairia)
+ - Benjamin Dos Santos
+ - GagnarTest (gagnartest)
+ - Tomas Javaisis
  - Florian Pfitzer (marmelatze)
- - Ivan Grigoriev (greedyivan)
  - Johann Saunier (prophet777)
- - Kevin SCHNEKENBURGER
- - Fabien Salles (blacked)
+ - Lucas Bäuerle
+ - Dario Savella
+ - Jack Thomas
  - Andreas Erhard (andaris)
- - Sergey Belyshkin (sbelyshkin)
+ - Evgeny Efimov (edefimov)
+ - John VanDeWeghe
+ - Daniel Badura
+ - Oleg Mifle
+ - gnito-org
  - Michael Devery (mickadoo)
+ - Loïc Ovigne (oviglo)
  - Antoine Corcy
- - Ahmed Ashraf (ahmedash95)
- - Gert Wijnalda (cinamo)
- - Luca Saba (lucasaba)
+ - Markkus Millend
+ - Clément
+ - Jorrit Schippers (jorrit)
+ - maxime.perrimond
+ - rvoisin
+ - cthulhu
  - Sascha Grossenbacher (berdir)
+ - Dmitry Derepko
+ - Rémi Leclerc
+ - Jan Vernarsky
+ - Jonas Hünig
+ - Amine Yakoubi
  - Robin Lehrmann
  - Szijarto Tamas
- - Thomas P
+ - Arend Hummeling
+ - Makdessi Alex
+ - Juan Miguel Besada Vidal (soutlink)
+ - dlorek
+ - Stuart Fyfe
  - Jaroslav Kuba
  - Benjamin Zikarsky (bzikarsky)
- - Kristijan Kanalaš (kristijan_kanalas_infostud)
+ - Jason Schilling (chapterjason)
+ - Nathan PAGE (nathix)
  - sl_toto (sl_toto)
  - Marek Pietrzak (mheki)
- - “Filip
+ - Dmitrii Lozhkin
+ - Marion Hurteau (marionleherisson)
  - Mickaël Andrieu (mickaelandrieu)
- - Simon Watiau (simonwatiau)
- - Ruben Jacobs (rubenj)
+ - Oscar Esteve (oesteve)
+ - Sobhan Sharifi (50bhan)
+ - Peter Potrowl
+ - Stephen
+ - Tomasz (timitao)
+ - Nguyen Tuan Minh (tuanminhgp)
+ - dbrekelmans
+ - Piet Steinhart
+ - mousezheng
+ - Rémy LESCALLIER
  - Simon Schick (simonsimcity)
+ - Victor Macko (victor_m)
  - Tristan Roussel
- - Niklas Keller
+ - Quentin Devos
+ - Jorge Vahldick (jvahldick)
+ - Vladimir Mantulo (mantulo)
+ - aim8604
+ - Aleksandr Dankovtsev
+ - Maciej Zgadzaj
+ - David Legatt (dlegatt)
  - Cameron Porter
  - Hossein Bukhamsin
  - Oliver Hoff
- - William Arslett
  - Christian Sciberras (uuf6429)
+ - Arthur Woimbée
+ - Théo DELCEY
+ - Andrii Serdiuk (andreyserdjuk)
+ - dangkhoagms (dangkhoagms)
+ - Floran Brutel (notFloran) (floran)
+ - Vlad Gapanovich (gapik)
  - origaminal
  - Matteo Beccati (matteobeccati)
- - Renan Gonçalves (renan_saddam)
- - Vitaliy Ryaboy (vitaliy)
+ - Konstantin Bogomolov
+ - Mark Spink
+ - Cesar Scur (cesarscur)
  - Kevin (oxfouzer)
  - Paweł Wacławczyk (pwc)
+ - Sagrario Meneses
  - Oleg Zinchenko (cystbear)
  - Baptiste Meyer (meyerbaptiste)
+ - Stefano A. (stefano93)
  - Tales Santos (tsantos84)
  - Johannes Klauss (cloppy)
+ - PierreRebeilleau
  - Evan Villemez
+ - Florian Hermann (fhermann)
  - fzerorubigd
  - Thomas Ploch
  - Benjamin Grandfond (benjamin)
  - Tiago Brito (blackmx)
  - Gintautas Miselis (naktibalda)
+ - Christian Rishøj
+ - Roromix
+ - Patrick Berenschot
+ - SuRiKmAn
+ - rtek
+ - Maxime AILLOUD (mailloud)
  - Richard van den Brand (ricbra)
- - Toon Verwerft (veewee)
+ - Sergey Melesh (sergex)
+ - mohammadreza honarkhah
  - develop
  - flip111
- - Douglas Hammond (wizhippo)
+ - Artem Oliinyk (artemoliynyk)
+ - fruty
  - VJ
  - RJ Garcia
- - Adrien Lucas (adrienlucas)
+ - Adam Wójs (awojs)
+ - Justin Reherman (jreherman)
  - Delf Tonder (leberknecht)
+ - Paweł Niedzielski (steveb)
+ - Peter Jaap Blaakmeer
+ - Agustin Gomes
  - Ondrej Exner
  - Mark Sonnabaum
+ - Adiel Cristo (arcristo)
+ - Artem Stepin (astepin)
+ - Fabian Kropfhamer (fabiank)
+ - Junaid Farooq (junaidfarooq)
  - Massimiliano Braglia (massimilianobraglia)
+ - Swen van Zanten (swenvanzanten)
+ - Frankie Wittevrongel
+ - Oleksiy (alexndlm)
  - Richard Quadling
  - James Hudson (mrthehud)
+ - Adam Prickett
  - Raphaëll Roussel
- - Michael Lutz
+ - Luke Towers
+ - Anton Kroshilin
+ - Norman Soetbeer
+ - William Thomson (gauss)
+ - Javier Espinosa (javespi)
  - jochenvdv
- - Michel Roca (mroca)
- - Reedy
+ - František Maša
  - Arturas Smorgun (asarturas)
+ - Andrea Sprega (asprega)
  - Aleksandr Volochnev (exelenz)
+ - Viktor Bajraktar (njutn95)
  - Robin van der Vleuten (robinvdvleuten)
  - Grinbergs Reinis (shima5)
+ - Ruud Arentsen
+ - Harald Tollefsen
+ - Tobias Bönner
+ - Arend-Jan Tetteroo
+ - Mbechezi Nawo
+ - Andre Eckardt (korve)
  - Michael Piecko (michael.piecko)
+ - Osayawe Ogbemudia Terry (terdia)
  - Toni Peric (tperic)
  - yclian
  - Aleksey Prilipko
- - Jelle Raaijmakers (gmta)
+ - AndrolGenhald
  - Andrew Berry
  - Wybren Koelmans (wybren_koelmans)
- - Roberto Nygaard
+ - Dmytro Dzubenko
+ - Benjamin RICHARD
+ - pdommelen
+ - Cedrick Oka
  - Davide Borsatto (davide.borsatto)
- - James Gilliland (neclimdul)
- - Gert de Pagter
+ - Guillaume Sainthillier (guillaume-sainthillier)
+ - Jens Hatlak
+ - Tayfun Aydin
+ - Arne Groskurth
+ - Ilya Chekalsky
+ - Ostrzyciel
  - Julien DIDIER (juliendidier)
- - Dalibor Karlović
- - Randy Geraads
- - Andreas Leathley (iquito)
- - Vadim Borodavko (javer)
+ - Ilia Sergunin (maranqz)
+ - Johan de Ruijter
+ - marbul
+ - Filippos Karailanidis
+ - David Brooks
+ - Volodymyr Kupriienko (greeflas)
  - Sebastian Grodzicki (sgrodzicki)
- - Mohamed Gamal
- - Eric COURTIAL
- - Xesxen
+ - Florian Caron (shalalalala)
+ - Serhiy Lunak (slunak)
+ - Wojciech Błoszyk (wbloszyk)
  - Jeroen van den Enden (endroid)
- - Arun Philip
+ - Jiri Barous
+ - abunch
+ - tamcy
+ - Mikko Pesari
+ - Aurélien Fontaine
  - Pascal Helfenstein
+ - Malcolm Fell (emarref)
+ - phuc vo (phucwan)
  - Baldur Rensch (brensch)
- - Carl Casbolt (carlcasbolt)
+ - Bogdan Scordaliu
+ - Daniel Rotter (danrot)
+ - Foxprodev
+ - developer-av
  - Vladyslav Petrovych
  - Loïc Chardonnet
+ - Hugo Sales
+ - Dale.Nash
  - Alex Xandra Albert Sim
  - Sergey Yastrebov
  - Carson Full (carsonfull)
- - kylekatarnls (kylekatarnls)
- - Trent Steel (trsteel88)
- - Steve Grunwell
  - Yuen-Chi Lian
+ - Maxim Semkin
+ - BrokenSourceCode
+ - Fabian Haase
+ - Nikita Popov (nikic)
  - Tarjei Huse (tarjei)
  - Besnik Br
- - Axel Guckelsberger (guite)
+ - Michael Olšavský
+ - Benny Born
+ - Emirald Mateli
+ - Tristan Pouliquen
  - Jose Gonzalez
- - Jonathan Sui Lioung Lee Slew (jlslew)
  - Claudio Zizza
- - Anatoly Pashin (b1rdex)
+ - Ivo Valchev
+ - Zlatoslav Desyatnikov
+ - Wickex
+ - tuqqu
+ - Neagu Cristian-Doru (cristian-neagu)
  - Dave Marshall (davedevelopment)
  - Jakub Kulhan (jakubkulhan)
- - Shaharia Azam
  - avorobiev
- - Gerben Oolbekkink
  - Gladhon
- - stoccc
+ - Kai
+ - Bartłomiej Zając
  - Grégoire Penverne (gpenverne)
  - Venu
  - Jonatan Männchen
  - Dennis Hotson
  - Andrew Tchircoff (andrewtch)
  - Lars Vierbergen (vierbergenlars)
- - Xav` (xavismeh)
+ - Bart Wach
+ - Jos Elstgeest
+ - Kirill Lazarev
+ - Serhii Smirnov
+ - Martins Eglitis
  - michaelwilliams
- - Alexandre Parent
+ - Wouter Diesveld
+ - Romain
+ - Matěj Humpál
+ - Guillaume Loulier (guikingone)
+ - Pedro Casado (pdr33n)
+ - Pierre Grimaud (pgrimaud)
+ - Alexander Janssen (tnajanssen)
  - 1emming
  - Nykopol (nykopol)
- - Thibault Richard (t-richard)
+ - Julien BERNARD
+ - Michael Zangerle
  - Jordan Deitch
+ - Raphael Hardt
  - Casper Valdemar Poulsen
- - Guillaume Verstraete
- - vladimir.panivko
+ - SnakePin
+ - Matthew Covey
+ - Anthony Massard (decap94)
+ - Chris Maiden (matason)
+ - Andrea Ruggiero (pupax)
  - Josiah (josiah)
- - Dennis Væversted (srnzitcom)
+ - Alexandre Beaujour
+ - George Yiannoulopoulos
  - Joschi Kuphal
  - John Bohn (jbohn)
- - Jason Tan (jt2k)
- - Jérémy REYNAUD (babeuloula)
+ - Peter Schultz
+ - Benhssaein Youssef
+ - bill moll
+ - PaoRuby
+ - Bizley
+ - Dominik Piekarski (dompie)
+ - Rares Sebastian Moldovan (raresmldvn)
  - Felds Liscia (felds)
- - Mathieu Rochette (mathroc)
+ - dsech
+ - Gilbertsoft
+ - tadas
+ - Bastien Picharles
+ - mamazu
+ - Victor Garcia
+ - Juan Mrad
+ - Denis Yuzhanin
+ - knezmilos13
+ - alireza
+ - Marcin Kruk
+ - Marek Víger (freezy)
  - Andrew Hilobok (hilobok)
+ - Wahyu Kristianto (kristories)
  - Noah Heck (myesain)
+ - Stephan Wentz (temp)
  - Christian Soronellas (theunic)
- - kick-the-bucket
  - fedor.f
  - Yosmany Garcia (yosmanyga)
- - Jeremiasz Major
- - Trevor North
+ - Markus Staab
+ - bahram
+ - Marie Minasyan (marie.minassyan)
  - Degory Valentine
  - izzyp
  - Jeroen Fiege (fieg)
  - Martin (meckhardt)
- - Marcel Hernandez
+ - Radosław Kowalewski
+ - JustDylan23
+ - Juraj Surman
+ - Victor
+ - Andreas Allacher
+ - Alexis
+ - Camille Dejoye (cdejoye)
  - Krzysztof Łabuś (crozin)
+ - cybernet (cybernet2u)
+ - Stefan Kleff (stefanxl)
+ - Thijs-jan Veldhuizen (tjveldhuizen)
  - Xavier Lacot (xavier)
- - Jon Dufresne
  - possum
  - Denis Zunke (donalberto)
  - _sir_kane (waly)
- - Antonin CLAUZIER (0x346e3730)
  - Olivier Maisonneuve
+ - Bruno BOUTAREL
+ - John Stevenson
+ - everyx
+ - Stanislav Gamayunov (happyproff)
  - Jonathan Johnson (jrjohnson)
- - Andrei C. (moldman)
+ - Alexander McCullagh (mccullagh)
+ - Paul L McNeely (mcneely)
  - Mike Meier (mykon)
  - Pedro Miguel Maymone de Resende (pedroresende)
- - stlrnz
+ - Sergey Fokin (tyraelqp)
  - Masterklavi
- - Adrien Wilmet (adrienfr)
  - Franco Traversaro (belinde)
  - Francis Turmel (fturmel)
- - Yannick Ihmels (ihmels)
  - Nikita Nefedov (nikita2206)
- - Alex Bacart
+ - Bernat Llibre
  - cgonzalez
- - hugovms
  - Ben
+ - Joni Halme
+ - aetxebeste
+ - roromix
+ - Vitali Tsyrkin
+ - Juga Paazmaya
+ - afaricamp
+ - Glodzienski
+ - riadh26
+ - Konstantinos Alexiou
+ - Dilek Erkut
+ - WaiSkats
+ - Morimoto Ryosuke
+ - Christoph König (chriskoenig)
+ - Dmytro Pigin (dotty)
  - Vincent Composieux (eko)
- - Cyril Pascal (paxal)
+ - Jm Aribau (jmaribau)
  - Jayson Xu (superjavason)
- - DemigodCode
  - fago
+ - popnikos
+ - Tito Costa
  - Jan Prieser
- - Maximilian Bösing
+ - Thiago Melo
+ - Giorgio Premi
  - Matt Johnson (gdibass)
+ - Gerhard Seidel (gseidel)
  - Zhuravlev Alexander (scif)
  - Stefano Degenkamp (steef)
  - James Michael DuPont
- - Carlos Buenosvinos (carlosbuenosvinos)
- - Christian Gripp (core23)
- - Jake (jakesoft)
+ - Eric Schildkamp
+ - agaktr
  - Vincent CHALAMON
- - Bahman Mehrdad (bahman)
+ - Mostafa
+ - kernig
+ - Gennadi Janzen
+ - SenTisso
+ - Joe Springe
+ - Flinsch
+ - botbotbot
+ - Timon van der Vorm
+ - G.R.Dalenoort
+ - Vladimir Khramtsov (chrome)
+ - Denys Voronin (hurricane)
+ - Jordan de Laune (jdelaune)
+ - Juan Gonzalez Montes (juanwilde)
+ - Mathieu Dewet (mdewet)
  - Christopher Hall (mythmakr)
+ - none (nelexa)
  - Patrick Dawkins (pjcdawkins)
  - Paul Kamer (pkamer)
  - Rafał Wrzeszcz (rafalwrzeszcz)
+ - Rémi Faivre (rfv)
  - Nguyen Xuan Quynh
  - Reen Lokum
- - Dennis Langen (nijusan)
  - Martin Parsiegla (spea)
- - Manuel Alejandro Paz Cetina
+ - Bernhard Rusch
+ - Ruben Jansen
+ - Marc Biorklund
+ - shreypuranik
+ - Thibaut Salanon
+ - Urban Suppiger
  - Denis Charrier (brucewouaigne)
- - Youssef Benhssaien (moghreb)
- - Mario Ramundo (rammar)
- - Ivan
- - Nico Haase
+ - Marcello Mönkemeyer (marcello-moenkemeyer)
+ - Sander De la Marche (sanderdlm)
  - Philipp Scheit (pscheit)
  - Pierre Vanliefland (pvanliefland)
  - Roy Klutman (royklutman)
  - Sofiane HADDAG (sofhad)
  - Quentin Schuler (sukei)
+ - VojtaB
  - frost-nzcr4
- - Shahriar56
- - Dhananjay Goratela
- - Kien Nguyen
+ - Yuri Karaban
+ - Johan
+ - Edwin
+ - Andriy
+ - Taylor Otwell
+ - Sami Mussbach
+ - qzylalala
+ - Mikolaj Czajkowski
+ - Shiro
+ - Reda DAOUDI
+ - Jesper Skytte
+ - Christiaan Wiesenekker
  - Bozhidar Hristov
- - arai
- - Achilles Kaloeridis (achilles)
+ - Foxprodev
+ - Eric Hertwig
+ - Sergey Panteleev
+ - Dmitry Hordinky
+ - Oliver Klee
+ - Niels Robin-Aubertin
+ - Mikko Ala-Fossi
+ - Jan Christoph Beyer
+ - Daniel Tiringer
+ - Koray Zorluoglu
+ - Roy-Orbison
+ - kshida
+ - Yasmany Cubela Medina (bitgandtter)
+ - Aryel Tupinamba (dfkimera)
+ - Hans Höchtl (hhoechtl)
+ - Jawira Portugal (jawira)
  - Laurent Bassin (lbassin)
- - Mouad ZIANI (mouadziani)
- - Tomasz Ignatiuk
+ - Roman Igoshin (masterro)
+ - Jeroen van den Nieuwenhuisen (nieuwenhuisen)
+ - Pierre Rebeilleau (pierrereb)
+ - Raphael de Almeida (raphaeldealmeida)
  - andrey1s
  - Abhoryo
  - Fabian Vogler (fabian)
- - Joachim Løvgaard (loevgaard)
- - Simon Podlipsky (simpod)
- - Shakhobiddin
  - Korvin Szanto
+ - Simon Ackermann
  - Stéphan Kochen
+ - Steven Dubois
  - Arjan Keeman
+ - Bálint Szekeres
  - Alaattin Kahramanlar (alaattin)
  - Sergey Zolotov (enleur)
  - Nicole Cordes (ichhabrecht)
+ - Mark Beech (jaybizzle)
  - Maksim Kotlyar (makasim)
- - siganushka (siganushka)
+ - Thibaut Arnoud (thibautarnoud)
  - Neil Ferreira
  - Julie Hourcade (juliehde)
  - Dmitry Parnas (parnas)
- - Loïc Beurlet
- - Ana Raro
- - Ana Raro
+ - Christian Weiske
+ - Maria Grazia Patteri
+ - Sébastien COURJEAN
+ - Marko Vušak
+ - Ismo Vuorinen
  - Tony Malzhacker
+ - Valentin
+ - Ali Tavafi
+ - Viet Pham
+ - Pchol
+ - divinity76
+ - Yiorgos Kalligeros
+ - Arek Bochinski
+ - Rafael Tovar
+ - Amin Hosseini (aminh)
  - Andreas Lutro (anlutro)
  - DUPUCH (bdupuch)
  - Cyril Quintin (cyqui)
+ - Cyrille Bourgois (cyrilleb)
  - Gerard van Helden (drm)
- - Florian Wolfsjaeger (flowolf)
- - Ivan Sarastov (isarastov)
  - Johnny Peck (johnnypeck)
- - Jordi Sala Morales (jsala)
+ - naitsirch (naitsirch)
+ - Geoffrey Monte (numerogeek)
+ - Martijn Boers (plebian)
+ - Plamen Mishev (pmishev)
+ - Sergii Dolgushev (serhey)
+ - Rein Baarsma (solidwebcode)
+ - Stephen Lewis (tehanomalousone)
+ - wicliff wolda (wickedone)
+ - Wim Molenberghs (wimm)
  - Loic Chardonnet
  - Ivan Menshykov
  - David Romaní
@@ -1181,149 +1665,302 @@ The Symfony Connect username in parenthesis allows to get more information
  - Alexander Li (aweelex)
  - Gustavo Falco (gfalco)
  - Matt Robinson (inanimatt)
- - Kristof Van Cauwenbergh (kristofvc)
- - Marco Lipparini (liarco)
- - Peter Bowyer (pbowyer)
+ - Marcel Berteler
+ - sdkawata
  - Aleksey Podskrebyshev
  - Calin Mihai Pristavu
- - Gabrielle Langer
+ - Rainrider
+ - Oliver Eglseder
+ - zcodes
  - Jörn Lang
  - David Marín Carreño (davefx)
  - Fabien LUCAS (flucas2)
- - Konstantin Grachev (grachevko)
  - Hidde Boomsma (hboomsma)
- - Johan Vlaar (johjohan)
- - Ondrej Machulda (ondram)
+ - Johan Wilfer (johanwilfer)
+ - Toby Griffiths (tog)
+ - Ashura
+ - Alessandra Lai
+ - Ernest Hymel
+ - Andrea Civita
+ - Nicolás Alonso
  - mwsaz
- - bogdan
- - Daniel Tiringer
+ - LoginovIlya
+ - carlos-ea
+ - Olexandr Kalaidzhy
+ - Jérémy Benoist
+ - Ferran Vidal
+ - youssef saoubou
+ - elattariyassine
+ - Carlos Tasada
+ - zors1
+ - Peter Simoncic
+ - lerminou
+ - Ahmad El-Bardan
+ - pdragun
+ - Noel Light-Hilary
+ - Emre YILMAZ
+ - Marcos Labad
+ - Antoine M
+ - Frank Jogeleit
+ - Ondřej Frei
+ - Volodymyr Panivko
+ - Jenne van der Meer
+ - Storkeus
+ - Anton Zagorskii
+ - ging-dev
+ - zakaria-amm
  - Geert De Deckere
+ - Agata
+ - dakur
  - grizlik
+ - florian-michael-mast
  - Henry Snoek
+ - Vlad Dumitrache
+ - Alex Kalineskou
  - Derek ROTH
  - Jeremy Benoist
  - Ben Johnson
  - Jan Kramer
  - mweimerskirch
- - Andrew Codispoti
+ - robmro27
+ - Vallel Blanco
+ - Bastien Clément
+ - Thomas Talbot
+ - Benjamin Franzke
+ - Pavinthan
+ - Sylvain METAYER
  - Benjamin Laugueux
- - Lctrs
+ - Ivo Valchev
+ - baron (bastien)
  - Benoît Bourgeois (bierdok)
+ - Damien Harper (damien.harper)
+ - Dominik Pesch (dombn)
  - Dmytro Boiko (eagle)
  - Shin Ohno (ganchiku)
- - Joppe De Cuyper (joppedc)
- - Matthieu Mota (matthieumota)
+ - Jaap van Otterdijk (jaapio)
+ - Kubicki Kamil (kubik)
+ - Simon Leblanc (leblanc_simon)
+ - Vladislav Nikolayev (luxemate)
+ - Martin Mandl (m2mtech)
+ - Maxime Pinot (maximepinot)
+ - Misha Klomp (mishaklomp)
  - Jean-Baptiste GOMOND (mjbgo)
+ - Mikhail Prosalov (mprosalov)
+ - Ulrik Nielsen (mrbase)
+ - Artem (nexim)
+ - Nicolas ASSING (nicolasassing)
+ - Pierre Gasté (pierre_g)
+ - Pierre-Olivier Vares (povares)
+ - Ronny López (ronnylt)
+ - Julius (sakalys)
+ - Samaël Villette (samadu61)
  - abdul malik ikhsan (samsonasik)
+ - Dmitry (staratel)
+ - Tito Miguel Costa (titomiguelcosta)
+ - Wim Godden (wimg)
  - Morgan Auchede
  - Christian Morgan
  - Alexander Miehe
- - Andrii Dembitskyi
- - Daniël Brekelmans (dbrekelmans)
  - Sascha Dens (saschadens)
- - Simon Heimberg (simon_heimberg)
- - Morten Wulff (wulff)
+ - Maxime Aknin (3m1x4m)
+ - Geordie
+ - Exploit.cz
  - Don Pinkster
  - Maksim Muruev
  - Emil Einarsson
- - Anderson Müller
+ - Jason Stephens
  - 243083df
+ - Tinjo Schöni
  - Thibault Duplessis
- - Rimas Kudelis
+ - Quentin Favrie
+ - Matthias Derer
+ - vladyslavstartsev
+ - Kévin
  - Marc Abramowitz
+ - michal
  - Martijn Evers
+ - Sjoerd Adema
  - Tony Tran
+ - Evgeniy Koval
+ - Claas Augner
  - Balazs Csaba
+ - Benoit Galati (benoitgalati)
  - Bill Hance (billhance)
  - Douglas Reith (douglas_reith)
  - Harry Walter (haswalt)
+ - Jeffrey Moelands (jeffreymoelands)
  - Jacques MOATI (jmoati)
  - Johnson Page (jwpage)
- - Kuba Werłos (kuba)
  - Ruben Gonzalez (rubenruateltek)
+ - Ruslan Zavacky (ruslanzavacky)
+ - Stefano Cappellini (stefano_cappellini)
  - Michael Roterman (wtfzdotnet)
- - Philipp Keck
- - Pavol Tuka
  - Arno Geurts
  - Adán Lobato (adanlobato)
  - Ian Jenkins (jenkoian)
- - Kai Eichinger (kai_eichinger)
  - Marcos Gómez Vilches (markitosgv)
  - Matthew Davis (mdavis1982)
- - Paulo Ribeiro (paulo)
- - Markus S. (staabm)
- - Marc Laporte
- - Michał Jusięga
+ - George Bateman
+ - misterx
+ - arend
+ - Vincent Godé
+ - helmi
+ - Michael Steininger
+ - Nardberjean
+ - jersoe
+ - Eric Grimois
+ - Beno!t POLASZEK
+ - Armando
+ - Jens Schulze
+ - Olatunbosun Egberinde
+ - Knallcharge
+ - Michel Bardelmeijer
+ - Ikko Ashimine
+ - Erwin Dirks
+ - Brad Jones
+ - Markus Ramšak
  - den
+ - George Dietrich
+ - jannick-holm
+ - Menno Holtkamp
+ - Ser5
+ - Clemens Krack
+ - Bruno Baguette
+ - Alexis Lefebvre
+ - Michal Forbak
+ - Alexey Berezuev
+ - Pierrick Charron
+ - gechetspr
+ - brian978
+ - Talha Zekeriya Durmuş
+ - bch36
+ - Steve Hyde
+ - Ettore Del Negro
+ - dima-gr
  - Gábor Tóth
+ - Rodolfo Ruiz
+ - tsilefy
+ - Enrico
+ - Jérémie Broutier
+ - Success Go
+ - Chris McGehee
+ - Benjamin Rosenberger
+ - Vladyslav Startsev
+ - Markus Klein
+ - Bruno Nogueira Nascimento Wowk
+ - Tomanhez
+ - satalaondrej
+ - Matthias Dötsch
+ - jonmldr
  - ouardisoft
+ - RTUnreal
+ - Richard Hodgson
+ - Sven Fabricius
+ - Bogdan
+ - Marco Pfeiffer
  - Daniel Cestari
  - Matt Janssen
- - Dmitriy Derepko
+ - Kévin Gonella
+ - Matteo Galli
+ - Ash014
+ - Loenix
+ - Simon Frost
+ - Cantepie
+ - detinkin
+ - Harry Wiseman
+ - Steve Marvell
+ - Shyim
+ - sabruss
+ - Andrejs Leonovs
+ - Signor Pedro
+ - Matthias Larisch
+ - Maxime  P
+ - Sean Templeton
+ - Yendric
  - Stéphane Delprat
- - Elan Ruusamäe (glen)
+ - Matthias Meyer
+ - Temuri Takalandze (abgeo)
+ - Bernard van der Esch (adeptofvoltron)
+ - Benedict Massolle (bemas)
+ - Gerard Berengue Llobera (bere)
+ - Ronny (big-r)
+ - Anton (bonio)
+ - Alexandre Fiocre (demos77)
+ - Jordane VASPARD (elementaire)
+ - Erwan Nader (ernadoo)
+ - Faizan Akram Dar (faizanakram)
+ - Gasan Guseynov (gassan)
+ - Greg Szczotka (greg606)
+ - Ian Littman (iansltx)
+ - Nathan DIdier (icz)
+ - Ilia Lazarev (ilzrv)
+ - Arkadiusz Kondas (itcraftsmanpl)
+ - Joao Paulo V Martins (jpjoao)
  - Brunet Laurent (lbrunet)
+ - Jérémy (libertjeremy)
  - Florent Viel (luxifer)
  - Maks 3w (maks3w)
+ - Mamikon Arakelyan (mamikon)
+ - Mathias Brodala (mbrodala)
  - Michiel Boeckaert (milio)
+ - Mike Milano (mmilano)
+ - Guillaume Lajarige (molkobain)
+ - Diego Aguiar (mollokhan)
  - Mikhail Yurasov (mym)
+ - PLAZANET Pierre (pedrotroller)
+ - Igor Tarasov (polosatus)
  - Robert Gruendler (pulse00)
- - Sebastian Paczkowski (sebpacz)
+ - Ramazan APAYDIN (rapaydin)
+ - Babichev Maxim (rez1dent3)
+ - Christopher Georg (sky-chris)
+ - Francisco Alvarez (sormes)
  - Simon Terrien (sterrien)
+ - Stephan Vierkant (svierkant)
  - Benoît Merlet (trompette)
+ - Aaron Piotrowski (trowski)
+ - Roman Tymoshyk (tymoshyk)
+ - Vincent MOULENE (vints24)
  - datibbaw
- - Dragos Protung (dragosprotung)
  - Koen Kuipers (koku)
- - Nicolas de Marqué (nicola)
- - Thiago Cordeiro (thiagocordeiro)
+ - Ryan Linnit
+ - Antoine Leblanc
+ - Andre Johnson
+ - MaPePeR
+ - Marco Pfeiffer
  - Matthieu Bontemps
+ - Vivien
  - Rootie
+ - david-binda
+ - Alexandru Năstase
+ - ddegentesh
+ - Anne-Julia Seitz
+ - Alexander Bauer (abauer)
  - Sébastien Santoro (dereckson)
+ - Gabriel Solomon (gabrielsolomon)
  - Daniel Alejandro Castro Arellano (lexcast)
+ - Aleksandar Dimitrov (netbull)
+ - Gary Houbre (thegarious)
  - Thomas Jarrand
  - Baptiste Leduc (bleduc)
  - Antoine Bluchet (soyuka)
  - Patrick Kaufmann
  - Anton Dyshkant
- - Paul Oms
- - Yann LUCAS (drixs6o9)
  - Reece Fowell (reecefowell)
- - Htun Htun Htet (ryanhhh91)
  - Guillaume Gammelin
  - Valérian Galliat
- - Sorin Pop (sorinpop)
  - d-ph
- - Stewart Malik
  - Renan Taranto (renan-taranto)
- - Stefan Graupner (efrane)
- - Gemorroj (gemorroj)
  - Thomas Talbot
- - Adrien Chinour
  - Rikijs Murgs
- - Mihail Krasilnikov (krasilnikovm)
  - Uladzimir Tsykun
- - iamvar
  - Amaury Leroux de Lens (amo__)
  - Christian Jul Jensen
  - Alexandre GESLIN
  - The Whole Life to Learn
- - Pierre Tondereau
- - Joel Lusavuvu (enigma97)
- - Alex Vo (votanlean)
  - Mikkel Paulson
  - ergiegonzaga
- - André Matthies
- - Piergiuseppe Longo
- - Kevin Auivinet
  - Liverbool (liverbool)
- - Valentin Nazarov
  - Dalibor Karlović
- - Aurélien MARTIN
- - Malte Schlüter
- - Jules Matsounga (hyoa)
- - Quentin Dequippe (qdequippe)
- - Yewhen Khoptynskyi (khoptynskyi)
- - Jérôme Nadaud (jnadaud)
  - Sam Malone
  - Ha Phan (haphan)
  - Chris Jones (leek)
@@ -1332,119 +1969,67 @@ The Symfony Connect username in parenthesis allows to get more information
  - xaav
  - Jean-Christophe Cuvelier [Artack]
  - Mahmoud Mostafa (mahmoud)
- - Alexandre Tranchant (alexandre_t)
- - Anthony Moutte
  - Ahmed Abdou
- - shreyadenny
- - Daniel Iwaniec
- - Thomas Ferney (thomasf)
  - Pieter
  - Michael Tibben
- - Hallison Boaventura (hallisonboaventura)
- - Mas Iting
  - Billie Thompson
- - Albion Bame (abame)
  - Ganesh Chandrasekaran (gxc4795)
  - Sander Marechal
- - Ivan Nemets
- - Grégoire Hébert (gregoirehebert)
  - Franz Wilding (killerpoke)
  - Oleg Golovakhin (doc_tr)
  - Icode4Food (icode4food)
  - Radosław Benkel
  - Kevin Nadin (kevinjhappy)
  - jean pasqualini (darkilliant)
- - Iliya Miroslavov Iliev (i.miroslavov)
- - Safonov Nikita (ns3777k)
  - Ross Motley (rossmotley)
  - ttomor
  - Mei Gwilym (meigwilym)
  - Michael H. Arieli
- - Nicolas Martin (cocorambo)
  - Tom Panier (neemzy)
  - Fred Cox
- - luffy1727
  - Luciano Mammino (loige)
- - LHommet Nicolas (nicolaslh)
  - fabios
  - Sander Coolen (scoolen)
- - Emil Masiakowski
- - Amirreza Shafaat (amirrezashafaat)
- - Laurent Clouet
- - Adoni Pavlakis (adoni)
  - Nicolas Le Goff (nlegoff)
- - Alex Hofbauer (alexhofbauer)
- - Maarten Nusteling (nusje2000)
  - Anne-Sophie Bachelard
- - Ahmed EBEN HASSINE (famas23)
  - Marvin Butkereit
  - Ben Oman
  - Chris de Kok
- - Eduard Bulava (nonanerz)
  - Andreas Kleemann (andesk)
- - Igor Timoshenko (igor.timoshenko)
  - Manuele Menozzi
- - “teerasak”
  - Anton Babenko (antonbabenko)
  - Irmantas Šiupšinskas (irmantas)
- - Benoit Mallo
  - Charles-Henri Bruyand
  - Danilo Silva
- - Giuseppe Campanelli
- - Valentin
- - pizzaminded
- - Matthieu Calie (matth--)
  - Konstantin S. M. Möllers (ksmmoellers)
  - Ken Stanley
- - ivan
  - Zachary Tong (polyfractal)
- - linh
- - Oleg Krasavin (okwinza)
- - Mario Blažek (marioblazek)
- - Jure (zamzung)
- - Michael Nelson
  - Ashura
  - Hryhorii Hrebiniuk
- - Eric Krona
  - johnstevenson
  - hamza
  - dantleech
- - Kajetan Kołtuniak (kajtii)
- - Sander Goossens (sandergo90)
  - Rudy Onfroy
  - Tero Alén (tero)
  - DerManoMann
- - Damien  Fayet (rainst0rm)
- - MatTheCat
  - Guillaume Royer
- - Erfan Bahramali
  - Artem (digi)
  - boite
  - Silvio Ginter
  - MGDSoft
- - Abdiel Carrazana (abdielcs)
  - Vadim Tyukov (vatson)
- - Arman
- - Gabi Udrescu
- - Adamo Crespi (aerendir)
  - David Wolter (davewww)
  - Sortex
  - chispita
  - Wojciech Sznapka
- - Luis Pabon (luispabon)
- - boulei_n
- - Anna Filina (afilina)
  - Gavin (gavin-markup)
  - Ksaveras Šakys (xawiers)
  - Shaun Simmons
  - Ariel J. Birnbaum
- - Patrick Luca Fazzi (ap3ir0n)
  - Danijel Obradović
  - Pablo Borowicz
- - Bruno Rodrigues de Araujo (brunosinister)
  - Máximo Cuadros (mcuadros)
  - Lukas Mencl
- - Jacek Wilczyński (jacekwilczynski)
  - tamirvs
  - gauss
  - julien.galenski
@@ -1452,10 +2037,8 @@ The Symfony Connect username in parenthesis allows to get more information
  - Chris Tiearney
  - Oliver Hoff
  - Ole Rößner (basster)
- - Laurent Moreau
  - Faton (notaf)
  - Tom Houdmont
- - tamar peled
  - Per Sandström (per)
  - Goran Juric
  - Laurent G. (laurentg)
@@ -1463,36 +2046,22 @@ The Symfony Connect username in parenthesis allows to get more information
  - Guido Donnari
  - Mert Simsek (mrtsmsk0)
  - Lin Clark
- - Christophe Meneses (c77men)
  - Jeremy David (jeremy.david)
- - Andrei O
  - Jordi Rejas
  - Troy McCabe
  - Ville Mattila
  - gr1ev0us
  - mlazovla
- - Alejandro Diaz Torres
- - Karl Shea
- - Valentin
  - Max Beutel
- - Łukasz Chruściel (lchrusciel)
- - Jan Vernieuwe (vernija)
  - Antanas Arvasevicius
  - Pierre Dudoret
  - Michal Trojanowski
  - Thomas
- - j.schmitt
- - Georgi Georgiev
+ - Norbert Schultheisz
  - Maximilian Berghoff (electricmaxxx)
- - Evgeny Anisiforov
- - TristanPouliquen
  - Piotr Antosik (antek88)
  - Nacho Martin (nacmartin)
- - mwos
- - Volker Killesreiter (ol0lll)
- - Vedran Mihočinec (v-m-i)
  - Sergey Novikov (s12v)
- - creiner
  - ProgMiner
  - Marcos Quesada (marcos_quesada)
  - Matthew (mattvick)
@@ -1500,45 +2069,26 @@ The Symfony Connect username in parenthesis allows to get more information
  - Viktor Novikov (nowiko)
  - Paul Mitchum (paul-m)
  - Angel Koilov (po_taka)
- - RevZer0 (rav)
  - Dan Finnie
- - Marek Binkowski
+ - Sofien Naas
  - Ken Marfilla (marfillaster)
  - Max Grigorian (maxakawizard)
  - benatespina (benatespina)
  - Denis Kop
- - Andrey Lebedev (alebedev)
- - Cristoforo Cervino (cristoforocervino)
  - Jean-Guilhem Rouel (jean-gui)
- - Yoann MOROCUTTI
  - EdgarPE
  - jfcixmedia
- - Tomasz Kusy
  - Dominic Tubach
  - Martijn Evers
- - Alexander Onatskiy
- - Philipp Fritsche
- - tarlepp
  - Benjamin Paap (benjaminpaap)
- - Claus Due (namelesscoder)
- - Guillaume Aveline
  - Christian
- - Alexandru Patranescu
  - Denis Golubovskiy (bukashk0zzz)
- - Arkadiusz Rzadkowolski (flies)
  - Serge (nfx)
- - Oksana Kozlova (oksanakozlova)
- - Quentin Moreau (sheitak)
  - Mikkel Paulson
  - Michał Strzelecki
- - Bert Ramakers
- - Angelov Dejan (angelov)
  - Aurimas Niekis (aurimasniekis)
  - Hugo Fonseca (fonsecas72)
- - Marc Duboc (icemad)
  - Martynas Narbutas
- - Timothée BARRAY
- - Nilmar Sanchez Muguercia
  - Bailey Parker
  - Antanas Arvasevicius
  - Eddie Abou-Jaoude (eddiejaoude)
@@ -1554,256 +2104,164 @@ The Symfony Connect username in parenthesis allows to get more information
  - Serhii Polishchuk (spolischook)
  - Tadas Gliaubicas (tadcka)
  - Thanos Polymeneas (thanos)
- - Atthaphon Urairat
  - Benoit Garret
  - Maximilian Ruta (deltachaos)
- - Jon Green (jontjs)
- - Mickaël Isaert (misaert)
  - Jakub Sacha
- - Julius Kiekbusch
  - Olaf Klischat
  - orlovv
  - Claude Dioudonnat
  - Jonathan Hedstrom
  - Peter Smeets (darkspartan)
  - Julien Bianchi (jubianchi)
+ - Tamás Nagy (t-bond)
  - Robert Meijers
+ - Tijs Verkoyen
  - James Sansbury
  - Marcin Chwedziak
- - Benjamin
  - hjkl
  - Dan Wilga
- - Oleksii Svitiashchuk
  - Andrew Tch
  - Alexander Cheprasov
- - Tristan Bessoussa (sf_tristanb)
  - Rodrigo Díez Villamuera (rodrigodiez)
  - Stephen Clouse
  - e-ivanov
- - Nathanaël Martel (nathanaelmartel)
- - Nicolas Jourdan (nicolasjc)
- - Benjamin Dos Santos
  - Yann Rabiller (einenlum)
- - GagnarTest (gagnartest)
  - Jochen Bayer (jocl)
- - Tomas Javaisis
  - Patrick Carlo-Hickman
  - Bruno MATEU
  - Jeremy Bush
- - Lucas Bäuerle
  - Thomason, James
- - Dario Savella
  - Gordienko Vladislav
  - Ener-Getick
  - Viacheslav Sychov
  - Helmut Hummel (helhum)
  - Matt Brunt
- - Jack Thomas
  - Carlos Ortega Huetos
  - Péter Buri (burci)
- - Evgeny Efimov (edefimov)
- - John VanDeWeghe
  - kaiwa
- - Daniel Badura
  - Charles Sanquer (csanquer)
  - Albert Ganiev (helios-ag)
  - Neil Katin
- - Oleg Mifle
  - David Otton
  - Will Donohoe
- - gnito-org
  - peter
+ - Jeroen de Boer
  - Jérémy Jourdin (jjk801)
  - BRAMILLE Sébastien (oktapodia)
- - Loïc Ovigne (oviglo)
  - Artem Kolesnikov (tyomo4ka)
- - Markkus Millend
- - Clément
  - Gustavo Adrian
- - Jorrit Schippers (jorrit)
  - Yannick
- - Kai Dederichs
  - Vladimir Luchaninov (luchaninov)
  - spdionis
- - maxime.perrimond
  - rchoquet
- - rvoisin
  - gitlost
  - Taras Girnyk
- - cthulhu
- - Dmitry Derepko
- - Rémi Leclerc
- - Jan Vernarsky
  - Sergio
- - Jonas Hünig
- - Amine Yakoubi
  - Eduardo García Sanz (coma)
- - Arend Hummeling
- - Makdessi Alex
  - fduch (fduch)
- - Juan Miguel Besada Vidal (soutlink)
- - dlorek
- - Stuart Fyfe
- - Jason Schilling (chapterjason)
  - David de Boer (ddeboer)
  - Eno Mullaraj (emullaraj)
  - Stephan Vock (glaubinix)
- - Nathan PAGE (nathix)
  - Ryan Rogers
  - Arnaud
  - Klaus Purer
- - Dmitrii Lozhkin
  - Gilles Doge (gido)
- - Marion Hurteau (marionleherisson)
- - Oscar Esteve (oesteve)
- - Sobhan Sharifi (50bhan)
- - Peter Potrowl
  - abulford
  - Philipp Kretzschmar
  - Ilya Vertakov
  - Brooks Boyd
- - Stephen
  - Roger Webb
  - Dmitriy Simushev
  - Pawel Smolinski
  - John Espiritu (johnillo)
- - Tomasz (timitao)
- - Nguyen Tuan Minh (tuanminhgp)
  - Oxan van Leeuwen
  - pkowalczyk
- - dbrekelmans
  - Soner Sayakci
  - Max Voloshin (maxvoloshin)
  - Nicolas Fabre (nfabre)
  - Raul Rodriguez (raul782)
- - Piet Steinhart
- - mousezheng
  - mshavliuk
- - Rémy LESCALLIER
  - MightyBranch
  - Kacper Gunia (cakper)
  - Derek Lambert (dlambert)
  - Peter Thompson (petert82)
- - Victor Macko (victor_m)
  - error56
  - Felicitus
  - alexpozzi
- - Quentin Devos
- - Jorge Vahldick (jvahldick)
+ - Marvin Feldmann (breyndotechse)
  - Krzysztof Przybyszewski (kprzybyszewski)
- - Vladimir Mantulo (mantulo)
+ - Boullé William (williamboulle)
  - Frederic Godfrin
  - Paul Matthews
- - aim8604
  - Jakub Kisielewski
  - Vacheslav Silyutin
- - Aleksandr Dankovtsev
- - Maciej Zgadzaj
  - Juan Traverso
- - David Legatt (dlegatt)
  - Alain Flaus (halundra)
- - Arthur Woimbée
  - tsufeki
- - Théo DELCEY
  - Philipp Strube
- - Thomas Nunninger
- - Andrii Serdiuk (andreyserdjuk)
  - Clement Herreman (clemherreman)
- - dangkhoagms (dangkhoagms)
  - Dan Ionut Dumitriu (danionut90)
  - Evgeny (disparity)
- - Floran Brutel (notFloran) (floran)
  - Vladislav Rastrusny (fractalizer)
- - Vlad Gapanovich (gapik)
  - Alexander Kurilo (kamazee)
  - nyro (nyro)
- - Konstantin Bogomolov
  - Marco
  - Marc Torres
- - Mark Spink
+ - gndk
  - Alberto Aldegheri
  - Dalibor Karlović
- - Cesar Scur (cesarscur)
- - Sagrario Meneses
  - Dmitri Petmanson
  - heccjj
  - Alexandre Melard
- - Stefano A. (stefano93)
- - PierreRebeilleau
  - Jay Klehr
  - Sergey Yuferev
  - Tobias Stöckler
  - Mario Young
+ - Sander Hagen
  - Ilia (aliance)
  - cilefen (cilefen)
- - Florian Hermann (fhermann)
  - Mo Di (modi)
  - Pablo Schläpfer
- - Christian Rishøj
- - Roromix
- - Patrick Berenschot
- - SuRiKmAn
- - rtek
  - Christian Wahler (christian)
  - Jelte Steijaert (jelte)
- - Maxime AILLOUD (mailloud)
  - David Négrier (moufmouf)
  - Quique Porta (quiqueporta)
- - mohammadreza honarkhah
- - Artem Oliinyk (artemoliynyk)
- - Ben Roberts (benr77)
  - Andrea Quintino (dirk39)
  - Tomasz Szymczyk (karion)
+ - Peter Dietrich (xosofox)
  - Alex Vasilchenko
  - sez-open
- - fruty
  - ConneXNL
  - Aharon Perkel
  - matze
- - Adam Wójs (awojs)
- - Justin Reherman (jreherman)
  - Rubén Calvo (rubencm)
- - Paweł Niedzielski (steveb)
  - Abdul.Mohsen B. A. A
  - Cédric Girard
- - Peter Jaap Blaakmeer
- - Agustin Gomes
  - pthompson
  - Malaney J. Hill
+ - Patryk Kozłowski
  - Alexandre Pavy
- - Adiel Cristo (arcristo)
- - Artem Stepin (astepin)
  - Christian Flach (cmfcmf)
- - Fabian Kropfhamer (fabiank)
- - Junaid Farooq (junaidfarooq)
  - Lars Ambrosius Wallenborn (larsborn)
  - Oriol Mangas Abellan (oriolman)
  - Sebastian Göttschkes (sgoettschkes)
- - Swen van Zanten (swenvanzanten)
- - Frankie Wittevrongel
  - Tatsuya Tsuruoka
  - Ross Tuck
+ - omniError
  - Zander Baldwin
- - Oleksiy (alexndlm)
  - Kévin Gomez (kevin)
  - Mihai Nica (redecs)
  - Andrei Igna
- - Adam Prickett
  - azine
- - Luke Towers
- - Anton Kroshilin
  - Pierre Tachoire
  - Dawid Sajdak
- - Norman Soetbeer
  - Ludek Stepan
+ - Mark van den Berg
  - Aaron Stephens (astephens)
  - Craig Menning (cmenning)
  - Balázs Benyó (duplabe)
  - Erika Heidi Reinaldo (erikaheidi)
- - William Thomson (gauss)
- - Javier Espinosa (javespi)
  - Marc J. Schmidt (marcjs)
- - František Maša
  - Sebastian Schwarz
  - karolsojko
  - Marco Jantke
@@ -1811,31 +2269,20 @@ The Symfony Connect username in parenthesis allows to get more information
  - Zacharias Luiten
  - Sebastian Utz
  - Adrien Gallou (agallou)
- - Andrea Sprega (asprega)
  - Maks Rafalko (bornfree)
  - Conrad Kleinespel (conradk)
  - Clément LEFEBVRE (nemoneph)
- - Viktor Bajraktar (njutn95)
  - Walter Dal Mut (wdalmut)
  - abluchet
- - Ruud Arentsen
- - Harald Tollefsen
- - Tobias Bönner
  - Matthieu
- - Arend-Jan Tetteroo
  - Albin Kerouaton
  - Sébastien HOUZÉ
- - Mbechezi Nawo
  - Jingyu Wang
  - steveYeah
  - Samy D (dinduks)
  - Keri Henare (kerihenare)
- - Andre Eckardt (korve)
  - Cédric Lahouste (rapotor)
  - Samuel Vogel (samuelvogel)
- - Osayawe Ogbemudia Terry (terdia)
- - AndrolGenhald
- - Damien Fa
  - Berat Doğan
  - Guillaume LECERF
  - Juanmi Rodriguez Cerón
@@ -1847,92 +2294,60 @@ The Symfony Connect username in parenthesis allows to get more information
  - Klaas Cuvelier (kcuvelier)
  - Flavien Knuchel (knuch)
  - Mathieu TUDISCO (mathieutu)
- - Dmytro Dzubenko
  - Peter Ward
  - markusu49
  - Steve Frécinaux
  - Constantine Shtompel
  - Jules Lamur
+ - zenas1210
  - Renato Mendes Figueiredo
- - Benjamin RICHARD
- - pdommelen
  - Eric Stern
  - ShiraNai7
- - Cedrick Oka
  - Antal Áron (antalaron)
- - Guillaume Sainthillier (guillaume-sainthillier)
  - Vašek Purchart (vasek-purchart)
  - Janusz Jabłoński (yanoosh)
  - Fleuv
- - Tayfun Aydin
  - Łukasz Makuch
- - Arne Groskurth
- - Ilya Chekalsky
- - Ostrzyciel
  - George Giannoulopoulos
  - Alexander Pasichnik (alex_brizzz)
  - Luis Ramirez (luisdeimos)
- - Ilia Sergunin (maranqz)
  - Daniel Richter (richtermeister)
  - Sandro Hopf (senaria)
  - ChrisC
  - Kim Laï Trinh
- - Johan de Ruijter
  - Jason Desrosiers
  - m.chwedziak
- - marbul
- - Filippos Karailanidis
  - Andreas Frömer
  - Philip Frank
- - David Brooks
  - Lance McNearney
  - Illia Antypenko (aivus)
  - Jelizaveta Lemeševa (broken_core)
  - Dominik Ritter (dritter)
  - Frank Neff (fneff)
- - Volodymyr Kupriienko (greeflas)
  - Ilya Biryukov (ibiryukov)
  - Roma (memphys)
- - Florian Caron (shalalalala)
- - Serhiy Lunak (slunak)
- - Wojciech Błoszyk (wbloszyk)
- - Jiri Barous
  - Giorgio Premi
- - abunch
- - tamcy
- - Mikko Pesari
- - Aurélien Fontaine
  - ncou
  - Ian Carroll
  - caponica
  - Daniel Kay (danielkay-cp)
  - Matt Daum (daum)
- - Malcolm Fell (emarref)
  - Alberto Pirovano (geezmo)
  - Pete Mitchell (peterjmit)
- - phuc vo (phucwan)
  - Tom Corrigan (tomcorrigan)
  - Luis Galeas
- - Bogdan Scordaliu
  - Martin Pärtel
- - Daniel Rotter (danrot)
  - Frédéric Bouchery (fbouchery)
  - Patrick Daley (padrig)
- - Foxprodev
- - developer-av
  - Max Summe
  - Ema Panz
- - Hugo Sales
- - Dale.Nash
  - Chihiro Adachi (chihiro-adachi)
  - Benjamin Georgeault (wedgesama)
  - Raphaëll Roussel
  - Tadcka
+ - Abudarham Yuval
  - Beth Binkovitz
- - Maxim Semkin
  - Gonzalo Míguez
- - BrokenSourceCode
- - Fabian Haase
  - Romain Geissler
  - Adrien Moiruad
  - Tomaz Ahlin
@@ -1942,13 +2357,8 @@ The Symfony Connect username in parenthesis allows to get more information
  - Daniel González Zaballos (dem3trio)
  - Emmanuel Vella (emmanuel.vella)
  - Guillaume BRETOU (guiguiboy)
- - Nikita Popov (nikic)
  - Carsten Nielsen (phreaknerd)
- - Michael Olšavský
  - Jay Severson
- - Benny Born
- - Emirald Mateli
- - Tristan Pouliquen
  - René Kerner
  - Nathaniel Catchpole
  - Adrien Samson (adriensamson)
@@ -1957,73 +2367,50 @@ The Symfony Connect username in parenthesis allows to get more information
  - Nicolas Eeckeloo (neeckeloo)
  - Andriy Prokopenko (sleepyboy)
  - Dariusz Ruminski
- - Ivo Valchev
  - Daniel Tschinder
  - Arnaud CHASSEUX
- - Zlatoslav Desyatnikov
- - Wickex
- - tuqqu
  - Wojciech Gorczyca
- - Neagu Cristian-Doru (cristian-neagu)
  - Mathieu Morlon (glutamatt)
  - Rafał Muszyński (rafmus90)
  - Sébastien Decrême (sebdec)
  - Timothy Anido (xanido)
+ - acoulton
  - Mara Blaga
  - Rick Prent
  - skalpa
- - Kai
- - Bartłomiej Zając
  - Pieter Jordaan
  - Tournoud (damientournoud)
  - Michael Dowling (mtdowling)
  - Karlos Presumido (oneko)
  - Tony Vermeiren (tony)
- - Bart Wach
- - Jos Elstgeest
- - Kirill Lazarev
  - Thomas Counsell
  - BilgeXA
  - mmokhi
- - Serhii Smirnov
  - Robert Queck
  - Peter Bouwdewijn
- - Martins Eglitis
- - Wouter Diesveld
- - Romain
- - Matěj Humpál
+ - Daniil Gentili
+ - Eduard Morcinek
  - Amine Matmati
  - Kristen Gilden
  - caalholm
  - Nouhail AL FIDI (alfidi)
  - Fabian Steiner (fabstei)
  - Felipy Amorim (felipyamorim)
- - Guillaume Loulier (guikingone)
  - Klaus Silveira (klaussilveira)
  - Michael Lively (mlivelyjr)
- - Pedro Casado (pdr33n)
- - Pierre Grimaud (pgrimaud)
  - Abderrahim (phydev)
  - Attila Bukor (r1pp3rj4ck)
- - Alexander Janssen (tnajanssen)
  - Thomas Chmielowiec (chmielot)
  - Jānis Lukss
- - Julien BERNARD
- - Michael Zangerle
  - rkerner
  - Alex Silcock
- - Raphael Hardt
  - Qingshan Luo
  - Ergie Gonzaga
  - Matthew J Mucklo
  - AnrDaemon
- - SnakePin
- - Matthew Covey
- - Anthony Massard (decap94)
+ - Charly Terrier (charlypoppins)
  - Emre Akinci (emre)
- - Chris Maiden (matason)
  - psampaz (psampaz)
- - Andrea Ruggiero (pupax)
  - Maxwell Vandervelde
  - kaywalker
  - Sebastian Ionescu
@@ -2033,9 +2420,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Simon Neidhold
  - Valentin VALCIU
  - Jeremiah VALERIE
- - Alexandre Beaujour
  - Patrik Patie Gmitter
- - George Yiannoulopoulos
  - Yannick Snobbert
  - Kevin Dew
  - James Cowgill
@@ -2044,118 +2429,80 @@ The Symfony Connect username in parenthesis allows to get more information
  - Nicolas Schwartz (nicoschwartz)
  - Tim Jabs (rubinum)
  - Stéphane Seng (stephaneseng)
- - Peter Schultz
  - Jonathan Gough
- - Benhssaein Youssef
  - Benoit Leveque
- - bill moll
  - Benjamin Bender
- - PaoRuby
- - Bizley
  - Jared Farrish
+ - Yohann Tilotti
  - karl.rixon
  - raplider
  - Konrad Mohrfeldt
  - Lance Chen
  - Ciaran McNulty (ciaranmcnulty)
- - Dominik Piekarski (dompie)
  - Andrew (drew)
  - j4nr6n (j4nr6n)
  - kor3k kor3k (kor3k)
- - Rares Sebastian Moldovan (raresmldvn)
  - Stelian Mocanita (stelian)
  - Gautier Deuette
- - dsech
- - Gilbertsoft
- - tadas
- - Bastien Picharles
  - Kirk Madera
- - mamazu
  - Keith Maika
  - Mephistofeles
  - Hoffmann András
  - LubenZA
- - Victor Garcia
- - Juan Mrad
- - Denis Yuzhanin
  - Flavian Sierk
- - knezmilos13
- - alireza
  - Michael Bessolov
  - Zdeněk Drahoš
  - Dan Harper
  - moldcraft
- - Marcin Kruk
  - Antoine Bellion (abellion)
  - Ramon Kleiss (akathos)
  - Antonio Peric-Mazar (antonioperic)
  - César Suárez (csuarez)
  - Bjorn Twachtmann (dotbjorn)
- - Marek Víger (freezy)
- - Wahyu Kristianto (kristories)
  - Tobias Genberg (lorceroth)
  - Michael Simonson (mikes)
  - Nicolas Badey (nico-b)
  - Olivier Scherler (oscherler)
  - Shane Preece (shane)
- - Stephan Wentz (temp)
  - Johannes Goslar
  - Geoff
  - georaldc
  - wusuopu
- - Markus Staab
  - Wouter de Wild
  - povilas
  - Gavin Staniforth
- - bahram
  - Alessandro Tagliapietra (alex88)
  - Nikita Starshinov (biji)
  - Alex Teterin (errogaht)
  - Gunnar Lium (gunnarlium)
  - Malte Wunsch (maltewunsch)
- - Marie Minasyan (marie.minassyan)
  - Maarten de Boer (mdeboer)
  - Tiago Garcia (tiagojsag)
  - Artiom
  - Jakub Simon
  - Bouke Haarsma
  - mlievertz
- - Radosław Kowalewski
  - Enrico Schultz
- - JustDylan23
- - Juraj Surman
+ - tpetry
  - Martin Eckhardt
  - natechicago
- - Victor
- - Andreas Allacher
- - Alexis
  - Leonid Terentyev
  - Sergei Gorjunov
  - Jonathan Poston
  - Adrian Olek (adrianolek)
- - Camille Dejoye (cdejoye)
- - cybernet (cybernet2u)
  - Jody Mickey (jwmickey)
  - Przemysław Piechota (kibao)
  - Martin Schophaus (m_schophaus_adcada)
  - Martynas Sudintas (martiis)
- - Stefan Kleff (stefanxl)
- - Thijs-jan Veldhuizen (tjveldhuizen)
+ - Anton Sukhachev (mrsuh)
  - ryunosuke
- - Bruno BOUTAREL
- - John Stevenson
  - Francisco Facioni (fran6co)
- - Stanislav Gamayunov (happyproff)
  - Iwan van Staveren (istaveren)
- - Alexander McCullagh (mccullagh)
- - Paul L McNeely (mcneely)
  - Povilas S. (povilas)
  - Laurent Negre (raulnet)
- - Sergey Fokin (tyraelqp)
  - Victoria Quirante Ruiz (victoria)
  - Evrard Boulou
  - pborreli
- - Bernat Llibre
  - Boris Betzholz
  - Eric Caron
  - Arnau González
@@ -2163,31 +2510,16 @@ The Symfony Connect username in parenthesis allows to get more information
  - Wing
  - Thomas Bibb
  - Stefan Koopmanschap
- - Joni Halme
  - Matt Farmer
  - catch
- - aetxebeste
- - roromix
- - Vitali Tsyrkin
- - Juga Paazmaya
  - Alexandre Segura
- - afaricamp
  - Josef Cech
- - Glodzienski
- - riadh26
- - Konstantinos Alexiou
  - Andrii Boiko
- - Dilek Erkut
  - Harold Iedema
- - WaiSkats
- - Morimoto Ryosuke
  - Ikhsan Agustian
  - Benoit Lévêque (benoit_leveque)
  - Simon Bouland (bouland)
- - Christoph König (chriskoenig)
- - Dmytro Pigin (dotty)
  - Jibé Barth (jibbarth)
- - Jm Aribau (jmaribau)
  - Matthew Foster (mfoster)
  - Reyo Stallenberg (reyostallenberg)
  - Paul Seiffert (seiffert)
@@ -2196,11 +2528,9 @@ The Symfony Connect username in parenthesis allows to get more information
  - Stefan Hüsges (tronsha)
  - Jake Bishop (yakobeyak)
  - Dan Blows
- - popnikos
  - Matt Wells
  - Nicolas Appriou
  - stloyd
- - Tito Costa
  - Andreas
  - Chris Tickner
  - Andrew Coulton
@@ -2208,85 +2538,58 @@ The Symfony Connect username in parenthesis allows to get more information
  - Jeremy Benoist
  - Michal Gebauer
  - Phil Davis
- - Thiago Melo
  - Gleb Sidora
  - David Stone
- - Giorgio Premi
- - Gerhard Seidel (gseidel)
  - Jovan Perovic (jperovic)
  - Pablo Maria Martelletti (pmartelletti)
  - Sander van der Vlugt (stranding)
  - Yassine Guedidi (yguedidi)
+ - Florian Bogey
  - Waqas Ahmed
  - Bert Hekman
  - Luis Muñoz
  - Matthew Donadio
  - Houziaux mike
  - Phobetor
- - Eric Schildkamp
  - Markus
- - agaktr
- - Mostafa
- - kernig
  - Thomas Chmielowiec
  - shdev
  - Andrey Ryaguzov
- - Gennadi Janzen
- - SenTisso
  - Stefan
  - Peter Bex
  - Manatsawin Hanmongkolchai
  - Gunther Konig
- - Joe Springe
  - Mickael GOETZ
+ - Tobias Speicher
+ - Jesper Noordsij
  - DerStoffel
- - Flinsch
  - Maciej Schmidt
- - botbotbot
- - Timon van der Vorm
  - nuncanada
  - Thierry Marianne
  - František Bereň
- - G.R.Dalenoort
- - Quentin Dreyer
  - Jeremiah VALERIE
  - Mike Francis
  - Almog Baku (almogbaku)
- - Vladimir Khramtsov (chrome)
  - Gerd Christian Kunze (derdu)
- - Denys Voronin (hurricane)
  - Ionel Scutelnicu (ionelscutelnicu)
- - Jordan de Laune (jdelaune)
- - Juan Gonzalez Montes (juanwilde)
  - Kamil Madejski (kmadejski)
- - Mathieu Dewet (mdewet)
- - none (nelexa)
  - Nicolas Tallefourtané (nicolab)
  - Botond Dani (picur)
- - Rémi Faivre (rfv)
  - Nick Stemerdink
- - Bernhard Rusch
  - David Stone
  - Grayson Koonce
- - Ruben Jansen
- - Marc Biorklund
- - shreypuranik
- - Thibaut Salanon
  - Romain Dorgueil
  - Christopher Parotat
  - Dennis Haarbrink
- - Urban Suppiger
  - 蝦米
  - Julius Beckmann (h4cc)
  - Andrey Helldar (helldar)
  - Julien JANVIER (jjanvier)
  - Karim Cassam Chenaï (ka)
  - Lorenzo Adinolfi (loru88)
- - Marcello Mönkemeyer (marcello-moenkemeyer)
  - Ahmed Shamim Hassan (me_shaon)
  - Michal Kurzeja (mkurzeja)
  - Nicolas Bastien (nicolas_bastien)
- - Sander De la Marche (sanderdlm)
  - Nikola Svitlica (thecelavi)
  - Andrew Zhilin (zhil)
  - Sjors Ottjes
@@ -2294,13 +2597,8 @@ The Symfony Connect username in parenthesis allows to get more information
  - Andy Stanberry
  - Felix Marezki
  - Normunds
- - Yuri Karaban
- - Johan
  - Thomas Rothe
- - Edwin
  - nietonfir
- - Andriy
- - Taylor Otwell
  - alefranz
  - David Barratt
  - Andrea Giannantonio
@@ -2308,91 +2606,59 @@ The Symfony Connect username in parenthesis allows to get more information
  - avi123
  - Pavel Prischepa
  - Philip Dahlstrøm
- - Sami Mussbach
- - qzylalala
+ - Pierre Schmitz
  - alsar
  - downace
  - Aarón Nieves Fernández
- - Mikolaj Czajkowski
  - Ph3nol
  - Kirill Saksin
- - Shiro
- - Reda DAOUDI
  - Koalabaerchen
  - michalmarcinkowski
  - Warwick
- - Jesper Skytte
  - Chris
  - Farid Jalilov
- - Christiaan Wiesenekker
  - Florent Olivaud
- - Foxprodev
- - Eric Hertwig
- - Sergey Panteleev
  - JakeFr
- - Dmitry Hordinky
- - Oliver Klee
- - Niels Robin-Aubertin
  - Simon Sargeant
  - efeen
- - Mikko Ala-Fossi
- - Jan Christoph Beyer
  - Nicolas Pion
  - Muhammed Akbulut
- - Daniel Tiringer
- - Koray Zorluoglu
- - Roy-Orbison
  - Aaron Somi
- - kshida
- - Yasmany Cubela Medina (bitgandtter)
  - Michał Dąbrowski (defrag)
- - Aryel Tupinamba (dfkimera)
- - Hans Höchtl (hhoechtl)
  - Simone Fumagalli (hpatoio)
  - Brian Graham (incognito)
  - Kevin Vergauwen (innocenzo)
  - Alessio Baglio (ioalessio)
- - Jawira Portugal (jawira)
  - Johannes Müller (johmue)
  - Jordi Llonch (jordillonch)
  - julien_tempo1 (julien_tempo1)
- - Roman Igoshin (masterro)
  - Nicholas Ruunu (nicholasruunu)
- - Jeroen van den Nieuwenhuisen (nieuwenhuisen)
- - Pierre Rebeilleau (pierrereb)
  - Milos Colakovic (project2481)
- - Raphael de Almeida (raphaeldealmeida)
  - Rénald Casagraude (rcasagraude)
  - Robin Duval (robin-duval)
  - Artem Lopata (bumz)
  - alex
  - Roman Orlov
- - Simon Ackermann
  - VolCh
  - Alexey Popkov
  - Gijs Kunze
  - Artyom Protaskin
- - Steven Dubois
  - Nathanael d. Noblet
  - helmer
  - ged15
+ - Simon Asika
  - Daan van Renterghem
- - Bálint Szekeres
  - amcastror
  - Bram Van der Sype (brammm)
  - Guile (guile)
- - Mark Beech (jaybizzle)
  - Julien Moulin (lizjulien)
  - Raito Akehanareru (raito)
  - Mauro Foti (skler)
- - Thibaut Arnoud (thibautarnoud)
  - Yannick Warnier (ywarnier)
  - Jörn Lang
  - Kevin Decherf
  - Paul LE CORRE
  - Jason Woods
- - Christian Weiske
- - Maria Grazia Patteri
  - klemens
  - dened
  - jpauli
@@ -2400,22 +2666,16 @@ The Symfony Connect username in parenthesis allows to get more information
  - Michael van Tricht
  - ReScO
  - Tim Strehle
- - Sébastien COURJEAN
  - Sam Ward
  - Hans N. Hjort
  - Walther Lalk
  - Adam
  - Ivo
- - Ismo Vuorinen
- - Valentin
  - Sören Bernstein
  - devel
  - taiiiraaa
- - Ali Tavafi
  - gedrox
- - Viet Pham
  - Alan Bondarchuk
- - Pchol
  - dropfen
  - Andrey Chernykh
  - Edvinas Klovas
@@ -2424,22 +2684,16 @@ The Symfony Connect username in parenthesis allows to get more information
  - Kevin EMO
  - Chansig
  - Tischoi
- - divinity76
  - Andreas Hasenack
  - J Bruni
  - Alexey Prilipko
  - vlakoff
  - thib92
- - Yiorgos Kalligeros
  - Rudolf Ratusiński
  - Bertalan Attila
- - Arek Bochinski
- - Rafael Tovar
- - Amin Hosseini (aminh)
  - AmsTaFF (amstaff)
  - Simon Müller (boscho)
  - Yannick Bensacq (cibou)
- - Cyrille Bourgois (cyrilleb)
  - Damien Vauchel (damien_vauchel)
  - Dmitrii Fedorenko (dmifedorenko)
  - Frédéric G. Marand (fgm)
@@ -2452,27 +2706,16 @@ The Symfony Connect username in parenthesis allows to get more information
  - Maxime Corteel (mcorteel)
  - Dan Patrick (mdpatrick)
  - Mathieu MARCHOIS (mmar)
- - naitsirch (naitsirch)
- - Geoffrey Monte (numerogeek)
- - Martijn Boers (plebian)
- - Plamen Mishev (pmishev)
  - Pedro Magalhães (pmmaga)
  - Rares Vlaseanu (raresvla)
  - Trevor N. Suarez (rican7)
- - Sergii Dolgushev (serhey)
  - Clément Bertillon (skigun)
- - Rein Baarsma (solidwebcode)
  - tante kinast (tante)
- - Stephen Lewis (tehanomalousone)
  - Adam RANDI (tiecoders)
  - Vincent LEFORT (vlefort)
  - Walid BOUGHDIRI (walidboughdiri)
- - wicliff wolda (wickedone)
- - Wim Molenberghs (wimm)
  - Darryl Hein (xmmedia)
  - Vladimir Sadicov (xtech)
- - Marcel Berteler
- - sdkawata
  - Peter van Dommelen
  - Tim van Densen
  - Andrzej
@@ -2487,12 +2730,9 @@ The Symfony Connect username in parenthesis allows to get more information
  - Tom Maguire
  - Mateusz Lerczak
  - Richard Quadling
- - Rainrider
  - David Zuelke
  - Adrian
- - Oliver Eglseder
  - neFAST
- - zcodes
  - Pierre Rineau
  - Florian Morello
  - Maxim Lovchikov
@@ -2501,98 +2741,59 @@ The Symfony Connect username in parenthesis allows to get more information
  - Ari Pringle (apringle)
  - Dan Ordille (dordille)
  - Jan Eichhorn (exeu)
+ - Georg Ringer (georgringer)
  - Grégory Pelletier (ip512)
- - Johan Wilfer (johanwilfer)
  - John Nickell (jrnickell)
  - Martin Mayer (martin)
  - Grzegorz Łukaszewicz (newicz)
  - Omar Yepez (oyepez003)
  - Jonny Schmid (schmidjon)
- - Toby Griffiths (tog)
- - Ashura
  - Götz Gottwald
- - Alessandra Lai
- - Ernest Hymel
- - Andrea Civita
- - Nicolás Alonso
- - LoginovIlya
  - Nick Chiu
  - Robert Campbell
  - Matt Lehner
- - carlos-ea
- - Olexandr Kalaidzhy
  - Helmut Januschka
- - Jérémy Benoist
  - Hein Zaw Htet™
  - Ruben Kruiswijk
  - Cosmin-Romeo TANASE
- - Ferran Vidal
  - Michael J
- - youssef saoubou
  - Joseph Maarek
  - Alexander Menk
  - Alex Pods
  - timaschew
  - Jelle Kapitein
  - Jochen Mandl
- - elattariyassine
  - Marin Nicolae
  - Alessandro Loffredo
  - Ian Phillips
- - Carlos Tasada
  - Haritz
  - Matthieu Prat
  - Brieuc Thomas
- - zors1
- - Peter Simoncic
- - lerminou
- - Ahmad El-Bardan
  - mantulo
- - pdragun
  - Paul Le Corre
- - Noel Light-Hilary
  - Filipe Guerra
  - Jean Ragouin
  - Gerben Wijnja
- - Emre YILMAZ
  - Rowan Manning
- - Marcos Labad
+ - qsz
  - Per Modin
  - David Windell
- - Antoine M
- - Frank Jogeleit
- - Ondřej Frei
- - Volodymyr Panivko
  - Gabriel Birke
  - Derek Bonner
+ - Ivan Kurnosov
  - martijn
- - Jenne van der Meer
  - annesosensio
  - NothingWeAre
- - Storkeus
  - goabonga
  - Alan Chen
- - Anton Zagorskii
- - ging-dev
- - zakaria-amm
  - Maerlyn
  - Even André Fiskvik
- - Agata
- - dakur
- - Matthias Schmidt
- - florian-michael-mast
- - Vlad Dumitrache
- - Alex Kalineskou
  - Erik van Wingerden
  - Valouleloup
- - robmro27
- - Vallel Blanco
  - Alexis MARQUIS
  - Gerrit Drost
  - Linnaea Von Lavia
  - Simon Mönch
- - Bastien Clément
- - Thomas Talbot
  - Javan Eskander
  - Lenar Lõhmus
  - Cristian Gonzalez
@@ -2601,28 +2802,21 @@ The Symfony Connect username in parenthesis allows to get more information
  - hainey
  - Juan M Martínez
  - Gilles Gauthier
- - Benjamin Franzke
- - Pavinthan
- - Sylvain METAYER
  - ddebree
  - Gyula Szucs
  - Tomas Liubinas
- - Ivo Valchev
  - Jan Hort
  - Klaas Naaijkens
  - Rafał
  - Adria Lopez (adlpz)
  - Aaron Scherer (aequasi)
- - baron (bastien)
  - Rosio (ben-rosio)
  - Simon Paarlberg (blamh)
  - Masao Maeda (brtriver)
- - Damien Harper (damien.harper)
  - Darius Leskauskas (darles)
  - david perez (davidpv)
  - David Joos (djoos)
  - Denis Klementjev (dklementjev)
- - Dominik Pesch (dombn)
  - Dominik Hajduk (dominikalp)
  - Tomáš Polívka (draczris)
  - Dennis Smink (dsmink)
@@ -2634,7 +2828,6 @@ The Symfony Connect username in parenthesis allows to get more information
  - Hadrien Cren (hcren)
  - Gusakov Nikita (hell0w0rd)
  - Oz (import)
- - Jaap van Otterdijk (jaapio)
  - Javier Núñez Berrocoso (javiernuber)
  - Jelle Bekker (jbekker)
  - Giovanni Albero (johntree)
@@ -2642,93 +2835,59 @@ The Symfony Connect username in parenthesis allows to get more information
  - Joeri Verdeyen (jverdeyen)
  - Kevin Verschaeve (keversc)
  - Kevin Herrera (kherge)
- - Kubicki Kamil (kubik)
- - Simon Leblanc (leblanc_simon)
  - Luis Ramón López López (lrlopez)
- - Vladislav Nikolayev (luxemate)
- - Martin Mandl (m2mtech)
  - Mehdi Mabrouk (mehdidev)
  - Bart Reunes (metalarend)
  - Muriel (metalmumu)
  - Michael Pohlers (mick_the_big)
- - Misha Klomp (mishaklomp)
  - mlpo (mlpo)
- - Mikhail Prosalov (mprosalov)
- - Ulrik Nielsen (mrbase)
  - Marek Šimeček (mssimi)
  - Dmitriy Tkachenko (neka)
  - Cayetano Soriano Gallego (neoshadybeat)
- - Artem (nexim)
- - Nicolas ASSING (nicolasassing)
  - Olivier Laviale (olvlvl)
- - Pierre Gasté (pierre_g)
  - Pablo Monterde Perez (plebs)
- - Pierre-Olivier Vares (povares)
  - Jimmy Leger (redpanda)
- - Ronny López (ronnylt)
- - Julius (sakalys)
- - Samaël Villette (samadu61)
- - Dmitry (staratel)
  - Marcin Szepczynski (szepczynski)
- - Tito Miguel Costa (titomiguelcosta)
  - Simone Di  Maulo (toretto460)
  - Cyrille Jouineau (tuxosaurus)
  - Lajos Veres (vlajos)
  - Vladimir Chernyshev (volch)
- - Wim Godden (wimg)
  - Yorkie Chadwick (yorkie76)
- - Maxime Aknin (3m1x4m)
- - Geordie
- - Exploit.cz
  - GuillaumeVerdon
  - ureimers
  - akimsko
  - Youpie
- - Jason Stephens
  - srsbiz
- - Tinjo Schöni
  - Taylan Kasap
  - Michael Orlitzky
  - Nicolas A. Bérard-Nault
- - Quentin Favrie
- - Matthias Derer
- - vladyslavstartsev
  - Saem Ghani
- - Kévin
  - Stefan Oderbolz
  - Gabriel Moreira
  - Alexey Popkov
  - ChS
- - michal
  - Alexis MARQUIS
  - Joseph Deray
  - Damian Sromek
  - Ben
  - Evgeniy Tetenchuk
- - Sjoerd Adema
  - Shrey Puranik
- - Evgeniy Koval
  - Lars Moelleken
  - dasmfm
- - Claas Augner
  - Mathias Geat
  - Angel Fernando Quiroz Campos (angelfqc)
  - Arnaud Buathier (arnapou)
- - Benoit Galati (benoitgalati)
  - Curtis (ccorliss)
  - chesteroni (chesteroni)
  - Mauricio Lopez (diaspar)
  - HADJEDJ Vincent (hadjedjvincent)
  - Daniele Cesarini (ijanki)
  - Ismail Asci (ismailasci)
- - Jeffrey Moelands (jeffreymoelands)
  - Simon (kosssi)
  - Ondřej Mirtes (mirtes)
  - Paulius Jarmalavičius (pjarmalavicius)
  - Ramon Ornelas (ramonornela)
  - Ricardo de Vries (ricardodevries)
- - Ruslan Zavacky (ruslanzavacky)
- - Stefano Cappellini (stefano_cappellini)
  - Thomas Dutrion (theocrite)
  - Till Klampaeckel (till)
  - Tobias Weinert (tweini)
@@ -2736,49 +2895,32 @@ The Symfony Connect username in parenthesis allows to get more information
  - goohib
  - Tom Counsell
  - Sepehr Lajevardi
- - George Bateman
  - Xavier HAUSHERR
  - Edwin Hageman
  - Mantas Urnieža
  - temperatur
  - Paul Andrieux
- - misterx
  - Cas
- - arend
- - Vincent Godé
- - helmi
- - Michael Steininger
- - Nardberjean
  - ghazy ben ahmed
  - Karolis
  - Myke79
- - jersoe
  - Brian Debuire
- - Eric Grimois
  - Piers Warmers
  - Sylvain Lorinet
  - klyk50
  - jc
  - BenjaminBeck
  - Aurelijus Rožėnas
- - Beno!t POLASZEK
- - Armando
  - Jordan Hoff
  - znerol
  - Christian Eikermann
+ - Sergei Shitikov
  - Antonio Angelino
- - Jens Schulze
+ - Pavel Golovin
  - Matt Fields
- - Olatunbosun Egberinde
  - Andras Debreczeni
- - Knallcharge
  - Vladimir Sazhin
- - Michel Bardelmeijer
  - Tomas Kmieliauskas
- - Ikko Ashimine
- - Erwin Dirks
- - Brad Jones
- - Markus Ramšak
  - Billie Thompson
  - lol768
  - jamogon
@@ -2788,11 +2930,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Jakub Chábek
  - Johannes
  - Jörg Rühl
- - George Dietrich
- - jannick-holm
  - wesleyh
- - Menno Holtkamp
- - Ser5
  - Michael Hudson-Doyle
  - Daniel Bannert
  - Karim Miladi
@@ -2800,58 +2938,41 @@ The Symfony Connect username in parenthesis allows to get more information
  - patrick-mcdougle
  - Tyler Stroud
  - Dariusz Czech
- - Clemens Krack
- - Bruno Baguette
  - Jack Wright
  - MrNicodemuz
  - Anonymous User
  - Paweł Tomulik
  - Eric J. Duran
+ - Blackfelix
  - Alexandru Bucur
- - Alexis Lefebvre
  - cmfcmf
- - Michal Forbak
  - Drew Butler
- - Alexey Berezuev
  - pawel-lewtak
- - Pierrick Charron
  - Steve Müller
  - omerida
  - Andras Ratz
  - andreabreu98
- - gechetspr
- - brian978
  - Michael Schneider
  - n-aleha
- - Talha Zekeriya Durmuş
  - Anatol Belski
  - Alexis BOYER
- - bch36
  - Kaipi Yann
  - adam-mospan
- - Steve Hyde
  - Sam Williams
- - Ettore Del Negro
  - Guillaume Aveline
  - Adrian Philipp
  - James Michael DuPont
  - Markus Tacker
  - Kasperki
- - dima-gr
  - Tammy D
- - Rodolfo Ruiz
- - tsilefy
- - Enrico
  - Ryan Rud
  - Ondrej Slinták
- - Jérémie Broutier
  - vlechemin
  - Brian Corrigan
  - Ladislav Tánczos
  - Brian Freytag
  - Skorney
  - Lucas Matte
- - Success Go
  - fmarchalemisys
  - mieszko4
  - Steve Preston
@@ -2861,39 +2982,24 @@ The Symfony Connect username in parenthesis allows to get more information
  - Neophy7e
  - bokonet
  - Arrilot
- - ampaze
- - Chris McGehee
  - Shaun Simmons
  - Markus Staab
  - Pierre-Louis LAUNAY
  - djama
- - Benjamin Rosenberger
- - Vladyslav Startsev
  - Michael Gwynne
  - Eduardo Conceição
  - changmin.keum
  - Jon Cave
  - Sébastien HOUZE
  - Abdulkadir N. A.
- - Markus Klein
  - Adam Klvač
- - Bruno Nogueira Nascimento Wowk
- - Tomanhez
- - satalaondrej
- - Matthias Dötsch
- - jonmldr
  - Yevgen Kovalienia
  - Lebnik
  - Shude
- - RTUnreal
- - Richard Hodgson
- - Sven Fabricius
  - Ondřej Führer
- - Bogdan
  - Sema
  - Thorsten Hallwas
  - Brian Freytag
- - Marco Pfeiffer
  - Alex Nostadt
  - Michael Squires
  - Egor Gorbachev
@@ -2906,20 +3012,13 @@ The Symfony Connect username in parenthesis allows to get more information
  - Edvin Hultberg
  - Vincent
  - Benjamin Long
- - Kévin Gonella
  - Ben Miller
  - Peter Gribanov
- - Matteo Galli
  - Bart Ruysseveldt
- - Ash014
- - Loenix
  - kwiateusz
  - Ilya Bulakh
  - David Soria Parra
- - Simon Frost
  - Sergiy Sokolenko
- - Cantepie
- - detinkin
  - Ahmed Abdulrahman
  - dinitrol
  - Penny Leach
@@ -2932,41 +3031,28 @@ The Symfony Connect username in parenthesis allows to get more information
  - Peter Zwosta
  - Michal Čihař
  - parhs
- - Harry Wiseman
  - Diego Campoy
  - Oncle Tom
  - Sam Anthony
  - Christian Stocker
  - Oussama Elgoumri
  - David Lima
- - Steve Marvell
  - Dawid Nowak
  - Lesnykh Ilia
- - Shyim
- - sabruss
  - darnel
  - Nicolas
  - Sergio Santoro
  - tirnanog06
- - Andrejs Leonovs
  - Alfonso Fernández García
  - phc
  - Дмитрий Пацура
- - Signor Pedro
- - Matthias Larisch
- - Maxime  P
- - Sean Templeton
  - Michaël VEROUX
  - Julia
  - Lin Lu
  - arduanov
  - sualko
- - Yendric
  - ADmad
  - Nicolas Roudaire
- - Matthias Meyer
- - Temuri Takalandze (abgeo)
- - Bernard van der Esch (adeptofvoltron)
  - Andreas Forsblom (aforsblo)
  - Alex Olmos (alexolmos)
  - Cedric BERTOLINI (alsciende)
@@ -2975,11 +3061,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Juan Ases García (ases)
  - Siragusa (asiragusa)
  - Daniel Basten (axhm3a)
- - Benedict Massolle (bemas)
- - Gerard Berengue Llobera (bere)
- - Ronny (big-r)
  - Bernd Matzner (bmatzner)
- - Anton (bonio)
  - Bram Tweedegolf (bram_tweedegolf)
  - Brandon Kelly (brandonkelly)
  - Choong Wei Tjeng (choonge)
@@ -2987,40 +3069,30 @@ The Symfony Connect username in parenthesis allows to get more information
  - Loïc Vernet (coil)
  - Christoph Vincent Schaefer (cvschaefer)
  - Damon Jones (damon__jones)
- - Alexandre Fiocre (demos77)
+ - David Courtey (david-crty)
  - Łukasz Giza (destroyer)
  - Daniel Londero (dlondero)
  - Dušan Kasan (dudo1904)
  - Sebastian Landwehr (dword123)
  - Adel ELHAIBA (eadel)
  - Damián Nohales (eagleoneraptor)
- - Jordane VASPARD (elementaire)
  - Elliot Anderson (elliot)
- - Erwan Nader (ernadoo)
  - Fabien D. (fabd)
- - Faizan Akram Dar (faizanakram)
  - Carsten Eilers (fnc)
  - Sorin Gitlan (forapathy)
  - Yohan Giarelli (frequence-web)
- - Gasan Guseynov (gassan)
  - Gerry Vandermaesen (gerryvdm)
  - Arash Tabrizian (ghost098)
- - Greg Szczotka (greg606)
- - Ian Littman (iansltx)
- - Nathan DIdier (icz)
  - Vladislav Krupenkin (ideea)
  - Ilija Tovilo (ilijatovilo)
  - Peter Orosz (ill_logical)
- - Ilia Lazarev (ilzrv)
  - Imangazaliev Muhammad (imangazaliev)
- - Arkadiusz Kondas (itcraftsmanpl)
  - j0k (j0k)
  - joris de wit (jdewit)
  - Jérémy CROMBEZ (jeremy)
  - Jose Manuel Gonzalez (jgonzalez)
  - Joachim Krempel (jkrempel)
  - Jorge Maiden (jorgemaiden)
- - Joao Paulo V Martins (jpjoao)
  - Justin Rainbow (jrainbow)
  - Juan Luis (juanlugb)
  - JuntaTom (juntatom)
@@ -3033,17 +3105,11 @@ The Symfony Connect username in parenthesis allows to get more information
  - samuel laulhau (lalop)
  - Laurent Bachelier (laurentb)
  - Luís Cobucci (lcobucci)
- - Jérémy (libertjeremy)
  - Mehdi Achour (machour)
- - Mamikon Arakelyan (mamikon)
  - Matt Ketmo (mattketmo)
  - Moritz Borgmann (mborgmann)
- - Mathias Brodala (mbrodala)
  - Matt Drollette (mdrollette)
  - Adam Monsen (meonkeys)
- - Mike Milano (mmilano)
- - Guillaume Lajarige (molkobain)
- - Diego Aguiar (mollokhan)
  - Ala Eddine Khefifi (nayzo)
  - emilienbouard (neime)
  - Nicholas Byfleet (nickbyfleet)
@@ -3051,17 +3117,13 @@ The Symfony Connect username in parenthesis allows to get more information
  - ollie harridge (ollietb)
  - Pawel Szczepanek (pauluz)
  - Philippe Degeeter (pdegeeter)
- - PLAZANET Pierre (pedrotroller)
  - Christian López Espínola (penyaskito)
  - Petr Jaroš (petajaros)
  - Philipp Hoffmann (philipphoffmann)
  - Alex Carol (picard89)
  - Daniel Perez Pinazo (pitiflautico)
- - Igor Tarasov (polosatus)
  - Maksym Pustynnikov (pustynnikov)
  - Ralf Kühnel (ralfkuehnel)
- - Ramazan APAYDIN (rapaydin)
- - Babichev Maxim (rez1dent3)
  - Rich Sage (richsage)
  - scourgen hung (scourgen)
  - Sebastian Busch (sebu)
@@ -3072,21 +3134,15 @@ The Symfony Connect username in parenthesis allows to get more information
  - Şəhriyar İmanov (shehriyari)
  - Thomas Baumgartner (shoplifter)
  - Schuyler Jager (sjager)
- - Christopher Georg (sky-chris)
  - Volker (skydiablo)
- - Francisco Alvarez (sormes)
  - Julien Sanchez (sumbobyboys)
- - Stephan Vierkant (svierkant)
  - Ron Gähler (t-ronx)
  - Guillermo Gisinger (t3chn0r)
  - Tom Newby (tomnewbyau)
  - Andrew Clark (tqt_andrew_clark)
- - Aaron Piotrowski (trowski)
  - David Lumaye (tux1124)
- - Roman Tymoshyk (tymoshyk)
  - Moritz Kraft (userfriendly)
  - Víctor Mateo (victormateo)
- - Vincent MOULENE (vints24)
  - David Grüner (vworldat)
  - Eugene Babushkin (warl)
  - Wouter Sioen (wouter_sioen)
@@ -3094,41 +3150,29 @@ The Symfony Connect username in parenthesis allows to get more information
  - Jesper Søndergaard Pedersen (zerrvox)
  - Florent Cailhol
  - szymek
- - Ryan Linnit
- - a.dmitryuk
  - Kovacs Nicolas
  - craigmarvelley
  - Stano Turza
- - Antoine Leblanc
  - drublic
- - Andre Johnson
- - MaPePeR
  - Andreas Streichardt
  - Alexandre Segura
- - Marco Pfeiffer
- - Vivien
  - Pascal Hofmann
- - david-binda
  - smokeybear87
  - Gustavo Adrian
  - damaya
  - Kevin Weber
- - Alexandru Năstase
  - Dionysis Arvanitis
  - Sergey Fedotov
  - Konstantin Scheumann
  - Michael
  - fh-github@fholzhauer.de
  - AbdElKader Bouadjadja
- - ddegentesh
  - DSeemiller
  - Jan Emrich
- - Anne-Julia Seitz
  - Mark Topper
  - Romain
  - Xavier REN
  - max
- - Alexander Bauer (abauer)
  - Ahmad Mayahi (ahmadmayahi)
  - Mohamed Karnichi (amiral)
  - Andrew Carter (andrewcarteruk)
@@ -3137,18 +3181,16 @@ The Symfony Connect username in parenthesis allows to get more information
  - Bogdan Rancichi (devck)
  - Daniel Kolvik (dkvk)
  - Marc Lemay (flug)
- - Gabriel Solomon (gabrielsolomon)
  - Henne Van Och (hennevo)
  - Jeroen De Dauw (jeroendedauw)
  - Maxime COLIN (maximecolin)
  - Muharrem Demirci (mdemirci)
  - Evgeny Z (meze)
- - Aleksandar Dimitrov (netbull)
+ - Pierre-Henry Soria 🌴 (pierrehenry)
  - Pierre Geyer (ptheg)
  - Thomas BERTRAND (sevrahk)
  - Vladislav (simpson)
  - Matej Žilák (teo_sk)
- - Gary Houbre (thegarious)
  - Vladislav Vlastovskiy (vlastv)
  - RENAUDIN Xavier (xorrox)
  - Yannick Vanhaeren (yvh)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    public const VERSION = '4.4.43-DEV';
+    public const VERSION = '4.4.43';
     public const VERSION_ID = 40443;
     public const MAJOR_VERSION = 4;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 43;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2022';
     public const END_OF_LIFE = '11/2023';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v4.4.42...v4.4.43)

 * bug #46765 [Serializer] Fix denormalization union types with constructor (@Gwemox)
 * bug #46769 [HttpKernel] Fix a PHP 8.1 deprecation notice in HttpCache (@mpdude)
 * bug #46747 Fix global state pollution between tests run with ApplicationTester (@Seldaek)
 * bug #46730 [Intl] Fix the IntlDateFormatter::formatObject signature (@damienalexandre)
 * bug #46668 [FrameworkBundle] Lower JsonSerializableNormalizer priority (@aprat84)
 * bug #46678 [HttpFoundation] Update "[Session] Overwrite invalid session id" to only validate when files session storage is used (@alexpott)
 * bug #45861 [Serializer] Try all possible denormalization route with union types when ALLOW_EXTRA_ATTRIBUTES=false (@T-bond)
 * bug #46676 [DoctrineBridge] Extend type guessing on enum fields (@Gigino Chianese)
 * bug #46699 [Cache] Respect $save option in all adapters (@jrjohnson)
 * bug #46697 [HttpKernel] Disable session tracking while collecting profiler data (@nicolas-grekas)
 * bug #46684 [MonologBridge] Fixed support of elasticsearch 7.+ in ElasticsearchLogstashHandler (@lyrixx)
 * bug #46368 [Mailer] Fix for missing sender name in case with usage of the EnvelopeListener (@bobahvas)
 * bug #46548 [Mime] Allow url as a path in the DataPart::fromPath (@wkania)
 * bug #46594 [FrameworkBundle] Fix XML cache config (@HeahDude)
 * bug #46595 [Console] Escape  in command name & description from getDefaultName() (@ogizanagi)
 * bug #46565 [WebProfilerBundle] Fix dark theme selected line highlight color & reuse css vars (@ogizanagi)
 * bug #46535 [Mime] Check that the path is a file in the DataPart::fromPath (@wkania)
 * bug #46543 [Cache] do not pass null to strlen() (@xabbuh)
 * bug #46478 [Contracts] remove static cache from `ServiceSubscriberTrait` (@kbond)
