### PR TITLE
[Workflow] Fix typo in MethodMarkingStore

### DIFF
--- a/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
@@ -58,8 +58,8 @@ final class MethodMarkingStore implements MarkingStoreInterface
         try {
             $marking = $subject->{$method}();
         } catch (\Error $e) {
-            $unInitializedPropertyMassage = sprintf('Typed property %s::$%s must not be accessed before initialization', get_debug_type($subject), $this->property);
-            if ($e->getMessage() !== $unInitializedPropertyMassage) {
+            $unInitializedPropertyMessage = sprintf('Typed property %s::$%s must not be accessed before initialization', get_debug_type($subject), $this->property);
+            if ($e->getMessage() !== $unInitializedPropertyMessage) {
                 throw $e;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This pull-request fixes a typo in the property name $unInitializedPropertyMassage