### PR TITLE
[Mailer] allow sub-classes to change the way the message id parsed

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -147,7 +147,7 @@ class SmtpTransport extends AbstractTransport
             throw $e;
         }
 
-        if ($this->mtaResult && $messageId = $this->parseMessageId()) {
+        if ($this->mtaResult && $messageId = $this->parseMessageId($this->mtaResult)) {
             $message->setMessageId($messageId);
         }
 
@@ -156,15 +156,15 @@ class SmtpTransport extends AbstractTransport
         return $message;
     }
 
-    protected function parseMessageId(): string
+    protected function parseMessageId(string $mtaResult): string
     {
         $regexps = [
             '/250 Ok (?P<id>[0-9a-f-]+)\r?$/mis',
-            '/250 Ok:? queued as (?P<id>[A-Z0-9]+)\r?$/mis'
+            '/250 Ok:? queued as (?P<id>[A-Z0-9]+)\r?$/mis',
         ];
         $matches = [];
         foreach ($regexps as $regexp) {
-            if (preg_match($regexp, $this->mtaResult, $matches)) {
+            if (preg_match($regexp, $mtaResult, $matches)) {
                 return $matches['id'];
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 