### PR TITLE
[Serializer] Revert deprecation of `ContextAwareEncoderInterface` and `ContextAwareDecoderInterface`

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -899,11 +899,11 @@ index f38069e471..0966eb3e89 100644
 +    public function decode(string $data, string $format, array $context = []): mixed;
  
      /**
-@@ -45,4 +45,4 @@ interface DecoderInterface
+@@ -44,4 +44,4 @@ interface DecoderInterface
       * @return bool
       */
--    public function supportsDecoding(string $format /* , array $context = [] */);
-+    public function supportsDecoding(string $format /* , array $context = [] */): bool;
+-    public function supportsDecoding(string $format);
++    public function supportsDecoding(string $format): bool;
  }
 diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
 index 44ba45f581..3398115497 100644

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -9,8 +9,6 @@ CHANGELOG
  * Set `Context` annotation as not final
  * Deprecate `ContextAwareNormalizerInterface`, use `NormalizerInterface` instead
  * Deprecate `ContextAwareDenormalizerInterface`, use `DenormalizerInterface` instead
- * Deprecate `ContextAwareEncoderInterface`, use `EncoderInterface` instead
- * Deprecate `ContextAwareDecoderInterface`, use `DecoderInterface` instead
  * Deprecate supporting denormalization for `AbstractUid` in `UidNormalizer`, use one of `AbstractUid` child class instead
  * Deprecate denormalizing to an abstract class in `UidNormalizer`
  * Add support for `can*()` methods to `ObjectNormalizer`

--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -67,9 +67,13 @@ class ChainDecoder implements ContextAwareDecoderInterface
             return $this->decoders[$this->decoderByFormat[$format]];
         }
 
+        $cache = true;
         foreach ($this->decoders as $i => $decoder) {
+            $cache = $cache && !$decoder instanceof ContextAwareDecoderInterface;
             if ($decoder->supportsDecoding($format, $context)) {
-                $this->decoderByFormat[$format] = $i;
+                if ($cache) {
+                    $this->decoderByFormat[$format] = $i;
+                }
 
                 return $decoder;
             }

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -90,9 +90,13 @@ class ChainEncoder implements ContextAwareEncoderInterface
             return $this->encoders[$this->encoderByFormat[$format]];
         }
 
+        $cache = true;
         foreach ($this->encoders as $i => $encoder) {
+            $cache = $cache && !$encoder instanceof ContextAwareEncoderInterface;
             if ($encoder->supportsEncoding($format, $context)) {
-                $this->encoderByFormat[$format] = $i;
+                if ($cache) {
+                    $this->encoderByFormat[$format] = $i;
+                }
 
                 return $encoder;
             }

--- a/src/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.php
@@ -15,8 +15,6 @@ namespace Symfony\Component\Serializer\Encoder;
  * Adds the support of an extra $context parameter for the supportsDecoding method.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
- *
- * @deprecated since symfony/serializer 6.1, use DecoderInterface instead
  */
 interface ContextAwareDecoderInterface extends DecoderInterface
 {

--- a/src/Symfony/Component/Serializer/Encoder/ContextAwareEncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/ContextAwareEncoderInterface.php
@@ -15,8 +15,6 @@ namespace Symfony\Component\Serializer\Encoder;
  * Adds the support of an extra $context parameter for the supportsEncoding method.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
- *
- * @deprecated since symfony/serializer 6.1, use EncoderInterface instead
  */
 interface ContextAwareEncoderInterface extends EncoderInterface
 {

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -124,10 +124,8 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsEncoding(string $format /* , array $context = [] */): bool
+    public function supportsEncoding(string $format): bool
     {
         return self::FORMAT === $format;
     }
@@ -212,10 +210,8 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsDecoding(string $format /* , array $context = [] */): bool
+    public function supportsDecoding(string $format): bool
     {
         return self::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
@@ -39,10 +39,9 @@ interface DecoderInterface
     /**
      * Checks whether the deserializer can decode from given format.
      *
-     * @param string $format  Format name
-     * @param array  $context Options that decoders have access to
+     * @param string $format Format name
      *
      * @return bool
      */
-    public function supportsDecoding(string $format /* , array $context = [] */);
+    public function supportsDecoding(string $format);
 }

--- a/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
@@ -32,8 +32,7 @@ interface EncoderInterface
     /**
      * Checks whether the serializer can encode to given format.
      *
-     * @param string $format  Format name
-     * @param array  $context Options that normalizers/encoders have access to
+     * @param string $format Format name
      */
-    public function supportsEncoding(string $format /* , array $context = [] */): bool;
+    public function supportsEncoding(string $format): bool;
 }

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -95,10 +95,8 @@ class JsonDecode implements DecoderInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsDecoding(string $format /* , array $context = [] */): bool
+    public function supportsDecoding(string $format): bool
     {
         return JsonEncoder::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -57,10 +57,8 @@ class JsonEncode implements EncoderInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsEncoding(string $format /* , array $context = [] */): bool
+    public function supportsEncoding(string $format): bool
     {
         return JsonEncoder::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
@@ -47,20 +47,16 @@ class JsonEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsEncoding(string $format /* , array $context = [] */): bool
+    public function supportsEncoding(string $format): bool
     {
         return self::FORMAT === $format;
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsDecoding(string $format /* , array $context = [] */): bool
+    public function supportsDecoding(string $format): bool
     {
         return self::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -166,20 +166,16 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsEncoding(string $format /* , array $context = [] */): bool
+    public function supportsEncoding(string $format): bool
     {
         return self::FORMAT === $format;
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsDecoding(string $format /* , array $context = [] */): bool
+    public function supportsDecoding(string $format): bool
     {
         return self::FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -67,10 +67,8 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsEncoding(string $format /* , array $context = [] */): bool
+    public function supportsEncoding(string $format): bool
     {
         return self::FORMAT === $format || self::ALTERNATIVE_FORMAT === $format;
     }
@@ -87,10 +85,8 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $context
      */
-    public function supportsDecoding(string $format /* , array $context = [] */): bool
+    public function supportsDecoding(string $format): bool
     {
         return self::FORMAT === $format || self::ALTERNATIVE_FORMAT === $format;
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Encoder\ChainDecoder;
+use Symfony\Component\Serializer\Encoder\ContextAwareDecoderInterface;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Exception\RuntimeException;
 
@@ -28,7 +29,7 @@ class ChainDecoderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->decoder1 = $this->createMock(DecoderInterface::class);
+        $this->decoder1 = $this->createMock(ContextAwareDecoderInterface::class);
         $this->decoder1
             ->method('supportsDecoding')
             ->willReturnMap([

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Serializer\Tests\Encoder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Debug\TraceableEncoder;
 use Symfony\Component\Serializer\Encoder\ChainEncoder;
+use Symfony\Component\Serializer\Encoder\ContextAwareEncoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Encoder\NormalizationAwareInterface;
 use Symfony\Component\Serializer\Exception\RuntimeException;
@@ -30,7 +31,7 @@ class ChainEncoderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->encoder1 = $this->createMock(EncoderInterface::class);
+        $this->encoder1 = $this->createMock(ContextAwareEncoderInterface::class);
         $this->encoder1
             ->method('supportsEncoding')
             ->willReturnMap([
@@ -106,7 +107,7 @@ class ChainEncoderTest extends TestCase
 
 class NormalizationAwareEncoder implements EncoderInterface, NormalizationAwareInterface
 {
-    public function supportsEncoding(string $format, array $context = []): bool
+    public function supportsEncoding(string $format): bool
     {
         return true;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While reviewing #43231, I figured out that the correct fix for #38270 was to make `ChainEncoder` properly consider `ContextAwareEncoderInterface` when deciding to cache or not.

Since this interface is useful to discriminate the cache/no-cache situations, we have to undeprecate it (from #43982.)

/cc @Guite and @mtarld FYI