### PR TITLE
[Serializer] Throw InvalidArgumentException if the data needed in the constructor doesn't belong to a backedEnum 

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -64,7 +64,7 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
         try {
             return $type::from($data);
         } catch (\ValueError $e) {
-            throw NotNormalizableValueException::createForUnexpectedDataType($e->getMessage(), $data, [Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true, $e->getCode(), $e);
+            throw new InvalidArgumentException('The data must belong to a backed enumeration of type '.$type);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyObjectWithEnumConstructor.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyObjectWithEnumConstructor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy;
+
+class DummyObjectWithEnumConstructor
+{
+    public function __construct(public StringBackedEnumDummy $get)
+    {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -115,8 +115,9 @@ class BackedEnumNormalizerTest extends TestCase
      */
     public function testDenormalizeBadBackingValueThrowsException()
     {
-        $this->expectException(NotNormalizableValueException::class);
-        $this->expectExceptionMessage('"POST" is not a valid backing value for enum "'.StringBackedEnumDummy::class.'"');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The data must belong to a backed enumeration of type '.StringBackedEnumDummy::class);
+
         $this->normalizer->denormalize('POST', StringBackedEnumDummy::class);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
@@ -58,6 +59,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo;
+use Symfony\Component\Serializer\Tests\Fixtures\DummyObjectWithEnumConstructor;
 use Symfony\Component\Serializer\Tests\Fixtures\FalseBuiltInDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Full;
@@ -1171,6 +1173,69 @@ class SerializerTest extends TestCase
         ];
 
         $this->assertSame($expected, $exceptionsAsArray);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testCollectDenormalizationErrorsWithEnumConstructor()
+    {
+        $serializer = new Serializer(
+            [
+                new BackedEnumNormalizer(),
+                new ObjectNormalizer(),
+            ],
+            ['json' => new JsonEncoder()]
+        );
+
+        try {
+            $serializer->deserialize('{"invalid": "GET"}', DummyObjectWithEnumConstructor::class, 'json', [
+                DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+            ]);
+        } catch (\Throwable $th) {
+            $this->assertInstanceOf(PartialDenormalizationException::class, $th);
+        }
+
+        $exceptionsAsArray = array_map(function (NotNormalizableValueException $e): array {
+            return [
+                'currentType' => $e->getCurrentType(),
+                'useMessageForUser' => $e->canUseMessageForUser(),
+                'message' => $e->getMessage(),
+            ];
+        }, $th->getErrors());
+
+        $expected = [
+            [
+                'currentType' => 'array',
+                'useMessageForUser' => true,
+                'message' => 'Failed to create object because the class misses the "get" property.',
+            ],
+        ];
+
+        $this->assertSame($expected, $exceptionsAsArray);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testNoCollectDenormalizationErrorsWithWrongEnum()
+    {
+        $serializer = new Serializer(
+            [
+                new BackedEnumNormalizer(),
+                new ObjectNormalizer(),
+            ],
+            ['json' => new JsonEncoder()]
+        );
+
+        try {
+            $serializer->deserialize('{"get": "invalid"}', DummyObjectWithEnumConstructor::class, 'json', [
+                DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+            ]);
+        } catch (\Throwable $th) {
+            $this->assertNotInstanceOf(PartialDenormalizationException::class, $th);
+            $this->assertInstanceOf(InvalidArgumentException::class, $th);
+        }
     }
 
     public function provideCollectDenormalizationErrors()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Tickets       | Fix #46977 [Serializer] Collect deserialization errors on enum cause TypeError 
| License       | MIT
| Doc PR        | 

Targeted case: Deserialization with "collect_denormalization_errors" set but the data to be serialized does not correspond to the scalar value of the targeted enum instance in the object's constructor.
updated in last commit : Keep "from "(in the previous commits I had switched to "tryFrom") to map the data submitted to an enum instance targeted.

Imho, even if the "collect_denormalization_errors" is specified, this type of error seems to have to be caught upstream. By just trying to collect the error we do not prevent the object from being instantiated. But this action is bound to fail because we already know that the data is not valid (checked by the BackedEnumNormalizer). This instantiation 'failure' leads to a confusing/misleading error (i.e. _Argument # 1 ($test) must be of type TestEnum, string given_) which is not the original error.