### PR TITLE
[FrameworkBundle] execute tests with the full range of supported Messenger component releases

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -48,7 +48,7 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/lock": "^5.4|^6.0",
         "symfony/mailer": "^5.4|^6.0",
-        "symfony/messenger": "^6.1",
+        "symfony/messenger": "^5.4|^6.0",
         "symfony/mime": "^5.4|^6.0",
         "symfony/notifier": "^5.4|^6.0",
         "symfony/process": "^5.4|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The conflict rule does not exclude the 5.4 and 6.0 releases of the Messenger component. So we should make sure that we also run tests against these versions.