### PR TITLE
[Cache] Ensured that redis adapter can use multiple redis sentinel hosts

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -171,7 +171,7 @@ jobs:
         env:
           REDIS_HOST: 'localhost:16379'
           REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
-          REDIS_SENTINEL_HOSTS: 'localhost:26379'
+          REDIS_SENTINEL_HOSTS: 'localhost:26379 localhost:26379 localhost:26379'
           REDIS_SENTINEL_SERVICE: redis_sentinel
           MESSENGER_REDIS_DSN: redis://127.0.0.1:7006/messages
           MESSENGER_AMQP_DSN: amqp://localhost/%2f/messages

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
@@ -47,9 +47,9 @@ class RedisAdapterSentinelTest extends AbstractRedisAdapterTest
     public function testExceptionMessageWhenFailingToRetrieveMasterInformation()
     {
         $hosts = getenv('REDIS_SENTINEL_HOSTS');
-        $firstHost = explode(' ', $hosts)[0];
+        $dsn = 'redis:?host['.str_replace(' ', ']&host[', $hosts).']';
         $this->expectException(\Symfony\Component\Cache\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to retrieve master information from master name "invalid-masterset-name" and address "'.$firstHost.'".');
-        AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => 'invalid-masterset-name']);
+        $this->expectExceptionMessage('Failed to retrieve master information from sentinel "invalid-masterset-name" and dsn "'.$dsn.'".');
+        AbstractAdapter::createConnection($dsn, ['redis_sentinel' => 'invalid-masterset-name']);
     }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -179,7 +179,7 @@ trait RedisTrait
         }
 
         if (null === $params['class'] && \extension_loaded('redis')) {
-            $class = $params['redis_cluster'] ? \RedisCluster::class : (1 < \count($hosts) ? \RedisArray::class : \Redis::class);
+            $class = $params['redis_cluster'] ? \RedisCluster::class : (1 < \count($hosts) && !isset($params['redis_sentinel']) ? \RedisArray::class : \Redis::class);
         } else {
             $class = $params['class'] ?? \Predis\Client::class;
 
@@ -193,21 +193,29 @@ trait RedisTrait
             $redis = new $class();
 
             $initializer = static function ($redis) use ($connect, $params, $dsn, $auth, $hosts, $tls) {
-                $host = $hosts[0]['host'] ?? $hosts[0]['path'];
-                $port = $hosts[0]['port'] ?? 0;
+                $hostIndex = 0;
+                do {
+                    $host = $hosts[$hostIndex]['host'] ?? $hosts[$hostIndex]['path'];
+                    $port = $hosts[$hostIndex]['port'] ?? 0;
+                    $address = false;
 
-                if (isset($hosts[0]['host']) && $tls) {
-                    $host = 'tls://'.$host;
-                }
-
-                if (isset($params['redis_sentinel'])) {
-                    $sentinel = new \RedisSentinel($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout']);
-
-                    if (!$address = $sentinel->getMasterAddrByName($params['redis_sentinel'])) {
-                        throw new InvalidArgumentException(sprintf('Failed to retrieve master information from master name "%s" and address "%s:%d".', $params['redis_sentinel'], $host, $port));
+                    if (isset($hosts[$hostIndex]['host']) && $tls) {
+                        $host = 'tls://'.$host;
                     }
 
-                    [$host, $port] = $address;
+                    if (!isset($params['redis_sentinel'])) {
+                        break;
+                    }
+
+                    $sentinel = new \RedisSentinel($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout']);
+
+                    if ($address = $sentinel->getMasterAddrByName($params['redis_sentinel'])) {
+                        [$host, $port] = $address;
+                    }
+                } while (++$hostIndex < \count($hosts) && !$address);
+
+                if (isset($params['redis_sentinel']) && !$address) {
+                    throw new InvalidArgumentException(sprintf('Failed to retrieve master information from sentinel "%s" and dsn "%s".', $params['redis_sentinel'], $dsn));
                 }
 
                 try {


### PR DESCRIPTION
This PR ensures that RedisAdapter for Symfony Cache component works as expected when a redis_sentinel argument is provided with multiple redis sentinel hosts. Previously if using the redis php extension and multiple hosts were provided RedisTrait::createConnection would ignore the redis_sentinel parameter and instead return a RedisArray object which would not work because it would be an array of sentinel hosts rather than redis hosts.

This PR introduces the correct behaviour where by RedisTrait::createConnection will loop through each of the provided sentinel hosts trying each one to get the address of the mast redis instance. If none of the provided hosts can return the address of a master instance it will throw an exception.

I'm not too sure how to test this behaviour. There doesn't appear to be any tests for redis sentinel behaviour in place currently. I have tested manually both with a multi redis sentinel setup and with a single standard redis instance and the code now functions as expected in both scenarios.

| Q             | A
| ------------- | ---
| Branch?         |  5.4
| Bug fix?      | yes/no
| New feature?  | no - bugfix
| Deprecations? | no - behaviour as documented and as implemented in 4.4
| Tickets       | [#46998](https://github.com/symfony/symfony/issues/46998)
| License       | MIT
| Doc PR        |  none - bugfix
