### PR TITLE
[Notifier] Update for V3 Engagespot API

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotOptions.php
@@ -37,15 +37,6 @@ final class EngagespotOptions implements MessageOptionsInterface
         return $this->options['to'];
     }
 
-    /**
-     * @return $this
-     */
-    public function campaignName(string $campaignName): static
-    {
-        $this->options['campaign_name'] = $campaignName;
-
-        return $this;
-    }
 
     /**
      * @return $this

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotTransportFactory.php
@@ -29,11 +29,11 @@ final class EngagespotTransportFactory extends AbstractTransportFactory
         }
 
         $apiKey = $dsn->getUser();
-        $campaignName = $dsn->getRequiredOption('campaign_name');
+        $apiSecret = $dsn->getPassword();
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new EngagespotTransport($apiKey, $campaignName, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new EngagespotTransport($apiKey, $apiSecret, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/README.md
@@ -7,12 +7,12 @@ DSN example
 -----------
 
 ```
-ENGAGESPOT_DSN=engagespot://API_KEY@default?campaign_name=CAMPAIGN_NAME
+ENGAGESPOT_DSN=engagespot://API_KEY:API_SECRET@default
 ```
 
 where:
  - `API_KEY` is your Engagespot API Key
- - `CAMPAIGN_NAME` is your default campaign name
+ - `API_SECRET` is your Engagespot API Secret
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/Tests/EngagespotTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/Tests/EngagespotTransportFactoryTest.php
@@ -27,14 +27,14 @@ final class EngagespotTransportFactoryTest extends TransportFactoryTestCase
     public function createProvider(): iterable
     {
         yield [
-            'engagespot://api.engagespot.co/2/campaigns?campaign_name=TEST',
-            'engagespot://apiKey@default?campaign_name=TEST',
+            'engagespot://api.engagespot.co/v3/notifications',
+            'engagespot://apiKey:apiSecret@default',
         ];
     }
 
     public function supportsProvider(): iterable
     {
-        yield [true, 'engagespot://apiKey@default'];
+        yield [true, 'engagespot://apiKey:apiSecret@default'];
         yield [false, 'somethingElse://username:password@default'];
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/Tests/EngagespotTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/Tests/EngagespotTransportTest.php
@@ -30,7 +30,7 @@ final class EngagespotTransportTest extends TransportTestCase
 
     public function toStringProvider(): iterable
     {
-        yield ['engagespot://api.engagespot.co/2/campaigns?campaign_name=TEST', $this->createTransport()];
+        yield ['engagespot://api.engagespot.co/v3/notifications', $this->createTransport()];
     }
 
     public function supportedMessagesProvider(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

Fixes a bug in the Engagespot notifier for the v3 API, two different API keys are required, and the response returned is an HTTP 202. Further, the response received from Engagespot API is not JSON
