### PR TITLE
[Console] [Completion] Make bash completion run in non interactive mode

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.bash
+++ b/src/Symfony/Component/Console/Resources/completion.bash
@@ -24,7 +24,7 @@ _sf_{{ COMMAND_NAME }}() {
     local cur prev words cword
     _get_comp_words_by_ref -n := cur prev words cword
 
-    local completecmd=("$sf_cmd" "_complete" "-sbash" "-c$cword" "-S{{ VERSION }}")
+    local completecmd=("$sf_cmd" "_complete" "--no-interaction" "-sbash" "-c$cword" "-S{{ VERSION }}")
     for w in ${words[@]}; do
         w=$(printf -- '%b' "$w")
         # remove quotes from typed values


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Refs https://github.com/composer/composer/issues/11024

Composer does prompt in some contexts, and that blocks/freezes the completion as it runs in an interactive context but is not actually visible. Explicitly setting it to be non interactive seems to be the fix to me.

TODO:

- [ ] A similar fix probably should be applied to other completion types supported in newer versions than 5.4