### PR TITLE
[DependencyInjection] [WIP] add a #[Memoize] method attribute

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/AccessInterceptor/Instanciator/AccessInterceptorValueHolderFactory.php
+++ b/src/Symfony/Bridge/ProxyManager/AccessInterceptor/Instanciator/AccessInterceptorValueHolderFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Bridge\ProxyManager\AccessInterceptor\Instanciator;
+
+use ProxyManager\Factory\AccessInterceptorValueHolderFactory as BaseFactory;
+
+final class AccessInterceptorValueHolderFactory extends BaseFactory
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/Memoizable.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Memoizable.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class Memoizable
+{}

--- a/src/Symfony/Component/DependencyInjection/Attribute/Memoize.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Memoize.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class Memoize
+{
+    public function __construct(
+        public string  $pool,
+        public ?string $keyGenerator = null,
+        public ?int    $ttl = null,
+    )
+    {}
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/MemoizePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MemoizePass.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Attribute\Memoizable;
+use Symfony\Component\DependencyInjection\Attribute\Memoize;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\MemoizeProxy\BaseKeyGenerator;
+use Symfony\Component\DependencyInjection\MemoizeProxy\MemoizeFactory;
+use Symfony\Component\DependencyInjection\Reference;
+
+class MemoizePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $container->register('dependency_injection.memoize_proxy.factory', MemoizeFactory::class)
+            ->setArguments([$container->getParameter('kernel.cache_dir').'/memoize']);
+        $container->register('dependency_injection.memoize_proxy.key_generator.base', BaseKeyGenerator::class);
+
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$definition->isAutoconfigured()) {
+                continue;
+            }
+
+            // Is MemoizeClass
+            if (!$class = $container->getReflectionClass($definition->getClass())) {
+                continue;
+            }
+            if (!$class->getAttributes(Memoizable::class, \ReflectionAttribute::IS_INSTANCEOF)) {
+                continue;
+            }
+
+            // Get Memoize methods
+            $methods = [];
+            foreach ($class->getMethods() as $method) {
+                if (!$memoize = $method->getAttributes(Memoize::class, \ReflectionAttribute::IS_INSTANCEOF)) {
+                    continue;
+                }
+                $memoize = $memoize[0]->newInstance();
+
+                $methods[$method->getName()] = [
+                    new Reference($memoize->pool),
+                    new Reference($memoize->keyGenerator ?: 'dependency_injection.memoize_proxy.key_generator.base'),
+                    $memoize->ttl,
+                ];
+            }
+
+            if (!$methods) {
+                continue;
+            }
+
+            // Create proxy
+            $proxy = $container->register($id.'.memoized', $definition->getClass());
+            $proxy->setDecoratedService($id);
+            $proxy->setFactory(new Reference('dependency_injection.memoize_proxy.factory'));
+            $proxy->setArguments([new Reference('.inner'), $methods]);
+        }
+    }
+
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -47,6 +47,7 @@ class PassConfig
                 new AttributeAutoconfigurationPass(),
                 new ResolveInstanceofConditionalsPass(),
                 new RegisterEnvVarProcessorsPass(),
+                new MemoizePass(),
             ],
             -1000 => [new ExtensionCompilerPass()],
         ];

--- a/src/Symfony/Component/DependencyInjection/MemoizeProxy/BaseKeyGenerator.php
+++ b/src/Symfony/Component/DependencyInjection/MemoizeProxy/BaseKeyGenerator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\MemoizeProxy;
+
+class BaseKeyGenerator implements KeyGeneratorInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(string $className, string $method, array $arguments): string
+    {
+        return hash('sha256', $className.$method.serialize($arguments));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/MemoizeProxy/Interceptor.php
+++ b/src/Symfony/Component/DependencyInjection/MemoizeProxy/Interceptor.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\MemoizeProxy;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+class Interceptor
+{
+    private CacheItemInterface $item;
+
+    public function __construct(
+        private readonly CacheItemPoolInterface $cache,
+        private readonly KeyGeneratorInterface $keyGenerator,
+        private readonly ?int $ttl = null
+    )
+    {
+    }
+
+    public function getPrefixInterceptor($proxy, $instance, $method, $params, &$returnEarly) {
+        $this->item = $this->cache->getItem(($this->keyGenerator)(\get_class($instance), $method, $params));
+        if ($this->item->isHit()) {
+            $returnEarly = true;
+
+            return $this->item->get();
+        }
+    }
+
+    public function getSuffixInterceptor($proxy, $instance, $method, $params, $returnValue) {
+        $this->item->expiresAfter($this->ttl);
+        $this->item->set($returnValue);
+        $this->cache->save($this->item);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/MemoizeProxy/KeyGeneratorInterface.php
+++ b/src/Symfony/Component/DependencyInjection/MemoizeProxy/KeyGeneratorInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\MemoizeProxy;
+
+interface KeyGeneratorInterface
+{
+    /**
+     * Generates a cache key for the given arguments.
+     */
+    public function __invoke(string $className, string $method, array $arguments): string;
+}

--- a/src/Symfony/Component/DependencyInjection/MemoizeProxy/MemoizeFactory.php
+++ b/src/Symfony/Component/DependencyInjection/MemoizeProxy/MemoizeFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\MemoizeProxy;
+
+use ProxyManager\Configuration;
+use ProxyManager\FileLocator\FileLocator;
+use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
+use ProxyManager\Proxy\AccessInterceptorValueHolderInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bridge\ProxyManager\AccessInterceptor\Instanciator\AccessInterceptorValueHolderFactory;
+
+/**
+ * Memoize a service by creating a ProxyManager\Proxy\AccessInterceptorValueHolder
+ */
+final class MemoizeFactory
+{
+    readonly private AccessInterceptorValueHolderFactory $factory;
+
+    public function __construct(string $cacheDirectory)
+    {
+        if (!is_dir($cacheDirectory)) {
+            @mkdir($cacheDirectory, 0777, true);
+        }
+
+        $config = new Configuration();
+        $config->setGeneratorStrategy(new FileWriterGeneratorStrategy(new FileLocator($cacheDirectory)));
+        $config->setProxiesTargetDir($cacheDirectory);
+
+        $this->factory = new AccessInterceptorValueHolderFactory($config);
+    }
+
+    /**
+     * @param object $service Service to memoize
+     * @param array<array{CacheItemPoolInterface, KeyGeneratorInterface, int}> $methods
+     */
+    public function __invoke(object $service, array $methods): AccessInterceptorValueHolderInterface
+    {
+        $proxy = $this->factory->createProxy($service);
+        foreach ($methods as $name => [$cache, $key, $ttl]) {
+            $interceptor = new Interceptor($cache, $key, $ttl);
+            $proxy->setMethodPrefixInterceptor($name, $interceptor->getPrefixInterceptor(...));
+            $proxy->setMethodSuffixInterceptor($name, $interceptor->getSuffixInterceptor(...));
+        }
+
+        return $proxy;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

Memoization is a common technique to avoid heavy computation by caching previous returned value.

This is a proposal to add `#[Memoize]` method attribute to Symfony in order to return a cached response using Cache 
component. Actually more a POC than PR.

**Proposed Usage:**

```php
#[Memoizable]
class MyService
{
    public function __construct(private readonly HttpClientInterface $client)
    {
    }

    #[Memoize(pool: 'cache.redis_pool', ttl: 5)]
    public function getSomeEndpoint(string $name): string
    {
        return $this->client->request('GET', '/api/some/endpoint')->getContent();
    }

    #[Memoize(pool: 'cache.pdo_pool', keyGenerator: CustomKeyGenerator::class, ttl: 3600)]
    public function getThatChangesRarely(string $name): string
    {
        return $this->client->request('GET', '/api/that/changes/rarely')->getContent();
    }
}
```

**Questions:**

Before going further (refactoring, adding tests, etc.), it could be a good thing to get some comments because 
each solution could take a lot of time to implement :

* How the service is created
  * By replacing the current service by a factory which will create the "proxy" from extended class **used in this 
    PR**. Final services won't be supported **used in this PR due to ProxyManager**.
  * By decorating the service (see last point). Interfaces have to be kept, all functions implemented and magic 
    methods implemented to retrieve/call public properties/methods.
* How to generate and dump the file
  * By using the `AccessInterceptorValueHolderFactory` if ProxyManager bridge is installed **used in this PR**.
  * By using a Generator like `AccessInterceptorValueHolderGenerator` to generate the class and using a custom 
    `PhpDumper` to save. Something similar as it's done for lazy services.
  * By generating manually, it can be a hard task to handle all specific cases.

**Is it new?**

A bundle already exists about memoization: https://github.com/RikudouSage/SymfonyMemoizeBundle but this PR differs:
* Cache can be configured (which cache, TTL, key generation).
* Generated classes use inheritance instead of decoration (for now, like lazy proxy does). 

