### PR TITLE
[EventDispatcher] Add support for a self-naming EventListener

### DIFF
--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add `NamedListener` interface and `AbstractNamedListener` class to support self-naming Event listeners in debug/profiling scenarios
+
 6.0
 ---
 

--- a/src/Symfony/Component/EventDispatcher/Debug/AbstractNamedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/AbstractNamedListener.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Debug;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @author Quentin Devos <quentin@devos.pm>
+ */
+abstract class AbstractNamedListener implements NamedListener
+{
+    protected string $name;
+    protected string $pretty;
+    protected ?string $callableRef = null;
+
+    public function __construct(callable|array $listener, ?string $name)
+    {
+        if (\is_array($listener)) {
+            [$this->name, $this->callableRef] = $this->parseListener($listener);
+            $this->pretty = $this->name.'::'.$listener[1];
+            $this->callableRef .= '::'.$listener[1];
+        } elseif ($listener instanceof NamedListener) {
+            $this->name = $listener->getName();
+            $this->pretty = $listener->getPretty();
+            $this->callableRef = $listener->getCallableRef();
+        } elseif ($listener instanceof \Closure) {
+            $r = new \ReflectionFunction($listener);
+            if (str_contains($r->name, '{closure}')) {
+                $this->pretty = $this->name = 'closure';
+            } elseif ($class = $r->getClosureScopeClass()) {
+                $this->name = $class->name;
+                $this->pretty = $this->name.'::'.$r->name;
+            } else {
+                $this->pretty = $this->name = $r->name;
+            }
+        } elseif (\is_string($listener)) {
+            $this->pretty = $this->name = $listener;
+        } else {
+            $this->name = get_debug_type($listener);
+            $this->pretty = $this->name.'::__invoke';
+            $this->callableRef = \get_class($listener).'::__invoke';
+        }
+
+        if (null !== $name) {
+            $this->name = $name;
+        }
+    }
+
+    private function parseListener(array $listener): array
+    {
+        if ($listener[0] instanceof \Closure) {
+            foreach ((new \ReflectionFunction($listener[0]))->getAttributes(\Closure::class) as $attribute) {
+                if ($name = $attribute->getArguments()['name'] ?? false) {
+                    return [$name, $attribute->getArguments()['class'] ?? $name];
+                }
+            }
+        }
+
+        if ($listener[0] instanceof NamedListener) {
+            return [$listener[0]->getName(), $listener[0]->getCallableRef()];
+        }
+
+        if (\is_object($listener[0])) {
+            return [get_debug_type($listener[0]), \get_class($listener[0])];
+        }
+
+        return [$listener[0], $listener[0]];
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPretty(): string
+    {
+        return $this->pretty;
+    }
+
+    public function getCallableRef(): ?string
+    {
+        return $this->callableRef;
+    }
+
+    abstract public function __invoke(object $event, string $eventName, EventDispatcherInterface $dispatcher): void;
+}

--- a/src/Symfony/Component/EventDispatcher/Debug/NamedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/NamedListener.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Debug;
+
+/**
+ * The NamedListener marks listener that are able to provide naming for themselves.
+ *
+ * @author Quentin Devos <quentin@devos.pm>
+ */
+interface NamedListener
+{
+    public function getName(): string;
+
+    public function getPretty(): string;
+
+    public function getCallableRef(): ?string;
+}

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/NamedListenerTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/NamedListenerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\Debug\AbstractNamedListener;
+use Symfony\Component\EventDispatcher\Debug\NamedListener;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class NamedListenerTest extends TestCase
+{
+    /**
+     * @dataProvider provideListenersToDescribe
+     */
+    public function testListenerDescription($listener, $expected)
+    {
+        $wrappedListener = new WrappingNamedListener($listener, null);
+
+        $this->assertSame($expected, [
+            $wrappedListener->getName(),
+            $wrappedListener->getPretty(),
+            $wrappedListener->getCallableRef(),
+        ]);
+    }
+
+    /**
+     * @dataProvider provideListenersToDescribe
+     */
+    public function testListenerDescriptionWithNameOverride($listener, $expected)
+    {
+        $wrappedListener = new WrappingNamedListener($listener, 'name_override');
+
+        $this->assertSame(['name_override', $expected[1], $expected[2]], [
+            $wrappedListener->getName(),
+            $wrappedListener->getPretty(),
+            $wrappedListener->getCallableRef(),
+        ]);
+    }
+
+    public function provideListenersToDescribe(): array
+    {
+        return [
+            [new BarListener(), ['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::__invoke', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::__invoke']],
+            [new WrappingNamedListener(new BarListener(), null), ['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::__invoke', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::__invoke']],
+            [[new BarListener(), 'listen'], ['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::listen', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::listen']],
+            [['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'listenStatic'],  ['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::listenStatic', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::listenStatic']],
+            [['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'invalidMethod'], ['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::invalidMethod', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::invalidMethod']],
+            ['var_dump', ['var_dump', 'var_dump', null]],
+            [function () {}, ['closure', 'closure', null]],
+            [\Closure::fromCallable([new BarListener(), 'listen']), ['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::listen', null]],
+            [\Closure::fromCallable(['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'listenStatic']), ['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::listenStatic', null]],
+            [\Closure::fromCallable(function () {}), ['closure', 'closure', null]],
+            [[#[\Closure(name: BarListener::class)] static fn () => new BarListener(), 'listen'], ['Symfony\Component\EventDispatcher\Tests\Debug\BarListener', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::listen', 'Symfony\Component\EventDispatcher\Tests\Debug\BarListener::listen']],
+            [new BarNamedListener('name', 'pretty', 'callable_ref'), ['name', 'pretty', 'callable_ref']],
+            [[new BarNamedListener('name', 'pretty', 'callable_ref'), 'getPretty'], ['name', 'name::getPretty', 'callable_ref::getPretty']],
+        ];
+    }
+}
+
+class WrappingNamedListener extends AbstractNamedListener
+{
+    public function __invoke(object $event, string $eventName, EventDispatcherInterface $dispatcher): void
+    {
+    }
+}
+
+class BarListener
+{
+    public function listen()
+    {
+    }
+
+    public function __invoke()
+    {
+    }
+
+    public static function listenStatic()
+    {
+    }
+}
+
+class BarNamedListener implements NamedListener
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly string $pretty,
+        private readonly ?string $callableRef = null,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPretty(): string
+    {
+        return $this->pretty;
+    }
+
+    public function getCallableRef(): ?string
+    {
+        return $this->callableRef;
+    }
+
+    public function __invoke()
+    {
+    }
+}


### PR DESCRIPTION
Signed-off-by: Quentin Devos <4972091+Okhoshi@users.noreply.github.com>

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Introduce `NamedListener` interface and the `AbstractNamedListener` abstract class to hold the canonical implementation. This interface and the matching class helps to create self-naming listeners, which is useful when working with multiple layers of wrapping on EventListeners.

One concrete example. I need to instrument the event listeners to collect timings for each executed listener (similarly to how the `WrappedListener` is used by the WebProfiler bundle). But because I cannot influence the way the `WrappedListener` define the name of the wrapped listener, it requires convoluted workaround to let any other listener wrapper works with the WrappedListener.

This interface lets a wrapping listener propagates the information coming for the wrapped listener up towards the top of the stack, such that every wrapper in the stack gets the information related to the real listener (and not related to the wrapping listener below it).

I'll create the Symfony-docs PR if this one satisfies the reviewers expectations :).