### PR TITLE
[Console] Fix OutputFormatterStyleStack::getCurrent return type

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
@@ -77,7 +77,7 @@ class OutputFormatterStyleStack implements ResetInterface
     /**
      * Computes current style with stacks top codes.
      */
-    public function getCurrent(): OutputFormatterStyle
+    public function getCurrent(): OutputFormatterStyleInterface
     {
         if (empty($this->styles)) {
             return $this->emptyStyle;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

`$styles` is an array of `OutputFormatterStyleInterface` so `getCurrent` method can return this interface
