### PR TITLE
[Mime] Re-allow addIdHeader to be used for 'In-Reply-To' and 'References' headers

### DIFF
--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -34,8 +34,8 @@ final class Headers
         'cc' => MailboxListHeader::class,
         'bcc' => MailboxListHeader::class,
         'message-id' => IdentificationHeader::class,
-        'in-reply-to' => UnstructuredHeader::class, // `In-Reply-To` and `References` are less strict than RFC 2822 (3.6.4) to allow users entering the original email's ...
-        'references' => UnstructuredHeader::class, // ... `Message-ID`, even if that is no valid `msg-id`
+        'in-reply-to' => [UnstructuredHeader::class, IdentificationHeader::class], // `In-Reply-To` and `References` are less strict than RFC 2822 (3.6.4) to allow users entering the original email's ...
+        'references' => [UnstructuredHeader::class, IdentificationHeader::class], // ... `Message-ID`, even if that is no valid `msg-id`
         'return-path' => PathHeader::class,
     ];
 
@@ -137,7 +137,11 @@ final class Headers
      */
     public function addHeader(string $name, mixed $argument, array $more = []): static
     {
-        $parts = explode('\\', self::HEADER_CLASS_MAP[strtolower($name)] ?? UnstructuredHeader::class);
+        $headerClass = self::HEADER_CLASS_MAP[strtolower($name)] ?? UnstructuredHeader::class;
+        if (\is_array($headerClass)) {
+            $headerClass = $headerClass[0];
+        }
+        $parts = explode('\\', $headerClass);
         $method = 'add'.ucfirst(array_pop($parts));
         if ('addUnstructuredHeader' === $method) {
             $method = 'addTextHeader';
@@ -220,10 +224,22 @@ final class Headers
     public static function checkHeaderClass(HeaderInterface $header): void
     {
         $name = strtolower($header->getName());
-
-        if (($c = self::HEADER_CLASS_MAP[$name] ?? null) && !$header instanceof $c) {
-            throw new LogicException(sprintf('The "%s" header must be an instance of "%s" (got "%s").', $header->getName(), $c, get_debug_type($header)));
+        $headerClasses = self::HEADER_CLASS_MAP[$name] ?? [];
+        if (!\is_array($headerClasses)) {
+            $headerClasses = [$headerClasses];
         }
+
+        if (!$headerClasses) {
+            return;
+        }
+
+        foreach ($headerClasses as $c) {
+            if ($header instanceof $c) {
+                return;
+            }
+        }
+
+        throw new LogicException(sprintf('The "%s" header must be an instance of "%s" (got "%s").', $header->getName(), implode('" or "', $headerClasses), get_debug_type($header)));
     }
 
     public function toString(): string

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -287,11 +287,25 @@ class HeadersTest extends TestCase
         $this->assertEquals('foobar', $headers->get('In-Reply-To')->getBody());
     }
 
+    public function testInReplyToAcceptsIdentifierValues()
+    {
+        $headers = new Headers();
+        $headers->addIdHeader('In-Reply-To', 'foo@bar.com');
+        $this->assertEquals('<foo@bar.com>', $headers->get('In-Reply-To')->getBodyAsString());
+    }
+
     public function testReferencesAcceptsNonIdentifierValues()
     {
         $headers = new Headers();
         $headers->addTextHeader('References', 'foobar');
         $this->assertEquals('foobar', $headers->get('References')->getBody());
+    }
+
+    public function testReferencesAcceptsIdentifierValues()
+    {
+        $headers = new Headers();
+        $headers->addIdHeader('References', 'foo@bar.com');
+        $this->assertEquals('<foo@bar.com>', $headers->get('References')->getBodyAsString());
     }
 
     public function testHeaderBody()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no (arguable: undo BC break)
| New feature?  | yes (arguable: undo BC break)
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/45097
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

https://github.com/symfony/symfony/pull/44732 causes messages using `addIdHeader('In-Reply-To', ...)` or `addIdHeader('References', ...)` to fail the headers check (see https://github.com/symfony/symfony/pull/44732#issuecomment-1003340733 ), requiring users to manually format the header value themselves.

This PR re-allows the previous behaviour of `addIdHeader` while keeping the new unstructured behaviour in-place as the default.

-----

(I'm not sure if this counts as a new feature or a bug fix since it "reintroduces" a previous feature)