### PR TITLE
Adding class with `type` constants

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Type.php
+++ b/src/Symfony/Component/Routing/Loader/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader;
+
+abstract class Type
+{
+    public const ANNOTATION = 'annotation';
+    public const XML = 'xml';
+    public const YAML = 'yaml';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Just an idea: Create a new class with `const`s for all loader `$types`, so that e.g. https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Routing/Loader/YamlFileLoader.php#L113 can be changed to:
```php
|| Type::YAML === $type);
```
And then also in configuration (code sample at https://symfony.com/doc/current/routing.html#route-groups-and-prefixes):
```php
$routes->import('../../src/Controller/', Type::ANNOTATION);
```