### PR TITLE
[Bridge] Corrects bug in test listener trait

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -271,7 +271,7 @@ class SymfonyTestsListenerTrait
             $assertions = \count(self::$expectedDeprecations) + $test->getNumAssertions();
             if ($test->doesNotPerformAssertions() && $assertions > 0) {
                 $test->getTestResultObject()->addFailure($test, new RiskyTestError(sprintf('This test is annotated with "@doesNotPerformAssertions", but performed %s assertions', $assertions)), $time);
-            } elseif ($assertions === 0 && $test->getTestResultObject()->noneSkipped()) {
+            } elseif ($assertions === 0 && !$test->doesNotPerformAssertions() && $test->getTestResultObject()->noneSkipped()) {
                 $test->getTestResultObject()->addFailure($test, new RiskyTestError('This test did not perform any assertions'), $time);
             }
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestNotRisky.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestNotRisky.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests\FailTests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
+/**
+ * This class is deliberately suffixed with *TestRisky.php so that it is ignored
+ * by PHPUnit. This test is designed to fail. See ../expectnotrisky.phpt.
+ */
+final class NoAssertionsTestNotRisky extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    /**
+     * Do not remove this test in the next major version.
+     */
+    public function testOne()
+    {
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/expectnotrisky.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/expectnotrisky.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test NoAssertionsTestNotRisky not risky test
+--SKIPIF--
+<?php if ('\\' === DIRECTORY_SEPARATOR && !extension_loaded('mbstring')) die('Skipping on Windows without mbstring');
+--FILE--
+<?php
+$test =  realpath(__DIR__.'/FailTests/NoAssertionsTestNotRisky.php');
+passthru('php '.getenv('SYMFONY_SIMPLE_PHPUNIT_BIN_DIR').'/simple-phpunit.php --fail-on-risky --colors=never '.$test);
+?>
+--EXPECTF--
+PHPUnit %s
+
+%ATesting Symfony\Bridge\PhpUnit\Tests\FailTests\NoAssertionsTestNotRisky
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 0 assertions)


### PR DESCRIPTION
If you enable the `SymfonyTestsListenerTrait`, use the
`ExpectDeprecationTrait`, and call
`$this->expectNotToPerformAssertions()`, an error was returned in your
test saying it was risky as it did not perform any assertions even
though it was expected not to.

This bug turned out to be caused by not checking if the
`doesNotPerformAssertions` flag had been set.

Issue: #41444

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #41444 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This fixes a bug that could occur when using this listener along with the `ExpectDeprecationTrait` trait and the `TestCase::expectNotToPerformAssertions()` method.  When that method is called, the user is saying that no assertions will happen but the listener didn't care and saw no assertions and none skipped so threw the 'No assertions' warning message.  This updates the listener to check the value of `TestCase::doesNotPerformAssertions` when deciding to warn about no assertions or not.