### PR TITLE
[Notifier] Allow to update Slack messages

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Allow to update Slack messages
+
 6.0
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -21,7 +21,7 @@ use Symfony\Component\Notifier\Notification\Notification;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class SlackOptions implements MessageOptionsInterface
+class SlackOptions implements MessageOptionsInterface
 {
     private const MAX_BLOCKS = 50;
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackSentMessage.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackSentMessage.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Slack;
+
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+
+/**
+ * @author Maxim Dovydenok <dovydenok.maxim@gmail.com>
+ */
+final class SlackSentMessage extends SentMessage
+{
+    private string $channelId;
+
+    public function __construct(MessageInterface $original, string $transport, string $channelId, string $messageId)
+    {
+        parent::__construct($original, $transport);
+        $this->channelId = $channelId;
+        $this->setMessageId($messageId);
+    }
+
+    public function getChannelId(): string
+    {
+        return $this->channelId;
+    }
+
+    public function getUpdateMessage(string $subject, array $options = []): ChatMessage
+    {
+        return new ChatMessage($subject, new UpdateMessageSlackOptions($this->channelId, $this->getMessageId(), $options));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Slack\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
+use Symfony\Component\Notifier\Bridge\Slack\SlackSentMessage;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\LogicException;
@@ -115,7 +116,7 @@ final class SlackTransportTest extends TransportTestCase
 
         $response->expects($this->once())
             ->method('getContent')
-            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247']));
+            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247', 'channel' => 'C123456']));
 
         $expectedBody = json_encode(['channel' => $channel, 'text' => $message]);
 
@@ -130,6 +131,8 @@ final class SlackTransportTest extends TransportTestCase
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
         $this->assertSame('1503435956.000247', $sentMessage->getMessageId());
+        $this->assertInstanceOf(SlackSentMessage::class, $sentMessage);
+        $this->assertSame('C123456', $sentMessage->getChannelId());
     }
 
     public function testSendWithNotification()
@@ -145,7 +148,7 @@ final class SlackTransportTest extends TransportTestCase
 
         $response->expects($this->once())
             ->method('getContent')
-            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247']));
+            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247', 'channel' => 'C123456']));
 
         $notification = new Notification($message);
         $chatMessage = ChatMessage::fromNotification($notification);
@@ -223,7 +226,7 @@ final class SlackTransportTest extends TransportTestCase
 
         $response->expects($this->once())
             ->method('getContent')
-            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247']));
+            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247', 'channel' => 'C123456']));
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
             $this->assertContains('Content-Type: application/json; charset=utf-8', $options['headers']);
@@ -262,5 +265,40 @@ final class SlackTransportTest extends TransportTestCase
         $this->expectExceptionMessage('Unable to post the Slack message: "invalid_blocks" (no more than 50 items allowed [json-pointer:/blocks]).');
 
         $transport->send(new ChatMessage('testMessage'));
+    }
+
+    public function testUpdateMessage()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247', 'channel' => 'C123456']));
+
+        $sentMessage = new SlackSentMessage(new ChatMessage('Hello'), 'slack', 'C123456', '1503435956.000247');
+        $chatMessage = $sentMessage->getUpdateMessage('Hello World');
+
+        $expectedBody = json_encode([
+            'channel' => 'C123456',
+            'ts' => '1503435956.000247',
+            'text' => 'Hello World',
+        ]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
+            $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
+            $this->assertStringEndsWith('chat.update', $url);
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'another-channel');
+
+        $sentMessage = $transport->send($chatMessage);
+
+        $this->assertSame('1503435956.000247', $sentMessage->getMessageId());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/UpdateMessageSlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/UpdateMessageSlackOptions.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Slack;
+
+/**
+ * @author Maxim Dovydenok <dovydenok.maxim@gmail.com>
+ */
+final class UpdateMessageSlackOptions extends SlackOptions
+{
+    public function __construct(string $channelId, string $messageId, array $options = [])
+    {
+        $options['channel'] = $channelId;
+        $options['ts'] = $messageId;
+
+        parent::__construct($options);
+    }
+}


### PR DESCRIPTION
Update existing SlackTransport to allow message updates. Because chat.update API method only allows channel ids, this PR also includes updates to SentMessage

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #47274
| License       | MIT
| Doc PR        | symfony/symfony-docs#17214

This pull request allows to update slack messages, for example to keep entity statuses up-to-date:
```php
// On entity creation
$message = sprintf('Entity #%s (%s)', $entity->getId(), $entity->getStatus());
$sentMessage = $this->chatter->send(new ChatMessage($message));

// On status changes
$message = sprintf('Entity #%s (%s)', $entity->getId(), $entity->getStatus());
$this->chatter->send(new ChatMessage($message, new UpdateMessageSlackOptions($sentMessage->getFullMessageId())));
```
