### PR TITLE
[Validator] Add additional hint when `egulias/email-validator` needs to be installed

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -100,6 +100,10 @@ class EmailValidator extends ConstraintValidator
         }
 
         if (null === $constraint->mode) {
+            if (Email::VALIDATION_MODE_STRICT === $this->defaultMode && !class_exists(EguliasEmailValidator::class)) {
+                throw new LogicException(sprintf('The "egulias/email-validator" component is required to make the "%s" constraint default to strict mode.', EguliasEmailValidator::class));
+            }
+
             $constraint->mode = $this->defaultMode;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When using the `Symfony\Component\Validator\Constraints\Email` constraint with `'mode' => 'strict'`, a helpful error message is shown when the necessary package is not installed.

However, when configuring `strict` mode as a framework setting (https://symfony.com/doc/current/reference/configuration/framework.html#email-validation-mode) and omitting the `mode` setting on the constraint itself, that message was missing.
