### PR TITLE
[Form] Provide string keys when iterating on a form

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -77,7 +77,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
     /**
      * A map of FormInterface instances.
      *
-     * @var OrderedHashMap<string, FormInterface>
+     * @var OrderedHashMap<FormInterface>
      */
     private OrderedHashMap $children;
 

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -333,6 +333,16 @@ class CompoundFormTest extends TestCase
         $this->assertSame($this->form->all(), iterator_to_array($this->form));
     }
 
+    public function testIteratorKeys()
+    {
+        $this->form->add($this->getBuilder('0')->getForm());
+        $this->form->add($this->getBuilder('1')->getForm());
+
+        foreach ($this->form as $key => $value) {
+            $this->assertIsString($key);
+        }
+    }
+
     public function testAddMapsViewDataToFormIfInitialized()
     {
         $form = $this->getBuilder()

--- a/src/Symfony/Component/Form/Tests/Util/OrderedHashMapTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/OrderedHashMapTest.php
@@ -51,7 +51,7 @@ class OrderedHashMapTest extends TestCase
         $map['foo'] = 2;
         $map[] = 3;
 
-        $this->assertSame([0 => 1, 'foo' => 2, 1 => 3], iterator_to_array($map));
+        $this->assertSame(['0' => 1, 'foo' => 2, '1' => 3], iterator_to_array($map));
     }
 
     public function testInsertLooselyEqualKeys()
@@ -496,12 +496,30 @@ class OrderedHashMapTest extends TestCase
         $this->assertNull($it1->current());
     }
 
+    public function testKeysAreString()
+    {
+        $map = new OrderedHashMap(['1' => 1]);
+        $map['2'] = 2;
+
+        $it = $map->getIterator();
+
+        $it->rewind();
+        $this->assertTrue($it->valid());
+        $this->assertSame('1', $it->key());
+        $this->assertSame(1, $it->current());
+
+        $it->next();
+        $this->assertTrue($it->valid());
+        $this->assertSame('2', $it->key());
+        $this->assertSame(2, $it->current());
+    }
+
     public function testCount()
     {
         $map = new OrderedHashMap();
         $map[] = 1;
         $map['foo'] = 2;
-        unset($map[0]);
+        unset($map['0']);
         $map[] = 3;
 
         $this->assertCount(2, $map);

--- a/src/Symfony/Component/Form/Util/OrderedHashMap.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMap.php
@@ -64,25 +64,24 @@ namespace Symfony\Component\Form\Util;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @template TKey of array-key
  * @template TValue
  *
- * @implements \ArrayAccess<TKey, TValue>
- * @implements \IteratorAggregate<TKey, TValue>
+ * @implements \ArrayAccess<string, TValue>
+ * @implements \IteratorAggregate<string, TValue>
  */
 class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 {
     /**
      * The elements of the map, indexed by their keys.
      *
-     * @var array<TKey, TValue>
+     * @var TValue[]
      */
     private array $elements = [];
 
     /**
      * The keys of the map in the order in which they were inserted or changed.
      *
-     * @var list<TKey>
+     * @var list<string>
      */
     private array $orderedKeys = [];
 
@@ -96,12 +95,13 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Creates a new map.
      *
-     * @param array<TKey, TValue> $elements The elements to insert initially
+     * @param TValue[] $elements The elements to insert initially
      */
     public function __construct(array $elements = [])
     {
         $this->elements = $elements;
-        $this->orderedKeys = array_keys($elements);
+        // the explicit string type-cast is necessary as digit-only keys would be returned as integers otherwise
+        $this->orderedKeys = array_map(strval(...), array_keys($elements));
     }
 
     public function offsetExists(mixed $key): bool

--- a/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
@@ -18,36 +18,34 @@ namespace Symfony\Component\Form\Util;
  *
  * @internal
  *
- * @template-covariant TKey of array-key
  * @template-covariant TValue
  *
- * @implements \Iterator<TKey, TValue>
+ * @implements \Iterator<string, TValue>
  */
 class OrderedHashMapIterator implements \Iterator
 {
-    /** @var array<TKey, TValue> */
+    /** @var TValue[] */
     private array $elements;
-    /** @var list<TKey> */
+    /** @var list<string> */
     private array $orderedKeys;
     private int $cursor = 0;
     private int $cursorId;
     /** @var array<int, int> */
     private array $managedCursors;
-    /** @var TKey|null */
-    private string|int|null $key = null;
+    private string|null $key = null;
     /** @var TValue|null */
     private mixed $current = null;
 
     /**
-     * @param array<TKey, TValue> $elements       The elements of the map, indexed by their
-     *                                            keys
-     * @param list<TKey>          $orderedKeys    The keys of the map in the order in which
-     *                                            they should be iterated
-     * @param array<int, int>     $managedCursors An array from which to reference the
-     *                                            iterator's cursor as long as it is alive.
-     *                                            This array is managed by the corresponding
-     *                                            {@link OrderedHashMap} instance to support
-     *                                            recognizing the deletion of elements.
+     * @param TValue[]        $elements       The elements of the map, indexed by their
+     *                                        keys
+     * @param list<string>    $orderedKeys    The keys of the map in the order in which
+     *                                        they should be iterated
+     * @param array<int, int> $managedCursors An array from which to reference the
+     *                                        iterator's cursor as long as it is alive.
+     *                                        This array is managed by the corresponding
+     *                                        {@link OrderedHashMap} instance to support
+     *                                        recognizing the deletion of elements.
      */
     public function __construct(array &$elements, array &$orderedKeys, array &$managedCursors)
     {
@@ -113,9 +111,7 @@ class OrderedHashMapIterator implements \Iterator
             return null;
         }
 
-        $array = [$this->key => null];
-
-        return key($array);
+        return $this->key;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2  as recommended by https://github.com/symfony/symfony/issues/46698#issuecomment-1169942792
| Bug fix?      | no (?)
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46698
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

cc @derrabus 