### PR TITLE
[Security] [AbstractToken] getUserIdentifier() must return a string

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -48,7 +48,7 @@ abstract class AbstractToken implements TokenInterface, \Serializable
 
     public function getUserIdentifier(): string
     {
-        return $this->user->getUserIdentifier();
+        return $this->user ? $this->user->getUserIdentifier() : '';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Fix the `getUserIdentifier()` method from Symfony\Component\Security\Core\Authentication\Token\AbstractToken, he method must return a string, but based on a nullable UserInterface object.
