### PR TITLE
[HttpKernel] Use Accept-Language header even if there are no enabled locales

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,7 +18,8 @@ CHANGELOG
    `workflow.state_machine`
  * Add `rate_limiter` configuration option to `messenger.transport` to allow rate limited transports using the RateLimiter component
  * Remove `@internal` tag from secret vaults to allow them to be used directly outside the framework bundle and custom vaults to be added
- * Deprecate "framework.form.legacy_error_messages" config node
+ * Deprecate `framework.form.legacy_error_messages` config node
+ * Set locale from request rather than default locale if `framework.enabled_locales` is empty and `framework.set_locale_from_accept_language` is true
 
 6.1
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -68,7 +68,7 @@ class LocaleListener implements EventSubscriberInterface
     {
         if ($locale = $request->attributes->get('_locale')) {
             $request->setLocale($locale);
-        } elseif ($this->useAcceptLanguageHeader && $this->enabledLocales && ($preferredLanguage = $request->getPreferredLanguage($this->enabledLocales))) {
+        } elseif ($this->useAcceptLanguageHeader && ($preferredLanguage = $request->getPreferredLanguage($this->enabledLocales))) {
             $request->setLocale($preferredLanguage);
             $request->attributes->set('_vary_by_language', true);
         }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -179,7 +179,7 @@ class LocaleListenerTest extends TestCase
 
         $listener->setDefaultLocale($event);
         $listener->onKernelRequest($event);
-        $this->assertEquals('de', $request->getLocale());
+        $this->assertEquals('fr_FR', $request->getLocale());
     }
 
     public function testRequestAttributeLocaleNotOverridenFromAcceptLanguageHeader()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47355
| License       | MIT
| Doc PR        | N/A

Don’t really know how I should consider this PR :thinking: 

It would affect people setting `set_locale_from_accept_language` to `true` with no `enabled_locales` when the request has a preferred language:

- before: set the default locale as request locale
- after: set the preferred language as request locale