### PR TITLE
[FrameworkBundle] Fix tests that use deprecated callable syntax

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -208,9 +208,23 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $callable);
     }
 
-    public function getDescribeCallableTestData()
+    public function getDescribeCallableTestData(): array
     {
         return $this->getDescriptionTestData(ObjectsProvider::getCallables());
+    }
+
+    /**
+     * @group legacy
+     * @dataProvider getDescribeDeprecatedCallableTestData
+     */
+    public function testDescribeDeprecatedCallable($callable, $expectedDescription)
+    {
+        $this->assertDescription($expectedDescription, $callable);
+    }
+
+    public function getDescribeDeprecatedCallableTestData(): array
+    {
+        return $this->getDescriptionTestData(ObjectsProvider::getDeprecatedCallables());
     }
 
     /** @dataProvider getClassDescriptionTestData */

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -229,17 +229,23 @@ class ObjectsProvider
         return ['event_dispatcher_1' => $eventDispatcher];
     }
 
-    public static function getCallables()
+    public static function getCallables(): array
     {
         return [
             'callable_1' => 'array_key_exists',
             'callable_2' => ['Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\CallableClass', 'staticMethod'],
             'callable_3' => [new CallableClass(), 'method'],
             'callable_4' => 'Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\CallableClass::staticMethod',
-            'callable_5' => ['Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\ExtendedCallableClass', 'parent::staticMethod'],
             'callable_6' => function () { return 'Closure'; },
             'callable_7' => new CallableClass(),
             'callable_from_callable' => \Closure::fromCallable(new CallableClass()),
+        ];
+    }
+
+    public static function getDeprecatedCallables(): array
+    {
+        return [
+            'callable_5' => ['Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\ExtendedCallableClass', 'parent::staticMethod'],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #44282
| License       | MIT
| Doc PR        | N/A

FrameworkBundle's tests currently fail because they use a deprecated way to referencing a callable: `[Foo::class, 'parent::bar']`. This PR moves this one fixture into a separate test with `@group legacy`.