### PR TITLE
AbstractSessionHandler implements SessionIdInterface

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+6.2
+---
+ * Implement `SessionIdInterface` in `AbstractSessionHandler`
+
 6.1
 ---
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -43,6 +43,8 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
 
     abstract protected function doDestroy(string $sessionId): bool;
 
+    abstract public function create_sid():string;
+
     public function validateId(string $sessionId): bool
     {
         $this->prefetchData = $this->read($sessionId);

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Session\SessionUtils;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-abstract class AbstractSessionHandler implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface
+abstract class AbstractSessionHandler implements \SessionHandlerInterface, \SessionIdInterface, \SessionUpdateTimestampHandlerInterface
 {
     private string $sessionName;
     private string $prefetchId;
@@ -34,7 +34,6 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
         if (!headers_sent() && !\ini_get('session.cache_limiter') && '0' !== \ini_get('session.cache_limiter')) {
             header(sprintf('Cache-Control: max-age=%d, private, must-revalidate', 60 * (int) \ini_get('session.cache_expire')));
         }
-
         return true;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -43,7 +43,9 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
 
     abstract protected function doDestroy(string $sessionId): bool;
 
-    abstract public function create_sid():string;
+    public function create_sid():string{
+        return session_create_id();
+    }
 
     public function validateId(string $sessionId): bool
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2  <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #45186 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | none <!-- required for new features -->

Add `SessionIdInterface` as implemented interface to `AbstractSessionHandler` to create the possibility of creating/setting the correct session id if it is provided in an alternative manner. For example, you can implement a custom `create_sid()` method in a SessionHandler class which uses the  `AbstractSessionHandler`.
