### PR TITLE
[FrameworkBundle] Display aliases in `debug:container` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `DomCrawlerAssertionsTrait::assertAnySelectorTextContains(string $selector, string $text)`
  * Add `DomCrawlerAssertionsTrait::assertAnySelectorTextSame(string $selector, string $text)`
  * Add `DomCrawlerAssertionsTrait::assertAnySelectorTextNotContains(string $selector, string $text)`
+ * Display aliases in debug:container command
  * Deprecate `EnableLoggerDebugModePass`, use argument `$debug` of HttpKernel's `Logger` instead
  * Deprecate `AddDebugLogProcessorPass::configureLogger()`, use HttpKernel's `DebugLoggerConfigurator` instead
  * Deprecate not setting the `framework.handle_all_throwables` config option; it will default to `true` in 7.0

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -44,6 +44,7 @@ class ContainerDebugCommand extends Command
             ->setDefinition([
                 new InputArgument('name', InputArgument::OPTIONAL, 'A service name (foo)'),
                 new InputOption('show-arguments', null, InputOption::VALUE_NONE, 'Show arguments in services'),
+                new InputOption('with-aliases', null, InputOption::VALUE_NONE, 'Display aliases for a single service'),
                 new InputOption('show-hidden', null, InputOption::VALUE_NONE, 'Show hidden (internal) services'),
                 new InputOption('tag', null, InputOption::VALUE_REQUIRED, 'Show all services with a specific tag'),
                 new InputOption('tags', null, InputOption::VALUE_NONE, 'Display tagged services for an application'),
@@ -153,6 +154,7 @@ EOF
         $helper = new DescriptorHelper();
         $options['format'] = $input->getOption('format');
         $options['show_arguments'] = $input->getOption('show-arguments');
+        $options['with_aliases'] = $input->getOption('with-aliases');
         $options['show_hidden'] = $input->getOption('show-hidden');
         $options['raw_text'] = $input->getOption('raw');
         $options['output'] = $io;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -76,7 +76,7 @@ class JsonDescriptor extends Descriptor
         if ($service instanceof Alias) {
             $this->describeContainerAlias($service, $options, $container);
         } elseif ($service instanceof Definition) {
-            $this->writeData($this->getContainerDefinitionData($service, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $container, $options['id']), $options);
+            $this->writeData($this->getContainerDefinitionData($service, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $container, $options['id'], isset($options['with_aliases']) && $options['with_aliases']), $options);
         } else {
             $this->writeData($service::class, $options);
         }
@@ -90,6 +90,7 @@ class JsonDescriptor extends Descriptor
         $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $omitTags = isset($options['omit_tags']) && $options['omit_tags'];
         $showArguments = isset($options['show_arguments']) && $options['show_arguments'];
+        $withAliases = isset($options['with_aliases']) && $options['with_aliases'];
         $data = ['definitions' => [], 'aliases' => [], 'services' => []];
 
         if (isset($options['filter'])) {
@@ -109,7 +110,7 @@ class JsonDescriptor extends Descriptor
                 if ($service->hasTag('container.excluded')) {
                     continue;
                 }
-                $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, $omitTags, $showArguments, $container, $serviceId);
+                $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, $omitTags, $showArguments, $container, $serviceId, $withAliases);
             } else {
                 $data['services'][$serviceId] = $service::class;
             }
@@ -120,7 +121,7 @@ class JsonDescriptor extends Descriptor
 
     protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $container = null): void
     {
-        $this->writeData($this->getContainerDefinitionData($definition, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $container, $options['id'] ?? null), $options);
+        $this->writeData($this->getContainerDefinitionData($definition, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $container, $options['id'] ?? null, isset($options['with_aliases']) && $options['with_aliases']), $options);
     }
 
     protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $container = null): void
@@ -132,7 +133,7 @@ class JsonDescriptor extends Descriptor
         }
 
         $this->writeData(
-            [$this->getContainerAliasData($alias), $this->getContainerDefinitionData($container->getDefinition((string) $alias), isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $container, (string) $alias)],
+            [$this->getContainerAliasData($alias), $this->getContainerDefinitionData($container->getDefinition((string) $alias), isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $container, (string) $alias, isset($options['with_aliases']) && $options['with_aliases'])],
             array_merge($options, ['id' => (string) $alias])
         );
     }
@@ -220,7 +221,7 @@ class JsonDescriptor extends Descriptor
         return $data;
     }
 
-    private function getContainerDefinitionData(Definition $definition, bool $omitTags = false, bool $showArguments = false, ContainerBuilder $container = null, string $id = null): array
+    private function getContainerDefinitionData(Definition $definition, bool $omitTags = false, bool $showArguments = false, ContainerBuilder $container = null, string $id = null, bool $withAliases = false): array
     {
         $data = [
             'class' => (string) $definition->getClass(),
@@ -245,7 +246,7 @@ class JsonDescriptor extends Descriptor
         }
 
         if ($showArguments) {
-            $data['arguments'] = $this->describeValue($definition->getArguments(), $omitTags, $showArguments, $container, $id);
+            $data['arguments'] = $this->describeValue($definition->getArguments(), $omitTags, $showArguments, $container, $id, $withAliases);
         }
 
         $data['file'] = $definition->getFile();
@@ -393,12 +394,12 @@ class JsonDescriptor extends Descriptor
         throw new \InvalidArgumentException('Callable is not describable.');
     }
 
-    private function describeValue($value, bool $omitTags, bool $showArguments, ContainerBuilder $container = null, string $id = null): mixed
+    private function describeValue($value, bool $omitTags, bool $showArguments, ContainerBuilder $container = null, string $id = null, bool $withAliases = false): mixed
     {
         if (\is_array($value)) {
             $data = [];
             foreach ($value as $k => $v) {
-                $data[$k] = $this->describeValue($v, $omitTags, $showArguments, $container, $id);
+                $data[$k] = $this->describeValue($v, $omitTags, $showArguments, $container, $id, $withAliases);
             }
 
             return $data;
@@ -409,10 +410,27 @@ class JsonDescriptor extends Descriptor
         }
 
         if ($value instanceof Reference) {
-            return [
-                'type' => 'service',
-                'id' => (string) $value,
-            ];
+            try {
+                $node = $container?->getCompiler()?->getServiceReferenceGraph()?->getNode((string) $value);
+
+                if ($withAliases && $node?->getValue()?->getClass()) {
+                    return [
+                        'alias' => $node->getValue()->getClass(),
+                        'type' => 'service',
+                        'id' => (string) $value,
+                    ];
+                } else {
+                    return [
+                        'type' => 'service',
+                        'id' => (string) $value,
+                    ];
+                }
+            } catch (\Throwable $throwable) {
+                return [
+                    'type' => 'service',
+                    'id' => (string) $value,
+                ];
+            }
         }
 
         if ($value instanceof AbstractArgument) {
@@ -424,7 +442,7 @@ class JsonDescriptor extends Descriptor
         }
 
         if ($value instanceof Definition) {
-            return $this->getContainerDefinitionData($value, $omitTags, $showArguments, $container, $id);
+            return $this->getContainerDefinitionData($value, $omitTags, $showArguments, $container, $id, $withAliases);
         }
 
         return $value;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -222,7 +222,20 @@ class MarkdownDescriptor extends Descriptor
         }
 
         if (isset($options['show_arguments']) && $options['show_arguments']) {
-            $output .= "\n".'- Arguments: '.($definition->getArguments() ? 'yes' : 'no');
+            if ($definition->getArguments()) {
+                foreach ($definition->getArguments() as $argument) {
+                    $output .= "\n".'- Argument: `'.$argument.'`';
+                    if (isset($options['with_aliases']) && $options['with_aliases']) {
+                        try {
+                            $node = $container?->getCompiler()?->getServiceReferenceGraph()?->getNode((string) $argument);
+                            $output .= "\n".'    - Alias: '.$node?->getValue()?->getClass();
+                        } catch (\Throwable $throwable) {
+                        }
+                    }
+                }
+            } else {
+                $output .= "\n".'- Arguments: no';
+            }
         }
 
         if ($definition->getFile()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -328,6 +328,7 @@ class TextDescriptor extends Descriptor
         }
 
         $showArguments = isset($options['show_arguments']) && $options['show_arguments'];
+        $withAliases = isset($options['with_aliases']) && $options['with_aliases'];
         $argumentsInformation = [];
         if ($showArguments && ($arguments = $definition->getArguments())) {
             foreach ($arguments as $argument) {
@@ -335,7 +336,16 @@ class TextDescriptor extends Descriptor
                     $argument = $argument->getValues()[0];
                 }
                 if ($argument instanceof Reference) {
-                    $argumentsInformation[] = sprintf('Service(%s)', (string) $argument);
+                    $node = $container?->getCompiler()?->getServiceReferenceGraph()?->getNode((string) $argument);
+
+                    if ($withAliases && $node?->getValue()?->getClass()) {
+                        $argumentsInformation[] = vsprintf('Alias(%s, Service(%s))', [
+                            $node->getValue()->getClass(),
+                            (string) $argument,
+                        ]);
+                    } else {
+                        $argumentsInformation[] = sprintf('Service(%s)', (string) $argument);
+                    }
                 } elseif ($argument instanceof IteratorArgument) {
                     if ($argument instanceof TaggedIteratorArgument) {
                         $argumentsInformation[] = sprintf('Tagged Iterator for "%s"%s', $argument->getTag(), $options['is_debug'] ? '' : sprintf(' (%d element(s))', \count($argument->getValues())));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #39381
| License       | MIT
| Doc PR        | -

Running `bin/console debug:container cache.app --show-arguments --with-aliases --format FORMAT` on a symfony/skeleton:6.2 project

```
Alias(Symfony\Component\Cache\Marshaller\DefaultMarshaller, Service(cache.default_marshaller))
```
```xml
<argument alias="Symfony\Component\Cache\Marshaller\DefaultMarshaller" type="service" id="cache.default_marshaller"/>
```
```json
{
    "alias": "Symfony\\Component\\Cache\\Marshaller\\DefaultMarshaller",
    "type": "service",
    "id": "cache.default_marshaller"
}
```
```md
- Argument: `cache.default_marshaller`
    - Alias: Symfony\Component\Cache\Marshaller\DefaultMarshaller
```

*EDIT*: It might break BC because methods' signature has been changed (Added an argument with a default value)