### PR TITLE
Force EOF to Unix style (LF) with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+* text=auto eol=lf
 /src/Symfony/Contracts export-ignore
 /src/Symfony/Bridge/PhpUnit export-ignore
 /src/Symfony/Component/Mailer/Bridge export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Pulling Symfony on Windows, with a default Git results in sources using the end-of-line ending CRLF. If this doesn't seem to prevent the use of Symfony, it strongly disrupts the tests by making many of them fail because the $expected string is false in an assertSame comparison.
Prefer to submit for 6.2, even if it's a bugfix, in the event that it disrupts existing development environments.

### Extract of Windows result on an unmodified gitconfig:
![image](https://user-images.githubusercontent.com/4020317/180583058-52617e03-93b7-4edc-bd2b-37ea787a6331.png)

### After the gitattribute *(fresh clone or reset hard after deleting all file)*:
![image](https://user-images.githubusercontent.com/4020317/180583144-f3294dbb-ed4a-4301-8ae9-621ee2ecc740.png)
