### PR TITLE
Remove .gitignore file from dist package

### DIFF
--- a/src/Symfony/Contracts/.gitattributes
+++ b/src/Symfony/Contracts/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Contracts/Cache/.gitattributes
+++ b/src/Symfony/Contracts/Cache/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Contracts/Deprecation/.gitattributes
+++ b/src/Symfony/Contracts/Deprecation/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Contracts/EventDispatcher/.gitattributes
+++ b/src/Symfony/Contracts/EventDispatcher/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Contracts/HttpClient/.gitattributes
+++ b/src/Symfony/Contracts/HttpClient/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Contracts/Service/.gitattributes
+++ b/src/Symfony/Contracts/Service/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Contracts/Translation/.gitattributes
+++ b/src/Symfony/Contracts/Translation/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Not a big deal, but `.gitignore` file is present in dist package fetched from packagist.