### PR TITLE
[LokaliseBridge] Fix push command --delete-missing options when there are no missing messages

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -120,10 +120,12 @@ final class LokaliseProvider implements ProviderInterface
         $keysIds = [];
 
         foreach ($catalogue->getDomains() as $domain) {
-            $keysToDelete = [];
-            foreach (array_keys($catalogue->all($domain)) as $key) {
-                $keysToDelete[] = $key;
+            $keysToDelete = array_keys($catalogue->all($domain));
+
+            if (!$keysToDelete) {
+                continue;
             }
+
             $keysIds += $this->getKeysIds($keysToDelete, $domain);
         }
 

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -699,10 +699,12 @@ class LokaliseProviderTest extends ProviderTestCase
         $translatorBag->addCatalogue(new MessageCatalogue('en', [
             'messages' => ['a' => 'trans_en_a'],
             'validators' => ['post.num_comments' => '{count, plural, one {# comment} other {# comments}}'],
+            'domain_without_missing_messages' => [],
         ]));
         $translatorBag->addCatalogue(new MessageCatalogue('fr', [
             'messages' => ['a' => 'trans_fr_a'],
             'validators' => ['post.num_comments' => '{count, plural, one {# commentaire} other {# commentaires}}'],
+            'domain_without_missing_messages' => [],
         ]));
 
         $provider = $this->createProvider(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

When `translation:push lokalise --delete-missing` command is executed and the messages are the same locally as in Lokalise, then the command removes all messages from Lokalise. This happens because the `getKeysIds` method in `LokaliseProvider` return all key ids when receives an empty array (empty `filter_keys` param in request to Lokalise API).

This code prevent execution of `getKeysIds` method when there are no messages to delete from Lokalise.