### PR TITLE
[DependencyInjection] Support Enum for tagged_locator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `enum` env var processor
  * Add `shuffle` env var processor
  * Add `resolve-env` option to `debug:config` command to display actual values of environment variables in dumped configuration
+ * Add support of `enum` method return type for `!tagged_locator`
 
 6.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -159,6 +159,10 @@ class PriorityTaggedServiceUtil
             return $default;
         }
 
+        if (\is_object($default) && enum_exists($default::class)) {
+            $default = $default->name;
+        }
+
         if (\is_int($default)) {
             $default = (string) $default;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #47027
| License       | MIT
| Doc PR        |  --


Add feature for using Enum in method return type for default_index_method in !tagged_locator

Example:
services.yaml
   ``` yaml
 _instanceof:
        App\File\Definition\Configuration\FileDefinitionConfiguratorInterface:
            tags: ['app.file.definition.configurator']

    App\TemplateConfiguration\Definition\FileDefinitionManager:
        arguments:
            $configuratorLocator: !tagged_locator {tag: app.file.definition.configurator, default_index_method: getType}
```
```
interface FileDefinitionConfiguratorInterface
{
    public function configureBuilder(NodeBuilder $builder): void;
    public static function getType(): FileDefinitionType;
}
```