### PR TITLE
[Mime] Add DataPart::setContentId()

### DIFF
--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -89,6 +89,20 @@ class DataPart extends TextPart
         return $this->setDisposition('inline');
     }
 
+    /**
+     * @return $this
+     */
+    public function setContentId(string $cid): static
+    {
+        if (!str_contains($cid, '@')) {
+            throw new InvalidArgumentException(sprintf('Invalid cid "%s".', $cid));
+        }
+
+        $this->cid = $cid;
+
+        return $this;
+    }
+
     public function getContentId(): string
     {
         return $this->cid ?: $this->cid = $this->generateContentId();

--- a/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
@@ -166,6 +166,22 @@ class DataPartTest extends TestCase
         $this->assertTrue($p->hasContentId());
     }
 
+    public function testSetContentId()
+    {
+        $p = new DataPart('content');
+        $p->setContentId('test@test');
+        $this->assertTrue($p->hasContentId());
+        $this->assertSame('test@test', $p->getContentId());
+    }
+
+    public function testSetContentIdInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $p = new DataPart('content');
+        $p->setContentId('test');
+    }
+
     public function testGetFilename()
     {
         $p = new DataPart('content', null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #46959 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a
