### PR TITLE
[FrameworkBundle] Add `resolve-env` option to debug:config command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
@@ -46,6 +47,7 @@ class ConfigDebugCommand extends AbstractConfigCommand
             ->setDefinition([
                 new InputArgument('name', InputArgument::OPTIONAL, 'The bundle name or the extension alias'),
                 new InputArgument('path', InputArgument::OPTIONAL, 'The configuration option path'),
+                new InputOption('resolve-env', null, InputOption::VALUE_NONE, 'Display resolved environment variable values instead of placeholders'),
             ])
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command dumps the current configuration for an
@@ -94,7 +96,7 @@ EOF
         $extensionAlias = $extension->getAlias();
         $container = $this->compileContainer();
 
-        $config = $this->getConfig($extension, $container);
+        $config = $this->getConfig($extension, $container, $input->getOption('resolve-env'));
 
         if (null === $path = $input->getArgument('path')) {
             $io->title(
@@ -210,12 +212,12 @@ EOF
         return $availableBundles;
     }
 
-    private function getConfig(ExtensionInterface $extension, ContainerBuilder $container)
+    private function getConfig(ExtensionInterface $extension, ContainerBuilder $container, bool $resolveEnvs = false)
     {
         return $container->resolveEnvPlaceholders(
             $container->getParameterBag()->resolveValue(
                 $this->getConfigForExtension($extension, $container)
-            )
+            ), $resolveEnvs ?: null
         );
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -60,6 +60,18 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString('secret: test', $tester->getDisplay());
     }
 
+    public function testParametersValuesAreFullyResolved()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(['name' => 'framework', '--resolve-env' => true]);
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertStringContainsString('locale: en', $tester->getDisplay());
+        $this->assertStringContainsString('secret: test', $tester->getDisplay());
+        $this->assertStringContainsString('cookie_httponly: true', $tester->getDisplay());
+        $this->assertStringContainsString('ide: null', $tester->getDisplay());
+    }
+
     public function testDefaultParameterValueIsResolvedIfConfigIsExisting()
     {
         $tester = $this->createCommandTester();

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add argument `&$asGhostObject` to LazyProxy's `DumperInterface` to allow using ghost objects for lazy loading services
  * Add `enum` env var processor
  * Add `shuffle` env var processor
+ * Add `resolve-env` option to `debug:config` command to display actual values of environment variables in dumped configuration
 
 6.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40582
| License       | MIT
| Doc PR        | _NA_

Add `--resolve-env` option to `debug:config` command to display actual values of environment variables in dumped configuration.

This main purpose of this command is debugging as its name suggests. In order to help the developer to debug its configuration, it is convenient to display the actual value of environment variables present in the dumped configuration, instead of placeholders.

Here is the result:

```
$ symfony console debug:config framework | grep secret
    secret: '%env(APP_SECRET)%'
    secrets:
        vault_directory: '/home/alexandredaubois/(...)/config/secrets/%env(default:kernel.environment:APP_RUNTIME_ENV)%'

$ symfony console debug:config framework --resolve-env | grep secret
    secret: 90d83502629d64dec4cd6e33c9b31267
    secrets:
        vault_directory: /home/alexandredaubois/(...)/config/secrets/dev
```