### PR TITLE
[Debug][ErrorHandler] fix operator precedence

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -354,7 +354,7 @@ class ErrorHandler
      */
     private function reRegister(int $prev)
     {
-        if ($prev !== $this->thrownErrors | $this->loggedErrors) {
+        if ($prev !== ($this->thrownErrors | $this->loggedErrors)) {
             $handler = set_error_handler('is_int');
             $handler = \is_array($handler) ? $handler[0] : null;
             restore_error_handler();

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -374,7 +374,7 @@ class ErrorHandler
      */
     private function reRegister(int $prev): void
     {
-        if ($prev !== $this->thrownErrors | $this->loggedErrors) {
+        if ($prev !== ($this->thrownErrors | $this->loggedErrors)) {
             $handler = set_error_handler('is_int');
             $handler = \is_array($handler) ? $handler[0] : null;
             restore_error_handler();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/10921#discussion_r932415182
| License       | MIT

But I'm struggling to come up with a *failing* test scenario :/ if the bug is only causing evaluating the condition as truthy instead of false when `$prev` is already equal to `$this->thrownErrors | $this->loggedErrors`, I guess it will just re-register the same, without real visible effect?