### PR TITLE
[Cache][WebProfilerBundle] Add adapter class to Cache `DataCollector`

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
@@ -97,6 +97,14 @@
                     <h3 class="tab-title">{{ name }} <span class="badge">{{ collector.statistics[name].calls }}</span></h3>
 
                     <div class="tab-content">
+                        <h4>Adapter</h4>
+                        <div class="card">
+                            {% if collector.adapters[name] is defined %}
+                                <code>{{ collector.adapters[name] }}</code>
+                            {% else %}
+                                <span class="text-muted">Unable to get adapter class.</span>
+                            {% endif %}
+                        </div>
                         {% if calls|length == 0 %}
                             <div class="empty">
                                 <p>No calls were made for {{ name }} pool.</p>

--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -260,6 +260,11 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, PruneableInt
         $this->calls = [];
     }
 
+    public function getPool(): AdapterInterface
+    {
+        return $this->pool;
+    }
+
     protected function start(string $name)
     {
         $this->calls[] = $event = new TraceableAdapterEvent();

--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -41,10 +41,11 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
      */
     public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
-        $empty = ['calls' => [], 'config' => [], 'options' => [], 'statistics' => []];
+        $empty = ['calls' => [], 'adapters' => [], 'config' => [], 'options' => [], 'statistics' => []];
         $this->data = ['instances' => $empty, 'total' => $empty];
         foreach ($this->instances as $name => $instance) {
             $this->data['instances']['calls'][$name] = $instance->getCalls();
+            $this->data['instances']['adapters'][$name] = \get_debug_type($instance->getPool());
         }
 
         $this->data['instances']['statistics'] = $this->calculateStatistics();
@@ -94,6 +95,14 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
     public function getCalls(): mixed
     {
         return $this->data['instances']['calls'];
+    }
+
+    /**
+     * Method returns all logged Cache adapter classes.
+     */
+    public function getAdapters(): array
+    {
+        return $this->data['instances']['adapters'];
     }
 
     private function calculateStatistics(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When debugging cache issues, it could be useful to know which adapter is used for each pool. This PR adds this information in the WebProfiler.

![image](https://user-images.githubusercontent.com/6114779/176461168-c59b4fe1-a3a9-4337-9fb6-2f2d4538bf9b.png)
