### PR TITLE
[VarExporter] do not call `unset()` on unknown variables

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyGhostObjectTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostObjectTrait.php
@@ -164,6 +164,7 @@ trait LazyGhostObjectTrait
     {
         $propertyScopes = Hydrator::$propertyScopes[static::class] ??= Hydrator::getPropertyScopes(static::class);
         $scope = null;
+        $state = null;
 
         if ([$class, , $readonlyScope] = $propertyScopes[$name] ?? null) {
             if (null !== $readonlyScope || isset($propertyScopes["\0$class\0$name"]) || isset($propertyScopes["\0*\0$name"])) {

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhostObject/ChildStdClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhostObject/ChildStdClass.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhostObject;
+
+use Symfony\Component\VarExporter\LazyGhostObjectInterface;
+use Symfony\Component\VarExporter\LazyGhostObjectTrait;
+
+class ChildStdClass extends \stdClass implements LazyGhostObjectInterface
+{
+    use LazyGhostObjectTrait;
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostObjectTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostObjectTraitTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarExporter\Internal\GhostObjectId;
 use Symfony\Component\VarExporter\Internal\GhostObjectRegistry;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhostObject\ChildMagicClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhostObject\ChildStdClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhostObject\ChildTestClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhostObject\MagicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhostObject\TestClass;
@@ -245,5 +246,14 @@ class LazyGhostObjectTraitTest extends TestCase
         });
 
         $this->assertSame(123, $instance->public);
+    }
+
+    public function testSetStdClassProperty()
+    {
+        $instance = ChildStdClass::createLazyGhostObject(function (ChildStdClass $ghost) {
+        });
+
+        $instance->public = 12;
+        $this->assertSame(12, $instance->public);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46926
| License       | MIT
| Doc PR        | 
