### PR TITLE
[DoctrineBridge] Avoid calling `AbstractPlatform::hasNativeGuidType()`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
@@ -18,6 +18,9 @@ use Symfony\Component\Uid\AbstractUid;
 
 abstract class AbstractUidType extends Type
 {
+    /**
+     * @return class-string<AbstractUid>
+     */
     abstract protected function getUidClass(): string;
 
     /**
@@ -25,7 +28,7 @@ abstract class AbstractUidType extends Type
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        if ($platform->hasNativeGuidType()) {
+        if ($this->hasNativeGuidType($platform)) {
             return $platform->getGuidTypeDeclarationSQL($column);
         }
 
@@ -64,7 +67,7 @@ abstract class AbstractUidType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
-        $toString = $platform->hasNativeGuidType() ? 'toRfc4122' : 'toBinary';
+        $toString = $this->hasNativeGuidType($platform) ? 'toRfc4122' : 'toBinary';
 
         if ($value instanceof AbstractUid) {
             return $value->$toString();
@@ -91,5 +94,15 @@ abstract class AbstractUidType extends Type
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
+    }
+
+    private function hasNativeGuidType(AbstractPlatform $platform): bool
+    {
+        // Compatibility with DBAL < 3.4
+        $method = \method_exists($platform, 'getStringTypeDeclarationSQL')
+            ? 'getStringTypeDeclarationSQL'
+            : 'getVarcharTypeDeclarationSQL';
+
+        return $platform->getGuidTypeDeclarationSQL([]) !== $platform->$method(['fixed' => true, 'length' => 36]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Follows doctrine/dbal#5509, alternative to https://github.com/doctrine/dbal/pull/5518
| License       | MIT
| Doc PR        | N/A

`AbstractPlatform::hasNativeGuidType()` has been deprecated in Doctrine DBAL. This PR inlines the logic of that method where we need it.

Furthermore, I took the liberty to refactor the corresponding tests a little. We don't really need to mock `AbstractPlatform` because we can work with actual instances. This also allows us to test the behavior of our implementation on different platforms.