### PR TITLE
[Serializer] Fix caching context-aware encoders/decoders in ChainEncoder/ChainDecoder

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -67,9 +67,13 @@ class ChainDecoder implements ContextAwareDecoderInterface
             return $this->decoders[$this->decoderByFormat[$format]];
         }
 
+        $cache = true;
         foreach ($this->decoders as $i => $decoder) {
+            $cache = $cache && !$decoder instanceof ContextAwareDecoderInterface;
             if ($decoder->supportsDecoding($format, $context)) {
-                $this->decoderByFormat[$format] = $i;
+                if ($cache) {
+                    $this->decoderByFormat[$format] = $i;
+                }
 
                 return $decoder;
             }

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -85,9 +85,13 @@ class ChainEncoder implements ContextAwareEncoderInterface
             return $this->encoders[$this->encoderByFormat[$format]];
         }
 
+        $cache = true;
         foreach ($this->encoders as $i => $encoder) {
+            $cache = $cache && !$encoder instanceof ContextAwareEncoderInterface;
             if ($encoder->supportsEncoding($format, $context)) {
-                $this->encoderByFormat[$format] = $i;
+                if ($cache) {
+                    $this->encoderByFormat[$format] = $i;
+                }
 
                 return $encoder;
             }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Encoder\ChainEncoder;
+use Symfony\Component\Serializer\Encoder\ContextAwareEncoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Encoder\NormalizationAwareInterface;
 use Symfony\Component\Serializer\Exception\RuntimeException;
@@ -29,7 +30,7 @@ class ChainEncoderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->encoder1 = $this->createMock(EncoderInterface::class);
+        $this->encoder1 = $this->createMock(ContextAwareEncoderInterface::class);
         $this->encoder1
             ->method('supportsEncoding')
             ->willReturnMap([
@@ -37,6 +38,7 @@ class ChainEncoderTest extends TestCase
                 [self::FORMAT_2, [], false],
                 [self::FORMAT_3, [], false],
                 [self::FORMAT_3, ['foo' => 'bar'], true],
+                [self::FORMAT_3, ['foo' => 'bar2'], false],
             ]);
 
         $this->encoder2 = $this->createMock(EncoderInterface::class);
@@ -46,6 +48,8 @@ class ChainEncoderTest extends TestCase
                 [self::FORMAT_1, [], false],
                 [self::FORMAT_2, [], true],
                 [self::FORMAT_3, [], false],
+                [self::FORMAT_3, ['foo' => 'bar'], false],
+                [self::FORMAT_3, ['foo' => 'bar2'], true],
             ]);
 
         $this->chainEncoder = new ChainEncoder([$this->encoder1, $this->encoder2]);
@@ -53,10 +57,26 @@ class ChainEncoderTest extends TestCase
 
     public function testSupportsEncoding()
     {
+        $this->encoder1
+            ->method('encode')
+            ->willReturn('result1');
+        $this->encoder2
+            ->method('encode')
+            ->willReturn('result2');
+
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_1));
+        $this->assertEquals('result1', $this->chainEncoder->encode('', self::FORMAT_1, []));
+
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_2));
+        $this->assertEquals('result2', $this->chainEncoder->encode('', self::FORMAT_2, []));
+
         $this->assertFalse($this->chainEncoder->supportsEncoding(self::FORMAT_3));
+
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_3, ['foo' => 'bar']));
+        $this->assertEquals('result1', $this->chainEncoder->encode('', self::FORMAT_3, ['foo' => 'bar']));
+
+        $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_3, ['foo' => 'bar2']));
+        $this->assertEquals('result2', $this->chainEncoder->encode('', self::FORMAT_3, ['foo' => 'bar2']));
     }
 
     public function testEncode()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38270
| License       | MIT
| Doc PR        | -

As proposed in https://github.com/symfony/symfony/pull/43231#issuecomment-1202259776
Will require #47150 on 6.1 until a proper solution is implemented, hopefully in 6.2.