### PR TITLE
[Mailer] Throw a more specific exception when a BodyRendererInterface is needed but not configured

### DIFF
--- a/src/Symfony/Component/Mailer/EventListener/MessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageListener.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Mailer\EventListener;
 
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\RuntimeException;
+use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mime\BodyRendererInterface;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\MailboxListHeader;
@@ -119,6 +121,10 @@ class MessageListener implements EventSubscriberInterface
     private function renderMessage(Message $message): void
     {
         if (!$this->renderer) {
+            if ($message instanceof TemplatedEmail && ($message->getTextTemplate() || $message->getHtmlTemplate())) {
+                throw new LogicException(sprintf('You must configure a "%s" when a "%s" instance has a text or HTML template set.', BodyRendererInterface::class, get_debug_type($message)));
+            }
+
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

When a `BodyRendereInterface` is not configured, you get the following error message if sending a `TemplatedEmail`:

```
A message must have a text or an HTML part or attachments.
```

After this PR, you will get a better error message:

```
You must register a "Symfony\Component\Mime\BodyRendererInterface" when a "Symfony\Bridge\Twig\Mime\TemplatedEmail" instance has a text or HTML template set.
```

That will help debugging such issues.
