### PR TITLE
[PropertyInfo] Make sure nested composite types do not crash ReflectionExtractor

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -334,6 +334,11 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $nullable = $reflectionType->allowsNull();
 
         foreach (($reflectionType instanceof \ReflectionUnionType || $reflectionType instanceof \ReflectionIntersectionType) ? $reflectionType->getTypes() : [$reflectionType] as $type) {
+            if (!$type instanceof \ReflectionNamedType) {
+                // Nested composite types are not supported yet.
+                return [];
+            }
+
             $phpTypeOrClass = $type->getName();
             if ('null' === $phpTypeOrClass || 'mixed' === $phpTypeOrClass || 'never' === $phpTypeOrClass) {
                 continue;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -281,10 +281,14 @@ class ReflectionExtractorTest extends TestCase
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php82Dummy', $property, []));
     }
 
-    public function php82TypesProvider()
+    public function php82TypesProvider(): iterable
     {
         yield ['nil', null];
         yield ['false', [new Type(Type::BUILTIN_TYPE_FALSE)]];
+
+        // Nesting intersection and union types is not supported yet,
+        // but we should make sure this kind of composite types does not crash the extractor.
+        yield ['someCollection', null];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php82Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php82Dummy.php
@@ -16,4 +16,6 @@ class Php82Dummy
     public null $nil = null;
 
     public false $false = false;
+
+    public (\Traversable&\Countable)|null $someCollection = null;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #44282
| License       | MIT
| Doc PR        | N/A

A composite type like `(\Traversable&\Countable)|null` which is allowed in PHP 8.2 currently causes a fatal error in `ReflectionExtractor` because of a call to an undefined function. This PR fixes it by making `ReflectionExtractor` report that it could not extract any types.

Implementing full support for composite types to the extent that PHP 8.2 supports them would not be too difficult, but it would probably not pass as a bugfix. Once this is merged up, I'll prepare a PR for the 6.2 branch implementing full support.