### PR TITLE
[HttpKernel] Declare properties used by CacheAttributeListenerTest explicitly

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
@@ -24,6 +24,12 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\CacheAttributeControl
 
 class CacheAttributeListenerTest extends TestCase
 {
+    private CacheAttributeListener $listener;
+    private Response $response;
+    private Cache $cache;
+    private Request $request;
+    private ResponseEvent $event;
+
     protected function setUp(): void
     {
         $this->listener = new CacheAttributeListener();
@@ -294,12 +300,12 @@ class CacheAttributeListenerTest extends TestCase
         $this->assertSame(CacheAttributeController::CLASS_SMAXAGE, $response->getMaxAge());
     }
 
-    private function createRequest(Cache $cache = null)
+    private function createRequest(Cache $cache): Request
     {
         return new Request([], [], ['_cache' => [$cache]]);
     }
 
-    private function createEventMock(Request $request, Response $response)
+    private function createEventMock(Request $request, Response $response): ResponseEvent
     {
         return new ResponseEvent($this->getKernel(), $request, HttpKernelInterface::MAIN_REQUEST, $response);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

A test case introduced by #46880 triggers deprecation notices on PHP 8.2 because none of the properties used is declared. This PR fixes the build by adding explicit property declarations.