### PR TITLE
[HttpFoundation] Prevent accepted rate limits with no remaining token to be preferred over denied ones

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -35,9 +35,7 @@ abstract class AbstractRequestRateLimiter implements RequestRateLimiterInterface
         foreach ($limiters as $limiter) {
             $rateLimit = $limiter->consume(1);
 
-            if (null === $minimalRateLimit || $rateLimit->getRemainingTokens() < $minimalRateLimit->getRemainingTokens()) {
-                $minimalRateLimit = $rateLimit;
-            }
+            $minimalRateLimit = $minimalRateLimit ? self::getMinimalRateLimit($minimalRateLimit, $rateLimit) : $rateLimit;
         }
 
         return $minimalRateLimit;
@@ -54,4 +52,20 @@ abstract class AbstractRequestRateLimiter implements RequestRateLimiterInterface
      * @return LimiterInterface[] a set of limiters using keys extracted from the request
      */
     abstract protected function getLimiters(Request $request): array;
+
+    private static function getMinimalRateLimit(RateLimit $first, RateLimit $second): RateLimit
+    {
+        if ($first->isAccepted() !== $second->isAccepted()) {
+            return $first->isAccepted() ? $second : $first;
+        }
+
+        $firstRemainingTokens = $first->getRemainingTokens();
+        $secondRemainingTokens = $second->getRemainingTokens();
+
+        if ($firstRemainingTokens === $secondRemainingTokens) {
+            return $first->getRetryAfter() < $second->getRetryAfter() ? $second : $first;
+        }
+
+        return $firstRemainingTokens > $secondRemainingTokens ? $second : $first;
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RateLimiter/AbstractRequestRateLimiterTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RateLimiter/AbstractRequestRateLimiterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RateLimiter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+
+class AbstractRequestRateLimiterTest extends TestCase
+{
+    /**
+     * @dataProvider provideRateLimits
+     */
+    public function testConsume(array $rateLimits, ?RateLimit $expected)
+    {
+        $rateLimiter = new MockAbstractRequestRateLimiter(array_map(function (RateLimit $rateLimit) {
+            $limiter = $this->createStub(LimiterInterface::class);
+            $limiter->method('consume')->willReturn($rateLimit);
+
+            return $limiter;
+        }, $rateLimits));
+
+        $this->assertSame($expected, $rateLimiter->consume(new Request()));
+    }
+
+    public function provideRateLimits()
+    {
+        $now = new \DateTimeImmutable();
+
+        yield 'Both accepted with different count of remaining tokens' => [
+            [
+                $expected = new RateLimit(0, $now, true, 1), // less remaining tokens
+                new RateLimit(1, $now, true, 1),
+            ],
+            $expected,
+        ];
+
+        yield 'Both accepted with same count of remaining tokens' => [
+            [
+                $expected = new RateLimit(0, $now->add(new \DateInterval('P1D')), true, 1), // longest wait time
+                new RateLimit(0, $now, true, 1),
+            ],
+            $expected,
+        ];
+
+        yield 'Accepted and denied' => [
+            [
+                new RateLimit(0, $now, true, 1),
+                $expected = new RateLimit(0, $now, false, 1), // denied
+            ],
+            $expected,
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RateLimiter/MockAbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RateLimiter/MockAbstractRequestRateLimiter.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RateLimiter;
+
+use Symfony\Component\HttpFoundation\RateLimiter\AbstractRequestRateLimiter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\LimiterInterface;
+
+class MockAbstractRequestRateLimiter extends AbstractRequestRateLimiter
+{
+    /**
+     * @var LimiterInterface[]
+     */
+    private $limiters;
+
+    public function __construct(array $limiters)
+    {
+        $this->limiters = $limiters;
+    }
+
+    protected function getLimiters(Request $request): array
+    {
+        return $this->limiters;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -27,7 +27,8 @@
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4",
         "symfony/mime": "^4.4|^5.0|^6.0",
-        "symfony/expression-language": "^4.4|^5.0|^6.0"
+        "symfony/expression-language": "^4.4|^5.0|^6.0",
+        "symfony/rate-limiter": "^5.2|^6.0"
     },
     "suggest" : {
         "symfony/mime": "To use the file extension guesser"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47282
| License       | MIT
| Doc PR        | N/A

When a rate limit is first accepted with no remaining token, following rejected rate limits will be ignored because they also will have no remaining token. The request would then be processed.