### PR TITLE
[PhpUnitBridge] Use triggering class to generate baseline for deprecation messages from DebugClassLoader

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -200,7 +200,9 @@ class Configuration
             return false;
         }
 
-        if ($deprecation->originatesFromAnObject()) {
+        if ($deprecation->originatesFromDebugClassLoader()) {
+            $location = $deprecation->triggeringClass();
+        } elseif ($deprecation->originatesFromAnObject()) {
             $location = $deprecation->originatingClass().'::'.$deprecation->originatingMethod();
         } else {
             $location = 'procedural code';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #45943
| License       | MIT
| Doc PR        | N/A

Fixes #45943 by using the triggering class to generate the baseline for messages from `DebugClassLoader`. 

This would break currently generated baselines, but as #45943 describes, those are broken already when running tests in another order, or when running a sub-/superset of tests.

I'll finish this PR by adding/updating tests if this approach is acceptable.