### PR TITLE
[Form] ignore missing keys when mapping DateTime objects to uninitialized arrrays

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataAccessor/PropertyPathAccessor.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataAccessor/PropertyPathAccessor.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\DataAccessorInterface;
 use Symfony\Component\Form\Exception\AccessException;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\PropertyAccess\Exception\AccessException as PropertyAccessException;
+use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -90,6 +91,10 @@ class PropertyPathAccessor implements DataAccessorInterface
         try {
             return $this->propertyAccessor->getValue($data, $propertyPath);
         } catch (PropertyAccessException $e) {
+            if (\is_array($data) && $e instanceof NoSuchIndexException) {
+                return null;
+            }
+
             if (!$e instanceof UninitializedPropertyException
                 // For versions without UninitializedPropertyException check the exception message
                 && (class_exists(UninitializedPropertyException::class) || false === strpos($e->getMessage(), 'You should initialize it'))

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Exception\AlreadySubmittedException;
+use Symfony\Component\Form\Extension\Core\DataAccessor\PropertyPathAccessor;
 use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
 use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
@@ -1079,13 +1080,40 @@ class CompoundFormTest extends TestCase
         $this->assertNull($this->form->get('bar')->getData());
     }
 
-    public function testMapDateTimeObjectsWithEmptyArrayData()
+    /**
+     * @group legacy
+     */
+    public function testMapDateTimeObjectsWithEmptyArrayDataUsingPropertyPathMapper()
     {
         $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
             ->enableExceptionOnInvalidIndex()
             ->getPropertyAccessor();
         $form = $this->factory->createBuilder()
             ->setDataMapper(new PropertyPathMapper($propertyAccessor))
+            ->add('date', DateType::class, [
+                'auto_initialize' => false,
+                'format' => 'dd/MM/yyyy',
+                'html5' => false,
+                'model_timezone' => 'UTC',
+                'view_timezone' => 'UTC',
+                'widget' => 'single_text',
+            ])
+            ->getForm();
+
+        $form->submit([
+            'date' => '04/08/2022',
+        ]);
+
+        $this->assertEquals(['date' => new \DateTime('2022-08-04', new \DateTimeZone('UTC'))], $form->getData());
+    }
+
+    public function testMapDateTimeObjectsWithEmptyArrayDataUsingDataMapper()
+    {
+        $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->enableExceptionOnInvalidIndex()
+            ->getPropertyAccessor();
+        $form = $this->factory->createBuilder()
+            ->setDataMapper(new DataMapper(new PropertyPathAccessor($propertyAccessor)))
             ->add('date', DateType::class, [
                 'auto_initialize' => false,
                 'format' => 'dd/MM/yyyy',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
@@ -14,10 +14,14 @@ namespace Symfony\Component\Form\Tests\Extension\Core\DataMapper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Core\DataAccessor\PropertyPathAccessor;
 use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigBuilder;
+use Symfony\Component\Form\FormFactoryBuilder;
 use Symfony\Component\Form\Tests\Fixtures\TypehintedPropertiesCar;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
 class DataMapperTest extends TestCase
@@ -387,6 +391,33 @@ class DataMapperTest extends TestCase
         $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $person);
 
         self::assertSame('Jane Doe', $person->myName());
+    }
+
+    public function testMapFormsToDataMapsDateTimeInstanceToArrayIfNotSetBefore()
+    {
+        $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->enableExceptionOnInvalidIndex()
+            ->getPropertyAccessor();
+        $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->enableExceptionOnInvalidIndex()
+            ->getPropertyAccessor();
+        $form = (new FormFactoryBuilder())->getFormFactory()->createBuilder()
+            ->setDataMapper(new DataMapper(new PropertyPathAccessor($propertyAccessor)))
+            ->add('date', DateType::class, [
+                'auto_initialize' => false,
+                'format' => 'dd/MM/yyyy',
+                'html5' => false,
+                'model_timezone' => 'UTC',
+                'view_timezone' => 'UTC',
+                'widget' => 'single_text',
+            ])
+            ->getForm();
+
+        $form->submit([
+            'date' => '04/08/2022',
+        ]);
+
+        $this->assertEquals(['date' => new \DateTime('2022-08-04', new \DateTimeZone('UTC'))], $form->getData());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

continues #47200 after merging changes up into the `5.4` branch