### PR TITLE
[HttpKernel] Strip exception file paths from log messages

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
@@ -90,7 +90,7 @@ class ErrorListener implements EventSubscriberInterface
 
         $e = FlattenException::createFromThrowable($throwable);
 
-        $this->logException($throwable, sprintf('Uncaught PHP Exception %s: "%s" at %s line %s', $e->getClass(), $e->getMessage(), $e->getFile(), $e->getLine()), $logLevel);
+        $this->logException($throwable, sprintf('Uncaught PHP Exception %s: "%s" at %s line %s', $e->getClass(), $e->getMessage(), basename($e->getFile()), $e->getLine()), $logLevel);
     }
 
     /**
@@ -118,7 +118,7 @@ class ErrorListener implements EventSubscriberInterface
         } catch (\Exception $e) {
             $f = FlattenException::createFromThrowable($e);
 
-            $this->logException($e, sprintf('Exception thrown when handling an exception (%s: %s at %s line %s)', $f->getClass(), $f->getMessage(), $e->getFile(), $e->getLine()));
+            $this->logException($e, sprintf('Exception thrown when handling an exception (%s: %s at %s line %s)', $f->getClass(), $f->getMessage(), basename($e->getFile()), $e->getLine()));
 
             $prev = $e;
             do {

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -96,7 +96,11 @@ class ErrorListenerTest extends TestCase
         }
 
         $this->assertEquals(3, $logger->countErrors());
-        $this->assertCount(3, $logger->getLogs('critical'));
+        $logs = $logger->getLogs('critical');
+        $this->assertCount(3, $logs);
+        $this->assertStringStartsWith('Uncaught PHP Exception Exception: "foo" at ErrorListenerTest.php line', $logs[0]);
+        $this->assertStringStartsWith('Uncaught PHP Exception Exception: "foo" at ErrorListenerTest.php line', $logs[1]);
+        $this->assertStringStartsWith('Exception thrown when handling an exception (RuntimeException: bar at ErrorListenerTest.php line', $logs[2]);
     }
 
     public function testHandleWithLoggerAndCustomConfiguration()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

In log messages, I would like to strip full file path to a file where error occurred. Instead, I suggest to use name of the file only. There are 2 reasons:
1. Whole $exception is supplied to logger anyways, so filepath is not lost from logs. I am only removing it from log _message_, not log entry. There isn't really a need to have filepath both in log message and log context.
2. We, similarly as lot of people use symlinks for deployments. This means real path after every release changes (/`app/releases/385`/ -> `/app/releases/386/` and so on). Since `Exception::getFile()` contains real path and not symlink path (`/app/current/`), every release log messages for exact same errors change. This causes error deduplication of 3rd parties like NewRelic and other APM solutions to not trigger, which means we are getting alerts for same old errors after every release.