### PR TITLE
[DependencyInjection] Add `shuffle` env processor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add argument `&$asGhostObject` to LazyProxy's `DumperInterface` to allow using ghost objects for lazy loading services
  * Add `enum` env var processor
+ * Add `shuffle` env var processor
 
 6.1
 ---

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -58,6 +58,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             'trim' => 'string',
             'require' => 'bool|int|float|string|array',
             'enum' => \BackedEnum::class,
+            'shuffle' => 'array',
         ];
     }
 
@@ -204,6 +205,12 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             }
 
             return null;
+        }
+
+        if ('shuffle' === $prefix) {
+            \is_array($env) ? shuffle($env) : throw new RuntimeException(sprintf('Env var "%s" cannot be shuffled, expected array, got "%s".', $name, get_debug_type($env)));
+
+            return $env;
         }
 
         if (!\is_scalar($env)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -708,6 +708,23 @@ class EnvVarProcessorTest extends TestCase
         $this->assertSame($processed, $result);
     }
 
+    public function testGetEnvShuffle()
+    {
+        mt_srand(2);
+
+        $this->assertSame(
+            ['bar', 'foo'],
+            (new EnvVarProcessor(new Container()))->getEnv('shuffle', '', fn () => ['foo', 'bar']),
+        );
+    }
+
+    public function testGetEnvShuffleInvalid()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Env var "foo" cannot be shuffled, expected array, got "string".');
+        (new EnvVarProcessor(new Container()))->getEnv('shuffle', 'foo', fn () => 'bar');
+    }
+
     public function validCsv()
     {
         $complex = <<<'CSV'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | waiting on approval of feature

Motivation of this: We are specifying list of hosts for Redis cluster as env var. The way redis library unfortunately works is that it always takes first host and tries to connect to it (and after initial connection is done successfully, only then jump to other nodes). This makes first host under load much more than others. This env var processor could be used to solve it and distribute the load better.