### PR TITLE
[Mailer] Add a way to change the Bus transport dynamically

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -102,6 +102,7 @@ use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendinblue\Transport\SendinblueTransportFactory;
 use Symfony\Component\Mailer\Command\MailerTestCommand;
+use Symfony\Component\Mailer\EventListener\MessengerTransportListener;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mercure\HubRegistry;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -2485,6 +2486,10 @@ class FrameworkExtension extends Extension
             $messageListener->setArgument(0, $headers);
         } else {
             $container->removeDefinition('mailer.message_listener');
+        }
+
+        if (!class_exists(MessengerTransportListener::class)) {
+            $container->removeDefinition('mailer.messenger_transport_listener');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
@@ -15,6 +15,7 @@ use Symfony\Component\Mailer\Command\MailerTestCommand;
 use Symfony\Component\Mailer\EventListener\EnvelopeListener;
 use Symfony\Component\Mailer\EventListener\MessageListener;
 use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
+use Symfony\Component\Mailer\EventListener\MessengerTransportListener;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mailer\Messenger\MessageHandler;
@@ -73,6 +74,9 @@ return static function (ContainerConfigurator $container) {
         ->set('mailer.message_logger_listener', MessageLoggerListener::class)
             ->tag('kernel.event_subscriber')
             ->tag('kernel.reset', ['method' => 'reset'])
+
+        ->set('mailer.messenger_transport_listener', MessengerTransportListener::class)
+            ->tag('kernel.event_subscriber')
 
         ->set('console.command.mailer_test', MailerTestCommand::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -47,7 +47,7 @@
         "symfony/html-sanitizer": "^6.1",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/lock": "^5.4|^6.0",
-        "symfony/mailer": "^5.4|^6.0",
+        "symfony/mailer": "^6.2",
         "symfony/messenger": "^6.1",
         "symfony/mime": "^5.4|^6.0",
         "symfony/notifier": "^5.4|^6.0",

--- a/src/Symfony/Component/Mailer/EventListener/MessengerTransportListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessengerTransportListener.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Mailer\Event\QueuingMessageEvent;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+use Symfony\Component\Mime\Message;
+
+/**
+ * Allows messages to be sent to specific Messenger transports via the "X-Bus-Transport" MIME header.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class MessengerTransportListener implements EventSubscriberInterface
+{
+    public function onMessage(QueuingMessageEvent $event): void
+    {
+        $message = $event->getMessage();
+        if (!$message instanceof Message || !$message->getHeaders()->has('X-Bus-Transport')) {
+            return;
+        }
+
+        $names = $message->getHeaders()->get('X-Bus-Transport')->getBody();
+        $names = array_map('trim', explode(',', $names));
+        $event->addStamp(new TransportNamesStamp($names));
+        $message->getHeaders()->remove('X-Bus-Transport');
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            QueuingMessageEvent::class => 'onMessage',
+        ];
+    }
+}

--- a/src/Symfony/Component/Mailer/Tests/EventListener/MessengerTransportListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/MessengerTransportListenerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Event\QueuingMessageEvent;
+use Symfony\Component\Mailer\EventListener\MessengerTransportListener;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Message;
+
+class MessengerTransportListenerTest extends TestCase
+{
+    public function testNoMessengerTransportStampsByDefault()
+    {
+        $l = new MessengerTransportListener();
+        $envelope = new Envelope(new Address('sender@example.com'), [new Address('recipient@example.com')]);
+        $message = new Message(new Headers());
+        $event = new QueuingMessageEvent($message, $envelope, 'smtp');
+        $l->onMessage($event);
+        $this->assertEmpty($event->getStamps());
+    }
+
+    public function testMessengerTransportStampViaHeader()
+    {
+        $l = new MessengerTransportListener();
+        $envelope = new Envelope(new Address('sender@example.com'), [new Address('recipient@example.com')]);
+        $headers = (new Headers())->addTextHeader('X-Bus-Transport', 'async');
+        $message = new Message($headers);
+        $event = new QueuingMessageEvent($message, $envelope, 'smtp');
+        $l->onMessage($event);
+        $this->assertCount(1, $event->getStamps());
+        /* @var TransportNamesStamp $stamp */
+        $this->assertInstanceOf(TransportNamesStamp::class, $stamp = $event->getStamps()[0]);
+        $this->assertSame(['async'], $stamp->getTransportNames());
+        $this->assertTrue($headers->has('X-Bus-Transport'));
+    }
+
+    public function testMessengerTransportStampsViaHeader()
+    {
+        $l = new MessengerTransportListener();
+        $envelope = new Envelope(new Address('sender@example.com'), [new Address('recipient@example.com')]);
+        $name = 'söme_very_long_and_weïrd transport name-for-messenger!';
+        $headers = (new Headers())->addTextHeader('X-Bus-Transport', ' async , async1,'.$name);
+        $message = new Message($headers);
+        $event = new QueuingMessageEvent($message, $envelope, 'smtp');
+        $l->onMessage($event);
+        $this->assertCount(1, $event->getStamps());
+        /* @var TransportNamesStamp $stamp */
+        $this->assertInstanceOf(TransportNamesStamp::class, $stamp = $event->getStamps()[0]);
+        $this->assertSame(['async', 'async1', $name], $stamp->getTransportNames());
+    }
+}

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -27,10 +27,11 @@
     "require-dev": {
         "symfony/console": "^5.4|^6.0",
         "symfony/http-client-contracts": "^1.1|^2|^3",
-        "symfony/messenger": "^5.4|^6.0"
+        "symfony/messenger": "^6.2"
     },
     "conflict": {
-        "symfony/http-kernel": "<5.4"
+        "symfony/http-kernel": "<5.4",
+        "symfony/messenger": "<6.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #36348 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

This PR relies on #39306. Once merged, this PR will be rebased.
This allows overriding the bus transport "dynamically" via the `X-Bus-Transport` header.
