### PR TITLE
[Security] Fix login url matching when app is not run with url rewriting or from a sub folder

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
@@ -41,7 +41,7 @@ abstract class AbstractLoginFormAuthenticator extends AbstractAuthenticator impl
      */
     public function supports(Request $request): bool
     {
-        return $request->isMethod('POST') && $this->getLoginUrl($request) === $request->getPathInfo();
+        return $request->isMethod('POST') && $this->getLoginUrl($request) === $request->getBaseUrl().$request->getPathInfo();
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractLoginFormAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractLoginFormAuthenticatorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authenticator\AbstractLoginFormAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+class AbstractLoginFormAuthenticatorTest extends TestCase
+{
+    /**
+     * @dataProvider provideSupportsData
+     */
+    public function testSupports(string $loginUrl, Request $request, bool $expected)
+    {
+        $authenticator = new ConcreteFormAuthenticator($loginUrl);
+        $this->assertSame($expected, $authenticator->supports($request));
+    }
+
+    public function provideSupportsData(): iterable
+    {
+        yield [
+            '/login',
+            Request::create('http://localhost/login', Request::METHOD_POST, [], [], [], [
+                'DOCUMENT_ROOT' => '/var/www/app/public',
+                'PHP_SELF' => '/index.php',
+                'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
+                'SCRIPT_NAME' => '/index.php',
+            ]),
+            true,
+        ];
+        yield [
+            '/login',
+            Request::create('http://localhost/somepath', Request::METHOD_POST, [], [], [], [
+                'DOCUMENT_ROOT' => '/var/www/app/public',
+                'PHP_SELF' => '/index.php',
+                'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
+                'SCRIPT_NAME' => '/index.php',
+            ]),
+            false,
+        ];
+        yield [
+            '/folder/login',
+            Request::create('http://localhost/folder/login', Request::METHOD_POST, [], [], [], [
+                'DOCUMENT_ROOT' => '/var/www/app/public',
+                'PHP_SELF' => '/folder/index.php',
+                'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
+                'SCRIPT_NAME' => '/folder/index.php',
+            ]),
+            true,
+        ];
+        yield [
+            '/folder/login',
+            Request::create('http://localhost/folder/somepath', Request::METHOD_POST, [], [], [], [
+                'DOCUMENT_ROOT' => '/var/www/app/public',
+                'PHP_SELF' => '/folder/index.php',
+                'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
+                'SCRIPT_NAME' => '/folder/index.php',
+            ]),
+            false,
+        ];
+        yield [
+            '/index.php/login',
+            Request::create('http://localhost/index.php/login', Request::METHOD_POST, [], [], [], [
+                'DOCUMENT_ROOT' => '/var/www/app/public',
+                'PHP_SELF' => '/index.php',
+                'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
+                'SCRIPT_NAME' => '/index.php',
+            ]),
+            true,
+        ];
+        yield [
+            '/index.php/login',
+            Request::create('http://localhost/index.php/somepath', Request::METHOD_POST, [], [], [], [
+                'DOCUMENT_ROOT' => '/var/www/app/public',
+                'PHP_SELF' => '/index.php',
+                'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
+                'SCRIPT_NAME' => '/index.php',
+            ]),
+            false,
+        ];
+    }
+}
+
+class ConcreteFormAuthenticator extends AbstractLoginFormAuthenticator
+{
+    private $loginUrl;
+
+    public function __construct(string $loginUrl)
+    {
+        $this->loginUrl = $loginUrl;
+    }
+
+    protected function getLoginUrl(Request $request): string
+    {
+        return $this->loginUrl;
+    }
+
+    public function authenticate(Request $request)
+    {
+        return new SelfValidatingPassport(new UserBadge('dummy'));
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+}


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #44893
| License       | MIT
| Doc PR        | not required

Uses the fix suggested by @weaverryan in https://github.com/symfony/symfony/issues/44893#issuecomment-1094411325. I also added three tests for scenarios which I could replicate from running a simple app on a real webserver (Apache and Nginx). This, however, might not be sufficient because there could be other combinations of server variables like `DOCUMENT_ROOT`, `PHP_SELF`, `SCRIPT_FILENAME`, `SCRIPT_NAME` and possibly others depending on the server configuration and setup. As long as `\Symfony\Component\HttpFoundation\Request::getBaseUrl()` and `\Symfony\Component\HttpFoundation\Request::getPathInfo()` work correctly, I assume that the fix will also be correct in all those constellations. 

The fix is based on the assumptions that:
- `\Symfony\Component\HttpFoundation\Request::getBaseUrl()` always returns an empty string when the application is run from root without the front controller script in the URL (using URL rewriting for example)
- `\Symfony\Component\HttpFoundation\Request::getBaseUrl()` always returns the path from the server root to the application base path (possibly including the front controller script)
- `\Symfony\Component\HttpFoundation\Request::getPathInfo()` always returns just the *routed* part of the request 

Please advise if you'd need some more tests.
