### PR TITLE
[Security] Allow configuring a redirect url via route name when switching user

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `Security::logout()` to logout programmatically
  * Add `security.firewalls.logout.enable_csrf` to enable CSRF protection using the default CSRF token generator
  * Add RFC6750 Access Token support to allow token-based authentication
+ * Add `security.firewalls.switch_user.target_route` option to configure redirect target route on switch user
 
 6.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -257,7 +257,7 @@ class MainConfiguration implements ConfigurationInterface
                     ->scalarNode('provider')->end()
                     ->scalarNode('parameter')->defaultValue('_switch_user')->end()
                     ->scalarNode('role')->defaultValue('ROLE_ALLOWED_TO_SWITCH')->end()
-                    ->scalarNode('target_url')->defaultValue(null)->end()
+                    ->scalarNode('target_route')->defaultValue(null)->end()
                 ->end()
             ->end()
             ->arrayNode('required_badges')

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -845,8 +845,8 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         if (!$userProvider) {
             throw new InvalidConfigurationException(sprintf('Not configuring explicitly the provider for the "switch_user" listener on "%s" firewall is ambiguous as there is more than one registered provider.', $id));
         }
-        if ($stateless && null !== $config['target_url']) {
-            throw new InvalidConfigurationException(sprintf('Cannot set a "target_url" for the "switch_user" listener on the "%s" firewall as it is stateless.', $id));
+        if ($stateless && null !== $config['target_route']) {
+            throw new InvalidConfigurationException(sprintf('Cannot set a "target_route" for the "switch_user" listener on the "%s" firewall as it is stateless.', $id));
         }
 
         $switchUserListenerId = 'security.authentication.switchuser_listener.'.$id;
@@ -857,7 +857,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $listener->replaceArgument(6, $config['parameter']);
         $listener->replaceArgument(7, $config['role']);
         $listener->replaceArgument(9, $stateless);
-        $listener->replaceArgument(10, $config['target_url']);
+        $listener->replaceArgument(11, $config['target_route']);
 
         return $switchUserListenerId;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
@@ -151,7 +151,8 @@ return static function (ContainerConfigurator $container) {
                 'ROLE_ALLOWED_TO_SWITCH',
                 service('event_dispatcher')->nullOnInvalid(),
                 false, // Stateless
-                abstract_arg('Target Url'),
+                service('router')->nullOnInvalid(),
+                abstract_arg('Target Route'),
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -165,7 +165,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 [
                     'parameter' => '_switch_user',
                     'role' => 'ROLE_ALLOWED_TO_SWITCH',
-                    'target_url' => null,
+                    'target_route' => null,
                 ],
                 [
                     'csrf_parameter' => '_csrf_token',

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -51,9 +52,10 @@ class SwitchUserListener extends AbstractListener
     private ?LoggerInterface $logger;
     private ?EventDispatcherInterface $dispatcher;
     private bool $stateless;
-    private ?string $targetUrl;
+    private ?UrlGeneratorInterface $urlGenerator;
+    private ?string $targetRoute;
 
-    public function __construct(TokenStorageInterface $tokenStorage, UserProviderInterface $provider, UserCheckerInterface $userChecker, string $firewallName, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, string $usernameParameter = '_switch_user', string $role = 'ROLE_ALLOWED_TO_SWITCH', EventDispatcherInterface $dispatcher = null, bool $stateless = false, string $targetUrl = null)
+    public function __construct(TokenStorageInterface $tokenStorage, UserProviderInterface $provider, UserCheckerInterface $userChecker, string $firewallName, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, string $usernameParameter = '_switch_user', string $role = 'ROLE_ALLOWED_TO_SWITCH', EventDispatcherInterface $dispatcher = null, bool $stateless = false, UrlGeneratorInterface $urlGenerator = null, string $targetRoute = null)
     {
         if ('' === $firewallName) {
             throw new \InvalidArgumentException('$firewallName must not be empty.');
@@ -69,7 +71,8 @@ class SwitchUserListener extends AbstractListener
         $this->logger = $logger;
         $this->dispatcher = $dispatcher;
         $this->stateless = $stateless;
-        $this->targetUrl = $targetUrl;
+        $this->urlGenerator = $urlGenerator;
+        $this->targetRoute = $targetRoute;
     }
 
     public function supports(Request $request): ?bool
@@ -121,7 +124,7 @@ class SwitchUserListener extends AbstractListener
         if (!$this->stateless) {
             $request->query->remove($this->usernameParameter);
             $request->server->set('QUERY_STRING', http_build_query($request->query->all(), '', '&'));
-            $response = new RedirectResponse($this->targetUrl ?? $request->getUri(), 302);
+            $response = new RedirectResponse($this->urlGenerator && $this->targetRoute ? $this->urlGenerator->generate($this->targetRoute) : $request->getUri(), 302);
 
             $event->setResponse($response);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yesish ([first version](https://github.com/symfony/symfony/pull/46338) is not released yet thus no bc)
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony-docs/pull/17024#issuecomment-1191330727 and discuss
| License       | MIT

---

Change the switch user redirect "target url" to a "target route", cf ticket 
First version can be found here https://github.com/symfony/symfony/pull/46338

Friendly ping @xabbuh from the ticket and @chalasr @fabpot as original reviewers

Before fixing tests, is adding such url generator arg in such position ok? the class is marked final

```yaml
# config/packages/security.yaml
security:
    firewalls:
        main:
            switch_user: { role: CAN_SWITCH_USER , target_route: my_app_route }
```