### PR TITLE
[Messenger] Ceil waiting time when multiplier is a float on retry

### DIFF
--- a/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
+++ b/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
@@ -80,6 +80,6 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
             return $this->maxDelayMilliseconds;
         }
 
-        return $delay;
+        return (int) ceil($delay);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
@@ -52,7 +52,7 @@ class MultiplierRetryStrategyTest extends TestCase
     /**
      * @dataProvider getWaitTimeTests
      */
-    public function testGetWaitTime(int $delay, int $multiplier, int $maxDelay, int $previousRetries, int $expectedDelay)
+    public function testGetWaitTime(int $delay, float $multiplier, int $maxDelay, int $previousRetries, int $expectedDelay)
     {
         $strategy = new MultiplierRetryStrategy(10, $delay, $multiplier, $maxDelay);
         $envelope = new Envelope(new \stdClass(), [new RedeliveryStamp($previousRetries)]);
@@ -83,5 +83,10 @@ class MultiplierRetryStrategyTest extends TestCase
         // never a delay
         yield [0, 2, 10000, 0, 0];
         yield [0, 2, 10000, 1, 0];
+
+        // Float delay
+        yield [1000, 1.5555, 5000, 0, 1000];
+        yield [1000, 1.5555, 5000, 1, 1555];
+        yield [1000, 1.5555, 5000, 2, 2419];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #46795
| License       | MIT
| Doc PR        | Not required

In the Messenger - MultiplierRetryStrategy the return type for the function `getWaitingTime` is int, however with the computation of that function we were returning a float, this is because float * int returns a float and the attribute $multiplier is a float.

With this fix, we are rounding up the delay and casting into an int.