### PR TITLE
Add context option to configure the indentation of nested nodes for `YamlEncoder`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Deprecate calling `AttributeMetadata::setSerializedName()`, `ClassMetadata::setClassDiscriminatorMapping()` without arguments
  * Change the signature of `AttributeMetadataInterface::setSerializedName()` to `setSerializedName(?string)`
  * Change the signature of `ClassMetadataInterface::setClassDiscriminatorMapping()` to `setClassDiscriminatorMapping(?ClassDiscriminatorMapping)`
+ * Add option YamlEncoder::YAML_INDENTATION to YamlEncoder constructor options to configure additional indentation for each level of nesting. This allows configuring indentation in the service configuration.
 
 6.1
 ---

--- a/src/Symfony/Component/Serializer/Context/Encoder/YamlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/YamlEncoderContextBuilder.php
@@ -18,6 +18,10 @@ use Symfony\Component\Serializer\Encoder\YamlEncoder;
 /**
  * A helper providing autocompletion for available YamlEncoder options.
  *
+ * Note that the "indentation" setting is not offered in this builder because
+ * it can only be set during the construction of the YamlEncoder, but not per
+ * call.
+ *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
 final class YamlEncoderContextBuilder implements ContextBuilderInterface

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -20,6 +20,9 @@ use Symfony\Component\Serializer\Exception\NotEncodableValueException;
  */
 class JsonEncode implements EncoderInterface
 {
+    /**
+     * Configure the JSON flags bitmask.
+     */
     public const OPTIONS = 'json_encode_options';
 
     private $defaultContext = [

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -28,7 +28,17 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
 
     public const PRESERVE_EMPTY_OBJECTS = 'preserve_empty_objects';
 
+    /**
+     * Override the amount of spaces to use for indentation of nested nodes.
+     *
+     * This option only works in the constructor, not in calls to `encode`.
+     */
+    public const YAML_INDENTATION = 'yaml_indentation';
+
     public const YAML_INLINE = 'yaml_inline';
+    /**
+     * Initial indentation for root element.
+     */
     public const YAML_INDENT = 'yaml_indent';
     public const YAML_FLAGS = 'yaml_flags';
 
@@ -46,8 +56,12 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
             throw new RuntimeException('The YamlEncoder class requires the "Yaml" component. Install "symfony/yaml" to use it.');
         }
 
-        $this->dumper = $dumper ?? new Dumper();
+        if (!$dumper) {
+            $dumper = \array_key_exists(self::YAML_INDENTATION, $defaultContext) ? new Dumper($defaultContext[self::YAML_INDENTATION]) : new Dumper();
+        }
+        $this->dumper = $dumper;
         $this->parser = $parser ?? new Parser();
+        unset($defaultContext[self::YAML_INDENTATION]);
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Encoder\YamlEncoder;
-use Symfony\Component\Yaml\Dumper;
-use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -58,9 +56,20 @@ class YamlEncoderTest extends TestCase
         $this->assertFalse($encoder->supportsDecoding('json'));
     }
 
+    public function testIndentation()
+    {
+        $encoder = new YamlEncoder(null, null, [YamlEncoder::YAML_INLINE => 100, YamlEncoder::YAML_INDENTATION => 7]);
+
+        $expected = <<<'END'
+foo:
+       bar: baz
+END;
+        $this->assertSame($expected."\n", $encoder->encode(['foo' => ['bar' => 'baz']], 'yaml'));
+    }
+
     public function testContext()
     {
-        $encoder = new YamlEncoder(new Dumper(), new Parser(), [YamlEncoder::YAML_INLINE => 1, YamlEncoder::YAML_INDENT => 4, YamlEncoder::YAML_FLAGS => Yaml::DUMP_OBJECT | Yaml::PARSE_OBJECT]);
+        $encoder = new YamlEncoder(null, null, [YamlEncoder::YAML_INLINE => 1, YamlEncoder::YAML_INDENT => 4, YamlEncoder::YAML_FLAGS => Yaml::DUMP_OBJECT | Yaml::PARSE_OBJECT]);
 
         $obj = new \stdClass();
         $obj->bar = 2;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Allow to configure the amount of spaces for indentation in Yaml Dumper.