### PR TITLE
[Mailer] MessageEvent should be dispatched when no message bus is configured

### DIFF
--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -39,17 +39,17 @@ final class Mailer implements MailerInterface
 
     public function send(RawMessage $message, Envelope $envelope = null): void
     {
-        if (null === $this->bus) {
-            $this->transport->send($message, $envelope);
-
-            return;
-        }
-
         if (null !== $this->dispatcher) {
             $message = clone $message;
             $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
             $event = new MessageEvent($message, $envelope, (string) $this->transport, true);
             $this->dispatcher->dispatch($event);
+        }
+
+        if (null === $this->bus) {
+            $this->transport->send($message, $envelope);
+
+            return;
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I found it weird that `MessageEvent` are not dispatched when the command bus is disabled with Symfony Mailer.

Without this fix it's not possible to use Symfony Mailer assertions for all use cases like asserting email headers.

:question: I did not add tests but please let me know if I should do so. I was really not sure where and how to test that behavior.
