### PR TITLE
[HttpClient] Allow passing json_encode flags

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Add new option `json_encode_flags` to pass custom flags to `json_encode()`
+
 6.1
 ---
 

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -84,7 +84,7 @@ trait HttpClientTrait
             if (isset($options['body']) && '' !== $options['body']) {
                 throw new InvalidArgumentException('Define either the "json" or the "body" option, setting both is not supported.');
             }
-            $options['body'] = self::jsonEncode($options['json']);
+            $options['body'] = self::jsonEncode($options['json'], $options['json_encode_flags'] ?? null);
             unset($options['json']);
 
             if (!isset($options['normalized_headers']['content-type'])) {

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -66,7 +66,8 @@ interface HttpClientInterface
         'ciphers' => null,
         'peer_fingerprint' => null,
         'capture_peer_cert_chain' => false,
-        'extra' => [],          // array - additional options that can be ignored if unsupported, unlike regular options
+        'extra' => [],          // array - additional options that can be ignored if unsupported, unlike regular options,
+        'json_encode_flags' => null,   // int - flags to pass to json_encode() when encoding the request body as JSON
     ];
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Allow passing custom flags when request body is a json payload.

```
$response = $client->request('POST', 'https://api.example.com', [
    'json' => [
        'test' => 'My test 🧪'
    ],
    'json_encode_flags' => JSON_UNESCAPED_UNICODE | JSON_HEX_TAG
]);
```