### PR TITLE
Expose AMQP Transport Connection.

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
@@ -35,6 +35,11 @@ class AmqpTransport implements QueueReceiverInterface, TransportInterface, Setup
         $this->serializer = $serializer ?? new PhpSerializer();
     }
 
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Use-case is to be able to open/close connections and to be able to recover in case of error in long-running process (RoadRunner).
Otherwise after you get 

AMQPException  TransportException
HTTP 500 Internal Server Error
Library error: a socket error occurred

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | not sure
| New feature?  | not sure
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
