### PR TITLE
[Form] ChoiceType choices must support TranslatableInterface

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Allow passing `TranslatableInterface` objects to the `ChoiceView` label
+
 6.1
 ---
 

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\ChoiceList\Loader\FilterChoiceLoaderDecorator;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
-use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * Default implementation of {@link ChoiceListFactoryInterface}.
@@ -175,7 +175,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
 
             if (false === $dynamicLabel) {
                 $label = false;
-            } elseif ($dynamicLabel instanceof TranslatableMessage) {
+            } elseif ($dynamicLabel instanceof TranslatableInterface) {
                 $label = $dynamicLabel;
             } else {
                 $label = (string) $dynamicLabel;

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\ChoiceList\View;
 
-use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * Represents a choice in templates.
@@ -37,13 +37,13 @@ class ChoiceView
     /**
      * Creates a new choice view.
      *
-     * @param mixed                            $data                       The original choice
-     * @param string                           $value                      The view representation of the choice
-     * @param string|TranslatableMessage|false $label                      The label displayed to humans; pass false to discard the label
-     * @param array                            $attr                       Additional attributes for the HTML tag
-     * @param array                            $labelTranslationParameters Additional parameters used to translate the label
+     * @param mixed                              $data                       The original choice
+     * @param string                             $value                      The view representation of the choice
+     * @param string|TranslatableInterface|false $label                      The label displayed to humans; pass false to discard the label
+     * @param array                              $attr                       Additional attributes for the HTML tag
+     * @param array                              $labelTranslationParameters Additional parameters used to translate the label
      */
-    public function __construct(mixed $data, string $value, string|TranslatableMessage|false $label, array $attr = [], array $labelTranslationParameters = [])
+    public function __construct(mixed $data, string $value, string|TranslatableInterface|false $label, array $attr = [], array $labelTranslationParameters = [])
     {
         $this->data = $data;
         $this->value = $value;

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Tests\Fixtures\ArrayChoiceLoader;
 use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DefaultChoiceListFactoryTest extends TestCase
 {
@@ -772,6 +774,26 @@ class DefaultChoiceListFactoryTest extends TestCase
         $this->assertInstanceOf(TranslatableMessage::class, $view->choices[0]->label);
         $this->assertEquals('my_message', $view->choices[0]->label->getMessage());
         $this->assertArrayHasKey('param1', $view->choices[0]->label->getParameters());
+    }
+
+    public function testPassTranslatableInterfaceAsLabelDoesntCastItToString()
+    {
+        $message = new class() implements TranslatableInterface {
+            public function trans(TranslatorInterface $translator, string $locale = null): string
+            {
+                return 'my_message';
+            }
+        };
+
+        $view = $this->factory->createView(
+            $this->list,
+            [$this->obj1],
+            static function () use ($message) {
+                return $message;
+            }
+        );
+
+        $this->assertSame($message, $view->choices[0]->label);
     }
 
     public function testCreateViewFlatLabelTranslationParametersAsArray()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #46902 
| License       | MIT
| Doc PR        |


Before this PR only `TranslatableMessage` was supported in ChoiceView/ChoiceType choices labels. 

Now `TranslatableInterface` contract is supported.