### PR TITLE
[Console] Terminal Color Mode refactoring and force Color Mode

### DIFF
--- a/src/Symfony/Component/Console/Color.php
+++ b/src/Symfony/Component/Console/Color.php
@@ -117,7 +117,7 @@ final class Color
         }
 
         if ('#' === $color[0]) {
-            return ($background ? '4' : '3').Terminal::getTermColorSupport()->convertFromHexToAnsiColorCode($color);
+            return ($background ? '4' : '3').Terminal::getColorMode()->convertFromHexToAnsiColorCode($color);
         }
 
         if (isset(self::COLORS[$color])) {

--- a/src/Symfony/Component/Console/Tests/ColorTest.php
+++ b/src/Symfony/Component/Console/Tests/ColorTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Console\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Color;
+use Symfony\Component\Console\Output\AnsiColorMode;
+use Symfony\Component\Console\Terminal;
 
 class ColorTest extends TestCase
 {
@@ -33,8 +35,7 @@ class ColorTest extends TestCase
 
     public function testTrueColors()
     {
-        $colorterm = getenv('COLORTERM');
-        putenv('COLORTERM=truecolor');
+        Terminal::setColorMode(AnsiColorMode::Ansi24);
 
         try {
             $color = new Color('#fff', '#000');
@@ -43,17 +44,13 @@ class ColorTest extends TestCase
             $color = new Color('#ffffff', '#000000');
             $this->assertSame("\033[38;2;255;255;255;48;2;0;0;0m \033[39;49m", $color->apply(' '));
         } finally {
-            (false !== $colorterm) ? putenv('COLORTERM='.$colorterm) : putenv('COLORTERM');
+            Terminal::setColorMode(null);
         }
     }
 
     public function testDegradedTrueColorsToAnsi4()
     {
-        $colorterm = getenv('COLORTERM');
-        $term = getenv('TERM');
-
-        putenv('COLORTERM=');
-        putenv('TERM=');
+        Terminal::setColorMode(AnsiColorMode::Ansi4);
 
         try {
             $color = new Color('#f00', '#ff0');
@@ -62,18 +59,13 @@ class ColorTest extends TestCase
             $color = new Color('#c0392b', '#f1c40f');
             $this->assertSame("\033[31;43m \033[39;49m", $color->apply(' '));
         } finally {
-            (false !== $colorterm) ? putenv('COLORTERM='.$colorterm) : putenv('COLORTERM');
-            (false !== $term) ? putenv('TERM='.$term) : putenv('TERM');
+            Terminal::setColorMode(null);
         }
     }
 
     public function testDegradedTrueColorsToAnsi8()
     {
-        $colorterm = getenv('COLORTERM');
-        $term = getenv('TERM');
-
-        putenv('COLORTERM=');
-        putenv('TERM=symfonyTest-256color');
+        Terminal::setColorMode(AnsiColorMode::Ansi8);
 
         try {
             $color = new Color('#f57255', '#8993c0');
@@ -82,8 +74,7 @@ class ColorTest extends TestCase
             $color = new Color('#000000', '#ffffff');
             $this->assertSame("\033[38;5;16;48;5;231m \033[39;49m", $color->apply(' '));
         } finally {
-            (false !== $colorterm) ? putenv('COLORTERM='.$colorterm) : putenv('COLORTERM');
-            (false !== $term) ? putenv('TERM='.$term) : putenv('TERM');
+            Terminal::setColorMode(null);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Continue #46944

Terminal Color Mode refactoring: Adding a way to force color mode by the dev. user (with a new method), fewer `getenv()` calls (cache value), simpler tests (use the a new method and a new constant).

For example, it can be useful in an environment where none of the expected environment variables are available (Docker container...) , but where the support of a specific mode is imperative.

A future evolution could be to add an optional default option to all commands to force a particular mode by the final user.

