### PR TITLE
Replace get_class() calls by ::class

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,6 +34,7 @@ return (new PhpCsFixer\Config())
         'no_superfluous_phpdoc_tags' => ['remove_inheritdoc' => true],
         'header_comment' => ['header' => $fileHeaderComment],
         'modernize_strpos' => true,
+        'get_class_to_class_keyword' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/Symfony/Bridge/Doctrine/DataCollector/ObjectParameter.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/ObjectParameter.php
@@ -23,7 +23,7 @@ final class ObjectParameter
         $this->object = $object;
         $this->error = $error;
         $this->stringable = \is_callable([$object, '__toString']);
-        $this->class = \get_class($object);
+        $this->class = $object::class;
     }
 
     public function getObject(): object

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -146,7 +146,7 @@ class EntityUserProviderTest extends TestCase
         $provider = new EntityUserProvider($this->getManager($em), 'Symfony\Bridge\Doctrine\Tests\Fixtures\User', 'name');
 
         $user2 = $em->getReference('Symfony\Bridge\Doctrine\Tests\Fixtures\User', ['id1' => 1, 'id2' => 1]);
-        $this->assertTrue($provider->supportsClass(\get_class($user2)));
+        $this->assertTrue($provider->supportsClass($user2::class));
     }
 
     public function testLoadUserByUserNameShouldLoadUserWhenProperInterfaceProvided()

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -75,14 +75,14 @@ class UniqueEntityValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException(sprintf('Object manager "%s" does not exist.', $constraint->em));
             }
         } else {
-            $em = $this->registry->getManagerForClass(\get_class($entity));
+            $em = $this->registry->getManagerForClass($entity::class);
 
             if (!$em) {
                 throw new ConstraintDefinitionException(sprintf('Unable to find the object manager associated with an entity of class "%s".', get_debug_type($entity)));
             }
         }
 
-        $class = $em->getClassMetadata(\get_class($entity));
+        $class = $em->getClassMetadata($entity::class);
 
         $criteria = [];
         $hasNullValue = false;
@@ -136,7 +136,7 @@ class UniqueEntityValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException(sprintf('The "%s" entity repository does not support the "%s" entity. The entity should be an instance of or extend "%s".', $constraint->entityClass, $class->getName(), $supportedClass));
             }
         } else {
-            $repository = $em->getRepository(\get_class($entity));
+            $repository = $em->getRepository($entity::class);
         }
 
         $arguments = [$criteria];
@@ -203,7 +203,7 @@ class UniqueEntityValidator extends ConstraintValidator
             return (string) $value;
         }
 
-        if ($class->getName() !== $idClass = \get_class($value)) {
+        if ($class->getName() !== $idClass = $value::class) {
             // non unique value might be a composite PK that consists of other entity objects
             if ($em->getMetadataFactory()->hasMetadataFor($idClass)) {
                 $identifiers = $em->getClassMetadata($idClass)->getIdentifierValues($value);
@@ -224,7 +224,7 @@ class UniqueEntityValidator extends ConstraintValidator
             if (!\is_object($id) || $id instanceof \DateTimeInterface) {
                 $idAsString = $this->formatValue($id, self::PRETTY_DATE);
             } else {
-                $idAsString = sprintf('object("%s")', \get_class($id));
+                $idAsString = sprintf('object("%s")', $id::class);
             }
 
             $id = sprintf('%s => %s', $field, $idAsString);

--- a/src/Symfony/Bridge/Doctrine/Validator/DoctrineInitializer.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/DoctrineInitializer.php
@@ -30,6 +30,6 @@ class DoctrineInitializer implements ObjectInitializerInterface
 
     public function initialize(object $object)
     {
-        $this->registry->getManagerForClass(\get_class($object))?->initializeObject($object);
+        $this->registry->getManagerForClass($object::class)?->initializeObject($object);
     }
 }

--- a/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
@@ -208,7 +208,7 @@ class NotificationEmail extends TemplatedEmail
             return $exception->getAsString();
         }
 
-        $message = \get_class($exception);
+        $message = $exception::class;
         if ('' !== $exception->getMessage()) {
             $message .= ': '.$exception->getMessage();
         }

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
@@ -53,7 +53,7 @@ class ConfigBuilderCacheWarmer implements CacheWarmerInterface
             try {
                 $this->dumpExtension($extension, $generator);
             } catch (\Exception $e) {
-                $this->logger?->warning('Failed to generate ConfigBuilder for extension {extensionClass}.', ['exception' => $e, 'extensionClass' => \get_class($extension)]);
+                $this->logger?->warning('Failed to generate ConfigBuilder for extension {extensionClass}.', ['exception' => $e, 'extensionClass' => $extension::class]);
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -67,7 +67,7 @@ EOT
             new TableSeparator(),
             ['<info>Kernel</>'],
             new TableSeparator(),
-            ['Type', \get_class($kernel)],
+            ['Type', $kernel::class],
             ['Environment', $kernel->getEnvironment()],
             ['Debug', $kernel->isDebug() ? 'true' : 'false'],
             ['Charset', $kernel->getCharset()],

--- a/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
@@ -44,7 +44,7 @@ trait BuildDebugContainerTrait
                 $this->initializeBundles();
 
                 return $this->buildContainer();
-            }, $kernel, \get_class($kernel));
+            }, $kernel, $kernel::class);
             $container = $buildContainer();
             $container->getCompilerPassConfig()->setRemovingPasses([]);
             $container->getCompilerPassConfig()->setAfterRemovingPasses([]);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -86,7 +86,7 @@ final class ContainerLintCommand extends Command
                 $this->initializeBundles();
 
                 return $this->buildContainer();
-            }, $kernel, \get_class($kernel));
+            }, $kernel, $kernel::class);
             $container = $buildContainer();
 
             $skippedIds = [];

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -158,7 +158,7 @@ abstract class Descriptor implements DescriptorInterface
         }
 
         if (\is_object($value)) {
-            return sprintf('object(%s)', \get_class($value));
+            return sprintf('object(%s)', $value::class);
         }
 
         if (\is_string($value)) {
@@ -335,7 +335,7 @@ abstract class Descriptor implements DescriptorInterface
         $getDefaultParameter = function (string $name) {
             return parent::get($name);
         };
-        $getDefaultParameter = $getDefaultParameter->bindTo($bag, \get_class($bag));
+        $getDefaultParameter = $getDefaultParameter->bindTo($bag, $bag::class);
 
         $getEnvReflection = new \ReflectionMethod($container, 'getEnv');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -78,7 +78,7 @@ class JsonDescriptor extends Descriptor
         } elseif ($service instanceof Definition) {
             $this->writeData($this->getContainerDefinitionData($service, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $builder, $options['id']), $options);
         } else {
-            $this->writeData(\get_class($service), $options);
+            $this->writeData($service::class, $options);
         }
     }
 
@@ -108,7 +108,7 @@ class JsonDescriptor extends Descriptor
             } elseif ($service instanceof Definition) {
                 $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, $omitTags, $showArguments, $builder, $serviceId);
             } else {
-                $data['services'][$serviceId] = \get_class($service);
+                $data['services'][$serviceId] = $service::class;
             }
         }
 
@@ -204,7 +204,7 @@ class JsonDescriptor extends Descriptor
             'hostRegex' => '' !== $route->getHost() ? $route->compile()->getHostRegex() : '',
             'scheme' => $route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY',
             'method' => $route->getMethods() ? implode('|', $route->getMethods()) : 'ANY',
-            'class' => \get_class($route),
+            'class' => $route::class,
             'defaults' => $route->getDefaults(),
             'requirements' => $route->getRequirements() ?: 'NO CUSTOM',
             'options' => $route->getOptions(),
@@ -382,7 +382,7 @@ class JsonDescriptor extends Descriptor
 
         if (method_exists($callable, '__invoke')) {
             $data['type'] = 'object';
-            $data['name'] = \get_class($callable);
+            $data['name'] = $callable::class;
 
             return $data;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -51,7 +51,7 @@ class MarkdownDescriptor extends Descriptor
             ."\n".'- Host Regex: '.('' !== $route->getHost() ? $route->compile()->getHostRegex() : '')
             ."\n".'- Scheme: '.($route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY')
             ."\n".'- Method: '.($route->getMethods() ? implode('|', $route->getMethods()) : 'ANY')
-            ."\n".'- Class: '.\get_class($route)
+            ."\n".'- Class: '.$route::class
             ."\n".'- Defaults: '.$this->formatRouterConfig($route->getDefaults())
             ."\n".'- Requirements: '.($route->getRequirements() ? $this->formatRouterConfig($route->getRequirements()) : 'NO CUSTOM')
             ."\n".'- Options: '.$this->formatRouterConfig($route->getOptions());
@@ -101,7 +101,7 @@ class MarkdownDescriptor extends Descriptor
         } elseif ($service instanceof Definition) {
             $this->describeContainerDefinition($service, $childOptions, $builder);
         } else {
-            $this->write(sprintf('**`%s`:** `%s`', $options['id'], \get_class($service)));
+            $this->write(sprintf('**`%s`:** `%s`', $options['id'], $service::class));
         }
     }
 
@@ -188,7 +188,7 @@ class MarkdownDescriptor extends Descriptor
             $this->write("\n\nServices\n--------\n");
             foreach ($services['services'] as $id => $service) {
                 $this->write("\n");
-                $this->write(sprintf('- `%s`: `%s`', $id, \get_class($service)));
+                $this->write(sprintf('- `%s`: `%s`', $id, $service::class));
             }
         }
     }
@@ -399,7 +399,7 @@ class MarkdownDescriptor extends Descriptor
 
         if (method_exists($callable, '__invoke')) {
             $string .= "\n- Type: `object`";
-            $string .= "\n".sprintf('- Name: `%s`', \get_class($callable));
+            $string .= "\n".sprintf('- Name: `%s`', $callable::class);
 
             return $this->write($string."\n");
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -98,7 +98,7 @@ class TextDescriptor extends Descriptor
             ['Scheme', $route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY'],
             ['Method', $route->getMethods() ? implode('|', $route->getMethods()) : 'ANY'],
             ['Requirements', $route->getRequirements() ? $this->formatRouterConfig($route->getRequirements()) : 'NO CUSTOM'],
-            ['Class', \get_class($route)],
+            ['Class', $route::class],
             ['Defaults', $this->formatRouterConfig($defaults)],
             ['Options', $this->formatRouterConfig($route->getOptions())],
         ];
@@ -156,7 +156,7 @@ class TextDescriptor extends Descriptor
             $options['output']->table(
                 ['Service ID', 'Class'],
                 [
-                    [$options['id'] ?? '-', \get_class($service)],
+                    [$options['id'] ?? '-', $service::class],
                 ]
             );
         }
@@ -244,7 +244,7 @@ class TextDescriptor extends Descriptor
                 $alias = $definition;
                 $tableRows[] = array_merge([$styledServiceId, sprintf('alias for "%s"', $alias)], $tagsCount ? array_fill(0, $tagsCount, '') : []);
             } else {
-                $tableRows[] = array_merge([$styledServiceId, \get_class($definition)], $tagsCount ? array_fill(0, $tagsCount, '') : []);
+                $tableRows[] = array_merge([$styledServiceId, $definition::class], $tagsCount ? array_fill(0, $tagsCount, '') : []);
             }
         }
 
@@ -625,7 +625,7 @@ class TextDescriptor extends Descriptor
         }
 
         if (method_exists($callable, '__invoke')) {
-            return sprintf('%s::__invoke()', \get_class($callable));
+            return sprintf('%s::__invoke()', $callable::class);
         }
 
         throw new \InvalidArgumentException('Callable is not describable.');

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -164,7 +164,7 @@ class XmlDescriptor extends Descriptor
             $routeXML->setAttribute('name', $name);
         }
 
-        $routeXML->setAttribute('class', \get_class($route));
+        $routeXML->setAttribute('class', $route::class);
 
         $routeXML->appendChild($pathXML = $dom->createElement('path'));
         $pathXML->setAttribute('regex', $route->compile()->getRegex());
@@ -269,7 +269,7 @@ class XmlDescriptor extends Descriptor
         } else {
             $dom->appendChild($serviceXML = $dom->createElement('service'));
             $serviceXML->setAttribute('id', $id);
-            $serviceXML->setAttribute('class', \get_class($service));
+            $serviceXML->setAttribute('class', $service::class);
         }
 
         return $dom;
@@ -577,7 +577,7 @@ class XmlDescriptor extends Descriptor
 
         if (method_exists($callable, '__invoke')) {
             $callableXML->setAttribute('type', 'object');
-            $callableXML->setAttribute('name', \get_class($callable));
+            $callableXML->setAttribute('name', $callable::class);
 
             return $dom;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -126,7 +126,7 @@ class CacheClearCommandTest extends TestCase
         \Closure::bind(function (Container $class) {
             unset($class->loadedDynamicParameters['kernel.build_dir']);
             unset($class->parameters['kernel.build_dir']);
-        }, null, \get_class($container))($container);
+        }, null, $container::class)($container);
 
         $input = new ArrayInput(['cache:clear']);
         $application = new Application($kernel);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
@@ -105,12 +105,12 @@ class ProfilerPassTest extends TestCase
         $profilerDefinition = $container->register('profiler', 'ProfilerClass');
 
         $container->registerForAutoconfiguration(DataCollectorInterface::class)->addTag('data_collector');
-        $container->register('mydatacollector', \get_class($dataCollector))->setAutoconfigured(true);
+        $container->register('mydatacollector', $dataCollector::class)->setAutoconfigured(true);
 
         (new ResolveInstanceofConditionalsPass())->process($container);
         (new ProfilerPass())->process($container);
 
-        $idForTemplate = \get_class($dataCollector);
+        $idForTemplate = $dataCollector::class;
         $this->assertSame(['mydatacollector' => [$idForTemplate, 'foo']], $container->getParameter('data_collector.templates'));
 
         // grab the method calls off of the "profiler" definition

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/AnnotatedController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/AnnotatedController.php
@@ -22,7 +22,7 @@ class AnnotatedController
      */
     public function requestDefaultNullAction(Request $request = null)
     {
-        return new Response($request ? \get_class($request) : null);
+        return new Response($request ? $request::class : null);
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
@@ -218,7 +218,7 @@ EOF
             array_map(
                 static function ($authenticator) {
                     return [
-                        \get_class($authenticator),
+                        $authenticator::class,
                     ];
                 },
                 $authenticators
@@ -253,7 +253,7 @@ EOF
         }
 
         if (method_exists($callable, '__invoke')) {
-            return sprintf('%s::__invoke()', \get_class($callable));
+            return sprintf('%s::__invoke()', $callable::class);
         }
 
         throw new \InvalidArgumentException('Callable is not describable.');

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -119,7 +119,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                 'impersonator_user' => $impersonatorUser,
                 'impersonation_exit_path' => null,
                 'token' => $token,
-                'token_class' => $this->hasVarDumper ? new ClassStub(\get_class($token)) : \get_class($token),
+                'token_class' => $this->hasVarDumper ? new ClassStub($token::class) : $token::class,
                 'logout_url' => $logoutUrl,
                 'user' => $token->getUserIdentifier(),
                 'roles' => $assignedRoles,
@@ -137,7 +137,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                     $voter = $voter->getDecoratedVoter();
                 }
 
-                $this->data['voters'][] = $this->hasVarDumper ? new ClassStub(\get_class($voter)) : \get_class($voter);
+                $this->data['voters'][] = $this->hasVarDumper ? new ClassStub($voter::class) : $voter::class;
             }
 
             // collect voter details

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -239,14 +239,14 @@ class SecurityDataCollectorTest extends TestCase
                 ],
             ]],
             [$decoratedVoter1, $decoratedVoter1],
-            [\get_class($voter1), \get_class($voter2)],
+            [$voter1::class, $voter2::class],
             [[
                 'attributes' => ['view'],
                 'object' => new \stdClass(),
                 'result' => true,
                 'voter_details' => [
-                    ['class' => \get_class($voter1), 'attributes' => ['view'], 'vote' => VoterInterface::ACCESS_ABSTAIN],
-                    ['class' => \get_class($voter2), 'attributes' => ['view'], 'vote' => VoterInterface::ACCESS_ABSTAIN],
+                    ['class' => $voter1::class, 'attributes' => ['view'], 'vote' => VoterInterface::ACCESS_ABSTAIN],
+                    ['class' => $voter2::class, 'attributes' => ['view'], 'vote' => VoterInterface::ACCESS_ABSTAIN],
                 ],
             ]],
         ];
@@ -276,17 +276,17 @@ class SecurityDataCollectorTest extends TestCase
                 ],
             ],
             [$decoratedVoter1, $decoratedVoter1],
-            [\get_class($voter1), \get_class($voter2)],
+            [$voter1::class, $voter2::class],
             [
                 [
                     'attributes' => ['view', 'edit'],
                     'object' => new \stdClass(),
                     'result' => false,
                     'voter_details' => [
-                        ['class' => \get_class($voter1), 'attributes' => ['view'], 'vote' => VoterInterface::ACCESS_DENIED],
-                        ['class' => \get_class($voter1), 'attributes' => ['edit'], 'vote' => VoterInterface::ACCESS_DENIED],
-                        ['class' => \get_class($voter2), 'attributes' => ['view'], 'vote' => VoterInterface::ACCESS_GRANTED],
-                        ['class' => \get_class($voter2), 'attributes' => ['edit'], 'vote' => VoterInterface::ACCESS_GRANTED],
+                        ['class' => $voter1::class, 'attributes' => ['view'], 'vote' => VoterInterface::ACCESS_DENIED],
+                        ['class' => $voter1::class, 'attributes' => ['edit'], 'vote' => VoterInterface::ACCESS_DENIED],
+                        ['class' => $voter2::class, 'attributes' => ['view'], 'vote' => VoterInterface::ACCESS_GRANTED],
+                        ['class' => $voter2::class, 'attributes' => ['edit'], 'vote' => VoterInterface::ACCESS_GRANTED],
                     ],
                 ],
                 [
@@ -294,8 +294,8 @@ class SecurityDataCollectorTest extends TestCase
                     'object' => new \stdClass(),
                     'result' => true,
                     'voter_details' => [
-                        ['class' => \get_class($voter1), 'attributes' => ['update'], 'vote' => VoterInterface::ACCESS_GRANTED],
-                        ['class' => \get_class($voter2), 'attributes' => ['update'], 'vote' => VoterInterface::ACCESS_GRANTED],
+                        ['class' => $voter1::class, 'attributes' => ['update'], 'vote' => VoterInterface::ACCESS_GRANTED],
+                        ['class' => $voter2::class, 'attributes' => ['update'], 'vote' => VoterInterface::ACCESS_GRANTED],
                     ],
                 ],
             ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RememberMeBundle/Security/StaticTokenProvider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RememberMeBundle/Security/StaticTokenProvider.php
@@ -23,8 +23,8 @@ class StaticTokenProvider implements TokenProviderInterface
     public function __construct($kernel)
     {
         // only reset the "internal db" for new tests
-        if (self::$kernelClass !== \get_class($kernel)) {
-            self::$kernelClass = \get_class($kernel);
+        if (self::$kernelClass !== $kernel::class) {
+            self::$kernelClass = $kernel::class;
             self::$db = [];
         }
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/SecuredPageBundle/Security/Core/User/ArrayUserProvider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/SecuredPageBundle/Security/Core/User/ArrayUserProvider.php
@@ -64,7 +64,7 @@ class ArrayUserProvider implements UserProviderInterface
         }
 
         $storedUser = $this->getUser($user->getUserIdentifier());
-        $class = \get_class($storedUser);
+        $class = $storedUser::class;
 
         return new $class($storedUser->getUserIdentifier(), $storedUser->getPassword(), $storedUser->getRoles(), $storedUser->isEnabled());
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -85,7 +85,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
                     $this->urlGenerator->generate('_profiler', ['token' => $response->headers->get('X-Debug-Token')], UrlGeneratorInterface::ABSOLUTE_URL)
                 );
             } catch (\Exception $e) {
-                $response->headers->set('X-Debug-Error', \get_class($e).': '.preg_replace('/\s+/', ' ', $e->getMessage()));
+                $response->headers->set('X-Debug-Error', $e::class.': '.preg_replace('/\s+/', ' ', $e->getMessage()));
             }
         }
 

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -326,7 +326,7 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
             $platform instanceof \Doctrine\DBAL\Platforms\OraclePlatform => $this->platformName = 'oci',
             $platform instanceof \Doctrine\DBAL\Platforms\SQLServerPlatform,
             $platform instanceof \Doctrine\DBAL\Platforms\SQLServer2012Platform => $this->platformName = 'sqlsrv',
-            default => $this->platformName = \get_class($platform),
+            default => $this->platformName = $platform::class,
         };
     }
 

--- a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
@@ -58,7 +58,7 @@ class MemcachedAdapter extends AbstractAdapter
         if (!static::isSupported()) {
             throw new CacheException('Memcached > 3.1.5 is required.');
         }
-        if ('Memcached' === \get_class($client)) {
+        if ('Memcached' === $client::class) {
             $opt = $client->getOption(\Memcached::OPT_SERIALIZER);
             if (\Memcached::SERIALIZER_PHP !== $opt && \Memcached::SERIALIZER_IGBINARY !== $opt) {
                 throw new CacheException('MemcachedAdapter: "serializer" option must be "php" or "igbinary".');

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -163,7 +163,7 @@ class Psr16CacheTest extends SimpleCacheTest
 
     protected function isPruned(CacheInterface $cache, string $name): bool
     {
-        if (Psr16Cache::class !== \get_class($cache)) {
+        if (Psr16Cache::class !== $cache::class) {
             $this->fail('Test classes for pruneable caches must implement `isPruned($cache, $name)` method.');
         }
 

--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -123,7 +123,7 @@ public function NAME(): string
                     $this->handleArrayNode($child, $class, $namespace);
                     break;
                 default:
-                    throw new \RuntimeException(sprintf('Unknown node "%s".', \get_class($child)));
+                    throw new \RuntimeException(sprintf('Unknown node "%s".', $child::class));
             }
         }
     }

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -104,7 +104,7 @@ class XmlReferenceDumper
                     if ($prototype->hasDefaultValue()) {
                         $prototypeValue = $prototype->getDefaultValue();
                     } else {
-                        $prototypeValue = match (\get_class($prototype)) {
+                        $prototypeValue = match ($prototype::class) {
                             ScalarNode::class => 'scalar value',
                             FloatNode::class,
                             IntegerNode::class => 'numeric value',

--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -100,7 +100,7 @@ class YamlReferenceDumper
         } elseif ($node instanceof EnumNode) {
             $comments[] = 'One of '.implode('; ', array_map('json_encode', $node->getValues()));
             $default = $node->hasDefaultValue() ? Inline::dump($node->getDefaultValue()) : '~';
-        } elseif (VariableNode::class === \get_class($node) && \is_array($example)) {
+        } elseif (VariableNode::class === $node::class && \is_array($example)) {
             // If there is an array example, we are sure we dont need to print a default value
             $default = '';
         } else {

--- a/src/Symfony/Component/Config/Exception/LoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/LoaderLoadException.php
@@ -71,7 +71,7 @@ class LoaderLoadException extends \Exception
     protected function varToString(mixed $var)
     {
         if (\is_object($var)) {
-            return sprintf('Object(%s)', \get_class($var));
+            return sprintf('Object(%s)', $var::class);
         }
 
         if (\is_array($var)) {

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -73,7 +73,7 @@ class ArrayNodeTest extends TestCase
     public function testIgnoreAndRemoveBehaviors(bool $ignore, bool $remove, array|\Exception $expected, string $message = '')
     {
         if ($expected instanceof \Exception) {
-            $this->expectException(\get_class($expected));
+            $this->expectException($expected::class);
             $this->expectExceptionMessage($expected->getMessage());
         }
         $node = new ArrayNode('root');

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
@@ -66,14 +66,14 @@ class NodeBuilderTest extends TestCase
         $node1 = $builder->node('', 'VaRiAbLe');
         $node2 = $builder->node('', 'variable');
 
-        $this->assertInstanceOf(\get_class($node1), $node2);
+        $this->assertInstanceOf($node1::class, $node2);
 
         $builder->setNodeClass('CuStOm', SomeNodeDefinition::class);
 
         $node1 = $builder->node('', 'CUSTOM');
         $node2 = $builder->node('', 'custom');
 
-        $this->assertInstanceOf(\get_class($node1), $node2);
+        $this->assertInstanceOf($node1::class, $node2);
     }
 
     public function testNumericNodeCreation()

--- a/src/Symfony/Component/Console/Logger/ConsoleLogger.php
+++ b/src/Symfony/Component/Console/Logger/ConsoleLogger.php
@@ -108,7 +108,7 @@ class ConsoleLogger extends AbstractLogger
             } elseif ($val instanceof \DateTimeInterface) {
                 $replacements["{{$key}}"] = $val->format(\DateTime::RFC3339);
             } elseif (\is_object($val)) {
-                $replacements["{{$key}}"] = '[object '.\get_class($val).']';
+                $replacements["{{$key}}"] = '[object '.$val::class.']';
             } else {
                 $replacements["{{$key}}"] = '['.\gettype($val).']';
             }

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -258,7 +258,7 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
             } elseif ($value instanceof ServiceLocatorArgument) {
                 $class = ServiceLocator::class;
             } elseif (\is_object($value)) {
-                $class = \get_class($value);
+                $class = $value::class;
             } else {
                 $class = \gettype($value);
                 $class = ['integer' => 'int', 'double' => 'float', 'boolean' => 'bool'][$class] ?? $class;

--- a/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
@@ -52,10 +52,10 @@ class Compiler
     public function log(CompilerPassInterface $pass, string $message)
     {
         if (str_contains($message, "\n")) {
-            $message = str_replace("\n", "\n".\get_class($pass).': ', trim($message));
+            $message = str_replace("\n", "\n".$pass::class.': ', trim($message));
         }
 
-        $this->log[] = \get_class($pass).': '.$message;
+        $this->log[] = $pass::class.': '.$message;
     }
 
     public function getLog(): array

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -151,7 +151,7 @@ class MergeExtensionConfigurationContainerBuilder extends ContainerBuilder
     {
         parent::__construct($parameterBag);
 
-        $this->extensionClass = \get_class($extension);
+        $this->extensionClass = $extension::class;
     }
 
     public function addCompilerPass(CompilerPassInterface $pass, string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION, int $priority = 0): static

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -107,7 +107,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
             $definition->setBindings([]);
             $definition = serialize($definition);
 
-            if (Definition::class === \get_class($abstract)) {
+            if (Definition::class === $abstract::class) {
                 // cast Definition to ChildDefinition
                 $definition = substr_replace($definition, '53', 2, 2);
                 $definition = substr_replace($definition, 'Child', 44, 0);

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -381,7 +381,7 @@ class XmlDumper extends Dumper
             case $value instanceof Parameter:
                 return '%'.$value.'%';
             case $value instanceof \UnitEnum:
-                return sprintf('%s::%s', \get_class($value), $value->name);
+                return sprintf('%s::%s', $value::class, $value->name);
             case \is_object($value) || \is_resource($value):
                 throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
             default:

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -297,7 +297,7 @@ class YamlDumper extends Dumper
         } elseif ($value instanceof Definition) {
             return new TaggedValue('service', (new Parser())->parse("_:\n".$this->addService('_', $value), Yaml::PARSE_CUSTOM_TAGS)['_']['_']);
         } elseif ($value instanceof \UnitEnum) {
-            return new TaggedValue('php/const', sprintf('%s::%s', \get_class($value), $value->name));
+            return new TaggedValue('php/const', sprintf('%s::%s', $value::class, $value->name));
         } elseif ($value instanceof AbstractArgument) {
             return new TaggedValue('abstract', $value->getText());
         } elseif (\is_object($value) || \is_resource($value)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -382,7 +382,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
         $container->setAlias('stdClass $someService', 'some.service');
         $container->setAlias('stdClass $some_service', 'some.service');
         $container->setAlias('stdClass $anotherService', 'some.service');
-        $container->register('foo', \get_class($subscriber))
+        $container->register('foo', $subscriber::class)
             ->addMethodCall('setContainer', [new Reference(PsrContainerInterface::class)])
             ->addTag('container.service_subscriber');
 
@@ -433,7 +433,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
         };
 
         $container->setParameter('parameter.1', 'foobar');
-        $container->register('foo', \get_class($subscriber))
+        $container->register('foo', $subscriber::class)
             ->addMethodCall('setContainer', [new Reference(PsrContainerInterface::class)])
             ->addTag('container.service_subscriber');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -293,7 +293,7 @@ class ResolveChildDefinitionsPassTest extends TestCase
         $this->assertSame('parentClass', $factory[0]->getClass());
 
         $argument = $container->getDefinition('sibling')->getArgument(0);
-        $this->assertSame('Symfony\Component\DependencyInjection\Definition', \get_class($argument));
+        $this->assertSame('Symfony\Component\DependencyInjection\Definition', $argument::class);
         $this->assertSame('parentClass', $argument->getClass());
 
         $properties = $container->getDefinition('sibling')->getProperties();

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -381,7 +381,7 @@ class ContainerBuilderTest extends TestCase
         $foo1 = $builder->get('foo1');
 
         $this->assertSame($foo1, $builder->get('foo1'), 'The same proxy is retrieved on multiple subsequent calls');
-        $this->assertSame('Bar\FooClass', \get_class($foo1));
+        $this->assertSame('Bar\FooClass', $foo1::class);
     }
 
     public function testCreateLazyProxy()

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -207,7 +207,7 @@ class FormTest extends TestCase
             $values,
             array_map(
                 function ($field) {
-                    $class = \get_class($field);
+                    $class = $field::class;
 
                     return [substr($class, strrpos($class, '\\') + 1), $field->getValue()];
                 },

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -327,7 +327,7 @@ class ErrorHandlerTest extends TestCase
 
         $handler = ErrorHandler::register();
         try {
-            trigger_error('foo '.\get_class($anonymousObject).' bar', \E_USER_WARNING);
+            trigger_error('foo '.$anonymousObject::class.' bar', \E_USER_WARNING);
             $this->fail('Exception expected.');
         } catch (\ErrorException $e) {
         } finally {
@@ -372,7 +372,7 @@ class ErrorHandlerTest extends TestCase
             $logArgCheck = function ($level, $message, $context) use ($expectedMessage, $exception) {
                 $this->assertSame($expectedMessage, $message);
                 $this->assertArrayHasKey('exception', $context);
-                $this->assertInstanceOf(\get_class($exception), $context['exception']);
+                $this->assertInstanceOf($exception::class, $context['exception']);
             };
 
             $logger

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -137,7 +137,7 @@ abstract class AbstractExtension implements FormExtensionInterface
                 throw new UnexpectedTypeException($type, FormTypeInterface::class);
             }
 
-            $this->types[\get_class($type)] = $type;
+            $this->types[$type::class] = $type;
         }
     }
 

--- a/src/Symfony/Component/Form/Command/DebugCommand.php
+++ b/src/Symfony/Component/Form/Command/DebugCommand.php
@@ -204,7 +204,7 @@ EOF
         $coreExtension = new CoreExtension();
         $loadTypesRefMethod = (new \ReflectionObject($coreExtension))->getMethod('loadTypes');
         $coreTypes = $loadTypesRefMethod->invoke($coreExtension);
-        $coreTypes = array_map(function (FormTypeInterface $type) { return \get_class($type); }, $coreTypes);
+        $coreTypes = array_map(function (FormTypeInterface $type) { return $type::class; }, $coreTypes);
         sort($coreTypes);
 
         return $coreTypes;

--- a/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
@@ -198,7 +198,7 @@ abstract class Descriptor implements DescriptorInterface
         foreach ($type->getTypeExtensions() as $extension) {
             $inheritedOptions = $optionsResolver->getDefinedOptions();
             $extension->configureOptions($optionsResolver);
-            $this->extensions[\get_class($extension)] = array_diff($optionsResolver->getDefinedOptions(), $inheritedOptions);
+            $this->extensions[$extension::class] = array_diff($optionsResolver->getDefinedOptions(), $inheritedOptions);
         }
     }
 }

--- a/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
+++ b/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
@@ -65,7 +65,7 @@ class DependencyInjectionExtension implements FormExtensionInterface
 
                 // validate the result of getExtendedTypes() to ensure it is consistent with the service definition
                 if (!\in_array($name, $extendedTypes, true)) {
-                    throw new InvalidArgumentException(sprintf('The extended type "%s" specified for the type extension class "%s" does not match any of the actual extended types (["%s"]).', $name, \get_class($extension), implode('", "', $extendedTypes)));
+                    throw new InvalidArgumentException(sprintf('The extended type "%s" specified for the type extension class "%s" does not match any of the actual extended types (["%s"]).', $name, $extension::class, implode('", "', $extendedTypes)));
                 }
             }
         }

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -99,7 +99,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      */
     public function guessTypeForConstraint(Constraint $constraint): ?TypeGuess
     {
-        switch (\get_class($constraint)) {
+        switch ($constraint::class) {
             case Type::class:
                 switch ($constraint->type) {
                     case 'array':
@@ -190,7 +190,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      */
     public function guessRequiredForConstraint(Constraint $constraint): ?ValueGuess
     {
-        return match (\get_class($constraint)) {
+        return match ($constraint::class) {
             NotNull::class,
             NotBlank::class,
             IsTrue::class => new ValueGuess(true, Guess::HIGH_CONFIDENCE),
@@ -203,7 +203,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      */
     public function guessMaxLengthForConstraint(Constraint $constraint): ?ValueGuess
     {
-        switch (\get_class($constraint)) {
+        switch ($constraint::class) {
             case Length::class:
                 if (is_numeric($constraint->max)) {
                     return new ValueGuess($constraint->max, Guess::HIGH_CONFIDENCE);
@@ -231,7 +231,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      */
     public function guessPatternForConstraint(Constraint $constraint): ?ValueGuess
     {
-        switch (\get_class($constraint)) {
+        switch ($constraint::class) {
             case Length::class:
                 if (is_numeric($constraint->min)) {
                     return new ValueGuess(sprintf('.{%s,}', (string) $constraint->min), Guess::LOW_CONFIDENCE);

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -90,7 +90,7 @@ class FormRegistry implements FormRegistryInterface
     private function resolveType(FormTypeInterface $type): ResolvedFormTypeInterface
     {
         $parentType = $type->getParent();
-        $fqcn = \get_class($type);
+        $fqcn = $type::class;
 
         if (isset($this->checkedTypes[$fqcn])) {
             $types = implode(' > ', array_merge(array_keys($this->checkedTypes), [$fqcn]));

--- a/src/Symfony/Component/Form/PreloadedExtension.php
+++ b/src/Symfony/Component/Form/PreloadedExtension.php
@@ -36,7 +36,7 @@ class PreloadedExtension implements FormExtensionInterface
         $this->typeGuesser = $typeGuesser;
 
         foreach ($types as $type) {
-            $this->types[\get_class($type)] = $type;
+            $this->types[$type::class] = $type;
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -263,7 +263,7 @@ TXT
         $coreExtension = new CoreExtension();
         $loadTypesRefMethod = (new \ReflectionObject($coreExtension))->getMethod('loadTypes');
         $coreTypes = $loadTypesRefMethod->invoke($coreExtension);
-        $coreTypes = array_map(function (FormTypeInterface $type) { return \get_class($type); }, $coreTypes);
+        $coreTypes = array_map(function (FormTypeInterface $type) { return $type::class; }, $coreTypes);
         sort($coreTypes);
 
         return $coreTypes;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
@@ -334,7 +334,7 @@ class DataMapperTest extends TestCase
         $article['publishedAt'] = $publishedAtValue;
         $propertyPath = new PropertyPath('[publishedAt]');
 
-        $config = new FormConfigBuilder('publishedAt', \get_class($publishedAt), $this->dispatcher);
+        $config = new FormConfigBuilder('publishedAt', $publishedAt::class, $this->dispatcher);
         $config->setByReference(false);
         $config->setPropertyPath($propertyPath);
         $config->setData($publishedAt);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -736,7 +736,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
     private function getCompoundForm($data, array $options = [])
     {
-        return $this->getBuilder('name', \is_object($data) ? \get_class($data) : null, $options)
+        return $this->getBuilder('name', \is_object($data) ? $data::class : null, $options)
             ->setData($data)
             ->setCompound(true)
             ->setDataMapper(new DataMapper())

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -113,7 +113,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
                     return $formMetadata;
                 }
 
-                return new ClassMetadata(\is_string($classOrObject) ? $classOrObject : \get_class($classOrObject));
+                return new ClassMetadata(\is_string($classOrObject) ? $classOrObject : $classOrObject::class);
             })
         ;
 

--- a/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
@@ -203,7 +203,7 @@ class HttplugClientTest extends TestCase
 
                 return $response;
             }, function (\Exception $exception) use (&$failureCallableCalled, $client) {
-                $this->assertSame(NetworkException::class, \get_class($exception));
+                $this->assertSame(NetworkException::class, $exception::class);
                 $this->assertSame(TransportException::class, \get_class($exception->getPrevious()));
                 $failureCallableCalled = true;
 
@@ -246,7 +246,7 @@ class HttplugClientTest extends TestCase
                     return $response;
                 },
                 function (\Exception $exception) use ($errorMessage, &$failureCallableCalled, $client, $request) {
-                    $this->assertSame(NetworkException::class, \get_class($exception));
+                    $this->assertSame(NetworkException::class, $exception::class);
                     $this->assertSame($errorMessage, $exception->getMessage());
                     $failureCallableCalled = true;
 

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -127,7 +127,7 @@ class JsonResponse extends Response
         try {
             $data = json_encode($data, $this->encodingOptions);
         } catch (\Exception $e) {
-            if ('Exception' === \get_class($e) && str_starts_with($e->getMessage(), 'Failed calling ')) {
+            if ('Exception' === $e::class && str_starts_with($e->getMessage(), 'Failed calling ')) {
                 throw $e->getPrevious() ?: $e;
             }
             throw $e;

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -240,7 +240,7 @@ class NativeSessionStorage implements SessionStorageInterface
         $previousHandler = set_error_handler(function ($type, $msg, $file, $line) use (&$previousHandler) {
             if (\E_WARNING === $type && str_starts_with($msg, 'session_write_close():')) {
                 $handler = $this->saveHandler instanceof SessionHandlerProxy ? $this->saveHandler->getHandler() : $this->saveHandler;
-                $msg = sprintf('session_write_close(): Failed to write session data with "%s" handler', \get_class($handler));
+                $msg = sprintf('session_write_close(): Failed to write session data with "%s" handler', $handler::class);
             }
 
             return $previousHandler ? $previousHandler($type, $msg, $file, $line) : false;

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -134,7 +134,7 @@ class ArgumentMetadata
             }
         } else {
             foreach ($this->attributes as $attribute) {
-                if (\get_class($attribute) === $name) {
+                if ($attribute::class === $name) {
                     $attributes[] = $attribute;
                 }
             }

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -62,7 +62,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
 
         if (isset($this->kernel)) {
             foreach ($this->kernel->getBundles() as $name => $bundle) {
-                $this->data['bundles'][$name] = new ClassStub(\get_class($bundle));
+                $this->data['bundles'][$name] = new ClassStub($bundle::class);
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -256,7 +256,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     private function varToString(mixed $var): string
     {
         if (\is_object($var)) {
-            return sprintf('an object of type %s', \get_class($var));
+            return sprintf('an object of type %s', $var::class);
         }
 
         if (\is_array($var)) {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -540,7 +540,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $bundlesMetadata = [];
 
         foreach ($this->bundles as $name => $bundle) {
-            $bundles[$name] = \get_class($bundle);
+            $bundles[$name] = $bundle::class;
             $bundlesMetadata[$name] = [
                 'path' => $bundle->getPath(),
                 'namespace' => $bundle->getNamespace(),

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UidValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UidValueResolverTest.php
@@ -63,7 +63,7 @@ class UidValueResolverTest extends TestCase
     {
         $this->assertEquals([$expected], (new UidValueResolver())->resolve(
             new Request([], [], ['id' => $requestUid]),
-            new ArgumentMetadata('id', \get_class($expected), false, false, null)
+            new ArgumentMetadata('id', $expected::class, false, false, null)
         ));
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -40,8 +40,8 @@ class ErrorListenerTest extends TestCase
         $logger = new TestLogger();
         $l = new ErrorListener('foo', $logger);
 
-        $_logger = new \ReflectionProperty(\get_class($l), 'logger');
-        $_controller = new \ReflectionProperty(\get_class($l), 'controller');
+        $_logger = new \ReflectionProperty($l::class, 'logger');
+        $_controller = new \ReflectionProperty($l::class, 'controller');
 
         $this->assertSame($logger, $_logger->getValue($l));
         $this->assertSame('foo', $_controller->getValue($l));

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -640,7 +640,7 @@ EOF
         $bundle
             ->expects($this->any())
             ->method('getName')
-            ->willReturn($bundleName ?? \get_class($bundle))
+            ->willReturn($bundleName ?? $bundle::class)
         ;
 
         $bundle

--- a/src/Symfony/Component/Intl/Resources/bin/common.php
+++ b/src/Symfony/Component/Intl/Resources/bin/common.php
@@ -85,7 +85,7 @@ set_exception_handler(function (Throwable $exception) {
             echo "Caused by\n";
         }
 
-        echo get_class($cause).': '.$cause->getMessage()."\n";
+        echo $cause::class.': '.$cause->getMessage()."\n";
         echo "\n";
         echo $cause->getFile().':'.$cause->getLine()."\n";
         echo $cause->getTraceAsString()."\n";

--- a/src/Symfony/Component/Mailer/Envelope.php
+++ b/src/Symfony/Component/Mailer/Envelope.php
@@ -35,7 +35,7 @@ class Envelope
 
     public static function create(RawMessage $message): self
     {
-        if (RawMessage::class === \get_class($message)) {
+        if (RawMessage::class === $message::class) {
             throw new LogicException('Cannot send a RawMessage instance without an explicit Envelope.');
         }
 

--- a/src/Symfony/Component/Mailer/Transport/Transports.php
+++ b/src/Symfony/Component/Mailer/Transport/Transports.php
@@ -47,7 +47,7 @@ final class Transports implements TransportInterface
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         /** @var Message $message */
-        if (RawMessage::class === \get_class($message) || !$message->getHeaders()->has('X-Transport')) {
+        if (RawMessage::class === $message::class || !$message->getHeaders()->has('X-Transport')) {
             return $this->default->send($message, $envelope);
         }
 

--- a/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
@@ -88,7 +88,7 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
             'stamps' => $tracedMessage['stamps'] ?? null,
             'stamps_after_dispatch' => $tracedMessage['stamps_after_dispatch'] ?? null,
             'message' => [
-                'type' => new ClassStub(\get_class($message)),
+                'type' => new ClassStub($message::class),
                 'value' => $message,
             ],
             'caller' => $tracedMessage['caller'],
@@ -98,7 +98,7 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
             $exception = $tracedMessage['exception'];
 
             $debugRepresentation['exception'] = [
-                'type' => \get_class($exception),
+                'type' => $exception::class,
                 'value' => $exception,
             ];
         }

--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -35,7 +35,7 @@ final class Envelope
         $this->message = $message;
 
         foreach ($stamps as $stamp) {
-            $this->stamps[\get_class($stamp)][] = $stamp;
+            $this->stamps[$stamp::class][] = $stamp;
         }
     }
 
@@ -59,7 +59,7 @@ final class Envelope
         $cloned = clone $this;
 
         foreach ($stamps as $stamp) {
-            $cloned->stamps[\get_class($stamp)][] = $stamp;
+            $cloned->stamps[$stamp::class][] = $stamp;
         }
 
         return $cloned;

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -56,7 +56,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
         $message = $envelope->getMessage();
         $context = [
-            'class' => \get_class($message),
+            'class' => $message::class,
         ];
 
         $shouldRetry = $retryStrategy && $this->shouldRetry($throwable, $envelope, $retryStrategy);
@@ -89,7 +89,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
     private function withLimitedHistory(Envelope $envelope, StampInterface ...$stamps): Envelope
     {
         foreach ($stamps as $stamp) {
-            $history = $envelope->all(\get_class($stamp));
+            $history = $envelope->all($stamp::class);
             if (\count($history) < $this->historySize) {
                 $envelope = $envelope->with($stamp);
                 continue;
@@ -101,7 +101,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
                 [$stamp]
             );
 
-            $envelope = $envelope->withoutAll(\get_class($stamp))->with(...$history);
+            $envelope = $envelope->withoutAll($stamp::class)->with(...$history);
         }
 
         return $envelope;

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -62,7 +62,7 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
 
         $this->logger?->info('Rejected message {class} will be sent to the failure transport {transport}.', [
             'class' => \get_class($envelope->getMessage()),
-            'transport' => \get_class($failureSender),
+            'transport' => $failureSender::class,
         ]);
 
         $failureSender->send($envelope);

--- a/src/Symfony/Component/Messenger/Exception/DelayedMessageHandlingException.php
+++ b/src/Symfony/Component/Messenger/Exception/DelayedMessageHandlingException.php
@@ -25,7 +25,7 @@ class DelayedMessageHandlingException extends RuntimeException
     {
         $exceptionMessages = implode(", \n", array_map(
             function (\Throwable $e) {
-                return \get_class($e).': '.$e->getMessage();
+                return $e::class.': '.$e->getMessage();
             },
             $exceptions
         ));

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -52,7 +52,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
         $message = $envelope->getMessage();
 
         $context = [
-            'class' => \get_class($message),
+            'class' => $message::class,
         ];
 
         $exceptions = [];

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -61,8 +61,8 @@ class SendMessageMiddleware implements MiddlewareInterface
                     $shouldDispatchEvent = false;
                 }
 
-                $this->logger->info('Sending message {class} with {alias} sender using {sender}', $context + ['alias' => $alias, 'sender' => \get_class($sender)]);
-                $envelope = $sender->send($envelope->with(new SentStamp(\get_class($sender), \is_string($alias) ? $alias : null)));
+                $this->logger->info('Sending message {class} with {alias} sender using {sender}', $context + ['alias' => $alias, 'sender' => $sender::class]);
+                $envelope = $sender->send($envelope->with(new SentStamp($sender::class, \is_string($alias) ? $alias : null)));
             }
         }
 

--- a/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
@@ -44,7 +44,7 @@ final class ErrorDetailsStamp implements StampInterface
             $flattenException = FlattenException::createFromThrowable($throwable);
         }
 
-        return new self(\get_class($throwable), $throwable->getCode(), $throwable->getMessage(), $flattenException);
+        return new self($throwable::class, $throwable->getCode(), $throwable->getMessage(), $flattenException);
     }
 
     public function getExceptionClass(): string

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -72,11 +72,11 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
     {
         $first = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
         $first->method('__invoke')->willReturn('first result');
-        $firstClass = \get_class($first);
+        $firstClass = $first::class;
 
         $second = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
         $second->method('__invoke')->willReturn(null);
-        $secondClass = \get_class($second);
+        $secondClass = $second::class;
 
         $failing = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
         $failing->method('__invoke')->will($this->throwException(new \Exception('handler failed.')));

--- a/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
@@ -36,7 +36,7 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
         $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['my_sender']], ['my_sender' => $sender]);
         $middleware = new SendMessageMiddleware($sendersLocator);
 
-        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp(\get_class($sender), 'my_sender')))->willReturnArgument(0);
+        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp($sender::class, 'my_sender')))->willReturnArgument(0);
 
         $envelope = $middleware->handle($envelope, $this->getStackMock(false));
 
@@ -91,7 +91,7 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
         $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['foo_sender']], ['foo_sender' => $sender]);
         $middleware = new SendMessageMiddleware($sendersLocator);
 
-        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp(\get_class($sender), 'foo_sender')))->willReturn($envelope);
+        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp($sender::class, 'foo_sender')))->willReturn($envelope);
 
         $middleware->handle($envelope, $this->getStackMock(false));
     }
@@ -105,7 +105,7 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
         $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['foo_sender']], ['foo_sender' => $sender]);
         $middleware = new SendMessageMiddleware($sendersLocator);
 
-        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp(\get_class($sender), 'foo_sender')))->willReturn($envelope);
+        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp($sender::class, 'foo_sender')))->willReturn($envelope);
 
         $middleware->handle($envelope, $this->getStackMock(false));
     }
@@ -119,7 +119,7 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
         $sendersLocator = $this->createSendersLocator([DummyMessageInterface::class => ['foo_sender']], ['foo_sender' => $sender]);
         $middleware = new SendMessageMiddleware($sendersLocator);
 
-        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp(\get_class($sender), 'foo_sender')))->willReturn($envelope);
+        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp($sender::class, 'foo_sender')))->willReturn($envelope);
 
         $middleware->handle($envelope, $this->getStackMock(false));
     }
@@ -133,7 +133,7 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
         $sendersLocator = $this->createSendersLocator(['*' => ['foo_sender']], ['foo_sender' => $sender]);
         $middleware = new SendMessageMiddleware($sendersLocator);
 
-        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp(\get_class($sender), 'foo_sender')))->willReturn($envelope);
+        $sender->expects($this->once())->method('send')->with($envelope->with(new SentStamp($sender::class, 'foo_sender')))->willReturn($envelope);
 
         $middleware->handle($envelope, $this->getStackMock(false));
     }

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -425,7 +425,7 @@ class WorkerTest extends TestCase
         $worker->run();
 
         $envelope = current($receiver->getAcknowledgedEnvelopes());
-        $this->assertCount(1, $envelope->all(\get_class($stamp)));
+        $this->assertCount(1, $envelope->all($stamp::class));
     }
 
     public function testWorkerRateLimitMessages()

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -211,7 +211,7 @@ class Worker
             if (null !== $this->logger) {
                 $message = $envelope->getMessage();
                 $context = [
-                    'class' => \get_class($message),
+                    'class' => $message::class,
                 ];
                 $this->logger->info('{class} was handled successfully (acknowledging to transport).', $context);
             }

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailAddressContains.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailAddressContains.php
@@ -37,7 +37,7 @@ final class EmailAddressContains extends Constraint
      */
     protected function matches($message): bool
     {
-        if (RawMessage::class === \get_class($message)) {
+        if (RawMessage::class === $message::class) {
             throw new \LogicException('Unable to test a message address on a RawMessage instance.');
         }
 

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailAttachmentCount.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailAttachmentCount.php
@@ -36,7 +36,7 @@ final class EmailAttachmentCount extends Constraint
      */
     protected function matches($message): bool
     {
-        if (RawMessage::class === \get_class($message) || Message::class === \get_class($message)) {
+        if (RawMessage::class === $message::class || Message::class === $message::class) {
             throw new \LogicException('Unable to test a message attachment on a RawMessage or Message instance.');
         }
 

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailHasHeader.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailHasHeader.php
@@ -33,7 +33,7 @@ final class EmailHasHeader extends Constraint
      */
     protected function matches($message): bool
     {
-        if (RawMessage::class === \get_class($message)) {
+        if (RawMessage::class === $message::class) {
             throw new \LogicException('Unable to test a message header on a RawMessage instance.');
         }
 

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailHeaderSame.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailHeaderSame.php
@@ -36,7 +36,7 @@ final class EmailHeaderSame extends Constraint
      */
     protected function matches($message): bool
     {
-        if (RawMessage::class === \get_class($message)) {
+        if (RawMessage::class === $message::class) {
             throw new \LogicException('Unable to test a message header on a RawMessage instance.');
         }
 

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailHtmlBodyContains.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailHtmlBodyContains.php
@@ -34,7 +34,7 @@ final class EmailHtmlBodyContains extends Constraint
      */
     protected function matches($message): bool
     {
-        if (RawMessage::class === \get_class($message) || Message::class === \get_class($message)) {
+        if (RawMessage::class === $message::class || Message::class === $message::class) {
             throw new \LogicException('Unable to test a message HTML body on a RawMessage or Message instance.');
         }
 

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailTextBodyContains.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailTextBodyContains.php
@@ -34,7 +34,7 @@ final class EmailTextBodyContains extends Constraint
      */
     protected function matches($message): bool
     {
-        if (RawMessage::class === \get_class($message) || Message::class === \get_class($message)) {
+        if (RawMessage::class === $message::class || Message::class === $message::class) {
             throw new \LogicException('Unable to test a message text body on a RawMessage or Message instance.');
         }
 

--- a/src/Symfony/Component/Notifier/Notification/Notification.php
+++ b/src/Symfony/Component/Notifier/Notification/Notification.php
@@ -139,7 +139,7 @@ class Notification
      */
     public function exception(\Throwable $exception): static
     {
-        $parts = explode('\\', \get_class($exception));
+        $parts = explode('\\', $exception::class);
 
         $this->subject = sprintf('%s: %s', array_pop($parts), $exception->getMessage());
         if (class_exists(FlattenException::class)) {
@@ -202,7 +202,7 @@ class Notification
             return $exception->getAsString();
         }
 
-        $message = \get_class($exception);
+        $message = $exception::class;
         if ('' !== $exception->getMessage()) {
             $message .= ': '.$exception->getMessage();
         }

--- a/src/Symfony/Component/Notifier/Notifier.php
+++ b/src/Symfony/Component/Notifier/Notifier.php
@@ -72,7 +72,7 @@ final class Notifier implements NotifierInterface
     {
         $channels = $notification->getChannels($recipient);
         if (!$channels) {
-            $errorPrefix = sprintf('Unable to determine which channels to use to send the "%s" notification', \get_class($notification));
+            $errorPrefix = sprintf('Unable to determine which channels to use to send the "%s" notification', $notification::class);
             $error = 'you should either pass channels in the constructor, override its "getChannels()" method';
             if (null === $this->policy) {
                 throw new LogicException(sprintf('%s; %s, or configure a "%s".', $errorPrefix, $error, ChannelPolicy::class));

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -1222,7 +1222,7 @@ class OptionsResolver implements Options
     private function formatValue(mixed $value): string
     {
         if (\is_object($value)) {
-            return \get_class($value);
+            return $value::class;
         }
 
         if (\is_array($value)) {

--- a/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
+++ b/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
@@ -143,7 +143,7 @@ EOF
         $hashedPassword = $hasher->hash($password, $salt);
 
         $rows = [
-            ['Hasher used', \get_class($hasher)],
+            ['Hasher used', $hasher::class],
             ['Password hash', $hashedPassword],
         ];
         if (!$emptySalt) {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -381,7 +381,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         $result = self::RESULT_PROTO;
         $object = $zval[self::VALUE];
-        $class = \get_class($object);
+        $class = $object::class;
         $access = $this->getReadInfo($class, $property);
 
         if (null !== $access) {
@@ -502,7 +502,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         $object = $zval[self::VALUE];
-        $class = \get_class($object);
+        $class = $object::class;
         $mutator = $this->getWriteInfo($class, $property, $value);
 
         if (PropertyWriteInfo::TYPE_NONE !== $mutator->getType()) {
@@ -597,13 +597,13 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private function isPropertyWritable(object $object, string $property): bool
     {
-        $mutatorForArray = $this->getWriteInfo(\get_class($object), $property, []);
+        $mutatorForArray = $this->getWriteInfo($object::class, $property, []);
 
         if (PropertyWriteInfo::TYPE_NONE !== $mutatorForArray->getType() || ($object instanceof \stdClass && property_exists($object, $property))) {
             return true;
         }
 
-        $mutator = $this->getWriteInfo(\get_class($object), $property, '');
+        $mutator = $this->getWriteInfo($object::class, $property, '');
 
         return PropertyWriteInfo::TYPE_NONE !== $mutator->getType() || ($object instanceof \stdClass && property_exists($object, $property));
     }

--- a/src/Symfony/Component/Routing/Requirement/EnumRequirement.php
+++ b/src/Symfony/Component/Routing/Requirement/EnumRequirement.php
@@ -38,7 +38,7 @@ final class EnumRequirement implements \Stringable
                     throw new InvalidArgumentException(sprintf('Case must be a "BackedEnum" instance, "%s" given.', get_debug_type($case)));
                 }
 
-                $class ??= \get_class($case);
+                $class ??= $case::class;
 
                 if (!$case instanceof $class) {
                     throw new InvalidArgumentException(sprintf('"%s::%s" is not a case of "%s".', get_debug_type($case), $case->name, $class));

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -86,7 +86,7 @@ final class AccessDecisionManager implements AccessDecisionManagerInterface
             $keyAttributes[] = \is_string($attribute) ? $attribute : null;
         }
         // use `get_class` to handle anonymous classes
-        $keyObject = \is_object($object) ? \get_class($object) : get_debug_type($object);
+        $keyObject = \is_object($object) ? $object::class : get_debug_type($object);
         foreach ($this->voters as $key => $voter) {
             if (!$voter instanceof CacheableVoterInterface) {
                 yield $voter;

--- a/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
+++ b/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
@@ -88,7 +88,7 @@ class SignatureHasher
             }
 
             if (!\is_scalar($value) && !$value instanceof \Stringable) {
-                throw new \InvalidArgumentException(sprintf('The property path "%s" on the user object "%s" must return a value that can be cast to a string, but "%s" was returned.', $property, \get_class($user), get_debug_type($value)));
+                throw new \InvalidArgumentException(sprintf('The property path "%s" on the user object "%s" must return a value that can be cast to a string, but "%s" was returned.', $property, $user::class, get_debug_type($value)));
             }
             $signatureFields[] = base64_encode($value);
         }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -102,13 +102,13 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         $skippedAuthenticators = [];
         $lazy = true;
         foreach ($this->authenticators as $authenticator) {
-            $this->logger?->debug('Checking support on authenticator.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
+            $this->logger?->debug('Checking support on authenticator.', ['firewall_name' => $this->firewallName, 'authenticator' => $authenticator::class]);
 
             if (false !== $supports = $authenticator->supports($request)) {
                 $authenticators[] = $authenticator;
                 $lazy = $lazy && null === $supports;
             } else {
-                $this->logger?->debug('Authenticator does not support the request.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
+                $this->logger?->debug('Authenticator does not support the request.', ['firewall_name' => $this->firewallName, 'authenticator' => $authenticator::class]);
                 $skippedAuthenticators[] = $authenticator;
             }
         }
@@ -181,7 +181,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
                     throw new BadCredentialsException(sprintf('Authentication failed: Security badge "%s" is not resolved, did you forget to register the correct listeners?', get_debug_type($badge)));
                 }
 
-                $resolvedBadges[] = \get_class($badge);
+                $resolvedBadges[] = $badge::class;
             }
 
             $missingRequiredBadges = array_diff($this->requiredBadges, $resolvedBadges);

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
@@ -50,7 +50,7 @@ final class TraceableAuthenticatorManagerListener extends AbstractListener
         foreach ($request->attributes->get('_security_skipped_authenticators') as $skippedAuthenticator) {
             $this->authenticatorsInfo[] = [
                 'supports' => false,
-                'stub' => $this->hasVardumper ? new ClassStub(\get_class($skippedAuthenticator)) : \get_class($skippedAuthenticator),
+                'stub' => $this->hasVardumper ? new ClassStub($skippedAuthenticator::class) : $skippedAuthenticator::class,
                 'passport' => null,
                 'duration' => 0,
             ];

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
@@ -70,7 +70,7 @@ class Passport
      */
     public function addBadge(BadgeInterface $badge): static
     {
-        $this->badges[\get_class($badge)] = $badge;
+        $this->badges[$badge::class] = $badge;
 
         return $this;
     }

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -52,7 +52,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
     {
         $series = base64_encode(random_bytes(64));
         $tokenValue = $this->generateHash(base64_encode(random_bytes(64)));
-        $token = new PersistentToken(\get_class($user), $user->getUserIdentifier(), $series, $tokenValue, new \DateTime());
+        $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $tokenValue, new \DateTime());
 
         $this->tokenProvider->createNewToken($token);
         $this->createCookie(RememberMeDetails::fromPersistentToken($token, time() + $this->options['lifetime']));

--- a/src/Symfony/Component/Security/Http/RememberMe/SignatureRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/SignatureRememberMeHandler.php
@@ -46,7 +46,7 @@ final class SignatureRememberMeHandler extends AbstractRememberMeHandler
         $expires = time() + $this->options['lifetime'];
         $value = $this->signatureHasher->computeSignatureHash($user, $expires);
 
-        $details = new RememberMeDetails(\get_class($user), $user->getUserIdentifier(), $expires, $value);
+        $details = new RememberMeDetails($user::class, $user->getUserIdentifier(), $expires, $value);
         $this->createCookie($details);
     }
 

--- a/src/Symfony/Component/Semaphore/Store/StoreFactory.php
+++ b/src/Symfony/Component/Semaphore/Store/StoreFactory.php
@@ -36,7 +36,7 @@ class StoreFactory
                 return new RedisStore($connection);
 
             case !\is_string($connection):
-                throw new InvalidArgumentException(sprintf('Unsupported Connection: "%s".', \get_class($connection)));
+                throw new InvalidArgumentException(sprintf('Unsupported Connection: "%s".', $connection::class));
             case str_starts_with($connection, 'redis://'):
             case str_starts_with($connection, 'rediss://'):
                 if (!class_exists(AbstractAdapter::class)) {

--- a/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
+++ b/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
@@ -29,7 +29,7 @@ final class ObjectPropertyListExtractor implements ObjectPropertyListExtractorIn
 
     public function getProperties(object $object, array $context = []): ?array
     {
-        $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
+        $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : $object::class;
 
         return $this->propertyListExtractor->getProperties($class, $context);
     }

--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
@@ -48,7 +48,7 @@ class ClassDiscriminatorFromClassMetadata implements ClassDiscriminatorResolverI
             }
         }
 
-        $cacheKey = \is_object($object) ? \get_class($object) : $object;
+        $cacheKey = \is_object($object) ? $object::class : $object;
         if (!\array_key_exists($cacheKey, $this->mappingForMappedObjectCache)) {
             $this->mappingForMappedObjectCache[$cacheKey] = $this->resolveMappingForMappedObject($object);
         }

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassResolverTrait.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassResolverTrait.php
@@ -37,6 +37,6 @@ trait ClassResolverTrait
             return ltrim($value, '\\');
         }
 
-        return \get_class($value);
+        return $value::class;
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
@@ -44,7 +44,7 @@ final class CompiledClassMetadataFactory implements ClassMetadataFactoryInterfac
 
     public function getMetadataFor(string|object $value): ClassMetadataInterface
     {
-        $className = \is_object($value) ? \get_class($value) : $value;
+        $className = \is_object($value) ? $value::class : $value;
 
         if (!isset($this->compiledClassMetadata[$className])) {
             return $this->classMetadataFactory->getMetadataFor($value);
@@ -69,7 +69,7 @@ final class CompiledClassMetadataFactory implements ClassMetadataFactoryInterfac
 
     public function hasMetadataFor(mixed $value): bool
     {
-        $className = \is_object($value) ? \get_class($value) : $value;
+        $className = \is_object($value) ? $value::class : $value;
 
         return isset($this->compiledClassMetadata[$className]) || $this->classMetadataFactory->hasMetadataFor($value);
     }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -156,7 +156,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $data = [];
         $stack = [];
         $attributes = $this->getAttributes($object, $format, $context);
-        $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
+        $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : $object::class;
         $attributesMetadata = $this->classMetadataFactory?->getMetadataFor($class)->getAttributesMetadata();
         if (isset($context[self::MAX_DEPTH_HANDLER])) {
             $maxDepthHandler = $context[self::MAX_DEPTH_HANDLER];
@@ -248,7 +248,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      */
     protected function getAttributes(object $object, ?string $format, array $context): array
     {
-        $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
+        $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : $object::class;
         $key = $class.'-'.$context['cache_key'];
 
         if (isset($this->attributesCache[$key])) {
@@ -318,7 +318,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         $reflectionClass = new \ReflectionClass($type);
         $object = $this->instantiateObject($normalizedData, $type, $context, $reflectionClass, $allowedAttributes, $format);
-        $resolvedClass = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
+        $resolvedClass = $this->objectClassResolver ? ($this->objectClassResolver)($object) : $object::class;
 
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -137,7 +137,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
     protected function setAttributeValue(object $object, string $attribute, mixed $value, string $format = null, array $context = [])
     {
         $setter = 'set'.ucfirst($attribute);
-        $key = \get_class($object).':'.$setter;
+        $key = $object::class.':'.$setter;
 
         if (!isset(self::$setterAccessibleCache[$key])) {
             self::$setterAccessibleCache[$key] = \is_callable([$object, $setter]) && !(new \ReflectionMethod($object, $setter))->isStatic();

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -61,7 +61,7 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
 
         if ($object instanceof AbstractPart) {
             $ret = $this->normalizer->normalize($object, $format, $context);
-            $ret['class'] = \get_class($object);
+            $ret['class'] = $object::class;
 
             return $ret;
         }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -45,7 +45,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
 
         $this->objectClassResolver = $objectClassResolver ?? function ($class) {
-            return \is_object($class) ? \get_class($class) : $class;
+            return \is_object($class) ? $class::class : $class;
         };
     }
 
@@ -56,7 +56,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
     protected function extractAttributes(object $object, string $format = null, array $context = []): array
     {
-        if (\stdClass::class === \get_class($object)) {
+        if (\stdClass::class === $object::class) {
             return array_keys((array) $object);
         }
 
@@ -119,7 +119,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
     protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = []): mixed
     {
-        $cacheKey = \get_class($object);
+        $cacheKey = $object::class;
         if (!\array_key_exists($cacheKey, $this->discriminatorCache)) {
             $this->discriminatorCache[$cacheKey] = null;
             if (null !== $this->classDiscriminatorResolver) {
@@ -147,7 +147,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         }
 
         if (null !== $this->classDiscriminatorResolver) {
-            $class = \is_object($classOrObject) ? \get_class($classOrObject) : $classOrObject;
+            $class = \is_object($classOrObject) ? $classOrObject::class : $classOrObject;
             if (null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForMappedObject($classOrObject)) {
                 $allowedAttributes[] = $attributesAsString ? $discriminatorMapping->getTypeProperty() : new AttributeMetadata($discriminatorMapping->getTypeProperty());
             }

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -59,7 +59,7 @@ class PropertyNormalizer extends AbstractObjectNormalizer
      */
     public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */): bool
     {
-        return parent::supportsNormalization($data, $format) && $this->supports(\get_class($data));
+        return parent::supportsNormalization($data, $format) && $this->supports($data::class);
     }
 
     /**
@@ -164,7 +164,7 @@ class PropertyNormalizer extends AbstractObjectNormalizer
                 || ($reflectionProperty->isProtected() && !\array_key_exists("\0*\0{$reflectionProperty->name}", $propertyValues))
                 || ($reflectionProperty->isPrivate() && !\array_key_exists("\0{$reflectionProperty->class}\0{$reflectionProperty->name}", $propertyValues))
             ) {
-                throw new UninitializedPropertyException(sprintf('The property "%s::$%s" is not initialized.', \get_class($object), $reflectionProperty->name));
+                throw new UninitializedPropertyException(sprintf('The property "%s::$%s" is not initialized.', $object::class, $reflectionProperty->name));
             }
         }
 

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -246,7 +246,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
      */
     private function getNormalizer(mixed $data, ?string $format, array $context): ?NormalizerInterface
     {
-        $type = \is_object($data) ? \get_class($data) : 'native-'.\gettype($data);
+        $type = \is_object($data) ? $data::class : 'native-'.\gettype($data);
 
         if (!isset($this->normalizerCache[$format][$type])) {
             $this->normalizerCache[$format][$type] = [];

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableEncoderTest.php
@@ -50,11 +50,11 @@ class TraceableEncoderTest extends TestCase
         $dataCollector
             ->expects($this->once())
             ->method('collectEncoding')
-            ->with($this->isType('string'), \get_class($encoder), $this->isType('float'));
+            ->with($this->isType('string'), $encoder::class, $this->isType('float'));
         $dataCollector
             ->expects($this->once())
             ->method('collectDecoding')
-            ->with($this->isType('string'), \get_class($decoder), $this->isType('float'));
+            ->with($this->isType('string'), $decoder::class, $this->isType('float'));
 
         (new TraceableEncoder($encoder, $dataCollector))->encode('data', 'format', [TraceableSerializer::DEBUG_TRACE_ID => 'debug']);
         (new TraceableEncoder($decoder, $dataCollector))->decode('data', 'format', [TraceableSerializer::DEBUG_TRACE_ID => 'debug']);

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableNormalizerTest.php
@@ -50,11 +50,11 @@ class TraceableNormalizerTest extends TestCase
         $dataCollector
             ->expects($this->once())
             ->method('collectNormalization')
-            ->with($this->isType('string'), \get_class($normalizer), $this->isType('float'));
+            ->with($this->isType('string'), $normalizer::class, $this->isType('float'));
         $dataCollector
             ->expects($this->once())
             ->method('collectDenormalization')
-            ->with($this->isType('string'), \get_class($denormalizer), $this->isType('float'));
+            ->with($this->isType('string'), $denormalizer::class, $this->isType('float'));
 
         (new TraceableNormalizer($normalizer, $dataCollector))->normalize('data', 'format', [TraceableSerializer::DEBUG_TRACE_ID => 'debug']);
         (new TraceableNormalizer($denormalizer, $dataCollector))->denormalize('data', 'type', 'format', [TraceableSerializer::DEBUG_TRACE_ID => 'debug']);

--- a/src/Symfony/Component/Serializer/Tests/Extractor/ObjectPropertyListExtractorTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Extractor/ObjectPropertyListExtractorTest.php
@@ -26,7 +26,7 @@ class ObjectPropertyListExtractorTest extends TestCase
         $propertyListExtractor = $this->createMock(PropertyListExtractorInterface::class);
         $propertyListExtractor->expects($this->once())
             ->method('getProperties')
-            ->with(\get_class($object), $context)
+            ->with($object::class, $context)
             ->willReturn($properties);
 
         $this->assertSame(

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
@@ -70,7 +70,7 @@ class CacheMetadataFactoryTest extends TestCase
         $anonymousObject = new class() {
         };
 
-        $metadata = new ClassMetadata(\get_class($anonymousObject));
+        $metadata = new ClassMetadata($anonymousObject::class);
         $decorated = $this->createMock(ClassMetadataFactoryInterface::class);
         $decorated
             ->expects($this->once())

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
@@ -107,8 +107,8 @@ trait CallbacksTestTrait
             }
         };
 
-        $obj = $normalizer->denormalize(['foo' => $valueBar], \get_class($objWithNoConstructorArgument), 'any', ['callbacks' => $callbacks]);
-        $this->assertInstanceof(\get_class($objWithNoConstructorArgument), $obj);
+        $obj = $normalizer->denormalize(['foo' => $valueBar], $objWithNoConstructorArgument::class, 'any', ['callbacks' => $callbacks]);
+        $this->assertInstanceof($objWithNoConstructorArgument::class, $obj);
         $this->assertEquals($result->getBar(), $obj->getBar());
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CircularReferenceTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CircularReferenceTestTrait.php
@@ -42,7 +42,7 @@ trait CircularReferenceTestTrait
         $obj = $this->getSelfReferencingModel();
 
         $this->expectException(CircularReferenceException::class);
-        $this->expectExceptionMessage(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured limit: %d).', \get_class($obj), $expectedLimit));
+        $this->expectExceptionMessage(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured limit: %d).', $obj::class, $expectedLimit));
         $normalizer->normalize($obj, null, $context);
     }
 
@@ -51,15 +51,15 @@ trait CircularReferenceTestTrait
         $normalizer = $this->getNormalizerForCircularReference([]);
 
         $obj = $this->getSelfReferencingModel();
-        $expected = ['me' => \get_class($obj)];
+        $expected = ['me' => $obj::class];
 
         $context = [
             'circular_reference_handler' => function ($actualObj, string $format, array $context) use ($obj) {
-                $this->assertInstanceOf(\get_class($obj), $actualObj);
+                $this->assertInstanceOf($obj::class, $actualObj);
                 $this->assertSame('test', $format);
                 $this->assertArrayHasKey('foo', $context);
 
-                return \get_class($actualObj);
+                return $actualObj::class;
             },
             'foo' => 'bar',
         ];

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -453,7 +453,7 @@ class PropertyNormalizerTest extends TestCase
             RootDummy::class,
             'any'
         );
-        $this->assertEquals(\get_class($root), RootDummy::class);
+        $this->assertEquals($root::class, RootDummy::class);
 
         // children (two dimension array)
         $this->assertCount(1, $root->children);

--- a/src/Symfony/Component/String/LazyString.php
+++ b/src/Symfony/Component/String/LazyString.php
@@ -86,7 +86,7 @@ class LazyString implements \Stringable, \JsonSerializable
         try {
             return $this->value = ($this->value)();
         } catch (\Throwable $e) {
-            if (\TypeError::class === \get_class($e) && __FILE__ === $e->getFile()) {
+            if (\TypeError::class === $e::class && __FILE__ === $e->getFile()) {
                 $type = explode(', ', $e->getMessage());
                 $type = substr(array_pop($type), 0, -\strlen(' returned'));
                 $r = new \ReflectionFunction($this->value);

--- a/src/Symfony/Component/String/Resources/bin/update-data.php
+++ b/src/Symfony/Component/String/Resources/bin/update-data.php
@@ -28,7 +28,7 @@ set_exception_handler(static function (Throwable $exception): void {
             echo "Caused by\n";
         }
 
-        echo get_class($cause).': '.$cause->getMessage()."\n";
+        echo $cause::class.': '.$cause->getMessage()."\n";
         echo "\n";
         echo $cause->getFile().':'.$cause->getLine()."\n";
         echo $cause->getTraceAsString()."\n";

--- a/src/Symfony/Component/Validator/Command/DebugCommand.php
+++ b/src/Symfony/Component/Validator/Command/DebugCommand.php
@@ -135,7 +135,7 @@ EOF
     {
         foreach ($classMetadata->getConstraints() as $constraint) {
             yield [
-                'class' => \get_class($constraint),
+                'class' => $constraint::class,
                 'groups' => $constraint->groups,
                 'options' => $this->getConstraintOptions($constraint),
             ];
@@ -161,7 +161,7 @@ EOF
         foreach ($propertyMetadata as $metadata) {
             foreach ($metadata->getConstraints() as $constraint) {
                 $data[] = [
-                    'class' => \get_class($constraint),
+                    'class' => $constraint::class,
                     'groups' => $constraint->groups,
                     'options' => $this->getConstraintOptions($constraint),
                 ];

--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -66,7 +66,7 @@ abstract class Composite extends Constraint
         foreach ($nestedConstraints as $constraint) {
             if (!$constraint instanceof Constraint) {
                 if (\is_object($constraint)) {
-                    $constraint = \get_class($constraint);
+                    $constraint = $constraint::class;
                 }
 
                 throw new ConstraintDefinitionException(sprintf('The value "%s" is not an instance of Constraint in constraint "%s".', $constraint, static::class));

--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -74,7 +74,7 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
             throw new NoSuchMetadataException(sprintf('Cannot create metadata for non-objects. Got: "%s".', get_debug_type($value)));
         }
 
-        $class = ltrim(\is_object($value) ? \get_class($value) : $value, '\\');
+        $class = ltrim(\is_object($value) ? $value::class : $value, '\\');
 
         if (isset($this->loadedClasses[$class])) {
             return $this->loadedClasses[$class];
@@ -139,7 +139,7 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
             return false;
         }
 
-        $class = ltrim(\is_object($value) ? \get_class($value) : $value, '\\');
+        $class = ltrim(\is_object($value) ? $value::class : $value, '\\');
 
         return class_exists($class) || interface_exists($class, false);
     }

--- a/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
@@ -132,7 +132,7 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
      */
     public function getReflectionMember(object|string $objectOrClassName): \ReflectionMethod|\ReflectionProperty
     {
-        $className = \is_string($objectOrClassName) ? $objectOrClassName : \get_class($objectOrClassName);
+        $className = \is_string($objectOrClassName) ? $objectOrClassName : $objectOrClassName::class;
         if (!isset($this->reflMember[$className])) {
             $this->reflMember[$className] = $this->newReflectionMember($objectOrClassName);
         }

--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
@@ -69,7 +69,7 @@ class PropertyMetadata extends MemberMetadata
 
     protected function newReflectionMember(object|string $objectOrClassName): \ReflectionMethod|\ReflectionProperty
     {
-        $originalClass = \is_string($objectOrClassName) ? $objectOrClassName : \get_class($objectOrClassName);
+        $originalClass = \is_string($objectOrClassName) ? $objectOrClassName : $objectOrClassName::class;
 
         while (!property_exists($objectOrClassName, $this->getName())) {
             $objectOrClassName = get_parent_class($objectOrClassName);

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -186,7 +186,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
     {
         $this->object = $object;
         $this->metadata = \is_object($object)
-            ? new ClassMetadata(\get_class($object))
+            ? new ClassMetadata($object::class)
             : null;
 
         $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
@@ -196,7 +196,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
     {
         $this->object = $object;
         $this->metadata = \is_object($object)
-            ? new PropertyMetadata(\get_class($object), $property)
+            ? new PropertyMetadata($object::class, $property)
             : null;
 
         $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -157,7 +157,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         $constraint = $this->createConstraint(['propertyPath' => 'foo']);
 
         $this->expectException(ConstraintDefinitionException::class);
-        $this->expectExceptionMessage(sprintf('Invalid property path "foo" provided to "%s" constraint', \get_class($constraint)));
+        $this->expectExceptionMessage(sprintf('Invalid property path "foo" provided to "%s" constraint', $constraint::class));
 
         $object = new ComparisonTest_Class(5);
 
@@ -239,7 +239,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
             'value' => 'foo',
         ]);
 
-        $constraintClass = \get_class($constraint);
+        $constraintClass = $constraint::class;
 
         return [
             [$constraint, sprintf('The compared value "foo" could not be converted to a "DateTimeImmutable" instance in the "%s" constraint.', $constraintClass), new \DateTimeImmutable()],

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -163,7 +163,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Bic(['ibanPropertyPath' => 'foo']);
 
         $this->expectException(ConstraintDefinitionException::class);
-        $this->expectExceptionMessage(sprintf('Invalid property path "foo" provided to "%s" constraint', \get_class($constraint)));
+        $this->expectExceptionMessage(sprintf('Invalid property path "foo" provided to "%s" constraint', $constraint::class));
 
         $object = new BicComparisonTestClass(5);
 

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -1258,7 +1258,7 @@ class RecursiveValidatorTest extends TestCase
             $context->addViolation('Violation in Group 3');
         };
 
-        $metadata = new ClassMetadata(\get_class($entity));
+        $metadata = new ClassMetadata($entity::class);
         $metadata->addConstraint(new Callback([
             'callback' => function () {},
             'groups' => 'Group 1',

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -183,7 +183,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             $this->validateGenericNode(
                 $propertyValue,
                 $object,
-                $cacheKey.':'.\get_class($object).':'.$propertyName,
+                $cacheKey.':'.$object::class.':'.$propertyName,
                 $propertyMetadata,
                 $propertyPath,
                 $groups,
@@ -212,7 +212,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
 
         if (\is_object($objectOrClass)) {
             $object = $objectOrClass;
-            $class = \get_class($object);
+            $class = $object::class;
             $cacheKey = $this->generateCacheKey($objectOrClass);
             $propertyPath = PropertyPath::append($this->defaultPropertyPath, $propertyName);
         } else {
@@ -501,7 +501,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
                 $this->validateGenericNode(
                     $propertyValue,
                     $object,
-                    $cacheKey.':'.\get_class($object).':'.$propertyName,
+                    $cacheKey.':'.$object::class.':'.$propertyName,
                     $propertyMetadata,
                     PropertyPath::append($propertyPath, $propertyName),
                     $groups,

--- a/src/Symfony/Component/VarDumper/Caster/CutStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/CutStub.php
@@ -27,7 +27,7 @@ class CutStub extends Stub
         switch (\gettype($value)) {
             case 'object':
                 $this->type = self::TYPE_OBJECT;
-                $this->class = \get_class($value);
+                $this->class = $value::class;
 
                 if ($value instanceof \Closure) {
                     ReflectionCaster::castClosure($value, [], $this, true, Caster::EXCLUDE_VERBOSE);

--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -218,7 +218,7 @@ class SplCaster
 
         if (!($flags & \ArrayObject::STD_PROP_LIST)) {
             $c->setFlags(\ArrayObject::STD_PROP_LIST);
-            $a = Caster::castObject($c, \get_class($c), method_exists($c, '__debugInfo'), $stub->class);
+            $a = Caster::castObject($c, $c::class, method_exists($c, '__debugInfo'), $stub->class);
             $c->setFlags($flags);
         }
         $a += [

--- a/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
@@ -49,7 +49,7 @@ class SymfonyCaster
 
     public static function castHttpClient($client, array $a, Stub $stub, bool $isNested)
     {
-        $multiKey = sprintf("\0%s\0multi", \get_class($client));
+        $multiKey = sprintf("\0%s\0multi", $client::class);
         if (isset($a[$multiKey])) {
             $a[$multiKey] = new CutStub($a[$multiKey]);
         }

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -126,7 +126,7 @@ class VarCloner extends AbstractCloner
                         if (empty($objRefs[$h = spl_object_id($v)])) {
                             $stub = new Stub();
                             $stub->type = Stub::TYPE_OBJECT;
-                            $stub->class = \get_class($v);
+                            $stub->class = $v::class;
                             $stub->value = $v;
                             $stub->handle = $h;
                             $a = $this->castObject($stub, 0 < $i);

--- a/src/Symfony/Component/VarDumper/Dumper/ContextualizedDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextualizedDumper.php
@@ -35,7 +35,7 @@ class ContextualizedDumper implements DataDumperInterface
     {
         $context = [];
         foreach ($this->contextProviders as $contextProvider) {
-            $context[\get_class($contextProvider)] = $contextProvider->getContext();
+            $context[$contextProvider::class] = $contextProvider->getContext();
         }
 
         $this->wrappedDumper->dump($data->withContext($context));

--- a/src/Symfony/Component/VarDumper/Exception/ThrowingCasterException.php
+++ b/src/Symfony/Component/VarDumper/Exception/ThrowingCasterException.php
@@ -21,6 +21,6 @@ class ThrowingCasterException extends \Exception
      */
     public function __construct(\Throwable $prev)
     {
-        parent::__construct('Unexpected '.\get_class($prev).' thrown from a caster: '.$prev->getMessage(), 0, $prev);
+        parent::__construct('Unexpected '.$prev::class.' thrown from a caster: '.$prev->getMessage(), 0, $prev);
     }
 }

--- a/src/Symfony/Component/VarExporter/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Hydrator.php
@@ -57,7 +57,7 @@ final class Hydrator
     public static function hydrate(object $instance, array $properties = [], array $scopedProperties = []): object
     {
         if ($properties) {
-            $class = \get_class($instance);
+            $class = $instance::class;
             $propertyScopes = InternalHydrator::$propertyScopes[$class] ??= InternalHydrator::getPropertyScopes($class);
 
             foreach ($properties as $name => &$value) {

--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -73,7 +73,7 @@ class Exporter
                 goto handle_value;
             }
 
-            $class = \get_class($value);
+            $class = $value::class;
             $reflector = Registry::$reflectors[$class] ??= Registry::getClassReflector($class);
 
             if ($reflector->hasMethod('__serialize')) {
@@ -364,7 +364,7 @@ class Exporter
             self::export($value->wakeups, $subIndent),
         ];
 
-        return '\\'.\get_class($value)."::hydrate(\n".$subIndent.implode(",\n".$subIndent, $code)."\n".$indent.')';
+        return '\\'.$value::class."::hydrate(\n".$subIndent.implode(",\n".$subIndent, $code)."\n".$indent.')';
     }
 
     /**

--- a/src/Symfony/Component/VarExporter/Internal/GhostObjectState.php
+++ b/src/Symfony/Component/VarExporter/Internal/GhostObjectState.php
@@ -65,7 +65,7 @@ class GhostObjectState
         }
 
         if (self::STATUS_UNINITIALIZED_FULL === $this->status) {
-            if ($defaultProperties = array_diff_key(GhostObjectRegistry::$defaultProperties[\get_class($instance)], (array) $instance)) {
+            if ($defaultProperties = array_diff_key(GhostObjectRegistry::$defaultProperties[$instance::class], (array) $instance)) {
                 Hydrator::hydrate($instance, $defaultProperties);
             }
 
@@ -77,7 +77,7 @@ class GhostObjectState
 
         $value = ($this->initializer)(...[$instance, $propertyName, $propertyScope]);
 
-        $propertyScope ??= \get_class($instance);
+        $propertyScope ??= $instance::class;
         $accessor = GhostObjectRegistry::$classAccessors[$propertyScope] ??= GhostObjectRegistry::getClassAccessors($propertyScope);
 
         $accessor['set']($instance, $propertyName, $value);

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -112,7 +112,7 @@ class Inline
             case $value instanceof \DateTimeInterface:
                 return $value->format('c');
             case $value instanceof \UnitEnum:
-                return sprintf('!php/const %s::%s', \get_class($value), $value->name);
+                return sprintf('!php/const %s::%s', $value::class, $value->name);
             case \is_object($value):
                 if ($value instanceof TaggedValue) {
                     return '!'.$value->getTag().' '.self::dump($value->getValue(), $flags);

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -1125,7 +1125,7 @@ abstract class HttpClientTestCase extends TestCase
         $client2 = $client->withOptions(['base_uri' => 'http://localhost:8057/']);
 
         $this->assertNotSame($client, $client2);
-        $this->assertSame(\get_class($client), \get_class($client2));
+        $this->assertSame($client::class, $client2::class);
 
         $response = $client2->request('GET', '/');
         $this->assertSame(200, $response->getStatusCode());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Replace `get_class()` by `::class`
