### PR TITLE
[DependencyInjection] Fix dumping lazy services with parametrized class

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -387,6 +387,19 @@ class ContainerBuilderTest extends TestCase
         $this->assertSame('Bar\FooClass', \get_class($foo1));
     }
 
+    public function testCreateLazyProxy()
+    {
+        $builder = new ContainerBuilder();
+
+        $builder->setParameter('foo1_class', 'Bar\FooClass');
+        $builder->register('foo1', '%foo1_class%')->setLazy(true);
+
+        $foo1 = $builder->get('foo1');
+
+        $this->assertSame($foo1, $builder->get('foo1'), 'The same proxy is retrieved on multiple subsequent calls');
+        $this->assertInstanceOf(\Bar\FooClass::class, $foo1);
+    }
+
     public function testCreateServiceClass()
     {
         $builder = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -6,7 +6,7 @@ namespace Container%s;
 
 include_once $this->targetDir.''.'/Fixtures/includes/foo.php';
 
-class FooClass_%s extends \Bar\FooClass implements \ProxyManager\Proxy\VirtualProxyInterface
+class FooClass_2b16075 extends \Bar\FooClass implements \Symfony\Component\VarExporter\LazyGhostObjectInterface
 %A
 
 if (!\class_exists('FooClass_%s', false)) {
@@ -82,25 +82,19 @@ class ProjectServiceContainer extends Container
     /**
      * Gets the public 'lazy_foo' shared service.
      *
-     * @return \Bar\FooClass
+     * @return object A %lazy_foo_class% instance
      */
     protected function getLazyFooService($lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $this->services['lazy_foo'] = $this->createProxy('FooClass_8976cfa', function () {
-                return \FooClass_8976cfa::staticProxyConstructor(function (&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) {
-                    $wrappedInstance = $this->getLazyFooService(false);
-
-                    $proxy->setProxyInitializer(null);
-
-                    return true;
-                });
+            return $this->services['lazy_foo'] = $this->createProxy('FooClass_2b16075', function () {
+                return \FooClass_2b16075::createLazyGhostObject($this->getLazyFooService(...));
             });
         }
 
         include_once $this->targetDir.''.'/Fixtures/includes/foo_lazy.php';
 
-        return new \Bar\FooClass(new \Bar\FooLazyClass());
+        return ($lazyLoad->__construct(new \Bar\FooLazyClass()) && false ?: $lazyLoad);
     }
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
@@ -162,6 +156,7 @@ class ProjectServiceContainer extends Container
         return [
             'container.dumper.inline_factories' => true,
             'container.dumper.inline_class_loader' => true,
+            'lazy_foo_class' => 'Bar\\FooClass',
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The class of lazy services is currently not resolved. This has never been an issue before, but it's going to be one on 6.2 since services are now lazy even if proxy-manager-bridge is not installed.

Spotted while working on https://github.com/doctrine/DoctrineBundle/pull/1545, which needs this patch.