### PR TITLE
[Messenger] Support for custom handler method containing a Union type tagged with #[AsMessageHandler]

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -231,7 +231,7 @@ class MessengerPass implements CompilerPassInterface
             }
 
             if ($types) {
-                return $types;
+                return ('__invoke' === $methodName) ? $types : array_fill_keys($types, $methodName);
             }
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandlerWithUnionTypes.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandlerWithUnionTypes.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class TaggedDummyHandlerWithUnionTypes
+{
+    public function __invoke(DummyMessage|SecondMessage $message)
+    {
+    }
+
+    #[AsMessageHandler]
+    public function handleUnionTypeMessage(UnionTypeOneMessage|UnionTypeTwoMessage $message)
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeOneMessage.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeOneMessage.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class UnionTypeOneMessage
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeTwoMessage.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeTwoMessage.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class UnionTypeTwoMessage
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #47206 
| License       | MIT
| Doc PR        | No

When Union Types were implemented for the #[AsMessageHandler] attribute, it wasn't designed with non `__invoke` methods in mind.

This fix detects if we are using `__invoke` or not and constructs the return to match the rest of the logic, mainly it allows for a `type => methodName` map if `__invoke` is not being used.
