### PR TITLE
[Console] fewer syscalls when fetching $LINES/$COLUMNS

### DIFF
--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -143,11 +143,11 @@ class Terminal
     private static function initDimensionsUsingStty()
     {
         if ($sttyString = self::getSttyColumns()) {
-            if (preg_match('/rows.(\d+);.columns.(\d+);/i', $sttyString, $matches)) {
+            if (preg_match('/rows.(\d+);.columns.(\d+);/is', $sttyString, $matches)) {
                 // extract [w, h] from "rows h; columns w;"
                 self::$width = (int) $matches[2];
                 self::$height = (int) $matches[1];
-            } elseif (preg_match('/;.(\d+).rows;.(\d+).columns/i', $sttyString, $matches)) {
+            } elseif (preg_match('/;.(\d+).rows;.(\d+).columns/is', $sttyString, $matches)) {
                 // extract [w, h] from "; h rows; w columns"
                 self::$width = (int) $matches[2];
                 self::$height = (int) $matches[1];
@@ -176,10 +176,10 @@ class Terminal
      */
     private static function getSttyColumns(): ?string
     {
-        return self::readFromProcess('stty -a | grep columns');
+        return self::readFromProcess(['stty', '-a']);
     }
 
-    private static function readFromProcess(string $command): ?string
+    private static function readFromProcess(string|array $command): ?string
     {
         if (!\function_exists('proc_open')) {
             return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47109 
| License       | MIT
| Doc PR        | -

Before this fix, the `stty -a | grep columns` call would invoke (a) sh, (b) stty and (c) grep. That involved 3 fork()s.
After this fix, only a single fork() is done.

(PHP appears not to have access to the appropriate ioctl() syscall, so a single fork+execve is still needed.)

Purpose: _fewer execve() calls means fewer things to audit._