### PR TITLE
[Console] Allow limiting the height of a console section

### DIFF
--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -103,6 +103,56 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertEquals('Foo'.\PHP_EOL."\x1b[1A\x1b[0JBar".\PHP_EOL, stream_get_contents($output->getStream()));
     }
 
+    public function testMaxHeight()
+    {
+        $expected = '';
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $output->setMaxHeight(3);
+
+        // fill the section
+        $output->writeln(['One', 'Two', 'Three']);
+        $expected .= 'One'.\PHP_EOL.'Two'.\PHP_EOL.'Three'.\PHP_EOL;
+
+        // cause overflow (redraw whole section, without first line)
+        $output->writeln('Four');
+        $expected .= "\x1b[3A\x1b[0J";
+        $expected .= 'Two'.\PHP_EOL.'Three'.\PHP_EOL.'Four'.\PHP_EOL;
+
+        // cause overflow with multiple new lines at once
+        $output->writeln('Five'.\PHP_EOL.'Six');
+        $expected .= "\x1b[3A\x1b[0J";
+        $expected .= 'Four'.\PHP_EOL.'Five'.\PHP_EOL.'Six'.\PHP_EOL;
+
+        // reset line height (redraw whole section, displaying all lines)
+        $output->setMaxHeight(0);
+        $expected .= "\x1b[3A\x1b[0J";
+        $expected .= 'One'.\PHP_EOL.'Two'.\PHP_EOL.'Three'.\PHP_EOL.'Four'.\PHP_EOL.'Five'.\PHP_EOL.'Six'.\PHP_EOL;
+
+        rewind($output->getStream());
+        $this->assertEquals($expected, stream_get_contents($output->getStream()));
+    }
+
+    public function testMaxHeightWithoutNewLine()
+    {
+        $expected = '';
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $output->setMaxHeight(3);
+
+        // fill the section
+        $output->writeln(['One', 'Two']);
+        $output->write('Three');
+        $expected .= 'One'.\PHP_EOL.'Two'.\PHP_EOL.'Three'.\PHP_EOL;
+
+        // append text to the last line
+        $output->write(' and Four');
+        $expected .= "\x1b[1A\x1b[0J".'Three and Four'.\PHP_EOL;
+
+        rewind($output->getStream());
+        $this->assertEquals($expected, stream_get_contents($output->getStream()));
+    }
+
     public function testOverwriteMultipleLines()
     {
         $sections = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | tbd

This extends the Section feature of the Symfony console with the possibility to define a maximum height. The content will automatically "scroll up" when the content exceeds this height.

<details>
<summary>code used in this example</summary>

```php
<?php

use Symfony\Component\Console\Helper\ProgressBar;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Symfony\Component\Console\SingleCommandApplication;
use Symfony\Component\Console\Style\SymfonyStyle;
use Symfony\Component\Console\Terminal;

require_once 'vendor/autoload.php';

(new SingleCommandApplication())
  ->setCode(function (InputInterface $input, OutputInterface $output): int {
    $output->writeln(['<comment>Testing sections', '================</>', '']);

    // section for log messages, set the max height to 3 lines
    $messageSection = $output->section();
    $messageSection->setMaxHeight(3);

    // section for the progress bar
    $progressSection = $output->section();
    $progressSection->writeln('');

    // run some heavy logic in 100 steps
    $progress = new ProgressBar($progressSection);
    $progress->start(100);
    for ($i = 0; $i < 100; $i++) {
      if (0 === $i % 10) {
        $messageSection->write('   Message from step '.$i);
      } elseif (0 === $i % 5) {
        $messageSection->writeln(' and '.$i);
      }

      $progress->advance();
      usleep(50000);
    }

    $progress->finish();

    // process finished, show all messages (i.e. remove height limitation)
    $messageSection->setMaxHeight(0);

    $progressSection->overwrite(['', '<bg=green>  </> All steps completed successfully!', '']);

    return SingleCommandApplication::SUCCESS;
  })
  ->run();
```
</details>

![sf-overflow-sections](https://user-images.githubusercontent.com/749025/185185711-0ed95d36-86cf-4f3a-9206-78077179889e.gif)

This terminal ui can be found in real world applications like the new Docker buildkit and Docker Compose V2. It's very useful to show verbose output in long running process, without taking over the complete terminal buffer.