### PR TITLE
[HttpFoundation] Fix TypeError on null `$_SESSION`  in `NativeSessionStorage::save()`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -256,7 +256,7 @@ class NativeSessionStorage implements SessionStorageInterface
                 unset($_SESSION[$key]);
             }
         }
-        if ([$key = $this->metadataBag->getStorageKey()] === array_keys($_SESSION)) {
+        if ($_SESSION && [$key = $this->metadataBag->getStorageKey()] === array_keys($_SESSION)) {
             unset($_SESSION[$key]);
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -321,4 +321,13 @@ class NativeSessionStorageTest extends TestCase
         $this->assertTrue($started);
         $this->assertSame('&~[', session_id());
     }
+
+    public function testSaveHandlesNullSessionGracefully()
+    {
+        $storage = $this->getStorage();
+        $_SESSION = null;
+        $storage->save();
+
+        $this->addToAssertionCount(1);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When sending concurrent requests via ajax async to a route pointing to a controller requiring an authenticated user through a stateful - session-based - firewall that calls `SessionInterface::save()`, it happens that `$_SESSION` is `null` under some conditions which causes the following error on PHP 8.1:

> Exception 'TypeError' with message 'array_keys(): Argument #1 ($array) must be of type array, null given' in /app/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php:246
…app/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php (246)
…age::save called at /app/vendor/symfony/http-foundation/Session/Session.php (198)

The issue prevents me from upgrading to PHP 8.1 in a project I'm working on with @jwage. 