### PR TITLE
Add verb route attributes

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/DeleteRoute.php
+++ b/src/Symfony/Component/Routing/Annotation/DeleteRoute.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Annotation;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS", "METHOD"})
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class DeleteRoute extends Route
+{
+    public function __construct(
+        string|array $path = null,
+        ?string $name = null,
+        array $requirements = [],
+        array $options = [],
+        array $defaults = [],
+        ?string $host = null,
+        array|string $schemes = [],
+        ?string $condition = null,
+        ?int $priority = null,
+        string $locale = null,
+        string $format = null,
+        bool $utf8 = null,
+        bool $stateless = null,
+        ?string $env = null
+    ) {
+        parent::__construct(
+            $path,
+            $name,
+            $requirements,
+            $options,
+            $defaults,
+            $host,
+            [Request::METHOD_DELETE],
+            $schemes,
+            $condition,
+            $priority,
+            $locale,
+            $format,
+            $utf8,
+            $stateless,
+            $env
+        );
+    }
+}

--- a/src/Symfony/Component/Routing/Annotation/GetRoute.php
+++ b/src/Symfony/Component/Routing/Annotation/GetRoute.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Annotation;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS", "METHOD"})
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class GetRoute extends Route
+{
+    public function __construct(
+        string|array $path = null,
+        ?string $name = null,
+        array $requirements = [],
+        array $options = [],
+        array $defaults = [],
+        ?string $host = null,
+        array|string $schemes = [],
+        ?string $condition = null,
+        ?int $priority = null,
+        string $locale = null,
+        string $format = null,
+        bool $utf8 = null,
+        bool $stateless = null,
+        ?string $env = null
+    ) {
+        parent::__construct(
+            $path,
+            $name,
+            $requirements,
+            $options,
+            $defaults,
+            $host,
+            [Request::METHOD_GET],
+            $schemes,
+            $condition,
+            $priority,
+            $locale,
+            $format,
+            $utf8,
+            $stateless,
+            $env
+        );
+    }
+}

--- a/src/Symfony/Component/Routing/Annotation/OptionsRoute.php
+++ b/src/Symfony/Component/Routing/Annotation/OptionsRoute.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Annotation;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS", "METHOD"})
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class OptionsRoute extends Route
+{
+    public function __construct(...$args) {
+        parent::__construct(...array_merge($args, ['methods' => [Request::METHOD_OPTIONS]]));
+    }
+}

--- a/src/Symfony/Component/Routing/Annotation/PatchRoute.php
+++ b/src/Symfony/Component/Routing/Annotation/PatchRoute.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Annotation;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS", "METHOD"})
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class PatchRoute extends Route
+{
+    public function __construct(
+        string|array $path = null,
+        ?string $name = null,
+        array $requirements = [],
+        array $options = [],
+        array $defaults = [],
+        ?string $host = null,
+        array|string $schemes = [],
+        ?string $condition = null,
+        ?int $priority = null,
+        string $locale = null,
+        string $format = null,
+        bool $utf8 = null,
+        bool $stateless = null,
+        ?string $env = null
+    ) {
+        parent::__construct(
+            $path,
+            $name,
+            $requirements,
+            $options,
+            $defaults,
+            $host,
+            [Request::METHOD_PATCH],
+            $schemes,
+            $condition,
+            $priority,
+            $locale,
+            $format,
+            $utf8,
+            $stateless,
+            $env
+        );
+    }
+}

--- a/src/Symfony/Component/Routing/Annotation/PostRoute.php
+++ b/src/Symfony/Component/Routing/Annotation/PostRoute.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Annotation;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS", "METHOD"})
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class PostRoute extends Route
+{
+    public function __construct(
+        string|array $path = null,
+        ?string $name = null,
+        array $requirements = [],
+        array $options = [],
+        array $defaults = [],
+        ?string $host = null,
+        array|string $schemes = [],
+        ?string $condition = null,
+        ?int $priority = null,
+        string $locale = null,
+        string $format = null,
+        bool $utf8 = null,
+        bool $stateless = null,
+        ?string $env = null
+    ) {
+        parent::__construct(
+            $path,
+            $name,
+            $requirements,
+            $options,
+            $defaults,
+            $host,
+            [Request::METHOD_POST],
+            $schemes,
+            $condition,
+            $priority,
+            $locale,
+            $format,
+            $utf8,
+            $stateless,
+            $env
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2  <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR adds shorthand classes for the Route attribute. These attributes automatically add the request verb to a route in order to help eliminate some common boilerplate code. For when the action needs to respont to multiple methods then the current approach can be used.

This PR adds the following classes: `DeleteRoute`, `GetRoute`, `OptionsRoute`, `PatchRoute`, `PostRoute`

Examples: 

Current: `#[Route('/Blog', methods: [Request::METHOD_GET])]`
Proposed: `#[GetRoute('/Blog')]`

Looking forward to your thoughts. The new attributes already work and can be used, however I wanted to add the test suite, change log, docs pr after getting some initial feedback here.

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
