### PR TITLE
[Serializer] Fix throwing right exception in ArrayDenormalizer with invalid type

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Exception\BadMethodCallException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -40,7 +41,7 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
             throw new BadMethodCallException('Please set a denormalizer before calling denormalize()!');
         }
         if (!\is_array($data)) {
-            throw new InvalidArgumentException('Data expected to be an array, '.get_debug_type($data).' given.');
+            throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('Data expected to be "%s", "%s" given.', $type, get_debug_type($data)), $data, [Type::BUILTIN_TYPE_ARRAY], $context['deserialization_path'] ?? null);
         }
         if (!str_ends_with($type, '[]')) {
             throw new InvalidArgumentException('Unsupported class: '.$type);

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
@@ -31,6 +31,8 @@ final class Php74Full
     public DummyMessageInterface $dummyMessage;
     /** @var TestFoo[] $nestedArray */
     public TestFoo $nestedObject;
+    /** @var Php74Full[] */
+    public $anotherCollection;
 }
 
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -854,7 +854,8 @@ class SerializerTest extends TestCase
             },
             "nestedObject": {
                 "int": "string"
-            }
+            },
+            "anotherCollection": null
         }';
 
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
@@ -1029,6 +1030,13 @@ class SerializerTest extends TestCase
                 'path' => 'nestedObject[int]',
                 'useMessageForUser' => true,
                 'message' => 'The type of the key "int" must be "int" ("string" given).',
+            ],
+            [
+                'currentType' => 'null',
+                'expectedTypes' => ['array'],
+                'path' => 'anotherCollection',
+                'useMessageForUser' => false,
+                'message' => 'Data expected to be "Symfony\Component\Serializer\Tests\Fixtures\Php74Full[]", "null" given.',
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Currently it's possible to catch most errors with serializer when using `DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true` but there was no tests trying to deserialize list of objects with an invalid value.

So it failed my expectations, because in an api using serializer, consumers could get 500 instead of the proper response, therefore I've submit this as a bugfix.