### PR TITLE
[Serializer] Ignore getter with required parameters (Fix #46592)

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -100,6 +100,11 @@ class AnnotationLoader implements LoaderInterface
                 continue;
             }
 
+            $getAccessor = preg_match('/^(get|)(.+)$/i', $method->name);
+            if ($getAccessor && 0 !== $method->getNumberOfRequiredParameters()) {
+                continue; /*  matches the BC behavior in `Symfony\Component\Serializer\Normalizer\ObjectNormalizer::extractAttributes` */
+            }
+
             $accessorOrMutator = preg_match('/^(get|is|has|set)(.+)$/i', $method->name, $matches);
             if ($accessorOrMutator) {
                 $attributeName = lcfirst($matches[2]);

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/Entity45016.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/Entity45016.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
 
 use Symfony\Component\Serializer\Annotation\Ignore;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/IgnoreDummyAdditionalGetter.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/IgnoreDummyAdditionalGetter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\Ignore;
+
+class IgnoreDummyAdditionalGetter
+{
+
+    private $myValue;
+
+    /**
+     * @Ignore()
+     */
+    public function getMyValue()
+    {
+        return $this->myValue;
+    }
+
+    public function getExtraValue(string $parameter) {
+        return $parameter;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+class IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations
+{
+
+    private $myValue;
+
+    public function getMyValue()
+    {
+        return $this->myValue;
+    }
+
+    public function getExtraValue(string $parameter) {
+        return $parameter;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/Entity45016.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/Entity45016.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
 
 use Symfony\Component\Serializer\Annotation\Ignore;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/IgnoreDummyAdditionalGetter.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/IgnoreDummyAdditionalGetter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Ignore;
+
+class IgnoreDummyAdditionalGetter
+{
+    private $myValue;
+
+    #[Ignore]
+    public function getIgnored2()
+    {
+        return $this->myValue;
+    }
+
+    public function getExtraValue(string $parameter) {
+        return $parameter;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+class IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations
+{
+    private $myValue;
+
+    public function getIgnored2()
+    {
+        return $this->myValue;
+    }
+
+    public function getExtraValue(string $parameter) {
+        return $parameter;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -150,6 +150,24 @@ abstract class AnnotationLoaderTest extends TestCase
         $loader->loadClassMetadata($metadata);
     }
 
+    public function testIgnoreGetterWirhRequiredParameterIfIgnoreAnnotationIsUsed()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace().'\IgnoreDummyAdditionalGetter');
+        $this->getLoaderForContextMapping()->loadClassMetadata($classMetadata);
+
+        $attributes = $classMetadata->getAttributesMetadata();
+        self::assertArrayNotHasKey('extraValue', $attributes);
+    }
+
+    public function testIgnoreGetterWirhRequiredParameterIfIgnoreAnnotationIsNotUsed()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace().'\IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations');
+        $this->getLoaderForContextMapping()->loadClassMetadata($classMetadata);
+
+        $attributes = $classMetadata->getAttributesMetadata();
+        self::assertArrayNotHasKey('extraValue', $attributes);
+    }
+
     abstract protected function createLoader(): AnnotationLoader;
 
     abstract protected function getNamespace(): string;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #46592 
| License       | MIT
| Doc PR        | na

If no Ignore annotation is used, the attributes for serialization are obtained using `Symfony\Component\Serializer\Normalizer\ObjectNormalizer::extractAttributes`.
There it is checked if the method has required parameters and if yes, the method is ignored. 

However, if you use the Ignore annotation, the attributes are determined with a different method. Here I have adapted at least for get methods the behavior as it was before.

If someone serialized a class with Ignore annotations before, he got here `\Symfony\Component\PropertyAccess\PropertyAccessor::readProperty` an exception as written in ticket #46592. With this fix the methods are ignored and there is no exception anymore. 


