### PR TITLE
Email image parts: regex for single closing quote

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -503,7 +503,7 @@ class Email extends Message
                 $html = stream_get_contents($html);
             }
             $htmlPart = new TextPart($html, $this->htmlCharset, 'html');
-            preg_match_all('(<img\s+[^>]*src\s*=\s*(?:([\'"])cid:([^"]+)\\1|cid:([^>\s]+)))i', $html, $names);
+            preg_match_all('(<img\s+[^>]*src\s*=\s*(?:([\'"])cid:(.+?)\\1|cid:([^>\s]+)))i', $html, $names);
             $names = array_filter(array_unique(array_merge($names[2], $names[3])));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The regex for image src matches for single and double opening quotes:
`([\'"])`

The corresponding matching for non-closing characters is implemented for double quotes only:
`([^"]+)`

This change adds a non-greedy regex `.+?` which matches for as few characters as possbile before the "correspondingly matched opening quote" `\\1` appears.
