### PR TITLE
[HttpFoundation] Do not send Set-Cookie header twice for deleted session cookie

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/deleted_cookie.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/deleted_cookie.expected
@@ -1,0 +1,11 @@
+
+Array
+(
+    [0] => Content-Type: text/plain; charset=utf-8
+    [1] => Cache-Control: max-age=0, private, must-revalidate
+    [2] => Cache-Control: max-age=0, must-revalidate, private
+    [3] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [4] => Expires: %s, %d %s %d %d:%d:%d GMT
+    [5] => Set-Cookie: PHPSESSID=deleted; expires=%s, %d-%s-%d %d:%d:%d GMT; Max-Age=%d; %s
+)
+shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/deleted_cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/deleted_cookie.php
@@ -1,0 +1,60 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionFactory;
+use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorageFactory;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\SessionListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/** @var Response $r */
+$r = require __DIR__.'/common.inc';
+
+$sessionId = 'vqd4dpbtst3af0k4sdl18nebkn';
+session_id($sessionId);
+$sessionName = session_name();
+$_COOKIE[$sessionName] = $sessionId;
+
+$request = new Request();
+$request->cookies->set($sessionName, $sessionId);
+
+$requestStack = new RequestStack();
+$requestStack->push($request);
+
+$sessionFactory = new SessionFactory($requestStack, new NativeSessionStorageFactory());
+
+$container = new Container();
+$container->set('request_stack', $requestStack);
+$container->set('session_factory', $sessionFactory);
+
+$listener = new SessionListener($container);
+
+$kernel = new class($r) implements HttpKernelInterface {
+    /**
+     * @var Response
+     */
+    private $response;
+
+    public function __construct(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
+    {
+        return $this->response;
+    }
+};
+
+$listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
+$session = $request->getSession();
+$session->set('foo', 'bar');
+$session->invalidate();
+
+$listener->onKernelResponse(new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $r));
+
+$r->sendHeaders();

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -24,6 +24,8 @@
     "require-dev": {
         "predis/predis": "~1.0",
         "symfony/cache": "^4.4|^5.0|^6.0",
+        "symfony/dependency-injection": "^5.4|^6.0",
+        "symfony/http-kernel": "^5.4.12|^6.1.4",
         "symfony/mime": "^4.4|^5.0|^6.0",
         "symfony/expression-language": "^4.4|^5.0|^6.0"
     },

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -158,6 +158,11 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
 
                 $isSessionEmpty = $session->isEmpty() && empty($_SESSION); // checking $_SESSION to keep compatibility with native sessions
                 if ($requestSessionCookieId && $isSessionEmpty) {
+                    // PHP internally sets the session cookie value to "deleted" when setcookie() is called with empty string $value argument
+                    // which happens in \Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler::destroy
+                    // when the session gets invalidated (for example on logout) so we must handle this case here too
+                    // otherwise we would send two Set-Cookie headers back with the response
+                    SessionUtils::popSessionCookie($sessionName, 'deleted');
                     $response->headers->clearCookie(
                         $sessionName,
                         $sessionCookiePath,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47228
| License       | MIT
| Doc PR        | -

In a user logout flow `\Symfony\Component\Security\Http\EventListener\SessionLogoutListener` gets triggered which invalidates the user session by calling `session_regenerate_id(true)` which calls `\Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler::destroy` which calls `setcookie($this->sessionName, '', $params);`. Calling `setcookie` with the second argument (the value) being an empty string signals to PHP that we want to send a `Set-Cookie` HTTP header to the client so that the client deletes the cookie (aka the expiry time of the cookie gets set to some time in the past) and PHP also sets the value of that cookie to `deleted` -> https://github.com/php/php-src/blob/php-8.1.9/ext/standard/head.c#L124

The `\Symfony\Component\HttpKernel\EventListener\AbstractSessionListener` class did not handle this case as `\Symfony\Component\HttpKernel\EventListener\AbstractSessionListener::onKernelResponse` method would call `$response->headers->clearCookie()` without calling the `popSessionCookie` method which would then add this same cookie again which would then result in two `Set-Cookie` headers being sent to the client for the same cookie.