### PR TITLE
[String] Add tests for AsciiSlugger

### DIFF
--- a/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
+++ b/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\String;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+class AsciiSluggerTest extends TestCase
+{
+    public function provideSlugTests(): iterable
+    {
+        yield ['', ''];
+        yield ['foo', ' foo '];
+        yield ['foo-bar', 'foo bar'];
+
+        yield ['foo-bar', 'foo@bar', '-'];
+        yield ['foo-at-bar', 'foo@bar', '-', 'en'];
+
+        yield ['e-a', 'é$!à'];
+        yield ['e_a', 'é$!à', '_'];
+
+        yield ['a', 'ä'];
+        yield ['a', 'ä', '-', 'fr'];
+        yield ['ae', 'ä', '-', 'de'];
+        yield ['ae', 'ä', '-', 'de_fr']; // Ensure we get the parent locale
+        yield ['g', 'ғ', '-'];
+        yield ['gh', 'ғ', '-', 'uz'];
+        yield ['gh', 'ғ', '-', 'uz_fr']; // Ensure we get the parent locale
+    }
+
+    /** @dataProvider provideSlugTests */
+    public function testSlug(string $expected, string $string, string $separator = '-', string $locale = null)
+    {
+        $slugger = new AsciiSlugger();
+
+        $this->assertSame($expected, (string) $slugger->slug($string, $separator, $locale));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

I'm gonna add some code to the slugger, but tests are missing!
The class does not exist on 4.4, so I used 5.4

If it's OK, a quick merge + merge 5.4 in 6.x would be wonderful :)
