### PR TITLE
[Filesystem] makePathRelative with existing files, remove ending /

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -463,6 +463,8 @@ class Filesystem
             throw new InvalidArgumentException(\sprintf('The end path "%s" is not absolute.', $endPath));
         }
 
+        $originalEndPath = $endPath;
+
         // Normalize separators on Windows
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $endPath = str_replace('\\', '/', $endPath);
@@ -518,6 +520,11 @@ class Filesystem
 
         // Construct $endPath from traversing to the common path, then to the remaining $endPath
         $relativePath = $traverser.('' !== $endPathRemainder ? $endPathRemainder.'/' : '');
+
+        // Remove ending "/" if $endPath points to an existing file
+        if (str_ends_with($relativePath, '/') && is_file($originalEndPath)) {
+            $relativePath = substr($relativePath, 0, -1);
+        }
 
         return '' === $relativePath ? './' : $relativePath;
     }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1218,6 +1218,19 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertSame('../../../', $this->filesystem->makePathRelative('var/lib/symfony/', '/var/lib/symfony/src/Symfony/Component'));
     }
 
+    public function testMakePathRelativeWithExistingFile()
+    {
+        $dir = $this->workspace.\DIRECTORY_SEPARATOR.'foo'.\DIRECTORY_SEPARATOR.'bar';
+        mkdir($dir, 0777, true);
+        $file = $dir.\DIRECTORY_SEPARATOR.'test.txt';
+        touch($file);
+
+        // File path must not get a trailing slash
+        $this->assertSame('foo/bar/test.txt', $this->filesystem->makePathRelative($file, $this->workspace));
+        // Directory path must still get a trailing slash
+        $this->assertSame('foo/bar/', $this->filesystem->makePathRelative($dir, $this->workspace));
+    }
+
     public function testMirrorCopiesFilesAndDirectoriesRecursively()
     {
         $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source'.\DIRECTORY_SEPARATOR;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

**Bug description:** [Filesystem::makePathRelative](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Filesystem/Filesystem.php#L425) adds wrongly an ending slash / to a resulting relative path, although provided `endPath` points to existing file.  

**Situation tl;dr:**
```php
$filesystem = new \Symfony\Component\Filesystem\Filesystem();
$filesystem->makePathRelative(
    endPath: '/var/www/html/project/foo/bar/tmp/test.txt',
    startPath: '/var/www/html/project'
); // output: "foo/bar/tmp/test.txt/"
```

**Discussion:** I thought at first that the method should be applied only to folders. However, Filesystem provides operations for files and folders. The provided relative path is therefore unexpected. The problem was discussed in pull request [#40051](https://github.com/symfony/symfony/pull/40051) without solving the issue because of the awareness of causing troubles in existing codebases. This issue exists because folder paths are occasionally defined with an ending slash. In the closed pull request, a solution was proposed that did not check if an `endPath` targets an existing file.

**Deprecations:** There should be no deprecations. Those who wanted to solve the described problem checked the unnecessary presence of the last slash. 

**Reproduce bug:**
```php
<?php

require __DIR__ . '/vendor/autoload.php';

$filesystem = new \Symfony\Component\Filesystem\Filesystem();

// Init situation
$projectDir = __DIR__;
$tmpFolderPath = "{$projectDir}/foo/bar/tmp";
$tmpFilePath = "{$tmpFolderPath}/test.txt";

$filesystem->mkdir($tmpFolderPath, 0700);
$filesystem->touch($tmpFilePath);

// Output: foo/bar/tmp/test.txt/
// Expected output: foo/bar/tmp/test.txt
$relativePath = $filesystem->makePathRelative($tmpFilePath, $projectDir);

// Debug info
dump([
    'projectDir' => $projectDir, // ✔ "/var/www/html/project"
    'tmpFolderPath' => $tmpFolderPath, // ✔ "/var/www/html/project/foo/bar/tmp"
    'tmpFilePath' => $tmpFilePath, // ✔ "/var/www/html/project/foo/bar/tmp/test.txt"
    'relativePath' => $relativePath, // ✘ "foo/bar/tmp/test.txt/" – expected: "foo/bar/tmp/test.txt"
    'tmpFolderPath.isFile' => file_exists($tmpFolderPath), // ✔ true
    'tmpFolderPath.isFolder' => is_dir($tmpFolderPath), // ✔ true
    'tmpFilePath.isFile' => file_exists($tmpFilePath), // ✔ true
    'tmpFilePath.isFolder' => is_dir($tmpFilePath), // ✔ false
]);
```

**Tests:** Filesystem has no tests that are trying to test with files instead of folders. New tests have to be defined. My PHP knowledge is not sufficient to create these tests reliably.