### PR TITLE
[String] Fix `width` method in `AbstractUnicodeString`

### DIFF
--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -498,8 +498,11 @@ abstract class AbstractUnicodeString extends AbstractString
                 )|[\p{Cc}\x7F]++)/xu', '', $s);
             }
 
-            // Non printable characters have been dropped, so wcswidth cannot logically return -1.
-            $width += $this->wcswidth($s);
+            $lineWidth = $this->wcswidth($s);
+
+            if ($lineWidth > $width) {
+                $width = $lineWidth;
+            }
         }
 
         return $width;

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -15,6 +15,19 @@ use Symfony\Component\String\Exception\InvalidArgumentException;
 
 abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
 {
+    public static function provideWidth(): array
+    {
+        return array_merge(
+            parent::provideWidth(),
+            [
+                [14, '<<<END
+This is a
+multiline text
+END'],
+            ]
+        );
+    }
+
     public function testCreateFromStringWithInvalidUtf8Input()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #47004
| License       | MIT
| Doc PR       | none - bugfix

This PR ensures that the `width` method of `AbstractUnicodeString` returns the width and not the length of the text.
