### PR TITLE
[VarExporter] Fix instanciation test on PHP 8.2 with readonly properties

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Internal/Hydrator.php
@@ -208,10 +208,6 @@ class Hydrator
                 };
         }
 
-        if (!$classReflector->isInternal()) {
-            return $baseHydrator->bindTo(null, $class);
-        }
-
         if ($classReflector->name !== $class) {
             return self::$simpleHydrators[$classReflector->name] ??= self::getSimpleHydrator($classReflector->name);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

`src/Symfony/Component/VarExporter/Tests/InstantiatorTest::testInstantiate` fails on PHP 8.2, on Symfony 6.2 only. 
This fails because of an initialization of a readonly property outside of its class scope (see: https://php.watch/versions/8.1/readonly#init) 