### PR TITLE
[Form] Casting `$name` to string

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -416,7 +416,7 @@ class ChoiceType extends AbstractType
                 continue;
             }
 
-            $this->addSubForm($builder, $name, $choiceView, $options);
+            $this->addSubForm($builder, (string) $name, $choiceView, $options);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

Casting `$name` to string before passing it to `addSubForm()`
