### PR TITLE
[Serializer] Prevent that bad Ignore method annotations lead to incorrect results

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -134,6 +134,10 @@ class AnnotationLoader implements LoaderInterface
 
                     $attributeMetadata->setSerializedName($annotation->getSerializedName());
                 } elseif ($annotation instanceof Ignore) {
+                    if (!$accessorOrMutator) {
+                        throw new MappingException(sprintf('Ignore on "%s::%s()" cannot be added. Ignore can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
+                    }
+
                     $attributeMetadata->setIgnore(true);
                 } elseif ($annotation instanceof Context) {
                     if (!$accessorOrMutator) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/Entity45016.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/Entity45016.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\Ignore;
+
+class Entity45016
+{
+    /**
+     * @var int
+     */
+    private $id = 1234;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @Ignore()
+     */
+    public function badIgnore(): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/Entity45016.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/Entity45016.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Ignore;
+
+class Entity45016
+{
+    /**
+     * @var int
+     */
+    private $id = 1234;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    #[Ignore]
+    public function badIgnore(): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -137,6 +137,19 @@ abstract class AnnotationLoaderTest extends TestCase
         $loader->loadClassMetadata($classMetadata);
     }
 
+    public function testCanHandleUnrelatedIgnoredMethods()
+    {
+        $class = $this->getNamespace().'\Entity45016';
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(sprintf('Ignore on "%s::badIgnore()" cannot be added', $class));
+
+        $metadata = new ClassMetadata($class);
+        $loader = $this->getLoaderForContextMapping();
+
+        $loader->loadClassMetadata($metadata);
+    }
+
     abstract protected function createLoader(): AnnotationLoader;
 
     abstract protected function getNamespace(): string;


### PR DESCRIPTION
fix https://github.com/symfony/symfony/issues/45016

| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #45016
| License       | MIT
| Doc PR        | na

By attaching the Ignore serializer annotation to a method that is not a set/get/has/is method, the property that was read before the method was marked as ignored. 
I have tweaked the behavior here so that it matches the other annotations. 

However, the change could now cause exceptions in older projects if they already have this bug built in. 
From my point of view, however, this is justifiable, because at the moment data may not be output correctly. 
