### PR TITLE
Fix deprecation in `InputBag` for non-scalar values

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -35,7 +35,7 @@ final class InputBag extends ParameterBag
 
         $value = parent::get($key, $this);
 
-        if (null !== $value && $this !== $value && !\is_scalar($value)) {
+        if (null !== $value && $this !== $value && !\is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
             trigger_deprecation('symfony/http-foundation', '5.1', 'Retrieving a non-scalar value from "%s()" is deprecated, and will throw a "%s" exception in Symfony 6.0, use "%s::all($key)" instead.', __METHOD__, BadRequestException::class, __CLASS__);
         }
 

--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -35,8 +35,8 @@ final class InputBag extends ParameterBag
 
         $value = parent::get($key, $this);
 
-        if (null !== $value && $this !== $value && !\is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
-            trigger_deprecation('symfony/http-foundation', '5.1', 'Retrieving a non-string value from "%s()" is deprecated, and will throw a "%s" exception in Symfony 6.0, use "%s::all($key)" instead.', __METHOD__, BadRequestException::class, __CLASS__);
+        if (null !== $value && $this !== $value && !\is_scalar($value)) {
+            trigger_deprecation('symfony/http-foundation', '5.1', 'Retrieving a non-scalar value from "%s()" is deprecated, and will throw a "%s" exception in Symfony 6.0, use "%s::all($key)" instead.', __METHOD__, BadRequestException::class, __CLASS__);
         }
 
         return $this === $value ? $default : $value;

--- a/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
@@ -72,10 +72,10 @@ class InputBagTest extends TestCase
     /**
      * @group legacy
      */
-    public function testGettingANonStringValueIsDeprecated()
+    public function testGettingANonScalarValueIsDeprecated()
     {
         $bag = new InputBag(['foo' => ['a', 'b']]);
-        $this->expectDeprecation('Since symfony/http-foundation 5.1: Retrieving a non-string value from "Symfony\Component\HttpFoundation\InputBag::get()" is deprecated, and will throw a "Symfony\Component\HttpFoundation\Exception\BadRequestException" exception in Symfony 6.0, use "Symfony\Component\HttpFoundation\InputBag::all($key)" instead.');
+        $this->expectDeprecation('Since symfony/http-foundation 5.1: Retrieving a non-scalar value from "Symfony\Component\HttpFoundation\InputBag::get()" is deprecated, and will throw a "Symfony\Component\HttpFoundation\Exception\BadRequestException" exception in Symfony 6.0, use "Symfony\Component\HttpFoundation\InputBag::all($key)" instead.');
         $bag->get('foo');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

In Symfony 6.0, `InputBag::get` was changed so that when you are retrieving a non-scalar value from it, it will throw a `BadRequestException`. This is also correctly documented in the UPGRADE.md. However, the deprecation in Symfony 5.4 assumes something different: it says that non-**string** values are deprecated. This PR fixes that.