### PR TITLE
[Console] Avoid constructor promotion in 5.4 branch

### DIFF
--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -24,7 +24,7 @@ class AsCommand
         string $name,
         string $description = null,
         array $aliases = [],
-        bool $hidden = false,
+        bool $hidden = false
     ) {
         if (!$hidden && !$aliases) {
             return;

--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -17,9 +17,12 @@ namespace Symfony\Component\Console\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class AsCommand
 {
+    public $name;
+    public $description;
+    
     public function __construct(
-        public string $name,
-        public ?string $description = null,
+        string $name,
+        ?string $description = null,
         array $aliases = [],
         bool $hidden = false,
     ) {
@@ -35,5 +38,6 @@ class AsCommand
         }
 
         $this->name = implode('|', $name);
+        $this->description = $description;
     }
 }

--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -19,10 +19,10 @@ class AsCommand
 {
     public $name;
     public $description;
-    
+
     public function __construct(
         string $name,
-        ?string $description = null,
+        string $description = null,
         array $aliases = [],
         bool $hidden = false,
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The 5.4 branch only requires PHP 7.2 so should not use constructor promotion.

For downstream https://phabricator.wikimedia.org/T301344
