### PR TITLE
[Console] Fix console section output without newline

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -138,6 +138,7 @@ class QuestionHelper extends Helper
         }
 
         if ($output instanceof ConsoleSectionOutput) {
+            $output->addContent(''); // add EOL to the question
             $output->addContent($ret);
         }
 

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -50,7 +50,7 @@ class ConsoleSectionOutput extends StreamOutput
         }
 
         if ($lines) {
-            array_splice($this->content, -($lines * 2)); // Multiply lines by 2 to cater for each new line added between content
+            array_splice($this->content, -$lines);
         } else {
             $lines = $this->lines;
             $this->content = [];
@@ -80,12 +80,42 @@ class ConsoleSectionOutput extends StreamOutput
     /**
      * @internal
      */
-    public function addContent(string $input)
+    public function addContent(string $input, bool $newline = true)
     {
-        foreach (explode(\PHP_EOL, $input) as $lineContent) {
-            $this->lines += ceil($this->getDisplayLength($lineContent) / $this->terminal->getWidth()) ?: 1;
-            $this->content[] = $lineContent;
-            $this->content[] = \PHP_EOL;
+        $width = $this->terminal->getWidth();
+        $lines = explode(\PHP_EOL, $input);
+        $count = \count($lines) - 1;
+        foreach ($lines as $i => $lineContent) {
+            // re-add the line break (that has been removed in the above `explode()` for
+            // - every line that is not the last line
+            // - if $newline is required, also add it to the last line
+            if ($i < $count || $newline) {
+                $lineContent .= \PHP_EOL;
+            }
+
+            // skip line if there is no text (or newline for that matter)
+            if ('' === $lineContent) {
+                continue;
+            }
+
+            // For the first line, check if the previous line (last entry of `$this->content`)
+            // needs to be continued (i.e. does not end with a line break).
+            if (0 === $i
+                && (false !== $lastLine = end($this->content))
+                && !str_ends_with($lastLine, \PHP_EOL)
+            ) {
+                // deduct the line count of the previous line
+                $this->lines -= (int) ceil($this->getDisplayLength($lastLine) / $width) ?: 1;
+                // concatenate previous and new line
+                $lineContent = $lastLine.$lineContent;
+                // replace last entry of `$this->content` with the new expanded line
+                array_splice($this->content, -1, 1, $lineContent);
+            } else {
+                // otherwise just add the new content
+                $this->content[] = $lineContent;
+            }
+
+            $this->lines += (int) ceil($this->getDisplayLength($lineContent) / $width) ?: 1;
         }
     }
 
@@ -100,11 +130,16 @@ class ConsoleSectionOutput extends StreamOutput
             return;
         }
 
-        $erasedContent = $this->popStreamContentUntilCurrentSection();
+        // Check if the previous line (last entry of `$this->content`) needs to be continued
+        // (i.e. does not end with a line break). In which case, it needs to be erased first.
+        $deleteLastLine = ($lastLine = end($this->content) ?: '') && !str_ends_with($lastLine, \PHP_EOL) ? 1 : 0;
+        $erasedContent = $this->popStreamContentUntilCurrentSection($deleteLastLine);
 
-        $this->addContent($message);
+        $this->addContent($message, $newline);
 
-        parent::doWrite($message, true);
+        // If the last line was removed, re-print its content together with the new content.
+        // Otherwise, just print the new content.
+        parent::doWrite($deleteLastLine ? $lastLine.$message : $message, true);
         parent::doWrite($erasedContent, false);
     }
 
@@ -123,7 +158,12 @@ class ConsoleSectionOutput extends StreamOutput
             }
 
             $numberOfLinesToClear += $section->lines;
-            $erasedContent[] = $section->getContent();
+            if ('' !== $sectionContent = $section->getContent()) {
+                if (!str_ends_with($sectionContent, \PHP_EOL)) {
+                    $sectionContent .= \PHP_EOL;
+                }
+                $erasedContent[] = $sectionContent;
+            }
         }
 
         if ($numberOfLinesToClear > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 4.4
| Bug fix      | yes
| New feature  | no
| Deprecations | no
| Tickets       | Fix #37304
| License       | MIT
| Doc PR        | n/a

As described in #37304, when writing to a output section, a newline would automatically be added, inrespective wether using `write()` or `writeln()`. This PR fixes said behaviour. Lines can now be appended to.