### PR TITLE
[Cache] make `Redis*Proxy` extend `Redis*`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,8 +18,8 @@ install:
     - cd ext
     - appveyor DownloadFile https://github.com/symfony/binary-utils/releases/download/v0.1/php_apcu-5.1.21-8.1-ts-vs16-x86.zip
     - 7z x php_apcu-5.1.21-8.1-ts-vs16-x86.zip -y >nul
-    - appveyor DownloadFile https://github.com/symfony/binary-utils/releases/download/v0.1/php_redis-5.3.7rc1-8.1-ts-vs16-x86.zip
-    - 7z x php_redis-5.3.7rc1-8.1-ts-vs16-x86.zip -y >nul
+    - appveyor DownloadFile https://github.com/symfony/binary-utils/releases/download/v0.1/php_redis-5.3.7-8.1-ts-vs16-x86.zip
+    - 7z x php_redis-5.3.7-8.1-ts-vs16-x86.zip -y >nul
     - cd ..
     - copy /Y php.ini-development php.ini-min
     - echo memory_limit=-1 >> php.ini-min

--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -12,8 +12,15 @@ $loader = require __DIR__.'/../vendor/autoload.php';
 Symfony\Component\ErrorHandler\DebugClassLoader::enable();
 
 foreach ($loader->getClassMap() as $class => $file) {
+    $file = realpath($file);
+
     switch (true) {
-        case false !== strpos($file = realpath($file), '/vendor/'):
+        case false !== strpos($file, '/src/Symfony/Component/Cache/Traits/Redis'):
+            if (!str_ends_with($file, 'Proxy.php')) {
+                break;
+            }
+            // no break;
+        case false !== strpos($file, '/vendor/'):
         case false !== strpos($file, '/src/Symfony/Bridge/PhpUnit/'):
         case false !== strpos($file, '/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Article.php'):
         case false !== strpos($file, '/src/Symfony/Component/Cache/Tests/Fixtures/DriverWrapper.php'):

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -134,7 +134,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
-          extensions: "json,couchbase-3.2.2,memcached,mongodb-1.12.0,redis-5.3.4,rdkafka,xsl,ldap"
+          extensions: "json,couchbase-3.2.2,memcached,mongodb-1.12.0,redis,rdkafka,xsl,ldap"
           ini-values: date.timezone=Europe/Paris,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1
           php-version: "${{ matrix.php }}"
           tools: pecl

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
     name: Tests
 
     env:
-      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,redis-5.3.4
+      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,redis
 
     strategy:
       matrix:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -66,6 +66,11 @@ return (new PhpCsFixer\Config())
             ->notPath('Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php')
             // stop removing spaces on the end of the line in strings
             ->notPath('Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php')
+            // auto-generated proxies
+            ->notPath('Symfony/Component/Cache/Traits/Redis5Proxy.php')
+            ->notPath('Symfony/Component/Cache/Traits/Redis6Proxy.php')
+            ->notPath('Symfony/Component/Cache/Traits/RedisCluster5Proxy.php')
+            ->notPath('Symfony/Component/Cache/Traits/RedisCluster6Proxy.php')
     )
     ->setCacheFile('.php-cs-fixer.cache')
 ;

--- a/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
@@ -12,15 +12,13 @@
 namespace Symfony\Component\Cache\Adapter;
 
 use Symfony\Component\Cache\Marshaller\MarshallerInterface;
-use Symfony\Component\Cache\Traits\RedisClusterProxy;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Cache\Traits\RedisTrait;
 
 class RedisAdapter extends AbstractAdapter
 {
     use RedisTrait;
 
-    public function __construct(\Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface|RedisProxy|RedisClusterProxy $redis, string $namespace = '', int $defaultLifetime = 0, MarshallerInterface $marshaller = null)
+    public function __construct(\Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface $redis, string $namespace = '', int $defaultLifetime = 0, MarshallerInterface $marshaller = null)
     {
         $this->init($redis, $namespace, $defaultLifetime, $marshaller);
     }

--- a/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
@@ -22,8 +22,6 @@ use Symfony\Component\Cache\Exception\LogicException;
 use Symfony\Component\Cache\Marshaller\DeflateMarshaller;
 use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 use Symfony\Component\Cache\Marshaller\TagAwareMarshaller;
-use Symfony\Component\Cache\Traits\RedisClusterProxy;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Cache\Traits\RedisTrait;
 
 /**
@@ -61,7 +59,7 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
     private string $redisEvictionPolicy;
     private string $namespace;
 
-    public function __construct(\Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface|RedisProxy|RedisClusterProxy $redis, string $namespace = '', int $defaultLifetime = 0, MarshallerInterface $marshaller = null)
+    public function __construct(\Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface $redis, string $namespace = '', int $defaultLifetime = 0, MarshallerInterface $marshaller = null)
     {
         if ($redis instanceof \Predis\ClientInterface && $redis->getConnection() instanceof ClusterInterface && !$redis->getConnection() instanceof PredisCluster) {
             throw new InvalidArgumentException(sprintf('Unsupported Predis cluster connection: only "%s" is, "%s" given.', PredisCluster::class, get_debug_type($redis->getConnection())));

--- a/src/Symfony/Component/Cache/Tests/RedisProxiesTest.php
+++ b/src/Symfony/Component/Cache/Tests/RedisProxiesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Traits;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarExporter\LazyProxyTrait;
+use Symfony\Component\VarExporter\ProxyHelper;
+
+/**
+ * @requires extension redis
+ */
+class RedisProxiesTest extends TestCase
+{
+    /**
+     * @testWith ["Redis"]
+     *           ["RedisCluster"]
+     */
+    public function testRedis5Proxy($class)
+    {
+        $proxy = file_get_contents(\dirname(__DIR__)."/Traits/{$class}5Proxy.php");
+        $proxy = substr($proxy, 0, 8 + strpos($proxy, "\n    ];"));
+        $methods = [];
+
+        foreach ((new \ReflectionClass($class))->getMethods() as $method) {
+            if ('reset' === $method->name || method_exists(LazyProxyTrait::class, $method->name)) {
+                continue;
+            }
+            $return = $method->getReturnType() instanceof \ReflectionNamedType && 'void' === (string) $method->getReturnType() ? '' : 'return ';
+            $methods[] = "\n    ".ProxyHelper::exportSignature($method, false)."\n".<<<EOPHP
+                {
+                    {$return}\$this->lazyObjectReal->{$method->name}(...\\func_get_args());
+                }
+
+            EOPHP;
+        }
+
+        uksort($methods, 'strnatcmp');
+        $proxy .= implode('', $methods)."}\n";
+
+        $this->assertStringEqualsFile(\dirname(__DIR__)."/Traits/{$class}5Proxy.php", $proxy);
+    }
+
+    /**
+     * @testWith ["Redis", "redis"]
+     *           ["RedisCluster", "redis_cluster"]
+     */
+    public function testRedis6Proxy($class, $stub)
+    {
+        $stub = file_get_contents("https://raw.githubusercontent.com/phpredis/phpredis/develop/{$stub}.stub.php");
+        $stub = preg_replace('/^class /m', 'return; \0', $stub);
+        $stub = preg_replace('/^return; class ([a-zA-Z]++)/m', 'interface \1StubInterface', $stub, 1);
+        eval(substr($stub, 5));
+
+        $proxy = file_get_contents(\dirname(__DIR__)."/Traits/{$class}6Proxy.php");
+        $proxy = substr($proxy, 0, 8 + strpos($proxy, "\n    ];"));
+        $methods = [];
+
+        foreach ((new \ReflectionClass($class.'StubInterface'))->getMethods() as $method) {
+            if ('reset' === $method->name || method_exists(LazyProxyTrait::class, $method->name)) {
+                continue;
+            }
+            $return = $method->getReturnType() instanceof \ReflectionNamedType && 'void' === (string) $method->getReturnType() ? '' : 'return ';
+            $methods[] = "\n    ".ProxyHelper::exportSignature($method, false)."\n".<<<EOPHP
+                {
+                    {$return}\$this->lazyObjectReal->{$method->name}(...\\func_get_args());
+                }
+
+            EOPHP;
+        }
+
+        uksort($methods, 'strnatcmp');
+        $proxy .= implode('', $methods)."}\n";
+
+        $this->assertStringEqualsFile(\dirname(__DIR__)."/Traits/{$class}6Proxy.php", $proxy);
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
@@ -1,0 +1,1234 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+use Symfony\Component\VarExporter\LazyObjectInterface;
+use Symfony\Component\VarExporter\LazyProxyTrait;
+use Symfony\Contracts\Service\ResetInterface;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
+
+/**
+ * @internal
+ */
+class Redis5Proxy extends \Redis implements ResetInterface, LazyObjectInterface
+{
+    use LazyProxyTrait {
+        resetLazyObject as reset;
+    }
+
+    private int $lazyObjectId;
+    private \Redis $lazyObjectReal;
+
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [
+        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
+        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
+    ];
+
+    public function __construct()
+    {
+        return $this->lazyObjectReal->__construct(...\func_get_args());
+    }
+
+    public function _prefix($key)
+    {
+        return $this->lazyObjectReal->_prefix(...\func_get_args());
+    }
+
+    public function _serialize($value)
+    {
+        return $this->lazyObjectReal->_serialize(...\func_get_args());
+    }
+
+    public function _unserialize($value)
+    {
+        return $this->lazyObjectReal->_unserialize(...\func_get_args());
+    }
+
+    public function _pack($value)
+    {
+        return $this->lazyObjectReal->_pack(...\func_get_args());
+    }
+
+    public function _unpack($value)
+    {
+        return $this->lazyObjectReal->_unpack(...\func_get_args());
+    }
+
+    public function _compress($value)
+    {
+        return $this->lazyObjectReal->_compress(...\func_get_args());
+    }
+
+    public function _uncompress($value)
+    {
+        return $this->lazyObjectReal->_uncompress(...\func_get_args());
+    }
+
+    public function acl($subcmd, ...$args)
+    {
+        return $this->lazyObjectReal->acl(...\func_get_args());
+    }
+
+    public function append($key, $value)
+    {
+        return $this->lazyObjectReal->append(...\func_get_args());
+    }
+
+    public function auth($auth)
+    {
+        return $this->lazyObjectReal->auth(...\func_get_args());
+    }
+
+    public function bgSave()
+    {
+        return $this->lazyObjectReal->bgSave(...\func_get_args());
+    }
+
+    public function bgrewriteaof()
+    {
+        return $this->lazyObjectReal->bgrewriteaof(...\func_get_args());
+    }
+
+    public function bitcount($key)
+    {
+        return $this->lazyObjectReal->bitcount(...\func_get_args());
+    }
+
+    public function bitop($operation, $ret_key, $key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->bitop(...\func_get_args());
+    }
+
+    public function bitpos($key, $bit, $start = null, $end = null)
+    {
+        return $this->lazyObjectReal->bitpos(...\func_get_args());
+    }
+
+    public function blPop($key, $timeout_or_key, ...$extra_args)
+    {
+        return $this->lazyObjectReal->blPop(...\func_get_args());
+    }
+
+    public function brPop($key, $timeout_or_key, ...$extra_args)
+    {
+        return $this->lazyObjectReal->brPop(...\func_get_args());
+    }
+
+    public function brpoplpush($src, $dst, $timeout)
+    {
+        return $this->lazyObjectReal->brpoplpush(...\func_get_args());
+    }
+
+    public function bzPopMax($key, $timeout_or_key, ...$extra_args)
+    {
+        return $this->lazyObjectReal->bzPopMax(...\func_get_args());
+    }
+
+    public function bzPopMin($key, $timeout_or_key, ...$extra_args)
+    {
+        return $this->lazyObjectReal->bzPopMin(...\func_get_args());
+    }
+
+    public function clearLastError()
+    {
+        return $this->lazyObjectReal->clearLastError(...\func_get_args());
+    }
+
+    public function client($cmd, ...$args)
+    {
+        return $this->lazyObjectReal->client(...\func_get_args());
+    }
+
+    public function close()
+    {
+        return $this->lazyObjectReal->close(...\func_get_args());
+    }
+
+    public function command(...$args)
+    {
+        return $this->lazyObjectReal->command(...\func_get_args());
+    }
+
+    public function config($cmd, $key, $value = null)
+    {
+        return $this->lazyObjectReal->config(...\func_get_args());
+    }
+
+    public function connect($host, $port = null, $timeout = null, $retry_interval = null)
+    {
+        return $this->lazyObjectReal->connect(...\func_get_args());
+    }
+
+    public function dbSize()
+    {
+        return $this->lazyObjectReal->dbSize(...\func_get_args());
+    }
+
+    public function debug($key)
+    {
+        return $this->lazyObjectReal->debug(...\func_get_args());
+    }
+
+    public function decr($key)
+    {
+        return $this->lazyObjectReal->decr(...\func_get_args());
+    }
+
+    public function decrBy($key, $value)
+    {
+        return $this->lazyObjectReal->decrBy(...\func_get_args());
+    }
+
+    public function del($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->del(...\func_get_args());
+    }
+
+    public function discard()
+    {
+        return $this->lazyObjectReal->discard(...\func_get_args());
+    }
+
+    public function dump($key)
+    {
+        return $this->lazyObjectReal->dump(...\func_get_args());
+    }
+
+    public function echo($msg)
+    {
+        return $this->lazyObjectReal->echo(...\func_get_args());
+    }
+
+    public function eval($script, $args = null, $num_keys = null)
+    {
+        return $this->lazyObjectReal->eval(...\func_get_args());
+    }
+
+    public function evalsha($script_sha, $args = null, $num_keys = null)
+    {
+        return $this->lazyObjectReal->evalsha(...\func_get_args());
+    }
+
+    public function exec()
+    {
+        return $this->lazyObjectReal->exec(...\func_get_args());
+    }
+
+    public function exists($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->exists(...\func_get_args());
+    }
+
+    public function expire($key, $timeout)
+    {
+        return $this->lazyObjectReal->expire(...\func_get_args());
+    }
+
+    public function expireAt($key, $timestamp)
+    {
+        return $this->lazyObjectReal->expireAt(...\func_get_args());
+    }
+
+    public function flushAll($async = null)
+    {
+        return $this->lazyObjectReal->flushAll(...\func_get_args());
+    }
+
+    public function flushDB($async = null)
+    {
+        return $this->lazyObjectReal->flushDB(...\func_get_args());
+    }
+
+    public function geoadd($key, $lng, $lat, $member, ...$other_triples)
+    {
+        return $this->lazyObjectReal->geoadd(...\func_get_args());
+    }
+
+    public function geodist($key, $src, $dst, $unit = null)
+    {
+        return $this->lazyObjectReal->geodist(...\func_get_args());
+    }
+
+    public function geohash($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->geohash(...\func_get_args());
+    }
+
+    public function geopos($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->geopos(...\func_get_args());
+    }
+
+    public function georadius($key, $lng, $lan, $radius, $unit, $opts = null)
+    {
+        return $this->lazyObjectReal->georadius(...\func_get_args());
+    }
+
+    public function georadius_ro($key, $lng, $lan, $radius, $unit, $opts = null)
+    {
+        return $this->lazyObjectReal->georadius_ro(...\func_get_args());
+    }
+
+    public function georadiusbymember($key, $member, $radius, $unit, $opts = null)
+    {
+        return $this->lazyObjectReal->georadiusbymember(...\func_get_args());
+    }
+
+    public function georadiusbymember_ro($key, $member, $radius, $unit, $opts = null)
+    {
+        return $this->lazyObjectReal->georadiusbymember_ro(...\func_get_args());
+    }
+
+    public function get($key)
+    {
+        return $this->lazyObjectReal->get(...\func_get_args());
+    }
+
+    public function getAuth()
+    {
+        return $this->lazyObjectReal->getAuth(...\func_get_args());
+    }
+
+    public function getBit($key, $offset)
+    {
+        return $this->lazyObjectReal->getBit(...\func_get_args());
+    }
+
+    public function getDBNum()
+    {
+        return $this->lazyObjectReal->getDBNum(...\func_get_args());
+    }
+
+    public function getHost()
+    {
+        return $this->lazyObjectReal->getHost(...\func_get_args());
+    }
+
+    public function getLastError()
+    {
+        return $this->lazyObjectReal->getLastError(...\func_get_args());
+    }
+
+    public function getMode()
+    {
+        return $this->lazyObjectReal->getMode(...\func_get_args());
+    }
+
+    public function getOption($option)
+    {
+        return $this->lazyObjectReal->getOption(...\func_get_args());
+    }
+
+    public function getPersistentID()
+    {
+        return $this->lazyObjectReal->getPersistentID(...\func_get_args());
+    }
+
+    public function getPort()
+    {
+        return $this->lazyObjectReal->getPort(...\func_get_args());
+    }
+
+    public function getRange($key, $start, $end)
+    {
+        return $this->lazyObjectReal->getRange(...\func_get_args());
+    }
+
+    public function getReadTimeout()
+    {
+        return $this->lazyObjectReal->getReadTimeout(...\func_get_args());
+    }
+
+    public function getSet($key, $value)
+    {
+        return $this->lazyObjectReal->getSet(...\func_get_args());
+    }
+
+    public function getTimeout()
+    {
+        return $this->lazyObjectReal->getTimeout(...\func_get_args());
+    }
+
+    public function hDel($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->hDel(...\func_get_args());
+    }
+
+    public function hExists($key, $member)
+    {
+        return $this->lazyObjectReal->hExists(...\func_get_args());
+    }
+
+    public function hGet($key, $member)
+    {
+        return $this->lazyObjectReal->hGet(...\func_get_args());
+    }
+
+    public function hGetAll($key)
+    {
+        return $this->lazyObjectReal->hGetAll(...\func_get_args());
+    }
+
+    public function hIncrBy($key, $member, $value)
+    {
+        return $this->lazyObjectReal->hIncrBy(...\func_get_args());
+    }
+
+    public function hIncrByFloat($key, $member, $value)
+    {
+        return $this->lazyObjectReal->hIncrByFloat(...\func_get_args());
+    }
+
+    public function hKeys($key)
+    {
+        return $this->lazyObjectReal->hKeys(...\func_get_args());
+    }
+
+    public function hLen($key)
+    {
+        return $this->lazyObjectReal->hLen(...\func_get_args());
+    }
+
+    public function hMget($key, $keys)
+    {
+        return $this->lazyObjectReal->hMget(...\func_get_args());
+    }
+
+    public function hMset($key, $pairs)
+    {
+        return $this->lazyObjectReal->hMset(...\func_get_args());
+    }
+
+    public function hSet($key, $member, $value)
+    {
+        return $this->lazyObjectReal->hSet(...\func_get_args());
+    }
+
+    public function hSetNx($key, $member, $value)
+    {
+        return $this->lazyObjectReal->hSetNx(...\func_get_args());
+    }
+
+    public function hStrLen($key, $member)
+    {
+        return $this->lazyObjectReal->hStrLen(...\func_get_args());
+    }
+
+    public function hVals($key)
+    {
+        return $this->lazyObjectReal->hVals(...\func_get_args());
+    }
+
+    public function hscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
+    {
+        return $this->lazyObjectReal->hscan(...\func_get_args());
+    }
+
+    public function incr($key)
+    {
+        return $this->lazyObjectReal->incr(...\func_get_args());
+    }
+
+    public function incrBy($key, $value)
+    {
+        return $this->lazyObjectReal->incrBy(...\func_get_args());
+    }
+
+    public function incrByFloat($key, $value)
+    {
+        return $this->lazyObjectReal->incrByFloat(...\func_get_args());
+    }
+
+    public function info($option = null)
+    {
+        return $this->lazyObjectReal->info(...\func_get_args());
+    }
+
+    public function isConnected()
+    {
+        return $this->lazyObjectReal->isConnected(...\func_get_args());
+    }
+
+    public function keys($pattern)
+    {
+        return $this->lazyObjectReal->keys(...\func_get_args());
+    }
+
+    public function lInsert($key, $position, $pivot, $value)
+    {
+        return $this->lazyObjectReal->lInsert(...\func_get_args());
+    }
+
+    public function lLen($key)
+    {
+        return $this->lazyObjectReal->lLen(...\func_get_args());
+    }
+
+    public function lPop($key)
+    {
+        return $this->lazyObjectReal->lPop(...\func_get_args());
+    }
+
+    public function lPush($key, $value)
+    {
+        return $this->lazyObjectReal->lPush(...\func_get_args());
+    }
+
+    public function lPushx($key, $value)
+    {
+        return $this->lazyObjectReal->lPushx(...\func_get_args());
+    }
+
+    public function lSet($key, $index, $value)
+    {
+        return $this->lazyObjectReal->lSet(...\func_get_args());
+    }
+
+    public function lastSave()
+    {
+        return $this->lazyObjectReal->lastSave(...\func_get_args());
+    }
+
+    public function lindex($key, $index)
+    {
+        return $this->lazyObjectReal->lindex(...\func_get_args());
+    }
+
+    public function lrange($key, $start, $end)
+    {
+        return $this->lazyObjectReal->lrange(...\func_get_args());
+    }
+
+    public function lrem($key, $value, $count)
+    {
+        return $this->lazyObjectReal->lrem(...\func_get_args());
+    }
+
+    public function ltrim($key, $start, $stop)
+    {
+        return $this->lazyObjectReal->ltrim(...\func_get_args());
+    }
+
+    public function mget($keys)
+    {
+        return $this->lazyObjectReal->mget(...\func_get_args());
+    }
+
+    public function migrate($host, $port, $key, $db, $timeout, $copy = null, $replace = null)
+    {
+        return $this->lazyObjectReal->migrate(...\func_get_args());
+    }
+
+    public function move($key, $dbindex)
+    {
+        return $this->lazyObjectReal->move(...\func_get_args());
+    }
+
+    public function mset($pairs)
+    {
+        return $this->lazyObjectReal->mset(...\func_get_args());
+    }
+
+    public function msetnx($pairs)
+    {
+        return $this->lazyObjectReal->msetnx(...\func_get_args());
+    }
+
+    public function multi($mode = null)
+    {
+        return $this->lazyObjectReal->multi(...\func_get_args());
+    }
+
+    public function object($field, $key)
+    {
+        return $this->lazyObjectReal->object(...\func_get_args());
+    }
+
+    public function pconnect($host, $port = null, $timeout = null)
+    {
+        return $this->lazyObjectReal->pconnect(...\func_get_args());
+    }
+
+    public function persist($key)
+    {
+        return $this->lazyObjectReal->persist(...\func_get_args());
+    }
+
+    public function pexpire($key, $timestamp)
+    {
+        return $this->lazyObjectReal->pexpire(...\func_get_args());
+    }
+
+    public function pexpireAt($key, $timestamp)
+    {
+        return $this->lazyObjectReal->pexpireAt(...\func_get_args());
+    }
+
+    public function pfadd($key, $elements)
+    {
+        return $this->lazyObjectReal->pfadd(...\func_get_args());
+    }
+
+    public function pfcount($key)
+    {
+        return $this->lazyObjectReal->pfcount(...\func_get_args());
+    }
+
+    public function pfmerge($dstkey, $keys)
+    {
+        return $this->lazyObjectReal->pfmerge(...\func_get_args());
+    }
+
+    public function ping()
+    {
+        return $this->lazyObjectReal->ping(...\func_get_args());
+    }
+
+    public function pipeline()
+    {
+        return $this->lazyObjectReal->pipeline(...\func_get_args());
+    }
+
+    public function psetex($key, $expire, $value)
+    {
+        return $this->lazyObjectReal->psetex(...\func_get_args());
+    }
+
+    public function psubscribe($patterns, $callback)
+    {
+        return $this->lazyObjectReal->psubscribe(...\func_get_args());
+    }
+
+    public function pttl($key)
+    {
+        return $this->lazyObjectReal->pttl(...\func_get_args());
+    }
+
+    public function publish($channel, $message)
+    {
+        return $this->lazyObjectReal->publish(...\func_get_args());
+    }
+
+    public function pubsub($cmd, ...$args)
+    {
+        return $this->lazyObjectReal->pubsub(...\func_get_args());
+    }
+
+    public function punsubscribe($pattern, ...$other_patterns)
+    {
+        return $this->lazyObjectReal->punsubscribe(...\func_get_args());
+    }
+
+    public function rPop($key)
+    {
+        return $this->lazyObjectReal->rPop(...\func_get_args());
+    }
+
+    public function rPush($key, $value)
+    {
+        return $this->lazyObjectReal->rPush(...\func_get_args());
+    }
+
+    public function rPushx($key, $value)
+    {
+        return $this->lazyObjectReal->rPushx(...\func_get_args());
+    }
+
+    public function randomKey()
+    {
+        return $this->lazyObjectReal->randomKey(...\func_get_args());
+    }
+
+    public function rawcommand($cmd, ...$args)
+    {
+        return $this->lazyObjectReal->rawcommand(...\func_get_args());
+    }
+
+    public function rename($key, $newkey)
+    {
+        return $this->lazyObjectReal->rename(...\func_get_args());
+    }
+
+    public function renameNx($key, $newkey)
+    {
+        return $this->lazyObjectReal->renameNx(...\func_get_args());
+    }
+
+    public function restore($ttl, $key, $value)
+    {
+        return $this->lazyObjectReal->restore(...\func_get_args());
+    }
+
+    public function role()
+    {
+        return $this->lazyObjectReal->role(...\func_get_args());
+    }
+
+    public function rpoplpush($src, $dst)
+    {
+        return $this->lazyObjectReal->rpoplpush(...\func_get_args());
+    }
+
+    public function sAdd($key, $value)
+    {
+        return $this->lazyObjectReal->sAdd(...\func_get_args());
+    }
+
+    public function sAddArray($key, $options)
+    {
+        return $this->lazyObjectReal->sAddArray(...\func_get_args());
+    }
+
+    public function sDiff($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sDiff(...\func_get_args());
+    }
+
+    public function sDiffStore($dst, $key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sDiffStore(...\func_get_args());
+    }
+
+    public function sInter($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sInter(...\func_get_args());
+    }
+
+    public function sInterStore($dst, $key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sInterStore(...\func_get_args());
+    }
+
+    public function sMembers($key)
+    {
+        return $this->lazyObjectReal->sMembers(...\func_get_args());
+    }
+
+    public function sMisMember($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->sMisMember(...\func_get_args());
+    }
+
+    public function sMove($src, $dst, $value)
+    {
+        return $this->lazyObjectReal->sMove(...\func_get_args());
+    }
+
+    public function sPop($key)
+    {
+        return $this->lazyObjectReal->sPop(...\func_get_args());
+    }
+
+    public function sRandMember($key, $count = null)
+    {
+        return $this->lazyObjectReal->sRandMember(...\func_get_args());
+    }
+
+    public function sUnion($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sUnion(...\func_get_args());
+    }
+
+    public function sUnionStore($dst, $key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sUnionStore(...\func_get_args());
+    }
+
+    public function save()
+    {
+        return $this->lazyObjectReal->save(...\func_get_args());
+    }
+
+    public function scan(&$i_iterator, $str_pattern = null, $i_count = null)
+    {
+        return $this->lazyObjectReal->scan(...\func_get_args());
+    }
+
+    public function scard($key)
+    {
+        return $this->lazyObjectReal->scard(...\func_get_args());
+    }
+
+    public function script($cmd, ...$args)
+    {
+        return $this->lazyObjectReal->script(...\func_get_args());
+    }
+
+    public function select($dbindex)
+    {
+        return $this->lazyObjectReal->select(...\func_get_args());
+    }
+
+    public function set($key, $value, $opts = null)
+    {
+        return $this->lazyObjectReal->set(...\func_get_args());
+    }
+
+    public function setBit($key, $offset, $value)
+    {
+        return $this->lazyObjectReal->setBit(...\func_get_args());
+    }
+
+    public function setOption($option, $value)
+    {
+        return $this->lazyObjectReal->setOption(...\func_get_args());
+    }
+
+    public function setRange($key, $offset, $value)
+    {
+        return $this->lazyObjectReal->setRange(...\func_get_args());
+    }
+
+    public function setex($key, $expire, $value)
+    {
+        return $this->lazyObjectReal->setex(...\func_get_args());
+    }
+
+    public function setnx($key, $value)
+    {
+        return $this->lazyObjectReal->setnx(...\func_get_args());
+    }
+
+    public function sismember($key, $value)
+    {
+        return $this->lazyObjectReal->sismember(...\func_get_args());
+    }
+
+    public function slaveof($host = null, $port = null)
+    {
+        return $this->lazyObjectReal->slaveof(...\func_get_args());
+    }
+
+    public function slowlog($arg, $option = null)
+    {
+        return $this->lazyObjectReal->slowlog(...\func_get_args());
+    }
+
+    public function sort($key, $options = null)
+    {
+        return $this->lazyObjectReal->sort(...\func_get_args());
+    }
+
+    public function sortAsc($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
+    {
+        return $this->lazyObjectReal->sortAsc(...\func_get_args());
+    }
+
+    public function sortAscAlpha($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
+    {
+        return $this->lazyObjectReal->sortAscAlpha(...\func_get_args());
+    }
+
+    public function sortDesc($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
+    {
+        return $this->lazyObjectReal->sortDesc(...\func_get_args());
+    }
+
+    public function sortDescAlpha($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
+    {
+        return $this->lazyObjectReal->sortDescAlpha(...\func_get_args());
+    }
+
+    public function srem($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->srem(...\func_get_args());
+    }
+
+    public function sscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
+    {
+        return $this->lazyObjectReal->sscan(...\func_get_args());
+    }
+
+    public function strlen($key)
+    {
+        return $this->lazyObjectReal->strlen(...\func_get_args());
+    }
+
+    public function subscribe($channels, $callback)
+    {
+        return $this->lazyObjectReal->subscribe(...\func_get_args());
+    }
+
+    public function swapdb($srcdb, $dstdb)
+    {
+        return $this->lazyObjectReal->swapdb(...\func_get_args());
+    }
+
+    public function time()
+    {
+        return $this->lazyObjectReal->time(...\func_get_args());
+    }
+
+    public function ttl($key)
+    {
+        return $this->lazyObjectReal->ttl(...\func_get_args());
+    }
+
+    public function type($key)
+    {
+        return $this->lazyObjectReal->type(...\func_get_args());
+    }
+
+    public function unlink($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->unlink(...\func_get_args());
+    }
+
+    public function unsubscribe($channel, ...$other_channels)
+    {
+        return $this->lazyObjectReal->unsubscribe(...\func_get_args());
+    }
+
+    public function unwatch()
+    {
+        return $this->lazyObjectReal->unwatch(...\func_get_args());
+    }
+
+    public function wait($numslaves, $timeout)
+    {
+        return $this->lazyObjectReal->wait(...\func_get_args());
+    }
+
+    public function watch($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->watch(...\func_get_args());
+    }
+
+    public function xack($str_key, $str_group, $arr_ids)
+    {
+        return $this->lazyObjectReal->xack(...\func_get_args());
+    }
+
+    public function xadd($str_key, $str_id, $arr_fields, $i_maxlen = null, $boo_approximate = null)
+    {
+        return $this->lazyObjectReal->xadd(...\func_get_args());
+    }
+
+    public function xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts = null)
+    {
+        return $this->lazyObjectReal->xclaim(...\func_get_args());
+    }
+
+    public function xdel($str_key, $arr_ids)
+    {
+        return $this->lazyObjectReal->xdel(...\func_get_args());
+    }
+
+    public function xgroup($str_operation, $str_key = null, $str_arg1 = null, $str_arg2 = null, $str_arg3 = null)
+    {
+        return $this->lazyObjectReal->xgroup(...\func_get_args());
+    }
+
+    public function xinfo($str_cmd, $str_key = null, $str_group = null)
+    {
+        return $this->lazyObjectReal->xinfo(...\func_get_args());
+    }
+
+    public function xlen($key)
+    {
+        return $this->lazyObjectReal->xlen(...\func_get_args());
+    }
+
+    public function xpending($str_key, $str_group, $str_start = null, $str_end = null, $i_count = null, $str_consumer = null)
+    {
+        return $this->lazyObjectReal->xpending(...\func_get_args());
+    }
+
+    public function xrange($str_key, $str_start, $str_end, $i_count = null)
+    {
+        return $this->lazyObjectReal->xrange(...\func_get_args());
+    }
+
+    public function xread($arr_streams, $i_count = null, $i_block = null)
+    {
+        return $this->lazyObjectReal->xread(...\func_get_args());
+    }
+
+    public function xreadgroup($str_group, $str_consumer, $arr_streams, $i_count = null, $i_block = null)
+    {
+        return $this->lazyObjectReal->xreadgroup(...\func_get_args());
+    }
+
+    public function xrevrange($str_key, $str_start, $str_end, $i_count = null)
+    {
+        return $this->lazyObjectReal->xrevrange(...\func_get_args());
+    }
+
+    public function xtrim($str_key, $i_maxlen, $boo_approximate = null)
+    {
+        return $this->lazyObjectReal->xtrim(...\func_get_args());
+    }
+
+    public function zAdd($key, $score, $value, ...$extra_args)
+    {
+        return $this->lazyObjectReal->zAdd(...\func_get_args());
+    }
+
+    public function zCard($key)
+    {
+        return $this->lazyObjectReal->zCard(...\func_get_args());
+    }
+
+    public function zCount($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zCount(...\func_get_args());
+    }
+
+    public function zIncrBy($key, $value, $member)
+    {
+        return $this->lazyObjectReal->zIncrBy(...\func_get_args());
+    }
+
+    public function zLexCount($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zLexCount(...\func_get_args());
+    }
+
+    public function zPopMax($key)
+    {
+        return $this->lazyObjectReal->zPopMax(...\func_get_args());
+    }
+
+    public function zPopMin($key)
+    {
+        return $this->lazyObjectReal->zPopMin(...\func_get_args());
+    }
+
+    public function zRange($key, $start, $end, $scores = null)
+    {
+        return $this->lazyObjectReal->zRange(...\func_get_args());
+    }
+
+    public function zRangeByLex($key, $min, $max, $offset = null, $limit = null)
+    {
+        return $this->lazyObjectReal->zRangeByLex(...\func_get_args());
+    }
+
+    public function zRangeByScore($key, $start, $end, $options = null)
+    {
+        return $this->lazyObjectReal->zRangeByScore(...\func_get_args());
+    }
+
+    public function zRank($key, $member)
+    {
+        return $this->lazyObjectReal->zRank(...\func_get_args());
+    }
+
+    public function zRem($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->zRem(...\func_get_args());
+    }
+
+    public function zRemRangeByLex($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zRemRangeByLex(...\func_get_args());
+    }
+
+    public function zRemRangeByRank($key, $start, $end)
+    {
+        return $this->lazyObjectReal->zRemRangeByRank(...\func_get_args());
+    }
+
+    public function zRemRangeByScore($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zRemRangeByScore(...\func_get_args());
+    }
+
+    public function zRevRange($key, $start, $end, $scores = null)
+    {
+        return $this->lazyObjectReal->zRevRange(...\func_get_args());
+    }
+
+    public function zRevRangeByLex($key, $min, $max, $offset = null, $limit = null)
+    {
+        return $this->lazyObjectReal->zRevRangeByLex(...\func_get_args());
+    }
+
+    public function zRevRangeByScore($key, $start, $end, $options = null)
+    {
+        return $this->lazyObjectReal->zRevRangeByScore(...\func_get_args());
+    }
+
+    public function zRevRank($key, $member)
+    {
+        return $this->lazyObjectReal->zRevRank(...\func_get_args());
+    }
+
+    public function zScore($key, $member)
+    {
+        return $this->lazyObjectReal->zScore(...\func_get_args());
+    }
+
+    public function zinterstore($key, $keys, $weights = null, $aggregate = null)
+    {
+        return $this->lazyObjectReal->zinterstore(...\func_get_args());
+    }
+
+    public function zscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
+    {
+        return $this->lazyObjectReal->zscan(...\func_get_args());
+    }
+
+    public function zunionstore($key, $keys, $weights = null, $aggregate = null)
+    {
+        return $this->lazyObjectReal->zunionstore(...\func_get_args());
+    }
+
+    public function delete($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->delete(...\func_get_args());
+    }
+
+    public function evaluate($script, $args = null, $num_keys = null)
+    {
+        return $this->lazyObjectReal->evaluate(...\func_get_args());
+    }
+
+    public function evaluateSha($script_sha, $args = null, $num_keys = null)
+    {
+        return $this->lazyObjectReal->evaluateSha(...\func_get_args());
+    }
+
+    public function getKeys($pattern)
+    {
+        return $this->lazyObjectReal->getKeys(...\func_get_args());
+    }
+
+    public function getMultiple($keys)
+    {
+        return $this->lazyObjectReal->getMultiple(...\func_get_args());
+    }
+
+    public function lGet($key, $index)
+    {
+        return $this->lazyObjectReal->lGet(...\func_get_args());
+    }
+
+    public function lGetRange($key, $start, $end)
+    {
+        return $this->lazyObjectReal->lGetRange(...\func_get_args());
+    }
+
+    public function lRemove($key, $value, $count)
+    {
+        return $this->lazyObjectReal->lRemove(...\func_get_args());
+    }
+
+    public function lSize($key)
+    {
+        return $this->lazyObjectReal->lSize(...\func_get_args());
+    }
+
+    public function listTrim($key, $start, $stop)
+    {
+        return $this->lazyObjectReal->listTrim(...\func_get_args());
+    }
+
+    public function open($host, $port = null, $timeout = null, $retry_interval = null)
+    {
+        return $this->lazyObjectReal->open(...\func_get_args());
+    }
+
+    public function popen($host, $port = null, $timeout = null)
+    {
+        return $this->lazyObjectReal->popen(...\func_get_args());
+    }
+
+    public function renameKey($key, $newkey)
+    {
+        return $this->lazyObjectReal->renameKey(...\func_get_args());
+    }
+
+    public function sContains($key, $value)
+    {
+        return $this->lazyObjectReal->sContains(...\func_get_args());
+    }
+
+    public function sGetMembers($key)
+    {
+        return $this->lazyObjectReal->sGetMembers(...\func_get_args());
+    }
+
+    public function sRemove($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->sRemove(...\func_get_args());
+    }
+
+    public function sSize($key)
+    {
+        return $this->lazyObjectReal->sSize(...\func_get_args());
+    }
+
+    public function sendEcho($msg)
+    {
+        return $this->lazyObjectReal->sendEcho(...\func_get_args());
+    }
+
+    public function setTimeout($key, $timeout)
+    {
+        return $this->lazyObjectReal->setTimeout(...\func_get_args());
+    }
+
+    public function substr($key, $start, $end)
+    {
+        return $this->lazyObjectReal->substr(...\func_get_args());
+    }
+
+    public function zDelete($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->zDelete(...\func_get_args());
+    }
+
+    public function zDeleteRangeByRank($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zDeleteRangeByRank(...\func_get_args());
+    }
+
+    public function zDeleteRangeByScore($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zDeleteRangeByScore(...\func_get_args());
+    }
+
+    public function zInter($key, $keys, $weights = null, $aggregate = null)
+    {
+        return $this->lazyObjectReal->zInter(...\func_get_args());
+    }
+
+    public function zRemove($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->zRemove(...\func_get_args());
+    }
+
+    public function zRemoveRangeByScore($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zRemoveRangeByScore(...\func_get_args());
+    }
+
+    public function zReverseRange($key, $start, $end, $scores = null)
+    {
+        return $this->lazyObjectReal->zReverseRange(...\func_get_args());
+    }
+
+    public function zSize($key)
+    {
+        return $this->lazyObjectReal->zSize(...\func_get_args());
+    }
+
+    public function zUnion($key, $keys, $weights = null, $aggregate = null)
+    {
+        return $this->lazyObjectReal->zUnion(...\func_get_args());
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -1,0 +1,1184 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+use Symfony\Component\VarExporter\LazyObjectInterface;
+use Symfony\Component\VarExporter\LazyProxyTrait;
+use Symfony\Contracts\Service\ResetInterface;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
+
+/**
+ * @internal
+ */
+class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
+{
+    use LazyProxyTrait {
+        resetLazyObject as reset;
+    }
+
+    private int $lazyObjectId;
+    private \Redis $lazyObjectReal;
+
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [
+        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
+        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
+    ];
+
+    public function __construct($options = null)
+    {
+        return $this->lazyObjectReal->__construct(...\func_get_args());
+    }
+
+    public function _compress($value): string
+    {
+        return $this->lazyObjectReal->_compress(...\func_get_args());
+    }
+
+    public function _pack($value): string
+    {
+        return $this->lazyObjectReal->_pack(...\func_get_args());
+    }
+
+    public function _prefix($key): string
+    {
+        return $this->lazyObjectReal->_prefix(...\func_get_args());
+    }
+
+    public function _serialize($value): string
+    {
+        return $this->lazyObjectReal->_serialize(...\func_get_args());
+    }
+
+    public function _uncompress($value): string
+    {
+        return $this->lazyObjectReal->_uncompress(...\func_get_args());
+    }
+
+    public function _unpack($value): mixed
+    {
+        return $this->lazyObjectReal->_unpack(...\func_get_args());
+    }
+
+    public function _unserialize($value): mixed
+    {
+        return $this->lazyObjectReal->_unserialize(...\func_get_args());
+    }
+
+    public function acl($subcmd, ...$args)
+    {
+        return $this->lazyObjectReal->acl(...\func_get_args());
+    }
+
+    public function append($key, $value)
+    {
+        return $this->lazyObjectReal->append(...\func_get_args());
+    }
+
+    public function auth(#[\SensitiveParameter] $credentials): bool
+    {
+        return $this->lazyObjectReal->auth(...\func_get_args());
+    }
+
+    public function bgSave(): bool
+    {
+        return $this->lazyObjectReal->bgSave(...\func_get_args());
+    }
+
+    public function bgrewriteaof(): bool
+    {
+        return $this->lazyObjectReal->bgrewriteaof(...\func_get_args());
+    }
+
+    public function bitcount($key, $start = 0, $end = -1)
+    {
+        return $this->lazyObjectReal->bitcount(...\func_get_args());
+    }
+
+    public function bitop($operation, $deskey, $srckey, ...$other_keys): int
+    {
+        return $this->lazyObjectReal->bitop(...\func_get_args());
+    }
+
+    public function bitpos($key, $bit, $start = 0, $end = -1)
+    {
+        return $this->lazyObjectReal->bitpos(...\func_get_args());
+    }
+
+    public function blPop($key, $timeout_or_key, ...$extra_args): array
+    {
+        return $this->lazyObjectReal->blPop(...\func_get_args());
+    }
+
+    public function brPop($key, $timeout_or_key, ...$extra_args): array
+    {
+        return $this->lazyObjectReal->brPop(...\func_get_args());
+    }
+
+    public function brpoplpush($src, $dst, $timeout): string
+    {
+        return $this->lazyObjectReal->brpoplpush(...\func_get_args());
+    }
+
+    public function bzPopMax($key, $timeout_or_key, ...$extra_args): array
+    {
+        return $this->lazyObjectReal->bzPopMax(...\func_get_args());
+    }
+
+    public function bzPopMin($key, $timeout_or_key, ...$extra_args): array
+    {
+        return $this->lazyObjectReal->bzPopMin(...\func_get_args());
+    }
+
+    public function clearLastError(): bool
+    {
+        return $this->lazyObjectReal->clearLastError(...\func_get_args());
+    }
+
+    public function client($opt, $arg = null): mixed
+    {
+        return $this->lazyObjectReal->client(...\func_get_args());
+    }
+
+    public function close(): bool
+    {
+        return $this->lazyObjectReal->close(...\func_get_args());
+    }
+
+    public function command($opt, $arg): mixed
+    {
+        return $this->lazyObjectReal->command(...\func_get_args());
+    }
+
+    public function config($operation, $key, $value = null): mixed
+    {
+        return $this->lazyObjectReal->config(...\func_get_args());
+    }
+
+    public function connect($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, $context = null): bool
+    {
+        return $this->lazyObjectReal->connect(...\func_get_args());
+    }
+
+    public function copy($src, $dst, $options = null): bool
+    {
+        return $this->lazyObjectReal->copy(...\func_get_args());
+    }
+
+    public function dbSize(): int
+    {
+        return $this->lazyObjectReal->dbSize(...\func_get_args());
+    }
+
+    public function debug($key): string
+    {
+        return $this->lazyObjectReal->debug(...\func_get_args());
+    }
+
+    public function decr($key)
+    {
+        return $this->lazyObjectReal->decr(...\func_get_args());
+    }
+
+    public function decrBy($key, $value)
+    {
+        return $this->lazyObjectReal->decrBy(...\func_get_args());
+    }
+
+    public function del($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->del(...\func_get_args());
+    }
+
+    public function delete($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->delete(...\func_get_args());
+    }
+
+    public function discard(): bool
+    {
+        return $this->lazyObjectReal->discard(...\func_get_args());
+    }
+
+    public function dump($key): string
+    {
+        return $this->lazyObjectReal->dump(...\func_get_args());
+    }
+
+    public function echo($str)
+    {
+        return $this->lazyObjectReal->echo(...\func_get_args());
+    }
+
+    public function eval($script, $keys = null, $num_keys = 0): mixed
+    {
+        return $this->lazyObjectReal->eval(...\func_get_args());
+    }
+
+    public function evalsha($sha1, $keys = null, $num_keys = 0): mixed
+    {
+        return $this->lazyObjectReal->evalsha(...\func_get_args());
+    }
+
+    public function exec(): array
+    {
+        return $this->lazyObjectReal->exec(...\func_get_args());
+    }
+
+    public function exists($key)
+    {
+        return $this->lazyObjectReal->exists(...\func_get_args());
+    }
+
+    public function expire($key, $timeout): bool
+    {
+        return $this->lazyObjectReal->expire(...\func_get_args());
+    }
+
+    public function expireAt($key, $timestamp): bool
+    {
+        return $this->lazyObjectReal->expireAt(...\func_get_args());
+    }
+
+    public function failover($to = null, $abort = false, $timeout = 0): bool
+    {
+        return $this->lazyObjectReal->failover(...\func_get_args());
+    }
+
+    public function flushAll($sync = null): bool
+    {
+        return $this->lazyObjectReal->flushAll(...\func_get_args());
+    }
+
+    public function flushDB($sync = null): bool
+    {
+        return $this->lazyObjectReal->flushDB(...\func_get_args());
+    }
+
+    public function geoadd($key, $lng, $lat, $member, ...$other_triples): int
+    {
+        return $this->lazyObjectReal->geoadd(...\func_get_args());
+    }
+
+    public function geodist($key, $src, $dst, $unit = null): array
+    {
+        return $this->lazyObjectReal->geodist(...\func_get_args());
+    }
+
+    public function geohash($key, $member, ...$other_members): array
+    {
+        return $this->lazyObjectReal->geohash(...\func_get_args());
+    }
+
+    public function geopos($key, $member, ...$other_members): array
+    {
+        return $this->lazyObjectReal->geopos(...\func_get_args());
+    }
+
+    public function georadius($key, $lng, $lat, $radius, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->georadius(...\func_get_args());
+    }
+
+    public function georadius_ro($key, $lng, $lat, $radius, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->georadius_ro(...\func_get_args());
+    }
+
+    public function georadiusbymember($key, $member, $radius, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->georadiusbymember(...\func_get_args());
+    }
+
+    public function georadiusbymember_ro($key, $member, $radius, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->georadiusbymember_ro(...\func_get_args());
+    }
+
+    public function geosearch($key, $position, $shape, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->geosearch(...\func_get_args());
+    }
+
+    public function geosearchstore($dst, $src, $position, $shape, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->geosearchstore(...\func_get_args());
+    }
+
+    public function get($key)
+    {
+        return $this->lazyObjectReal->get(...\func_get_args());
+    }
+
+    public function getAuth(): mixed
+    {
+        return $this->lazyObjectReal->getAuth(...\func_get_args());
+    }
+
+    public function getBit($key, $idx)
+    {
+        return $this->lazyObjectReal->getBit(...\func_get_args());
+    }
+
+    public function getEx($key, $options = []): bool|string
+    {
+        return $this->lazyObjectReal->getEx(...\func_get_args());
+    }
+
+    public function getDBNum(): int
+    {
+        return $this->lazyObjectReal->getDBNum(...\func_get_args());
+    }
+
+    public function getDel($key): bool|string
+    {
+        return $this->lazyObjectReal->getDel(...\func_get_args());
+    }
+
+    public function getHost(): string
+    {
+        return $this->lazyObjectReal->getHost(...\func_get_args());
+    }
+
+    public function getLastError(): ?string
+    {
+        return $this->lazyObjectReal->getLastError(...\func_get_args());
+    }
+
+    public function getMode(): int
+    {
+        return $this->lazyObjectReal->getMode(...\func_get_args());
+    }
+
+    public function getOption($option): mixed
+    {
+        return $this->lazyObjectReal->getOption(...\func_get_args());
+    }
+
+    public function getPersistentID(): ?string
+    {
+        return $this->lazyObjectReal->getPersistentID(...\func_get_args());
+    }
+
+    public function getPort(): int
+    {
+        return $this->lazyObjectReal->getPort(...\func_get_args());
+    }
+
+    public function getRange($key, $start, $end)
+    {
+        return $this->lazyObjectReal->getRange(...\func_get_args());
+    }
+
+    public function getReadTimeout(): int
+    {
+        return $this->lazyObjectReal->getReadTimeout(...\func_get_args());
+    }
+
+    public function getset($key, $value)
+    {
+        return $this->lazyObjectReal->getset(...\func_get_args());
+    }
+
+    public function getTimeout(): int
+    {
+        return $this->lazyObjectReal->getTimeout(...\func_get_args());
+    }
+
+    public function hDel($key, $member, ...$other_members): int
+    {
+        return $this->lazyObjectReal->hDel(...\func_get_args());
+    }
+
+    public function hExists($key, $member): bool
+    {
+        return $this->lazyObjectReal->hExists(...\func_get_args());
+    }
+
+    public function hGet($key, $member): string
+    {
+        return $this->lazyObjectReal->hGet(...\func_get_args());
+    }
+
+    public function hGetAll($key): array
+    {
+        return $this->lazyObjectReal->hGetAll(...\func_get_args());
+    }
+
+    public function hIncrBy($key, $member, $value): int
+    {
+        return $this->lazyObjectReal->hIncrBy(...\func_get_args());
+    }
+
+    public function hIncrByFloat($key, $member, $value): float
+    {
+        return $this->lazyObjectReal->hIncrByFloat(...\func_get_args());
+    }
+
+    public function hKeys($key): array
+    {
+        return $this->lazyObjectReal->hKeys(...\func_get_args());
+    }
+
+    public function hLen($key): int
+    {
+        return $this->lazyObjectReal->hLen(...\func_get_args());
+    }
+
+    public function hMget($key, $keys): array
+    {
+        return $this->lazyObjectReal->hMget(...\func_get_args());
+    }
+
+    public function hMset($key, $keyvals): bool
+    {
+        return $this->lazyObjectReal->hMset(...\func_get_args());
+    }
+
+    public function hRandField($key, $options = null): array|string
+    {
+        return $this->lazyObjectReal->hRandField(...\func_get_args());
+    }
+
+    public function hSet($key, $member, $value): int
+    {
+        return $this->lazyObjectReal->hSet(...\func_get_args());
+    }
+
+    public function hSetNx($key, $member, $value): int
+    {
+        return $this->lazyObjectReal->hSetNx(...\func_get_args());
+    }
+
+    public function hStrLen($key, $member): int
+    {
+        return $this->lazyObjectReal->hStrLen(...\func_get_args());
+    }
+
+    public function hVals($key): array
+    {
+        return $this->lazyObjectReal->hVals(...\func_get_args());
+    }
+
+    public function hscan($key, &$iterator, $pattern = null, $count = 0): array|bool
+    {
+        return $this->lazyObjectReal->hscan(...\func_get_args());
+    }
+
+    public function incr($key)
+    {
+        return $this->lazyObjectReal->incr(...\func_get_args());
+    }
+
+    public function incrBy($key, $value)
+    {
+        return $this->lazyObjectReal->incrBy(...\func_get_args());
+    }
+
+    public function incrByFloat($key, $value)
+    {
+        return $this->lazyObjectReal->incrByFloat(...\func_get_args());
+    }
+
+    public function info($opt = null): array
+    {
+        return $this->lazyObjectReal->info(...\func_get_args());
+    }
+
+    public function isConnected(): bool
+    {
+        return $this->lazyObjectReal->isConnected(...\func_get_args());
+    }
+
+    public function keys($pattern)
+    {
+        return $this->lazyObjectReal->keys(...\func_get_args());
+    }
+
+    public function lInsert($key, $pos, $pivot, $value)
+    {
+        return $this->lazyObjectReal->lInsert(...\func_get_args());
+    }
+
+    public function lLen($key): int
+    {
+        return $this->lazyObjectReal->lLen(...\func_get_args());
+    }
+
+    public function lMove($src, $dst, $wherefrom, $whereto): string
+    {
+        return $this->lazyObjectReal->lMove(...\func_get_args());
+    }
+
+    public function lPop($key, $count = 0): array|bool|string
+    {
+        return $this->lazyObjectReal->lPop(...\func_get_args());
+    }
+
+    public function lPos($key, $value, $options = null): array|bool|int
+    {
+        return $this->lazyObjectReal->lPos(...\func_get_args());
+    }
+
+    public function lPush($key, ...$elements)
+    {
+        return $this->lazyObjectReal->lPush(...\func_get_args());
+    }
+
+    public function rPush($key, ...$elements)
+    {
+        return $this->lazyObjectReal->rPush(...\func_get_args());
+    }
+
+    public function lPushx($key, $value)
+    {
+        return $this->lazyObjectReal->lPushx(...\func_get_args());
+    }
+
+    public function rPushx($key, $value)
+    {
+        return $this->lazyObjectReal->rPushx(...\func_get_args());
+    }
+
+    public function lSet($key, $index, $value): bool
+    {
+        return $this->lazyObjectReal->lSet(...\func_get_args());
+    }
+
+    public function lastSave(): int
+    {
+        return $this->lazyObjectReal->lastSave(...\func_get_args());
+    }
+
+    public function lindex($key, $index): string
+    {
+        return $this->lazyObjectReal->lindex(...\func_get_args());
+    }
+
+    public function lrange($key, $start, $end): array
+    {
+        return $this->lazyObjectReal->lrange(...\func_get_args());
+    }
+
+    public function lrem($key, $value, $count = 0): bool
+    {
+        return $this->lazyObjectReal->lrem(...\func_get_args());
+    }
+
+    public function ltrim($key, $start, $end): bool
+    {
+        return $this->lazyObjectReal->ltrim(...\func_get_args());
+    }
+
+    public function mget($keys)
+    {
+        return $this->lazyObjectReal->mget(...\func_get_args());
+    }
+
+    public function migrate($host, $port, $key, $dst, $timeout, $copy = false, $replace = false): bool
+    {
+        return $this->lazyObjectReal->migrate(...\func_get_args());
+    }
+
+    public function move($key, $index): bool
+    {
+        return $this->lazyObjectReal->move(...\func_get_args());
+    }
+
+    public function mset($key_values): bool
+    {
+        return $this->lazyObjectReal->mset(...\func_get_args());
+    }
+
+    public function msetnx($key_values): int
+    {
+        return $this->lazyObjectReal->msetnx(...\func_get_args());
+    }
+
+    public function multi($value = \Redis::MULTI): \Redis|bool
+    {
+        return $this->lazyObjectReal->multi(...\func_get_args());
+    }
+
+    public function object($subcommand, $key): int|string
+    {
+        return $this->lazyObjectReal->object(...\func_get_args());
+    }
+
+    public function open($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, $context = null): bool
+    {
+        return $this->lazyObjectReal->open(...\func_get_args());
+    }
+
+    public function pconnect($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, $context = null): bool
+    {
+        return $this->lazyObjectReal->pconnect(...\func_get_args());
+    }
+
+    public function persist($key): bool
+    {
+        return $this->lazyObjectReal->persist(...\func_get_args());
+    }
+
+    public function pexpire($key, $timeout): bool
+    {
+        return $this->lazyObjectReal->pexpire(...\func_get_args());
+    }
+
+    public function pexpireAt($key, $timestamp): bool
+    {
+        return $this->lazyObjectReal->pexpireAt(...\func_get_args());
+    }
+
+    public function pfadd($key, $elements): int
+    {
+        return $this->lazyObjectReal->pfadd(...\func_get_args());
+    }
+
+    public function pfcount($key): int
+    {
+        return $this->lazyObjectReal->pfcount(...\func_get_args());
+    }
+
+    public function pfmerge($dst, $keys): bool
+    {
+        return $this->lazyObjectReal->pfmerge(...\func_get_args());
+    }
+
+    public function ping($key = null)
+    {
+        return $this->lazyObjectReal->ping(...\func_get_args());
+    }
+
+    public function pipeline(): \Redis|bool
+    {
+        return $this->lazyObjectReal->pipeline(...\func_get_args());
+    }
+
+    public function popen($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, $context = null): bool
+    {
+        return $this->lazyObjectReal->popen(...\func_get_args());
+    }
+
+    public function psetex($key, $expire, $value)
+    {
+        return $this->lazyObjectReal->psetex(...\func_get_args());
+    }
+
+    public function psubscribe($patterns, $cb): bool
+    {
+        return $this->lazyObjectReal->psubscribe(...\func_get_args());
+    }
+
+    public function pttl($key): int
+    {
+        return $this->lazyObjectReal->pttl(...\func_get_args());
+    }
+
+    public function publish($channel, $message): int
+    {
+        return $this->lazyObjectReal->publish(...\func_get_args());
+    }
+
+    public function pubsub($command, $arg = null): mixed
+    {
+        return $this->lazyObjectReal->pubsub(...\func_get_args());
+    }
+
+    public function punsubscribe($patterns): array|bool
+    {
+        return $this->lazyObjectReal->punsubscribe(...\func_get_args());
+    }
+
+    public function rPop($key, $count = 0): array|bool|string
+    {
+        return $this->lazyObjectReal->rPop(...\func_get_args());
+    }
+
+    public function randomKey()
+    {
+        return $this->lazyObjectReal->randomKey(...\func_get_args());
+    }
+
+    public function rawcommand($command, ...$args): mixed
+    {
+        return $this->lazyObjectReal->rawcommand(...\func_get_args());
+    }
+
+    public function rename($key_src, $key_dst)
+    {
+        return $this->lazyObjectReal->rename(...\func_get_args());
+    }
+
+    public function renameNx($key_src, $key_dst)
+    {
+        return $this->lazyObjectReal->renameNx(...\func_get_args());
+    }
+
+    public function restore($key, $timeout, $value): bool
+    {
+        return $this->lazyObjectReal->restore(...\func_get_args());
+    }
+
+    public function role(): mixed
+    {
+        return $this->lazyObjectReal->role(...\func_get_args());
+    }
+
+    public function rpoplpush($src, $dst): string
+    {
+        return $this->lazyObjectReal->rpoplpush(...\func_get_args());
+    }
+
+    public function sAdd($key, $value, ...$other_values): int
+    {
+        return $this->lazyObjectReal->sAdd(...\func_get_args());
+    }
+
+    public function sAddArray($key, $values): int
+    {
+        return $this->lazyObjectReal->sAddArray(...\func_get_args());
+    }
+
+    public function sDiff($key, ...$other_keys): array
+    {
+        return $this->lazyObjectReal->sDiff(...\func_get_args());
+    }
+
+    public function sDiffStore($dst, $key, ...$other_keys): int
+    {
+        return $this->lazyObjectReal->sDiffStore(...\func_get_args());
+    }
+
+    public function sInter($key, ...$other_keys): array
+    {
+        return $this->lazyObjectReal->sInter(...\func_get_args());
+    }
+
+    public function sInterStore($dst, $key, ...$other_keys): int
+    {
+        return $this->lazyObjectReal->sInterStore(...\func_get_args());
+    }
+
+    public function sMembers($key): array
+    {
+        return $this->lazyObjectReal->sMembers(...\func_get_args());
+    }
+
+    public function sMisMember($key, $member, ...$other_members): array
+    {
+        return $this->lazyObjectReal->sMisMember(...\func_get_args());
+    }
+
+    public function sMove($src, $dst, $value): bool
+    {
+        return $this->lazyObjectReal->sMove(...\func_get_args());
+    }
+
+    public function sPop($key, $count = 0): array|string
+    {
+        return $this->lazyObjectReal->sPop(...\func_get_args());
+    }
+
+    public function sRandMember($key, $count = 0): array|string
+    {
+        return $this->lazyObjectReal->sRandMember(...\func_get_args());
+    }
+
+    public function sUnion($key, ...$other_keys): array
+    {
+        return $this->lazyObjectReal->sUnion(...\func_get_args());
+    }
+
+    public function sUnionStore($dst, $key, ...$other_keys): int
+    {
+        return $this->lazyObjectReal->sUnionStore(...\func_get_args());
+    }
+
+    public function save(): bool
+    {
+        return $this->lazyObjectReal->save(...\func_get_args());
+    }
+
+    public function scan(&$iterator, $pattern = null, $count = 0): array
+    {
+        return $this->lazyObjectReal->scan(...\func_get_args());
+    }
+
+    public function scard($key): int
+    {
+        return $this->lazyObjectReal->scard(...\func_get_args());
+    }
+
+    public function script($command, ...$args): mixed
+    {
+        return $this->lazyObjectReal->script(...\func_get_args());
+    }
+
+    public function select($db): bool
+    {
+        return $this->lazyObjectReal->select(...\func_get_args());
+    }
+
+    public function set($key, $value, $opt = null)
+    {
+        return $this->lazyObjectReal->set(...\func_get_args());
+    }
+
+    public function setBit($key, $idx, $value)
+    {
+        return $this->lazyObjectReal->setBit(...\func_get_args());
+    }
+
+    public function setRange($key, $start, $value)
+    {
+        return $this->lazyObjectReal->setRange(...\func_get_args());
+    }
+
+    public function setOption($option, $value): bool
+    {
+        return $this->lazyObjectReal->setOption(...\func_get_args());
+    }
+
+    public function setex($key, $expire, $value)
+    {
+        return $this->lazyObjectReal->setex(...\func_get_args());
+    }
+
+    public function setnx($key, $value)
+    {
+        return $this->lazyObjectReal->setnx(...\func_get_args());
+    }
+
+    public function sismember($key, $value): bool
+    {
+        return $this->lazyObjectReal->sismember(...\func_get_args());
+    }
+
+    public function slaveof($host = null, $port = 6379): bool
+    {
+        return $this->lazyObjectReal->slaveof(...\func_get_args());
+    }
+
+    public function slowlog($mode, $option = 0): mixed
+    {
+        return $this->lazyObjectReal->slowlog(...\func_get_args());
+    }
+
+    public function sort($key, $options = null): mixed
+    {
+        return $this->lazyObjectReal->sort(...\func_get_args());
+    }
+
+    public function sortAsc($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
+    {
+        return $this->lazyObjectReal->sortAsc(...\func_get_args());
+    }
+
+    public function sortAscAlpha($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
+    {
+        return $this->lazyObjectReal->sortAscAlpha(...\func_get_args());
+    }
+
+    public function sortDesc($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
+    {
+        return $this->lazyObjectReal->sortDesc(...\func_get_args());
+    }
+
+    public function sortDescAlpha($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
+    {
+        return $this->lazyObjectReal->sortDescAlpha(...\func_get_args());
+    }
+
+    public function srem($key, $value, ...$other_values): int
+    {
+        return $this->lazyObjectReal->srem(...\func_get_args());
+    }
+
+    public function sscan($key, &$iterator, $pattern = null, $count = 0): array
+    {
+        return $this->lazyObjectReal->sscan(...\func_get_args());
+    }
+
+    public function strlen($key)
+    {
+        return $this->lazyObjectReal->strlen(...\func_get_args());
+    }
+
+    public function subscribe($channels, $cb): bool
+    {
+        return $this->lazyObjectReal->subscribe(...\func_get_args());
+    }
+
+    public function swapdb($src, $dst): bool
+    {
+        return $this->lazyObjectReal->swapdb(...\func_get_args());
+    }
+
+    public function time(): array
+    {
+        return $this->lazyObjectReal->time(...\func_get_args());
+    }
+
+    public function ttl($key): int
+    {
+        return $this->lazyObjectReal->ttl(...\func_get_args());
+    }
+
+    public function type($key)
+    {
+        return $this->lazyObjectReal->type(...\func_get_args());
+    }
+
+    public function unlink($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->unlink(...\func_get_args());
+    }
+
+    public function unsubscribe($channels): array|bool
+    {
+        return $this->lazyObjectReal->unsubscribe(...\func_get_args());
+    }
+
+    public function unwatch()
+    {
+        return $this->lazyObjectReal->unwatch(...\func_get_args());
+    }
+
+    public function watch($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->watch(...\func_get_args());
+    }
+
+    public function wait($count, $timeout): int
+    {
+        return $this->lazyObjectReal->wait(...\func_get_args());
+    }
+
+    public function xack($key, $group, $ids): int
+    {
+        return $this->lazyObjectReal->xack(...\func_get_args());
+    }
+
+    public function xadd($key, $id, $values, $maxlen = 0, $approx = false, $nomkstream = false): string
+    {
+        return $this->lazyObjectReal->xadd(...\func_get_args());
+    }
+
+    public function xautoclaim($key, $group, $consumer, $min_idle, $start, $count = -1, $justid = false): array|bool
+    {
+        return $this->lazyObjectReal->xautoclaim(...\func_get_args());
+    }
+
+    public function xclaim($key, $group, $consumer, $min_idle, $ids, $options): array|bool
+    {
+        return $this->lazyObjectReal->xclaim(...\func_get_args());
+    }
+
+    public function xdel($key, $ids): int
+    {
+        return $this->lazyObjectReal->xdel(...\func_get_args());
+    }
+
+    public function xgroup($operation, $key = null, $arg1 = null, $arg2 = null, $arg3 = false): mixed
+    {
+        return $this->lazyObjectReal->xgroup(...\func_get_args());
+    }
+
+    public function xinfo($operation, $arg1 = null, $arg2 = null): mixed
+    {
+        return $this->lazyObjectReal->xinfo(...\func_get_args());
+    }
+
+    public function xlen($key): int
+    {
+        return $this->lazyObjectReal->xlen(...\func_get_args());
+    }
+
+    public function xpending($key, $group, $start = null, $end = null, $count = -1, $consumer = null): string
+    {
+        return $this->lazyObjectReal->xpending(...\func_get_args());
+    }
+
+    public function xrange($key, $start, $end, $count = -1): array|bool
+    {
+        return $this->lazyObjectReal->xrange(...\func_get_args());
+    }
+
+    public function xread($streams, $count = -1, $block = -1): array|bool
+    {
+        return $this->lazyObjectReal->xread(...\func_get_args());
+    }
+
+    public function xreadgroup($group, $consumer, $streams, $count = 1, $block = 1): array|bool
+    {
+        return $this->lazyObjectReal->xreadgroup(...\func_get_args());
+    }
+
+    public function xrevrange($key, $start, $end, $count = -1): array|bool
+    {
+        return $this->lazyObjectReal->xrevrange(...\func_get_args());
+    }
+
+    public function xtrim($key, $maxlen, $approx = false): int
+    {
+        return $this->lazyObjectReal->xtrim(...\func_get_args());
+    }
+
+    public function zAdd($key, $score, $value): int
+    {
+        return $this->lazyObjectReal->zAdd(...\func_get_args());
+    }
+
+    public function zCard($key): int
+    {
+        return $this->lazyObjectReal->zCard(...\func_get_args());
+    }
+
+    public function zCount($key, $start, $end): int
+    {
+        return $this->lazyObjectReal->zCount(...\func_get_args());
+    }
+
+    public function zIncrBy($key, $value, $member): float
+    {
+        return $this->lazyObjectReal->zIncrBy(...\func_get_args());
+    }
+
+    public function zLexCount($key, $min, $max): int
+    {
+        return $this->lazyObjectReal->zLexCount(...\func_get_args());
+    }
+
+    public function zMscore($key, $member, ...$other_members): array
+    {
+        return $this->lazyObjectReal->zMscore(...\func_get_args());
+    }
+
+    public function zPopMax($key, $value = null): array
+    {
+        return $this->lazyObjectReal->zPopMax(...\func_get_args());
+    }
+
+    public function zPopMin($key, $value = null): array
+    {
+        return $this->lazyObjectReal->zPopMin(...\func_get_args());
+    }
+
+    public function zRange($key, $start, $end, $scores = null): array
+    {
+        return $this->lazyObjectReal->zRange(...\func_get_args());
+    }
+
+    public function zRangeByLex($key, $min, $max, $offset = -1, $count = -1): array
+    {
+        return $this->lazyObjectReal->zRangeByLex(...\func_get_args());
+    }
+
+    public function zRangeByScore($key, $start, $end, $options = []): array
+    {
+        return $this->lazyObjectReal->zRangeByScore(...\func_get_args());
+    }
+
+    public function zRandMember($key, $options = null): array|string
+    {
+        return $this->lazyObjectReal->zRandMember(...\func_get_args());
+    }
+
+    public function zRank($key, $member): int
+    {
+        return $this->lazyObjectReal->zRank(...\func_get_args());
+    }
+
+    public function zRem($key, $member, ...$other_members): int
+    {
+        return $this->lazyObjectReal->zRem(...\func_get_args());
+    }
+
+    public function zRemRangeByLex($key, $min, $max): int
+    {
+        return $this->lazyObjectReal->zRemRangeByLex(...\func_get_args());
+    }
+
+    public function zRemRangeByRank($key, $start, $end): int
+    {
+        return $this->lazyObjectReal->zRemRangeByRank(...\func_get_args());
+    }
+
+    public function zRemRangeByScore($key, $start, $end): int
+    {
+        return $this->lazyObjectReal->zRemRangeByScore(...\func_get_args());
+    }
+
+    public function zRevRange($key, $start, $end, $scores = null): array
+    {
+        return $this->lazyObjectReal->zRevRange(...\func_get_args());
+    }
+
+    public function zRevRangeByLex($key, $min, $max, $offset = -1, $count = -1): array
+    {
+        return $this->lazyObjectReal->zRevRangeByLex(...\func_get_args());
+    }
+
+    public function zRevRangeByScore($key, $start, $end, $options = []): array
+    {
+        return $this->lazyObjectReal->zRevRangeByScore(...\func_get_args());
+    }
+
+    public function zRevRank($key, $member): int
+    {
+        return $this->lazyObjectReal->zRevRank(...\func_get_args());
+    }
+
+    public function zScore($key, $member): float
+    {
+        return $this->lazyObjectReal->zScore(...\func_get_args());
+    }
+
+    public function zdiff($keys, $options = null): array
+    {
+        return $this->lazyObjectReal->zdiff(...\func_get_args());
+    }
+
+    public function zdiffstore($dst, $keys, $options = null): int
+    {
+        return $this->lazyObjectReal->zdiffstore(...\func_get_args());
+    }
+
+    public function zinter($keys, $weights = null, $options = null): array
+    {
+        return $this->lazyObjectReal->zinter(...\func_get_args());
+    }
+
+    public function zinterstore($dst, $keys, $weights = null, $aggregate = null): int
+    {
+        return $this->lazyObjectReal->zinterstore(...\func_get_args());
+    }
+
+    public function zscan($key, &$iterator, $pattern = null, $count = 0): array|bool
+    {
+        return $this->lazyObjectReal->zscan(...\func_get_args());
+    }
+
+    public function zunion($keys, $weights = null, $options = null): array
+    {
+        return $this->lazyObjectReal->zunion(...\func_get_args());
+    }
+
+    public function zunionstore($dst, $keys, $weights = null, $aggregate = null): int
+    {
+        return $this->lazyObjectReal->zunionstore(...\func_get_args());
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
@@ -1,0 +1,989 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+use Symfony\Component\VarExporter\LazyObjectInterface;
+use Symfony\Component\VarExporter\LazyProxyTrait;
+use Symfony\Contracts\Service\ResetInterface;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
+
+/**
+ * @internal
+ */
+class RedisCluster5Proxy extends \RedisCluster implements ResetInterface, LazyObjectInterface
+{
+    use LazyProxyTrait {
+        resetLazyObject as reset;
+    }
+
+    private int $lazyObjectId;
+    private \RedisCluster $lazyObjectReal;
+
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [
+        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
+        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
+    ];
+
+    public function __construct($name, $seeds = null, $timeout = null, $read_timeout = null, $persistent = null, $auth = null)
+    {
+        return $this->lazyObjectReal->__construct(...\func_get_args());
+    }
+
+    public function _masters()
+    {
+        return $this->lazyObjectReal->_masters(...\func_get_args());
+    }
+
+    public function _prefix($key)
+    {
+        return $this->lazyObjectReal->_prefix(...\func_get_args());
+    }
+
+    public function _redir()
+    {
+        return $this->lazyObjectReal->_redir(...\func_get_args());
+    }
+
+    public function _serialize($value)
+    {
+        return $this->lazyObjectReal->_serialize(...\func_get_args());
+    }
+
+    public function _unserialize($value)
+    {
+        return $this->lazyObjectReal->_unserialize(...\func_get_args());
+    }
+
+    public function _compress($value)
+    {
+        return $this->lazyObjectReal->_compress(...\func_get_args());
+    }
+
+    public function _uncompress($value)
+    {
+        return $this->lazyObjectReal->_uncompress(...\func_get_args());
+    }
+
+    public function _pack($value)
+    {
+        return $this->lazyObjectReal->_pack(...\func_get_args());
+    }
+
+    public function _unpack($value)
+    {
+        return $this->lazyObjectReal->_unpack(...\func_get_args());
+    }
+
+    public function acl($key_or_address, $subcmd, ...$args)
+    {
+        return $this->lazyObjectReal->acl(...\func_get_args());
+    }
+
+    public function append($key, $value)
+    {
+        return $this->lazyObjectReal->append(...\func_get_args());
+    }
+
+    public function bgrewriteaof($key_or_address)
+    {
+        return $this->lazyObjectReal->bgrewriteaof(...\func_get_args());
+    }
+
+    public function bgsave($key_or_address)
+    {
+        return $this->lazyObjectReal->bgsave(...\func_get_args());
+    }
+
+    public function bitcount($key)
+    {
+        return $this->lazyObjectReal->bitcount(...\func_get_args());
+    }
+
+    public function bitop($operation, $ret_key, $key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->bitop(...\func_get_args());
+    }
+
+    public function bitpos($key, $bit, $start = null, $end = null)
+    {
+        return $this->lazyObjectReal->bitpos(...\func_get_args());
+    }
+
+    public function blpop($key, $timeout_or_key, ...$extra_args)
+    {
+        return $this->lazyObjectReal->blpop(...\func_get_args());
+    }
+
+    public function brpop($key, $timeout_or_key, ...$extra_args)
+    {
+        return $this->lazyObjectReal->brpop(...\func_get_args());
+    }
+
+    public function brpoplpush($src, $dst, $timeout)
+    {
+        return $this->lazyObjectReal->brpoplpush(...\func_get_args());
+    }
+
+    public function clearlasterror()
+    {
+        return $this->lazyObjectReal->clearlasterror(...\func_get_args());
+    }
+
+    public function bzpopmax($key, $timeout_or_key, ...$extra_args)
+    {
+        return $this->lazyObjectReal->bzpopmax(...\func_get_args());
+    }
+
+    public function bzpopmin($key, $timeout_or_key, ...$extra_args)
+    {
+        return $this->lazyObjectReal->bzpopmin(...\func_get_args());
+    }
+
+    public function client($key_or_address, $arg = null, ...$other_args)
+    {
+        return $this->lazyObjectReal->client(...\func_get_args());
+    }
+
+    public function close()
+    {
+        return $this->lazyObjectReal->close(...\func_get_args());
+    }
+
+    public function cluster($key_or_address, $arg = null, ...$other_args)
+    {
+        return $this->lazyObjectReal->cluster(...\func_get_args());
+    }
+
+    public function command(...$args)
+    {
+        return $this->lazyObjectReal->command(...\func_get_args());
+    }
+
+    public function config($key_or_address, $arg = null, ...$other_args)
+    {
+        return $this->lazyObjectReal->config(...\func_get_args());
+    }
+
+    public function dbsize($key_or_address)
+    {
+        return $this->lazyObjectReal->dbsize(...\func_get_args());
+    }
+
+    public function decr($key)
+    {
+        return $this->lazyObjectReal->decr(...\func_get_args());
+    }
+
+    public function decrby($key, $value)
+    {
+        return $this->lazyObjectReal->decrby(...\func_get_args());
+    }
+
+    public function del($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->del(...\func_get_args());
+    }
+
+    public function discard()
+    {
+        return $this->lazyObjectReal->discard(...\func_get_args());
+    }
+
+    public function dump($key)
+    {
+        return $this->lazyObjectReal->dump(...\func_get_args());
+    }
+
+    public function echo($msg)
+    {
+        return $this->lazyObjectReal->echo(...\func_get_args());
+    }
+
+    public function eval($script, $args = null, $num_keys = null)
+    {
+        return $this->lazyObjectReal->eval(...\func_get_args());
+    }
+
+    public function evalsha($script_sha, $args = null, $num_keys = null)
+    {
+        return $this->lazyObjectReal->evalsha(...\func_get_args());
+    }
+
+    public function exec()
+    {
+        return $this->lazyObjectReal->exec(...\func_get_args());
+    }
+
+    public function exists($key)
+    {
+        return $this->lazyObjectReal->exists(...\func_get_args());
+    }
+
+    public function expire($key, $timeout)
+    {
+        return $this->lazyObjectReal->expire(...\func_get_args());
+    }
+
+    public function expireat($key, $timestamp)
+    {
+        return $this->lazyObjectReal->expireat(...\func_get_args());
+    }
+
+    public function flushall($key_or_address, $async = null)
+    {
+        return $this->lazyObjectReal->flushall(...\func_get_args());
+    }
+
+    public function flushdb($key_or_address, $async = null)
+    {
+        return $this->lazyObjectReal->flushdb(...\func_get_args());
+    }
+
+    public function geoadd($key, $lng, $lat, $member, ...$other_triples)
+    {
+        return $this->lazyObjectReal->geoadd(...\func_get_args());
+    }
+
+    public function geodist($key, $src, $dst, $unit = null)
+    {
+        return $this->lazyObjectReal->geodist(...\func_get_args());
+    }
+
+    public function geohash($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->geohash(...\func_get_args());
+    }
+
+    public function geopos($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->geopos(...\func_get_args());
+    }
+
+    public function georadius($key, $lng, $lan, $radius, $unit, $opts = null)
+    {
+        return $this->lazyObjectReal->georadius(...\func_get_args());
+    }
+
+    public function georadius_ro($key, $lng, $lan, $radius, $unit, $opts = null)
+    {
+        return $this->lazyObjectReal->georadius_ro(...\func_get_args());
+    }
+
+    public function georadiusbymember($key, $member, $radius, $unit, $opts = null)
+    {
+        return $this->lazyObjectReal->georadiusbymember(...\func_get_args());
+    }
+
+    public function georadiusbymember_ro($key, $member, $radius, $unit, $opts = null)
+    {
+        return $this->lazyObjectReal->georadiusbymember_ro(...\func_get_args());
+    }
+
+    public function get($key)
+    {
+        return $this->lazyObjectReal->get(...\func_get_args());
+    }
+
+    public function getbit($key, $offset)
+    {
+        return $this->lazyObjectReal->getbit(...\func_get_args());
+    }
+
+    public function getlasterror()
+    {
+        return $this->lazyObjectReal->getlasterror(...\func_get_args());
+    }
+
+    public function getmode()
+    {
+        return $this->lazyObjectReal->getmode(...\func_get_args());
+    }
+
+    public function getoption($option)
+    {
+        return $this->lazyObjectReal->getoption(...\func_get_args());
+    }
+
+    public function getrange($key, $start, $end)
+    {
+        return $this->lazyObjectReal->getrange(...\func_get_args());
+    }
+
+    public function getset($key, $value)
+    {
+        return $this->lazyObjectReal->getset(...\func_get_args());
+    }
+
+    public function hdel($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->hdel(...\func_get_args());
+    }
+
+    public function hexists($key, $member)
+    {
+        return $this->lazyObjectReal->hexists(...\func_get_args());
+    }
+
+    public function hget($key, $member)
+    {
+        return $this->lazyObjectReal->hget(...\func_get_args());
+    }
+
+    public function hgetall($key)
+    {
+        return $this->lazyObjectReal->hgetall(...\func_get_args());
+    }
+
+    public function hincrby($key, $member, $value)
+    {
+        return $this->lazyObjectReal->hincrby(...\func_get_args());
+    }
+
+    public function hincrbyfloat($key, $member, $value)
+    {
+        return $this->lazyObjectReal->hincrbyfloat(...\func_get_args());
+    }
+
+    public function hkeys($key)
+    {
+        return $this->lazyObjectReal->hkeys(...\func_get_args());
+    }
+
+    public function hlen($key)
+    {
+        return $this->lazyObjectReal->hlen(...\func_get_args());
+    }
+
+    public function hmget($key, $keys)
+    {
+        return $this->lazyObjectReal->hmget(...\func_get_args());
+    }
+
+    public function hmset($key, $pairs)
+    {
+        return $this->lazyObjectReal->hmset(...\func_get_args());
+    }
+
+    public function hscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
+    {
+        return $this->lazyObjectReal->hscan(...\func_get_args());
+    }
+
+    public function hset($key, $member, $value)
+    {
+        return $this->lazyObjectReal->hset(...\func_get_args());
+    }
+
+    public function hsetnx($key, $member, $value)
+    {
+        return $this->lazyObjectReal->hsetnx(...\func_get_args());
+    }
+
+    public function hstrlen($key, $member)
+    {
+        return $this->lazyObjectReal->hstrlen(...\func_get_args());
+    }
+
+    public function hvals($key)
+    {
+        return $this->lazyObjectReal->hvals(...\func_get_args());
+    }
+
+    public function incr($key)
+    {
+        return $this->lazyObjectReal->incr(...\func_get_args());
+    }
+
+    public function incrby($key, $value)
+    {
+        return $this->lazyObjectReal->incrby(...\func_get_args());
+    }
+
+    public function incrbyfloat($key, $value)
+    {
+        return $this->lazyObjectReal->incrbyfloat(...\func_get_args());
+    }
+
+    public function info($key_or_address, $option = null)
+    {
+        return $this->lazyObjectReal->info(...\func_get_args());
+    }
+
+    public function keys($pattern)
+    {
+        return $this->lazyObjectReal->keys(...\func_get_args());
+    }
+
+    public function lastsave($key_or_address)
+    {
+        return $this->lazyObjectReal->lastsave(...\func_get_args());
+    }
+
+    public function lget($key, $index)
+    {
+        return $this->lazyObjectReal->lget(...\func_get_args());
+    }
+
+    public function lindex($key, $index)
+    {
+        return $this->lazyObjectReal->lindex(...\func_get_args());
+    }
+
+    public function linsert($key, $position, $pivot, $value)
+    {
+        return $this->lazyObjectReal->linsert(...\func_get_args());
+    }
+
+    public function llen($key)
+    {
+        return $this->lazyObjectReal->llen(...\func_get_args());
+    }
+
+    public function lpop($key)
+    {
+        return $this->lazyObjectReal->lpop(...\func_get_args());
+    }
+
+    public function lpush($key, $value)
+    {
+        return $this->lazyObjectReal->lpush(...\func_get_args());
+    }
+
+    public function lpushx($key, $value)
+    {
+        return $this->lazyObjectReal->lpushx(...\func_get_args());
+    }
+
+    public function lrange($key, $start, $end)
+    {
+        return $this->lazyObjectReal->lrange(...\func_get_args());
+    }
+
+    public function lrem($key, $value)
+    {
+        return $this->lazyObjectReal->lrem(...\func_get_args());
+    }
+
+    public function lset($key, $index, $value)
+    {
+        return $this->lazyObjectReal->lset(...\func_get_args());
+    }
+
+    public function ltrim($key, $start, $stop)
+    {
+        return $this->lazyObjectReal->ltrim(...\func_get_args());
+    }
+
+    public function mget($keys)
+    {
+        return $this->lazyObjectReal->mget(...\func_get_args());
+    }
+
+    public function mset($pairs)
+    {
+        return $this->lazyObjectReal->mset(...\func_get_args());
+    }
+
+    public function msetnx($pairs)
+    {
+        return $this->lazyObjectReal->msetnx(...\func_get_args());
+    }
+
+    public function multi()
+    {
+        return $this->lazyObjectReal->multi(...\func_get_args());
+    }
+
+    public function object($field, $key)
+    {
+        return $this->lazyObjectReal->object(...\func_get_args());
+    }
+
+    public function persist($key)
+    {
+        return $this->lazyObjectReal->persist(...\func_get_args());
+    }
+
+    public function pexpire($key, $timestamp)
+    {
+        return $this->lazyObjectReal->pexpire(...\func_get_args());
+    }
+
+    public function pexpireat($key, $timestamp)
+    {
+        return $this->lazyObjectReal->pexpireat(...\func_get_args());
+    }
+
+    public function pfadd($key, $elements)
+    {
+        return $this->lazyObjectReal->pfadd(...\func_get_args());
+    }
+
+    public function pfcount($key)
+    {
+        return $this->lazyObjectReal->pfcount(...\func_get_args());
+    }
+
+    public function pfmerge($dstkey, $keys)
+    {
+        return $this->lazyObjectReal->pfmerge(...\func_get_args());
+    }
+
+    public function ping($key_or_address)
+    {
+        return $this->lazyObjectReal->ping(...\func_get_args());
+    }
+
+    public function psetex($key, $expire, $value)
+    {
+        return $this->lazyObjectReal->psetex(...\func_get_args());
+    }
+
+    public function psubscribe($patterns, $callback)
+    {
+        return $this->lazyObjectReal->psubscribe(...\func_get_args());
+    }
+
+    public function pttl($key)
+    {
+        return $this->lazyObjectReal->pttl(...\func_get_args());
+    }
+
+    public function publish($channel, $message)
+    {
+        return $this->lazyObjectReal->publish(...\func_get_args());
+    }
+
+    public function pubsub($key_or_address, $arg = null, ...$other_args)
+    {
+        return $this->lazyObjectReal->pubsub(...\func_get_args());
+    }
+
+    public function punsubscribe($pattern, ...$other_patterns)
+    {
+        return $this->lazyObjectReal->punsubscribe(...\func_get_args());
+    }
+
+    public function randomkey($key_or_address)
+    {
+        return $this->lazyObjectReal->randomkey(...\func_get_args());
+    }
+
+    public function rawcommand($cmd, ...$args)
+    {
+        return $this->lazyObjectReal->rawcommand(...\func_get_args());
+    }
+
+    public function rename($key, $newkey)
+    {
+        return $this->lazyObjectReal->rename(...\func_get_args());
+    }
+
+    public function renamenx($key, $newkey)
+    {
+        return $this->lazyObjectReal->renamenx(...\func_get_args());
+    }
+
+    public function restore($ttl, $key, $value)
+    {
+        return $this->lazyObjectReal->restore(...\func_get_args());
+    }
+
+    public function role()
+    {
+        return $this->lazyObjectReal->role(...\func_get_args());
+    }
+
+    public function rpop($key)
+    {
+        return $this->lazyObjectReal->rpop(...\func_get_args());
+    }
+
+    public function rpoplpush($src, $dst)
+    {
+        return $this->lazyObjectReal->rpoplpush(...\func_get_args());
+    }
+
+    public function rpush($key, $value)
+    {
+        return $this->lazyObjectReal->rpush(...\func_get_args());
+    }
+
+    public function rpushx($key, $value)
+    {
+        return $this->lazyObjectReal->rpushx(...\func_get_args());
+    }
+
+    public function sadd($key, $value)
+    {
+        return $this->lazyObjectReal->sadd(...\func_get_args());
+    }
+
+    public function saddarray($key, $options)
+    {
+        return $this->lazyObjectReal->saddarray(...\func_get_args());
+    }
+
+    public function save($key_or_address)
+    {
+        return $this->lazyObjectReal->save(...\func_get_args());
+    }
+
+    public function scan(&$i_iterator, $str_node, $str_pattern = null, $i_count = null)
+    {
+        return $this->lazyObjectReal->scan(...\func_get_args());
+    }
+
+    public function scard($key)
+    {
+        return $this->lazyObjectReal->scard(...\func_get_args());
+    }
+
+    public function script($key_or_address, $arg = null, ...$other_args)
+    {
+        return $this->lazyObjectReal->script(...\func_get_args());
+    }
+
+    public function sdiff($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sdiff(...\func_get_args());
+    }
+
+    public function sdiffstore($dst, $key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sdiffstore(...\func_get_args());
+    }
+
+    public function set($key, $value, $opts = null)
+    {
+        return $this->lazyObjectReal->set(...\func_get_args());
+    }
+
+    public function setbit($key, $offset, $value)
+    {
+        return $this->lazyObjectReal->setbit(...\func_get_args());
+    }
+
+    public function setex($key, $expire, $value)
+    {
+        return $this->lazyObjectReal->setex(...\func_get_args());
+    }
+
+    public function setnx($key, $value)
+    {
+        return $this->lazyObjectReal->setnx(...\func_get_args());
+    }
+
+    public function setoption($option, $value)
+    {
+        return $this->lazyObjectReal->setoption(...\func_get_args());
+    }
+
+    public function setrange($key, $offset, $value)
+    {
+        return $this->lazyObjectReal->setrange(...\func_get_args());
+    }
+
+    public function sinter($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sinter(...\func_get_args());
+    }
+
+    public function sinterstore($dst, $key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sinterstore(...\func_get_args());
+    }
+
+    public function sismember($key, $value)
+    {
+        return $this->lazyObjectReal->sismember(...\func_get_args());
+    }
+
+    public function slowlog($key_or_address, $arg = null, ...$other_args)
+    {
+        return $this->lazyObjectReal->slowlog(...\func_get_args());
+    }
+
+    public function smembers($key)
+    {
+        return $this->lazyObjectReal->smembers(...\func_get_args());
+    }
+
+    public function smove($src, $dst, $value)
+    {
+        return $this->lazyObjectReal->smove(...\func_get_args());
+    }
+
+    public function sort($key, $options = null)
+    {
+        return $this->lazyObjectReal->sort(...\func_get_args());
+    }
+
+    public function spop($key)
+    {
+        return $this->lazyObjectReal->spop(...\func_get_args());
+    }
+
+    public function srandmember($key, $count = null)
+    {
+        return $this->lazyObjectReal->srandmember(...\func_get_args());
+    }
+
+    public function srem($key, $value)
+    {
+        return $this->lazyObjectReal->srem(...\func_get_args());
+    }
+
+    public function sscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
+    {
+        return $this->lazyObjectReal->sscan(...\func_get_args());
+    }
+
+    public function strlen($key)
+    {
+        return $this->lazyObjectReal->strlen(...\func_get_args());
+    }
+
+    public function subscribe($channels, $callback)
+    {
+        return $this->lazyObjectReal->subscribe(...\func_get_args());
+    }
+
+    public function sunion($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sunion(...\func_get_args());
+    }
+
+    public function sunionstore($dst, $key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->sunionstore(...\func_get_args());
+    }
+
+    public function time()
+    {
+        return $this->lazyObjectReal->time(...\func_get_args());
+    }
+
+    public function ttl($key)
+    {
+        return $this->lazyObjectReal->ttl(...\func_get_args());
+    }
+
+    public function type($key)
+    {
+        return $this->lazyObjectReal->type(...\func_get_args());
+    }
+
+    public function unsubscribe($channel, ...$other_channels)
+    {
+        return $this->lazyObjectReal->unsubscribe(...\func_get_args());
+    }
+
+    public function unlink($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->unlink(...\func_get_args());
+    }
+
+    public function unwatch()
+    {
+        return $this->lazyObjectReal->unwatch(...\func_get_args());
+    }
+
+    public function watch($key, ...$other_keys)
+    {
+        return $this->lazyObjectReal->watch(...\func_get_args());
+    }
+
+    public function xack($str_key, $str_group, $arr_ids)
+    {
+        return $this->lazyObjectReal->xack(...\func_get_args());
+    }
+
+    public function xadd($str_key, $str_id, $arr_fields, $i_maxlen = null, $boo_approximate = null)
+    {
+        return $this->lazyObjectReal->xadd(...\func_get_args());
+    }
+
+    public function xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts = null)
+    {
+        return $this->lazyObjectReal->xclaim(...\func_get_args());
+    }
+
+    public function xdel($str_key, $arr_ids)
+    {
+        return $this->lazyObjectReal->xdel(...\func_get_args());
+    }
+
+    public function xgroup($str_operation, $str_key = null, $str_arg1 = null, $str_arg2 = null, $str_arg3 = null)
+    {
+        return $this->lazyObjectReal->xgroup(...\func_get_args());
+    }
+
+    public function xinfo($str_cmd, $str_key = null, $str_group = null)
+    {
+        return $this->lazyObjectReal->xinfo(...\func_get_args());
+    }
+
+    public function xlen($key)
+    {
+        return $this->lazyObjectReal->xlen(...\func_get_args());
+    }
+
+    public function xpending($str_key, $str_group, $str_start = null, $str_end = null, $i_count = null, $str_consumer = null)
+    {
+        return $this->lazyObjectReal->xpending(...\func_get_args());
+    }
+
+    public function xrange($str_key, $str_start, $str_end, $i_count = null)
+    {
+        return $this->lazyObjectReal->xrange(...\func_get_args());
+    }
+
+    public function xread($arr_streams, $i_count = null, $i_block = null)
+    {
+        return $this->lazyObjectReal->xread(...\func_get_args());
+    }
+
+    public function xreadgroup($str_group, $str_consumer, $arr_streams, $i_count = null, $i_block = null)
+    {
+        return $this->lazyObjectReal->xreadgroup(...\func_get_args());
+    }
+
+    public function xrevrange($str_key, $str_start, $str_end, $i_count = null)
+    {
+        return $this->lazyObjectReal->xrevrange(...\func_get_args());
+    }
+
+    public function xtrim($str_key, $i_maxlen, $boo_approximate = null)
+    {
+        return $this->lazyObjectReal->xtrim(...\func_get_args());
+    }
+
+    public function zadd($key, $score, $value, ...$extra_args)
+    {
+        return $this->lazyObjectReal->zadd(...\func_get_args());
+    }
+
+    public function zcard($key)
+    {
+        return $this->lazyObjectReal->zcard(...\func_get_args());
+    }
+
+    public function zcount($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zcount(...\func_get_args());
+    }
+
+    public function zincrby($key, $value, $member)
+    {
+        return $this->lazyObjectReal->zincrby(...\func_get_args());
+    }
+
+    public function zinterstore($key, $keys, $weights = null, $aggregate = null)
+    {
+        return $this->lazyObjectReal->zinterstore(...\func_get_args());
+    }
+
+    public function zlexcount($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zlexcount(...\func_get_args());
+    }
+
+    public function zpopmax($key)
+    {
+        return $this->lazyObjectReal->zpopmax(...\func_get_args());
+    }
+
+    public function zpopmin($key)
+    {
+        return $this->lazyObjectReal->zpopmin(...\func_get_args());
+    }
+
+    public function zrange($key, $start, $end, $scores = null)
+    {
+        return $this->lazyObjectReal->zrange(...\func_get_args());
+    }
+
+    public function zrangebylex($key, $min, $max, $offset = null, $limit = null)
+    {
+        return $this->lazyObjectReal->zrangebylex(...\func_get_args());
+    }
+
+    public function zrangebyscore($key, $start, $end, $options = null)
+    {
+        return $this->lazyObjectReal->zrangebyscore(...\func_get_args());
+    }
+
+    public function zrank($key, $member)
+    {
+        return $this->lazyObjectReal->zrank(...\func_get_args());
+    }
+
+    public function zrem($key, $member, ...$other_members)
+    {
+        return $this->lazyObjectReal->zrem(...\func_get_args());
+    }
+
+    public function zremrangebylex($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zremrangebylex(...\func_get_args());
+    }
+
+    public function zremrangebyrank($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zremrangebyrank(...\func_get_args());
+    }
+
+    public function zremrangebyscore($key, $min, $max)
+    {
+        return $this->lazyObjectReal->zremrangebyscore(...\func_get_args());
+    }
+
+    public function zrevrange($key, $start, $end, $scores = null)
+    {
+        return $this->lazyObjectReal->zrevrange(...\func_get_args());
+    }
+
+    public function zrevrangebylex($key, $min, $max, $offset = null, $limit = null)
+    {
+        return $this->lazyObjectReal->zrevrangebylex(...\func_get_args());
+    }
+
+    public function zrevrangebyscore($key, $start, $end, $options = null)
+    {
+        return $this->lazyObjectReal->zrevrangebyscore(...\func_get_args());
+    }
+
+    public function zrevrank($key, $member)
+    {
+        return $this->lazyObjectReal->zrevrank(...\func_get_args());
+    }
+
+    public function zscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
+    {
+        return $this->lazyObjectReal->zscan(...\func_get_args());
+    }
+
+    public function zscore($key, $member)
+    {
+        return $this->lazyObjectReal->zscore(...\func_get_args());
+    }
+
+    public function zunionstore($key, $keys, $weights = null, $aggregate = null)
+    {
+        return $this->lazyObjectReal->zunionstore(...\func_get_args());
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
@@ -1,0 +1,994 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+use Symfony\Component\VarExporter\LazyObjectInterface;
+use Symfony\Component\VarExporter\LazyProxyTrait;
+use Symfony\Contracts\Service\ResetInterface;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
+
+/**
+ * @internal
+ */
+class RedisCluster6Proxy extends \RedisCluster implements ResetInterface, LazyObjectInterface
+{
+    use LazyProxyTrait {
+        resetLazyObject as reset;
+    }
+
+    private int $lazyObjectId;
+    private \RedisCluster $lazyObjectReal;
+
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [
+        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
+        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
+    ];
+
+    public function __construct($name, $seeds = null, $timeout = 0, $read_timeout = 0, $persistent = false, #[\SensitiveParameter] $auth = null, $context = null)
+    {
+        return $this->lazyObjectReal->__construct(...\func_get_args());
+    }
+
+    public function _compress($value): string
+    {
+        return $this->lazyObjectReal->_compress(...\func_get_args());
+    }
+
+    public function _masters(): array
+    {
+        return $this->lazyObjectReal->_masters(...\func_get_args());
+    }
+
+    public function _pack($value): string
+    {
+        return $this->lazyObjectReal->_pack(...\func_get_args());
+    }
+
+    public function _prefix($key): bool|string
+    {
+        return $this->lazyObjectReal->_prefix(...\func_get_args());
+    }
+
+    public function _redir(): ?string
+    {
+        return $this->lazyObjectReal->_redir(...\func_get_args());
+    }
+
+    public function _serialize($value): bool|string
+    {
+        return $this->lazyObjectReal->_serialize(...\func_get_args());
+    }
+
+    public function _uncompress($value): string
+    {
+        return $this->lazyObjectReal->_uncompress(...\func_get_args());
+    }
+
+    public function _unpack($value): mixed
+    {
+        return $this->lazyObjectReal->_unpack(...\func_get_args());
+    }
+
+    public function _unserialize($value): mixed
+    {
+        return $this->lazyObjectReal->_unserialize(...\func_get_args());
+    }
+
+    public function acl($key_or_address, $subcmd, ...$args): mixed
+    {
+        return $this->lazyObjectReal->acl(...\func_get_args());
+    }
+
+    public function append($key, $value): bool|int
+    {
+        return $this->lazyObjectReal->append(...\func_get_args());
+    }
+
+    public function bgrewriteaof($key_or_address): bool
+    {
+        return $this->lazyObjectReal->bgrewriteaof(...\func_get_args());
+    }
+
+    public function bgsave($key_or_address): bool
+    {
+        return $this->lazyObjectReal->bgsave(...\func_get_args());
+    }
+
+    public function bitcount($key, $start = 0, $end = -1): bool|int
+    {
+        return $this->lazyObjectReal->bitcount(...\func_get_args());
+    }
+
+    public function bitop($operation, $deskey, $srckey, ...$otherkeys): bool|int
+    {
+        return $this->lazyObjectReal->bitop(...\func_get_args());
+    }
+
+    public function bitpos($key, $bit, $start = null, $end = null): bool|int
+    {
+        return $this->lazyObjectReal->bitpos(...\func_get_args());
+    }
+
+    public function blpop($key, $timeout_or_key, ...$extra_args): array
+    {
+        return $this->lazyObjectReal->blpop(...\func_get_args());
+    }
+
+    public function brpop($key, $timeout_or_key, ...$extra_args): array
+    {
+        return $this->lazyObjectReal->brpop(...\func_get_args());
+    }
+
+    public function brpoplpush($srckey, $deskey, $timeout): mixed
+    {
+        return $this->lazyObjectReal->brpoplpush(...\func_get_args());
+    }
+
+    public function bzpopmax($key, $timeout_or_key, ...$extra_args): array
+    {
+        return $this->lazyObjectReal->bzpopmax(...\func_get_args());
+    }
+
+    public function bzpopmin($key, $timeout_or_key, ...$extra_args): array
+    {
+        return $this->lazyObjectReal->bzpopmin(...\func_get_args());
+    }
+
+    public function clearlasterror(): bool
+    {
+        return $this->lazyObjectReal->clearlasterror(...\func_get_args());
+    }
+
+    public function client($node, $subcommand, $arg): array|bool|string
+    {
+        return $this->lazyObjectReal->client(...\func_get_args());
+    }
+
+    public function close(): bool
+    {
+        return $this->lazyObjectReal->close(...\func_get_args());
+    }
+
+    public function cluster($node, $command, ...$extra_args): mixed
+    {
+        return $this->lazyObjectReal->cluster(...\func_get_args());
+    }
+
+    public function command(...$extra_args): mixed
+    {
+        return $this->lazyObjectReal->command(...\func_get_args());
+    }
+
+    public function config($node, $subcommand, ...$extra_args): mixed
+    {
+        return $this->lazyObjectReal->config(...\func_get_args());
+    }
+
+    public function dbsize($key_or_address): int
+    {
+        return $this->lazyObjectReal->dbsize(...\func_get_args());
+    }
+
+    public function decr($key): int
+    {
+        return $this->lazyObjectReal->decr(...\func_get_args());
+    }
+
+    public function decrby($key, $value): int
+    {
+        return $this->lazyObjectReal->decrby(...\func_get_args());
+    }
+
+    public function decrbyfloat($key, $value): float
+    {
+        return $this->lazyObjectReal->decrbyfloat(...\func_get_args());
+    }
+
+    public function del($key, ...$other_keys): array
+    {
+        return $this->lazyObjectReal->del(...\func_get_args());
+    }
+
+    public function discard(): bool
+    {
+        return $this->lazyObjectReal->discard(...\func_get_args());
+    }
+
+    public function dump($key): string
+    {
+        return $this->lazyObjectReal->dump(...\func_get_args());
+    }
+
+    public function echo($node, $msg): string
+    {
+        return $this->lazyObjectReal->echo(...\func_get_args());
+    }
+
+    public function eval($script, $args = [], $num_keys = 0): mixed
+    {
+        return $this->lazyObjectReal->eval(...\func_get_args());
+    }
+
+    public function evalsha($script_sha, $args = [], $num_keys = 0): mixed
+    {
+        return $this->lazyObjectReal->evalsha(...\func_get_args());
+    }
+
+    public function exec(): array
+    {
+        return $this->lazyObjectReal->exec(...\func_get_args());
+    }
+
+    public function exists($key): int
+    {
+        return $this->lazyObjectReal->exists(...\func_get_args());
+    }
+
+    public function expire($key, $timeout): bool
+    {
+        return $this->lazyObjectReal->expire(...\func_get_args());
+    }
+
+    public function expireat($key, $timestamp): bool
+    {
+        return $this->lazyObjectReal->expireat(...\func_get_args());
+    }
+
+    public function flushall($node, $async = false): bool
+    {
+        return $this->lazyObjectReal->flushall(...\func_get_args());
+    }
+
+    public function flushdb($node, $async = false): bool
+    {
+        return $this->lazyObjectReal->flushdb(...\func_get_args());
+    }
+
+    public function geoadd($key, $lng, $lat, $member, ...$other_triples): int
+    {
+        return $this->lazyObjectReal->geoadd(...\func_get_args());
+    }
+
+    public function geodist($key, $src, $dest, $unit = null): array
+    {
+        return $this->lazyObjectReal->geodist(...\func_get_args());
+    }
+
+    public function geohash($key, $member, ...$other_members): array
+    {
+        return $this->lazyObjectReal->geohash(...\func_get_args());
+    }
+
+    public function geopos($key, $member, ...$other_members): array
+    {
+        return $this->lazyObjectReal->geopos(...\func_get_args());
+    }
+
+    public function georadius($key, $lng, $lat, $radius, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->georadius(...\func_get_args());
+    }
+
+    public function georadius_ro($key, $lng, $lat, $radius, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->georadius_ro(...\func_get_args());
+    }
+
+    public function georadiusbymember($key, $member, $radius, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->georadiusbymember(...\func_get_args());
+    }
+
+    public function georadiusbymember_ro($key, $member, $radius, $unit, $options = []): array
+    {
+        return $this->lazyObjectReal->georadiusbymember_ro(...\func_get_args());
+    }
+
+    public function get($key): string
+    {
+        return $this->lazyObjectReal->get(...\func_get_args());
+    }
+
+    public function getbit($key, $value): int
+    {
+        return $this->lazyObjectReal->getbit(...\func_get_args());
+    }
+
+    public function getlasterror(): ?string
+    {
+        return $this->lazyObjectReal->getlasterror(...\func_get_args());
+    }
+
+    public function getmode(): int
+    {
+        return $this->lazyObjectReal->getmode(...\func_get_args());
+    }
+
+    public function getoption($option): mixed
+    {
+        return $this->lazyObjectReal->getoption(...\func_get_args());
+    }
+
+    public function getrange($key, $start, $end): string
+    {
+        return $this->lazyObjectReal->getrange(...\func_get_args());
+    }
+
+    public function getset($key, $value): string
+    {
+        return $this->lazyObjectReal->getset(...\func_get_args());
+    }
+
+    public function hdel($key, $member, ...$other_members): int
+    {
+        return $this->lazyObjectReal->hdel(...\func_get_args());
+    }
+
+    public function hexists($key, $member): bool
+    {
+        return $this->lazyObjectReal->hexists(...\func_get_args());
+    }
+
+    public function hget($key, $member): string
+    {
+        return $this->lazyObjectReal->hget(...\func_get_args());
+    }
+
+    public function hgetall($key): array
+    {
+        return $this->lazyObjectReal->hgetall(...\func_get_args());
+    }
+
+    public function hincrby($key, $member, $value): int
+    {
+        return $this->lazyObjectReal->hincrby(...\func_get_args());
+    }
+
+    public function hincrbyfloat($key, $member, $value): float
+    {
+        return $this->lazyObjectReal->hincrbyfloat(...\func_get_args());
+    }
+
+    public function hkeys($key): array
+    {
+        return $this->lazyObjectReal->hkeys(...\func_get_args());
+    }
+
+    public function hlen($key): int
+    {
+        return $this->lazyObjectReal->hlen(...\func_get_args());
+    }
+
+    public function hmget($key, $members): array
+    {
+        return $this->lazyObjectReal->hmget(...\func_get_args());
+    }
+
+    public function hmset($key, $key_values): bool
+    {
+        return $this->lazyObjectReal->hmset(...\func_get_args());
+    }
+
+    public function hscan($key, &$iterator, $pattern = null, $count = 0): array|bool
+    {
+        return $this->lazyObjectReal->hscan(...\func_get_args());
+    }
+
+    public function hset($key, $member, $value): int
+    {
+        return $this->lazyObjectReal->hset(...\func_get_args());
+    }
+
+    public function hsetnx($key, $member, $value): bool
+    {
+        return $this->lazyObjectReal->hsetnx(...\func_get_args());
+    }
+
+    public function hstrlen($key, $field): int
+    {
+        return $this->lazyObjectReal->hstrlen(...\func_get_args());
+    }
+
+    public function hvals($key): array
+    {
+        return $this->lazyObjectReal->hvals(...\func_get_args());
+    }
+
+    public function incr($key): int
+    {
+        return $this->lazyObjectReal->incr(...\func_get_args());
+    }
+
+    public function incrby($key, $value): int
+    {
+        return $this->lazyObjectReal->incrby(...\func_get_args());
+    }
+
+    public function incrbyfloat($key, $value): float
+    {
+        return $this->lazyObjectReal->incrbyfloat(...\func_get_args());
+    }
+
+    public function info($node, $section = null): array
+    {
+        return $this->lazyObjectReal->info(...\func_get_args());
+    }
+
+    public function keys($pattern): array
+    {
+        return $this->lazyObjectReal->keys(...\func_get_args());
+    }
+
+    public function lastsave($node): int
+    {
+        return $this->lazyObjectReal->lastsave(...\func_get_args());
+    }
+
+    public function lget($key, $index): bool|string
+    {
+        return $this->lazyObjectReal->lget(...\func_get_args());
+    }
+
+    public function lindex($key, $index): bool|string
+    {
+        return $this->lazyObjectReal->lindex(...\func_get_args());
+    }
+
+    public function linsert($key, $pos, $pivot, $value): int
+    {
+        return $this->lazyObjectReal->linsert(...\func_get_args());
+    }
+
+    public function llen($key): bool|int
+    {
+        return $this->lazyObjectReal->llen(...\func_get_args());
+    }
+
+    public function lpop($key, $count = 0): array|bool|string
+    {
+        return $this->lazyObjectReal->lpop(...\func_get_args());
+    }
+
+    public function lpush($key, $value, ...$other_values): bool|int
+    {
+        return $this->lazyObjectReal->lpush(...\func_get_args());
+    }
+
+    public function lpushx($key, $value): bool|int
+    {
+        return $this->lazyObjectReal->lpushx(...\func_get_args());
+    }
+
+    public function lrange($key, $start, $end): array
+    {
+        return $this->lazyObjectReal->lrange(...\func_get_args());
+    }
+
+    public function lrem($key, $count, $value): bool|int
+    {
+        return $this->lazyObjectReal->lrem(...\func_get_args());
+    }
+
+    public function lset($key, $index, $value): bool
+    {
+        return $this->lazyObjectReal->lset(...\func_get_args());
+    }
+
+    public function ltrim($key, $start, $end): bool
+    {
+        return $this->lazyObjectReal->ltrim(...\func_get_args());
+    }
+
+    public function mget($keys): array
+    {
+        return $this->lazyObjectReal->mget(...\func_get_args());
+    }
+
+    public function mset($key_values): bool
+    {
+        return $this->lazyObjectReal->mset(...\func_get_args());
+    }
+
+    public function msetnx($key_values): int
+    {
+        return $this->lazyObjectReal->msetnx(...\func_get_args());
+    }
+
+    public function multi(): \RedisCluster|bool
+    {
+        return $this->lazyObjectReal->multi(...\func_get_args());
+    }
+
+    public function object($subcommand, $key): int|string
+    {
+        return $this->lazyObjectReal->object(...\func_get_args());
+    }
+
+    public function persist($key): bool
+    {
+        return $this->lazyObjectReal->persist(...\func_get_args());
+    }
+
+    public function pexpire($key, $timeout): bool
+    {
+        return $this->lazyObjectReal->pexpire(...\func_get_args());
+    }
+
+    public function pexpireat($key, $timestamp): bool
+    {
+        return $this->lazyObjectReal->pexpireat(...\func_get_args());
+    }
+
+    public function pfadd($key, $elements): bool
+    {
+        return $this->lazyObjectReal->pfadd(...\func_get_args());
+    }
+
+    public function pfcount($key): int
+    {
+        return $this->lazyObjectReal->pfcount(...\func_get_args());
+    }
+
+    public function pfmerge($key, $keys): bool
+    {
+        return $this->lazyObjectReal->pfmerge(...\func_get_args());
+    }
+
+    public function ping($key_or_address, $message): mixed
+    {
+        return $this->lazyObjectReal->ping(...\func_get_args());
+    }
+
+    public function psetex($key, $timeout, $value): bool
+    {
+        return $this->lazyObjectReal->psetex(...\func_get_args());
+    }
+
+    public function psubscribe($patterns, $callback): void
+    {
+        $this->lazyObjectReal->psubscribe(...\func_get_args());
+    }
+
+    public function pttl($key): int
+    {
+        return $this->lazyObjectReal->pttl(...\func_get_args());
+    }
+
+    public function publish($channel, $message): bool
+    {
+        return $this->lazyObjectReal->publish(...\func_get_args());
+    }
+
+    public function pubsub($key_or_address, ...$values): mixed
+    {
+        return $this->lazyObjectReal->pubsub(...\func_get_args());
+    }
+
+    public function punsubscribe($pattern, ...$other_patterns): array|bool
+    {
+        return $this->lazyObjectReal->punsubscribe(...\func_get_args());
+    }
+
+    public function randomkey($key_or_address): bool|string
+    {
+        return $this->lazyObjectReal->randomkey(...\func_get_args());
+    }
+
+    public function rawcommand($key_or_address, $command, ...$args): mixed
+    {
+        return $this->lazyObjectReal->rawcommand(...\func_get_args());
+    }
+
+    public function rename($key, $newkey): bool
+    {
+        return $this->lazyObjectReal->rename(...\func_get_args());
+    }
+
+    public function renamenx($key, $newkey): bool
+    {
+        return $this->lazyObjectReal->renamenx(...\func_get_args());
+    }
+
+    public function restore($key, $timeout, $value): bool
+    {
+        return $this->lazyObjectReal->restore(...\func_get_args());
+    }
+
+    public function role($key_or_address): mixed
+    {
+        return $this->lazyObjectReal->role(...\func_get_args());
+    }
+
+    public function rpop($key, $count = 0): array|bool|string
+    {
+        return $this->lazyObjectReal->rpop(...\func_get_args());
+    }
+
+    public function rpoplpush($src, $dst): bool|string
+    {
+        return $this->lazyObjectReal->rpoplpush(...\func_get_args());
+    }
+
+    public function rpush($key, $value, ...$other_values): bool|int
+    {
+        return $this->lazyObjectReal->rpush(...\func_get_args());
+    }
+
+    public function rpushx($key, $value): bool|int
+    {
+        return $this->lazyObjectReal->rpushx(...\func_get_args());
+    }
+
+    public function sadd($key, $value, ...$other_values): bool|int
+    {
+        return $this->lazyObjectReal->sadd(...\func_get_args());
+    }
+
+    public function saddarray($key, $values): bool|int
+    {
+        return $this->lazyObjectReal->saddarray(...\func_get_args());
+    }
+
+    public function save($key_or_address): bool
+    {
+        return $this->lazyObjectReal->save(...\func_get_args());
+    }
+
+    public function scan(&$iterator, $node, $pattern = null, $count = 0): array|bool
+    {
+        return $this->lazyObjectReal->scan(...\func_get_args());
+    }
+
+    public function scard($key): int
+    {
+        return $this->lazyObjectReal->scard(...\func_get_args());
+    }
+
+    public function script($key_or_address, ...$args): mixed
+    {
+        return $this->lazyObjectReal->script(...\func_get_args());
+    }
+
+    public function sdiff($key, ...$other_keys): array
+    {
+        return $this->lazyObjectReal->sdiff(...\func_get_args());
+    }
+
+    public function sdiffstore($dst, $key, ...$other_keys): int
+    {
+        return $this->lazyObjectReal->sdiffstore(...\func_get_args());
+    }
+
+    public function set($key, $value): bool
+    {
+        return $this->lazyObjectReal->set(...\func_get_args());
+    }
+
+    public function setbit($key, $offset, $onoff): bool
+    {
+        return $this->lazyObjectReal->setbit(...\func_get_args());
+    }
+
+    public function setex($key, $value, $timeout): bool
+    {
+        return $this->lazyObjectReal->setex(...\func_get_args());
+    }
+
+    public function setnx($key, $value, $timeout): bool
+    {
+        return $this->lazyObjectReal->setnx(...\func_get_args());
+    }
+
+    public function setoption($option, $value): bool
+    {
+        return $this->lazyObjectReal->setoption(...\func_get_args());
+    }
+
+    public function setrange($key, $offset, $value): int
+    {
+        return $this->lazyObjectReal->setrange(...\func_get_args());
+    }
+
+    public function sinter($key, ...$other_keys): array
+    {
+        return $this->lazyObjectReal->sinter(...\func_get_args());
+    }
+
+    public function sinterstore($dst, $key, ...$other_keys): bool
+    {
+        return $this->lazyObjectReal->sinterstore(...\func_get_args());
+    }
+
+    public function sismember($key): int
+    {
+        return $this->lazyObjectReal->sismember(...\func_get_args());
+    }
+
+    public function slowlog($key_or_address, ...$args): mixed
+    {
+        return $this->lazyObjectReal->slowlog(...\func_get_args());
+    }
+
+    public function smembers($key): array
+    {
+        return $this->lazyObjectReal->smembers(...\func_get_args());
+    }
+
+    public function smove($src, $dst, $member): bool
+    {
+        return $this->lazyObjectReal->smove(...\func_get_args());
+    }
+
+    public function sort($key, $options): bool|int|string
+    {
+        return $this->lazyObjectReal->sort(...\func_get_args());
+    }
+
+    public function spop($key): array|string
+    {
+        return $this->lazyObjectReal->spop(...\func_get_args());
+    }
+
+    public function srandmember($key, $count = 0): array|string
+    {
+        return $this->lazyObjectReal->srandmember(...\func_get_args());
+    }
+
+    public function srem($key, $value, ...$other_values): int
+    {
+        return $this->lazyObjectReal->srem(...\func_get_args());
+    }
+
+    public function sscan($key, &$iterator, $node, $pattern = null, $count = 0): array|bool
+    {
+        return $this->lazyObjectReal->sscan(...\func_get_args());
+    }
+
+    public function strlen($key): int
+    {
+        return $this->lazyObjectReal->strlen(...\func_get_args());
+    }
+
+    public function subscribe($channels, $cb): void
+    {
+        $this->lazyObjectReal->subscribe(...\func_get_args());
+    }
+
+    public function sunion($key, ...$other_keys): array|bool
+    {
+        return $this->lazyObjectReal->sunion(...\func_get_args());
+    }
+
+    public function sunionstore($dst, $key, ...$other_keys): int
+    {
+        return $this->lazyObjectReal->sunionstore(...\func_get_args());
+    }
+
+    public function time($key_or_address): array|bool
+    {
+        return $this->lazyObjectReal->time(...\func_get_args());
+    }
+
+    public function ttl($key): int
+    {
+        return $this->lazyObjectReal->ttl(...\func_get_args());
+    }
+
+    public function type($key): int
+    {
+        return $this->lazyObjectReal->type(...\func_get_args());
+    }
+
+    public function unsubscribe($channels): array|bool
+    {
+        return $this->lazyObjectReal->unsubscribe(...\func_get_args());
+    }
+
+    public function unlink($key, ...$other_keys): array
+    {
+        return $this->lazyObjectReal->unlink(...\func_get_args());
+    }
+
+    public function unwatch(): bool
+    {
+        return $this->lazyObjectReal->unwatch(...\func_get_args());
+    }
+
+    public function watch($key, ...$other_keys): bool
+    {
+        return $this->lazyObjectReal->watch(...\func_get_args());
+    }
+
+    public function xack($key, $group, $ids): int
+    {
+        return $this->lazyObjectReal->xack(...\func_get_args());
+    }
+
+    public function xadd($key, $id, $values, $maxlen = 0, $approx = false): string
+    {
+        return $this->lazyObjectReal->xadd(...\func_get_args());
+    }
+
+    public function xclaim($key, $group, $consumer, $min_iddle, $ids, $options): array|string
+    {
+        return $this->lazyObjectReal->xclaim(...\func_get_args());
+    }
+
+    public function xdel($key, $ids): int
+    {
+        return $this->lazyObjectReal->xdel(...\func_get_args());
+    }
+
+    public function xgroup($operation, $key = null, $arg1 = null, $arg2 = null, $arg3 = false): mixed
+    {
+        return $this->lazyObjectReal->xgroup(...\func_get_args());
+    }
+
+    public function xinfo($operation, $arg1 = null, $arg2 = null): mixed
+    {
+        return $this->lazyObjectReal->xinfo(...\func_get_args());
+    }
+
+    public function xlen($key): int
+    {
+        return $this->lazyObjectReal->xlen(...\func_get_args());
+    }
+
+    public function xpending($key, $group, $start = null, $end = null, $count = -1, $consumer = null): string
+    {
+        return $this->lazyObjectReal->xpending(...\func_get_args());
+    }
+
+    public function xrange($key, $start, $end, $count = -1): array|bool
+    {
+        return $this->lazyObjectReal->xrange(...\func_get_args());
+    }
+
+    public function xread($streams, $count = -1, $block = -1): array|bool
+    {
+        return $this->lazyObjectReal->xread(...\func_get_args());
+    }
+
+    public function xreadgroup($group, $consumer, $streams, $count = 1, $block = 1): array|bool
+    {
+        return $this->lazyObjectReal->xreadgroup(...\func_get_args());
+    }
+
+    public function xrevrange($key, $start, $end, $count = -1): array|bool
+    {
+        return $this->lazyObjectReal->xrevrange(...\func_get_args());
+    }
+
+    public function xtrim($key, $maxlen, $approx = false): int
+    {
+        return $this->lazyObjectReal->xtrim(...\func_get_args());
+    }
+
+    public function zadd($key, $score, $member, ...$extra_args): int
+    {
+        return $this->lazyObjectReal->zadd(...\func_get_args());
+    }
+
+    public function zcard($key): int
+    {
+        return $this->lazyObjectReal->zcard(...\func_get_args());
+    }
+
+    public function zcount($key, $start, $end): int
+    {
+        return $this->lazyObjectReal->zcount(...\func_get_args());
+    }
+
+    public function zincrby($key, $value, $member): float
+    {
+        return $this->lazyObjectReal->zincrby(...\func_get_args());
+    }
+
+    public function zinterstore($key, $keys, $weights = null, $aggregate = null): int
+    {
+        return $this->lazyObjectReal->zinterstore(...\func_get_args());
+    }
+
+    public function zlexcount($key, $min, $max): int
+    {
+        return $this->lazyObjectReal->zlexcount(...\func_get_args());
+    }
+
+    public function zpopmax($key, $value = null): array|bool
+    {
+        return $this->lazyObjectReal->zpopmax(...\func_get_args());
+    }
+
+    public function zpopmin($key, $value = null): array|bool
+    {
+        return $this->lazyObjectReal->zpopmin(...\func_get_args());
+    }
+
+    public function zrange($key, $start, $end, $options = null): array|bool
+    {
+        return $this->lazyObjectReal->zrange(...\func_get_args());
+    }
+
+    public function zrangebylex($key, $start, $end, $options = null): array|bool
+    {
+        return $this->lazyObjectReal->zrangebylex(...\func_get_args());
+    }
+
+    public function zrangebyscore($key, $start, $end, $options = null): array|bool
+    {
+        return $this->lazyObjectReal->zrangebyscore(...\func_get_args());
+    }
+
+    public function zrank($key, $member): int
+    {
+        return $this->lazyObjectReal->zrank(...\func_get_args());
+    }
+
+    public function zrem($key, $value, ...$other_values): int
+    {
+        return $this->lazyObjectReal->zrem(...\func_get_args());
+    }
+
+    public function zremrangebylex($key, $min, $max): int
+    {
+        return $this->lazyObjectReal->zremrangebylex(...\func_get_args());
+    }
+
+    public function zremrangebyrank($key, $min, $max): int
+    {
+        return $this->lazyObjectReal->zremrangebyrank(...\func_get_args());
+    }
+
+    public function zremrangebyscore($key, $min, $max): int
+    {
+        return $this->lazyObjectReal->zremrangebyscore(...\func_get_args());
+    }
+
+    public function zrevrange($key, $min, $max, $options = null): array|bool
+    {
+        return $this->lazyObjectReal->zrevrange(...\func_get_args());
+    }
+
+    public function zrevrangebylex($key, $min, $max, $options = null): array|bool
+    {
+        return $this->lazyObjectReal->zrevrangebylex(...\func_get_args());
+    }
+
+    public function zrevrangebyscore($key, $min, $max, $options = null): array|bool
+    {
+        return $this->lazyObjectReal->zrevrangebyscore(...\func_get_args());
+    }
+
+    public function zrevrank($key, $member): int
+    {
+        return $this->lazyObjectReal->zrevrank(...\func_get_args());
+    }
+
+    public function zscan($key, &$iterator, $pattern = null, $count = 0): array|bool
+    {
+        return $this->lazyObjectReal->zscan(...\func_get_args());
+    }
+
+    public function zscore($key): float
+    {
+        return $this->lazyObjectReal->zscore(...\func_get_args());
+    }
+
+    public function zunionstore($key, $keys, $weights = null, $aggregate = null): int
+    {
+        return $this->lazyObjectReal->zunionstore(...\func_get_args());
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RedisClusterNodeProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisClusterNodeProxy.php
@@ -24,13 +24,10 @@ namespace Symfony\Component\Cache\Traits;
  */
 class RedisClusterNodeProxy
 {
-    private array $host;
-    private \RedisCluster|RedisClusterProxy $redis;
-
-    public function __construct(array $host, \RedisCluster|RedisClusterProxy $redis)
-    {
-        $this->host = $host;
-        $this->redis = $redis;
+    public function __construct(
+        private array $host,
+        private \RedisCluster $redis,
+    ) {
     }
 
     public function __call(string $method, array $args)

--- a/src/Symfony/Component/Cache/Traits/RedisClusterProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisClusterProxy.php
@@ -11,52 +11,13 @@
 
 namespace Symfony\Component\Cache\Traits;
 
-/**
- * @author Alessandro Chitolina <alekitto@gmail.com>
- *
- * @internal
- */
-class RedisClusterProxy
-{
-    private \RedisCluster $redis;
+class_alias(6.0 <= (float) phpversion('redis') ? RedisCluster6Proxy::class : RedisCluster5Proxy::class, RedisClusterProxy::class);
 
-    public function __construct(
-        private \Closure $initializer,
-    ) {
-    }
-
-    public function __call(string $method, array $args)
+if (false) {
+    /**
+     * @internal
+     */
+    class RedisClusterProxy extends \RedisCluster
     {
-        $this->redis ??= ($this->initializer)();
-
-        return $this->redis->{$method}(...$args);
-    }
-
-    public function hscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
-    {
-        $this->redis ??= ($this->initializer)();
-
-        return $this->redis->hscan($strKey, $iIterator, $strPattern, $iCount);
-    }
-
-    public function scan(&$iIterator, $strPattern = null, $iCount = null)
-    {
-        $this->redis ??= ($this->initializer)();
-
-        return $this->redis->scan($iIterator, $strPattern, $iCount);
-    }
-
-    public function sscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
-    {
-        $this->redis ??= ($this->initializer)();
-
-        return $this->redis->sscan($strKey, $iIterator, $strPattern, $iCount);
-    }
-
-    public function zscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
-    {
-        $this->redis ??= ($this->initializer)();
-
-        return $this->redis->zscan($strKey, $iIterator, $strPattern, $iCount);
     }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisProxy.php
@@ -11,55 +11,13 @@
 
 namespace Symfony\Component\Cache\Traits;
 
-/**
- * @author Nicolas Grekas <p@tchwork.com>
- *
- * @internal
- */
-class RedisProxy
-{
-    private \Redis $redis;
-    private \Closure $initializer;
-    private bool $ready = false;
+class_alias(6.0 <= (float) phpversion('redis') ? Redis6Proxy::class : Redis5Proxy::class, RedisProxy::class);
 
-    public function __construct(\Redis $redis, \Closure $initializer)
+if (false) {
+    /**
+     * @internal
+     */
+    class RedisProxy extends \Redis
     {
-        $this->redis = $redis;
-        $this->initializer = $initializer;
-    }
-
-    public function __call(string $method, array $args)
-    {
-        $this->ready ?: $this->ready = $this->initializer->__invoke($this->redis);
-
-        return $this->redis->{$method}(...$args);
-    }
-
-    public function hscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
-    {
-        $this->ready ?: $this->ready = $this->initializer->__invoke($this->redis);
-
-        return $this->redis->hscan($strKey, $iIterator, $strPattern, $iCount);
-    }
-
-    public function scan(&$iIterator, $strPattern = null, $iCount = null)
-    {
-        $this->ready ?: $this->ready = $this->initializer->__invoke($this->redis);
-
-        return $this->redis->scan($iIterator, $strPattern, $iCount);
-    }
-
-    public function sscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
-    {
-        $this->ready ?: $this->ready = $this->initializer->__invoke($this->redis);
-
-        return $this->redis->sscan($strKey, $iIterator, $strPattern, $iCount);
-    }
-
-    public function zscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
-    {
-        $this->ready ?: $this->ready = $this->initializer->__invoke($this->redis);
-
-        return $this->redis->zscan($strKey, $iIterator, $strPattern, $iCount);
     }
 }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -26,7 +26,7 @@
         "psr/log": "^1.1|^2|^3",
         "symfony/cache-contracts": "^1.1.7|^2|^3",
         "symfony/service-contracts": "^1.1|^2|^3",
-        "symfony/var-exporter": "^5.4|^6.0"
+        "symfony/var-exporter": "^6.2"
     },
     "require-dev": {
         "cache/integration-tests": "dev-master",

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
 use Predis\Response\ErrorInterface;
-use Symfony\Component\Cache\Traits\RedisClusterProxy;
-use Symfony\Component\Cache\Traits\RedisProxy;
 
 /**
  * Redis based session storage handler based on the Redis class
@@ -23,8 +21,6 @@ use Symfony\Component\Cache\Traits\RedisProxy;
  */
 class RedisSessionHandler extends AbstractSessionHandler
 {
-    private \Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface|RedisProxy|RedisClusterProxy $redis;
-
     /**
      * Key prefix for shared environments.
      */
@@ -42,13 +38,14 @@ class RedisSessionHandler extends AbstractSessionHandler
      *
      * @throws \InvalidArgumentException When unsupported client or options are passed
      */
-    public function __construct(\Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface|RedisProxy|RedisClusterProxy $redis, array $options = [])
-    {
+    public function __construct(
+        private \Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface $redis,
+        array $options = [],
+    ) {
         if ($diff = array_diff(array_keys($options), ['prefix', 'ttl'])) {
             throw new \InvalidArgumentException(sprintf('The following options are not supported "%s".', implode(', ', $diff)));
         }
 
-        $this->redis = $redis;
         $this->prefix = $options['prefix'] ?? 'sf_s';
         $this->ttl = $options['ttl'] ?? null;
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
 use Doctrine\DBAL\DriverManager;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
-use Symfony\Component\Cache\Traits\RedisClusterProxy;
-use Symfony\Component\Cache\Traits\RedisProxy;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -37,8 +35,6 @@ class SessionHandlerFactory
             case $connection instanceof \RedisArray:
             case $connection instanceof \RedisCluster:
             case $connection instanceof \Predis\ClientInterface:
-            case $connection instanceof RedisProxy:
-            case $connection instanceof RedisClusterProxy:
                 return new RedisSessionHandler($connection);
 
             case $connection instanceof \Memcached:

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -29,6 +29,9 @@
         "symfony/expression-language": "^5.4|^6.0",
         "symfony/rate-limiter": "^5.2|^6.0"
     },
+    "conflict": {
+        "symfony/cache": "<6.2"
+    },
     "suggest" : {
         "symfony/mime": "To use the file extension guesser"
     },

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\Lock\Store;
 
 use Predis\Response\ServerException;
-use Symfony\Component\Cache\Traits\RedisClusterProxy;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockStorageException;
@@ -31,21 +29,18 @@ class RedisStore implements SharedLockStoreInterface
 {
     use ExpiringStoreTrait;
 
-    private \Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface|RedisProxy|RedisClusterProxy $redis;
-    private float $initialTtl;
     private bool $supportTime;
 
     /**
      * @param float $initialTtl The expiration delay of locks in seconds
      */
-    public function __construct(\Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface|RedisProxy|RedisClusterProxy $redis, float $initialTtl = 300.0)
-    {
+    public function __construct(
+        private \Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface $redis,
+        private float $initialTtl = 300.0,
+    ) {
         if ($initialTtl <= 0) {
             throw new InvalidTtlException(sprintf('"%s()" expects a strictly positive TTL. Got %d.', __METHOD__, $initialTtl));
         }
-
-        $this->redis = $redis;
-        $this->initialTtl = $initialTtl;
     }
 
     public function save(Key $key)
@@ -231,12 +226,7 @@ class RedisStore implements SharedLockStoreInterface
 
     private function evaluate(string $script, string $resource, array $args): mixed
     {
-        if (
-            $this->redis instanceof \Redis ||
-            $this->redis instanceof \RedisCluster ||
-            $this->redis instanceof RedisProxy ||
-            $this->redis instanceof RedisClusterProxy
-        ) {
+        if ($this->redis instanceof \Redis || $this->redis instanceof \RedisCluster) {
             $this->redis->clearLastError();
             $result = $this->redis->eval($script, array_merge([$resource], $args), 1);
             if (null !== $err = $this->redis->getLastError()) {

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Lock\Store;
 
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
-use Symfony\Component\Cache\Traits\RedisClusterProxy;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\PersistingStoreInterface;
 
@@ -32,8 +30,6 @@ class StoreFactory
             case $connection instanceof \RedisArray:
             case $connection instanceof \RedisCluster:
             case $connection instanceof \Predis\ClientInterface:
-            case $connection instanceof RedisProxy:
-            case $connection instanceof RedisClusterProxy:
                 return new RedisStore($connection);
 
             case $connection instanceof \Memcached:

--- a/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
-use Symfony\Component\Cache\Traits\RedisClusterProxy;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
@@ -87,12 +85,7 @@ class Symfony51Store
 
     private function evaluate(string $script, string $resource, array $args)
     {
-        if (
-            $this->redis instanceof \Redis ||
-            $this->redis instanceof \RedisCluster ||
-            $this->redis instanceof RedisProxy ||
-            $this->redis instanceof RedisClusterProxy
-        ) {
+        if ($this->redis instanceof \Redis || $this->redis instanceof \RedisCluster) {
             return $this->redis->eval($script, array_merge([$resource], $args), 1);
         }
 

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -15,7 +15,6 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Lock\Store\DoctrineDbalPostgreSqlStore;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
 use Symfony\Component\Lock\Store\FlockStore;
@@ -48,9 +47,6 @@ class StoreFactoryTest extends TestCase
     {
         if (class_exists(\Redis::class)) {
             yield [new \Redis(), RedisStore::class];
-        }
-        if (class_exists(RedisProxy::class)) {
-            yield [$this->createMock(RedisProxy::class), RedisStore::class];
         }
         yield [new \Predis\Client(), RedisStore::class];
         if (class_exists(\Memcached::class)) {

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -24,7 +24,8 @@
         "predis/predis": "~1.0"
     },
     "conflict": {
-        "doctrine/dbal": "<2.13"
+        "doctrine/dbal": "<2.13",
+        "symfony/cache": "<6.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Lock\\": "" },

--- a/src/Symfony/Component/Semaphore/Store/RedisStore.php
+++ b/src/Symfony/Component/Semaphore/Store/RedisStore.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Semaphore\Store;
 
-use Symfony\Component\Cache\Traits\RedisClusterProxy;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Semaphore\Exception\InvalidArgumentException;
 use Symfony\Component\Semaphore\Exception\SemaphoreAcquiringException;
 use Symfony\Component\Semaphore\Exception\SemaphoreExpiredException;
@@ -27,11 +25,9 @@ use Symfony\Component\Semaphore\PersistingStoreInterface;
  */
 class RedisStore implements PersistingStoreInterface
 {
-    private $redis;
-
-    public function __construct(\Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface|RedisProxy|RedisClusterProxy $redis)
-    {
-        $this->redis = $redis;
+    public function __construct(
+        private \Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface $redis,
+    ) {
     }
 
     public function save(Key $key, float $ttlInSecond)
@@ -161,12 +157,7 @@ class RedisStore implements PersistingStoreInterface
 
     private function evaluate(string $script, string $resource, array $args): mixed
     {
-        if (
-            $this->redis instanceof \Redis ||
-            $this->redis instanceof \RedisCluster ||
-            $this->redis instanceof RedisProxy ||
-            $this->redis instanceof RedisClusterProxy
-        ) {
+        if ($this->redis instanceof \Redis || $this->redis instanceof \RedisCluster) {
             return $this->redis->eval($script, array_merge([$resource], $args), 1);
         }
 

--- a/src/Symfony/Component/Semaphore/Store/StoreFactory.php
+++ b/src/Symfony/Component/Semaphore/Store/StoreFactory.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\Semaphore\Store;
 
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
-use Symfony\Component\Cache\Traits\RedisClusterProxy;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Semaphore\Exception\InvalidArgumentException;
 use Symfony\Component\Semaphore\PersistingStoreInterface;
 
@@ -31,8 +29,6 @@ class StoreFactory
             case $connection instanceof \RedisArray:
             case $connection instanceof \RedisCluster:
             case $connection instanceof \Predis\ClientInterface:
-            case $connection instanceof RedisProxy:
-            case $connection instanceof RedisClusterProxy:
                 return new RedisStore($connection);
 
             case !\is_string($connection):

--- a/src/Symfony/Component/Semaphore/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/StoreFactoryTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Semaphore\Tests\Store;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Semaphore\Store\RedisStore;
 use Symfony\Component\Semaphore\Store\StoreFactory;
 
@@ -36,9 +35,6 @@ class StoreFactoryTest extends TestCase
     {
         if (class_exists(\Redis::class)) {
             yield [$this->createMock(\Redis::class), RedisStore::class];
-        }
-        if (class_exists(RedisProxy::class)) {
-            yield [$this->createMock(RedisProxy::class), RedisStore::class];
         }
         yield [new \Predis\Client(), RedisStore::class];
         if (class_exists(\Redis::class) && class_exists(AbstractAdapter::class)) {

--- a/src/Symfony/Component/Semaphore/composer.json
+++ b/src/Symfony/Component/Semaphore/composer.json
@@ -26,6 +26,9 @@
     "require-dev": {
         "predis/predis": "~1.0"
     },
+    "conflict": {
+        "symfony/cache": "<6.2"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Semaphore\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47267, #42428
| License       | MIT
| Doc PR        | -

`Redis*Proxy` did not extend native classes because we missed the code infrastructure to generate appropriate proxies.
With #47236, we now have it. This PR adds generated proxies to the cache component to keep it lazy-able out of the box.
