### PR TITLE
[TwigBridge] Allow to set parent checkbox div class via {'row_class': 'foo'}

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * Add `github` format & autodetection to render errors as annotations when
   running the Twig linter command in a Github Actions environment.
+* Add opportunity to set custom parent `div` class in checkbox widget  
 
 5.3
 ---

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -211,7 +211,7 @@
 {%- block checkbox_widget -%}
     {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
     {%- set parent_label_class = parent_label_class|default(label_attr.class|default('')) -%}
-    {%- set row_class = 'form-check' -%}
+    {%- set row_class = row_class|default('form-check') -%}
     {%- if 'checkbox-inline' in parent_label_class %}
         {% set row_class = row_class ~ ' form-check-inline' %}
     {% endif -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

We can't set parent checkbox div class at the moment (it hardcore in template). This PR allow us to do this:
```twig
{{ form_widget(form.agreeTerms, {'row_class': 'some custom classes'}) }}
```
result
```htm
<div class="some custom classes">
    <input type="checkbox" ...>
    <label ...>
</div>
```
This PR can be used with v6+ too.