### PR TITLE
[DependencyInjection] Container building optimization

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -117,9 +117,15 @@ class MergeExtensionConfigurationParameterBag extends EnvPlaceholderParameterBag
         // serialize config and container to catch env vars nested in object graphs
         $config = serialize($config).serialize($container->getDefinitions()).serialize($container->getAliases()).serialize($container->getParameterBag()->all());
 
+        if (false === stripos($config, 'env_')) {
+            return;
+        }
+
+        preg_match_all('/env_[a-f0-9]{16}_\w+_[a-f0-9]{32}/Ui', $config, $matches);
+        $usedPlaceholders = array_flip($matches[0]);
         foreach (parent::getEnvPlaceholders() as $env => $placeholders) {
             foreach ($placeholders as $placeholder) {
-                if (false !== stripos($config, $placeholder)) {
+                if (isset($usedPlaceholders[$placeholder])) {
                     $this->processedEnvPlaceholders[$env] = $placeholders;
                     break;
                 }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1358,15 +1358,17 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             return $result;
         }
 
-        if (!\is_string($value) || 38 > \strlen($value) || !preg_match('/env[_(]/i', $value)) {
+        if (!\is_string($value) || 38 > \strlen($value) || false === stripos($value, 'env_')) {
             return $value;
         }
         $envPlaceholders = $bag instanceof EnvPlaceholderParameterBag ? $bag->getEnvPlaceholders() : $this->envPlaceholders;
 
         $completed = false;
+        preg_match_all('/env_[a-f0-9]{16}_\w+_[a-f0-9]{32}/Ui', $value, $matches);
+        $usedPlaceholders = array_flip($matches[0]);
         foreach ($envPlaceholders as $env => $placeholders) {
             foreach ($placeholders as $placeholder) {
-                if (false !== stripos($value, $placeholder)) {
+                if (isset($usedPlaceholders[$placeholder])) {
                     if (true === $format) {
                         $resolved = $bag->escapeValue($this->getEnv($env));
                     } else {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -153,6 +153,19 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->assertSame(['scalar_node' => $expected], $container->resolveEnvPlaceholders($ext->getConfig()));
     }
 
+    public function testSurroundedEnvInConfig()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension());
+        $container->prependExtensionConfig('env_extension', [
+            'scalar_node' => $expected = 'foo%env(BAR)%baz',
+        ]);
+
+        $this->doProcess($container);
+
+        $this->assertSame(['scalar_node' => $expected], $container->resolveEnvPlaceholders($ext->getConfig()));
+    }
+
     public function testEnvIsIncompatibleWithArrayNode()
     {
         $this->expectException(InvalidConfigurationException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

When you have to much env variables and many services in your container, container compilаtion can take much time due to the function stripos which is called much time.

It happens because method freezeAfterProcessing try to find env placeholders in config, but make it in two foreach.
So i offer to get all possible placeholders with preg_match_all and do not use stripos for each placeholed.

Same situation with method resolveEnvPlaceholders. But in this method we should left stripos for hard cases when in value could be something like this 'env_1418b707a69b8575_const_HOST_74bcc04c4799f2ca10fb754fe5581c89env_1418b707a69b8575_const_CORE_URL_91ef68034c1e9e8b58c13725d3bafdc0'

In my project it helps me to save 40 seconds in container building.

Related to my previous fix https://github.com/symfony/symfony/pull/44876