### PR TITLE
[6.0] [Yaml] Restore two failing test methods in DumperTest.

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -440,6 +440,28 @@ YAML;
         $this->assertSameData($data, $this->parser->parse($yaml, Yaml::PARSE_CUSTOM_TAGS));
     }
 
+    public function testDumpingTaggedValueTopLevelAssoc()
+    {
+        $data = new TaggedValue('user', ['name' => 'jane']);
+
+        // @todo Fix the dumper, eliminate this exception.
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Symfony\Component\Yaml\Inline::isHash(): Argument #1 ($value) must be of type ArrayObject|stdClass|array, Symfony\Component\Yaml\Tag\TaggedValue given');
+
+        $this->dumper->dump($data, 2);
+    }
+
+    public function testDumpingTaggedValueTopLevelMultiLine()
+    {
+        $data = new TaggedValue('text', "a\nb\n");
+
+        // @todo Fix the dumper, eliminate this exception.
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Symfony\Component\Yaml\Inline::isHash(): Argument #1 ($value) must be of type ArrayObject|stdClass|array, Symfony\Component\Yaml\Tag\TaggedValue given');
+
+        $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+    }
+
     public function testDumpingTaggedValueSpecialCharsInTag()
     {
         // @todo Validate the tag name in the TaggedValue constructor.

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -677,7 +677,7 @@ data:
     nested_inlined_multi_line_string: { inlined_multi_line: "foo\nbar\r\nempty line:\n\nbaz" }
 
 YAML
-);
+        );
         $this->assertSame($expected, $yml);
         $this->assertSame($data, $this->parser->parse($yml));
     }


### PR DESCRIPTION
The methods were lost in merge commit 8752c8bf3d4243e710e533b9880243d123e90c0e - too bad we can't show a direct diff between two commits for a single file in github.

The test methods document the misbehavior as known issues. They will be changed when the failing behavior is fixed in #46731.
(I personally think this is a good way to write tests in preparation for a fix)

Unlike in 4.4, in 6.0 these failing calls throw exceptions.

This should be a preparation for https://github.com/symfony/symfony/pull/46731, or before merging https://github.com/symfony/symfony/pull/47167 to 6.0.

| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Follow-up to PR #46739 
| License       | MIT
| Doc PR        | 
