### PR TITLE
[DependencyInjection] Allow attribute autoconfiguration on static methods

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
@@ -120,7 +120,7 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
 
         if ($this->methodAttributeConfigurators || $this->parameterAttributeConfigurators) {
             foreach ($classReflector->getMethods(\ReflectionMethod::IS_PUBLIC) as $methodReflector) {
-                if ($methodReflector->isStatic() || $methodReflector->isConstructor() || $methodReflector->isDestructor()) {
+                if ($methodReflector->isConstructor() || $methodReflector->isDestructor()) {
                     continue;
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StaticMethodTag.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StaticMethodTag.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomMethodAttribute;
+
+final class StaticMethodTag
+{
+    #[CustomMethodAttribute('static')]
+    public static function method(): void
+    {
+    }
+}


### PR DESCRIPTION
| Q                | A
| ------------ | ---
| Branch?      | 6.2
| Bug fix?      | no
| Tickets       | #47060 
| License       | MIT

A static method can be used to carry complex configuration payload for DI.
A static method can be used to generate a Closure that can be hooked in the container (a static message handler with no dependency).
Using simple attribute autoconfigurator to wire those case easily.