### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,9 @@ This will help reviewers and should be a good start for the documentation.
 Additionally (see https://symfony.com/releases):
  - Always add tests and ensure they pass.
  - Bug fixes must be submitted against the lowest maintained branch where they apply
-   (lowest branches are regularly merged to upper ones so they get the fixes too.)
+   (lowest branches are regularly merged to upper ones so they get the fixes too).
  - Features and deprecations must be submitted against the latest branch.
+ - For new features, provide some code snippets to help understand usage.  
  - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
  - Never break backward compatibility (see https://symfony.com/bc).
 -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| License       | MIT

I propose to add this info to encourage devs to auto describe their new feature added in their PR description to ease the addition in the documentation later 

When browsing the auto PR on the symfony-docs repo, pointing to a recent merged PR, it may and probably should allow easier/better documentation integration process after feature is merged :)

friendly ping @javiereguiluz @wouterj @OskarStark 

——

It reminds me https://blog.codinghorror.com/if-it-isnt-documented-it-doesnt-exist