### PR TITLE
[FrameworkBundle] remove the ChatterInterface alias when the chatter service is removed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -162,8 +162,10 @@ use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
 use Symfony\Component\Notifier\Bridge\Vonage\VonageTransportFactory;
 use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransportFactory;
 use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
+use Symfony\Component\Notifier\ChatterInterface;
 use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\Notifier\Recipient\Recipient;
+use Symfony\Component\Notifier\TexterInterface;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface as NotifierTransportFactoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
@@ -2489,11 +2491,13 @@ class FrameworkExtension extends Extension
             $container->getDefinition('chatter.transports')->setArgument(0, $config['chatter_transports']);
         } else {
             $container->removeDefinition('chatter');
+            $container->removeAlias(ChatterInterface::class);
         }
         if ($config['texter_transports']) {
             $container->getDefinition('texter.transports')->setArgument(0, $config['texter_transports']);
         } else {
             $container->removeDefinition('texter');
+            $container->removeAlias(TexterInterface::class);
         }
 
         if ($this->mailerConfigEnabled) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -53,6 +53,8 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\LoggerPass;
 use Symfony\Component\HttpKernel\Fragment\FragmentUriGeneratorInterface;
 use Symfony\Component\Messenger\Transport\TransportFactory;
+use Symfony\Component\Notifier\ChatterInterface;
+use Symfony\Component\Notifier\TexterInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -2022,7 +2024,9 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('notifier'));
         $this->assertFalse($container->hasDefinition('chatter'));
+        $this->assertFalse($container->hasAlias(ChatterInterface::class));
         $this->assertFalse($container->hasDefinition('texter'));
+        $this->assertFalse($container->hasAlias(TexterInterface::class));
     }
 
     public function testIfNotifierTransportsAreKnownByFrameworkExtension()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47122
| License       | MIT
| Doc PR        |
