### PR TITLE
[Validator] add `checkTldDns` option to `UrlValidator`

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate the "loose" e-mail validation mode, use "html5" instead
+ * Add the `checkTldDns` option to the `UrlValidator`, to enable/disable DNS check whether the top-level domain has a valid name server
 
 6.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -24,9 +24,11 @@ use Symfony\Component\Validator\Exception\InvalidArgumentException;
 class Url extends Constraint
 {
     public const INVALID_URL_ERROR = '57c2f299-1154-4870-89bb-ef3b1f5ad229';
+    public const INVALID_TLD_ERROR = '6c079631-e31d-4e2a-9075-65abeb7a0455';
 
     protected const ERROR_NAMES = [
         self::INVALID_URL_ERROR => 'INVALID_URL_ERROR',
+        self::INVALID_TLD_ERROR => 'INVALID_TLD_ERROR',
     ];
 
     /**
@@ -34,9 +36,10 @@ class Url extends Constraint
      */
     protected static $errorNames = self::ERROR_NAMES;
 
-    public $message = 'This value is not a valid URL.';
-    public $protocols = ['http', 'https'];
-    public $relativeProtocol = false;
+    public string $message = 'This value is not a valid URL.';
+    public array $protocols = ['http', 'https'];
+    public mixed $relativeProtocol = false;
+    public bool $checkTldDns = false;
     public $normalizer;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -82,5 +82,17 @@ class UrlValidator extends ConstraintValidator
 
             return;
         }
+
+        if ($constraint->checkTldDns) {
+            /* check whether TLD has a name server */
+            $host = parse_url($value, \PHP_URL_HOST);
+            $tld = substr($host, strrpos($host, '.') + 1);
+            if (!$tld || !checkdnsrr($tld, 'NS')) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Url::INVALID_TLD_ERROR)
+                    ->addViolation();
+            }
+        }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -311,6 +311,61 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             ['git://[::1]/'],
         ];
     }
+
+    public function getInvalidTldUrls()
+    {
+        return [
+            ['http://www.example.com.'],
+            ['http://symfony.tldnotreal/blog/'],
+            ['http://localhost'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidTldUrls
+     */
+    public function testInvalidTld($url)
+    {
+        $constraint = new Url([
+            'message' => 'myMessage',
+            'checkTldDns' => true,
+        ]);
+
+        $this->validator->validate($url, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$url.'"')
+            ->setCode(Url::INVALID_TLD_ERROR)
+            ->assertRaised();
+    }
+
+    public function getValidUrlsWithValidTld()
+    {
+        return [
+            ['http://a.pl'],
+            ['http://www.example.com'],
+            ['http://www.example.museum'],
+            ['https://example.net:80/'],
+            ['http://www.example.coop/'],
+            ['http://xn--sopaulo-xwa.com.br/'],
+            ['http://العربية.idn.icann.org/'],
+            ['http://☎.com/'],
+        ];
+    }
+
+    /**
+     * @dataProvider getValidUrlsWithValidTld
+     */
+    public function testValidTld($url)
+    {
+        $constraint = new Url([
+            'checkTldDns' => true,
+        ]);
+
+        $this->validator->validate($url, $constraint);
+
+        $this->assertNoViolation();
+    }
 }
 
 class EmailProvider


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #39986 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


With Symfony 5.0 the option "checkDns" was removed from the "UrlValidator" and the validator was completely changed to RegEx checks. 
See: https://symfony.com/doc/4.4/reference/constraints/Url.html#checkdns

In issue #39986 it was noted that there is no way to check if this checked URL would really be usable. 

While I can understand that individual DNS records might be temporarily unavailable, TLD name servers should generally always be available. 

For this reason, I added the new option "checkTldDns" in this MR based on the option from Symfony 4.4 and earlier.  This will perform a NS DNS query to the TLD of the checked URL. 

Of course, this is still not an absolutely secure method but optionally allows to increase the security of the check. 

If there is a chance that this will be added, I will be happy to write the doc for it as well.  

