### PR TITLE
[DependencyInjection] Allow service subscribers to return `SubscribedService[]`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\LazyProxy\ProxyHelper;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\TypedReference;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
 
 /**
  * Inspects existing service definitions and wires the autowired ones using the type hints of their classes.
@@ -104,6 +105,19 @@ class AutowirePass extends AbstractRecursivePass
     private function doProcessValue(mixed $value, bool $isRoot = false): mixed
     {
         if ($value instanceof TypedReference) {
+            if ($attributes = $value->getAttributes()) {
+                $attribute = array_pop($attributes);
+
+                if ($attributes) {
+                    throw new AutowiringFailedException($this->currentId, sprintf('Using multiple attributes with "%s" is not supported.', SubscribedService::class));
+                }
+
+                if (!$attribute instanceof Target) {
+                    return $this->processAttribute($attribute, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $value->getInvalidBehavior());
+                }
+
+                $value = new TypedReference($value->getType(), $value->getType(), $value->getInvalidBehavior(), $attribute->name);
+            }
             if ($ref = $this->getAutowiredReference($value, true)) {
                 return $ref;
             }
@@ -156,6 +170,29 @@ class AutowirePass extends AbstractRecursivePass
         }
 
         return $value;
+    }
+
+    private function processAttribute(object $attribute, bool $isOptional = false): mixed
+    {
+        switch (true) {
+            case $attribute instanceof Autowire:
+                $value = $this->container->getParameterBag()->resolveValue($attribute->value);
+
+                return $value instanceof Reference && $isOptional ? new Reference($value, ContainerInterface::NULL_ON_INVALID_REFERENCE) : $value;
+
+            case $attribute instanceof TaggedIterator:
+                return new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, false, $attribute->defaultPriorityMethod, (array) $attribute->exclude);
+
+            case $attribute instanceof TaggedLocator:
+                return new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, true, $attribute->defaultPriorityMethod, (array) $attribute->exclude));
+
+            case $attribute instanceof MapDecorated:
+                $definition = $this->container->getDefinition($this->currentId);
+
+                return new Reference($definition->innerServiceId ?? $this->currentId.'.inner', $definition->decorationOnInvalid ?? ContainerInterface::NULL_ON_INVALID_REFERENCE);
+        }
+
+        throw new AutowiringFailedException($this->currentId, sprintf('"%s" is an unsupported attribute.', $attribute::class));
     }
 
     private function autowireCalls(\ReflectionClass $reflectionClass, bool $isRoot, bool $checkAttributes): array
@@ -249,34 +286,8 @@ class AutowirePass extends AbstractRecursivePass
 
             if ($checkAttributes) {
                 foreach ($parameter->getAttributes() as $attribute) {
-                    if (TaggedIterator::class === $attribute->getName()) {
-                        $attribute = $attribute->newInstance();
-                        $arguments[$index] = new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, false, $attribute->defaultPriorityMethod, (array) $attribute->exclude);
-                        break;
-                    }
-
-                    if (TaggedLocator::class === $attribute->getName()) {
-                        $attribute = $attribute->newInstance();
-                        $arguments[$index] = new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, true, $attribute->defaultPriorityMethod, (array) $attribute->exclude));
-                        break;
-                    }
-
-                    if (Autowire::class === $attribute->getName()) {
-                        $value = $attribute->newInstance()->value;
-                        $value = $this->container->getParameterBag()->resolveValue($value);
-
-                        if ($value instanceof Reference && $parameter->allowsNull()) {
-                            $value = new Reference($value, ContainerInterface::NULL_ON_INVALID_REFERENCE);
-                        }
-
-                        $arguments[$index] = $value;
-
-                        break;
-                    }
-
-                    if (MapDecorated::class === $attribute->getName()) {
-                        $definition = $this->container->getDefinition($this->currentId);
-                        $arguments[$index] = new Reference($definition->innerServiceId ?? $this->currentId.'.inner', $definition->decorationOnInvalid ?? ContainerInterface::NULL_ON_INVALID_REFERENCE);
+                    if (\in_array($attribute->getName(), [TaggedIterator::class, TaggedLocator::class, Autowire::class, MapDecorated::class], true)) {
+                        $arguments[$index] = $this->processAttribute($attribute->newInstance(), $parameter->allowsNull());
 
                         break;
                     }
@@ -315,7 +326,7 @@ class AutowirePass extends AbstractRecursivePass
             }
 
             $getValue = function () use ($type, $parameter, $class, $method) {
-                if (!$value = $this->getAutowiredReference($ref = new TypedReference($type, $type, ContainerBuilder::EXCEPTION_ON_INVALID_REFERENCE, Target::parseName($parameter)), true)) {
+                if (!$value = $this->getAutowiredReference($ref = new TypedReference($type, $type, ContainerBuilder::EXCEPTION_ON_INVALID_REFERENCE, Target::parseName($parameter)), false)) {
                     $failureMessage = $this->createTypeNotFoundMessageCallback($ref, sprintf('argument "$%s" of method "%s()"', $parameter->name, $class !== $this->currentId ? $class.'::'.$method : $method));
 
                     if ($parameter->isDefaultValueAvailable()) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -44,10 +44,10 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.JmEob1b' => true,
-            '.service_locator.KIgkoLM' => true,
-            '.service_locator.qUb.lJI' => true,
-            '.service_locator.qUb.lJI.foo_service' => true,
+            '.service_locator.0H1ht0q' => true,
+            '.service_locator.0H1ht0q.foo_service' => true,
+            '.service_locator.2hyyc9y' => true,
+            '.service_locator.KGUGnmw' => true,
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => true,
         ];
     }

--- a/src/Symfony/Component/DependencyInjection/TypedReference.php
+++ b/src/Symfony/Component/DependencyInjection/TypedReference.php
@@ -20,18 +20,21 @@ class TypedReference extends Reference
 {
     private string $type;
     private ?string $name;
+    private array $attributes;
 
     /**
      * @param string      $id              The service identifier
      * @param string      $type            The PHP type of the identified service
      * @param int         $invalidBehavior The behavior when the service does not exist
      * @param string|null $name            The name of the argument targeting the service
+     * @param array       $attributes      The attributes to be used
      */
-    public function __construct(string $id, string $type, int $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, string $name = null)
+    public function __construct(string $id, string $type, int $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, string $name = null, array $attributes = [])
     {
         $this->name = $type === $id ? $name : null;
         parent::__construct($id, $invalidBehavior);
         $this->type = $type;
+        $this->attributes = $attributes;
     }
 
     public function getType()
@@ -42,5 +45,10 @@ class TypedReference extends Reference
     public function getName(): ?string
     {
         return $this->name;
+    }
+
+    public function getAttributes(): array
+    {
+        return $this->attributes;
     }
 }

--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.2
+---
+
+ * Allow `ServiceSubscriberInterface::getSubscribedServices()` to return `SubscribedService[]`
+
 3.0
 ---
 

--- a/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
+++ b/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
@@ -11,9 +11,14 @@
 
 namespace Symfony\Contracts\Service\Attribute;
 
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Service\ServiceSubscriberTrait;
 
 /**
+ * For use as the return value for {@see ServiceSubscriberInterface}.
+ *
+ * @example new SubscribedService('http_client', HttpClientInterface::class, false, new Target('githubApi'))
+ *
  * Use with {@see ServiceSubscriberTrait} to mark a method's return type
  * as a subscribed service.
  *
@@ -22,12 +27,21 @@ use Symfony\Contracts\Service\ServiceSubscriberTrait;
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class SubscribedService
 {
+    /** @var object[] */
+    public array $attributes;
+
     /**
-     * @param string|null $key The key to use for the service
-     *                         If null, use "ClassName::methodName"
+     * @param string|null       $key        The key to use for the service
+     * @param class-string|null $type       The service class
+     * @param bool              $nullable   Whether the service is optional
+     * @param object|object[]   $attributes One or more dependency injection attributes to use
      */
     public function __construct(
-        public ?string $key = null
+        public ?string $key = null,
+        public ?string $type = null,
+        public bool $nullable = false,
+        array|object $attributes = [],
     ) {
+        $this->attributes = \is_array($attributes) ? $attributes : [$attributes];
     }
 }

--- a/src/Symfony/Contracts/Service/ServiceSubscriberInterface.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Contracts\Service;
 
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+
 /**
  * A ServiceSubscriber exposes its dependencies via the static {@link getSubscribedServices} method.
  *
@@ -29,7 +31,8 @@ namespace Symfony\Contracts\Service;
 interface ServiceSubscriberInterface
 {
     /**
-     * Returns an array of service types required by such instances, optionally keyed by the service names used internally.
+     * Returns an array of service types (or {@see SubscribedService} objects) required
+     * by such instances, optionally keyed by the service names used internally.
      *
      * For mandatory dependencies:
      *
@@ -47,7 +50,13 @@ interface ServiceSubscriberInterface
      *  * ['?Psr\Log\LoggerInterface'] is a shortcut for
      *  * ['Psr\Log\LoggerInterface' => '?Psr\Log\LoggerInterface']
      *
-     * @return string[] The required service types, optionally keyed by service names
+     * additionally, an array of {@see SubscribedService}'s can be returned:
+     *
+     *  * [new SubscribedService('logger', Psr\Log\LoggerInterface::class)]
+     *  * [new SubscribedService(type: Psr\Log\LoggerInterface::class, nullable: true)]
+     *  * [new SubscribedService('http_client', HttpClientInterface::class, attributes: new Target('githubApi'))]
+     *
+     * @return string[]|SubscribedService[] The required service types, optionally keyed by service names
      */
     public static function getSubscribedServices(): array;
 }

--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -50,13 +50,17 @@ trait ServiceSubscriberTrait
                 throw new \LogicException(sprintf('Cannot use "%s" on methods without a return type in "%s::%s()".', SubscribedService::class, $method->name, self::class));
             }
 
-            $serviceId = $returnType instanceof \ReflectionNamedType ? $returnType->getName() : (string) $returnType;
+            /* @var SubscribedService $attribute */
+            $attribute = $attribute->newInstance();
+            $attribute->key ??= self::class.'::'.$method->name;
+            $attribute->type ??= $returnType instanceof \ReflectionNamedType ? $returnType->getName() : (string) $returnType;
+            $attribute->nullable = $returnType->allowsNull();
 
-            if ($returnType->allowsNull()) {
-                $serviceId = '?'.$serviceId;
+            if ($attribute->attributes) {
+                $services[] = $attribute;
+            } else {
+                $services[$attribute->key] = ($attribute->nullable ? '?' : '').$attribute->type;
             }
-
-            $services[$attribute->newInstance()->key ?? self::class.'::'.$method->name] = $serviceId;
         }
 
         return $services;

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir1\Service1;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir2\Service2;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Service\Attribute\SubscribedService;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
@@ -27,6 +28,7 @@ class ServiceSubscriberTraitTest extends TestCase
         $expected = [
             TestService::class.'::aService' => Service2::class,
             TestService::class.'::nullableService' => '?'.Service2::class,
+            new SubscribedService(TestService::class.'::withAttribute', Service2::class, true, new Required()),
         ];
 
         $this->assertEquals($expected, ChildTestService::getSubscribedServices());
@@ -91,6 +93,11 @@ class TestService extends ParentTestService implements ServiceSubscriberInterfac
 
     #[SubscribedService]
     public function nullableService(): ?Service2
+    {
+    }
+
+    #[SubscribedService(attributes: new Required())]
+    public function withAttribute(): ?Service2
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This allows `ServiceSubscriberInterface::getSubscribedServices()` to return `SubscribedService[]` which now has the ability to add DI attribute objects (ie `Target`).

```php
public static function getSubscribedServices(): array
{
    return [
        new SubscribedService('logger', Psr\Log\LoggerInterface::class),
        new SubscribedService(type: Psr\Log\LoggerInterface::class, nullable: true),
        new SubscribedService('http_client', HttpClientInterface::class, attributes: new Target('githubApi'))),
    ];
}
```

When using the `ServiceSubscriberTrait`, the `SubscribedService` attribute can add attributes as well:

```php
#[SubscribedService(attributes: new Target('githubApi'))]
private function httpClient(): ?HttpClientInterface
{
    return $this->container->get(__METHOD__);
}
```

TODO:
- [x] Implementation
- [x] Tests
- [x] Changelog