### PR TITLE
[HttpFoundation] prevent incomplete profile dumps

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -170,13 +170,14 @@ class FileProfilerStorage implements ProfilerStorageInterface
         ];
 
         $context = stream_context_create();
+        $wrapper = '';
 
         if (\function_exists('gzcompress')) {
-            $file = 'compress.zlib://'.$file;
+            $wrapper = 'compress.zlib://';
             stream_context_set_option($context, 'zlib', 'level', 3);
         }
 
-        if (false === file_put_contents($file, serialize($data), 0, $context)) {
+        if (false === file_put_contents($wrapper.$file.'.tmp', serialize($data), 0, $context) || false === rename($file.'.tmp', $file)) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47280
| License       | MIT

Write profile dump into tempfile and rename it after it is completely written to prevent loading incomplete profile dumps.