### PR TITLE
[DependencyInjection] Make `Container::getEnv` public

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -329,8 +329,6 @@ abstract class Descriptor implements DescriptorInterface
         };
         $getDefaultParameter = $getDefaultParameter->bindTo($bag, \get_class($bag));
 
-        $getEnvReflection = new \ReflectionMethod($container, 'getEnv');
-
         $envs = [];
 
         foreach ($envVars as $env) {
@@ -343,7 +341,7 @@ abstract class Descriptor implements DescriptorInterface
             if (false === ($runtimeValue = $_ENV[$name] ?? $_SERVER[$name] ?? getenv($name))) {
                 $runtimeValue = null;
             }
-            $processedValue = ($hasRuntime = null !== $runtimeValue) || $hasDefault ? $getEnvReflection->invoke($container, $env) : null;
+            $processedValue = ($hasRuntime = null !== $runtimeValue) || $hasDefault ? $container->getEnv($env) : null;
             $envs["$name$processor"] = [
                 'name' => $name,
                 'processor' => $processor,

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -334,7 +334,7 @@ class Container implements ContainerInterface, ResetInterface
      *
      * @throws EnvNotFoundException When the environment variable is not found and has no default value
      */
-    protected function getEnv(string $name): mixed
+    public function getEnv(string $name): mixed
     {
         if (isset($this->resolving[$envName = "env($name)"])) {
             throw new ParameterCircularReferenceException(array_keys($this->resolving));

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1549,7 +1549,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * {@inheritdoc}
      */
-    protected function getEnv(string $name): mixed
+    public function getEnv(string $name): mixed
     {
         $value = parent::getEnv($name);
         $bag = $this->getParameterBag();
@@ -1612,7 +1612,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             if (!class_exists(Expression::class)) {
                 throw new LogicException('Expressions cannot be used without the ExpressionLanguage component. Try running "composer require symfony/expression-language".');
             }
-            $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders, null, $this->getEnv(...));
+            $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders, null);
         }
 
         return $this->expressionLanguage;

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 /**
  * ContainerInterface is the interface implemented by service container classes.
  *
+ * @method mixed getEnv Fetches a variable from the environment.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
@@ -30,10 +30,10 @@ class ExpressionLanguage extends BaseExpressionLanguage
     /**
      * {@inheritdoc}
      */
-    public function __construct(CacheItemPoolInterface $cache = null, array $providers = [], callable $serviceCompiler = null, \Closure $getEnv = null)
+    public function __construct(CacheItemPoolInterface $cache = null, array $providers = [], callable $serviceCompiler = null)
     {
         // prepend the default provider to let users override it easily
-        array_unshift($providers, new ExpressionLanguageProvider($serviceCompiler, $getEnv));
+        array_unshift($providers, new ExpressionLanguageProvider($serviceCompiler));
 
         parent::__construct($cache, $providers);
     }

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
@@ -28,12 +28,9 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
 {
     private ?\Closure $serviceCompiler;
 
-    private ?\Closure $getEnv;
-
-    public function __construct(callable $serviceCompiler = null, \Closure $getEnv = null)
+    public function __construct(callable $serviceCompiler = null)
     {
         $this->serviceCompiler = null === $serviceCompiler ? null : $serviceCompiler(...);
-        $this->getEnv = $getEnv;
     }
 
     public function getFunctions(): array
@@ -54,11 +51,7 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
             new ExpressionFunction('env', function ($arg) {
                 return sprintf('$this->getEnv(%s)', $arg);
             }, function (array $variables, $value) {
-                if (!$this->getEnv) {
-                    throw new LogicException('You need to pass a getEnv closure to the expression langage provider to use the "env" function.');
-                }
-
-                return ($this->getEnv)($value);
+                return $variables['container']->getEnv($value);
             }),
 
             new ExpressionFunction('arg', function ($arg) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature? | yes
| Deprecations? | no
| Tickets       | Fix #34173, https://github.com/symfony/symfony/pull/45450#discussion_r808173737
| License       | MIT
| Doc PR        | to be added if accepted

In our app we're controlling certain features' availability with feature switches defined in envs (to prevent non-tech folks from turning them on without our assitance). We'd like to show whether those switches are on or off in the administration panel. Sadly, there is no kosher way to get those values during runtime other than injecting every variable we want to show. By making `getEnv` public we're exposing not only raw values one could get with `getenv` but more importantly processors. By the way we're also ironing out two not-so-great hacks to get env variables in Symfony itself (included in PR).

Code will need finishing if we agree this is good idea:
- [ ] I'll deal with new interface method according to the rules
- [ ] Documentation will be written

I just don't want to waste time on these in case the PR will be shot down :)



