### PR TITLE
[String] fix AsciiSlugger tests if transliterator_transliterate() isn't present

### DIFF
--- a/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
+++ b/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
@@ -32,9 +32,9 @@ class AsciiSluggerTest extends TestCase
         yield ['a', 'ä', '-', 'fr'];
         yield ['ae', 'ä', '-', 'de'];
         yield ['ae', 'ä', '-', 'de_fr']; // Ensure we get the parent locale
-        yield ['g', 'ғ', '-'];
-        yield ['gh', 'ғ', '-', 'uz'];
-        yield ['gh', 'ғ', '-', 'uz_fr']; // Ensure we get the parent locale
+        yield [\function_exists('transliterator_transliterate') ? 'g' : '', 'ғ', '-'];
+        yield [\function_exists('transliterator_transliterate') ? 'gh' : '', 'ғ', '-', 'uz'];
+        yield [\function_exists('transliterator_transliterate') ? 'gh' : '', 'ғ', '-', 'uz_fr']; // Ensure we get the parent locale
     }
 
     /** @dataProvider provideSlugTests */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 