### PR TITLE
[DependencyInjection] Allow array attributes for service tags

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -48,11 +48,7 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
             throw new InvalidArgumentException('The tag name in "_defaults" must be a non-empty string.');
         }
 
-        foreach ($attributes as $attribute => $value) {
-            if (null !== $value && !\is_scalar($value)) {
-                throw new InvalidArgumentException(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type.', $name, $attribute));
-            }
-        }
+        $this->validateAttributes($name, $attributes);
 
         $this->definition->addTag($name, $attributes);
 
@@ -65,5 +61,16 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
     final public function instanceof(string $fqcn): InstanceofConfigurator
     {
         return $this->parent->instanceof($fqcn);
+    }
+
+    private function validateAttributes(string $tagName, array $attributes, string $prefix = ''): void
+    {
+        foreach ($attributes as $attribute => $value) {
+            if (\is_array($value)) {
+                $this->validateAttributes($tagName, $value, $attribute.'.');
+            } elseif (!\is_scalar($value ?? '')) {
+                throw new InvalidArgumentException(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type or an array of scalar-type.', $tagName, $prefix.$attribute));
+            }
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
@@ -26,14 +26,21 @@ trait TagTrait
             throw new InvalidArgumentException(sprintf('The tag name for service "%s" must be a non-empty string.', $this->id));
         }
 
-        foreach ($attributes as $attribute => $value) {
-            if (!\is_scalar($value) && null !== $value) {
-                throw new InvalidArgumentException(sprintf('A tag attribute must be of a scalar-type for service "%s", tag "%s", attribute "%s".', $this->id, $name, $attribute));
-            }
-        }
+        $this->validateAttributes($name, $attributes);
 
         $this->definition->addTag($name, $attributes);
 
         return $this;
+    }
+
+    private function validateAttributes(string $tagName, array $attributes, string $prefix = ''): void
+    {
+        foreach ($attributes as $attribute => $value) {
+            if (\is_array($value)) {
+                $this->validateAttributes($tagName, $value, $attribute.'.');
+            } elseif (!\is_scalar($value ?? '')) {
+                throw new InvalidArgumentException(sprintf('A tag attribute must be of a scalar-type or an array of scalar-types for service "%s", tag "%s", attribute "%s".', $this->id, $tagName, $prefix.$attribute));
+            }
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -342,10 +342,13 @@ class XmlFileLoader extends FileLoader
         $tags = $this->getChildren($service, 'tag');
 
         foreach ($tags as $tag) {
-            $parameters = [];
-            $tagName = $tag->nodeValue;
+            if ('' === $tagName = $tag->hasChildNodes() || '' === $tag->nodeValue ? $tag->getAttribute('name') : $tag->nodeValue) {
+                throw new InvalidArgumentException(sprintf('The tag name for service "%s" in "%s" must be a non-empty string.', (string) $service->getAttribute('id'), $file));
+            }
+
+            $parameters = $this->getTagAttributes($tag, sprintf('The attribute name of tag "%s" for service "%s" in %s must be a non-empty string.', $tagName, (string) $service->getAttribute('id'), $file));
             foreach ($tag->attributes as $name => $node) {
-                if ('name' === $name && '' === $tagName) {
+                if ('name' === $name) {
                     continue;
                 }
 
@@ -354,10 +357,6 @@ class XmlFileLoader extends FileLoader
                 }
                 // keep not normalized key
                 $parameters[$name] = XmlUtils::phpize($node->nodeValue);
-            }
-
-            if ('' === $tagName && '' === $tagName = $tag->getAttribute('name')) {
-                throw new InvalidArgumentException(sprintf('The tag name for service "%s" in "%s" must be a non-empty string.', $service->getAttribute('id'), $file));
             }
 
             $definition->addTag($tagName, $parameters);
@@ -588,6 +587,30 @@ class XmlFileLoader extends FileLoader
         }
 
         return $children;
+    }
+
+    private function getTagAttributes(\DOMNode $node, string $missingName): array
+    {
+        $parameters = [];
+        $children = $this->getChildren($node, 'attribute');
+
+        foreach ($children as $childNode) {
+            if ('' === $name = $childNode->getAttribute('name')) {
+                throw new InvalidArgumentException($missingName);
+            }
+
+            if ($this->getChildren($childNode, 'attribute')) {
+                $parameters[$name] = $this->getTagAttributes($childNode, $missingName);
+            } else {
+                if (str_contains($name, '-') && !str_contains($name, '_') && !\array_key_exists($normalizedName = str_replace('-', '_', $name), $parameters)) {
+                    $parameters[$normalizedName] = XmlUtils::phpize($childNode->nodeValue);
+                }
+                // keep not normalized key
+                $parameters[$name] = XmlUtils::phpize($childNode->nodeValue);
+            }
+        }
+
+        return $parameters;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -303,11 +303,7 @@ class YamlFileLoader extends FileLoader
                     throw new InvalidArgumentException(sprintf('The tag name in "_defaults" must be a non-empty string in "%s".', $file));
                 }
 
-                foreach ($tag as $attribute => $value) {
-                    if (!\is_scalar($value) && null !== $value) {
-                        throw new InvalidArgumentException(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type in "%s". Check your YAML syntax.', $name, $attribute, $file));
-                    }
-                }
+                $this->validateAttributes(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type in "%s". Check your YAML syntax.', $name, '%s', $file), $tag);
             }
         }
 
@@ -611,11 +607,7 @@ class YamlFileLoader extends FileLoader
                 throw new InvalidArgumentException(sprintf('The tag name for service "%s" in "%s" must be a non-empty string.', $id, $file));
             }
 
-            foreach ($tag as $attribute => $value) {
-                if (!\is_scalar($value) && null !== $value) {
-                    throw new InvalidArgumentException(sprintf('A "tags" attribute must be of a scalar-type for service "%s", tag "%s", attribute "%s" in "%s". Check your YAML syntax.', $id, $name, $attribute, $file));
-                }
-            }
+            $this->validateAttributes(sprintf('A "tags" attribute must be of a scalar-type for service "%s", tag "%s", attribute "%s" in "%s". Check your YAML syntax.', $id, $name, '%s', $file), $tag);
 
             $definition->addTag($name, $tag);
         }
@@ -951,6 +943,17 @@ class YamlFileLoader extends FileLoader
         foreach ($definition as $key => $value) {
             if (!isset($keywords[$key])) {
                 throw new InvalidArgumentException(sprintf('The configuration key "%s" is unsupported for definition "%s" in "%s". Allowed configuration keys are "%s".', $key, $id, $file, implode('", "', $keywords)));
+            }
+        }
+    }
+
+    private function validateAttributes(string $message, array $attributes, string $prefix = ''): void
+    {
+        foreach ($attributes as $attribute => $value) {
+            if (\is_array($value)) {
+                $this->validateAttributes($message, $value, $attribute.'.');
+            } elseif (!\is_scalar($value ?? '')) {
+                throw new InvalidArgumentException(sprintf($message, $prefix.$attribute));
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -219,12 +219,11 @@
     <xsd:attribute name="public" type="boolean" />
   </xsd:complexType>
 
-  <xsd:complexType name="tag">
-    <xsd:simpleContent>
-      <xsd:extension base="xsd:string">
-        <xsd:anyAttribute namespace="##any" processContents="lax" />
-      </xsd:extension>
-    </xsd:simpleContent>
+  <xsd:complexType name="tag" mixed="true">
+    <xsd:choice minOccurs="0">
+      <xsd:element name="attribute" type="tag_attribute" maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:anyAttribute namespace="##any" processContents="lax" />
   </xsd:complexType>
 
   <xsd:complexType name="deprecated">
@@ -234,6 +233,13 @@
         <xsd:attribute name="version" type="xsd:string" use="required" />
       </xsd:extension>
     </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="tag_attribute" mixed="true">
+    <xsd:choice minOccurs="0">
+      <xsd:element name="attribute" type="tag_attribute" maxOccurs="unbounded" />
+    </xsd:choice>
+    <xsd:attribute name="name" type="xsd:string" use="required" />
   </xsd:complexType>
 
   <xsd:complexType name="parameters">

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -264,4 +264,12 @@ class XmlDumperTest extends TestCase
         $dumper = new XmlDumper($container);
         $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_with_abstract_argument.xml', $dumper->dump());
     }
+
+    public function testDumpNonScalarTags()
+    {
+        $container = include self::$fixturesPath.'/containers/container_non_scalar_tags.php';
+        $dumper = new XmlDumper($container);
+
+        $this->assertEquals(file_get_contents(self::$fixturesPath.'/xml/services_with_array_tags.xml'), $dumper->dump());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -161,6 +161,14 @@ class YamlDumperTest extends TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_with_abstract_argument.yml', $dumper->dump());
     }
 
+    public function testDumpNonScalarTags()
+    {
+        $container = include self::$fixturesPath.'/containers/container_non_scalar_tags.php';
+        $dumper = new YamlDumper($container);
+
+        $this->assertEquals(file_get_contents(self::$fixturesPath.'/yaml/services_with_array_tags.yml'), $dumper->dump());
+    }
+
     private function assertEqualYamlStructure(string $expected, string $yaml, string $message = '')
     {
         $parser = new Parser();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_non_scalar_tags.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_non_scalar_tags.php
@@ -1,0 +1,20 @@
+<?php
+
+require_once __DIR__.'/../includes/classes.php';
+require_once __DIR__.'/../includes/foo.php';
+
+use Bar\FooClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+$container = new ContainerBuilder();
+$container
+    ->register('foo', FooClass::class)
+    ->addTag('foo_tag', [
+        'foo' => 'bar',
+        'bar' => [
+            'foo' => 'bar',
+            'bar' => 'foo'
+        ]])
+;
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_array_tags.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_array_tags.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="foo" class="Bar\FooClass">
+      <tag name="foo_tag">
+        <attribute name="foo">bar</attribute>
+        <attribute name="bar">
+          <attribute name="foo">bar</attribute>
+          <attribute name="bar">foo</attribute>
+        </attribute>
+      </tag>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_array_tags.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_array_tags.yml
@@ -1,0 +1,10 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo:
+        class: Bar\FooClass
+        tags:
+            - foo_tag: { foo: bar, bar: { foo: bar, bar: foo } }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/tag_array_arguments.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/tag_array_arguments.yml
@@ -2,5 +2,5 @@ services:
     foo_service:
         class:    FooClass
         tags:
-          # tag-attribute is not a scalar
+          # tag-attribute is an array
           - { name: foo, bar: { foo: foo, bar: bar } }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -418,6 +418,15 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals(new ServiceClosureArgument(new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)), $container->getDefinition('foo')->getArgument(0));
     }
 
+    public function testParseServiceTagsWithArrayAttributes()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_with_array_tags.xml');
+
+        $this->assertEquals(['foo_tag' => [['foo' => 'bar', 'bar' => ['foo' => 'bar', 'bar' => 'foo']]]], $container->getDefinition('foo')->getTags());
+    }
+
     public function testParseTagsWithoutNameThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -418,16 +418,14 @@ class YamlFileLoaderTest extends TestCase
         $this->assertCount(1, $container->getDefinition('foo_service')->getTag('foo'));
     }
 
-    public function testTagWithAttributeArrayThrowsException()
+    public function testTagWithAttributeArray()
     {
-        $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
-        try {
-            $loader->load('badtag3.yml');
-            $this->fail('->load() should throw an exception when a tag-attribute is not a scalar');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf(InvalidArgumentException::class, $e, '->load() throws an InvalidArgumentException if a tag-attribute is not a scalar');
-            $this->assertStringStartsWith('A "tags" attribute must be of a scalar-type for service "foo_service", tag "foo", attribute "bar"', $e->getMessage(), '->load() throws an InvalidArgumentException if a tag-attribute is not a scalar');
-        }
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('tag_array_arguments.yml');
+
+        $definition = $container->getDefinition('foo_service');
+        $this->assertEquals(['foo' => [['bar' => ['foo' => 'foo', 'bar' => 'bar']]]], $definition->getTags());
     }
 
     public function testLoadYamlOnlyWithKeys()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/38339, https://github.com/symfony/symfony/pull/38540
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This adds array attribute support for container service tags as described in https://github.com/symfony/symfony/issues/38339. The most notable change is the additions to the XML schema for services, because that's the current limitation for not using array.

This is reopening https://github.com/symfony/symfony/pull/38540 as new PR since the other one was ("accidentially") closed 😊 
/cc @nicolas-grekas 