### PR TITLE
Change incorrect message, when the sender in the global envelope or the from header of asEmailMessage() is not defined.

### DIFF
--- a/src/Symfony/Component/Notifier/Channel/EmailChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/EmailChannel.php
@@ -57,7 +57,7 @@ class EmailChannel implements ChannelInterface
         if ($email instanceof Email) {
             if (!$email->getFrom()) {
                 if (null === $this->from) {
-                    throw new LogicException(sprintf('To send the "%s" notification by email, you should either configure a global "from" header, set a sender in the global "envelope" of the mailer configuration or set a "from" header in the "asEmailMessage()" method.', get_debug_type($notification)));
+                    throw new LogicException(sprintf('To send the "%s" notification by email, you must configure the global "from" header. For this you can set a sender in the global "envelope" of the mailer configuration or set a "from" header in the "asEmailMessage()" method.', get_debug_type($notification)));
                 }
 
                 $email->from($this->from);


### PR DESCRIPTION
See issue: https://github.com/symfony/symfony/issues/47313

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix 47313
| License       | MIT
| Doc PR        | no

Correction of an error message containing a syntax structure error.
See issue: https://github.com/symfony/symfony/issues/47313
