### PR TITLE
[Messenger] catch all exceptions while deserializing a message

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -19,7 +19,6 @@ use Symfony\Component\Messenger\Stamp\SerializerStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
-use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
@@ -79,7 +78,7 @@ class Serializer implements SerializerInterface
 
         try {
             $message = $this->serializer->deserialize($encodedEnvelope['body'], $encodedEnvelope['headers']['type'], $this->format, $context);
-        } catch (ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             throw new MessageDecodingFailedException('Could not decode message: '.$e->getMessage(), $e->getCode(), $e);
         }
 
@@ -117,7 +116,7 @@ class Serializer implements SerializerInterface
 
             try {
                 $stamps[] = $this->serializer->deserialize($value, substr($name, \strlen(self::STAMP_HEADER_PREFIX)).'[]', $this->format, $this->context);
-            } catch (ExceptionInterface $e) {
+            } catch (\Throwable $e) {
                 throw new MessageDecodingFailedException('Could not decode stamp: '.$e->getMessage(), $e->getCode(), $e);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes/no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hello,

In Messenger, while deserializing a message, if an error is encountered in a custom denormalizer, the error is not caught, and then `MessageDecodingFailedException` is not thrown. Then, if RabbitMQ is used, it results in a cyclic error where the message is always requeued without any way to kick it out from the queue.

My guess would be to catch any error that would happen while deserializing, even if the general policy is to never catch `\Throwable`. There is high amount of risk that if a given message have created an error once, it will create an error on every attempt to deserialize it. 

Or maybe we can at least catch `\Error|Symfony\Component\Serializer\Exception\ExceptionInterface` in order to cover all cases related to type error an so on... 