### PR TITLE
[Security] Allow redirect after login to absolute URLs

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -73,7 +73,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
         $options = $this->options;
         $failureUrl = ParameterBagUtils::getRequestParameterValue($request, $options['failure_path_parameter']);
 
-        if (\is_string($failureUrl) && str_starts_with($failureUrl, '/')) {
+        if (\is_string($failureUrl) && (str_starts_with($failureUrl, '/') || str_starts_with($failureUrl, 'http'))) {
             $options['failure_path'] = $failureUrl;
         } elseif ($this->logger && $failureUrl) {
             $this->logger->debug(sprintf('Ignoring query parameter "%s": not a valid URL.', $options['failure_path_parameter']));

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -107,7 +107,7 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
 
         $targetUrl = ParameterBagUtils::getRequestParameterValue($request, $this->options['target_path_parameter']);
 
-        if (\is_string($targetUrl) && str_starts_with($targetUrl, '/')) {
+        if (\is_string($targetUrl) && (str_starts_with($targetUrl, '/') || str_starts_with($targetUrl, 'http'))) {
             return $targetUrl;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -207,6 +207,21 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
         $handler->onAuthenticationFailure($this->request, $this->exception);
     }
 
+    public function testAbsoluteUrlRedirectionFromRequest()
+    {
+        $options = ['failure_path_parameter' => '_my_failure_path'];
+
+        $this->request->expects($this->once())
+            ->method('get')->with('_my_failure_path')
+            ->willReturn('https://localhost/some-path');
+
+        $this->httpUtils->expects($this->once())
+            ->method('createRedirectResponse')->with($this->request, 'https://localhost/some-path');
+
+        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
+        $handler->onAuthenticationFailure($this->request, $this->exception);
+    }
+
     private function getRequest()
     {
         $request = $this->createMock(Request::class);

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -135,4 +135,21 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
 
         $handler->onAuthenticationSuccess($request, $token);
     }
+
+    public function testTargetPathWithAbsoluteUrlFromRequest()
+    {
+        $options = ['target_path_parameter' => '_my_target_path'];
+
+        $request = $this->createMock(Request::class);
+        $request->expects($this->once())
+            ->method('get')->with('_my_target_path')
+            ->willReturn('https://localhost/some-path');
+
+        $httpUtils = $this->createMock(HttpUtils::class);
+        $httpUtils->expects($this->once())
+            ->method('createRedirectResponse')->with($request, 'https://localhost/some-path');
+
+        $handler = new DefaultAuthenticationSuccessHandler($httpUtils, $options);
+        $handler->onAuthenticationSuccess($request, $this->createMock(TokenInterface::class));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46533
| License       | MIT
| Doc PR        | 

Fixes the regression introduced by https://github.com/symfony/symfony/pull/46317, and once again allows absolute URLs to be the target of authentication redirection, as specified in the documentation (https://symfony.com/doc/current/security/form_login.html#changing-the-default-page)
