### PR TITLE
Provide the commands to run Symfony Tests through Docker :whale:

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,8 +1,17 @@
-FROM php:8.1-cli-alpine3.15
+FROM php:8.1-cli-bullseye
 
-RUN apk add --no-cache libxslt-dev \
+ENV DEBIAN_FRONTEND=noninteractive
+
+# git is required to allow Composer to work with symfony/runtime
+# ext-xsl is required by lorenzo/pinky through twig/inky-extra
+RUN apt-get update \
+    && apt-get install --yes git libxslt-dev \
+    && apt-get clean ; rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure xsl \
     && docker-php-ext-install xsl
+
+# ensure that git is available
+RUN git --version
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -4,13 +4,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # git is required to allow Composer to work with symfony/runtime
 # ext-xsl is required by lorenzo/pinky through twig/inky-extra
+# libonig-dev is required by the mbstring extension
 # zip will allow Composer to install dependencies without using git clone,
 # so that it won't hit the rate limits of Github
 RUN apt-get update \
-    && apt-get install --yes git libxslt-dev libzip-dev unzip \
-    && apt-get clean ; rm -rf /var/lib/apt/lists/* \
+    && apt-get install --yes git libxslt-dev libzip-dev libonig-dev unzip \
+    && apt-get clean ; rm -rf /var/lib/apt/lists/*
+
+RUN pecl install apcu
+
+# configure intl and xsl in 2 steps, otherwise it fails
+RUN docker-php-ext-configure intl \
     && docker-php-ext-configure xsl \
-    && docker-php-ext-install xsl zip
+    && docker-php-ext-install intl mbstring xsl zip \
+    && docker-php-ext-enable apcu
 
 # ensure that git is available
 RUN git --version

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -24,6 +24,6 @@ RUN docker-php-ext-configure intl \
 # ensure that git is available
 RUN git --version
 
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
 
 WORKDIR /symfony

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:8.1-cli-alpine3.15
+
+RUN apk add --no-cache libxslt-dev \
+    && docker-php-ext-configure xsl \
+    && docker-php-ext-install xsl
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+WORKDIR /symfony

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -4,11 +4,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # git is required to allow Composer to work with symfony/runtime
 # ext-xsl is required by lorenzo/pinky through twig/inky-extra
+# zip will allow Composer to install dependencies without using git clone,
+# so that it won't hit the rate limits of Github
 RUN apt-get update \
-    && apt-get install --yes git libxslt-dev \
+    && apt-get install --yes git libxslt-dev libzip-dev unzip \
     && apt-get clean ; rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure xsl \
-    && docker-php-ext-install xsl
+    && docker-php-ext-install xsl zip
 
 # ensure that git is available
 RUN git --version

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:8.1-cli-bullseye
+ARG DOCKER_PHP_VERSION=8.2
+
+FROM php:${DOCKER_PHP_VERSION}-cli-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,7 @@
     "scripts": {
         "docker-build": "docker build --build-arg DOCKER_PHP_VERSION=${DOCKER_PHP_VERSION} --tag symfony-tests .docker/",
         "docker-run": "docker run --rm --tty --user $(id --user):$(id --group) --volume $(pwd):/symfony symfony-tests",
-        "docker-composer": "@docker-run env COMPOSER_ROOT_VERSION=6.2.x-dev composer update",
+        "docker-composer": "@docker-run env COMPOSER_ROOT_VERSION=6.3.x-dev composer update",
         "docker-tests": "@docker-run ./phpunit"
     },
     "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -195,13 +195,13 @@
         "docker-build": "docker build --tag symfony-tests .docker/",
         "docker-run": "docker run --rm --tty --user $(id --user):$(id --group) --volume $(pwd):/symfony symfony-tests",
         "docker-composer": "@docker-run env COMPOSER_ROOT_VERSION=6.2.x-dev composer update",
-        "docker-tests": "@docker-run ./phpunit src/Symfony/"
+        "docker-tests": "@docker-run ./phpunit"
     },
     "scripts-descriptions": {
         "docker-build": "Build the Docker image",
         "docker-run": "Base command to run Docker",
         "docker-composer": "Install dependencies through Composer",
-        "docker-tests": "Run tests, you can pass arguments, e.g. “composer docker-tests -- --debug src/Symfony/Component/Yaml/”."
+        "docker-tests": "Run tests, you should pass arguments, e.g. “composer docker-tests src/Symfony/Component/Yaml/” for testing a specific folder or “composer docker-tests src/Symfony/” to run the whole test suite in parallel. Options for PHPUnit must be prepend with --, e.g. “composer docker-tests -- --verbose --debug src/Symfony/Component/Yaml/”"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -215,7 +215,12 @@
         },
         {
             "type": "path",
-            "url": "src/Symfony/Component/Runtime"
+            "url": "src/Symfony/Component/Runtime",
+            "options": {
+                "versions": {
+                    "symfony/runtime": "6.2.x-dev"
+                }
+            }
         }
     ],
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -193,7 +193,7 @@
     },
     "scripts": {
         "docker-build": "docker build --tag symfony-tests .docker/",
-        "docker-run": "docker run --rm --tty --volume $(pwd):/symfony symfony-tests",
+        "docker-run": "docker run --rm --tty --user $(id --user):$(id --group) --volume $(pwd):/symfony symfony-tests",
         "docker-composer": "@docker-run env COMPOSER_ROOT_VERSION=6.2.x-dev composer update",
         "docker-tests": "@docker-run php ./phpunit"
     },

--- a/composer.json
+++ b/composer.json
@@ -191,6 +191,18 @@
             "src/Symfony/Component/VarDumper/Resources/functions/dump.php"
         ]
     },
+    "scripts": {
+        "docker-build": "docker build --tag symfony-tests .docker/",
+        "docker-run": "docker run --rm --tty --volume $(pwd):/symfony symfony-tests",
+        "docker-composer": "@docker-run env COMPOSER_ROOT_VERSION=6.2.x-dev composer update",
+        "docker-tests": "@docker-run php ./phpunit"
+    },
+    "scripts-descriptions": {
+        "docker-build": "Build the Docker image",
+        "docker-run": "Base command to run Docker",
+        "docker-composer": "Install dependencies through Composer",
+        "docker-tests": "Run tests, you can pass arguments, e.g. “composer docker-tests -- src/Symfony/Component/Yaml/”."
+    },
     "repositories": [
         {
             "type": "path",

--- a/composer.json
+++ b/composer.json
@@ -215,12 +215,7 @@
         },
         {
             "type": "path",
-            "url": "src/Symfony/Component/Runtime",
-            "options": {
-                "versions": {
-                    "symfony/runtime": "6.2.x-dev"
-                }
-            }
+            "url": "src/Symfony/Component/Runtime"
         }
     ],
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -192,16 +192,16 @@
         ]
     },
     "scripts": {
-        "docker-build": "docker build --tag symfony-tests .docker/",
+        "docker-build": "docker build --build-arg DOCKER_PHP_VERSION=${DOCKER_PHP_VERSION} --tag symfony-tests .docker/",
         "docker-run": "docker run --rm --tty --user $(id --user):$(id --group) --volume $(pwd):/symfony symfony-tests",
         "docker-composer": "@docker-run env COMPOSER_ROOT_VERSION=6.2.x-dev composer update",
         "docker-tests": "@docker-run ./phpunit"
     },
     "scripts-descriptions": {
-        "docker-build": "Build the Docker image",
+        "docker-build": "Build the Docker image, you can use a different version by defining “DOCKER_PHP_VERSION”, e.g. “env DOCKER_PHP_VERSION=\"8.1\" composer docker-build”",
         "docker-run": "Base command to run Docker",
         "docker-composer": "Install dependencies through Composer",
-        "docker-tests": "Run tests, you should pass arguments, e.g. “composer docker-tests src/Symfony/Component/Yaml/” for testing a specific folder or “composer docker-tests src/Symfony/” to run the whole test suite in parallel. Options for PHPUnit must be prepend with --, e.g. “composer docker-tests -- --verbose --debug src/Symfony/Component/Yaml/”"
+        "docker-tests": "Run tests, you should pass arguments, e.g. “composer docker-tests src/Symfony/Component/DependencyInjection/” for testing a specific folder or “composer docker-tests src/Symfony/” to run the whole test suite in parallel. Options for PHPUnit must be prepend with --, e.g. “composer docker-tests -- --verbose --debug src/Symfony/Component/DependencyInjection/”"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -194,13 +194,13 @@
     "scripts": {
         "docker-build": "docker build --build-arg DOCKER_PHP_VERSION=${DOCKER_PHP_VERSION} --tag symfony-tests .docker/",
         "docker-run": "docker run --rm --tty --user $(id --user):$(id --group) --volume $(pwd):/symfony symfony-tests",
-        "docker-composer": "@docker-run env COMPOSER_ROOT_VERSION=6.3.x-dev composer update",
+        "docker-install-dependencies": "@docker-run env COMPOSER_ROOT_VERSION=6.3.x-dev composer update",
         "docker-tests": "@docker-run ./phpunit"
     },
     "scripts-descriptions": {
         "docker-build": "Build the Docker image, you can use a different version by defining “DOCKER_PHP_VERSION”, e.g. “env DOCKER_PHP_VERSION=\"8.1\" composer docker-build”",
         "docker-run": "Base command to run Docker",
-        "docker-composer": "Install dependencies through Composer",
+        "docker-install-dependencies": "Install dependencies through Composer",
         "docker-tests": "Run tests, you should pass arguments, e.g. “composer docker-tests src/Symfony/Component/DependencyInjection/” for testing a specific folder or “composer docker-tests src/Symfony/” to run the whole test suite in parallel. Options for PHPUnit must be prepend with --, e.g. “composer docker-tests -- --verbose --debug src/Symfony/Component/DependencyInjection/”"
     },
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -201,7 +201,7 @@
         "docker-build": "Build the Docker image",
         "docker-run": "Base command to run Docker",
         "docker-composer": "Install dependencies through Composer",
-        "docker-tests": "Run tests, you can pass arguments, e.g. “composer docker-tests -- src/Symfony/Component/Yaml/”."
+        "docker-tests": "Run tests, you can pass arguments, e.g. “composer docker-tests -- --debug src/Symfony/Component/Yaml/”."
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -195,7 +195,7 @@
         "docker-build": "docker build --tag symfony-tests .docker/",
         "docker-run": "docker run --rm --tty --user $(id --user):$(id --group) --volume $(pwd):/symfony symfony-tests",
         "docker-composer": "@docker-run env COMPOSER_ROOT_VERSION=6.2.x-dev composer update",
-        "docker-tests": "@docker-run php ./phpunit"
+        "docker-tests": "@docker-run ./phpunit src/Symfony/"
     },
     "scripts-descriptions": {
         "docker-build": "Build the Docker image",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes, but only for internal development of Symfony
| Deprecations? | no
| Tickets       | Fix #47032
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/17080

This PR add some scripts to Composer:

```bash
  docker-build                 Build the Docker image, you can use a different version by defining “DOCKER_PHP_VERSION”, e.g. “env DOCKER_PHP_VERSION="8.1" composer docker-build”
  docker-install-dependencies  Install dependencies through Composer
  docker-run                   Base command to run Docker
  docker-tests                 Run tests, you should pass arguments, e.g. “composer docker-tests src/Symfony/Component/DependencyInjection/” for testing a specific folder or “composer docker-tests src/Symfony/” to run the whole test suite in parallel. Options for PHPUnit must be prepend with --, e.g. “composer docker-tests -- --verbose --debug src/Symfony/Component/DependencyInjection/”
```

They allow anyone to run tests through Docker easily, with all the benefits of Docker: the environment is independent of the system, the system dependencies can be added easily, the build is reproducible, etc.

How to use it:

```bash
$ composer docker-build
$ composer docker-install-dependencies
$ composer docker-tests src/Symfony/Component/Yaml/
```

(these are shortcuts to `composer run-script …`)

We can also specify another version of PHP:

```bash
env DOCKER_PHP_VERSION="8.1" composer docker-build
```

Try it:

```bash
git clone --branch add-composer-script-and-docker-for-development --single-branch \
--depth 5 -- git@github.com:alexislefebvre/symfony.git
cd symfony/
composer docker-build
composer docker-composer
composer docker-tests -- src/Symfony/Component/Yaml/
 ```

I only tested on Linux, it may not work on Windows.

Caveat: Running the whole test suite with `composer run-script docker-tests` crash with the output `^[[54;19R` and I don't understand why. It is probably not due to a timeout from Composer since it appears before the default timeout of 5 minutes.

<details><summary>example with full output</summary>
<p>

```bash
$ git clone --branch add-composer-script-and-docker-for-development --single-branch \
--depth 5 -- git@github.com:alexislefebvre/symfony.git
Clonage dans 'symfony'...
remote: Enumerating objects: 12977, done.
remote: Counting objects: 100% (12977/12977), done.
remote: Compressing objects: 100% (10046/10046), done.
remote: Total 12977 (delta 5146), reused 5941 (delta 2414), pack-reused 0
Réception d'objets: 100% (12977/12977), 12.76 Mio | 13.51 Mio/s, fait.
Résolution des deltas: 100% (5146/5146), fait.
$ cd symfony/
$ composer docker-build
> docker build --tag symfony-tests .docker/
Sending build context to Docker daemon  2.048kB
Step 1/4 : FROM php:8.1-cli-alpine3.15
 ---> 6781ff42796c
Step 2/4 : RUN apk add --no-cache libxslt-dev     && docker-php-ext-configure xsl     && docker-php-ext-install xsl
 ---> Using cache
 ---> 224639ddac78
Step 3/4 : COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 ---> Using cache
 ---> 0bf66081e129
Step 4/4 : WORKDIR /symfony
 ---> Using cache
 ---> 6d9316a0bc11
Successfully built 6d9316a0bc11
Successfully tagged symfony-tests:latest
$ composer docker-composer
> docker run --rm --tty --volume $(pwd):/symfony symfony-tests 'env' 'COMPOSER_ROOT_VERSION=6.2.x-dev' 'composer' 'update'
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Lock file operations: 87 installs, 0 updates, 0 removals
[…]
$ composer docker-tests
> docker run --rm --tty --volume $(pwd):/symfony symfony-tests 'php' './phpunit' 'src/Symfony/Component/Yaml/'
No composer.json found in the current directory, showing available packages from packagist.org
[…]
  - Installing symfony/phpunit-bridge (dev-main): Symlinking from ../../vendor/symfony/phpunit-bridge
7 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating optimized autoload files
24 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
PHPUnit 9.5.21 #StandWithUkraine

Testing /symfony/src/Symfony/Component/Yaml
...............................................................  63 / 722 (  8%)
............................................................... 126 / 722 ( 17%)
............................................................... 189 / 722 ( 26%)
............................................................... 252 / 722 ( 34%)
............................................................... 315 / 722 ( 43%)
............................................................... 378 / 722 ( 52%)
............................................................... 441 / 722 ( 61%)
............................................................... 504 / 722 ( 69%)
............................................................... 567 / 722 ( 78%)
............................................................... 630 / 722 ( 87%)
............................................................... 693 / 722 ( 95%)
........S....................                                   722 / 722 (100%)

Time: 00:00.247, Memory: 22.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 722, Assertions: 1053, Skipped: 1.
 ```

</p>
</details>