### PR TITLE
Flush backend output buffer after closing.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1236,6 +1236,7 @@ class Response
         while ($level-- > $targetLevel && ($s = $status[$level]) && (!isset($s['del']) ? !isset($s['flags']) || ($s['flags'] & $flags) === $flags : $s['del'])) {
             if ($flush) {
                 ob_end_flush();
+                flush();
             } else {
                 ob_end_clean();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | ~~no~~ yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Currently, `Response::send()` does some backend/server specific shutdown, with the default case being closing userland output buffers. PHP's output buffering may or may not be `On` by default.

I recently discovered in the course of debugging my Drupal 9 project that closing output buffers may not be enough to flush the response's content to the client. In my case, output buffering wasn't enabled at all, making `Response::closeOutputBuffers()` a no-op. In either case, it appears necessary to also call `flush()`. This is important if the calling script/framework [wishes to perform additional work after sending the request but before shutting down](https://www.drupal.org/project/drupal/issues/3295790).

According to the [PHP docs for flush()](https://www.php.net/manual/en/function.flush.php), this seems to be necessary in addition to closing all active output buffers (if used.)

> Flushes the system write buffers of PHP and whatever backend PHP is using (CGI, a web server, etc). This attempts to push current output all the way to the browser with a few caveats.
>
> flush() may not be able to override the buffering scheme of your web server and it has no effect on any client-side buffering in the browser. It also doesn't affect PHP's userspace output buffering mechanism. This means ob_flush() should be called before flush() to flush the output buffers if they are in use.

If it is Symfony's intent that the "final" `flush()` call be done by the implementing code/extending framework, it would be good to explicitly note that.