### PR TITLE
[PhpUnitBridge] fix order of returned array values for mocked hrtime()

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -100,7 +100,7 @@ class ClockMock
             return PHP_INT_SIZE === 8 ? (int) $number : (float) $number;
         }
 
-        return [(int) $ns, (int) self::$now];
+        return [(int) self::$now, (int) $ns];
     }
 
     public static function register($class)

--- a/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
@@ -72,7 +72,7 @@ class ClockMockTest extends TestCase
 
     public function testHrTime()
     {
-        $this->assertSame([125000000, 1234567890], hrtime());
+        $this->assertSame([1234567890, 125000000], hrtime());
     }
 
     public function testHrTimeAsNumber()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
