### PR TITLE
[String] Add support for emoji in AsciiSlugger

### DIFF
--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+  * Add support for emoji in `AsciiSlugger`
+
 5.4
 ---
 

--- a/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
+++ b/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
@@ -16,6 +16,16 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
 
 class AsciiSluggerTest extends TestCase
 {
+    /**
+     * @dataProvider provideSlugTests
+     */
+    public function testSlug(string $expected, string $string, string $separator = '-', string $locale = null)
+    {
+        $slugger = new AsciiSlugger();
+
+        $this->assertSame($expected, (string) $slugger->slug($string, $separator, $locale));
+    }
+
     public function provideSlugTests(): iterable
     {
         yield ['', ''];
@@ -37,11 +47,52 @@ class AsciiSluggerTest extends TestCase
         yield [\function_exists('transliterator_transliterate') ? 'gh' : '', 'ғ', '-', 'uz_fr']; // Ensure we get the parent locale
     }
 
-    /** @dataProvider provideSlugTests */
-    public function testSlug(string $expected, string $string, string $separator = '-', string $locale = null)
+    /**
+     * @dataProvider provideSlugEmojiTests
+     * @requires extension intl
+     */
+    public function testSlugEmoji(string $expected, string $string, ?string $locale, string|bool $emoji = true)
     {
         $slugger = new AsciiSlugger();
+        $slugger = $slugger->withEmoji($emoji);
 
-        $this->assertSame($expected, (string) $slugger->slug($string, $separator, $locale));
+        $this->assertSame($expected, (string) $slugger->slug($string, '-', $locale));
+    }
+
+    public function provideSlugEmojiTests(): iterable
+    {
+        yield [
+            'un-chat-qui-sourit-chat-noir-et-un-tete-de-lion-vont-au-parc-national',
+            'un 😺, 🐈‍⬛, et un 🦁 vont au 🏞️',
+            'fr',
+        ];
+        yield [
+            'a-grinning-cat-black-cat-and-a-lion-go-to-national-park-smiling-face-with-heart-eyes-party-popper-yellow-heart',
+            'a 😺, 🐈‍⬛, and a 🦁 go to 🏞️... 😍 🎉 💛',
+            'en',
+        ];
+        yield [
+            'a-and-a-go-to',
+            'a 😺, 🐈‍⬛, and a 🦁 go to 🏞️... 😍 🎉 💛',
+            null,
+        ];
+        yield [
+            'a-smiley-cat-black-cat-and-a-lion-face-go-to-national-park-heart-eyes-tada-yellow-heart',
+            'a 😺, 🐈‍⬛, and a 🦁 go to 🏞️... 😍 🎉 💛',
+            null,
+            'slack',
+        ];
+        yield [
+            'a-smiley-cat-black-cat-and-a-lion-go-to-national-park-heart-eyes-tada-yellow-heart',
+            'a 😺, 🐈‍⬛, and a 🦁 go to 🏞️... 😍 🎉 💛',
+            null,
+            'github',
+        ];
+        yield [
+            'a-smiley-cat-black-cat-and-a-lion-go-to-national-park-heart-eyes-tada-yellow-heart',
+            'a 😺, 🐈‍⬛, and a 🦁 go to 🏞️... 😍 🎉 💛',
+            'en',
+            'github',
+        ];
     }
 }

--- a/src/Symfony/Component/String/composer.json
+++ b/src/Symfony/Component/String/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "symfony/error-handler": "^5.4|^6.0",
+        "symfony/intl": "^6.2",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/translation-contracts": "^2.0|^3.0",
         "symfony/var-exporter": "^5.4|^6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

Usage

```php
use Symfony\Component\String\Slugger\AsciiSlugger;

$slugger = new AsciiSlugger();
$slugger = $slugger->withEmoji();

$slugger->slug('a 😺, 🐈‍⬛, and a 🦁 go to 🏞️... 😍 🎉 💛', '-', 'en');
// a-grinning-cat-black-cat-and-a-lion-go-to-national-park-smiling-face-with-heart-eyes-party-popper-yellow-heart

$slugger->slug('un 😺, 🐈‍⬛, et un 🦁 vont au 🏞️');
// un-chat-qui-sourit-chat-noir-et-un-tete-de-lion-vont-au-parc-national
```
