### PR TITLE
[DoctrineBridge] Do not ignore null IDs in EntityValueResolver

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -74,7 +74,7 @@ final class EntityValueResolver implements ArgumentValueResolverInterface
             if (null === $object = $this->findViaExpression($class, $request, $options->expr, $options)) {
                 $errorMessage = sprintf('The expression "%s" returned null', $options->expr);
             }
-            // find by identifier?
+        // find by identifier?
         } elseif (false === $object = $this->find($class, $request, $options, $name)) {
             // find by criteria
             if (false === $object = $this->findOneBy($class, $request, $options)) {
@@ -123,7 +123,7 @@ final class EntityValueResolver implements ArgumentValueResolverInterface
 
         $id = $this->getIdentifier($request, $options, $name);
         if (false === $id || null === $id) {
-            return false;
+            return $id;
         }
 
         $objectManager = $this->getManager($options->objectManager, $class);

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\Doctrine\Tests\ArgumentResolver;
 
 use Doctrine\DBAL\Types\ConversionException;
@@ -214,6 +223,21 @@ class EntityValueResolverTest extends TestCase
         $this->assertYieldEquals([$object], $ret);
     }
 
+    public function testApplyWithNullId()
+    {
+        $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();
+        $converter = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('id', null);
+
+        $argument = $this->createArgument(isNullable: true);
+
+        $ret = $converter->resolve($request, $argument);
+
+        $this->assertYieldEquals([null], $ret);
+    }
+
     public function testApplyWithConversionFailedException()
     {
         $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();
@@ -276,7 +300,7 @@ class EntityValueResolverTest extends TestCase
         $converter = new EntityValueResolver($registry);
 
         $request = new Request();
-        $request->attributes->set('arg', null);
+        $request->attributes->set('guess', null);
 
         $argument = $this->createArgument('stdClass', new MapEntity(), 'arg', true);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47166
| License       | MIT
| Doc PR        | N/A

The `EntityValueResolver` first try to fetch an entity by its ID but handle null and non-existent IDs the same.

If a `null` ID is present, it feels weird to ignore it and try matching an entity using other request attributes. Better return `null` in this case.