### PR TITLE
[Mime]  ignore the cached body when comparing e-mails for equality

### DIFF
--- a/src/Symfony/Component/Mime/Tests/MessageConverterTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageConverterTest.php
@@ -76,6 +76,12 @@ class MessageConverterTest extends TestCase
             $expected->html('HTML content');
             $converted->html('HTML content');
         }
+
+        $r = new \ReflectionProperty($expected, 'cachedBody');
+        $r->setAccessible(true);
+        $r->setValue($expected, null);
+        $r->setValue($converted, null);
+
         $this->assertEquals($expected, $converted);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/46863#issuecomment-1177344251
| License       | MIT
| Doc PR        | 