### PR TITLE
[Messenger] Batch handlers v2

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -661,7 +661,8 @@ class FrameworkExtension extends Extension
         $container->registerAttributeForAutoconfiguration(AsMessageHandler::class, static function (ChildDefinition $definition, AsMessageHandler $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
             $tagAttributes = get_object_vars($attribute);
             $tagAttributes['from_transport'] = $tagAttributes['fromTransport'];
-            unset($tagAttributes['fromTransport']);
+            $tagAttributes['batch_strategy'] = $tagAttributes['batchStrategy'];
+            unset($tagAttributes['fromTransport'], $tagAttributes['batchStrategy']);
             if ($reflector instanceof \ReflectionMethod) {
                 if (isset($tagAttributes['method'])) {
                     throw new LogicException(sprintf('AsMessageHandler attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));

--- a/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
@@ -25,6 +25,7 @@ class AsMessageHandler
         public ?string $handles = null,
         public ?string $method = null,
         public int $priority = 0,
+        public ?string $batchStrategy = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerAdapter.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerAdapter.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+/**
+ * @internal
+ */
+class BatchHandlerAdapter implements BatchHandlerInterface
+{
+    private readonly \Closure $handler;
+    private readonly BatchStrategyInterface $batchStrategy;
+    private \SplObjectStorage $ackMap;
+    private ?object $lastMessage;
+
+    public function __construct(callable $handler, BatchStrategyInterface $batchStrategy)
+    {
+        $this->batchStrategy = $batchStrategy;
+        $this->handler = $handler(...);
+
+        $this->ackMap = new \SplObjectStorage();
+        $this->lastMessage = null;
+    }
+
+    public function __invoke(object $message, Acknowledger $ack = null): mixed
+    {
+        $this->lastMessage = $message;
+
+        if (null === $ack) {
+            $ack = new Acknowledger(get_debug_type($this));
+            $this->ackMap[$message] = $ack;
+
+            $this->flush(true);
+
+            return $ack->getResult();
+        }
+
+        $this->ackMap[$message] = $ack;
+        if (!$this->shouldFlush()) {
+            return $this->ackMap->count();
+        }
+
+        $this->flush(true);
+
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush(bool $force): void
+    {
+        if (!$this->lastMessage) {
+            return;
+        }
+
+        $ackMap = $this->ackMap;
+        $this->ackMap = new \SplObjectStorage();
+        $this->lastMessage = null;
+
+        $this->batchStrategy->beforeHandle();
+        ($this->handler)(new Result($ackMap), ...\iterator_to_array($ackMap));
+        $this->batchStrategy->afterHandle();
+    }
+
+    private function shouldFlush(): bool
+    {
+        return $this->lastMessage && $this->batchStrategy->shouldHandle($this->lastMessage);
+    }
+}

--- a/src/Symfony/Component/Messenger/Handler/BatchStrategyInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchStrategyInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+interface BatchStrategyInterface
+{
+    public function shouldHandle(object $lastMessage): bool;
+
+    public function beforeHandle(): void;
+
+    public function afterHandle(): void;
+}

--- a/src/Symfony/Component/Messenger/Handler/BatchStrategyProviderInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchStrategyProviderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+interface BatchStrategyProviderInterface
+{
+    public function getBatchStrategy(): BatchStrategyInterface;
+}

--- a/src/Symfony/Component/Messenger/Handler/CountBatchStrategy.php
+++ b/src/Symfony/Component/Messenger/Handler/CountBatchStrategy.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+class CountBatchStrategy implements BatchStrategyInterface
+{
+    private int $bufferSize = 0;
+
+    public function __construct(private readonly int $flushSize)
+    {
+    }
+
+    public function shouldHandle(object $lastMessage): bool
+    {
+        return ++$this->bufferSize >= $this->flushSize;
+    }
+
+    public function beforeHandle(): void
+    {
+        $this->bufferSize = 0;
+    }
+
+    public function afterHandle(): void
+    {
+        // no operation
+    }
+}

--- a/src/Symfony/Component/Messenger/Handler/Result.php
+++ b/src/Symfony/Component/Messenger/Handler/Result.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+final class Result
+{
+    public function __construct(private \SplObjectStorage $ackMap)
+    {
+    }
+
+    public function ok(object $message, mixed $result = null): void
+    {
+        $this->ackMap[$message]->ack($result);
+    }
+
+    public function error(object $message, \Throwable $e): void
+    {
+        $this->ackMap[$message]->nack($e);
+    }
+}

--- a/src/Symfony/Component/Messenger/Handler/ResultWrappedHandler.php
+++ b/src/Symfony/Component/Messenger/Handler/ResultWrappedHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+/**
+ * @internal
+ */
+class ResultWrappedHandler
+{
+    public function __construct(private readonly \Closure $handler)
+    {
+    }
+
+    public function __invoke(Result $r, object ...$messages): int
+    {
+        try {
+            $lastResult = ($this->handler)(...$messages);
+        } catch (\Throwable $e) {
+            foreach ($messages as $message) {
+                $r->error($message, $e);
+            }
+
+            return \count($messages);
+        }
+
+        $length = \count($messages);
+        $lastMessage = \array_pop($messages);
+
+        foreach ($messages as $message) {
+            $r->ok($message);
+        }
+
+        $r->ok($lastMessage, $lastResult);
+
+        return $length;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | possible...
| Tickets       | nope
| License       | MIT
| Doc PR        | TBD


_The Messenger component is a good core of asynchronous applications. Since my team utilizes event-driven architecture, we heavily rely on the library. We've been collecting many ideas on improvement over the past years. Most of them are about extending and flexibility, so they require internal changes to the library. Unfortunately, some changes block each other, so it's difficult to do them piece by piece. Nevertheless, I will try. The first small piece is below._

### Introdution
The common example of batch handler (merged in #43354) is:

```php
class MyBatchHandler implements BatchHandlerInterface
{
    use BatchHandlerTrait;

    public function __invoke(MyMessage $message, Acknowledger $ack = null)
    {
        return $this->handle($message, $ack);
    }

    private function process(array $jobs): void
    {
        foreach ($jobs as [$message, $ack]) {
            try {
                // [...] compute $result from $message
                $ack->ack($result);
            } catch (\Throwable $e) {
                $ack->nack($e);
            }
        }
    }
}
```

Where the `compute $result from $message` is a place for **real** handler job. The other things are part of batch processing itself, which the handler shouldn't care about.

### Proposal

In my vision, the ideal batch handler would look like this:

```php
#[AsMessageHandler(batchStrategy: new BatchCount(10))]
class MyBatchHandler
{
    public function __invoke(MyMessage ...$messages)
    {
        // handle $messages
    }
}
```

Or an interface alternative to an attribute:

```php
class MyBatchHandler implements BatchStrategyProviderInterface
{
    public function __invoke(MyMessage ...$messages)
    {
        // handle $messages
    }

    public function getBatchStrategy(): BatchStrategyInterface
    {
        return new CountBatchStrategy(10);
    }
}
```

A bit easier, isn't it? However, this way disables the features which we are used to: separate acknowledging and returning results. There is an option to return them, I'll descire it below.

#### How batches work

A batch processing consists of parts:

1. Buffering
2. Handling the buffer
3. Acknowledge received messages

The first part (buffering) can be easily done by the library internals. The only thing it needs is trigger where to flush the buffer (run a handler). The second part is the handler's job. And the acknowledging... hm, it's some opinionable part.

#### Triggering a handler

Generally, rules for triggering a handler are more complex than just message counting. Most likely they would look like: "do not process a batch faster than once per 10 seconds if the buffer is less than 100 messages". Rules can be different, and most likely they would be shared between handlers in a group.

```php
class MyBatchStrategy implements BatchStrategyInterface
{
    private int $bufferSize = 0;
    private int $lastHandledNanoseconds = 0;

    public function shouldHandle(object $lastMessage): bool
    {
        return ($lastMessage->forceHandling)
            || (++$this->bufferSize >= 100)
            || (\hrtime(true) - $this->lastHandledNanoseconds > 1_000_000_000);
    }

    public function beforeHandle(): void
    {
        $this->bufferSize = 0;
    }

    public function afterHandle(): void
    {
        $this->lastHandledNanoseconds = \hrtime(true);
    }
}
```

#### Acknowledging

I believe that a batch must be acknowledged or rejected entirely at once. Because it's a batch. If someone needs to acknowledge messages separately, it means that there is no batch but some infrastructure specific optimization or misuse. So, if a handler finishes without an error, the entire batch should be acknowledged.

#### Returning results

Handlers shouldn't care how they are run synchronously or asynchronously, they should do their job interchangeably and never return a result, but save it or dispatch further. [Here](https://symfonycasts.com/screencast/messenger/messenger-event-dispatcher#eventdispatcher-communicates-back) is a perfect explanation of the difference between Messenger and Event Dispatcher. It refers to the main architecture idea of the Messenger which makes it so powerful: it **never communicates back**.

_The possibility of returning results through synchronous transport is a historical accident and a misuse of the tool._

#### Use legacy features

I absolutely sure they are useless. However, it's might be overkill to change all legacy code. As I promised, there is a way to use them:

```php
#[AsMessageHandler(batchStrategy: new BatchCount(10))]
class MyBatchHandler
{
    public function __invoke(Result $r, MyMessage ...$messages)
    {
        $results = $errors = [];
        try {
                // compute $results from $messages
        } catch (\Throwable $e) {
                // save $errors
        }
        foreach ($results as [$message, $result]) $r->ack($message, $result);
        foreach ($errors as [$message, $error]) $r->reject($message, $error);
    }
}
```

The `Result` object has a `SplObjectStorage` that maps messeges with `Acknowledger`, so it can be shared.

### Deprecations

I'd like to deprecate `BatchHandlerInterface`, `Acknowledger` and `HandledStamp::getResult()`.

### Implementation

There is no proper implementation yet. The PR has a dirty draft to show an idea and play with it. Some tests failed because of a new optional argument in `HandlerDescriptor`, but it works.