### PR TITLE
[Finder] fix tests on Windows

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -903,10 +903,18 @@ class FinderTest extends Iterator\RealIteratorTestCase
     {
         $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->sortByCaseInsensitiveName(true));
-        $this->assertOrderedIterator($this->toAbsolute([
-            'foo',
-            'foo/bar.tmp',
-            'foo bar',
+
+        $expected = ['foo'];
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $expected[] = 'foo bar';
+            $expected[] = 'foo/bar.tmp';
+        } else {
+            $expected[] = 'foo/bar.tmp';
+            $expected[] = 'foo bar';
+        }
+
+        $expected = array_merge($expected, [
             'qux',
             'qux/baz_1_2.py',
             'qux/baz_100_1.py',
@@ -921,7 +929,8 @@ class FinderTest extends Iterator\RealIteratorTestCase
             'toto',
             'zebulon.php',
             'Zephire.php',
-        ]), $finder->in(self::$tmpDir)->getIterator());
+        ]);
+        $this->assertOrderedIterator($this->toAbsolute($expected), $finder->in(self::$tmpDir)->getIterator());
 
         $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->sortByCaseInsensitiveName(false));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

`strnatcasecmp()` handles forward slashes different to backslashes (see https://3v4l.org/F2373)