### PR TITLE
[Process] Support using `Process::findExecutable()` independently of `open_basedir`

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `RunProcessMessage` and `RunProcessMessageHandler`
+ * Support using `Process::findExecutable()` independently of `open_basedir`
 
 5.2.0
 -----

--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -50,25 +50,10 @@ class ExecutableFinder
      */
     public function find(string $name, string $default = null, array $extraDirs = []): ?string
     {
-        if (\ini_get('open_basedir')) {
-            $searchPath = array_merge(explode(\PATH_SEPARATOR, \ini_get('open_basedir')), $extraDirs);
-            $dirs = [];
-            foreach ($searchPath as $path) {
-                // Silencing against https://bugs.php.net/69240
-                if (@is_dir($path)) {
-                    $dirs[] = $path;
-                } else {
-                    if (basename($path) == $name && @is_executable($path)) {
-                        return $path;
-                    }
-                }
-            }
-        } else {
-            $dirs = array_merge(
-                explode(\PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
-                $extraDirs
-            );
-        }
+        $dirs = array_merge(
+            explode(\PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
+            $extraDirs
+        );
 
         $suffixes = [''];
         if ('\\' === \DIRECTORY_SEPARATOR) {
@@ -80,7 +65,16 @@ class ExecutableFinder
                 if (@is_file($file = $dir.\DIRECTORY_SEPARATOR.$name.$suffix) && ('\\' === \DIRECTORY_SEPARATOR || @is_executable($file))) {
                     return $file;
                 }
+
+                if (!@is_dir($dir) && basename($dir) === $name.$suffix && @is_executable($dir)) {
+                    return $dir;
+                }
             }
+        }
+
+        $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v';
+        if (\function_exists('exec') && ($executablePath = strtok(@exec($command.' '.escapeshellarg($name)), \PHP_EOL)) && is_executable($executablePath)) {
+            return $executablePath;
         }
 
         return $default;

--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -34,7 +34,7 @@ class PhpExecutableFinder
         if ($php = getenv('PHP_BINARY')) {
             if (!is_executable($php)) {
                 $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v';
-                if ($php = strtok(exec($command.' '.escapeshellarg($php)), \PHP_EOL)) {
+                if (\function_exists('exec') && $php = strtok(exec($command.' '.escapeshellarg($php)), \PHP_EOL)) {
                     if (!is_executable($php)) {
                         return false;
                     }

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -19,20 +19,9 @@ use Symfony\Component\Process\ExecutableFinder;
  */
 class ExecutableFinderTest extends TestCase
 {
-    private string|false $path = false;
-
     protected function tearDown(): void
     {
-        if ($this->path) {
-            // Restore path if it was changed.
-            putenv('PATH='.$this->path);
-        }
-    }
-
-    private function setPath($path)
-    {
-        $this->path = getenv('PATH');
-        putenv('PATH='.$path);
+        putenv('PATH='.($_SERVER['PATH'] ?? $_SERVER['Path']));
     }
 
     public function testFind()
@@ -41,7 +30,7 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot test when open_basedir is set');
         }
 
-        $this->setPath(\dirname(\PHP_BINARY));
+        putenv('PATH='.\dirname(\PHP_BINARY));
 
         $finder = new ExecutableFinder();
         $result = $finder->find($this->getPhpBinaryName());
@@ -57,7 +46,7 @@ class ExecutableFinderTest extends TestCase
 
         $expected = 'defaultValue';
 
-        $this->setPath('');
+        putenv('PATH=');
 
         $finder = new ExecutableFinder();
         $result = $finder->find('foo', $expected);
@@ -71,7 +60,7 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot test when open_basedir is set');
         }
 
-        $this->setPath('');
+        putenv('PATH=');
 
         $finder = new ExecutableFinder();
 
@@ -86,7 +75,7 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot test when open_basedir is set');
         }
 
-        $this->setPath('');
+        putenv('PATH=');
 
         $extraDirs = [\dirname(\PHP_BINARY)];
 
@@ -129,7 +118,6 @@ class ExecutableFinderTest extends TestCase
             $this->markTestSkipped('Cannot run test on windows');
         }
 
-        $this->setPath('');
         $this->iniSet('open_basedir', \PHP_BINARY.\PATH_SEPARATOR.'/');
 
         $finder = new ExecutableFinder();
@@ -154,7 +142,7 @@ class ExecutableFinderTest extends TestCase
 
         $this->assertFalse(is_executable($target));
 
-        $this->setPath(sys_get_temp_dir());
+        putenv('PATH='.sys_get_temp_dir());
 
         $finder = new ExecutableFinder();
         $result = $finder->find(basename($target), false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #41006
| License       | MIT

With this PR `Console::findExecutable()` will find executables also if the their path is not allowed in `open_basedir` config similar to  https://github.com/symfony/symfony/blob/ddaedd28bd2e4fc22b64567753cf934fe9d68c4c/src/Symfony/Component/Process/PhpExecutableFinder.php#L36-L41
`Console::findExecutable()`'s responsibility is to find an executable which can be called with a Symfony Process or by PHP's functions like `exec`, `system` etc.

The goal of PHP's `open_basedir` config is to restrict reading / writing files within PHP processes. Imho this is completely independent of finding an executable.

If PHP's intention was to restrict executing applications which are not present in `open_basedir`'s paths, it would have been implemented there.