### PR TITLE
[Console] Fix various completion edge cases

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -761,6 +761,21 @@ class Application implements ResetInterface
             }));
         }
 
+        // check whether all commands left are aliases to the same one
+        if (\count($commands) > 1) {
+            $uniqueCommands = array_unique(array_map(function ($nameOrAlias) use (&$commandList) {
+                if (!$commandList[$nameOrAlias] instanceof Command) {
+                    $commandList[$nameOrAlias] = $this->commandLoader->get($nameOrAlias);
+                }
+
+                return $commandList[$nameOrAlias]->getName();
+            }, $commands));
+
+            if (1 === \count($uniqueCommands)) {
+                $commands = [reset($uniqueCommands)];
+            }
+        }
+
         if (\count($commands) > 1) {
             $usableWidth = $this->terminal->getWidth() - 10;
             $abbrevs = array_values($commands);

--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -115,24 +115,30 @@ final class CompleteCommand extends Command
                 '<info>Messages:</>',
             ]);
 
-            $command = $this->findCommand($completionInput, $output);
+            if ($command = $this->findCommand($completionInput, $output)) {
+                $command->mergeApplicationDefinition();
+                $completionInput->bind($command->getDefinition());
+            }
+
             if (null === $command) {
                 $this->log('  No command found, completing using the Application class.');
 
                 $this->getApplication()->complete($completionInput, $suggestions);
             } elseif (
                 $completionInput->mustSuggestArgumentValuesFor('command')
-                && $command->getName() !== $completionInput->getCompletionValue()
-                && !\in_array($completionInput->getCompletionValue(), $command->getAliases(), true)
             ) {
-                $this->log('  No command found, completing using the Application class.');
+                $this->log('  Command found, completing command name.');
 
                 // expand shortcut names ("cache:cl<TAB>") into their full name ("cache:clear")
-                $suggestions->suggestValues(array_filter(array_merge([$command->getName()], $command->getAliases())));
+                $commandNames = array_filter(array_merge([$command->getName()], $command->getAliases()));
+                foreach ($commandNames as $name) {
+                    if (str_starts_with($name, $completionInput->getCompletionValue())) {
+                        $commandNames = [$name];
+                        break;
+                    }
+                }
+                $suggestions->suggestValues($commandNames);
             } else {
-                $command->mergeApplicationDefinition();
-                $completionInput->bind($command->getDefinition());
-
                 if (CompletionInput::TYPE_OPTION_NAME === $completionInput->getCompletionType()) {
                     $this->log('  Completing option names for the <comment>'.($command instanceof LazyCommand ? $command->getCommand() : $command)::class.'</> command.');
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -101,6 +101,7 @@ class ApplicationTest extends TestCase
         require_once self::$fixturesPath.'/TestAmbiguousCommandRegistering2.php';
         require_once self::$fixturesPath.'/FooHiddenCommand.php';
         require_once self::$fixturesPath.'/BarHiddenCommand.php';
+        require_once self::$fixturesPath.'/ManyAliasesCommand.php';
     }
 
     protected function normalizeLineBreaks($text)
@@ -413,6 +414,18 @@ class ApplicationTest extends TestCase
         $this->expectExceptionMessage('Command "FoO:BaR" is ambiguous');
 
         $application->find('FoO:BaR');
+    }
+
+    public function testFindSingleWithAmbiguousAliases()
+    {
+        $application = new Application();
+        $application->add(new \ManyAliasesCommand());
+        $application->add(new \AlternativeCommand());
+
+        $this->assertInstanceOf(\ManyAliasesCommand::class, $application->find('a'), '->find() will find the correct command using a short alias');
+        $this->assertInstanceOf(\ManyAliasesCommand::class, $application->find('alias'), '->find() will find the correct command using a long alias');
+        $this->assertInstanceOf(\ManyAliasesCommand::class, $application->find('aliased'), '->find() will find the correct command using the right name');
+        $this->assertInstanceOf(\ManyAliasesCommand::class, $application->find('ali'), '->find() will find the correct command using an ambiguous shortened version');
     }
 
     public function testFindWithCommandLoader()

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -105,10 +105,12 @@ class CompleteCommandTest extends TestCase
 
     public static function provideCompleteCommandNameInputs()
     {
-        yield 'empty' => [['bin/console'], ['help', 'list', 'completion', 'hello', 'ahoy']];
-        yield 'partial' => [['bin/console', 'he'], ['help', 'list', 'completion', 'hello', 'ahoy']];
-        yield 'complete-shortcut-name' => [['bin/console', 'hell'], ['hello', 'ahoy']];
-        yield 'complete-aliases' => [['bin/console', 'ah'], ['hello', 'ahoy']];
+        yield 'empty' => [['bin/console'], ['help', 'list', 'completion', 'hello', 'ahoy', 'h', 'ahah']];
+        yield 'partial' => [['bin/console', 'he'], ['help', 'list', 'completion', 'hello', 'ahoy', 'h', 'ahah']];
+        yield 'complete-shortcut-name' => [['bin/console', 'hell'], ['hello']];
+        yield 'complete-aliases' => [['bin/console', 'ah'], ['ahoy']];
+        yield 'short-alias-completes-to-name' => [['bin/console', 'h'], ['hello']];
+        yield 'ambiguous-of-same-command-completes-to-first-match' => [['bin/console', 'ah'], ['ahoy']];
     }
 
     /**
@@ -126,6 +128,7 @@ class CompleteCommandTest extends TestCase
         yield 'custom' => [['bin/console', 'hello'], ['Fabien', 'Robin', 'Wouter']];
         yield 'definition-aliased' => [['bin/console', 'ahoy', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction', '--global-option']];
         yield 'custom-aliased' => [['bin/console', 'ahoy'], ['Fabien', 'Robin', 'Wouter']];
+        yield 'custom-aliased-input' => [['bin/console', 'ahoy', 'Fa'], ['Fabien', 'Robin', 'Wouter']];
         yield 'global-option-values' => [['bin/console', '--global-option'], ['foo', 'bar', 'baz']];
         yield 'global-option-with-command-values' => [['bin/console', 'ahoy', '--global-option'], ['foo', 'bar', 'baz']];
     }
@@ -142,7 +145,7 @@ class CompleteCommandTest_HelloCommand extends Command
     public function configure(): void
     {
         $this->setName('hello')
-             ->setAliases(['ahoy'])
+             ->setAliases(['ahoy', 'h', 'ahah'])
              ->setDescription('Hello test command')
              ->addArgument('name', InputArgument::REQUIRED)
         ;

--- a/src/Symfony/Component/Console/Tests/Fixtures/ManyAliasesCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/ManyAliasesCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+
+class ManyAliasesCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('aliased')
+            ->setAliases(['a', 'alias', 'alias2', 'alias3'])
+            ->setDescription('Aliased command');
+    }
+}
+
+class AlternativeCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('alternative')
+            ->setDescription('Aliased command 2');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Refs https://github.com/composer/composer/issues/11029

There are two things I am trying to fix here:

- `composer require yiisoft/yii-[TAB]` works, but `composer req yiisoft/yii-[TAB]` does not work
- `composer up` suggets `upgrade update` but both are aliases to the same command, so I fixed it to make it always just suggest one name, which lets the shell complete to `composer update ` and then I can tab again to get more relevant completions.

The fixes work almost.. I have one problem for which I need help from someone (maybe @wouterj?).

See the changes in CompleteCommand. The current code is doing smth like:

- try to find a command
- if none found, autocomplete command names
- if a command is found and the completion does not match the command name/aliases, suggest command name
- otherwise bind the command and forward completion to the command

This is problematic because it breaks the 1st case I mentioned above, and it also is just fairly dodgy if you are trying to complete an arg with the command's name as input (e.g. `composer require require`) it will kinda stay stuck on suggesting the command's name even tho you are completing another arg here.

So I am trying to change it to a flow like:

- try to find a command
- if a command is found check where the completion input/caret is.
- if the caret is at the end of the command name, complete that
- otherwise bind the command and then check what can be completed

But it seems like CompletionInput does not work correctly there.. see these few examples from the completion debug output after I added some extra logging:
```
            $command = $this->findCommand($completionInput, $output);
            $this->log('  START, completing command name ("'.$completionInput->getCompletionName().'/'.$completionInput->getCompletionType().'")');
            if (null !== $command && !$completionInput->mustSuggestArgumentValuesFor('command')) {
                $command->mergeApplicationDefinition();
                $completionInput->bind($command->getDefinition());
                $this->log('  BOUND, completing command name ("'.$completionInput->getCompletionName().'/'.$completionInput->getCompletionType().'")');
            }
````

```
Input: ("|" indicates the cursor position)
  c req|
Command:
  /var/www/composer/bin/composer _complete -sbash -c1 -S2.4.999-dev+source -ic -ireq
Messages:
  START, completing command name ("command/argument_value")

Input: ("|" indicates the cursor position)
  c require |
Command:
  /var/www/composer/bin/composer _complete -sbash -c2 -S2.4.999-dev+source -ic -irequire
Messages:
  START, completing command name ("/none")
  BOUND, completing command name ("packages/argument_value")

Input: ("|" indicates the cursor position)
  c require foo|
Command:
  /var/www/composer/bin/composer _complete -sbash -c2 -S2.4.999-dev+source -ic -irequire -ifoo
Messages:
  START, completing command name ("command/argument_value")
```

As you can see when the input is `c req|` it completes the command argument as it should, then with `c require |` it also works as it should, detecting the space and moving to `none` completion. But then as soon as you have some more text it goes back to think it is completing the command argument and that makes no sense. 

I am too dumb or tired to figure out what's going on in the CompletionInput class or its tests, so I'd appreciate input there :)