### PR TITLE
[Security] Allow using expressions with the #[IsGranted] attribute

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
@@ -36,6 +36,7 @@ class AddExpressionLanguageProvidersPass implements CompilerPassInterface
 
         if (!$container->hasDefinition('cache.system')) {
             $container->removeDefinition('cache.security_expression_language');
+            $container->removeDefinition('cache.security_is_granted_attribute_expression_language');
         }
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -112,6 +112,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         if (!$container::willBeAvailable('symfony/expression-language', ExpressionLanguage::class, ['symfony/security-bundle'])) {
             $container->removeDefinition('security.expression_language');
             $container->removeDefinition('security.access.expression_voter');
+            $container->removeDefinition('security.is_granted_attribute_expression_language');
         }
 
         // set some global scalars

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\Security;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
 use Symfony\Component\Ldap\Security\LdapUserProvider;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
@@ -275,7 +276,17 @@ return static function (ContainerConfigurator $container) {
             ->tag('kernel.cache_warmer')
 
         ->set('controller.is_granted_attribute_listener', IsGrantedAttributeListener::class)
-            ->args([service('security.authorization_checker')])
+            ->args([
+                service('security.authorization_checker'),
+                service('security.is_granted_attribute_expression_language')->nullOnInvalid(),
+            ])
             ->tag('kernel.event_subscriber')
+
+        ->set('security.is_granted_attribute_expression_language', BaseExpressionLanguage::class)
+            ->args([service('cache.security_is_granted_attribute_expression_language')->nullOnInvalid()])
+
+        ->set('cache.security_is_granted_attribute_expression_language')
+            ->parent('cache.system')
+            ->tag('cache.pool')
     ;
 };

--- a/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Http\Attribute;
 
+use Symfony\Component\ExpressionLanguage\Expression;
+
 /**
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */
@@ -21,12 +23,14 @@ final class IsGranted
         /**
          * Sets the first argument that will be passed to isGranted().
          */
-        public string $attribute,
+        public string|Expression $attribute,
 
         /**
          * Sets the second argument passed to isGranted().
+         *
+         * @var array<string|Expression>|string|Expression|null
          */
-        public array|string|null $subject = null,
+        public array|string|Expression|null $subject = null,
 
         /**
          * The message of the exception - has a nice default if not set.

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate empty username or password when using when using `JsonLoginAuthenticator`
  * Set custom lifetime for login link
  * Add `$lifetime` parameter to `LoginLinkHandlerInterface::createLoginLink()`
+ * Allow using expressions as `#[IsGranted()]` attribute and subject
 
 6.0
 ---

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Security\Http\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -28,7 +30,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class IsGrantedAttributeListener implements EventSubscriberInterface
 {
     public function __construct(
-        private AuthorizationCheckerInterface $authChecker,
+        private readonly AuthorizationCheckerInterface $authChecker,
+        private ?ExpressionLanguage $expressionLanguage = null,
     ) {
     }
 
@@ -42,21 +45,15 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
         $arguments = $event->getNamedArguments();
 
         foreach ($attributes as $attribute) {
-            $subjectRef = $attribute->subject;
             $subject = null;
 
-            if ($subjectRef) {
+            if ($subjectRef = $attribute->subject) {
                 if (\is_array($subjectRef)) {
-                    foreach ($subjectRef as $ref) {
-                        if (!\array_key_exists($ref, $arguments)) {
-                            throw new RuntimeException(sprintf('Could not find the subject "%s" for the #[IsGranted] attribute. Try adding a "$%s" argument to your controller method.', $ref, $ref));
-                        }
-                        $subject[$ref] = $arguments[$ref];
+                    foreach ($subjectRef as $refKey => $ref) {
+                        $subject[\is_string($refKey) ? $refKey : (string) $ref] = $this->getIsGrantedSubject($ref, $arguments);
                     }
-                } elseif (!\array_key_exists($subjectRef, $arguments)) {
-                    throw new RuntimeException(sprintf('Could not find the subject "%s" for the #[IsGranted] attribute. Try adding a "$%s" argument to your controller method.', $subjectRef, $subjectRef));
                 } else {
-                    $subject = $arguments[$subjectRef];
+                    $subject = $this->getIsGrantedSubject($subjectRef, $arguments);
                 }
             }
 
@@ -81,15 +78,37 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
         return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 10]];
     }
 
+    private function getIsGrantedSubject(string|Expression $subjectRef, array $arguments): mixed
+    {
+        if ($subjectRef instanceof Expression) {
+            $this->expressionLanguage ??= new ExpressionLanguage();
+
+            return $this->expressionLanguage->evaluate($subjectRef, [
+                'args' => $arguments,
+            ]);
+        }
+
+        if (!\array_key_exists($subjectRef, $arguments)) {
+            throw new RuntimeException(sprintf('Could not find the subject "%s" for the #[IsGranted] attribute. Try adding a "$%s" argument to your controller method.', $subjectRef, $subjectRef));
+        }
+
+        return $arguments[$subjectRef];
+    }
+
     private function getIsGrantedString(IsGranted $isGranted): string
     {
-        $processValue = fn ($value) => sprintf('"%s"', $value);
+        $processValue = fn ($value) => sprintf($value instanceof Expression ? 'new Expression("%s")' : '"%s"', $value);
 
         $argsString = $processValue($isGranted->attribute);
 
         if (null !== $subject = $isGranted->subject) {
-            $subject = array_map($processValue, (array) $subject);
-            $argsString .= ', '.(1 === \count($subject) ? reset($subject) : '['.implode(', ', $subject).']');
+            $subject = !\is_array($subject) ? $processValue($subject) : array_map(function ($key, $value) use ($processValue) {
+                $value = $processValue($value);
+
+                return \is_string($key) ? sprintf('"%s" => %s', $key, $value) : $value;
+            }, array_keys($subject), $subject);
+
+            $argsString .= ', '.(!\is_array($subject) ? $subject : '['.implode(', ', $subject).']');
         }
 
         return $argsString;

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Tests\Fixtures;
 
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class IsGrantedAttributeMethodsController
@@ -41,6 +42,24 @@ class IsGrantedAttributeMethodsController
 
     #[IsGranted(attribute: 'ROLE_ADMIN', message: 'Not found', statusCode: 404)]
     public function notFound()
+    {
+    }
+
+    #[IsGranted(attribute: new Expression('"ROLE_ADMIN" in role_names or is_granted("POST_VIEW", subject)'), subject: 'post')]
+    public function withExpressionInAttribute($post)
+    {
+    }
+
+    #[IsGranted(attribute: new Expression('user === subject'), subject: new Expression('args["post"].getAuthor()'))]
+    public function withExpressionInSubject($post)
+    {
+    }
+
+    #[IsGranted(attribute: new Expression('user === subject["author"]'), subject: [
+        'author' => new Expression('args["post"].getAuthor()'),
+        'alias' => 'arg2Name',
+    ])]
+    public function withNestedExpressionInSubject($post, $arg2Name)
     {
     }
 }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/security-core": "^5.4.7|^6.0",
+        "symfony/security-core": "^6.0",
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/http-kernel": "^6.2",
         "symfony/polyfill-mbstring": "~1.0",
@@ -25,6 +25,7 @@
     },
     "require-dev": {
         "symfony/cache": "^5.4|^6.0",
+        "symfony/expression-language": "^5.4|^6.0",
         "symfony/rate-limiter": "^5.4|^6.0",
         "symfony/routing": "^5.4|^6.0",
         "symfony/security-csrf": "^5.4|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #46912
| License       | MIT
| Doc PR        | -

Allows using the expression language with the `#[IsGranted]` attribute:

```php
#[IsGranted(
    attribute: new Expression('"ROLE_ADMIN" in role_names or is_granted("POST_VIEW", subject)'),
    subject: 'post',
)]
public function index(Post $post)
{
}

#[IsGranted(
    attribute: new Expression('user === subject'),
    subject: new Expression('args["post"].getAuthor()'),
)]
public function index(Post $post)
{
}

#[IsGranted(
    attribute: new Expression('user === subject["author"] and subject["post"].isPublished()'),
    subject: [
        'author' => new Expression('args["post"].getAuthor()'),
        'post' => 'post',
    ],
)]
public function index(Post $post)
{
}
```