### PR TITLE
Fix broken request stack state if throwable is thrown.

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -76,6 +76,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     {
         $request->headers->set('X-Php-Ob-Level', (string) ob_get_level());
 
+        $this->requestStack->push($request);
         try {
             return $this->handleRaw($request, $type);
         } catch (\Exception $e) {
@@ -89,6 +90,8 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
             }
 
             return $this->handleThrowable($e, $request, $type);
+        } finally {
+            $this->requestStack->pop();
         }
     }
 
@@ -127,8 +130,6 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      */
     private function handleRaw(Request $request, int $type = self::MASTER_REQUEST): Response
     {
-        $this->requestStack->push($request);
-
         // request
         $event = new RequestEvent($this, $request, $type);
         $this->dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -205,7 +206,6 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     private function finishRequest(Request $request, int $type)
     {
         $this->dispatcher->dispatch(new FinishRequestEvent($this, $request, $type), KernelEvents::FINISH_REQUEST);
-        $this->requestStack->pop();
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -39,6 +39,45 @@ class HttpKernelTest extends TestCase
         $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
     }
 
+    public function testRequestStackIsNotBrokenWhenControllerThrowsAnExceptionAndCatchIsTrue()
+    {
+        $requestStack = new RequestStack();
+        $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \RuntimeException(); }, $requestStack);
+
+        try {
+            $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
+        } catch (\Throwable $exception) {
+        }
+
+        self::assertNull($requestStack->getCurrentRequest());
+    }
+
+    public function testRequestStackIsNotBrokenWhenControllerThrowsAnExceptionAndCatchIsFalse()
+    {
+        $requestStack = new RequestStack();
+        $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \RuntimeException(); }, $requestStack);
+
+        try {
+            $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, false);
+        } catch (\Throwable $exception) {
+        }
+
+        self::assertNull($requestStack->getCurrentRequest());
+    }
+
+    public function testRequestStackIsNotBrokenWhenControllerThrowsAnThrowable()
+    {
+        $requestStack = new RequestStack();
+        $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \Error(); }, $requestStack);
+
+        try {
+            $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
+        } catch (\Throwable $exception) {
+        }
+
+        self::assertNull($requestStack->getCurrentRequest());
+    }
+
     public function testHandleWhenControllerThrowsAnExceptionAndCatchIsFalseAndNoListenerIsRegistered()
     {
         $this->expectException(\RuntimeException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When using long-running server (like roadrunner) if Throwable is thrown - requestStack is never pop out and it stays in broken state and next requests receive previous request object.