### PR TITLE
[HttpFoundation] Deprecate `\Stringable` support in `InputBag`

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -13,6 +13,7 @@ HttpFoundation
 --------------
 
  * Deprecate `Request::getContentType()`, use `Request::getContentTypeFormat()` instead
+ * Deprecate passing `\Stringable` objects to `InputBag`, use scalars, arrays or null instead.
 
 Mailer
 --------

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Deprecate passing `\Stringable` objects to `InputBag`, use scalars, arrays or null instead.
+
 6.1
 ---
 

--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -27,14 +27,24 @@ final class InputBag extends ParameterBag
      */
     public function get(string $key, mixed $default = null): string|int|float|bool|null
     {
+        // @deprecated since symfony 6.2, in 7.0 change to:
+        // if (null !== $default && !\is_scalar($default)) {
         if (null !== $default && !\is_scalar($default) && !$default instanceof \Stringable) {
             throw new \InvalidArgumentException(sprintf('Expected a scalar value as a 2nd argument to "%s()", "%s" given.', __METHOD__, get_debug_type($default)));
+        }
+
+        if ($default instanceof \Stringable) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Passing a "%s" object as 2nd argument ($default) to "%s()" is deprecated, pass a scalar or null instead.', get_debug_type($default), __METHOD__);
         }
 
         $value = parent::get($key, $this);
 
         if (null !== $value && $this !== $value && !\is_scalar($value) && !$value instanceof \Stringable) {
             throw new BadRequestException(sprintf('Input value "%s" contains a non-scalar value.', $key));
+        }
+
+        if ($value instanceof \Stringable) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Retrieving a "%s" object from "%s()" is deprecated, use scalars or null instead.', get_debug_type($value), __METHOD__);
         }
 
         return $this === $value ? $default : $value;
@@ -66,8 +76,14 @@ final class InputBag extends ParameterBag
      */
     public function set(string $key, mixed $value)
     {
+        // @deprecated since symfony 6.2, in 7.0 change to:
+        // if (null !== $value && !\is_scalar($value) && !\is_array($value)) {
         if (null !== $value && !\is_scalar($value) && !\is_array($value) && !$value instanceof \Stringable) {
             throw new \InvalidArgumentException(sprintf('Expected a scalar, or an array as a 2nd argument to "%s()", "%s" given.', __METHOD__, get_debug_type($value)));
+        }
+
+        if ($value instanceof \Stringable) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Passing a "%s" object as a 2nd argument ($value) to "%s()" is deprecated. Pass a scalar, an array or null instead.', get_debug_type($value), __METHOD__);
         }
 
         $this->parameters[$key] = $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/pull/46957#issuecomment-1192731661
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

As discussed in https://github.com/symfony/symfony/pull/46957, it seems there is no valid use case for using `\Stringable` objects with InputBag.