### PR TITLE
[Security] Allow `Expression` as `AccessDeniedException` attribute

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Exception;
 
+use Symfony\Component\ExpressionLanguage\Expression;
+
 /**
  * AccessDeniedException is thrown when the account has not the required role.
  *
@@ -35,11 +37,11 @@ class AccessDeniedException extends RuntimeException
     }
 
     /**
-     * @param array|string $attributes
+     * @param array|string|Expression $attributes
      */
     public function setAttributes($attributes)
     {
-        $this->attributes = (array) $attributes;
+        $this->attributes = $attributes instanceof Expression ? [$attributes] : (array) $attributes;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the `AccessDeniedException::setAttributes()` method accepts a string or an array. However, there are several ways the method could receive [an instance of `Expression` as well](https://symfony.com/doc/4.4/security/expressions.html), eg:
```php
$this->denyAccessUnlessGranted(new Expression('"ROLE_ADMIN" in role_names'))
```
On Symfony 5.4 or lower there are no type hints so the object gets cast to an array:

https://github.com/symfony/symfony/blob/ee2eb1c2ba82483da7ea566b7ce830b4eb1200f9/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php#L37-L43
```
array(1) {
  ["*expression"]=>
  string(15) "some expression"
}
```

On 6.0 or higher, because of the added type hints, it gets cast into a string instead.
https://github.com/symfony/symfony/blob/c090b9aeefc3c539b3984c211a4b465d5e257b2c/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php#L34-L37