### PR TITLE
[FrameworkBundle] fix writes to static $kernel property

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -77,7 +77,7 @@ abstract class KernelTestCase extends TestCase
 
         $kernel = static::createKernel($options);
         $kernel->boot();
-        self::$kernel = $kernel;
+        static::$kernel = $kernel;
         static::$booted = true;
 
         $container = static::$kernel->getContainer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47186
| License       | MIT
| Doc PR        | 
