### PR TITLE
[Serializer] Deprecate using datetime construct as fallback on default format mismatch

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -107,6 +107,13 @@ SecurityBundle
  * Deprecate enabling bundle and not configuring it
  * Deprecate the `security.firewalls.logout.csrf_token_generator` config option, use `security.firewalls.logout.csrf_token_manager` instead
 
+Serializer
+----------
+
+* Deprecate datetime constructor as a fallback whenever the `DateTimeNormalizer`
+  default format mismatches. Use the `DateTimeNormalizer::FORMAT_AUTO` when
+  denormalizing to explicitly rely on the PHP datetime constructor instead.
+
 Validator
 ---------
 

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
    * `JsonSerializableNormalizer`
    * `ObjectNormalizer`
    * `PropertyNormalizer`
+ * Deprecate datetime constructor as a fallback whenever the `DateTimeNormalizer` default format mismatches
 
 6.2
 ---

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
    * `ObjectNormalizer`
    * `PropertyNormalizer`
  * Deprecate datetime constructor as a fallback whenever the `DateTimeNormalizer` default format mismatches
+ * Add `DateTimeNormalizer::FORMAT_AUTO` to denormalize datetime objects using the PHP datetime constructor
 
 6.2
 ---

--- a/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
@@ -36,6 +36,16 @@ final class DateTimeNormalizerContextBuilder implements ContextBuilderInterface
     }
 
     /**
+     * Configures the denormalization format of the date to use PHP datetime construct.
+     *
+     * @see https://www.php.net/manual/en/datetime.construct.php
+     */
+    public function withAutoDenormalizationFormat(): static
+    {
+        return $this->with(DateTimeNormalizer::FORMAT_KEY, DateTimeNormalizer::FORMAT_AUTO);
+    }
+
+    /**
      * Configures the timezone of the date.
      *
      * It could be either a \DateTimeZone or a string

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -120,6 +120,8 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
             if (false !== $object) {
                 return $object;
             }
+
+            trigger_deprecation('symfony/serializer', '6.2', 'Relying on a datetime constructor as a fallback when using a specific default date format (`datetime_format`) for the DateTimeNormalizer is deprecated. Respect the "%s" default format.', $defaultDateTimeFormat);
         }
 
         try {

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateTimeNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateTimeNormalizerContextBuilderTest.php
@@ -57,6 +57,11 @@ class DateTimeNormalizerContextBuilderTest extends TestCase
             DateTimeNormalizer::FORMAT_KEY => null,
             DateTimeNormalizer::TIMEZONE_KEY => null,
         ]];
+
+        yield 'With auto format' => [[
+            DateTimeNormalizer::FORMAT_KEY => DateTimeNormalizer::FORMAT_KEY,
+            DateTimeNormalizer::TIMEZONE_KEY => null,
+        ]];
     }
 
     public function testCastTimezoneStringToTimezone()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -707,7 +707,7 @@ class ObjectNormalizerTest extends TestCase
 
         $obj = $serializer->denormalize([
             'inner' => ['foo' => 'foo', 'bar' => 'bar'],
-            'date' => '1988/01/21',
+            'date' => '1988-01-21T00:00:00+00:00',
             'inners' => [['foo' => 1], ['foo' => 2]],
         ], ObjectOuter::class);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Relates to #43329 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

This PR is a follow-up to https://github.com/symfony/symfony/pull/43329 and aims to enforce the configured **default format** is always respected, instead of silently fallback to the `\DateTime` & `\DateTimeImmutable` constructors. 
As of today, the only way to enforce this format is to set it **locally** through the **context**.

For now, the PR just adds the deprecation in case the fallback path is reached. One could argue this might be enough, since not respecting the expected format as an end user of an API might be considered as an issue in the first place.

Still:

1. **Do we need a better upgrade path?**
   e.g:
   ```php
    \DateTimeNormalizer::USE_DATETIME_CONSTRUCT_AS_FALLBACK => false,
   ```
   and trigger a deprec if this flag is not set. Default 6.2: `true`, 7.0: `false`

1. **Do we want to keep the ability to use the datetime constructs as fallbacks?**
   e.g:
    ```php
     \DateTimeNormalizer::USE_DATETIME_CONSTRUCT_AS_FALLBACK => false,
    ```
    Then, this behavior should be consistent whenever a default format or a context one is used (there is no fallback right now if set from the context)

1. **Do we want to keep the datetime constructs call whenever the default format is `null`?** 
     Then, one should be able to "unset" the default format by passing in the context:
    ```php
    $this->normalizer->denormalize('now', \DateTime::class, null, [\DateTimeNormalizer::FORMAT_KEY => null]);
    ```
    (currently fallbacks to the default format) or use a special value to do so (`php-datetime-string` ?).