### PR TITLE
[Config] Deprecate ArrayNodeDefinition::ignoreExtraKeys in favor of s etIgnoreExtraKeys and setRemoveExtraKeys

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 6.2 to 6.3
 =======================
 
+Config
+------
+
+* Deprecate `ArrayNodeDefinition::ignoreExtraKeys()`, use `ArrayNodeDefinition::setIgnoreExtraKeys(true)` and `ArrayNodeDefinition::setRemoveExtraKeys()` instead
+
 Console
 -------
 

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow enum values in `EnumNode`
+ * Deprecate `ArrayNodeDefinition::ignoreExtraKeys()`, use `ArrayNodeDefinition::setIgnoreExtraKeys(true)` and `ArrayNodeDefinition::setRemoveExtraKeys()` instead
 
 6.2
 ---

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -308,11 +308,35 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
      * @param bool $remove Whether to remove the extra keys
      *
      * @return $this
+     *
+     * @deprecated since Symfony 6.3, use setIgnoreExtraKeys(true) and setIgnoreExtraKeys() instead
      */
     public function ignoreExtraKeys(bool $remove = true): static
     {
-        $this->ignoreExtraKeys = true;
-        $this->removeExtraKeys = $remove;
+        trigger_deprecation('symfony/config', '6.3', 'The "%s()" method is deprecated, use "setIgnoreExtraKeys(true)" and "setIgnoreExtraKeys()" instead.', __METHOD__);
+
+        $this->setIgnoreExtraKeys(true);
+        $this->setRemoveExtraKeys($remove);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setIgnoreExtraKeys(bool $ignoreExtraKeys): static
+    {
+        $this->ignoreExtraKeys = $ignoreExtraKeys;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setRemoveExtraKeys(bool $removeExtraKeys): static
+    {
+        $this->removeExtraKeys = $removeExtraKeys;
 
         return $this;
     }

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.php
@@ -23,7 +23,8 @@ class ArrayExtraKeys implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('foo')
-                    ->ignoreExtraKeys(false)
+                    ->setIgnoreExtraKeys(true)
+                    ->setRemoveExtraKeys(false)
                     ->children()
                         ->scalarNode('baz')->end()
                         ->scalarNode('qux')->end()
@@ -31,7 +32,8 @@ class ArrayExtraKeys implements ConfigurationInterface
                 ->end()
                 ->arrayNode('bar')
                     ->prototype('array')
-                        ->ignoreExtraKeys(false)
+                        ->setIgnoreExtraKeys(true)
+                        ->setRemoveExtraKeys(false)
                         ->children()
                             ->scalarNode('corge')->end()
                             ->scalarNode('grault')->end()
@@ -39,7 +41,8 @@ class ArrayExtraKeys implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('baz')
-                    ->ignoreExtraKeys(false)
+                    ->setIgnoreExtraKeys(true)
+                    ->setRemoveExtraKeys(false)
                 ->end()
             ;
 

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
@@ -23,6 +24,8 @@ use Symfony\Component\Config\Definition\PrototypedArrayNode;
 
 class ArrayNodeDefinitionTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testAppendingSomeNode()
     {
         $parent = new ArrayNodeDefinition('root');
@@ -208,16 +211,45 @@ class ArrayNodeDefinitionTest extends TestCase
         $this->assertTrue($this->getField($enabledNode, 'defaultValue'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testIgnoreExtraKeys()
     {
         $node = new ArrayNodeDefinition('root');
 
         $this->assertFalse($this->getField($node, 'ignoreExtraKeys'));
 
+        $this->expectDeprecation('Since symfony/config 6.3: The "Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::ignoreExtraKeys()" method is deprecated, use "setIgnoreExtraKeys(true)" and "setIgnoreExtraKeys()" instead.');
+
         $result = $node->ignoreExtraKeys();
 
         $this->assertEquals($node, $result);
         $this->assertTrue($this->getField($node, 'ignoreExtraKeys'));
+    }
+
+    public function testSetIgnoreExtraKeys()
+    {
+        $node = new ArrayNodeDefinition('root');
+
+        $this->assertFalse($this->getField($node, 'ignoreExtraKeys'));
+
+        $result = $node->setIgnoreExtraKeys(true);
+
+        $this->assertEquals($node, $result);
+        $this->assertTrue($this->getField($node, 'ignoreExtraKeys'));
+    }
+
+    public function testSetRemoveExtraKeys()
+    {
+        $node = new ArrayNodeDefinition('root');
+
+        $this->assertTrue($this->getField($node, 'removeExtraKeys'));
+
+        $result = $node->setRemoveExtraKeys(false);
+
+        $this->assertEquals($node, $result);
+        $this->assertFalse($this->getField($node, 'removeExtraKeys'));
     }
 
     public function testNormalizeKeys()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #33590
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

`ArrayNodeDefinition::ignoreExtraKeys($bool)` is ambiguous, it control `ArrayNode::ignoreExtraKeys` and `ArrayNode::removeExtraKeys` at the same time.

Introduce unambiguous methods and deprecate `ignoreExtraKeys`

(It's seems better than create human helper constant)

(Unrelated fabbot failure)