### PR TITLE
[SecurityBundle] Use correct adjective

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/Security.php
@@ -76,7 +76,7 @@ class Security extends LegacySecurity
                 throw new LogicException(sprintf('No authenticator was found for the firewall "%s".', $firewallName));
             }
             if (1 < \count($authenticatorIds)) {
-                throw new LogicException(sprintf('Too much authenticators were found for the current firewall "%s". You must provide an instance of "%s" to login programmatically. The available authenticators for the firewall "%s" are "%s".', $firewallName, AuthenticatorInterface::class, $firewallName, implode('" ,"', $authenticatorIds)));
+                throw new LogicException(sprintf('Too many authenticators were found for the current firewall "%s". You must provide an instance of "%s" to login programmatically. The available authenticators for the firewall "%s" are "%s".', $firewallName, AuthenticatorInterface::class, $firewallName, implode('" ,"', $authenticatorIds)));
             }
 
             return $firewallAuthenticatorLocator->get($authenticatorIds[0]);


### PR DESCRIPTION
The word 'many' is used to describe nouns that can be counted, whereas much refers to mass.

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix nix
| License       | MIT
| Doc PR        | n.a.
