### PR TITLE
[Mailer] Add new events

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add a `mailer:test` command
+ * Add `SentMessageEvent` and `FailedMessageEvent` events
 
 6.1
 ---

--- a/src/Symfony/Component/Mailer/Event/FailedMessageEvent.php
+++ b/src/Symfony/Component/Mailer/Event/FailedMessageEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Event;
+
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class FailedMessageEvent extends Event
+{
+    public function __construct(
+        private RawMessage $message,
+        private \Throwable $error,
+    ) {
+    }
+
+    public function getMessage(): RawMessage
+    {
+        return $this->message;
+    }
+
+    public function getError(): \Throwable
+    {
+        return $this->error;
+    }
+}

--- a/src/Symfony/Component/Mailer/Event/SentMessageEvent.php
+++ b/src/Symfony/Component/Mailer/Event/SentMessageEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Event;
+
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class SentMessageEvent extends Event
+{
+    public function __construct(private SentMessage $message)
+    {
+    }
+
+    public function getMessage(): SentMessage
+    {
+        return $this->message;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #42108 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

Dispatching 2 new events: `SentMessageEvent` and `FailedMessageEvent` when sending an email.
It allows acting on the `SentMessage` or the "initial" message in case of a failure.
