### PR TITLE
[ExpressionLanguage] Revert readonly flag on ConstantNode::$isNullSafe

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
@@ -20,7 +20,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  */
 class ConstantNode extends Node
 {
-    public readonly bool $isNullSafe;
+    public bool $isNullSafe;
     private bool $isIdentifier;
 
     public function __construct(mixed $value, bool $isIdentifier = false, bool $isNullSafe = false)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Since #45795, the new property `ConstantNode::$isNullSafe` is `readonly` but when Hydrator of VarExporter component tries to hydrate `Symfony\Component\ExpressionLanguage\Compiler\ConstantNode` [here](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/VarExporter/Internal/Hydrator.php#L63), we get an "Error: Cannot initialize readonly property Symfony\Component\ExpressionLanguage\Node\ConstantNode::$isNullSafe from scope Symfony\Component\VarExporter\Internal\Hydrator".

My stacktrace :

> Error: Cannot initialize readonly property Symfony\Component\ExpressionLanguage\Node\ConstantNode::$isNullSafe from scope Symfony\Component\VarExporter\Internal\Hydrator
>    │
>    ╵ /app/vendor/symfony/var-exporter/Internal/Hydrator.php:63
>    ╵ /app/vendor/symfony/var-exporter/Internal/Hydrator.php:43
>    ╵ /app/var/cache/test/pools/system/RT-ma9MMTZ/G/C/sXxDeGNGSoIu4LvAqLrg:139
>    ╵ /app/vendor/symfony/cache/Adapter/PhpFilesAdapter.php:118
>    ╵ /app/vendor/symfony/cache/Traits/AbstractAdapterTrait.php:210
>    ╵ /app/vendor/symfony/cache/Adapter/TraceableAdapter.php:77
>    ╵ /app/vendor/symfony/expression-language/ExpressionLanguage.php:78
>    ╵ /app/vendor/symfony/expression-language/ExpressionLanguage.php:59
>    ╵ /app/vendor/symfony/validator/Constraints/ExpressionValidator.php:45
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:758
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:603
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:517
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:314
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:139
>    ╵ /app/vendor/symfony/form/Extension/Validator/Constraints/FormValidator.php:108
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:758
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:489
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:314
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:139
>    ╵ /app/vendor/symfony/validator/Validator/RecursiveValidator.php:97
>    ╵ /app/vendor/symfony/validator/Validator/TraceableValidator.php:67
>    ╵ /app/vendor/symfony/form/Extension/Validator/EventListener/ValidationListener.php:49
>    ╵ /app/vendor/symfony/event-dispatcher/EventDispatcher.php:230
>    ╵ /app/vendor/symfony/event-dispatcher/EventDispatcher.php:59
>    ╵ /app/vendor/symfony/event-dispatcher/ImmutableEventDispatcher.php:33
>    ╵ /app/vendor/symfony/form/Form.php:642
>    ╵ /app/tests/Infrastructure/UserInterface/Http/Form/MyFormWithExpressionConstraintTest.php:32

Friendly ping @mytuny