### PR TITLE
[Validator] : Fix "PHP Warning: Undefined array key 1" in NotCompromisedPasswordValidator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/NotCompromisedPasswordValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotCompromisedPasswordValidator.php
@@ -91,6 +91,10 @@ class NotCompromisedPasswordValidator extends ConstraintValidator
         }
 
         foreach (explode("\r\n", $result) as $line) {
+            if (!str_contains($line, ':')) {
+                continue;
+            }
+
             [$hashSuffix, $count] = explode(':', $line);
 
             if ($hashPrefix.$hashSuffix === $hash && $constraint->threshold <= (int) $count) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
@@ -165,6 +165,31 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testEndpointWithInvalidValueInReturn()
+    {
+        $returnValue = implode(
+            "\r\n",
+            [
+                '36039744C253F9B2A4E90CBEDB02EBFB82D:5',
+                'This should not break the validator',
+                '3686792BBC66A72D40D928ED15621124CFE:7',
+                '36EEC709091B810AA240179A44317ED415C:2',
+                '',
+            ]
+        );
+
+        $validator = new NotCompromisedPasswordValidator(
+            $this->createHttpClientStub($returnValue),
+            'UTF-8',
+            true,
+            'https://password-check.internal.example.com/range/%s'
+        );
+
+        $validator->validate(self::PASSWORD_NOT_LEAKED, new NotCompromisedPassword());
+
+        $this->assertNoViolation();
+    }
+
     public function testInvalidConstraint()
     {
         $this->expectException(UnexpectedTypeException::class);
@@ -202,11 +227,11 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
         }
     }
 
-    private function createHttpClientStub(): HttpClientInterface
+    private function createHttpClientStub(?string $returnValue = null): HttpClientInterface
     {
         $httpClientStub = $this->createMock(HttpClientInterface::class);
         $httpClientStub->method('request')->willReturnCallback(
-            function (string $method, string $url): ResponseInterface {
+            function (string $method, string $url) use ($returnValue): ResponseInterface {
                 if (self::PASSWORD_TRIGGERING_AN_ERROR_RANGE_URL === $url) {
                     throw new class('Problem contacting the Have I been Pwned API.') extends \Exception implements ServerExceptionInterface {
                         public function getResponse(): ResponseInterface
@@ -219,7 +244,7 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
                 $responseStub = $this->createMock(ResponseInterface::class);
                 $responseStub
                     ->method('getContent')
-                    ->willReturn(implode("\r\n", self::RETURN));
+                    ->willReturn($returnValue ?? implode("\r\n", self::RETURN));
 
                 return $responseStub;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46935
| License       | MIT

This PR is made based on #46935.
With this approach the validator will still work if it ends up on a line that does not contain the exploding operator `:`. So other cases than just an empty string are caught with this.
