### PR TITLE
[Messenger] Add options to `FailedMessagesShowCommand`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -27,7 +27,7 @@ CHANGELOG
  * Deprecate not setting the `reset_on_message` config option, its default value will change to `true` in 6.0
  * Add log when worker should stop.
  * Add log when `SIGTERM` is received.
- * Add the options `stats` and `class-filter` to `FailedMessagesShowCommand`
+ * Add `--stats` and `--class-filter` options to `FailedMessagesShowCommand`
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -27,6 +27,7 @@ CHANGELOG
  * Deprecate not setting the `reset_on_message` config option, its default value will change to `true` in 6.0
  * Add log when worker should stop.
  * Add log when `SIGTERM` is received.
+ * Add the options `stats` and `class-filter` to `FailedMessagesShowCommand`
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -90,7 +90,7 @@ EOF
         return 0;
     }
 
-    private function listMessages(?string $failedTransportName, SymfonyStyle $io, int $max, ?string $classFilter)
+    private function listMessages(?string $failedTransportName, SymfonyStyle $io, int $max, string $classFilter = null)
     {
         /** @var ListableReceiverInterface $receiver */
         $receiver = $this->getReceiver($failedTransportName);

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -78,7 +78,7 @@ class FailedMessagesShowCommandTest extends TestCase
   Error         Things are bad!      
   Error Code    123                  
   Error Class   Exception            
-  Transport     async                
+  Transport     async
 EOF
             ,
             $redeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')),
@@ -120,7 +120,7 @@ EOF
   Error         Things are bad!      
   Error Code    123                  
   Error Class   Exception            
-  Transport     async                
+  Transport     async
 EOF
             ,
             $redeliveryStamp2->getRedeliveredAt()->format('Y-m-d H:i:s')),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39330 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14689

See #39330
