### PR TITLE
[Messenger] Remove an unused method

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Sync/SyncTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/Sync/SyncTransport.php
@@ -37,11 +37,6 @@ class SyncTransport implements TransportInterface
         throw new InvalidArgumentException('You cannot receive messages from the Messenger SyncTransport.');
     }
 
-    public function stop(): void
-    {
-        throw new InvalidArgumentException('You cannot call stop() on the Messenger SyncTransport.');
-    }
-
     public function ack(Envelope $envelope): void
     {
         throw new InvalidArgumentException('You cannot call ack() on the Messenger SyncTransport.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

A minor cleanup as the `stop()` method was removed from the `ReceiverInterface` in Symfony 4.3.
