### PR TITLE
[DependencyInjection] Fail gracefully when attempting to autowire composite types

### DIFF
--- a/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
@@ -32,6 +32,11 @@ class ProxyHelper
             return null;
         }
 
+        return self::getTypeHintForType($type, $r, $noBuiltin);
+    }
+
+    private static function getTypeHintForType(\ReflectionType $type, \ReflectionFunctionAbstract $r, bool $noBuiltin): ?string
+    {
         $types = [];
         $glue = '|';
         if ($type instanceof \ReflectionUnionType) {
@@ -46,6 +51,17 @@ class ProxyHelper
         }
 
         foreach ($reflectionTypes as $type) {
+            if ($type instanceof \ReflectionIntersectionType) {
+                $typeHint = self::getTypeHintForType($type, $r, $noBuiltin);
+                if (null === $typeHint) {
+                    return null;
+                }
+
+                $types[] = sprintf('(%s)', $typeHint);
+
+                continue;
+            }
+
             if ($type->isBuiltin()) {
                 if (!$noBuiltin) {
                     $types[] = $type->getName();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -10,6 +10,9 @@ if (\PHP_VERSION_ID >= 80000) {
 if (\PHP_VERSION_ID >= 80100) {
     require __DIR__.'/intersectiontype_classes.php';
 }
+if (\PHP_VERSION_ID >= 80200) {
+    require __DIR__.'/compositetype_classes.php';
+}
 
 class Foo
 {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/compositetype_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/compositetype_classes.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+interface YetAnotherInterface
+{
+}
+
+class CompositeTypeClasses
+{
+    public function __construct((CollisionInterface&AnotherInterface)|YetAnotherInterface $collision)
+    {
+    }
+}
+
+class NullableIntersection
+{
+    public function __construct((CollisionInterface&AnotherInterface)|null $a)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #44282
| License       | MIT
| Doc PR        | N/A

Symfony 4.4 does not support autowiring union types. Unfortunately, we run into a fatal error when autowiring is attempted for a parameter with an intersection type nested into a union (`(A&B)|C`). Ironically, the error occurs while we try to generate a nice exception message.

This PR fixes this, so the developer gets a nice exception message about the parameter that cannot be autowired.

For nullable unions however, `null` is injected. This already was the case for `A|null` and it works out of the box for `(A&B)|null`. I've added a test case that covers this case.