### PR TITLE
[ProgressBar] Empty iterable throws Exception on "maximum number of steps is not set"

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -51,6 +51,7 @@ final class ProgressBar
     private int $step = 0;
     private int $startingStep = 0;
     private int $max = 0;
+    private bool $isMaxKnown = false;
     private int $startTime;
     private int $stepWidth;
     private float $percent = 0.0;
@@ -289,6 +290,8 @@ final class ProgressBar
      */
     public function iterate(iterable $iterable, int $max = null): iterable
     {
+        $this->isMaxKnown = is_countable($iterable);
+
         $this->start($max ?? (is_countable($iterable) ? \count($iterable) : 0));
 
         foreach ($iterable as $key => $value) {
@@ -377,6 +380,7 @@ final class ProgressBar
         $this->format = null;
         $this->max = max(0, $max);
         $this->stepWidth = $this->max ? Helper::width((string) $this->max) : 4;
+        $this->isMaxKnown = $this->isMaxKnown || 0 < $this->max;
     }
 
     /**
@@ -519,14 +523,14 @@ final class ProgressBar
                 return Helper::formatTime(time() - $bar->getStartTime());
             },
             'remaining' => function (self $bar) {
-                if (!isset($bar->max)) {
+                if (!$bar->isMaxKnown && !$bar->getMaxSteps()) {
                     throw new LogicException('Unable to display the remaining time if the maximum number of steps is not set.');
                 }
 
                 return Helper::formatTime($bar->getRemaining());
             },
             'estimated' => function (self $bar) {
-                if (!isset($bar->max)) {
+                if (!$bar->isMaxKnown && !$bar->getMaxSteps()) {
                     throw new LogicException('Unable to display the estimated time if the maximum number of steps is not set.');
                 }
 

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -196,7 +196,7 @@ final class ProgressBar
 
     public function getBarOffset(): float
     {
-        return floor($this->max ? $this->percent * $this->barWidth : (null === $this->redrawFreq ? (int) (min(5, $this->barWidth / 15) * $this->writeCount) : $this->step) % $this->barWidth);
+        return floor($this->isMaxKnown || $this->max ? $this->percent * $this->barWidth : (null === $this->redrawFreq ? (int) (min(5, $this->barWidth / 15) * $this->writeCount) : $this->step) % $this->barWidth);
     }
 
     public function getEstimated(): float
@@ -234,7 +234,7 @@ final class ProgressBar
 
     public function getBarCharacter(): string
     {
-        return $this->barChar ?? ($this->max ? '=' : $this->emptyBarChar);
+        return $this->barChar ?? ($this->isMaxKnown || $this->max ? '=' : $this->emptyBarChar);
     }
 
     public function setEmptyBarCharacter(string $char)
@@ -355,6 +355,8 @@ final class ProgressBar
         $currPeriod = (int) ($step / $redrawFreq);
         $this->step = $step;
         $this->percent = $this->max ? (float) $this->step / $this->max : 0;
+        if ($this->isMaxKnown && 0 == $this->max)
+            $this->percent = 1.0;
         $timeInterval = microtime(true) - $this->lastWriteTime;
 
         // Draw regardless of other limits

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -50,7 +50,7 @@ final class ProgressBar
     private OutputInterface $output;
     private int $step = 0;
     private int $startingStep = 0;
-    private ?int $max = null;
+    private int $max = 0;
     private int $startTime;
     private int $stepWidth;
     private float $percent = 0.0;

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -519,14 +519,14 @@ final class ProgressBar
                 return Helper::formatTime(time() - $bar->getStartTime());
             },
             'remaining' => function (self $bar) {
-                if (!$bar->getMaxSteps()) {
+                if (!isset($bar->max)) {
                     throw new LogicException('Unable to display the remaining time if the maximum number of steps is not set.');
                 }
 
                 return Helper::formatTime($bar->getRemaining());
             },
             'estimated' => function (self $bar) {
-                if (!$bar->getMaxSteps()) {
+                if (!isset($bar->max)) {
                     throw new LogicException('Unable to display the estimated time if the maximum number of steps is not set.');
                 }
 

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -209,7 +209,7 @@ final class ProgressBar
 
     public function getRemaining(): float
     {
-        if (!$this->step) {
+        if (!$this->step || $this->step === $this->startingStep) {
             return 0;
         }
 

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -311,6 +311,8 @@ final class ProgressBar
      */
     public function start(int $max = null, int $startAt = 0): void
     {
+        $this->isMaxKnown = !is_null($max);
+
         $this->startTime = time();
         $this->step = $startAt;
         $this->startingStep = $startAt;

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -1035,6 +1036,23 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
             $this->generateOutput('    2 [============================]'),
             stream_get_contents($output->getStream())
         );
+    }
+
+    public function testEmptyInputWithDebugFormat()
+    {
+        try {
+            $bar = new ProgressBar($output = $this->getOutputStream());
+            $bar->setFormat("%elapsed%/%estimated%");
+
+            $input = [];
+            foreach ($bar->iterate($input) as $item)
+                var_dump($item);
+
+            // succeed the test if we reach this code (no exception happened)
+            $this->assertTrue(true);
+        } catch(Exception $e) {
+            $this->fail();
+        }
     }
 
     protected function getOutputStream($decorated = true, $verbosity = StreamOutput::VERBOSITY_NORMAL)

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -1042,15 +1042,21 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
     {
         try {
             $bar = new ProgressBar($output = $this->getOutputStream());
-            $bar->setFormat("%elapsed%/%estimated%");
+            $bar->setFormat('%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%');
 
             $input = [];
-            foreach ($bar->iterate($input) as $item)
+            foreach ($bar->iterate($input) as $item) {
                 var_dump($item);
+            }
 
             // succeed the test if we reach this code (no exception happened)
-            $this->assertTrue(true);
-        } catch(Exception $e) {
+            rewind($output->getStream());
+            $this->assertEquals(
+                '   0/0 [>---------------------------]   0% < 1 sec/< 1 sec' .
+                $this->generateOutput('   0/0 [============================] 100% < 1 sec/< 1 sec'),
+                stream_get_contents($output->getStream())
+            );
+        } catch (Exception $e) {
             $this->fail();
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #47244 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

**Bug Description**
When using the progress bar with an empty input and time estimates, an error has been thrown which stopped the execution:

```
            $bar = new ProgressBar($output = $this->getOutputStream());
            $bar->setFormat("%elapsed%/%estimated%");

            $input = [];
            foreach ($bar->iterate($input) as $item)
                var_dump($item);
```

I dug around in the code and found a semantically incorrect check for `getMaxSteps()` that evaluated a maxSteps of 0 (because of an empty input) to be interpreted like maxSteps has not been set at all und thus, triggering

```
                if (!$bar->getMaxSteps())) {
                    throw new LogicException('Unable to display the .* time if the maximum number of steps is not set.');
                }
```

**Fix Proposal**

I propose to change the check to be semantically correct as in "0 is a valid value of maxSteps, null is not".

More details and a bit of discussion in #47244.

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
