### PR TITLE
Remove wrong PHPDoc

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -40,8 +40,6 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @throws AuthenticationCredentialsNotFoundException when the token storage has no authentication token and $exceptionOnNoToken is set to true
      */
     final public function isGranted(mixed $attribute, mixed $subject = null): bool
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes (just phpdoc removal)
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

From 6.0, isGranted doesn't throw anymore an exception when there is no token in the storage.
