### PR TITLE
[Serializer] Fix XmlEncoder encoding attribute false

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -417,6 +417,9 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
                     if (!\is_scalar($data)) {
                         $data = $this->serializer->normalize($data, $format, $context);
                     }
+                    if (\is_bool($data)) {
+                        $data = (int) $data;
+                    }
                     $parentNode->setAttribute($attributeName, $data);
                 } elseif ('#' === $key) {
                     $append = $this->selectNodeType($parentNode, $data, $format, $context);

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -111,6 +111,13 @@ class XmlEncoderTest extends TestCase
             'föo_bär' => 'a',
             'Bar' => [1, 2, 3],
             'a' => 'b',
+            'scalars' => [
+                '@bool-true' => true,
+                '@bool-false' => false,
+                '@int' => 3,
+                '@float' => 3.4,
+                '@sring' => 'a',
+            ],
         ];
         $expected = '<?xml version="1.0"?>'."\n".
             '<response>'.
@@ -121,6 +128,7 @@ class XmlEncoderTest extends TestCase
             '<Bar>2</Bar>'.
             '<Bar>3</Bar>'.
             '<a>b</a>'.
+            '<scalars bool-true="1" bool-false="0" int="3" float="3.4" sring="a"/>'.
             '</response>'."\n";
         $this->assertEquals($expected, $this->encoder->encode($obj, 'xml'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| Deprecations? | no
| Tickets       | Fix #47002 
| License       | MIT
| Doc PR        | 

```php
[
    'foo' => [
        '@bar' = true,
        '@baz' = false,
    ]
]
```

Before patch:
```xml
<foo bar="1" baz="">
```

After patch:
```xml
<foo bar="1" baz="0">
```
