### PR TITLE
Allow extending `#[When]` attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `enum` env var processor
  * Add `shuffle` env var processor
  * Add `resolve-env` option to `debug:config` command to display actual values of environment variables in dumped configuration
+ * Allow #[When] to be extended
 
 6.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -120,7 +120,7 @@ abstract class FileLoader extends BaseFileLoader
             if (null === $errorMessage && $autoconfigureAttributes && $this->env) {
                 $r = $this->container->getReflectionClass($class);
                 $attribute = null;
-                foreach ($r->getAttributes(When::class) as $attribute) {
+                foreach ($r->getAttributes(When::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
                     if ($this->env === $attribute->newInstance()->env) {
                         $attribute = null;
                         break;

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -101,7 +101,7 @@ class PhpFileLoader extends FileLoader
         $r = new \ReflectionFunction($callback);
 
         $attribute = null;
-        foreach ($r->getAttributes(When::class) as $attribute) {
+        foreach ($r->getAttributes(When::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             if ($this->env === $attribute->newInstance()->env) {
                 $attribute = null;
                 break;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
 
 use Symfony\Component\DependencyInjection\Attribute\When;
 
-#[When(env: 'prod')]
+#[ProductionOnly]
 #[When(env: 'dev')]
 class Foo implements FooInterface, Sub\BarInterface
 {
@@ -14,5 +14,14 @@ class Foo implements FooInterface, Sub\BarInterface
 
     public function setFoo(self $foo)
     {
+    }
+}
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
+class ProductionOnly extends When
+{
+    public function __construct()
+    {
+        parent::__construct('prod');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #46643
| License       | MIT
| Doc PR        | 


This allows people to extend the `#[When]` attribute with something like this:

```php
namespace App\Symfony;

use Attribute;
use Symfony\Component\DependencyInjection\Attribute\When;

#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION | Attribute::IS_REPEATABLE)]
final class Exclude extends When
{
    public function __construct()
    {
        parent::__construct('never');
    }
}
```

Then they can use `#[Exclude]` instead of `#[When(env: 'never')]`.

Or they can create `#[ProductionOnly]` instead of `#[When(env: 'prod')]`.

I hoped that https://github.com/symfony/symfony/pull/46655 would be merged but it turns out that is not going to happen.

References:
- https://github.com/symfony/symfony/issues/46643
- https://github.com/symfony/symfony/pull/46655