### PR TITLE
[Translation] Remove unneeded check and temporary variable

### DIFF
--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -64,9 +64,8 @@ final class TranslationPullCommand extends Command
         if ($input->mustSuggestOptionValuesFor('domains')) {
             $provider = $this->providerCollection->get($input->getArgument('provider'));
 
-            if ($provider && method_exists($provider, 'getDomains')) {
-                $domains = $provider->getDomains();
-                $suggestions->suggestValues($domains);
+            if (method_exists($provider, 'getDomains')) {
+                $suggestions->suggestValues($provider->getDomains());
             }
 
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

In this pull request, I just remove an unneeded check and a temporary variable.
- $this->providerCollection->get('provider') call always return an instance of `Symfony\Component\Translation\Provider\ProviderInterface`. Therefore, we needn't checking whether $provider is set.
- We can pass $provider->getDomains() directly into $suggestions->suggestValues() call instead of creating a temporary variable.