### PR TITLE
[Mailer] Add missing dependency for OhMySmtp

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/OhMySmtp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/OhMySmtp/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": ">=8.1",
         "psr/event-dispatcher": "^1",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/mailer": "^5.4|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes* <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Added missing dependency on `symfony/deprecation-contracts` for OhMyStmp Mailer bridge.