### PR TITLE
[HttpKernel] Fix passing `null` to `\trim()` method in LoggerDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -144,7 +144,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
 
         $allChannels = [];
         foreach ($this->getProcessedLogs() as $log) {
-            if ('' === trim($log['channel'])) {
+            if ('' === trim($log['channel'] ?? '')) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #47235
| License       | MIT
| Doc PR        | -

The full explanation of the bug context is described in the [reproducer](https://github.com/SVillette/SymfonyTrimDeprecationReproducer) repository

To be short, the fact of logging deprecations in dev environment and accessing the deprecations panel in the profiler triggered a PHP deprecation because the `\trim()` method was called with `null`.