### PR TITLE
[Serializer] Fallback looking for DiscriminatorMap on interfaces

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
@@ -78,7 +78,9 @@ class ClassDiscriminatorFromClassMetadata implements ClassDiscriminatorResolverI
     {
         $reflectionClass = new \ReflectionClass($object);
         if ($parentClass = $reflectionClass->getParentClass()) {
-            return $this->getMappingForMappedObject($parentClass->getName());
+            if (null !== ($parentMapping = $this->getMappingForMappedObject($parentClass->getName()))) {
+                return $parentMapping;
+            }
         }
 
         foreach ($reflectionClass->getInterfaceNames() as $interfaceName) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageInterface.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
 /**
  * @DiscriminatorMap(typeProperty="type", mapping={
  *    "one"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne",
- *    "two"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo"
+ *    "two"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo",
+ *    "three"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberThree"
  * })
  *
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberThree.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberThree.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ */
+class DummyMessageNumberThree extends \stdClass implements DummyMessageInterface
+{
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -58,6 +58,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummySecondC
 use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne;
+use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberThree;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyObjectWithEnumConstructor;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyObjectWithEnumProperty;
@@ -479,6 +480,18 @@ class SerializerTest extends TestCase
 
         $example = new DummyMessageNumberTwo();
         $example->setNested($nested);
+
+        $serializer = $this->serializerWithClassDiscriminator();
+
+        $serialized = $serializer->serialize($example, 'json');
+        $deserialized = $serializer->deserialize($serialized, DummyMessageInterface::class, 'json');
+
+        $this->assertEquals($example, $deserialized);
+    }
+
+    public function testDeserializeAndSerializeNestedAbstractAndInterfacedObjectsWithTheClassMetadataDiscriminator()
+    {
+        $example = new DummyMessageNumberThree();
 
         $serializer = $this->serializerWithClassDiscriminator();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47219
| License       | MIT
| Doc PR        | No

First time here
Trying to properly fix #47219 but I'm not sure about the impact of this changes
I am also not sure either if it should be a 6.2 or 6.1 based branch

- [x] Globally validate the behavior
- [x] Add tests