### PR TITLE
[Serializer] enable JSON_PRESERVE_ZERO_FRACTION by default

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -23,7 +23,7 @@ class JsonEncode implements EncoderInterface
     public const OPTIONS = 'json_encode_options';
 
     private $defaultContext = [
-        self::OPTIONS => 0,
+        self::OPTIONS => \JSON_PRESERVE_ZERO_FRACTION,
     ];
 
     public function __construct(array $defaultContext = [])


### PR DESCRIPTION
this makes json output float values that happen to be full numbers with a `.0`, so `4.0` or `0.0` instead of `4` resp `0`. that in turn helps when consuming the json in a type-safe language.

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | As discussed in #47183
| License       | MIT
| Doc PR        | -

In #47183, @nicolas-grekas said that we should enable the preserve zero fraction flag by default in the serializer.

I am a bit unsure if we should consider this a BC break, as it does change the output of JSON data. Should it be considered a bugfix against 6.1, a feature against 6.2 or a BC break that has to wait until 7.0?
