### PR TITLE
[Security] Remove using multiple attributes with #[IsGranted]

### DIFF
--- a/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
@@ -21,7 +21,7 @@ final class IsGranted
         /**
          * Sets the first argument that will be passed to isGranted().
          */
-        public array|string|null $attributes = null,
+        public string $attribute,
 
         /**
          * Sets the second argument passed to isGranted().

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -60,7 +60,7 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
                 }
             }
 
-            if (!$this->authChecker->isGranted($attribute->attributes, $subject)) {
+            if (!$this->authChecker->isGranted($attribute->attribute, $subject)) {
                 $message = $attribute->message ?: sprintf('Access Denied by #[IsGranted(%s)] on controller', $this->getIsGrantedString($attribute));
 
                 if ($statusCode = $attribute->statusCode) {
@@ -68,7 +68,7 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
                 }
 
                 $accessDeniedException = new AccessDeniedException($message);
-                $accessDeniedException->setAttributes($attribute->attributes);
+                $accessDeniedException->setAttributes($attribute->attribute);
                 $accessDeniedException->setSubject($subject);
 
                 throw $accessDeniedException;
@@ -83,11 +83,13 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
 
     private function getIsGrantedString(IsGranted $isGranted): string
     {
-        $attributes = array_map(fn ($attribute) => '"'.$attribute.'"', (array) $isGranted->attributes);
-        $argsString = 1 === \count($attributes) ? reset($attributes) : '['.implode(', ', $attributes).']';
+        $processValue = fn ($value) => sprintf('"%s"', $value);
 
-        if (null !== $isGranted->subject) {
-            $argsString .= ', "'.implode('", "', (array) $isGranted->subject).'"';
+        $argsString = $processValue($isGranted->attribute);
+
+        if (null !== $subject = $isGranted->subject) {
+            $subject = array_map($processValue, (array) $subject);
+            $argsString .= ', '.(1 === \count($subject) ? reset($subject) : '['.implode(', ', $subject).']');
         }
 
         return $argsString;

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeController.php
@@ -13,10 +13,10 @@ namespace Symfony\Component\Security\Http\Tests\Fixtures;
 
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
-#[IsGranted(attributes: ['ROLE_ADMIN', 'ROLE_USER'])]
+#[IsGranted(attribute: 'ROLE_USER')]
 class IsGrantedAttributeController
 {
-    #[IsGranted(attributes: ['ROLE_ADMIN'])]
+    #[IsGranted(attribute: 'ROLE_ADMIN')]
     public function foo()
     {
     }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
@@ -19,42 +19,27 @@ class IsGrantedAttributeMethodsController
     {
     }
 
-    #[IsGranted()]
-    public function emptyAttribute()
-    {
-    }
-
-    #[IsGranted(attributes: 'ROLE_ADMIN')]
+    #[IsGranted(attribute: 'ROLE_ADMIN')]
     public function admin()
     {
     }
 
-    #[IsGranted(attributes: ['ROLE_ADMIN', 'ROLE_USER'])]
-    public function adminOrUser()
-    {
-    }
-
-    #[IsGranted(attributes: ['ROLE_ADMIN', 'ROLE_USER'], subject: 'product')]
-    public function adminOrUserWithSubject($product)
-    {
-    }
-
-    #[IsGranted(attributes: 'ROLE_ADMIN', subject: 'arg2Name')]
+    #[IsGranted(attribute: 'ROLE_ADMIN', subject: 'arg2Name')]
     public function withSubject($arg1Name, $arg2Name)
     {
     }
 
-    #[IsGranted(attributes: 'ROLE_ADMIN', subject: ['arg1Name', 'arg2Name'])]
+    #[IsGranted(attribute: 'ROLE_ADMIN', subject: ['arg1Name', 'arg2Name'])]
     public function withSubjectArray($arg1Name, $arg2Name)
     {
     }
 
-    #[IsGranted(attributes: 'ROLE_ADMIN', subject: 'non_existent')]
+    #[IsGranted(attribute: 'ROLE_ADMIN', subject: 'non_existent')]
     public function withMissingSubject()
     {
     }
 
-    #[IsGranted(attributes: 'ROLE_ADMIN', statusCode: 404, message: 'Not found')]
+    #[IsGranted(attribute: 'ROLE_ADMIN', message: 'Not found', statusCode: 404)]
     public function notFound()
     {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/46978#discussion_r934676719
| License       | MIT
| Doc PR        | -

Passing multiple attributes to `isGranted()` has been removed in #33584, so the following doesn't work any more:

```php
#[IsGranted(attributes: ['ROLE_ADMIN'])]
public function index(Post $post)
{
}

#[IsGranted(attributes: ['ROLE_USER', 'ROLE_ADMIN'])]
public function index(Post $post)
{
}
```

As mentioned in https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/648 , expressions should be used instead, see #46978 . This PR removes the possibility of using multiple attributes with `#[IsGranted]`.

Also, it's currently possible to use `#[IsGranted()]` with no attributes (`null`). Since this doesn't seem to work either, nor can I find a reason why it even should, this PR removes that option as well. If I'm wrong about this one, please let me know.