### PR TITLE
[FrameworkBundle] Fail gracefully when forms use disabled CSRF

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -496,6 +496,10 @@ class FrameworkExtension extends Extension
         }
 
         if ($this->isConfigEnabled($container, $config['form']['csrf_protection'])) {
+            if (!$container->hasDefinition('security.csrf.token_generator')) {
+                throw new \LogicException('To use form CSRF protection `framework.csrf_protection` must be enabled.');
+            }
+
             $loader->load('form_csrf.xml');
 
             $container->setParameter('form.type_extension.csrf.enabled', true);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_csrf_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_csrf_disabled.php
@@ -1,0 +1,8 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'csrf_protection' => false,
+    'form' => [
+        'csrf_protection' => true,
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_disabled.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+            https://symfony.com/schema/dic/services/services-1.0.xsd
+            http://symfony.com/schema/dic/symfony
+            https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+>
+    <framework:config>
+        <framework:csrf-protection enabled="false"/>
+        <framework:form enabled="true">
+            <framework:csrf-protection enabled="true"/>
+        </framework:form>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_csrf_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_csrf_disabled.yml
@@ -1,0 +1,4 @@
+framework:
+    csrf_protection: false
+    form:
+        csrf_protection: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -84,6 +84,14 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('%form.type_extension.csrf.field_name%', $def->getArgument(2));
     }
 
+    public function testFormCsrfProtectionWithCsrfDisabled()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('To use form CSRF protection `framework.csrf_protection` must be enabled.');
+
+        $this->createContainerFromFile('form_csrf_disabled');
+    }
+
     public function testPropertyAccessWithDefaultValue()
     {
         $container = $this->createContainerFromFile('full');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | kind of
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

Relates to https://github.com/symfony/symfony-docs/pull/16973.

Currently with the following config in Symfony demo:
```yaml
# config/packages/framework.yaml
framework:
    csrf_protection: false
    form:
        csrf_protection: true
```
we get:
>The service "form.type_extension.csrf" has a dependency on a non-existent service "security.csrf.token_manager".

We should consider this PR as a bug fix to make this exception actionable.