### PR TITLE
[Messenger] Fix TypeError getWaitingTime with float multiplier

### DIFF
--- a/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
+++ b/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
@@ -80,6 +80,6 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
             return $this->maxDelayMilliseconds;
         }
 
-        return $delay;
+        return (int) $delay;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46795 
| License       | MIT

Fix for when `strict_types=1` is enabled

`$delay` is a float so cast is needed