### PR TITLE
Throw error with debug message when ExpressionLanguage Component is not installed

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
@@ -27,6 +27,10 @@ class ExpressionLanguageSyntaxValidator extends ConstraintValidator
 
     public function __construct(ExpressionLanguage $expressionLanguage = null)
     {
+        if (!class_exists(ExpressionLanguage::class)) {
+            throw new \LogicException(sprintf('The "%s" class requires the "ExpressionLanguage" component. Try running "composer require symfony/expression-language".', self::class));
+        }
+
         $this->expressionLanguage = $expressionLanguage;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       |
| License       | MIT
| Doc PR        |

When using the ExpressionLanguageSyntax constraints without installing the ExpressionLanguage component you get a random error. This PR throws an exception with a debugging message to suggest you install the expression language component.