### PR TITLE
[HttpFoundation] use constants instead of ints for status codes

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -45,7 +45,7 @@ class BinaryFileResponse extends Response
      * @param bool                $autoEtag           Whether the ETag header should be automatically set
      * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
      */
-    public function __construct(\SplFileInfo|string $file, int $status = 200, array $headers = [], bool $public = true, string $contentDisposition = null, bool $autoEtag = false, bool $autoLastModified = true)
+    public function __construct(\SplFileInfo|string $file, int $status = Response::HTTP_OK, array $headers = [], bool $public = true, string $contentDisposition = null, bool $autoEtag = false, bool $autoLastModified = true)
     {
         parent::__construct(null, $status, $headers);
 

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -36,7 +36,7 @@ class JsonResponse extends Response
     /**
      * @param bool $json If the data is already a JSON string
      */
-    public function __construct(mixed $data = null, int $status = 200, array $headers = [], bool $json = false)
+    public function __construct(mixed $data = null, int $status = Response::HTTP_OK, array $headers = [], bool $json = false)
     {
         parent::__construct('', $status, $headers);
 
@@ -63,7 +63,7 @@ class JsonResponse extends Response
      * @param int    $status  The response status code
      * @param array  $headers An array of response headers
      */
-    public static function fromJsonString(string $data, int $status = 200, array $headers = []): static
+    public static function fromJsonString(string $data, int $status = Response::HTTP_OK, array $headers = []): static
     {
         return new static($data, $status, $headers, true);
     }

--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -32,7 +32,7 @@ class RedirectResponse extends Response
      *
      * @see https://tools.ietf.org/html/rfc2616#section-10.3
      */
-    public function __construct(string $url, int $status = 302, array $headers = [])
+    public function __construct(string $url, int $status = Response::HTTP_FOUND, array $headers = [])
     {
         parent::__construct('', $status, $headers);
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -214,7 +214,7 @@ class Response
     /**
      * @throws \InvalidArgumentException When the HTTP status code is not valid
      */
-    public function __construct(?string $content = '', int $status = 200, array $headers = [])
+    public function __construct(?string $content = '', int $status = self::HTTP_OK, array $headers = [])
     {
         $this->headers = new ResponseHeaderBag($headers);
         $this->setContent($content);

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -30,7 +30,7 @@ class StreamedResponse extends Response
     protected $streamed;
     private bool $headersSent;
 
-    public function __construct(callable $callback = null, int $status = 200, array $headers = [])
+    public function __construct(callable $callback = null, int $status = Response::HTTP_OK, array $headers = [])
     {
         parent::__construct(null, $status, $headers);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | 

Use constants instead of [*magic numbers*](https://wiki.c2.com/?MagicNumber).