### PR TITLE
Enable intl.use_exceptions in debug mode

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Debug.php
+++ b/src/Symfony/Component/ErrorHandler/Debug.php
@@ -33,6 +33,7 @@ class Debug
         ini_set('assert.active', 1);
         ini_set('assert.warning', 0);
         ini_set('assert.exception', 1);
+        ini_set('intl.use_exceptions', 1);
 
         DebugClassLoader::enable();
 

--- a/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
+++ b/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
@@ -35,6 +35,9 @@ class BasicErrorHandler
             ini_set('assert.warning', 0);
             ini_set('assert.exception', 1);
         }
+        if ($debug) {
+            ini_set('intl.use_exceptions', 1);
+        }
 
         set_error_handler(new self());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Let's be stricter by default in debug mode.