### PR TITLE
[Console] get full command path for command in search path

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.bash
+++ b/src/Symfony/Component/Console/Resources/completion.bash
@@ -13,9 +13,11 @@ _sf_{{ COMMAND_NAME }}() {
     # for an alias, get the real script behind it
     if [[ $(type -t $sf_cmd) == "alias" ]]; then
         sf_cmd=$(alias $sf_cmd | sed -E "s/alias $sf_cmd='(.*)'/\1/")
+    else
+        sf_cmd=$(type -p $sf_cmd)
     fi
 
-    if [ ! -f "$sf_cmd" ]; then
+    if [ ! -x "$sf_cmd" ]; then
         return 1
     fi
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 


Working on composer 2.4.0RC1 will autocompletion

When the command is in the search path, **-f** fails, so we need to switch to its full path

```
$ type -p ./composer
./composer

$ type -p composer
/usr/bin/composer

```