### PR TITLE
[Mailer] Fix error message in case of an STMP error

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -94,15 +94,7 @@ class EsmtpTransport extends SmtpTransport
 
     protected function doHeloCommand(): void
     {
-        try {
-            $response = $this->executeCommand(sprintf("EHLO %s\r\n", $this->getLocalDomain()), [250]);
-        } catch (TransportExceptionInterface $e) {
-            parent::doHeloCommand();
-
-            return;
-        }
-
-        $capabilities = $this->getCapabilities($response);
+        $capabilities = $this->callHeloCommand();
 
         /** @var SocketStream $stream */
         $stream = $this->getStream();
@@ -116,14 +108,7 @@ class EsmtpTransport extends SmtpTransport
                 throw new TransportException('Unable to connect with STARTTLS.');
             }
 
-            try {
-                $response = $this->executeCommand(sprintf("EHLO %s\r\n", $this->getLocalDomain()), [250]);
-                $capabilities = $this->getCapabilities($response);
-            } catch (TransportExceptionInterface $e) {
-                parent::doHeloCommand();
-
-                return;
-            }
+            $capabilities = $this->callHeloCommand();
         }
 
         if (\array_key_exists('AUTH', $capabilities)) {
@@ -131,10 +116,22 @@ class EsmtpTransport extends SmtpTransport
         }
     }
 
-    private function getCapabilities(string $ehloResponse): array
+    private function callHeloCommand(): array
     {
+        try {
+            $response = $this->executeCommand(sprintf("EHLO %s\r\n", $this->getLocalDomain()), [250]);
+        } catch (TransportExceptionInterface $e) {
+            try {
+                parent::doHeloCommand();
+            } catch (TransportExceptionInterface $ex) {
+                if (!$ex->getCode()) {
+                    throw $e;
+                }
+            }
+        }
+
         $capabilities = [];
-        $lines = explode("\r\n", trim($ehloResponse));
+        $lines = explode("\r\n", trim($response));
         array_shift($lines);
         foreach ($lines as $line) {
             if (preg_match('/^[0-9]{3}[ -]([A-Z0-9-]+)((?:[ =].*)?)$/Di', $line, $matches)) {

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -295,15 +295,13 @@ class SmtpTransport extends AbstractTransport
             throw new LogicException('You must set the expected response code.');
         }
 
-        if (!$response) {
-            throw new TransportException(sprintf('Expected response code "%s" but got an empty response.', implode('/', $codes)));
-        }
-
         [$code] = sscanf($response, '%3d');
         $valid = \in_array($code, $codes);
 
-        if (!$valid) {
-            throw new TransportException(sprintf('Expected response code "%s" but got code "%s", with message "%s".', implode('/', $codes), $code, trim($response)), $code);
+        if (!$valid || !$response) {
+            $codeStr = $code ? sprintf('code "%s"', $code) : 'empty code';
+            $responseStr = $response ? sprintf(', with message "%s"', trim($response)) : '';
+            throw new TransportException(sprintf('Expected response code "%s" but got ', implode('/', $codes), $codeStr).$codeStr.$responseStr.'.', $code);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40414 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

Better exception messages are generally done in the "main" branch, but this one is quite nasty as it masks the actual error message from the SMTP server, so I think it deserves to be merged in 4.4.
