### PR TITLE
[ErrorHandler] Fix return type patching for list and class-string pseudo types

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -70,6 +70,8 @@ class DebugClassLoader
         'self' => 'self',
         'parent' => 'parent',
         'mixed' => 'mixed',
+        'list' => 'array',
+        'class-string' => 'string',
     ] + (\PHP_VERSION_ID >= 80000 ? [
         'static' => 'static',
         '$this' => 'static',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Return type patching currently fails because we use a `class-string` pseudo type.

https://github.com/symfony/symfony/runs/7431801606?check_suite_focus=true

This PR should fix the issue when merging it up.