### PR TITLE
[HttpClient] Psr18Client ignore invalid HTTP headers

### DIFF
--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -100,7 +100,11 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
 
             foreach ($response->getHeaders(false) as $name => $values) {
                 foreach ($values as $value) {
-                    $psrResponse = $psrResponse->withAddedHeader($name, $value);
+                    try {
+                        $psrResponse = $psrResponse->withAddedHeader($name, $value);
+                    } catch (\InvalidArgumentException $e) {
+                        // ignore invalid header
+                    }
                 }
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs

Hi, 
I working on a library that I am working on supports PSR-18 and PSR-7 implementations.
I tried following PSR-7 libraries:
nyholm/psr7
laminas/laminas-diactoros
slim/psr7

and following PSR-18 clients:
php-http/curl-client
symfony/http-client
guzzlehttp/guzzle

and when I tried combination of all these PSR-7 and PSR-18 libraries.
I faced issue only on `symfony/http-client` _Psr18Client_ client. 
Error is caused when I received response with header name containing leading space " x-xss-protection". This library does not trim response header names that is why all 3 PSR-7 libraries throwing error "**Header values must be RFC 7230 compatible strings**" when used in combination with `symfony/http-client`.
The other 2 PSR-18 clients trim header names:

[guzzlehttp/guzzle: GuzzleHttp\Handler\CurlFactory::createHeaderFn()](https://github.com/guzzle/guzzle/blob/b50a2a1251152e43f6a37f0fa053e730a67d25ba/src/Handler/CurlFactory.php#L567)

[php-http/curl-client: Http\Client\Curl\Client::prepareRequestOptions()](https://github.com/php-http/curl-client/blob/2ed4245a817d859dd0c1d51c7078cdb343cf5233/src/Client.php#L226)

So, I added trim line on _Psr18Client_, hope it does not break anything, it is working for me at least. 

I guess this fix should be done on all maintained versions of this library as well.

PS
I also, tried to trim using `Symfony\Component\HttpClient\HttpClientTrait::normalizeHeaders()` but it does not do anything about this leading space in the header name.

