### PR TITLE
[Console][FrameworkBundle][HttpKernel][WebProfilerBundle] Enable profiling commands

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
@@ -50,7 +50,7 @@ return static function (ContainerConfigurator $container) {
                 service('debug.stopwatch')->ignoreOnInvalid(),
                 service('debug.file_link_formatter')->ignoreOnInvalid(),
                 param('kernel.charset'),
-                service('request_stack'),
+                service('.virtual_request_stack'),
                 null, // var_dumper.cli_dumper or var_dumper.server_connection when debug.dump_destination is set
             ])
             ->tag('data_collector', [

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -33,6 +33,7 @@ CHANGELOG
  * Add parameters deprecations to the output of `debug:container` command
  * Change `framework.asset_mapper.importmap_polyfill` from a URL to the name of an item in the importmap
  * Provide `$buildDir` when running `CacheWarmer` to build read-only resources
+ * Add the global `--profile` option to the console to enable profiling commands
 
 6.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -14,6 +14,8 @@ namespace Symfony\Bundle\FrameworkBundle\Console;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\ListCommand;
+use Symfony\Component\Console\Command\TraceableCommand;
+use Symfony\Component\Console\Debug\CliRequest;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -42,6 +44,7 @@ class Application extends BaseApplication
         $inputDefinition = $this->getDefinition();
         $inputDefinition->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', $kernel->getEnvironment()));
         $inputDefinition->addOption(new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switch off debug mode.'));
+        $inputDefinition->addOption(new InputOption('--profile', null, InputOption::VALUE_NONE, 'Enables profiling (requires debug).'));
     }
 
     /**
@@ -79,18 +82,47 @@ class Application extends BaseApplication
 
     protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output): int
     {
+        $requestStack = null;
+        $renderRegistrationErrors = true;
+
         if (!$command instanceof ListCommand) {
             if ($this->registrationErrors) {
                 $this->renderRegistrationErrors($input, $output);
                 $this->registrationErrors = [];
+                $renderRegistrationErrors = false;
             }
-
-            return parent::doRunCommand($command, $input, $output);
         }
 
-        $returnCode = parent::doRunCommand($command, $input, $output);
+        if ($input->hasParameterOption('--profile')) {
+            $container = $this->kernel->getContainer();
 
-        if ($this->registrationErrors) {
+            if (!$this->kernel->isDebug()) {
+                if ($output instanceof ConsoleOutputInterface) {
+                    $output = $output->getErrorOutput();
+                }
+
+                (new SymfonyStyle($input, $output))->warning('Debug mode should be enabled when the "--profile" option is used.');
+            } elseif (!$container->has('debug.stopwatch')) {
+                if ($output instanceof ConsoleOutputInterface) {
+                    $output = $output->getErrorOutput();
+                }
+
+                (new SymfonyStyle($input, $output))->warning('The "--profile" option needs the Stopwatch component. Try running "composer require symfony/stopwatch".');
+            } else {
+                $command = new TraceableCommand($command, $container->get('debug.stopwatch'));
+
+                $requestStack = $container->get('.virtual_request_stack');
+                $requestStack->push(new CliRequest($command));
+            }
+        }
+
+        try {
+            $returnCode = parent::doRunCommand($command, $input, $output);
+        } finally {
+            $requestStack?->pop();
+        }
+
+        if ($renderRegistrationErrors && $this->registrationErrors) {
             $this->renderRegistrationErrors($input, $output);
             $this->registrationErrors = [];
         }

--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\EventListener;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Debug\CliRequest;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * @internal
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+final class ConsoleProfilerListener implements EventSubscriberInterface
+{
+    private ?\Throwable $error = null;
+    /** @var \SplObjectStorage<Request, Profile> */
+    private \SplObjectStorage $profiles;
+    /** @var \SplObjectStorage<Request, ?Request> */
+    private \SplObjectStorage $parents;
+
+    public function __construct(
+        private readonly Profiler $profiler,
+        private readonly RequestStack $requestStack,
+        private readonly Stopwatch $stopwatch,
+        private readonly UrlGeneratorInterface $urlGenerator,
+    ) {
+        $this->profiles = new \SplObjectStorage();
+        $this->parents = new \SplObjectStorage();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::COMMAND => ['initialize', 4096],
+            ConsoleEvents::ERROR => ['catch', -2048],
+            ConsoleEvents::TERMINATE => ['profile', -4096],
+        ];
+    }
+
+    public function initialize(ConsoleCommandEvent $event): void
+    {
+        if (!$event->getInput()->getOption('profile')) {
+            $this->profiler->disable();
+
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request instanceof CliRequest || $request->command !== $event->getCommand()) {
+            return;
+        }
+
+        $request->attributes->set('_stopwatch_token', substr(hash('sha256', uniqid(mt_rand(), true)), 0, 6));
+        $this->stopwatch->openSection();
+    }
+
+    public function catch(ConsoleErrorEvent $event): void
+    {
+        $this->error = $event->getError();
+    }
+
+    public function profile(ConsoleTerminateEvent $event): void
+    {
+        if (!$this->profiler->isEnabled()) {
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request instanceof CliRequest || $request->command !== $event->getCommand()) {
+            return;
+        }
+
+        if (null !== $sectionId = $request->attributes->get('_stopwatch_token')) {
+            // we must close the section before saving the profile to allow late collect
+            try {
+                $this->stopwatch->stopSection($sectionId);
+            } catch (\LogicException) {
+                // noop
+            }
+        }
+
+        $request->command->exitCode = $event->getExitCode();
+        $request->command->interruptedBySignal = $event->getInterruptingSignal();
+
+        $profile = $this->profiler->collect($request, $request->getResponse(), $this->error);
+        $this->error = null;
+        $this->profiles[$request] = $profile;
+
+        if ($this->parents[$request] = $this->requestStack->getParentRequest()) {
+            // do not save on sub commands
+            return;
+        }
+
+        // attach children to parents
+        foreach ($this->profiles as $request) {
+            if (null !== $parentRequest = $this->parents[$request]) {
+                if (isset($this->profiles[$parentRequest])) {
+                    $this->profiles[$parentRequest]->addChild($this->profiles[$request]);
+                }
+            }
+        }
+
+        $output = $event->getOutput();
+        $output = $output instanceof ConsoleOutputInterface && $output->isVerbose() ? $output->getErrorOutput() : null;
+
+        // save profiles
+        foreach ($this->profiles as $r) {
+            $p = $this->profiles[$r];
+            $this->profiler->saveProfile($p);
+
+            $token = $p->getToken();
+            $output?->writeln(sprintf(
+                'See profile <href=%s>%s</>',
+                $this->urlGenerator->generate('_profiler', ['token' => $token], UrlGeneratorInterface::ABSOLUTE_URL),
+                $token
+            ));
+        }
+
+        $this->profiles = new \SplObjectStorage();
+        $this->parents = new \SplObjectStorage();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\FrameworkBundle\DataCollector\RouterDataCollector;
+use Symfony\Component\Console\DataCollector\CommandDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\AjaxDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
@@ -30,7 +31,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('data_collector.request', RequestDataCollector::class)
             ->args([
-                service('request_stack')->ignoreOnInvalid(),
+                service('.virtual_request_stack')->ignoreOnInvalid(),
             ])
             ->tag('kernel.event_subscriber')
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/request.html.twig', 'id' => 'request', 'priority' => 335])
@@ -48,7 +49,7 @@ return static function (ContainerConfigurator $container) {
         ->set('data_collector.events', EventDataCollector::class)
             ->args([
                 tagged_iterator('event_dispatcher.dispatcher', 'name'),
-                service('request_stack')->ignoreOnInvalid(),
+                service('.virtual_request_stack')->ignoreOnInvalid(),
             ])
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/events.html.twig', 'id' => 'events', 'priority' => 290])
 
@@ -56,7 +57,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('logger')->ignoreOnInvalid(),
                 sprintf('%s/%s', param('kernel.build_dir'), param('kernel.container_class')),
-                service('request_stack')->ignoreOnInvalid(),
+                service('.virtual_request_stack')->ignoreOnInvalid(),
             ])
             ->tag('monolog.logger', ['channel' => 'profiler'])
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/logger.html.twig', 'id' => 'logger', 'priority' => 300])
@@ -74,5 +75,8 @@ return static function (ContainerConfigurator $container) {
         ->set('data_collector.router', RouterDataCollector::class)
             ->tag('kernel.event_listener', ['event' => KernelEvents::CONTROLLER, 'method' => 'onKernelController'])
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/router.html.twig', 'id' => 'router', 'priority' => 285])
+
+        ->set('.data_collector.command', CommandDataCollector::class)
+            ->tag('data_collector', ['template' => '@WebProfiler/Collector/command.html.twig', 'id' => 'command', 'priority' => 335])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\NotTaggedController
 use Symfony\Component\HttpKernel\Controller\TraceableArgumentResolver;
 use Symfony\Component\HttpKernel\Controller\TraceableControllerResolver;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
+use Symfony\Component\HttpKernel\Debug\VirtualRequestStack;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -24,7 +25,7 @@ return static function (ContainerConfigurator $container) {
                 service('debug.event_dispatcher.inner'),
                 service('debug.stopwatch'),
                 service('logger')->nullOnInvalid(),
-                service('request_stack')->nullOnInvalid(),
+                service('.virtual_request_stack')->nullOnInvalid(),
             ])
             ->tag('monolog.logger', ['channel' => 'event'])
             ->tag('kernel.reset', ['method' => 'reset'])
@@ -46,5 +47,9 @@ return static function (ContainerConfigurator $container) {
         ->set('argument_resolver.not_tagged_controller', NotTaggedControllerValueResolver::class)
             ->args([abstract_arg('Controller argument, set in FrameworkExtension')])
             ->tag('controller.argument_value_resolver', ['priority' => -200])
+
+        ->set('.virtual_request_stack', VirtualRequestStack::class)
+            ->args([service('request_stack')])
+            ->public()
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\FrameworkBundle\EventListener\ConsoleProfilerListener;
 use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
@@ -33,6 +34,15 @@ return static function (ContainerConfigurator $container) {
                 null,
                 param('profiler_listener.only_exceptions'),
                 param('profiler_listener.only_main_requests'),
+            ])
+            ->tag('kernel.event_subscriber')
+
+        ->set('console_profiler_listener', ConsoleProfilerListener::class)
+            ->args([
+                service('profiler'),
+                service('.virtual_request_stack'),
+                service('debug.stopwatch'),
+                service('router'),
             ])
             ->tag('kernel.event_subscriber')
     ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -242,17 +243,25 @@ class ApplicationTest extends TestCase
     {
         $container = $this->createMock(ContainerInterface::class);
 
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->expects($this->any())
+            ->method('push')
+        ;
+
         if ($useDispatcher) {
             $dispatcher = $this->createMock(EventDispatcherInterface::class);
             $dispatcher
                 ->expects($this->atLeastOnce())
                 ->method('dispatch')
             ;
-            $container
-                ->expects($this->atLeastOnce())
+
+            $container->expects($this->atLeastOnce())
                 ->method('get')
-                ->with($this->equalTo('event_dispatcher'))
-                ->willReturn($dispatcher);
+                ->willReturnMap([
+                    ['.virtual_request_stack', 2, $requestStack],
+                    ['event_dispatcher', 1, $dispatcher],
+                ])
+            ;
         }
 
         $container

--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add console commands to the profiler
+
 6.3
 ---
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/command.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/command.html.twig
@@ -1,0 +1,249 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block menu %}
+    <span class="label">
+        <span class="icon">{{ source('@WebProfiler/Icon/command.svg') }}</span>
+        <strong>Console Command</strong>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h2>
+        {% set command = collector.command %}
+        <a href="{{ command.file|file_link(command.line) }}">
+            {% if command.executor is defined %}
+                {{ command.executor|abbr_method }}
+            {% else %}
+                {{ command.class|abbr_class }}
+            {% endif %}
+        </a>
+    </h2>
+
+    <div class="sf-tabs">
+        <div class="tab">
+            <h3 class="tab-title">Command</h3>
+
+            <div class="tab-content">
+                <div class="metrics">
+                    <div class="metric">
+                        <span class="value">{{ collector.duration }}</span>
+                        <span class="label">Duration</span>
+                    </div>
+
+                    <div class="metric">
+                        <span class="value">{{ collector.maxMemoryUsage }}</span>
+                        <span class="label">Peak Memory Usage</span>
+                    </div>
+
+                    <div class="metric">
+                        <span class="value">{{ collector.verbosityLevel }}</span>
+                        <span class="label">Verbosity Level</span>
+                    </div>
+                </div>
+
+                <div class="metrics">
+                    <div class="metric">
+                        <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.signalable is not empty ? 'yes' : 'no') ~ '.svg') }}</span>
+                        <span class="label">Signalable</span>
+                    </div>
+
+                    <div class="metric">
+                        <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.interactive ? 'yes' : 'no') ~ '.svg') }}</span>
+                        <span class="label">Interactive</span>
+                    </div>
+
+                    <div class="metric">
+                        <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.validateInput ? 'yes' : 'no') ~ '.svg') }}</span>
+                        <span class="label">Validate Input</span>
+                    </div>
+
+                    <div class="metric">
+                        <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.enabled ? 'yes' : 'no') ~ '.svg') }}</span>
+                        <span class="label">Enabled</span>
+                    </div>
+
+                    <div class="metric">
+                        <span class="value">{{ source('@WebProfiler/Icon/' ~ (collector.visible ? 'yes' : 'no') ~ '.svg') }}</span>
+                        <span class="label">Visible</span>
+                    </div>
+                </div>
+
+                <h3>Arguments</h3>
+
+                {% if collector.arguments is empty %}
+                    <div class="empty">
+                        <p>No arguments were set</p>
+                    </div>
+                {% else %}
+                    {% include '@WebProfiler/Profiler/table.html.twig' with { data: collector.arguments, labels: ['Argument', 'Value'], maxDepth: 2 } only %}
+                {% endif %}
+
+                <h3>Options</h3>
+
+                {% if collector.options is empty %}
+                    <div class="empty">
+                        <p>No options were set</p>
+                    </div>
+                {% else %}
+                    {% include '@WebProfiler/Profiler/table.html.twig' with { data: collector.options, labels: ['Option', 'Value'], maxDepth: 2 } only %}
+                {% endif %}
+
+                {% if collector.interactive %}
+                    <h3>Interactive Inputs</h3>
+
+                    <p class="help">
+                        The values which have been set interactively.
+                    </p>
+
+                    {% if collector.interactiveInputs is empty %}
+                        <div class="empty">
+                            <p>No inputs were set</p>
+                        </div>
+                    {% else %}
+                        {% include '@WebProfiler/Profiler/table.html.twig' with { data: collector.interactiveInputs, labels: ['Input', 'Value'], maxDepth: 2 } only %}
+                    {% endif %}
+                {% endif %}
+
+                <h3>Application inputs</h3>
+
+                {% if collector.applicationInputs is empty %}
+                    <div class="empty">
+                        <p>No application inputs are set</p>
+                    </div>
+                {% else %}
+                    {% include '@WebProfiler/Profiler/table.html.twig' with { data: collector.applicationInputs, labels: ['Input', 'Value'], maxDepth: 2 } only %}
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="tab">
+            <h3 class="tab-title">Input / Output</h3>
+
+            <div class="tab-content">
+                <table>
+                    <tr>
+                        <td class="font-normal">Input</td>
+                        <td class="font-normal">{{ profiler_dump(collector.input) }}</td>
+                    </tr>
+                    <tr>
+                        <td class="font-normal">Output</td>
+                        <td class="font-normal">{{ profiler_dump(collector.output) }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+
+        <div class="tab">
+            <h3 class="tab-title">Helper Set</h3>
+
+            <div class="tab-content">
+                {% if collector.helperSet is empty %}
+                    <div class="empty">
+                        <p>No helpers</p>
+                    </div>
+                {% else %}
+                    <table class="{{ class|default('') }}">
+                        <thead>
+                        <tr>
+                            <th scope="col">Helpers</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for helper in collector.helperSet|sort %}
+                            <tr>
+                                <td>{{ profiler_dump(helper) }}</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="tab">
+            {% set request_collector = profile.collectors.request %}
+            <h3 class="tab-title">Server Parameters</h3>
+            <div class="tab-content">
+                <h3>Server Parameters</h3>
+                <h4>Defined in .env</h4>
+                {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: request_collector.dotenvvars }, with_context = false) }}
+
+                <h4>Defined as regular env variables</h4>
+                {% set requestserver = [] %}
+                {% for key, value in request_collector.requestserver|filter((_, key) => key not in request_collector.dotenvvars.keys) %}
+                    {% set requestserver = requestserver|merge({(key): value}) %}
+                {% endfor %}
+                {{ include('@WebProfiler/Profiler/table.html.twig', { data: requestserver }, with_context = false) }}
+            </div>
+        </div>
+
+        {% if collector.signalable is not empty %}
+            <div class="tab">
+                <h3 class="tab-title">Signals</h3>
+
+                <div class="tab-content">
+                    <h3>Subscribed signals</h3>
+                    {{ collector.signalable|join(', ') }}
+
+                    <h3>Handled signals</h3>
+                    {% if collector.handledSignals is empty %}
+                        <div class="empty">
+                            <p>No signals handled</p>
+                        </div>
+                    {% else %}
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Signal</th>
+                                    <th>Times handled</th>
+                                    <th>Total execution time</th>
+                                    <th>Memory peak</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for signal, data in collector.handledSignals %}
+                                    <tr>
+                                        <td>{{ signal }}</td>
+                                        <td>{{ data.handled }}</td>
+                                        <td>{{ data.duration }} ms</td>
+                                        <td>{{ data.memory }} MiB</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
+
+        {% if profile.parent %}
+            <div class="tab">
+                <h3 class="tab-title">Parent Command</h3>
+
+                <div class="tab-content">
+                    <h3>
+                        <a href="{{ path('_profiler', { token: profile.parent.token }) }}">Return to parent command</a>
+                        <small>(token = {{ profile.parent.token }})</small>
+                    </h3>
+
+                    {{ profile.parent.url }}
+                </div>
+            </div>
+        {% endif %}
+
+        {% if profile.children|length %}
+            <div class="tab">
+                <h3 class="tab-title">Sub Commands <span class="badge">{{ profile.children|length }}</span></h3>
+
+                <div class="tab-content">
+                    {% for child in profile.children %}
+                        <h3>
+                            {{ child.url }}
+                            <small>(token = <a href="{{ path('_profiler', { token: child.token }) }}">{{ child.token }}</a>)</small>
+                        </h3>
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -103,7 +103,7 @@
             <div class="metric-group">
                 <div class="metric">
                     <span class="value">{{ profile.children|length }}</span>
-                    <span class="label">Sub-Request{{ profile.children|length > 1 ? 's' }}</span>
+                    <span class="label">Sub-{{ profile_type|title }}{{ profile.children|length > 1 ? 's' }}</span>
                 </div>
 
                 {% set subrequests_time = has_time_events
@@ -112,7 +112,7 @@
 
                 <div class="metric">
                     <span class="value">{{ subrequests_time }} <span class="unit">ms</span></span>
-                    <span class="label">Sub-Request{{ profile.children|length > 1 ? 's' }} time</span>
+                    <span class="label">Sub-{{ profile_type|title }}{{ profile.children|length > 1 ? 's' }} time</span>
                 </div>
             </div>
         {% endif %}
@@ -143,24 +143,24 @@
 
     {% if profile.parent %}
         <h3 class="dump-inline">
-            Sub-Request {{ profiler_dump(profile.getcollector('request').requestattributes.get('_controller')) }}
+            Sub-{{ profile_type|title }} {{ profiler_dump(profile.getcollector('request').requestattributes.get('_controller')) }}
             <small>
                 {{ collector.events.__section__.duration }} ms
-                <a class="newline" href="{{ path('_profiler', { token: profile.parent.token, panel: 'time' }) }}">Return to parent request</a>
+                <a class="newline" href="{{ path('_profiler', { token: profile.parent.token, panel: 'time' }) }}">Return to parent {{ profile_type }}</a>
             </small>
         </h3>
     {% elseif profile.children|length > 0 %}
         <h3>
-            Main Request <small>{{ collector.events.__section__.duration }} ms</small>
+            Main {{ profile_type|title }} <small>{{ collector.events.__section__.duration }} ms</small>
         </h3>
     {% endif %}
 
     {{ _self.display_timeline(token, collector.events, collector.events.__section__.origin) }}
 
     {% if profile.children|length %}
-        <p class="help">Note: sections with a striped background correspond to sub-requests.</p>
+        <p class="help">Note: sections with a striped background correspond to sub-{{ profile_type }}s.</p>
 
-        <h3>Sub-requests <small>({{ profile.children|length }})</small></h3>
+        <h3>Sub-{{ profile_type }}s <small>({{ profile.children|length }})</small></h3>
 
         {% for child in profile.children %}
             {% set events = child.getcollector('time').events %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/command.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/command.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-terminal-2" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <path d="M8 9l3 3l-3 3"></path>
+    <line x1="13" y1="15" x2="16" y2="15"></line>
+    <rect x="3" y="4" width="18" height="16" rx="2"></rect>
+</svg>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/_command_summary.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/_command_summary.html.twig
@@ -1,0 +1,44 @@
+{% set status_code = profile.statuscode|default(0) %}
+{% set interrupted = command_collector is same as false ? null : command_collector.interruptedBySignal %}
+{% set css_class = status_code == 113 or interrupted is not null ? 'status-warning' : status_code > 0 ? 'status-error' : 'status-success' %}
+
+<div class="status {{ css_class }}">
+    <div class="container">
+        {% if status_code > 0 %}
+            <p class="status-error-details">
+                <span class="icon">{{ source('@WebProfiler/Icon/alert-circle.svg') }}</span>
+                <span class="status-response-status-code">Error ({{ status_code }})</span>
+            </p>
+        {% endif %}
+
+        <h2>
+            <span class="status-request-method">
+                {{ profile.method|upper }}
+            </span>
+
+            {{ profile.url|length < 160 ? profile.url : profile.url[:160] ~ '…' }}
+        </h2>
+
+        <dl class="metadata">
+            {% if status_code == 0 or interrupted %}
+                <span class="status-response-status-code">{{ interrupted is null ? 'Success' : 'Interrupted by signal: ' ~ interrupted }}</span>
+            {% endif %}
+
+            {% if request_collector.requestserver.has('SYMFONY_CLI_BINARY_NAME') %}
+                <dt>Symfony CLI</dt>
+                <dd>v{{ request_collector.requestserver.get('SYMFONY_CLI_VERSION') }}</dd>
+            {% endif %}
+
+            <dt>Application</dt>
+            <dd>
+                <a href="{{ path('_profiler_search_results', { token: token, limit: 10, ip: profile.ip }) }}">{{ profile.ip }}</a>
+            </dd>
+
+            <dt>Profiled on</dt>
+            <dd><time data-convert-to-user-timezone data-render-as-datetime datetime="{{ profile.time|date('c') }}">{{ profile.time|date('r') }}</time></dd>
+
+            <dt>Token</dt>
+            <dd>{{ profile.token }}</dd>
+        </dl>
+    </div>
+</div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/_request_summary.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/_request_summary.html.twig
@@ -1,0 +1,99 @@
+{% set status_code = request_collector ? request_collector.statuscode|default(0) : 0 %}
+{% set css_class = status_code > 399 ? 'status-error' : status_code > 299 ? 'status-warning' : 'status-success' %}
+
+{% if request_collector and request_collector.redirect %}
+    {% set redirect = request_collector.redirect %}
+    {% set link_to_source_code = redirect.controller.class is defined ? redirect.controller.file|file_link(redirect.controller.line) %}
+    {% set redirect_route_name = '@' ~ redirect.route %}
+
+    <div class="status status-compact status-warning">
+        <span class="icon icon-redirect">{{ source('@WebProfiler/Icon/redirect.svg') }}</span>
+
+        <span class="status-response-status-code">{{ redirect.status_code }}</span> redirect from
+
+        <span class="status-request-method">{{ redirect.method }}</span>
+
+        {% if link_to_source_code %}
+            <a href="{{ link_to_source_code }}" title="{{ redirect.controller.file }}">{{ redirect_route_name }}</a>
+        {% else %}
+            {{ redirect_route_name }}
+        {% endif %}
+
+        (<a href="{{ path('_profiler', { token: redirect.token, panel: request.query.get('panel', 'request') }) }}">{{ redirect.token }}</a>)
+    </div>
+{% endif %}
+
+<div class="status {{ css_class }}">
+    {% if status_code > 399 %}
+        <p class="status-error-details">
+            <span class="icon">{{ source('@WebProfiler/Icon/alert-circle.svg') }}</span>
+            <span class="status-response-status-code">Error {{ status_code }}</span>
+            <span class="status-response-status-text">{{ request_collector.statusText }}</span>
+        </p>
+    {% endif %}
+
+    <h2>
+        <span class="status-request-method">
+            {{ profile.method|upper }}
+        </span>
+
+        {% set profile_title = profile.url|length < 160 ? profile.url : profile.url[:160] ~ '…' %}
+        {% if profile.method|upper in ['GET', 'HEAD'] %}
+            <a href="{{ profile.url }}">{{ profile_title }}</a>
+        {% else %}
+            {{ profile_title }}
+        {% endif %}
+    </h2>
+
+    <dl class="metadata">
+        {% if status_code < 400 %}
+            <dt>Response</dt>
+            <dd>
+                <span class="status-response-status-code">{{ status_code }}</span>
+                <span class="status-response-status-text">{{ request_collector.statusText }}</span>
+            </dd>
+        {% endif %}
+
+        {% set referer = request_collector ? request_collector.requestheaders.get('referer') : null %}
+        {% if referer %}
+            <dt></dt>
+            <dd>
+                <span class="icon icon-referer">{{ source('@WebProfiler/Icon/referrer.svg') }}</span>
+                <a href="{{ referer }}" class="referer">Browse referrer URL</a>
+            </dd>
+        {% endif %}
+
+        <dt>IP</dt>
+        <dd>
+            <a href="{{ path('_profiler_search_results', { token: token, limit: 10, ip: profile.ip }) }}">{{ profile.ip }}</a>
+        </dd>
+
+        <dt>Profiled on</dt>
+        <dd><time data-convert-to-user-timezone data-render-as-datetime datetime="{{ profile.time|date('c') }}">{{ profile.time|date('r') }}</time></dd>
+
+        <dt>Token</dt>
+        <dd>{{ profile.token }}</dd>
+    </dl>
+</div>
+
+{% if request_collector and request_collector.forwardtoken -%}
+    {% set forward_profile = profile.childByToken(request_collector.forwardtoken) %}
+    {% set controller = forward_profile ? forward_profile.collector('request').controller : 'n/a' %}
+    <div class="status status-compact status-compact-forward">
+        <span class="icon icon-forward">{{ source('@WebProfiler/Icon/forward.svg') }}</span>
+
+        Forwarded to
+
+        {% set link = controller.file is defined ? controller.file|file_link(controller.line) : null -%}
+        {%- if link %}<a href="{{ link }}" title="{{ controller.file }}">{% endif -%}
+            {% if controller.class is defined %}
+                {{- controller.class|abbr_class|striptags -}}
+                {{- controller.method ? ' :: ' ~ controller.method -}}
+            {% else %}
+                {{- controller -}}
+            {% endif %}
+            {%- if link %}</a>{% endif %}
+        (<a href="{{ path('_profiler', { token: request_collector.forwardtoken }) }}">{{ request_collector.forwardtoken }}</a>)
+
+    </div>
+{%- endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/header.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/header.html.twig
@@ -1,6 +1,21 @@
 <div id="header">
     <h1><a href="{{ path('_profiler_home') }}">{{ source('@WebProfiler/Icon/symfony.svg') }} Symfony Profiler</a></h1>
 
+    <div class="sf-tabs" data-processed="true">
+        <div class="tab-navigation">
+            <span class="tab-control{{ 'request' == profile_type ? ' active' }}">
+                <a href="{{ path('_profiler_search_results', {token: 'empty', limit: 10}) }}">
+                    HTTP Requests
+                </a>
+            </span>
+            <span class="tab-control{{ 'command' == profile_type ? ' active' }}">
+                <a href="{{ path('_profiler_search_results', {token: 'empty', limit: 10, type: 'command'}) }}">
+                    Console Commands
+                </a>
+            </span>
+        </div>
+    </div>
+
     <div class="search">
         <form method="get" action="https://symfony.com/search" target="_blank">
             <div class="form-row">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -2,111 +2,20 @@
 
 {% block body %}
     <div class="container">
-        {{ include('@WebProfiler/Profiler/header.html.twig', with_context = false) }}
+        {{ include('@WebProfiler/Profiler/header.html.twig', {profile_type: profile_type}, with_context = false) }}
 
         <div id="summary">
         {% block summary %}
             {% if profile is defined %}
                 {% set request_collector = profile.collectors.request|default(false) %}
-                {% set status_code = request_collector ? request_collector.statuscode|default(0) : 0 %}
-                {% set css_class = status_code > 399 ? 'status-error' : status_code > 299 ? 'status-warning' : 'status-success' %}
 
-                {% if request_collector and request_collector.redirect %}
-                    {% set redirect = request_collector.redirect %}
-                    {% set link_to_source_code = redirect.controller.class is defined ? redirect.controller.file|file_link(redirect.controller.line) %}
-                    {% set redirect_route_name = '@' ~ redirect.route %}
-
-                    <div class="status status-compact status-warning">
-                        <span class="icon icon-redirect">{{ source('@WebProfiler/Icon/redirect.svg') }}</span>
-
-                        <span class="status-response-status-code">{{ redirect.status_code }}</span> redirect from
-
-                        <span class="status-request-method">{{ redirect.method }}</span>
-
-                        {% if link_to_source_code %}
-                            <a href="{{ link_to_source_code }}" title="{{ redirect.controller.file }}">{{ redirect_route_name }}</a>
-                        {% else %}
-                            {{ redirect_route_name }}
-                        {% endif %}
-
-                        (<a href="{{ path('_profiler', { token: redirect.token, panel: request.query.get('panel', 'request') }) }}">{{ redirect.token }}</a>)
-                    </div>
-                {% endif %}
-
-                <div class="status {{ css_class }}">
-                    {% if status_code > 399 %}
-                        <p class="status-error-details">
-                            <span class="icon">{{ source('@WebProfiler/Icon/alert-circle.svg') }}</span>
-                            <span class="status-response-status-code">Error {{ status_code }}</span>
-                            <span class="status-response-status-text">{{ request_collector.statusText }}</span>
-                        </p>
-                    {% endif %}
-
-                    <h2>
-                        <span class="status-request-method">
-                            {{ profile.method|upper }}
-                        </span>
-
-                        {% set profile_title = profile.url|length < 160 ? profile.url : profile.url[:160] ~ '…' %}
-                        {% if profile.method|upper in ['GET', 'HEAD'] %}
-                            <a href="{{ profile.url }}">{{ profile_title }}</a>
-                        {% else %}
-                            {{ profile_title }}
-                        {% endif %}
-                    </h2>
-
-                    <dl class="metadata">
-                        {% if status_code < 400 %}
-                            <dt>Response</dt>
-                            <dd>
-                                <span class="status-response-status-code">{{ status_code }}</span>
-                                <span class="status-response-status-text">{{ request_collector.statusText }}</span>
-                            </dd>
-                        {% endif %}
-
-                        {% set referer = request_collector ? request_collector.requestheaders.get('referer') : null %}
-                        {% if referer %}
-                            <dt></dt>
-                            <dd>
-                                <span class="icon icon-referer">{{ source('@WebProfiler/Icon/referrer.svg') }}</span>
-                                <a href="{{ referer }}" class="referer">Browse referrer URL</a>
-                            </dd>
-                        {% endif %}
-
-                        <dt>IP</dt>
-                        <dd>
-                            <a href="{{ path('_profiler_search_results', { token: token, limit: 10, ip: profile.ip }) }}">{{ profile.ip }}</a>
-                        </dd>
-
-                        <dt>Profiled on</dt>
-                        <dd><time data-convert-to-user-timezone data-render-as-datetime datetime="{{ profile.time|date('c') }}">{{ profile.time|date('r') }}</time></dd>
-
-                        <dt>Token</dt>
-                        <dd>{{ profile.token }}</dd>
-                    </dl>
-                </div>
-
-                {% if request_collector and request_collector.forwardtoken -%}
-                    {% set forward_profile = profile.childByToken(request_collector.forwardtoken) %}
-                    {% set controller = forward_profile ? forward_profile.collector('request').controller : 'n/a' %}
-                    <div class="status status-compact status-compact-forward">
-                        <span class="icon icon-forward">{{ source('@WebProfiler/Icon/forward.svg') }}</span>
-
-                        Forwarded to
-
-                            {% set link = controller.file is defined ? controller.file|file_link(controller.line) : null -%}
-                            {%- if link %}<a href="{{ link }}" title="{{ controller.file }}">{% endif -%}
-                                {% if controller.class is defined %}
-                                    {{- controller.class|abbr_class|striptags -}}
-                                    {{- controller.method ? ' :: ' ~ controller.method -}}
-                                {% else %}
-                                    {{- controller -}}
-                                {% endif %}
-                                {%- if link %}</a>{% endif %}
-                            (<a href="{{ path('_profiler', { token: request_collector.forwardtoken }) }}">{{ request_collector.forwardtoken }}</a>)
-
-                    </div>
-                {%- endif %}
+                {% include '@WebProfiler/Profiler/_%s_summary.html.twig'|format(profile_type) with {
+                    profile: profile,
+                    command_collector: profile.collectors.command|default(false) ,
+                    request_collector: request_collector,
+                    request: request,
+                    token: token
+                } only %}
             {% endif %}
         {% endblock %}
     </div>
@@ -119,8 +28,8 @@
                             <div id="sidebar-shortcuts">
                                 {% block sidebar_shortcuts_links %}
                                     <div class="shortcuts">
-                                        <a class="btn btn-link" href="{{ path('_profiler_search', { limit: 10 }) }}">Last 10</a>
-                                        <a class="btn btn-link" href="{{ path('_profiler', { token: 'latest' }|merge(request.query.all)) }}">Latest</a>
+                                        <a class="btn btn-link" href="{{ path('_profiler_search', { limit: 10, type: profile_type }) }}">Last 10</a>
+                                        <a class="btn btn-link" href="{{ path('_profiler', { token: 'latest', type: profile_type }|merge(request.query.all)) }}">Latest</a>
 
                                         <a class="sf-toggle btn btn-link" data-toggle-selector="#sidebar-search" {% if tokens is defined or about is defined %}data-toggle-initial="display"{% endif %}>
                                             {{ source('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>
@@ -128,12 +37,18 @@
                                     </div>
                                 {% endblock sidebar_shortcuts_links %}
 
-                                {{ render(controller('web_profiler.controller.profiler::searchBarAction', query=request.query.all)) }}
+                                {{ render(controller('web_profiler.controller.profiler::searchBarAction', query={type: profile_type }|merge(request.query.all))) }}
                             </div>
 
                             {% if templates is defined %}
                                 <ul id="menu-profiler">
-                                    {% for name, template in templates %}
+                                    {% if 'request' is same as(profile_type) %}
+                                        {% set excludes = ['command'] %}
+                                    {% elseif 'command' is same as(profile_type) %}
+                                        {% set excludes = ['request', 'router'] %}
+                                    {% endif %}
+
+                                    {% for name, template in templates|filter((t, n) => n not in excludes) %}
                                         {% set menu -%}
                                             {%- if block('menu', template) is defined -%}
                                                 {% with { collector: profile.getcollector(name), profiler_markup_version: profiler_markup_version } %}
@@ -143,7 +58,7 @@
                                         {%- endset %}
                                         {% if menu is not empty %}
                                             <li class="{{ name }} {{ name == panel ? 'selected' }}">
-                                                <a href="{{ path('_profiler', { token: token, panel: name }) }}">{{ menu|raw }}</a>
+                                                <a href="{{ path('_profiler', { token: token, panel: name, type: profile_type }) }}">{{ menu|raw }}</a>
                                             </li>
                                         {% endif %}
                                     {% endfor %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -44,17 +44,45 @@
         <table id="search-results">
             <thead>
                 <tr>
-                    <th scope="col" class="text-center">Status</th>
-                    <th scope="col">IP</th>
-                    <th scope="col">Method</th>
-                    <th scope="col">URL</th>
+                    <th scope="col" class="text-center">
+                        {% if 'command' == profile_type %}
+                            Exit code
+                        {% else %}
+                            Status
+                        {% endif %}
+                    </th>
+                    <th scope="col">
+                        {% if 'command' == profile_type %}
+                            Application
+                        {% else %}
+                            IP
+                        {% endif %}
+                    </th>
+                    <th scope="col">
+                        {% if 'command' == profile_type %}
+                            Mode
+                        {% else %}
+                            Method
+                        {% endif %}
+                    </th>
+                    <th scope="col">
+                        {% if 'command' == profile_type %}
+                            Command
+                        {% else %}
+                            URL
+                        {% endif %}
+                    </th>
                     <th scope="col">Time</th>
                     <th scope="col">Token</th>
                 </tr>
             </thead>
             <tbody>
                 {% for result in tokens %}
-                    {% set css_class = result.status_code|default(0) > 399 ? 'status-error' : result.status_code|default(0) > 299 ? 'status-warning' : 'status-success' %}
+                    {% if 'command' == profile_type %}
+                        {% set css_class = result.status_code == 113 ? 'status-warning' : result.status_code > 0 ? 'status-error' : 'status-success' %}
+                    {% else %}
+                        {% set css_class = result.status_code|default(0) > 399 ? 'status-error' : result.status_code|default(0) > 299 ? 'status-warning' : 'status-success' %}
+                    {% endif %}
 
                     <tr>
                         <td class="text-center">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
@@ -1,29 +1,60 @@
 <div id="sidebar-search" class="{{ (render_hidden_by_default ?? true) ? 'hidden' }}">
     <form action="{{ path('_profiler_search') }}" method="get">
         <div class="form-group">
-            <label for="ip">IP</label>
+            <label for="ip">
+                {% if 'command' == profile_type %}
+                    Application
+                {% else %}
+                    IP
+                {% endif %}
+            </label>
             <input type="text" name="ip" id="ip" value="{{ ip }}">
         </div>
 
         <div class="form-group-row">
             <div class="form-group">
-                <label for="method">Method</label>
+                <label for="method">
+                    {% if 'command' == profile_type %}
+                        Mode
+                    {% else %}
+                        Method
+                    {% endif %}
+                </label>
                 <select name="method" id="method">
                     <option value="">Any</option>
-                    {% for m in ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT'] %}
+                    {% if 'command' == profile_type %}
+                        {% set methods = ['BATCH', 'INTERACTIVE'] %}
+                    {% else %}
+                        {% set methods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT'] %}
+                    {% endif %}
+                    {% for m in methods %}
                         <option {{ m == method ? 'selected="selected"' }}>{{ m }}</option>
                     {% endfor %}
                 </select>
             </div>
 
             <div class="form-group">
-                <label for="status_code">Status</label>
-                <input type="number" name="status_code" id="status_code" min="100" max="599" value="{{ status_code }}">
+                <label for="status_code">
+                    {% if 'command' == profile_type %}
+                        Exit code
+                        {% set min_and_max = 'min=%d max=%d'|format(0, 255) %}
+                    {% else %}
+                        Status
+                        {% set min_and_max = 'min=%d max=%d'|format(100, 599) %}
+                    {% endif %}
+                </label>
+                <input type="number" name="status_code" id="status_code" {{ min_and_max }} value="{{ status_code }}">
             </div>
         </div>
 
         <div class="form-group">
-            <label for="url">URL</label>
+            <label for="url">
+                {% if 'command' == profile_type %}
+                    Command
+                {% else %}
+                    URL
+                {% endif %}
+            </label>
             <input type="text" name="url" id="url" value="{{ url }}">
         </div>
 
@@ -51,6 +82,8 @@
                     {% endfor %}
                 </select>
             </div>
+
+            <input type="hidden" name="type" value="{{ profile_type }}">
 
             <div class="form-group">
                 <button type="submit" class="btn btn-sm">Search</button>

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -245,6 +245,7 @@ class ProfilerControllerTest extends WebTestCase
                 'time' => 0,
                 'parent' => null,
                 'status_code' => 200,
+                'virtual_type' => 'request',
             ],
             [
                 'token' => 'token2',
@@ -254,6 +255,7 @@ class ProfilerControllerTest extends WebTestCase
                 'time' => 0,
                 'parent' => null,
                 'status_code' => 404,
+                'virtual_type' => 'request',
             ],
         ];
         $profiler
@@ -285,6 +287,7 @@ class ProfilerControllerTest extends WebTestCase
                 'request' => $request,
                 'csp_script_nonce' => $withCsp ? 'dummy_nonce' : null,
                 'csp_style_nonce' => $withCsp ? 'dummy_nonce' : null,
+                'profile_type' => 'request',
             ]));
 
         $response = $controller->searchResultsAction($request, 'empty');

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/config": "^5.4|^6.0|^7.0",
-        "symfony/framework-bundle": "^6.2|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/routing": "^5.4|^6.0|^7.0",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",

--- a/src/Symfony/Component/Console/Command/TraceableCommand.php
+++ b/src/Symfony/Component/Console/Command/TraceableCommand.php
@@ -1,0 +1,356 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Helper\HelperInterface;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * @internal
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+final class TraceableCommand extends Command implements SignalableCommandInterface
+{
+    public readonly Command $command;
+    public int $exitCode;
+    public ?int $interruptedBySignal = null;
+    public bool $ignoreValidation;
+    public bool $isInteractive = false;
+    public string $duration = 'n/a';
+    public string $maxMemoryUsage = 'n/a';
+    public InputInterface $input;
+    public OutputInterface $output;
+    /** @var array<string, mixed> */
+    public array $arguments;
+    /** @var array<string, mixed> */
+    public array $options;
+    /** @var array<string, mixed> */
+    public array $interactiveInputs = [];
+    public array $handledSignals = [];
+
+    public function __construct(
+        Command $command,
+        private readonly Stopwatch $stopwatch,
+    ) {
+        if ($command instanceof LazyCommand) {
+            $command = $command->getCommand();
+        }
+
+        $this->command = $command;
+
+        // prevent call to self::getDefaultDescription()
+        $this->setDescription($command->getDescription());
+
+        parent::__construct($command->getName());
+
+        // init below enables calling {@see parent::run()}
+        [$code, $processTitle, $ignoreValidationErrors] = \Closure::bind(function () {
+            return [$this->code, $this->processTitle, $this->ignoreValidationErrors];
+        }, $command, Command::class)();
+
+        if (\is_callable($code)) {
+            $this->setCode($code);
+        }
+
+        if ($processTitle) {
+            parent::setProcessTitle($processTitle);
+        }
+
+        if ($ignoreValidationErrors) {
+            parent::ignoreValidationErrors();
+        }
+
+        $this->ignoreValidation = $ignoreValidationErrors;
+    }
+
+    public function __call(string $name, array $arguments): mixed
+    {
+        return $this->command->{$name}(...$arguments);
+    }
+
+    public function getSubscribedSignals(): array
+    {
+        return $this->command instanceof SignalableCommandInterface ? $this->command->getSubscribedSignals() : [];
+    }
+
+    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    {
+        if (!$this->command instanceof SignalableCommandInterface) {
+            return false;
+        }
+
+        $event = $this->stopwatch->start($this->getName().'.handle_signal');
+
+        $exit = $this->command->handleSignal($signal, $previousExitCode);
+
+        $event->stop();
+
+        if (!isset($this->handledSignals[$signal])) {
+            $this->handledSignals[$signal] = [
+                'handled' => 0,
+                'duration' => 0,
+                'memory' => 0,
+            ];
+        }
+
+        ++$this->handledSignals[$signal]['handled'];
+        $this->handledSignals[$signal]['duration'] += $event->getDuration();
+        $this->handledSignals[$signal]['memory'] = max(
+            $this->handledSignals[$signal]['memory'],
+            $event->getMemory() >> 20
+        );
+
+        return $exit;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Calling parent method is required to be used in {@see parent::run()}.
+     */
+    public function ignoreValidationErrors(): void
+    {
+        $this->ignoreValidation = true;
+        $this->command->ignoreValidationErrors();
+
+        parent::ignoreValidationErrors();
+    }
+
+    public function setApplication(Application $application = null): void
+    {
+        $this->command->setApplication($application);
+    }
+
+    public function getApplication(): ?Application
+    {
+        return $this->command->getApplication();
+    }
+
+    public function setHelperSet(HelperSet $helperSet): void
+    {
+        $this->command->setHelperSet($helperSet);
+    }
+
+    public function getHelperSet(): ?HelperSet
+    {
+        return $this->command->getHelperSet();
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->command->isEnabled();
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        $this->command->complete($input, $suggestions);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Calling parent method is required to be used in {@see parent::run()}.
+     */
+    public function setCode(callable $code): static
+    {
+        $this->command->setCode($code);
+
+        return parent::setCode(function (InputInterface $input, OutputInterface $output) use ($code): int {
+            $event = $this->stopwatch->start($this->getName().'.code');
+
+            $this->exitCode = $code($input, $output);
+
+            $event->stop();
+
+            return $this->exitCode;
+        });
+    }
+
+    /**
+     * @internal
+     */
+    public function mergeApplicationDefinition(bool $mergeArgs = true): void
+    {
+        $this->command->mergeApplicationDefinition($mergeArgs);
+    }
+
+    public function setDefinition(array|InputDefinition $definition): static
+    {
+        $this->command->setDefinition($definition);
+
+        return $this;
+    }
+
+    public function getDefinition(): InputDefinition
+    {
+        return $this->command->getDefinition();
+    }
+
+    public function getNativeDefinition(): InputDefinition
+    {
+        return $this->command->getNativeDefinition();
+    }
+
+    public function addArgument(string $name, int $mode = null, string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
+    {
+        $this->command->addArgument($name, $mode, $description, $default, $suggestedValues);
+
+        return $this;
+    }
+
+    public function addOption(string $name, string|array $shortcut = null, int $mode = null, string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
+    {
+        $this->command->addOption($name, $shortcut, $mode, $description, $default, $suggestedValues);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Calling parent method is required to be used in {@see parent::run()}.
+     */
+    public function setProcessTitle(string $title): static
+    {
+        $this->command->setProcessTitle($title);
+
+        return parent::setProcessTitle($title);
+    }
+
+    public function setHelp(string $help): static
+    {
+        $this->command->setHelp($help);
+
+        return $this;
+    }
+
+    public function getHelp(): string
+    {
+        return $this->command->getHelp();
+    }
+
+    public function getProcessedHelp(): string
+    {
+        return $this->command->getProcessedHelp();
+    }
+
+    public function getSynopsis(bool $short = false): string
+    {
+        return $this->command->getSynopsis($short);
+    }
+
+    public function addUsage(string $usage): static
+    {
+        $this->command->addUsage($usage);
+
+        return $this;
+    }
+
+    public function getUsages(): array
+    {
+        return $this->command->getUsages();
+    }
+
+    public function getHelper(string $name): HelperInterface
+    {
+        return $this->command->getHelper($name);
+    }
+
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+        $this->input = $input;
+        $this->output = $output;
+        $this->arguments = $input->getArguments();
+        $this->options = $input->getOptions();
+        $event = $this->stopwatch->start($this->getName(), 'command');
+
+        try {
+            $this->exitCode = parent::run($input, $output);
+        } finally {
+            $event->stop();
+
+            if ($output instanceof ConsoleOutputInterface && $output->isDebug()) {
+                $output->getErrorOutput()->writeln((string) $event);
+            }
+
+            $this->duration = $event->getDuration().' ms';
+            $this->maxMemoryUsage = ($event->getMemory() >> 20).' MiB';
+
+            if ($this->isInteractive) {
+                $this->extractInteractiveInputs($input->getArguments(), $input->getOptions());
+            }
+        }
+
+        return $this->exitCode;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $event = $this->stopwatch->start($this->getName().'.init', 'command');
+
+        $this->command->initialize($input, $output);
+
+        $event->stop();
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        if (!$this->isInteractive = Command::class !== (new \ReflectionMethod($this->command, 'interact'))->getDeclaringClass()->getName()) {
+            return;
+        }
+
+        $event = $this->stopwatch->start($this->getName().'.interact', 'command');
+
+        $this->command->interact($input, $output);
+
+        $event->stop();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $event = $this->stopwatch->start($this->getName().'.execute', 'command');
+
+        $exitCode = $this->command->execute($input, $output);
+
+        $event->stop();
+
+        return $exitCode;
+    }
+
+    private function extractInteractiveInputs(array $arguments, array $options): void
+    {
+        foreach ($arguments as $argName => $argValue) {
+            if (\array_key_exists($argName, $this->arguments) && $this->arguments[$argName] === $argValue) {
+                continue;
+            }
+
+            $this->interactiveInputs[$argName] = $argValue;
+        }
+
+        foreach ($options as $optName => $optValue) {
+            if (\array_key_exists($optName, $this->options) && $this->options[$optName] === $optValue) {
+                continue;
+            }
+
+            $this->interactiveInputs['--'.$optName] = $optValue;
+        }
+    }
+}

--- a/src/Symfony/Component/Console/DataCollector/CommandDataCollector.php
+++ b/src/Symfony/Component/Console/DataCollector/CommandDataCollector.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\DataCollector;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Debug\CliRequest;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SignalRegistry\SignalMap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
+
+/**
+ * @internal
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+final class CommandDataCollector extends DataCollector
+{
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    {
+        if (!$request instanceof CliRequest) {
+            return;
+        }
+
+        $command = $request->command;
+        $application = $command->getApplication();
+
+        $this->data = [
+            'command' => $this->cloneVar($command->command),
+            'exit_code' => $command->exitCode,
+            'interrupted_by_signal' => $command->interruptedBySignal,
+            'duration' => $command->duration,
+            'max_memory_usage' => $command->maxMemoryUsage,
+            'verbosity_level' => match ($command->output->getVerbosity()) {
+                OutputInterface::VERBOSITY_QUIET => 'quiet',
+                OutputInterface::VERBOSITY_NORMAL => 'normal',
+                OutputInterface::VERBOSITY_VERBOSE => 'verbose',
+                OutputInterface::VERBOSITY_VERY_VERBOSE => 'very verbose',
+                OutputInterface::VERBOSITY_DEBUG => 'debug',
+            },
+            'interactive' => $command->isInteractive,
+            'validate_input' => !$command->ignoreValidation,
+            'enabled' => $command->isEnabled(),
+            'visible' => !$command->isHidden(),
+            'input' => $this->cloneVar($command->input),
+            'output' => $this->cloneVar($command->output),
+            'interactive_inputs' => array_map($this->cloneVar(...), $command->interactiveInputs),
+            'signalable' => $command->getSubscribedSignals(),
+            'handled_signals' => $command->handledSignals,
+            'helper_set' => array_map($this->cloneVar(...), iterator_to_array($command->getHelperSet())),
+        ];
+
+        $baseDefinition = $application->getDefinition();
+
+        foreach ($command->arguments as $argName => $argValue) {
+            if ($baseDefinition->hasArgument($argName)) {
+                $this->data['application_inputs'][$argName] = $this->cloneVar($argValue);
+            } else {
+                $this->data['arguments'][$argName] = $this->cloneVar($argValue);
+            }
+        }
+
+        foreach ($command->options as $optName => $optValue) {
+            if ($baseDefinition->hasOption($optName)) {
+                $this->data['application_inputs']['--'.$optName] = $this->cloneVar($optValue);
+            } else {
+                $this->data['options'][$optName] = $this->cloneVar($optValue);
+            }
+        }
+    }
+
+    public function getName(): string
+    {
+        return 'command';
+    }
+
+    /**
+     * @return array{
+     *     class?: class-string,
+     *     executor?: string,
+     *     file: string,
+     *     line: int,
+     * }
+     */
+    public function getCommand(): array
+    {
+        $class = $this->data['command']->getType();
+        $r = new \ReflectionMethod($class, 'execute');
+
+        if (Command::class !== $r->getDeclaringClass()) {
+            return [
+                'executor' => $class.'::'.$r->name,
+                'file' => $r->getFileName(),
+                'line' => $r->getStartLine(),
+            ];
+        }
+
+        $r = new \ReflectionClass($class);
+
+        return [
+            'class' => $class,
+            'file' => $r->getFileName(),
+            'line' => $r->getStartLine(),
+        ];
+    }
+
+    public function getInterruptedBySignal(): ?string
+    {
+        if (isset($this->data['interrupted_by_signal'])) {
+            return sprintf('%s (%d)', SignalMap::getSignalName($this->data['interrupted_by_signal']), $this->data['interrupted_by_signal']);
+        }
+
+        return null;
+    }
+
+    public function getDuration(): string
+    {
+        return $this->data['duration'];
+    }
+
+    public function getMaxMemoryUsage(): string
+    {
+        return $this->data['max_memory_usage'];
+    }
+
+    public function getVerbosityLevel(): string
+    {
+        return $this->data['verbosity_level'];
+    }
+
+    public function getInteractive(): bool
+    {
+        return $this->data['interactive'];
+    }
+
+    public function getValidateInput(): bool
+    {
+        return $this->data['validate_input'];
+    }
+
+    public function getEnabled(): bool
+    {
+        return $this->data['enabled'];
+    }
+
+    public function getVisible(): bool
+    {
+        return $this->data['visible'];
+    }
+
+    public function getInput(): Data
+    {
+        return $this->data['input'];
+    }
+
+    public function getOutput(): Data
+    {
+        return $this->data['output'];
+    }
+
+    /**
+     * @return Data[]
+     */
+    public function getArguments(): array
+    {
+        return $this->data['arguments'] ?? [];
+    }
+
+    /**
+     * @return Data[]
+     */
+    public function getOptions(): array
+    {
+        return $this->data['options'] ?? [];
+    }
+
+    /**
+     * @return Data[]
+     */
+    public function getApplicationInputs(): array
+    {
+        return $this->data['application_inputs'] ?? [];
+    }
+
+    /**
+     * @return Data[]
+     */
+    public function getInteractiveInputs(): array
+    {
+        return $this->data['interactive_inputs'] ?? [];
+    }
+
+    public function getSignalable(): array
+    {
+        return array_map(
+            static fn (int $signal): string => sprintf('%s (%d)', SignalMap::getSignalName($signal), $signal),
+            $this->data['signalable']
+        );
+    }
+
+    public function getHandledSignals(): array
+    {
+        $keys = array_map(
+            static fn (int $signal): string => sprintf('%s (%d)', SignalMap::getSignalName($signal), $signal),
+            array_keys($this->data['handled_signals'])
+        );
+
+        return array_combine($keys, array_values($this->data['handled_signals']));
+    }
+
+    /**
+     * @return Data[]
+     */
+    public function getHelperSet(): array
+    {
+        return $this->data['helper_set'] ?? [];
+    }
+
+    public function reset(): void
+    {
+        $this->data = [];
+    }
+}

--- a/src/Symfony/Component/Console/Debug/CliRequest.php
+++ b/src/Symfony/Component/Console/Debug/CliRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Debug;
+
+use Symfony\Component\Console\Command\TraceableCommand;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+final class CliRequest extends Request
+{
+    public function __construct(
+        public readonly TraceableCommand $command,
+    ) {
+        parent::__construct(
+            attributes: ['_controller' => \get_class($command->command), '_virtual_type' => 'command'],
+            server: $_SERVER,
+        );
+    }
+
+    // Methods below allow to populate a profile, thus enable search and filtering
+    public function getUri(): string
+    {
+        if ($this->server->has('SYMFONY_CLI_BINARY_NAME')) {
+            $binary = $this->server->get('SYMFONY_CLI_BINARY_NAME').' console';
+        } else {
+            $binary = $this->server->get('argv')[0];
+        }
+
+        return $binary.' '.$this->command->input;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->command->isInteractive ? 'INTERACTIVE' : 'BATCH';
+    }
+
+    public function getResponse(): Response
+    {
+        return new class($this->command->exitCode) extends Response {
+            public function __construct(private readonly int $exitCode)
+            {
+                parent::__construct();
+            }
+
+            public function getStatusCode(): int
+            {
+                return $this->exitCode;
+            }
+        };
+    }
+
+    public function getClientIp(): string
+    {
+        $application = $this->command->getApplication();
+
+        return $application->getName().' '.$application->getVersion();
+    }
+}

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -26,9 +26,12 @@
         "symfony/config": "^5.4|^6.0|^7.0",
         "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+        "symfony/http-foundation": "^6.4|^7.0",
+        "symfony/http-kernel": "^6.4|^7.0",
         "symfony/lock": "^5.4|^6.0|^7.0",
         "symfony/messenger": "^5.4|^6.0|^7.0",
         "symfony/process": "^5.4|^6.0|^7.0",
+        "symfony/stopwatch": "^5.4|^6.0|^7.0",
         "symfony/var-dumper": "^5.4|^6.0|^7.0",
         "psr/log": "^1|^2|^3"
     },

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Deprecate `UriSigner`, use `UriSigner` from the HttpFoundation component instead
  * Deprecate `FileLinkFormatter`, use `FileLinkFormatter` from the ErrorHandler component instead
  * Add argument `$buildDir` to `WarmableInterface`
+ * Add argument `$filter` to `Profiler::find()` and `FileProfilerStorage::find()`
 
 6.3
 ---

--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -44,7 +44,6 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
             $dispatchers = [$this->defaultDispatcher => $dispatchers];
         }
         $this->dispatchers = $dispatchers ?? [];
-        $this->requestStack = $requestStack;
     }
 
     public function collect(Request $request, Response $response, \Throwable $exception = null): void

--- a/src/Symfony/Component/HttpKernel/Debug/VirtualRequestStack.php
+++ b/src/Symfony/Component/HttpKernel/Debug/VirtualRequestStack.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Debug;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * A stack able to deal with virtual requests.
+ *
+ * @internal
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+final class VirtualRequestStack extends RequestStack
+{
+    public function __construct(
+        private readonly RequestStack $decorated,
+    ) {
+    }
+
+    public function push(Request $request): void
+    {
+        if ($request->attributes->has('_virtual_type')) {
+            if ($this->decorated->getCurrentRequest()) {
+                throw new \LogicException('Cannot mix virtual and HTTP requests.');
+            }
+
+            parent::push($request);
+
+            return;
+        }
+
+        $this->decorated->push($request);
+    }
+
+    public function pop(): ?Request
+    {
+        return $this->decorated->pop() ?? parent::pop();
+    }
+
+    public function getCurrentRequest(): ?Request
+    {
+        return $this->decorated->getCurrentRequest() ?? parent::getCurrentRequest();
+    }
+
+    public function getMainRequest(): ?Request
+    {
+        return $this->decorated->getMainRequest() ?? parent::getMainRequest();
+    }
+
+    public function getParentRequest(): ?Request
+    {
+        return $this->decorated->getParentRequest() ?? parent::getParentRequest();
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -42,8 +42,12 @@ class FileProfilerStorage implements ProfilerStorageInterface
         }
     }
 
-    public function find(?string $ip, ?string $url, ?int $limit, ?string $method, int $start = null, int $end = null, string $statusCode = null): array
+    /**
+     * @param \Closure|null $filter A filter to apply on the list of tokens
+     */
+    public function find(?string $ip, ?string $url, ?int $limit, ?string $method, int $start = null, int $end = null, string $statusCode = null/* , \Closure $filter = null */): array
     {
+        $filter = 7 < \func_num_args() ? func_get_arg(7) : null;
         $file = $this->getIndexFilename();
 
         if (!file_exists($file)) {
@@ -57,12 +61,12 @@ class FileProfilerStorage implements ProfilerStorageInterface
         while (\count($result) < $limit && $line = $this->readLineFromFile($file)) {
             $values = str_getcsv($line);
 
-            if (7 !== \count($values)) {
+            if (7 > \count($values)) {
                 // skip invalid lines
                 continue;
             }
 
-            [$csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode] = $values;
+            [$csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode, $csvVirtualType] = $values + [7 => null];
             $csvTime = (int) $csvTime;
 
             $urlFilter = false;
@@ -82,7 +86,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
-            $result[$csvToken] = [
+            $profile = [
                 'token' => $csvToken,
                 'ip' => $csvIp,
                 'method' => $csvMethod,
@@ -90,7 +94,14 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 'time' => $csvTime,
                 'parent' => $csvParent,
                 'status_code' => $csvStatusCode,
+                'virtual_type' => $csvVirtualType ?: 'request',
             ];
+
+            if ($filter && !$filter($profile)) {
+                continue;
+            }
+
+            $result[$csvToken] = $profile;
         }
 
         fclose($file);
@@ -154,6 +165,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
             'url' => $profile->getUrl(),
             'time' => $profile->getTime(),
             'status_code' => $profile->getStatusCode(),
+            'virtual_type' => $profile->getVirtualType() ?? 'request',
         ];
 
         $data = serialize($data);
@@ -180,6 +192,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 $profile->getTime() ?: time(),
                 $profile->getParentToken(),
                 $profile->getStatusCode(),
+                $profile->getVirtualType() ?? 'request',
             ]);
             fclose($file);
 
@@ -267,6 +280,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
         $profile->setUrl($data['url']);
         $profile->setTime($data['time']);
         $profile->setStatusCode($data['status_code']);
+        $profile->setVirtualType($data['virtual_type'] ?: 'request');
         $profile->setCollectors($data['data']);
 
         if (!$parent && $data['parent']) {
@@ -322,7 +336,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
         while ($line = fgets($handle)) {
             $values = str_getcsv($line);
 
-            if (7 !== \count($values)) {
+            if (7 > \count($values)) {
                 // skip invalid lines
                 $offset += \strlen($line);
                 continue;

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -33,6 +33,7 @@ class Profile
     private ?int $time = null;
     private ?int $statusCode = null;
     private ?self $parent = null;
+    private ?string $virtualType = null;
 
     /**
      * @var Profile[]
@@ -161,6 +162,22 @@ class Profile
     }
 
     /**
+     * @internal
+     */
+    public function setVirtualType(?string $virtualType): void
+    {
+        $this->virtualType = $virtualType;
+    }
+
+    /**
+     * @internal
+     */
+    public function getVirtualType(): ?string
+    {
+        return $this->virtualType;
+    }
+
+    /**
      * Finds children profilers.
      *
      * @return self[]
@@ -263,6 +280,6 @@ class Profile
 
     public function __sleep(): array
     {
-        return ['token', 'parent', 'children', 'collectors', 'ip', 'method', 'url', 'time', 'statusCode'];
+        return ['token', 'parent', 'children', 'collectors', 'ip', 'method', 'url', 'time', 'statusCode', 'virtualType'];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -121,15 +121,18 @@ class Profiler implements ResetInterface
     /**
      * Finds profiler tokens for the given criteria.
      *
-     * @param int|null    $limit The maximum number of tokens to return
-     * @param string|null $start The start date to search from
-     * @param string|null $end   The end date to search to
+     * @param int|null      $limit The maximum number of tokens to return
+     * @param string|null   $start The start date to search from
+     * @param string|null   $end   The end date to search to
+     * @param \Closure|null $filter A filter to apply on the list of tokens
      *
      * @see https://php.net/datetime.formats for the supported date/time formats
      */
-    public function find(?string $ip, ?string $url, ?int $limit, ?string $method, ?string $start, ?string $end, string $statusCode = null): array
+    public function find(?string $ip, ?string $url, ?int $limit, ?string $method, ?string $start, ?string $end, string $statusCode = null/* , \Closure $filter = null */): array
     {
-        return $this->storage->find($ip, $url, $limit, $method, $this->getTimestamp($start), $this->getTimestamp($end), $statusCode);
+        $filter = 7 < \func_num_args() ? func_get_arg(7) : null;
+
+        return $this->storage->find($ip, $url, $limit, $method, $this->getTimestamp($start), $this->getTimestamp($end), $statusCode, $filter);
     }
 
     /**
@@ -150,6 +153,10 @@ class Profiler implements ResetInterface
             $profile->setIp($request->getClientIp());
         } catch (ConflictingHeadersException) {
             $profile->setIp('Unknown');
+        }
+
+        if ($request->attributes->has('_virtual_type')) {
+            $profile->setVirtualType($request->attributes->get('_virtual_type'));
         }
 
         if ($prevToken = $response->headers->get('X-Debug-Token')) {

--- a/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
@@ -29,11 +29,12 @@ interface ProfilerStorageInterface
     /**
      * Finds profiler tokens for the given criteria.
      *
-     * @param int|null $limit The maximum number of tokens to return
-     * @param int|null $start The start date to search from
-     * @param int|null $end   The end date to search to
+     * @param int|null      $limit  The maximum number of tokens to return
+     * @param int|null      $start  The start date to search from
+     * @param int|null      $end    The end date to search to
+     * @param \Closure|null $filter A filter to apply on the list of tokens
      */
-    public function find(?string $ip, ?string $url, ?int $limit, ?string $method, int $start = null, int $end = null): array;
+    public function find(?string $ip, ?string $url, ?int $limit, ?string $method, int $start = null, int $end = null/* , \Closure $filter = null */): array;
 
     /**
      * Reads data associated with the given token.

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -377,6 +377,14 @@ class FileProfilerStorageTest extends TestCase
             '0',
         ];
 
+        yield 'One unexpired profile with virtual type' => [
+            <<<CSV
+            token0,127.0.0.0,,http://foo.bar/0,{$oneHourAgo->getTimestamp()},,virtual
+
+            CSV,
+            '0',
+        ];
+
         $threeDaysAgo = new \DateTimeImmutable('-3 days');
 
         yield 'One expired profile' => [
@@ -385,6 +393,14 @@ class FileProfilerStorageTest extends TestCase
 
             CSV,
             '48',
+        ];
+
+        yield 'One expired profile with virtual type' => [
+            <<<CSV
+            token0,127.0.0.0,,http://foo.bar/0,{$threeDaysAgo->getTimestamp()},,virtual
+
+            CSV,
+            '55',
         ];
 
         $fourDaysAgo = new \DateTimeImmutable('-4 days');
@@ -399,6 +415,16 @@ class FileProfilerStorageTest extends TestCase
 
             CSV,
             '96',
+        ];
+
+        yield 'Multiple expired profiles with virtual type' => [
+            <<<CSV
+            token0,127.0.0.0,,http://foo.bar/0,{$fourDaysAgo->getTimestamp()},,virtual
+            token1,127.0.0.1,,http://foo.bar/1,{$threeDaysAgo->getTimestamp()},,virtual
+            token2,127.0.0.2,,http://foo.bar/2,{$oneHourAgo->getTimestamp()},,virtual
+
+            CSV,
+            '110',
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45241
| License       | MIT
| Doc PR        | ~

TLDR;

I've shown a POC of this feature at the Symfony Live Paris last April to some of the core team members (ping @nicolas-grekas, @stof, @lyrixx, @chalasr, @GromNaN).
I propose here a new work from scratch addressing the comments I already got and based on Javier's profiler redesign (#47148).
Reviews should better be done by commits.

Summary
---------
This PR aims to leverage the profiler and its collectors by using a `VirtualRequestStack` to aggregate data on virtual requests.
Such requests are obfuscated by default to avoid side effects.
It can feel like a hack... or a pragmatic way to get, without much complexity, tons of useful feedback on what's going on during console execution, from basic info about the command, time/memory metrics, to every existing features already available in HTTP context: events, message dispatching, http requests, emails, serialization, validation, cache, database queries... and so on, all that just out of the box!

Previous work
--------------

There were some work to extract the Profiler logic in a dedicated component, that proved to require a lot of complexity and BC breaks in the API:
* #10374
* #14809 (see https://github.com/symfony/symfony/pull/14809#issuecomment-313340589)
* #20502

Screenshots
------------
For now I've focused only on the functional parts.

<details><summary>Search view</summary>
<img width="1221" alt="Screenshot 2022-08-28 at 11 29 25 PM" src="https://user-images.githubusercontent.com/10107633/187095381-851f6be5-cf8c-4fec-aa7b-9f9f80bf8404.png">
</details>
<details><summary>Command panel</summary>
<img width="1210" alt="Screenshot 2022-08-28 at 11 30 54 PM" src="https://user-images.githubusercontent.com/10107633/187095971-de8f9b85-eeb4-48cf-aff7-fdac0c6f9264.png">
<img width="974" alt="Screenshot 2022-08-28 at 11 31 08 PM" src="https://user-images.githubusercontent.com/10107633/187095980-337f4373-ebe5-4de5-bfb4-3715be868274.png">
<img width="962" alt="Screenshot 2022-08-28 at 11 31 21 PM" src="https://user-images.githubusercontent.com/10107633/187096022-ab18f70a-704a-4c75-81a6-43ca5b66eb9a.png">
<img width="964" alt="Screenshot 2022-08-28 at 11 31 34 PM" src="https://user-images.githubusercontent.com/10107633/187096037-cc45805e-ba65-447f-bca6-2d2ea38239b8.png">

If the command is signal-able the following panel will be available:
<img width="961" alt="Screenshot 2022-08-28 at 11 31 46 PM" src="https://user-images.githubusercontent.com/10107633/187096084-2f6a39be-a780-411b-9000-b9ae3407e82b.png">

If sub commands are run using `$this->getApplication()->run()` sub profiles will be shown as for requests:
<img width="696" alt="Screenshot 2022-08-28 at 11 31 56 PM" src="https://user-images.githubusercontent.com/10107633/187096105-bb7e4a84-42bc-47ed-9f58-527a771c48cc.png">
</details>

The server tab is the same as in the request panel.

<details><summary>Performance panel</summary>
<img width="977" alt="Screenshot 2022-08-28 at 11 32 23 PM" src="https://user-images.githubusercontent.com/10107633/187096138-3ff3f347-61c7-4ade-8c73-b48d5b504c04.png">
<img width="969" alt="Screenshot 2022-08-28 at 11 32 32 PM" src="https://user-images.githubusercontent.com/10107633/187096168-35be4773-4941-4e5e-8dd4-f6cc009e5d48.png">
</details>
<details>
<summary>Failing command</summary>
The exception panel is shown by default as for requests:
<img width="1217" alt="Screenshot 2022-08-28 at 11 33 42 PM" src="https://user-images.githubusercontent.com/10107633/187096210-7b206c72-c2e4-4eb3-9978-916cd3dd6cd6.png">
</details>

<details>
<summary>Sub command</summary>
<img width="1217" alt="Screenshot 2022-08-28 at 11 33 19 PM" src="https://user-images.githubusercontent.com/10107633/187096188-a090fb91-b7b8-4f98-a1d7-99b3605bf48b.png">
</details>

<details>
<summary>Profile token when verbose</summary>
(clickable links with compatible terminals)
<img width="534" alt="Screenshot 2022-08-28 at 11 26 51 PM" src="https://user-images.githubusercontent.com/10107633/187096349-8f7619b2-feb4-427c-a315-f4a844536316.png">
</details>

<details>
<summary>Command interrupted by signal</summary>
<img width="1246" alt="Screenshot 2022-10-22 at 4 16 37 PM" src="https://user-images.githubusercontent.com/10107633/197344164-50d72a25-a6e7-4e77-ad87-2d5f54b29b93.png">
</details>

Opt-in profiling
---------------

Use the new global option `--profile` (in debug only) to profile a command.

Future scopes
--------------

* When I've discussed the limitation of profiling long running processes such as `messenger:consume` with @GromNaN (one of the reasons why I've added an `excludes` option), he told that it would be nice it we could find a way to profile consumers as well.
So I've added ~an abstract `VirtualRequest`~ a `_virtual_type` request attribute and a `virtualType` property to profiles, that will allow to create a `MessengerWorkerRequest` and  a new type of profile with ease in a follow-up PR if the current implementation is accepted.
* We could add some dedicated casters for input and output in the `VarDumper` component (/cc @nicolas-grekas)
* It could be interesting to decorate and collect traces from some helpers (i.e. when running processes)
* ~Add a global option in debug to enable/disable the profiler on the fly when running commands (e.g. a negatable `--profile` flag)~
  **[update] implemented in current scope in replacement of semantic config.**
* Extract profiling to a new component.

Limitations
-----------
* ~No sub profiles are created when using `$this->getApplication()->find(...)->run()` because events (needed by the profiler to hook into) are dispatched from `Application::run()`, not from `Command::run()`.~
  **[update] The docs has been updated in https://github.com/symfony/symfony-docs/pull/18741.**
* ~No profiles are created when killing the command process (i.e. using `ctrl-C`, should we add a handler to some signals to force saving profiles?~
  **[update] I've added support for this.**
* ~Signals as int may not be as useful as they could in the profiler pages, does it worth trying to add a label to some (knowing that some signals can have different constants (labels) with the same int value)?~
  **[update] done thanks to https://github.com/symfony/symfony/pull/50663.**
* ~Long running processes should be excluded via configuration to avoid memory leaks~
  **[update] profiling is now opt-in using the `--profile` option.**
* Profiling `messenger:consume` does not work since the kernel is reset after handling a message.

__________________

TODO
------

* [x] I've left some todos inside the code for reviewers to share they thought before I try going further
* [x] Add a few tests
* [x] Get help for the UI (new top nav, ~svg for the command panel~) /cc @javiereguiluz
* ~PR on `symfony/recipes` to add the new `framework.profiler.cli` node~