### PR TITLE
[FrameworkBundle] execute tests with the full range of supported Mailer component releases

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -47,7 +47,7 @@
         "symfony/html-sanitizer": "^6.1",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/lock": "^5.4|^6.0",
-        "symfony/mailer": "^6.2",
+        "symfony/mailer": "^5.4|^6.0",
         "symfony/messenger": "^6.1",
         "symfony/mime": "^5.4|^6.0",
         "symfony/notifier": "^5.4|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The conflict rule does not exclude the 5.4, 6.0 and 6.1 releases of the Mailer component. So we should make sure that we also run tests against these versions.