### PR TITLE
[String] CamelCase/SnakeCase on uppercase word

### DIFF
--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -162,7 +162,7 @@ abstract class AbstractUnicodeString extends AbstractString
     public function camel(): parent
     {
         $str = clone $this;
-        $str->string = str_replace(' ', '', preg_replace_callback('/\b./u', static function ($m) use (&$i) {
+        $str->string = str_replace(' ', '', preg_replace_callback('/\b.(?![A-Z]{2,})/u', static function ($m) use (&$i) {
             return 1 === ++$i ? ('İ' === $m[0] ? 'i̇' : mb_strtolower($m[0], 'UTF-8')) : mb_convert_case($m[0], \MB_CASE_TITLE, 'UTF-8');
         }, preg_replace('/[^\pL0-9]++/u', ' ', $this->string)));
 

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -103,7 +103,10 @@ class ByteString extends AbstractString
     public function camel(): parent
     {
         $str = clone $this;
-        $str->string = lcfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $this->string))));
+
+        $parts = explode(' ', trim(ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $this->string))));
+        $parts[0] = 1 !== \strlen($parts[0]) && ctype_upper($parts[0]) ? $parts[0] : lcfirst($parts[0]);
+        $str->string = implode('', $parts);
 
         return $str;
     }

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1042,11 +1042,13 @@ abstract class AbstractAsciiTestCase extends TestCase
         return [
             ['', ''],
             ['xY', 'x_y'],
+            ['xuYo', 'xu_yo'],
             ['symfonyIsGreat', 'symfony_is_great'],
             ['symfony5IsGreat', 'symfony_5_is_great'],
             ['symfonyIsGreat', 'Symfony is great'],
             ['symfonyIsAGreatFramework', 'Symfony is a great framework'],
             ['symfonyIsGREAT', '*Symfony* is GREAT!!'],
+            ['SYMFONY', 'SYMFONY'],
         ];
     }
 
@@ -1066,6 +1068,7 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['', ''],
             ['x_y', 'x_y'],
             ['x_y', 'X_Y'],
+            ['xu_yo', 'xu_yo'],
             ['symfony_is_great', 'symfonyIsGreat'],
             ['symfony5_is_great', 'symfony5IsGreat'],
             ['symfony5is_great', 'symfony5isGreat'],
@@ -1073,6 +1076,7 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['symfony_is_a_great_framework', 'symfonyIsAGreatFramework'],
             ['symfony_is_great', 'symfonyIsGREAT'],
             ['symfony_is_really_great', 'symfonyIsREALLYGreat'],
+            ['symfony', 'SYMFONY'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | ~
| Tickets       | Fix #47421 
| License       | MIT
| Doc PR        | 

The behavior of `->snake()` method from String component has changed in 6.1.4, now, using `u('SYMFONY')->snake()` return `s_ymfony` instead of `symfony` (#47185).

After, some investigations, it seams the `->camel()` behavior is not exactly the expected one: `u('SYMFONY')->camel()` return `sYMFONY` instead of `SYMFONY`.

This PR give theses behaviors:
- CamelCase:
    - '' => ''
    - x_y => xY
    - xu_yo => xuYo
    - symfony_is_great => symfonyIsGreat
    - symfony_5_is_great => symfony5IsGreat
    - Symfony is great => symfonyIsGreat
    - Symfony is a great framework => symfonyIsAGreatFramework
    - \*Symfony\* is GREAT!! => symfonyIsGREAT
    - **SYMFONY => SYMFONY**

- SnakeCase:
    - '' => ''
    - x_y => x_y
    - X_Y => x_y
    - xu_yo => xu_yo
    - symfonyIsGreat => symfony_is_great
    - symfony5IsGreat => symfony5_is_great
    - symfony5isGreat => symfony5is_great
    - Symfony is great => symfony_is_great
    - symfonyIsAGreatFramework => symfony_is_a_great_framework
    - symfonyIsGREAT => symfony_is_great
    - symfonyIsREALLYGreat => symfony_is_really_great
    - **SYMFONY => symfony**
