### PR TITLE
[WebProfilerBundle] Fix profile search bar link query params

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -108,7 +108,7 @@
                             {{ include('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>
                         </a>
 
-                        {{ render(controller('web_profiler.controller.profiler::searchBarAction', request.query.all)) }}
+                        {{ render(controller('web_profiler.controller.profiler::searchBarAction', query=request.query.all)) }}
                     </div>
                 </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

Spotted while working on #47416.
The second argument of `controller()` is `attributes`.