### PR TITLE
[HttpFoundation] Rename `Request::getContentType()` to `getContentFormat()`

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -9,6 +9,11 @@ FrameworkBundle
    `Symfony\Component\Serializer\Normalizer\NormalizerInterface` or implement `NormalizerAwareInterface` instead
  * Deprecate `AbstractController::renderForm()`, use `render()` instead
 
+HttpFoundation
+--------------
+
+ * Deprecate `Request::getContentType()`, use `getContentFormat()` instead
+
 Mailer
 --------
 

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Deprecate the `Request::getContentType()` method and add `getContentFormat()` as replacement
+
 6.1
 ---
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1332,8 +1332,20 @@ class Request
 
     /**
      * Gets the format associated with the request.
+     *
+     * @deprecated since Symfony 6.2, use getContentFormat() instead.
      */
     public function getContentType(): ?string
+    {
+        trigger_deprecation('symfony/http-foundation', '6.2', 'The "%s::getContentType()" method is deprecated, use "getContentFormat()" instead.', get_debug_type($this));
+
+        return $this->getContentFormat();
+    }
+
+    /**
+     * Gets the format associated with the request.
+     */
+    public function getContentFormat(): ?string
     {
         return $this->getFormat($this->headers->get('CONTENT_TYPE', ''));
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException;
 use Symfony\Component\HttpFoundation\Exception\JsonException;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
@@ -23,6 +24,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class RequestTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     protected function tearDown(): void
     {
         Request::setTrustedProxies([], -1);
@@ -80,10 +83,20 @@ class RequestTest extends TestCase
 
     public function testGetContentType()
     {
+        $this->expectDeprecation('Since symfony/http-foundation 6.2: The "Symfony\Component\HttpFoundation\Request::getContentType()" method is deprecated, use "getContentFormat()" instead.');
+
         $request = new Request();
         $contentType = $request->getContentType();
 
         $this->assertNull($contentType);
+    }
+
+    public function testGetContentFormat()
+    {
+        $request = new Request();
+        $contentFormat = $request->getContentFormat();
+
+        $this->assertNull($contentFormat);
     }
 
     public function testSetDefaultLocale()

--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -74,7 +74,7 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
     {
         return ($this->options['post_only'] ? $request->isMethod('POST') : true)
             && $this->httpUtils->checkRequestPath($request, $this->options['check_path'])
-            && ($this->options['form_only'] ? 'form' === $request->getContentType() : true);
+            && ($this->options['form_only'] ? 'form' === $request->getContentFormat() : true);
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -63,7 +63,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
 
     public function supports(Request $request): ?bool
     {
-        if (!str_contains($request->getRequestFormat() ?? '', 'json') && !str_contains($request->getContentType() ?? '', 'json')) {
+        if (!str_contains($request->getRequestFormat() ?? '', 'json') && !str_contains($request->getContentFormat() ?? '', 'json')) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #39750
| License       | MIT
| Doc PR        | n/a

This PR renames the `Request::getContentType()` to `getContentFormat()` for less confusion.