### PR TITLE
[Messenger] Blocking consumer

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
@@ -63,7 +63,7 @@ class AmqpReceiverTest extends TestCase
 
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->method('pull')->willReturnCallback(function (string $queueName, callable $callback) use ($amqpQueue, $amqpEnvelope) {
-            call_user_func($callback, $amqpEnvelope, $amqpQueue);
+            \call_user_func($callback, $amqpEnvelope, $amqpQueue);
         });
 
         $receiver = new AmqpReceiver($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
@@ -74,7 +74,7 @@ class AmqpTransportTest extends TestCase
         $serializer->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->method('pull')->willReturnCallback(function (string $queueName, callable $callback) use ($amqpQueue, $amqpEnvelope) {
-            call_user_func($callback, $amqpEnvelope, $amqpQueue);
+            \call_user_func($callback, $amqpEnvelope, $amqpQueue);
         });
 
         $transport->pull(function (Envelope $envelope) use ($decodedMessage) {

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -55,7 +55,7 @@ class AmqpReceiver implements QueueReceiverInterface, QueueBlockingReceiverInter
      */
     public function pullFromQueues(array $queueNames, callable $callback): void
     {
-        if (0 === count($queueNames)) {
+        if (0 === \count($queueNames)) {
             return;
         }
 
@@ -71,7 +71,7 @@ class AmqpReceiver implements QueueReceiverInterface, QueueBlockingReceiverInter
 
     private function pullEnvelope(string $queueName, ?callable $callback): void
     {
-        if ($callback !== null) {
+        if (null !== $callback) {
             $callback = function (\AMQPEnvelope $amqpEnvelope, \AMQPQueue $queue) use ($callback) {
                 $queueName = $queue->getName();
                 $body = $amqpEnvelope->getBody();

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -42,17 +42,11 @@ class AmqpReceiver implements QueueReceiverInterface, QueueBlockingReceiverInter
         yield from $this->getFromQueues($this->connection->getQueueNames());
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function pull(callable $callback): void
     {
         $this->pullFromQueues($this->connection->getQueueNames(), $callback);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function pullFromQueues(array $queueNames, callable $callback): void
     {
         if (0 === \count($queueNames)) {
@@ -88,9 +82,6 @@ class AmqpReceiver implements QueueReceiverInterface, QueueBlockingReceiverInter
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFromQueues(array $queueNames): iterable
     {
         foreach ($queueNames as $queueName) {

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Messenger\Bridge\Amqp\Transport;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Receiver\BlockingReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
@@ -22,7 +24,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class AmqpTransport implements QueueReceiverInterface, TransportInterface, SetupableTransportInterface, MessageCountAwareInterface
+class AmqpTransport implements QueueReceiverInterface, BlockingReceiverInterface, TransportInterface, SetupableTransportInterface, MessageCountAwareInterface
 {
     private SerializerInterface $serializer;
     private Connection $connection;
@@ -40,6 +42,17 @@ class AmqpTransport implements QueueReceiverInterface, TransportInterface, Setup
         return $this->getReceiver()->get();
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function pull(callable $callback): void
+    {
+        $this->getReceiver()->pull($callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getFromQueues(array $queueNames): iterable
     {
         return $this->getReceiver()->getFromQueues($queueNames);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
@@ -41,25 +41,16 @@ class AmqpTransport implements QueueReceiverInterface, QueueBlockingReceiverInte
         return $this->getReceiver()->get();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function pull(callable $callback): void
     {
         $this->getReceiver()->pull($callback);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function pullFromQueues(array $queueNames, callable $callback): void
     {
         $this->receiver->pullFromQueues($queueNames, $callback);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFromQueues(array $queueNames): iterable
     {
         return $this->getReceiver()->getFromQueues($queueNames);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
@@ -12,9 +12,8 @@
 namespace Symfony\Component\Messenger\Bridge\Amqp\Transport;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Exception\TransportException;
-use Symfony\Component\Messenger\Transport\Receiver\BlockingReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Receiver\QueueBlockingReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -24,7 +23,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class AmqpTransport implements QueueReceiverInterface, BlockingReceiverInterface, TransportInterface, SetupableTransportInterface, MessageCountAwareInterface
+class AmqpTransport implements QueueReceiverInterface, QueueBlockingReceiverInterface, TransportInterface, SetupableTransportInterface, MessageCountAwareInterface
 {
     private SerializerInterface $serializer;
     private Connection $connection;
@@ -48,6 +47,14 @@ class AmqpTransport implements QueueReceiverInterface, BlockingReceiverInterface
     public function pull(callable $callback): void
     {
         $this->getReceiver()->pull($callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pullFromQueues(array $queueNames, callable $callback): void
+    {
+        $this->receiver->pullFromQueues($queueNames, $callback);
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
@@ -48,7 +48,7 @@ class AmqpTransport implements QueueReceiverInterface, QueueBlockingReceiverInte
 
     public function pullFromQueues(array $queueNames, callable $callback): void
     {
-        $this->receiver->pullFromQueues($queueNames, $callback);
+        $this->getReceiver()->pullFromQueues($queueNames, $callback);
     }
 
     public function getFromQueues(array $queueNames): iterable

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -437,9 +437,9 @@ class Connection
      * Consume a message from the specified queue in blocking mode.
      *
      * @param ?callable(\AMQPEnvelope,\AMQPQueue):?false $callback If callback return false, then processing thread will be
-     * returned from AMQPQueue::consume() to PHP script. If null is passed, then the messages delivered to this client
-     * will be made available to the first real callback registered. That allows one to have a single callback
-     * consuming from multiple queues.
+     *                                                             returned from AMQPQueue::consume() to PHP script. If null is passed, then the messages delivered to this client
+     *                                                             will be made available to the first real callback registered. That allows one to have a single callback
+     *                                                             consuming from multiple queues.
      *
      * @throws \AMQPException
      */

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -433,6 +433,27 @@ class Connection
         return null;
     }
 
+    /**
+     * Consume a message from the specified queue in blocking mode.
+     *
+     * @param ?callable(\AMQPEnvelope,\AMQPQueue):?false $callback If callback return false, then processing thread will be
+     * returned from AMQPQueue::consume() to PHP script. If null is passed, then the messages delivered to this client
+     * will be made available to the first real callback registered. That allows one to have a single callback
+     * consuming from multiple queues.
+     *
+     * @throws \AMQPException
+     */
+    public function pull(string $queueName, ?callable $callback): void
+    {
+        $this->clearWhenDisconnected();
+
+        if ($this->autoSetupExchange) {
+            $this->setupExchangeAndQueues();
+        }
+
+        $this->queue($queueName)->consume($callback);
+    }
+
     public function ack(\AMQPEnvelope $message, string $queueName): bool
     {
         return $this->queue($queueName)->ack($message->getDeliveryTag());

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.3
 ---
 
+ * Add `--blocking-mode` option to `messenger:consume` (will use more efficient `consume` method instead of `get` method in amqp transport)
  * Add support for namespace wildcards in the HandlersLocator to allow routing multiple messages within the same namespace
  * Deprecate `Symfony\Component\Messenger\Transport\InMemoryTransport` and
    `Symfony\Component\Messenger\Transport\InMemoryTransportFactory` in favor of

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -33,7 +33,6 @@ use Symfony\Component\Messenger\EventListener\StopWorkerOnMemoryLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnTimeLimitListener;
 use Symfony\Component\Messenger\RoutableMessageBus;
-use Symfony\Component\Messenger\Transport\Receiver\BlockingReceiverInterface;
 use Symfony\Component\Messenger\Worker;
 
 /**

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -124,7 +124,6 @@ Use the --no-reset option to prevent services resetting after each message (may 
 
 Use the --blocking-mode option to force receiver to work in blocking mode
 ("consume" method will be used instead of "get" in RabbitMQ for example).
---queues option will be ignored.
 Only supported by some receivers, and you should pass only one receiver:
 
     <info>php %command.full_name% <receiver-name> --blocking-mode</info>

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -79,7 +79,7 @@ class ConsumeMessagesCommandTest extends TestCase
 
         $receiver = $this->createMock(QueueBlockingReceiverInterface::class);
         $receiver->expects($this->once())->method('pullFromQueues')->willReturnCallback(function (array $queueNames, callable $callback) use ($envelope) {
-            call_user_func($callback, $envelope);
+            \call_user_func($callback, $envelope);
         });
 
         $receiverLocator = $this->createMock(ContainerInterface::class);

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -106,7 +106,7 @@ class ConsumeMessagesCommandTest extends TestCase
         ]);
 
         $tester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Consuming messages from transport "dummy-receiver"', $tester->getDisplay());
     }
 
     public function testRunWithBusOption()

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Tests\ResettableDummyReceiver;
-use Symfony\Component\Messenger\Transport\Receiver\BlockingReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\QueueBlockingReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 class ConsumeMessagesCommandTest extends TestCase
@@ -77,8 +77,8 @@ class ConsumeMessagesCommandTest extends TestCase
     {
         $envelope = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
 
-        $receiver = $this->createMock(BlockingReceiverInterface::class);
-        $receiver->expects($this->once())->method('pull')->willReturnCallback(function (callable $callback) use ($envelope) {
+        $receiver = $this->createMock(QueueBlockingReceiverInterface::class);
+        $receiver->expects($this->once())->method('pullFromQueues')->willReturnCallback(function (array $queueNames, callable $callback) use ($envelope) {
             call_user_func($callback, $envelope);
         });
 
@@ -102,6 +102,7 @@ class ConsumeMessagesCommandTest extends TestCase
             'receivers' => ['dummy-receiver'],
             '--limit' => 1,
             '--blocking-mode' => true,
+            '--queues' => ['foo'],
         ]);
 
         $tester->assertCommandIsSuccessful();

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Tests\ResettableDummyReceiver;
+use Symfony\Component\Messenger\Transport\Receiver\BlockingReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 class ConsumeMessagesCommandTest extends TestCase
@@ -70,6 +71,41 @@ class ConsumeMessagesCommandTest extends TestCase
 
         $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('[OK] Consuming messages from transport "dummy-receiver"', $tester->getDisplay());
+    }
+
+    public function testRunWithBlockingModeOption()
+    {
+        $envelope = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
+
+        $receiver = $this->createMock(BlockingReceiverInterface::class);
+        $receiver->expects($this->once())->method('pull')->willReturnCallback(function (callable $callback) use ($envelope) {
+            call_user_func($callback, $envelope);
+        });
+
+        $receiverLocator = $this->createMock(ContainerInterface::class);
+        $receiverLocator->expects($this->once())->method('has')->with('dummy-receiver')->willReturn(true);
+        $receiverLocator->expects($this->once())->method('get')->with('dummy-receiver')->willReturn($receiver);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch');
+
+        $busLocator = $this->createMock(ContainerInterface::class);
+        $busLocator->expects($this->once())->method('has')->with('dummy-bus')->willReturn(true);
+        $busLocator->expects($this->once())->method('get')->with('dummy-bus')->willReturn($bus);
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
+
+        $application = new Application();
+        $application->add($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+        $tester->execute([
+            'receivers' => ['dummy-receiver'],
+            '--limit' => 1,
+            '--blocking-mode' => true,
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
     }
 
     public function testRunWithBusOption()

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -28,7 +28,6 @@ use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\Exception\RuntimeException;
-use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Handler\Acknowledger;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
 use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
@@ -694,7 +693,7 @@ class WorkerTest extends TestCase
         $worker = new Worker(['transport' => $receiver], $bus, $dispatcher);
         $worker->run([
             'blocking-mode' => true,
-            'queues' => ['foo']
+            'queues' => ['foo'],
         ]);
 
         $this->assertSame($apiMessage, $envelopes[0]->getMessage());
@@ -782,7 +781,7 @@ class BlockingDummyReceiver extends DummyReceiver implements BlockingReceiverInt
         foreach ($envelopes as $envelope) {
             $shouldContinue = $callback($envelope);
 
-            if ($shouldContinue === false) {
+            if (false === $shouldContinue) {
                 return;
             }
         }

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\Exception\RuntimeException;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Handler\Acknowledger;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
 use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
@@ -41,6 +42,7 @@ use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Receiver\BlockingReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Worker;
@@ -578,6 +580,79 @@ class WorkerTest extends TestCase
 
         $this->assertSame($expectedMessages, $handler->processedMessages);
     }
+
+    public function testBlockingMode()
+    {
+        $apiMessage = new DummyMessage('API');
+        $ipaMessage = new DummyMessage('IPA');
+
+        $receiver = new BlockingDummyReceiver([
+            [new Envelope($apiMessage), new Envelope($ipaMessage)],
+        ]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $envelopes = [];
+
+        $bus->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function ($envelope) use (&$envelopes) {
+                return $envelopes[] = $envelope;
+            });
+
+        $dispatcher = new class() implements EventDispatcherInterface {
+            private StopWorkerOnMessageLimitListener $listener;
+
+            public function __construct()
+            {
+                $this->listener = new StopWorkerOnMessageLimitListener(2);
+            }
+
+            public function dispatch(object $event): object
+            {
+                if ($event instanceof WorkerRunningEvent) {
+                    $this->listener->onWorkerRunning($event);
+                }
+
+                return $event;
+            }
+        };
+
+        $worker = new Worker(['transport' => $receiver], $bus, $dispatcher);
+        $worker->run(['blocking-mode' => true]);
+
+        $this->assertSame($apiMessage, $envelopes[0]->getMessage());
+        $this->assertSame($ipaMessage, $envelopes[1]->getMessage());
+        $this->assertCount(1, $envelopes[0]->all(ReceivedStamp::class));
+        $this->assertCount(1, $envelopes[0]->all(ConsumedByWorkerStamp::class));
+        $this->assertSame('transport', $envelopes[0]->last(ReceivedStamp::class)->getTransportName());
+
+        $this->assertSame(2, $receiver->getAcknowledgeCount());
+    }
+
+    public function testReceiverDoesNotSupportBlockingMode()
+    {
+        $receiver = $this->createMock(QueueReceiverInterface::class);
+
+        $bus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+
+        $worker = new Worker(['transport' => $receiver], $bus);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('Receiver for "transport" does not implement "%s".', BlockingReceiverInterface::class));
+        $worker->run(['blocking-mode' => true]);
+    }
+
+    public function testMoreThanOneReceiverInBlockingMode()
+    {
+        $receiver1 = $this->createMock(QueueReceiverInterface::class);
+        $receiver2 = $this->createMock(QueueReceiverInterface::class);
+
+        $bus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+
+        $worker = new Worker(['transport1' => $receiver1, 'transport2' => $receiver2], $bus);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('In blocking mode only one receiver is supported');
+        $worker->run(['blocking-mode' => true]);
+    }
 }
 
 class DummyReceiver implements ReceiverInterface
@@ -628,6 +703,22 @@ class DummyReceiver implements ReceiverInterface
     public function getAcknowledgedEnvelopes(): array
     {
         return $this->acknowledgedEnvelopes;
+    }
+}
+
+class BlockingDummyReceiver extends DummyReceiver implements BlockingReceiverInterface
+{
+    public function pull(callable $callback): void
+    {
+        $envelopes = $this->get();
+
+        foreach ($envelopes as $envelope) {
+            $shouldContinue = $callback($envelope);
+
+            if ($shouldContinue === false) {
+                return;
+            }
+        }
     }
 }
 

--- a/src/Symfony/Component/Messenger/Transport/Receiver/BlockingReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/BlockingReceiverInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Receiver;
+
+use Symfony\Component\Messenger\Exception\TransportException;
+
+/**
+ * @author Alexander Melikhov <amelihovv@ya.ru>
+ */
+interface BlockingReceiverInterface extends ReceiverInterface
+{
+    /**
+     * @param callable(\AMQPEnvelope):?false $callback If callback return false, then processing thread will be
+     * returned to PHP script.
+     *
+     * @throws TransportException If there is an issue communicating with the transport
+     */
+    public function pull(callable $callback): void;
+}

--- a/src/Symfony/Component/Messenger/Transport/Receiver/BlockingReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/BlockingReceiverInterface.php
@@ -19,8 +19,8 @@ use Symfony\Component\Messenger\Exception\TransportException;
 interface BlockingReceiverInterface extends ReceiverInterface
 {
     /**
-     * @param callable(\AMQPEnvelope):?false $callback if callback return false, then processing thread will be
-     *                                                 returned to PHP script
+     * @param callable(\Symfony\Component\Messenger\Envelope):?false $callback if callback return false, then processing thread will be
+     *                                                                         returned to PHP script
      *
      * @throws TransportException If there is an issue communicating with the transport
      */

--- a/src/Symfony/Component/Messenger/Transport/Receiver/BlockingReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/BlockingReceiverInterface.php
@@ -19,8 +19,8 @@ use Symfony\Component\Messenger\Exception\TransportException;
 interface BlockingReceiverInterface extends ReceiverInterface
 {
     /**
-     * @param callable(\AMQPEnvelope):?false $callback If callback return false, then processing thread will be
-     * returned to PHP script.
+     * @param callable(\AMQPEnvelope):?false $callback if callback return false, then processing thread will be
+     *                                                 returned to PHP script
      *
      * @throws TransportException If there is an issue communicating with the transport
      */

--- a/src/Symfony/Component/Messenger/Transport/Receiver/QueueBlockingReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/QueueBlockingReceiverInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Receiver;
+
+/**
+ * Some transports may have multiple queues. This interface is used to read from only some queues in blocking mode.
+ *
+ * @author Alexander Melikhov <amelihovv@ya.ru>
+ */
+interface QueueBlockingReceiverInterface extends BlockingReceiverInterface
+{
+    /**
+     * Pull messages from the specified queue names instead of consuming from all queues.
+     *
+     * @param string[] $queueNames
+     * @param callable(\AMQPEnvelope):?false $callback If callback return false, then processing thread will be
+     * returned to PHP script.
+     */
+    public function pullFromQueues(array $queueNames, callable $callback): void;
+}

--- a/src/Symfony/Component/Messenger/Transport/Receiver/QueueBlockingReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/QueueBlockingReceiverInterface.php
@@ -21,9 +21,9 @@ interface QueueBlockingReceiverInterface extends BlockingReceiverInterface
     /**
      * Pull messages from the specified queue names instead of consuming from all queues.
      *
-     * @param string[] $queueNames
-     * @param callable(\AMQPEnvelope):?false $callback If callback return false, then processing thread will be
-     * returned to PHP script.
+     * @param string[]                       $queueNames
+     * @param callable(\AMQPEnvelope):?false $callback   if callback return false, then processing thread will be
+     *                                                   returned to PHP script
      */
     public function pullFromQueues(array $queueNames, callable $callback): void;
 }

--- a/src/Symfony/Component/Messenger/Transport/Receiver/QueueBlockingReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/QueueBlockingReceiverInterface.php
@@ -22,8 +22,8 @@ interface QueueBlockingReceiverInterface extends BlockingReceiverInterface
      * Pull messages from the specified queue names instead of consuming from all queues.
      *
      * @param string[]                       $queueNames
-     * @param callable(\AMQPEnvelope):?false $callback   if callback return false, then processing thread will be
-     *                                                   returned to PHP script
+     * @param callable(\Symfony\Component\Messenger\Envelope):?false $callback   if callback return false, then processing thread will be
+     *                                                                           returned to PHP script
      */
     public function pullFromQueues(array $queueNames, callable $callback): void;
 }

--- a/src/Symfony/Component/Messenger/Transport/Receiver/QueueBlockingReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/QueueBlockingReceiverInterface.php
@@ -21,7 +21,7 @@ interface QueueBlockingReceiverInterface extends BlockingReceiverInterface
     /**
      * Pull messages from the specified queue names instead of consuming from all queues.
      *
-     * @param string[]                       $queueNames
+     * @param string[]                                               $queueNames
      * @param callable(\Symfony\Component\Messenger\Envelope):?false $callback   if callback return false, then processing thread will be
      *                                                                           returned to PHP script
      */

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -104,10 +104,8 @@ class Worker
                     if (!$receiver instanceof QueueBlockingReceiverInterface) {
                         throw new RuntimeException(sprintf('Receiver for "%s" does not implement "%s".', $transportName, QueueBlockingReceiverInterface::class));
                     }
-                } else {
-                    if (!$receiver instanceof QueueReceiverInterface) {
-                        throw new RuntimeException(sprintf('Receiver for "%s" does not implement "%s".', $transportName, QueueReceiverInterface::class));
-                    }
+                } elseif (!$receiver instanceof QueueReceiverInterface) {
+                    throw new RuntimeException(sprintf('Receiver for "%s" does not implement "%s".', $transportName, QueueReceiverInterface::class));
                 }
             }
         }
@@ -130,10 +128,10 @@ class Worker
                     };
 
                     if ($queueNames) {
-                        /* @var QueueBlockingReceiverInterface $receiver */
+                        /** @var QueueBlockingReceiverInterface $receiver */
                         $receiver->pullFromQueues($queueNames, $callback);
                     } else {
-                        /* @var BlockingReceiverInterface $receiver */
+                        /** @var BlockingReceiverInterface $receiver */
                         $receiver->pull($callback);
                     }
                 } else {

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -128,10 +128,10 @@ class Worker
                     };
 
                     if ($queueNames) {
-                        /** @var QueueBlockingReceiverInterface $receiver */
+                        \assert($receiver instanceof QueueBlockingReceiverInterface);
                         $receiver->pullFromQueues($queueNames, $callback);
                     } else {
-                        /** @var BlockingReceiverInterface $receiver */
+                        \assert($receiver instanceof BlockingReceiverInterface);
                         $receiver->pull($callback);
                     }
                 } else {

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -84,8 +84,8 @@ class Worker
         $this->metadata->set(['queueNames' => $queueNames]);
 
         if ($blockingMode) {
-            if (count($this->receivers) > 1) {
-                throw new RuntimeException('In blocking mode only one receiver is supported');
+            if (\count($this->receivers) > 1) {
+                throw new RuntimeException('In blocking mode only one receiver is supported.');
             }
 
             foreach ($this->receivers as $transportName => $receiver) {
@@ -130,10 +130,10 @@ class Worker
                     };
 
                     if ($queueNames) {
-                        /** @var QueueBlockingReceiverInterface $receiver */
+                        /* @var QueueBlockingReceiverInterface $receiver */
                         $receiver->pullFromQueues($queueNames, $callback);
                     } else {
-                        /** @var BlockingReceiverInterface $receiver */
+                        /* @var BlockingReceiverInterface $receiver */
                         $receiver->pull($callback);
                     }
                 } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #30259
| License       | MIT
| Doc PR        | It will be created later if this PR will be approved and merged

Introduced new mode for `messenger:consume` command. This mode is useful for RabbitMq, because more efficient method of fetching messages is used (`consume` instead of `get`).

https://www.rabbitmq.com/consumers.html#fetching

> Fetching messages one by one is highly discouraged as it is very inefficient compared to regular long-lived consumers. As with any polling-based algorithm, it will be extremely wasteful in systems where message publishing is sporadic and queues can stay empty for prolonged periods of time.

I know that current architecture of messenger component is not very suited for blocking connection, `--time-limit/--memory-limit` options and `messenger:stop-workers` will not work if there are no messages in queue. But I think that is ok, these options/command will take effect as soon as any message will be received.

My work is based on https://github.com/Cafeine42/amqp-messenger, in which a lot of code is duplicated and very difficult to maintain. I hope this PR will be merged and this functionality will be maintained by community and symfony team.
