### PR TITLE
[GHA] Set `COMPOSER_NO_AUDIT`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -115,6 +115,8 @@ jobs:
           echo "::group::install phpunit"
           ./phpunit install
           echo "::endgroup::"
+        env:
+          COMPOSER_NO_AUDIT: 1
 
       - name: Run tests
         run: ./phpunit --group integration -v

--- a/.github/workflows/intl-data-tests.yml
+++ b/.github/workflows/intl-data-tests.yml
@@ -65,6 +65,8 @@ jobs:
           echo "::group::install phpunit"
           ./phpunit install
           echo "::endgroup::"
+        env:
+          COMPOSER_NO_AUDIT: 1
 
       - name: Report the ICU version
         run: uconv -V && php -i | grep 'ICU version'

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -43,6 +43,8 @@ jobs:
           export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
           composer remove --dev --no-update --no-interaction symfony/phpunit-bridge
           composer require --no-progress --ansi psalm/phar phpunit/phpunit:^9.5 php-http/discovery psr/event-dispatcher mongodb/mongodb
+        env:
+          COMPOSER_NO_AUDIT: 1
 
       - name: Generate Psalm baseline
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -141,6 +141,8 @@ jobs:
           echo "::group::install phpunit"
           ./phpunit install
           echo "::endgroup::"
+        env:
+          COMPOSER_NO_AUDIT: 1
 
       - name: Patch return types
         if: "matrix.php == '8.1' && ! matrix.mode"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Running the audit step introduced in https://github.com/composer/composer/releases/tag/2.4.0 should not be necessary in a CI context. 
The env var could be set by https://github.com/shivammathur/setup-php directly at some point, but it's not for sure yet: https://github.com/shivammathur/setup-php/issues/635.