### PR TITLE
[Serializer] Fix inherited method visibility in AbstractObjectNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -228,8 +228,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     /**
      * Computes the normalization context merged with current one. Metadata always wins over global context, as more specific.
+     *
+     * @internal
      */
-    private function getAttributeNormalizationContext(object $object, string $attribute, array $context): array
+    protected function getAttributeNormalizationContext(object $object, string $attribute, array $context): array
     {
         if (null === $metadata = $this->getAttributeMetadata($object, $attribute)) {
             return $context;
@@ -240,8 +242,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     /**
      * Computes the denormalization context merged with current one. Metadata always wins over global context, as more specific.
+     *
+     * @internal
      */
-    private function getAttributeDenormalizationContext(string $class, string $attribute, array $context): array
+    protected function getAttributeDenormalizationContext(string $class, string $attribute, array $context): array
     {
         $context['deserialization_path'] = ($context['deserialization_path'] ?? false) ? $context['deserialization_path'].'.'.$attribute : $attribute;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixes

> PHP Fatal error:  Access level to Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::getAttributeNormalizationContext() must be protected (as in class Symfony\Component\Serializer\Normalizer\AbstractNormalizer) or weaker in /Users/robinchalas/Workspace/contrib/symfony/symfony/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php on line 232

Introduced in #46680.