### PR TITLE
Add a mailer:test command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -101,6 +101,7 @@ use Symfony\Component\Mailer\Bridge\OhMySmtp\Transport\OhMySmtpTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendinblue\Transport\SendinblueTransportFactory;
+use Symfony\Component\Mailer\Command\MailerTestCommand;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mercure\HubRegistry;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -384,6 +385,10 @@ class FrameworkExtension extends Extension
 
         if ($this->mailerConfigEnabled = $this->isConfigEnabled($container, $config['mailer'])) {
             $this->registerMailerConfiguration($config['mailer'], $container, $loader);
+        }
+
+        if (!$this->mailerConfigEnabled || !class_exists(MailerTestCommand::class)) {
+            $container->removeDefinition('console.command.mailer_test');
         }
 
         $propertyInfoEnabled = $this->isConfigEnabled($container, $config['property_info']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Mailer\Command\MailerTestCommand;
 use Symfony\Component\Mailer\EventListener\EnvelopeListener;
 use Symfony\Component\Mailer\EventListener\MessageListener;
 use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
@@ -72,5 +73,11 @@ return static function (ContainerConfigurator $container) {
         ->set('mailer.message_logger_listener', MessageLoggerListener::class)
             ->tag('kernel.event_subscriber')
             ->tag('kernel.reset', ['method' => 'reset'])
+
+        ->set('console.command.mailer_test', MailerTestCommand::class)
+            ->args([
+                service('mailer.transports'),
+            ])
+            ->tag('console.command')
     ;
 };

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add a `mailer:test` command
+
 6.1
 ---
 

--- a/src/Symfony/Component/Mailer/Command/MailerTestCommand.php
+++ b/src/Symfony/Component/Mailer/Command/MailerTestCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Email;
+
+/**
+ * A console command to test Mailer transports.
+ */
+#[AsCommand(name: 'mailer:test', description: 'Test Mailer transports by sending an email')]
+final class MailerTestCommand extends Command
+{
+    public function __construct(private TransportInterface $transport)
+    {
+        $this->transport = $transport;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->addArgument('to', InputArgument::REQUIRED, 'The recipient of the message')
+            ->addOption('from', null, InputOption::VALUE_OPTIONAL, 'The sender of the message', 'from@example.org')
+            ->addOption('subject', null, InputOption::VALUE_OPTIONAL, 'The subject of the message', 'Testing transport')
+            ->addOption('body', null, InputOption::VALUE_OPTIONAL, 'The body of the message', 'Testing body')
+            ->addOption('transport', null, InputOption::VALUE_OPTIONAL, 'The transport to be used')
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> command tests a Mailer transport by sending a simple email message:
+
+<info>php %command.full_name% to@example.com</info>
+
+You can also specify a specific transport:
+
+    <info>php %command.full_name% to@example.com --transport=transport_name</info>
+
+Note that this command bypasses the Messenger bus if configured.
+
+EOF
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $message = (new Email())
+            ->to($input->getArgument('to'))
+            ->from($input->getOption('from'))
+            ->subject($input->getOption('subject'))
+            ->text($input->getOption('body'))
+        ;
+        if ($transport = $input->getOption('transport')) {
+            $message->getHeaders()->addTextHeader('X-Transport', $transport);
+        }
+
+        $this->transport->send($message);
+
+        return 0;
+    }
+}

--- a/src/Symfony/Component/Mailer/Tests/Command/MailerTestCommandTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Command/MailerTestCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Mailer\Command\MailerTestCommand;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Email;
+
+class MailerTestCommandTest extends TestCase
+{
+    public function testSendsEmail()
+    {
+        $from = 'from@example.com';
+        $to = 'to@example.com';
+        $subject = 'Foobar';
+        $body = 'Lorem ipsum dolor sit amet.';
+
+        $mailer = $this->createMock(TransportInterface::class);
+        $mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with(self::callback(static function (Email $message) use ($from, $to, $subject, $body): bool {
+                return
+                    $message->getFrom()[0]->getAddress() === $from &&
+                    $message->getTo()[0]->getAddress() === $to &&
+                    $message->getSubject() === $subject &&
+                    $message->getTextBody() === $body
+                ;
+            }))
+        ;
+
+        $tester = new CommandTester(new MailerTestCommand($mailer));
+        $tester->execute([
+            'to' => $to,
+            '--from' => $from,
+            '--subject' => $subject,
+            '--body' => $body,
+        ]);
+    }
+
+    public function testUsesCustomTransport()
+    {
+        $transport = 'foobar';
+
+        $mailer = $this->createMock(TransportInterface::class);
+        $mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with(self::callback(static function (Email $message) use ($transport): bool {
+                return $message->getHeaders()->getHeaderBody('X-Transport') === $transport;
+            }))
+        ;
+
+        $tester = new CommandTester(new MailerTestCommand($mailer));
+        $tester->execute([
+            'to' => 'to@example.com',
+            '--transport' => $transport,
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #43687, Fix #39173, Fix #37409
| License       | MIT
| Doc PR        | 

This PR introduces a `mailer:test` command that helps test if sending emails works correctly.
The only argument is the `To` header. Everything is optional.
There is no support for complex emails (STDIN for body, HTML support, attachments, ...) as the goal is to test if a transport works correctly.

Note that this command bypasses the Messenger bus if configured to ease testing even when the messenger consumer is not running.
