### PR TITLE
[Console] Show Application-level console options when showing synopsis or when error occurred

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * Improve truecolor terminal detection in some cases
 * Add support for 256 color terminals (conversion from Ansi24 to Ansi8 if terminal is capable of it)
+* Show Application-level console options when showing synopsis or when error occured
 
 6.1
 ---

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
 * Improve truecolor terminal detection in some cases
 * Add support for 256 color terminals (conversion from Ansi24 to Ansi8 if terminal is capable of it)
-* Show Application-level console options when showing synopsis or when error occured
+* Show Application-level console options when showing synopsis or when error occurred
 
 6.1
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -375,15 +375,19 @@ class Command
      *
      * @internal
      */
-    public function mergeApplicationDefinition(bool $mergeArgs = true)
+    public function mergeApplicationDefinition(bool $mergeArgs = true, bool $mergeOptions = true)
     {
         if (null === $this->application) {
             return;
         }
 
         $this->fullDefinition = new InputDefinition();
-        $this->fullDefinition->setOptions($this->definition->getOptions());
-        $this->fullDefinition->addOptions($this->application->getDefinition()->getOptions());
+        if ($mergeOptions) {
+            $this->fullDefinition->setOptions($this->definition->getOptions());
+            $this->fullDefinition->addOptions($this->application->getDefinition()->getOptions());
+        } else {
+            $this->fullDefinition->setOptions($this->definition->getOptions());
+        }
 
         if ($mergeArgs) {
             $this->fullDefinition->setArguments($this->application->getDefinition()->getArguments());

--- a/src/Symfony/Component/Console/Command/LazyCommand.php
+++ b/src/Symfony/Component/Console/Command/LazyCommand.php
@@ -88,9 +88,9 @@ final class LazyCommand extends Command
     /**
      * @internal
      */
-    public function mergeApplicationDefinition(bool $mergeArgs = true): void
+    public function mergeApplicationDefinition(bool $mergeArgs = true, bool $mergeOptions = false): void
     {
-        $this->getCommand()->mergeApplicationDefinition($mergeArgs);
+        $this->getCommand()->mergeApplicationDefinition($mergeArgs, $mergeOptions);
     }
 
     public function setDefinition(array|InputDefinition $definition): static

--- a/src/Symfony/Component/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/Descriptor.php
@@ -77,7 +77,7 @@ abstract class Descriptor implements DescriptorInterface
     /**
      * Describes an InputDefinition instance.
      */
-    abstract protected function describeInputDefinition(InputDefinition $definition, array $options = []);
+    abstract protected function describeInputDefinition(InputDefinition $definition, array $options = [], string $prefix = '');
 
     /**
      * Describes a Command instance.

--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -163,7 +163,7 @@ class JsonDescriptor extends Descriptor
             ];
 
             $definition = $command->getApplication()?->getDefinition();
-            if ($definition?->getOptions() || $definition?->getArguments()) {
+            if ($definition && ($definition->getOptions() || $definition->getArguments())) {
                 $data['definition'] = $this->getInputDefinitionData($command->getApplication()->getDefinition(), 'application-level ');
             }
 

--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -39,9 +39,9 @@ class JsonDescriptor extends Descriptor
         }
     }
 
-    protected function describeInputDefinition(InputDefinition $definition, array $options = [])
+    protected function describeInputDefinition(InputDefinition $definition, array $options = [], string $prefix = '')
     {
-        $this->writeData($this->getInputDefinitionData($definition), $options);
+        $this->writeData($this->getInputDefinitionData($definition, $prefix), $options);
     }
 
     protected function describeCommand(Command $command, array $options = [])
@@ -120,7 +120,7 @@ class JsonDescriptor extends Descriptor
         ];
     }
 
-    private function getInputDefinitionData(InputDefinition $definition): array
+    private function getInputDefinitionData(InputDefinition $definition, string $prefix = ''): array
     {
         $inputArguments = [];
         foreach ($definition->getArguments() as $name => $argument) {
@@ -135,7 +135,7 @@ class JsonDescriptor extends Descriptor
             }
         }
 
-        return ['arguments' => $inputArguments, 'options' => $inputOptions];
+        return ["$prefix arguments" => $inputArguments, "$prefix options" => $inputOptions];
     }
 
     private function getCommandData(Command $command, bool $short = false): array
@@ -150,12 +150,15 @@ class JsonDescriptor extends Descriptor
                 'usage' => $command->getAliases(),
             ];
         } else {
-            $command->mergeApplicationDefinition(false);
+            $command->mergeApplicationDefinition(false, false);
 
             $data += [
                 'usage' => array_merge([$command->getSynopsis()], $command->getUsages(), $command->getAliases()),
                 'help' => $command->getProcessedHelp(),
-                'definition' => $this->getInputDefinitionData($command->getDefinition()),
+                'definition' => array_merge(
+                    $this->getInputDefinitionData($command->getApplication()->getDefinition(), 'application-level'),
+                    $this->getInputDefinitionData($command->getDefinition(), 'command-level')
+                ),
             ];
         }
 

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -138,13 +138,13 @@ class MarkdownDescriptor extends Descriptor
         $definition = $command->getApplication()?->getDefinition();
         if ($definition?->getOptions() || $definition?->getArguments()) {
             $this->write("\n\n");
-            $this->describeInputDefinition($definition, prefix: 'Application-level');
+            $this->describeInputDefinition($definition, prefix: 'Application-level ');
         }
 
         $definition = $command->getDefinition();
         if ($definition->getOptions() || $definition->getArguments()) {
             $this->write("\n\n");
-            $this->describeInputDefinition($definition, prefix: 'Command-level');
+            $this->describeInputDefinition($definition, prefix: 'Command-level ');
         }
     }
 

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -78,7 +78,7 @@ class MarkdownDescriptor extends Descriptor
     protected function describeInputDefinition(InputDefinition $definition, array $options = [], string $prefix = '')
     {
         if ($showArguments = \count($definition->getArguments()) > 0) {
-            $this->write("### $prefix Arguments");
+            $this->write("### {$prefix}Arguments");
             foreach ($definition->getArguments() as $argument) {
                 $this->write("\n\n");
                 if (null !== $describeInputArgument = $this->describeInputArgument($argument)) {
@@ -92,7 +92,7 @@ class MarkdownDescriptor extends Descriptor
                 $this->write("\n\n");
             }
 
-            $this->write("### $prefix Options");
+            $this->write("### {$prefix}Options");
             foreach ($definition->getOptions() as $option) {
                 $this->write("\n\n");
                 if (null !== $describeInputOption = $this->describeInputOption($option)) {
@@ -135,8 +135,8 @@ class MarkdownDescriptor extends Descriptor
             $this->write($help);
         }
 
-        $definition = $command->getApplication()->getDefinition();
-        if ($definition->getOptions() || $definition->getArguments()) {
+        $definition = $command->getApplication()?->getDefinition();
+        if ($definition?->getOptions() || $definition?->getArguments()) {
             $this->write("\n\n");
             $this->describeInputDefinition($definition, prefix: 'Application-level');
         }

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -136,7 +136,7 @@ class MarkdownDescriptor extends Descriptor
         }
 
         $definition = $command->getApplication()?->getDefinition();
-        if ($definition?->getOptions() || $definition?->getArguments()) {
+        if ($definition && ($definition->getOptions() || $definition->getArguments())) {
             $this->write("\n\n");
             $this->describeInputDefinition($definition, prefix: 'Application-level ');
         }

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -75,10 +75,10 @@ class MarkdownDescriptor extends Descriptor
         );
     }
 
-    protected function describeInputDefinition(InputDefinition $definition, array $options = [])
+    protected function describeInputDefinition(InputDefinition $definition, array $options = [], string $prefix = '')
     {
         if ($showArguments = \count($definition->getArguments()) > 0) {
-            $this->write('### Arguments');
+            $this->write("### $prefix Arguments");
             foreach ($definition->getArguments() as $argument) {
                 $this->write("\n\n");
                 if (null !== $describeInputArgument = $this->describeInputArgument($argument)) {
@@ -92,7 +92,7 @@ class MarkdownDescriptor extends Descriptor
                 $this->write("\n\n");
             }
 
-            $this->write('### Options');
+            $this->write("### $prefix Options");
             foreach ($definition->getOptions() as $option) {
                 $this->write("\n\n");
                 if (null !== $describeInputOption = $this->describeInputOption($option)) {
@@ -118,7 +118,7 @@ class MarkdownDescriptor extends Descriptor
             return;
         }
 
-        $command->mergeApplicationDefinition(false);
+        $command->mergeApplicationDefinition(false, false);
 
         $this->write(
             '`'.$command->getName()."`\n"
@@ -135,10 +135,16 @@ class MarkdownDescriptor extends Descriptor
             $this->write($help);
         }
 
+        $definition = $command->getApplication()->getDefinition();
+        if ($definition->getOptions() || $definition->getArguments()) {
+            $this->write("\n\n");
+            $this->describeInputDefinition($definition, prefix: 'Application-level');
+        }
+
         $definition = $command->getDefinition();
         if ($definition->getOptions() || $definition->getArguments()) {
             $this->write("\n\n");
-            $this->describeInputDefinition($definition);
+            $this->describeInputDefinition($definition, prefix: 'Command-level');
         }
     }
 

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -91,7 +91,7 @@ class TextDescriptor extends Descriptor
         }
 
         if ($definition->getArguments()) {
-            $this->writeText("<comment>$prefix Arguments:</comment>", $options);
+            $this->writeText("<comment>{$prefix}Arguments:</comment>", $options);
             $this->writeText("\n");
             foreach ($definition->getArguments() as $argument) {
                 $this->describeInputArgument($argument, array_merge($options, ['total_width' => $totalWidth]));
@@ -106,7 +106,7 @@ class TextDescriptor extends Descriptor
         if ($definition->getOptions()) {
             $laterOptions = [];
 
-            $this->writeText("<comment>$prefix Options:</comment>", $options);
+            $this->writeText("<comment>{$prefix}Options:</comment>", $options);
             foreach ($definition->getOptions() as $option) {
                 if (\strlen($option->getShortcut() ?? '') > 1) {
                     $laterOptions[] = $option;
@@ -142,17 +142,17 @@ class TextDescriptor extends Descriptor
 
         $command->mergeApplicationDefinition(false, false);
 
-        $definition = $command->getApplication()->getDefinition();
-        if ($definition->getOptions() || $definition->getArguments()) {
+        $definition = $command->getApplication()?->getDefinition();
+        if ($definition?->getOptions() || $definition?->getArguments()) {
             $this->writeText("\n");
-            $this->describeInputDefinition($definition, $options, 'Application-level');
+            $this->describeInputDefinition($definition, $options, 'Application-level ');
             $this->writeText("\n");
         }
 
         $definition = $command->getDefinition();
         if ($definition->getOptions() || $definition->getArguments()) {
             $this->writeText("\n");
-            $this->describeInputDefinition($definition, $options, 'Command-level');
+            $this->describeInputDefinition($definition, $options, 'Command-level ');
             $this->writeText("\n");
         }
 

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -83,7 +83,7 @@ class TextDescriptor extends Descriptor
         ), $options);
     }
 
-    protected function describeInputDefinition(InputDefinition $definition, array $options = [])
+    protected function describeInputDefinition(InputDefinition $definition, array $options = [], string $prefix = '')
     {
         $totalWidth = $this->calculateTotalWidthForOptions($definition->getOptions());
         foreach ($definition->getArguments() as $argument) {
@@ -91,7 +91,7 @@ class TextDescriptor extends Descriptor
         }
 
         if ($definition->getArguments()) {
-            $this->writeText('<comment>Arguments:</comment>', $options);
+            $this->writeText("<comment>$prefix Arguments:</comment>", $options);
             $this->writeText("\n");
             foreach ($definition->getArguments() as $argument) {
                 $this->describeInputArgument($argument, array_merge($options, ['total_width' => $totalWidth]));
@@ -106,7 +106,7 @@ class TextDescriptor extends Descriptor
         if ($definition->getOptions()) {
             $laterOptions = [];
 
-            $this->writeText('<comment>Options:</comment>', $options);
+            $this->writeText("<comment>$prefix Options:</comment>", $options);
             foreach ($definition->getOptions() as $option) {
                 if (\strlen($option->getShortcut() ?? '') > 1) {
                     $laterOptions[] = $option;
@@ -140,10 +140,19 @@ class TextDescriptor extends Descriptor
         }
         $this->writeText("\n");
 
+        $command->mergeApplicationDefinition(false, false);
+
+        $definition = $command->getApplication()->getDefinition();
+        if ($definition->getOptions() || $definition->getArguments()) {
+            $this->writeText("\n");
+            $this->describeInputDefinition($definition, $options, 'Application-level');
+            $this->writeText("\n");
+        }
+
         $definition = $command->getDefinition();
         if ($definition->getOptions() || $definition->getArguments()) {
             $this->writeText("\n");
-            $this->describeInputDefinition($definition, $options);
+            $this->describeInputDefinition($definition, $options, 'Command-level');
             $this->writeText("\n");
         }
 

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -143,7 +143,7 @@ class TextDescriptor extends Descriptor
         $command->mergeApplicationDefinition(false, false);
 
         $definition = $command->getApplication()?->getDefinition();
-        if ($definition?->getOptions() || $definition?->getArguments()) {
+        if ($definition && ($definition->getOptions() || $definition->getArguments())) {
             $this->writeText("\n");
             $this->describeInputDefinition($definition, $options, 'Application-level ');
             $this->writeText("\n");

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -26,20 +26,26 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class XmlDescriptor extends Descriptor
 {
-    public function getInputDefinitionDocument(InputDefinition $definition, string $prefix = ''): \DOMDocument
+    public function getInputDefinitionDocument(InputDefinition $definition, string $type = ''): \DOMDocument
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($definitionXML = $dom->createElement('definition'));
 
         if ($definition->getArguments()) {
-            $definitionXML->appendChild($argumentsXML = $dom->createElement($prefix . 'arguments'));
+            $definitionXML->appendChild($argumentsXML = $dom->createElement('arguments'));
+            if ($type) {
+                $argumentsXML->setAttribute('type', $type);
+            }
             foreach ($definition->getArguments() as $argument) {
                 $this->appendDocument($argumentsXML, $this->getInputArgumentDocument($argument));
             }
         }
 
         if ($definition->getOptions()) {
-            $definitionXML->appendChild($optionsXML = $dom->createElement($prefix . 'options'));
+            $definitionXML->appendChild($optionsXML = $dom->createElement('options'));
+            if ($type) {
+                $optionsXML->setAttribute('type', $type);
+            }
             foreach ($definition->getOptions() as $option) {
                 $this->appendDocument($optionsXML, $this->getInputOptionDocument($option));
             }
@@ -78,13 +84,13 @@ class XmlDescriptor extends Descriptor
 
             $definition = $command->getApplication()?->getDefinition();
             if ($definition?->getOptions() || $definition?->getArguments()) {
-                $definitionXML = $this->getInputDefinitionDocument($definition, 'application-level-');
+                $definitionXML = $this->getInputDefinitionDocument($definition, 'application-level');
                 $this->appendDocument($commandXML, $definitionXML->getElementsByTagName('definition')->item(0));
             }
 
             $definition = $command->getDefinition();
             if ($definition?->getOptions() || $definition?->getArguments()) {
-                $definitionXML = $this->getInputDefinitionDocument($definition, 'command-level-');
+                $definitionXML = $this->getInputDefinitionDocument($definition, 'command-level');
                 $this->appendDocument($commandXML, $definitionXML->getElementsByTagName('definition')->item(0));
             }
 
@@ -144,9 +150,9 @@ class XmlDescriptor extends Descriptor
         $this->writeDocument($this->getInputOptionDocument($option));
     }
 
-    protected function describeInputDefinition(InputDefinition $definition, array $options = [], string $prefix = '')
+    protected function describeInputDefinition(InputDefinition $definition, array $options = [], string $type = '')
     {
-        $this->writeDocument($this->getInputDefinitionDocument($definition, $prefix));
+        $this->writeDocument($this->getInputDefinitionDocument($definition, $type));
     }
 
     protected function describeCommand(Command $command, array $options = [])

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -31,14 +31,18 @@ class XmlDescriptor extends Descriptor
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($definitionXML = $dom->createElement('definition'));
 
-        $definitionXML->appendChild($argumentsXML = $dom->createElement("$prefix-arguments"));
-        foreach ($definition->getArguments() as $argument) {
-            $this->appendDocument($argumentsXML, $this->getInputArgumentDocument($argument));
+        if ($definition->getArguments()) {
+            $definitionXML->appendChild($argumentsXML = $dom->createElement($prefix . 'arguments'));
+            foreach ($definition->getArguments() as $argument) {
+                $this->appendDocument($argumentsXML, $this->getInputArgumentDocument($argument));
+            }
         }
 
-        $definitionXML->appendChild($optionsXML = $dom->createElement("$prefix-options"));
-        foreach ($definition->getOptions() as $option) {
-            $this->appendDocument($optionsXML, $this->getInputOptionDocument($option));
+        if ($definition->getOptions()) {
+            $definitionXML->appendChild($optionsXML = $dom->createElement($prefix . 'options'));
+            foreach ($definition->getOptions() as $option) {
+                $this->appendDocument($optionsXML, $this->getInputOptionDocument($option));
+            }
         }
 
         return $dom;
@@ -72,11 +76,18 @@ class XmlDescriptor extends Descriptor
             $commandXML->appendChild($helpXML = $dom->createElement('help'));
             $helpXML->appendChild($dom->createTextNode(str_replace("\n", "\n ", $command->getProcessedHelp())));
 
-            $definitionXML = $this->getInputDefinitionDocument($command->getApplication()->getDefinition(), 'application-level');
-            $this->appendDocument($commandXML, $definitionXML->getElementsByTagName('definition')->item(0));
+            $definition = $command->getApplication()?->getDefinition();
+            if ($definition?->getOptions() || $definition?->getArguments()) {
+                $definitionXML = $this->getInputDefinitionDocument($definition, 'application-level-');
+                $this->appendDocument($commandXML, $definitionXML->getElementsByTagName('definition')->item(0));
+            }
 
-            $definitionXML = $this->getInputDefinitionDocument($command->getDefinition(), 'command-level');
-            $this->appendDocument($commandXML, $definitionXML->getElementsByTagName('definition')->item(0));
+            $definition = $command->getDefinition();
+            if ($definition?->getOptions() || $definition?->getArguments()) {
+                $definitionXML = $this->getInputDefinitionDocument($definition, 'command-level-');
+                $this->appendDocument($commandXML, $definitionXML->getElementsByTagName('definition')->item(0));
+            }
+
         }
 
         return $dom;

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -83,13 +83,13 @@ class XmlDescriptor extends Descriptor
             $helpXML->appendChild($dom->createTextNode(str_replace("\n", "\n ", $command->getProcessedHelp())));
 
             $definition = $command->getApplication()?->getDefinition();
-            if ($definition?->getOptions() || $definition?->getArguments()) {
+            if ($definition && ($definition->getOptions() || $definition->getArguments())) {
                 $definitionXML = $this->getInputDefinitionDocument($definition, 'application-level');
                 $this->appendDocument($commandXML, $definitionXML->getElementsByTagName('definition')->item(0));
             }
 
             $definition = $command->getDefinition();
-            if ($definition?->getOptions() || $definition?->getArguments()) {
+            if ($definition->getOptions() || $definition->getArguments()) {
                 $definitionXML = $this->getInputDefinitionDocument($definition, 'command-level');
                 $this->appendDocument($commandXML, $definitionXML->getElementsByTagName('definition')->item(0));
             }
@@ -149,9 +149,9 @@ class XmlDescriptor extends Descriptor
         $this->writeDocument($this->getInputOptionDocument($option));
     }
 
-    protected function describeInputDefinition(InputDefinition $definition, array $options = [], string $type = '')
+    protected function describeInputDefinition(InputDefinition $definition, array $options = [], string $prefix = '')
     {
-        $this->writeDocument($this->getInputDefinitionDocument($definition, $type));
+        $this->writeDocument($this->getInputDefinitionDocument($definition, $prefix));
     }
 
     protected function describeCommand(Command $command, array $options = [])

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -93,7 +93,6 @@ class XmlDescriptor extends Descriptor
                 $definitionXML = $this->getInputDefinitionDocument($definition, 'command-level');
                 $this->appendDocument($commandXML, $definitionXML->getElementsByTagName('definition')->item(0));
             }
-
         }
 
         return $dom;

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -9,17 +9,16 @@
             "description": "Internal command to provide shell completion suggestions",
             "help": "Internal command to provide shell completion suggestions",
             "definition": {
-                "arguments": [],
-                "options": {
-                    "symfony": {
-                        "name": "--symfony",
-                        "shortcut": "-S",
-                        "accept_value": true,
-                        "is_value_required": true,
-                        "is_multiple": false,
-                        "description": "deprecated",
-                        "default": null
-                    },
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "The command to execute",
+                        "default": ""
+                    }
+                },
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",
@@ -82,7 +81,10 @@
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
                         "default": false
-                    },
+                    }
+                },
+                "command-level arguments": [],
+                "command-level options": {
                     "shell": {
                         "name": "--shell",
                         "shortcut": "-s",
@@ -118,6 +120,15 @@
                         "is_multiple": false,
                         "description": "The API version of the completion script",
                         "default": null
+                    },
+                    "symfony": {
+                        "name": "--symfony",
+                        "shortcut": "-S",
+                        "accept_value": true,
+                        "is_value_required": true,
+                        "is_multiple": false,
+                        "description": "deprecated",
+                        "default": null
                     }
                 }
             }
@@ -131,16 +142,16 @@
             "description": "Dump the shell completion script",
             "help": "Dump the shell completion script",
             "definition": {
-                "arguments": {
-                    "shell": {
-                        "name": "shell",
-                        "is_required": false,
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
                         "is_array": false,
-                        "description": "The shell type (e.g. \"bash\"), the value of the \"$SHELL\" env var will be used if this is not given",
-                        "default": null
+                        "description": "The command to execute",
+                        "default": ""
                     }
                 },
-                "options": {
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",
@@ -203,7 +214,18 @@
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
                         "default": false
-                    },
+                    }
+                },
+                "command-level arguments": {
+                    "shell": {
+                        "name": "shell",
+                        "is_required": false,
+                        "is_array": false,
+                        "description": "The shell type (e.g. \"bash\"), the value of the \"$SHELL\" env var will be used if this is not given",
+                        "default": null
+                    }
+                },
+                "command-level options": {
                     "debug": {
                         "name": "--debug",
                         "shortcut": "",
@@ -225,7 +247,81 @@
             "description": "Display help for a command",
             "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>%%PHP_SELF%% help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
             "definition": {
-                "arguments": {
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "The command to execute",
+                        "default": ""
+                    }
+                },
+                "application-level options": {
+                    "help": {
+                        "name": "--help",
+                        "shortcut": "-h",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
+                        "default": false
+                    },
+                    "quiet": {
+                        "name": "--quiet",
+                        "shortcut": "-q",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
+                    "verbose": {
+                        "name": "--verbose",
+                        "shortcut": "-v|-vv|-vvv",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
+                        "default": false
+                    },
+                    "version": {
+                        "name": "--version",
+                        "shortcut": "-V",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this application version",
+                        "default": false
+                    },
+                    "ansi": {
+                        "name": "--ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "default": null
+                    },
+                    "no-ansi": {
+                        "name": "--no-ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Negate the \"--ansi\" option",
+                        "default": null
+                    },
+                    "no-interaction": {
+                        "name": "--no-interaction",
+                        "shortcut": "-n",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not ask any interactive question",
+                        "default": false
+                    }
+                },
+                "command-level arguments": {
                     "command_name": {
                         "name": "command_name",
                         "is_required": false,
@@ -234,7 +330,7 @@
                         "default": "help"
                     }
                 },
-                "options": {
+                "command-level options": {
                     "format": {
                         "name": "--format",
                         "shortcut": "",
@@ -252,7 +348,29 @@
                         "is_multiple": false,
                         "description": "To output raw command help",
                         "default": false
-                    },
+                    }
+                }
+            }
+        },
+        {
+            "name": "list",
+            "hidden": false,
+            "usage": [
+                "list [--raw] [--format FORMAT] [--short] [--] [<namespace>]"
+            ],
+            "description": "List commands",
+            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>%%PHP_SELF%% list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>%%PHP_SELF%% list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>%%PHP_SELF%% list --raw<\/info>",
+            "definition": {
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "The command to execute",
+                        "default": ""
+                    }
+                },
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",
@@ -316,19 +434,8 @@
                         "description": "Do not ask any interactive question",
                         "default": false
                     }
-                }
-            }
-        },
-        {
-            "name": "list",
-            "hidden": false,
-            "usage": [
-                "list [--raw] [--format FORMAT] [--short] [--] [<namespace>]"
-            ],
-            "description": "List commands",
-            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>%%PHP_SELF%% list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>%%PHP_SELF%% list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>%%PHP_SELF%% list --raw<\/info>",
-            "definition": {
-                "arguments": {
+                },
+                "command-level arguments": {
                     "namespace": {
                         "name": "namespace",
                         "is_required": false,
@@ -337,7 +444,7 @@
                         "default": null
                     }
                 },
-                "options": {
+                "command-level options": {
                     "raw": {
                         "name": "--raw",
                         "shortcut": "",
@@ -355,69 +462,6 @@
                         "is_multiple": false,
                         "description": "The output format (txt, xml, json, or md)",
                         "default": "txt"
-                    },
-                    "help": {
-                        "name": "--help",
-                        "shortcut": "-h",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
-                        "default": false
-                    },
-                    "quiet": {
-                        "name": "--quiet",
-                        "shortcut": "-q",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Do not output any message",
-                        "default": false
-                    },
-                    "verbose": {
-                        "name": "--verbose",
-                        "shortcut": "-v|-vv|-vvv",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
-                        "default": false
-                    },
-                    "version": {
-                        "name": "--version",
-                        "shortcut": "-V",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Display this application version",
-                        "default": false
-                    },
-                    "ansi": {
-                        "name": "--ansi",
-                        "shortcut": "",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
-                        "default": null
-                    },
-                    "no-ansi": {
-                        "name": "--no-ansi",
-                        "shortcut": "",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
-                        "default": null
-                    },
-                    "no-interaction": {
-                        "name": "--no-interaction",
-                        "shortcut": "-n",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Do not ask any interactive question",
-                        "default": false
                     },
                     "short": {
                         "name": "--short",

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
@@ -16,27 +16,17 @@ Dump the shell completion script
 
 Dump the shell completion script
 
-### Arguments
+### Application-level Arguments
 
-#### `shell`
+#### `command`
 
-The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+The command to execute
 
-* Is required: no
+* Is required: yes
 * Is array: no
 * Default: `NULL`
 
-### Options
-
-#### `--debug`
-
-Tail the completion debug log
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -91,6 +81,28 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+### Command-level Arguments
+
+#### `shell`
+
+The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+* Is required: no
+* Is array: no
+* Default: `NULL`
+
+### Command-level Options
+
+#### `--debug`
+
+Tail the completion debug log
 
 * Accept value: no
 * Is value required: no
@@ -117,37 +129,17 @@ You can also output the help in other formats by using the --format option:
 
 To display the list of available commands, please use the list command.
 
-### Arguments
+### Application-level Arguments
 
-#### `command_name`
+#### `command`
 
-The command name
+The command to execute
 
-* Is required: no
+* Is required: yes
 * Is array: no
-* Default: `'help'`
+* Default: `NULL`
 
-### Options
-
-#### `--format`
-
-The output format (txt, xml, json, or md)
-
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `'txt'`
-
-#### `--raw`
-
-To output raw command help
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -202,6 +194,38 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+### Command-level Arguments
+
+#### `command_name`
+
+The command name
+
+* Is required: no
+* Is array: no
+* Default: `'help'`
+
+### Command-level Options
+
+#### `--format`
+
+The output format (txt, xml, json, or md)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'txt'`
+
+#### `--raw`
+
+To output raw command help
 
 * Accept value: no
 * Is value required: no
@@ -234,47 +258,17 @@ It's also possible to get raw list of commands (useful for embedding command run
 
   %%PHP_SELF%% list --raw
 
-### Arguments
+### Application-level Arguments
 
-#### `namespace`
+#### `command`
 
-The namespace name
+The command to execute
 
-* Is required: no
+* Is required: yes
 * Is array: no
 * Default: `NULL`
 
-### Options
-
-#### `--raw`
-
-To output raw command list
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
-
-#### `--format`
-
-The output format (txt, xml, json, or md)
-
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `'txt'`
-
-#### `--short`
-
-To skip describing commands' arguments
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -329,6 +323,48 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+### Command-level Arguments
+
+#### `namespace`
+
+The namespace name
+
+* Is required: no
+* Is array: no
+* Default: `NULL`
+
+### Command-level Options
+
+#### `--raw`
+
+To output raw command list
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--format`
+
+The output format (txt, xml, json, or md)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'txt'`
+
+#### `--short`
+
+To skip describing commands' arguments
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -7,8 +7,36 @@
       </usages>
       <description>Internal command to provide shell completion suggestions</description>
       <help>Internal command to provide shell completion suggestions</help>
-      <arguments/>
-      <options>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="application-level">
+        <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Do not output any message</description>
+        </option>
+        <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
+        </option>
+        <option name="--version" shortcut="-V" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Display this application version</description>
+        </option>
+        <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Force (or disable --no-ansi) ANSI output</description>
+        </option>
+        <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Negate the "--ansi" option</description>
+        </option>
+        <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Do not ask any interactive question</description>
+        </option>
+      </options>
+      <options type="command-level">
         <option name="--shell" shortcut="-s" accept_value="1" is_value_required="1" is_multiple="0">
           <description>The shell type ("bash", "fish", "zsh")</description>
           <defaults/>
@@ -29,6 +57,21 @@
           <description>deprecated</description>
           <defaults/>
         </option>
+      </options>
+    </command>
+    <command id="completion" name="completion" hidden="0">
+      <usages>
+        <usage>completion [--debug] [--] [&lt;shell&gt;]</usage>
+      </usages>
+      <description>Dump the shell completion script</description>
+      <help>Dump the shell completion script</help>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
@@ -51,43 +94,15 @@
           <description>Do not ask any interactive question</description>
         </option>
       </options>
-    </command>
-    <command id="completion" name="completion" hidden="0">
-      <usages>
-        <usage>completion [--debug] [--] [&lt;shell&gt;]</usage>
-      </usages>
-      <description>Dump the shell completion script</description>
-      <help>Dump the shell completion script</help>
-      <arguments>
+      <arguments type="command-level">
         <argument name="shell" is_required="0" is_array="0">
           <description>The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given</description>
           <defaults/>
         </argument>
       </arguments>
-      <options>
+      <options type="command-level">
         <option name="--debug" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Tail the completion debug log</description>
-        </option>
-        <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
-        </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Do not output any message</description>
-        </option>
-        <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
-        </option>
-        <option name="--version" shortcut="-V" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this application version</description>
-        </option>
-        <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
-        </option>
-        <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
-        </option>
-        <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Do not ask any interactive question</description>
         </option>
       </options>
     </command>
@@ -105,24 +120,13 @@
    &lt;info&gt;%%PHP_SELF%% help --format=xml list&lt;/info&gt;
  
  To display the list of available commands, please use the &lt;info&gt;list&lt;/info&gt; command.</help>
-      <arguments>
-        <argument name="command_name" is_required="0" is_array="0">
-          <description>The command name</description>
-          <defaults>
-            <default>help</default>
-          </defaults>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
+          <defaults/>
         </argument>
       </arguments>
-      <options>
-        <option name="--format" shortcut="" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The output format (txt, xml, json, or md)</description>
-          <defaults>
-            <default>txt</default>
-          </defaults>
-        </option>
-        <option name="--raw" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>To output raw command help</description>
-        </option>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
@@ -143,6 +147,25 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+      </options>
+      <arguments type="command-level">
+        <argument name="command_name" is_required="0" is_array="0">
+          <description>The command name</description>
+          <defaults>
+            <default>help</default>
+          </defaults>
+        </argument>
+      </arguments>
+      <options type="command-level">
+        <option name="--format" shortcut="" accept_value="1" is_value_required="1" is_multiple="0">
+          <description>The output format (txt, xml, json, or md)</description>
+          <defaults>
+            <default>txt</default>
+          </defaults>
+        </option>
+        <option name="--raw" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>To output raw command help</description>
         </option>
       </options>
     </command>
@@ -166,25 +189,13 @@
  It's also possible to get raw list of commands (useful for embedding command runner):
  
    &lt;info&gt;%%PHP_SELF%% list --raw&lt;/info&gt;</help>
-      <arguments>
-        <argument name="namespace" is_required="0" is_array="0">
-          <description>The namespace name</description>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
           <defaults/>
         </argument>
       </arguments>
-      <options>
-        <option name="--raw" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>To output raw command list</description>
-        </option>
-        <option name="--format" shortcut="" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The output format (txt, xml, json, or md)</description>
-          <defaults>
-            <default>txt</default>
-          </defaults>
-        </option>
-        <option name="--short" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>To skip describing commands' arguments</description>
-        </option>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
@@ -205,6 +216,26 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+      </options>
+      <arguments type="command-level">
+        <argument name="namespace" is_required="0" is_array="0">
+          <description>The namespace name</description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="command-level">
+        <option name="--raw" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>To output raw command list</description>
+        </option>
+        <option name="--format" shortcut="" accept_value="1" is_value_required="1" is_multiple="0">
+          <description>The output format (txt, xml, json, or md)</description>
+          <defaults>
+            <default>txt</default>
+          </defaults>
+        </option>
+        <option name="--short" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>To skip describing commands' arguments</description>
         </option>
       </options>
     </command>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -13,17 +13,16 @@
             "description": "Internal command to provide shell completion suggestions",
             "help": "Internal command to provide shell completion suggestions",
             "definition": {
-                "arguments": [],
-                "options": {
-                    "symfony": {
-                        "name": "--symfony",
-                        "shortcut": "-S",
-                        "accept_value": true,
-                        "is_value_required": true,
-                        "is_multiple": false,
-                        "description": "deprecated",
-                        "default": null
-                    },
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "The command to execute",
+                        "default": ""
+                    }
+                },
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",
@@ -86,7 +85,10 @@
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
                         "default": false
-                    },
+                    }
+                },
+                "command-level arguments": [],
+                "command-level options": {
                     "shell": {
                         "name": "--shell",
                         "shortcut": "-s",
@@ -122,6 +124,15 @@
                         "is_multiple": false,
                         "description": "The API version of the completion script",
                         "default": null
+                    },
+                    "symfony": {
+                        "name": "--symfony",
+                        "shortcut": "-S",
+                        "accept_value": true,
+                        "is_value_required": true,
+                        "is_multiple": false,
+                        "description": "deprecated",
+                        "default": null
                     }
                 }
             }
@@ -135,16 +146,16 @@
             "description": "Dump the shell completion script",
             "help": "Dump the shell completion script",
             "definition": {
-                "arguments": {
-                    "shell": {
-                        "name": "shell",
-                        "is_required": false,
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
                         "is_array": false,
-                        "description": "The shell type (e.g. \"bash\"), the value of the \"$SHELL\" env var will be used if this is not given",
-                        "default": null
+                        "description": "The command to execute",
+                        "default": ""
                     }
                 },
-                "options": {
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",
@@ -207,7 +218,18 @@
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
                         "default": false
-                    },
+                    }
+                },
+                "command-level arguments": {
+                    "shell": {
+                        "name": "shell",
+                        "is_required": false,
+                        "is_array": false,
+                        "description": "The shell type (e.g. \"bash\"), the value of the \"$SHELL\" env var will be used if this is not given",
+                        "default": null
+                    }
+                },
+                "command-level options": {
                     "debug": {
                         "name": "--debug",
                         "shortcut": "",
@@ -229,7 +251,81 @@
             "description": "Display help for a command",
             "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>%%PHP_SELF%% help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
             "definition": {
-                "arguments": {
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "The command to execute",
+                        "default": ""
+                    }
+                },
+                "application-level options": {
+                    "help": {
+                        "name": "--help",
+                        "shortcut": "-h",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
+                        "default": false
+                    },
+                    "quiet": {
+                        "name": "--quiet",
+                        "shortcut": "-q",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
+                    "verbose": {
+                        "name": "--verbose",
+                        "shortcut": "-v|-vv|-vvv",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
+                        "default": false
+                    },
+                    "version": {
+                        "name": "--version",
+                        "shortcut": "-V",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this application version",
+                        "default": false
+                    },
+                    "ansi": {
+                        "name": "--ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "default": null
+                    },
+                    "no-ansi": {
+                        "name": "--no-ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Negate the \"--ansi\" option",
+                        "default": null
+                    },
+                    "no-interaction": {
+                        "name": "--no-interaction",
+                        "shortcut": "-n",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not ask any interactive question",
+                        "default": false
+                    }
+                },
+                "command-level arguments": {
                     "command_name": {
                         "name": "command_name",
                         "is_required": false,
@@ -238,7 +334,7 @@
                         "default": "help"
                     }
                 },
-                "options": {
+                "command-level options": {
                     "format": {
                         "name": "--format",
                         "shortcut": "",
@@ -256,7 +352,29 @@
                         "is_multiple": false,
                         "description": "To output raw command help",
                         "default": false
-                    },
+                    }
+                }
+            }
+        },
+        {
+            "name": "list",
+            "hidden": false,
+            "usage": [
+                "list [--raw] [--format FORMAT] [--short] [--] [<namespace>]"
+            ],
+            "description": "List commands",
+            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>%%PHP_SELF%% list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>%%PHP_SELF%% list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>%%PHP_SELF%% list --raw<\/info>",
+            "definition": {
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "The command to execute",
+                        "default": ""
+                    }
+                },
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",
@@ -320,19 +438,8 @@
                         "description": "Do not ask any interactive question",
                         "default": false
                     }
-                }
-            }
-        },
-        {
-            "name": "list",
-            "hidden": false,
-            "usage": [
-                "list [--raw] [--format FORMAT] [--short] [--] [<namespace>]"
-            ],
-            "description": "List commands",
-            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>%%PHP_SELF%% list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>%%PHP_SELF%% list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>%%PHP_SELF%% list --raw<\/info>",
-            "definition": {
-                "arguments": {
+                },
+                "command-level arguments": {
                     "namespace": {
                         "name": "namespace",
                         "is_required": false,
@@ -341,7 +448,7 @@
                         "default": null
                     }
                 },
-                "options": {
+                "command-level options": {
                     "raw": {
                         "name": "--raw",
                         "shortcut": "",
@@ -359,69 +466,6 @@
                         "is_multiple": false,
                         "description": "The output format (txt, xml, json, or md)",
                         "default": "txt"
-                    },
-                    "help": {
-                        "name": "--help",
-                        "shortcut": "-h",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
-                        "default": false
-                    },
-                    "quiet": {
-                        "name": "--quiet",
-                        "shortcut": "-q",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Do not output any message",
-                        "default": false
-                    },
-                    "verbose": {
-                        "name": "--verbose",
-                        "shortcut": "-v|-vv|-vvv",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
-                        "default": false
-                    },
-                    "version": {
-                        "name": "--version",
-                        "shortcut": "-V",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Display this application version",
-                        "default": false
-                    },
-                    "ansi": {
-                        "name": "--ansi",
-                        "shortcut": "",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
-                        "default": null
-                    },
-                    "no-ansi": {
-                        "name": "--no-ansi",
-                        "shortcut": "",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
-                        "default": null
-                    },
-                    "no-interaction": {
-                        "name": "--no-interaction",
-                        "shortcut": "-n",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "Do not ask any interactive question",
-                        "default": false
                     },
                     "short": {
                         "name": "--short",
@@ -446,8 +490,16 @@
             "description": "command 1 description",
             "help": "command 1 help",
             "definition": {
-                "arguments": [],
-                "options": {
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "The command to execute",
+                        "default": ""
+                    }
+                },
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",
@@ -525,25 +577,16 @@
             "description": "command 2 description",
             "help": "command 2 help",
             "definition": {
-                "arguments": {
-                    "argument_name": {
-                        "name": "argument_name",
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
                         "is_required": true,
                         "is_array": false,
-                        "description": "",
-                        "default": null
+                        "description": "The command to execute",
+                        "default": ""
                     }
                 },
-                "options": {
-                    "option_name": {
-                        "name": "--option_name",
-                        "shortcut": "-o",
-                        "accept_value": false,
-                        "is_value_required": false,
-                        "is_multiple": false,
-                        "description": "",
-                        "default": false
-                    },
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",
@@ -607,6 +650,26 @@
                         "description": "Do not ask any interactive question",
                         "default": false
                     }
+                },
+                "command-level arguments": {
+                    "argument_name": {
+                        "name": "argument_name",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "",
+                        "default": null
+                    }
+                },
+                "command-level options": {
+                    "option_name": {
+                        "name": "--option_name",
+                        "shortcut": "-o",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "",
+                        "default": false
+                    }
                 }
             }
         },
@@ -619,8 +682,16 @@
             "description": "command 3 description",
             "help": "command 3 help",
             "definition": {
-                "arguments": {},
-                "options": {
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "The command to execute",
+                        "default": ""
+                    }
+                },
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",
@@ -695,11 +766,19 @@
                 "descriptor:alias_command4",
                 "command4:descriptor"
             ],
-            "description": null,
+            "description": "",
             "help": "",
             "definition": {
-                "arguments": {},
-                "options": {
+                "application-level arguments": {
+                    "command": {
+                        "name": "command",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "The command to execute",
+                        "default": ""
+                    }
+                },
+                "application-level options": {
                     "help": {
                         "name": "--help",
                         "shortcut": "-h",

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -29,27 +29,17 @@ Dump the shell completion script
 
 Dump the shell completion script
 
-### Arguments
+### Application-level Arguments
 
-#### `shell`
+#### `command`
 
-The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+The command to execute
 
-* Is required: no
+* Is required: yes
 * Is array: no
 * Default: `NULL`
 
-### Options
-
-#### `--debug`
-
-Tail the completion debug log
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -104,6 +94,28 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+### Command-level Arguments
+
+#### `shell`
+
+The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+* Is required: no
+* Is array: no
+* Default: `NULL`
+
+### Command-level Options
+
+#### `--debug`
+
+Tail the completion debug log
 
 * Accept value: no
 * Is value required: no
@@ -130,37 +142,17 @@ You can also output the help in other formats by using the --format option:
 
 To display the list of available commands, please use the list command.
 
-### Arguments
+### Application-level Arguments
 
-#### `command_name`
+#### `command`
 
-The command name
+The command to execute
 
-* Is required: no
+* Is required: yes
 * Is array: no
-* Default: `'help'`
+* Default: `NULL`
 
-### Options
-
-#### `--format`
-
-The output format (txt, xml, json, or md)
-
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `'txt'`
-
-#### `--raw`
-
-To output raw command help
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -215,6 +207,38 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+### Command-level Arguments
+
+#### `command_name`
+
+The command name
+
+* Is required: no
+* Is array: no
+* Default: `'help'`
+
+### Command-level Options
+
+#### `--format`
+
+The output format (txt, xml, json, or md)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'txt'`
+
+#### `--raw`
+
+To output raw command help
 
 * Accept value: no
 * Is value required: no
@@ -247,47 +271,17 @@ It's also possible to get raw list of commands (useful for embedding command run
 
   %%PHP_SELF%% list --raw
 
-### Arguments
+### Application-level Arguments
 
-#### `namespace`
+#### `command`
 
-The namespace name
+The command to execute
 
-* Is required: no
+* Is required: yes
 * Is array: no
 * Default: `NULL`
 
-### Options
-
-#### `--raw`
-
-To output raw command list
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
-
-#### `--format`
-
-The output format (txt, xml, json, or md)
-
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `'txt'`
-
-#### `--short`
-
-To skip describing commands' arguments
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -349,6 +343,48 @@ Do not ask any interactive question
 * Is negatable: no
 * Default: `false`
 
+### Command-level Arguments
+
+#### `namespace`
+
+The namespace name
+
+* Is required: no
+* Is array: no
+* Default: `NULL`
+
+### Command-level Options
+
+#### `--raw`
+
+To output raw command list
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--format`
+
+The output format (txt, xml, json, or md)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'txt'`
+
+#### `--short`
+
+To skip describing commands' arguments
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
 `descriptor:command1`
 ---------------------
 
@@ -362,7 +398,17 @@ command 1 description
 
 command 1 help
 
-### Options
+### Application-level Arguments
+
+#### `command`
+
+The command to execute
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Application-level Options
 
 #### `--help|-h`
 
@@ -437,23 +483,17 @@ command 2 description
 
 command 2 help
 
-### Arguments
+### Application-level Arguments
 
-#### `argument_name`
+#### `command`
+
+The command to execute
 
 * Is required: yes
 * Is array: no
 * Default: `NULL`
 
-### Options
-
-#### `--option_name|-o`
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -515,6 +555,24 @@ Do not ask any interactive question
 * Is negatable: no
 * Default: `false`
 
+### Command-level Arguments
+
+#### `argument_name`
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Command-level Options
+
+#### `--option_name|-o`
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
 `descriptor:command4`
 ---------------------
 
@@ -525,7 +583,17 @@ Do not ask any interactive question
 * `command4:descriptor`
 
 
-### Options
+### Application-level Arguments
+
+#### `command`
+
+The command to execute
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Application-level Options
 
 #### `--help|-h`
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -7,8 +7,36 @@
       </usages>
       <description>Internal command to provide shell completion suggestions</description>
       <help>Internal command to provide shell completion suggestions</help>
-      <arguments/>
-      <options>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="application-level">
+        <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Do not output any message</description>
+        </option>
+        <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
+        </option>
+        <option name="--version" shortcut="-V" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Display this application version</description>
+        </option>
+        <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Force (or disable --no-ansi) ANSI output</description>
+        </option>
+        <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Negate the "--ansi" option</description>
+        </option>
+        <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Do not ask any interactive question</description>
+        </option>
+      </options>
+      <options type="command-level">
         <option name="--shell" shortcut="-s" accept_value="1" is_value_required="1" is_multiple="0">
           <description>The shell type ("bash", "fish", "zsh")</description>
           <defaults/>
@@ -29,6 +57,21 @@
           <description>deprecated</description>
           <defaults/>
         </option>
+      </options>
+    </command>
+    <command id="completion" name="completion" hidden="0">
+      <usages>
+        <usage>completion [--debug] [--] [&lt;shell&gt;]</usage>
+      </usages>
+      <description>Dump the shell completion script</description>
+      <help>Dump the shell completion script</help>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
@@ -51,43 +94,15 @@
           <description>Do not ask any interactive question</description>
         </option>
       </options>
-    </command>
-    <command id="completion" name="completion" hidden="0">
-      <usages>
-        <usage>completion [--debug] [--] [&lt;shell&gt;]</usage>
-      </usages>
-      <description>Dump the shell completion script</description>
-      <help>Dump the shell completion script</help>
-      <arguments>
+      <arguments type="command-level">
         <argument name="shell" is_required="0" is_array="0">
           <description>The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given</description>
           <defaults/>
         </argument>
       </arguments>
-      <options>
+      <options type="command-level">
         <option name="--debug" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Tail the completion debug log</description>
-        </option>
-        <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
-        </option>
-        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Do not output any message</description>
-        </option>
-        <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
-        </option>
-        <option name="--version" shortcut="-V" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this application version</description>
-        </option>
-        <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
-        </option>
-        <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
-        </option>
-        <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Do not ask any interactive question</description>
         </option>
       </options>
     </command>
@@ -105,24 +120,13 @@
    &lt;info&gt;%%PHP_SELF%% help --format=xml list&lt;/info&gt;
  
  To display the list of available commands, please use the &lt;info&gt;list&lt;/info&gt; command.</help>
-      <arguments>
-        <argument name="command_name" is_required="0" is_array="0">
-          <description>The command name</description>
-          <defaults>
-            <default>help</default>
-          </defaults>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
+          <defaults/>
         </argument>
       </arguments>
-      <options>
-        <option name="--format" shortcut="" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The output format (txt, xml, json, or md)</description>
-          <defaults>
-            <default>txt</default>
-          </defaults>
-        </option>
-        <option name="--raw" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>To output raw command help</description>
-        </option>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
@@ -143,6 +147,25 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+      </options>
+      <arguments type="command-level">
+        <argument name="command_name" is_required="0" is_array="0">
+          <description>The command name</description>
+          <defaults>
+            <default>help</default>
+          </defaults>
+        </argument>
+      </arguments>
+      <options type="command-level">
+        <option name="--format" shortcut="" accept_value="1" is_value_required="1" is_multiple="0">
+          <description>The output format (txt, xml, json, or md)</description>
+          <defaults>
+            <default>txt</default>
+          </defaults>
+        </option>
+        <option name="--raw" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>To output raw command help</description>
         </option>
       </options>
     </command>
@@ -166,25 +189,13 @@
  It's also possible to get raw list of commands (useful for embedding command runner):
  
    &lt;info&gt;%%PHP_SELF%% list --raw&lt;/info&gt;</help>
-      <arguments>
-        <argument name="namespace" is_required="0" is_array="0">
-          <description>The namespace name</description>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
           <defaults/>
         </argument>
       </arguments>
-      <options>
-        <option name="--raw" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>To output raw command list</description>
-        </option>
-        <option name="--format" shortcut="" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The output format (txt, xml, json, or md)</description>
-          <defaults>
-            <default>txt</default>
-          </defaults>
-        </option>
-        <option name="--short" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>To skip describing commands' arguments</description>
-        </option>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
@@ -207,6 +218,26 @@
           <description>Do not ask any interactive question</description>
         </option>
       </options>
+      <arguments type="command-level">
+        <argument name="namespace" is_required="0" is_array="0">
+          <description>The namespace name</description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="command-level">
+        <option name="--raw" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>To output raw command list</description>
+        </option>
+        <option name="--format" shortcut="" accept_value="1" is_value_required="1" is_multiple="0">
+          <description>The output format (txt, xml, json, or md)</description>
+          <defaults>
+            <default>txt</default>
+          </defaults>
+        </option>
+        <option name="--short" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>To skip describing commands' arguments</description>
+        </option>
+      </options>
     </command>
     <command id="descriptor:command1" name="descriptor:command1" hidden="0">
       <usages>
@@ -216,8 +247,13 @@
       </usages>
       <description>command 1 description</description>
       <help>command 1 help</help>
-      <arguments/>
-      <options>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
@@ -249,16 +285,13 @@
       </usages>
       <description>command 2 description</description>
       <help>command 2 help</help>
-      <arguments>
-        <argument name="argument_name" is_required="1" is_array="0">
-          <description></description>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
           <defaults/>
         </argument>
       </arguments>
-      <options>
-        <option name="--option_name" shortcut="-o" accept_value="0" is_value_required="0" is_multiple="0">
-          <description></description>
-        </option>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
@@ -281,6 +314,17 @@
           <description>Do not ask any interactive question</description>
         </option>
       </options>
+      <arguments type="command-level">
+        <argument name="argument_name" is_required="1" is_array="0">
+          <description></description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="command-level">
+        <option name="--option_name" shortcut="-o" accept_value="0" is_value_required="0" is_multiple="0">
+          <description></description>
+        </option>
+      </options>
     </command>
     <command id="descriptor:command3" name="descriptor:command3" hidden="1">
       <usages>
@@ -288,8 +332,13 @@
       </usages>
       <description>command 3 description</description>
       <help>command 3 help</help>
-      <arguments/>
-      <options>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
@@ -321,8 +370,13 @@
       </usages>
       <description></description>
       <help></help>
-      <arguments/>
-      <options>
+      <arguments type="application-level">
+        <argument name="command" is_required="1" is_array="0">
+          <description>The command to execute</description>
+          <defaults/>
+        </argument>
+      </arguments>
+      <options type="application-level">
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
@@ -20,27 +20,17 @@ Dump the shell completion script
 
 Dump the shell completion script
 
-### Arguments
+### Application-level Arguments
 
-#### `shell`
+#### `command`
 
-The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+The command to execute
 
-* Is required: no
+* Is required: yes
 * Is array: no
 * Default: `NULL`
 
-### Options
-
-#### `--debug`
-
-Tail the completion debug log
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -95,6 +85,28 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+### Command-level Arguments
+
+#### `shell`
+
+The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+* Is required: no
+* Is array: no
+* Default: `NULL`
+
+### Command-level Options
+
+#### `--debug`
+
+Tail the completion debug log
 
 * Accept value: no
 * Is value required: no
@@ -121,37 +133,17 @@ You can also output the help in other formats by using the --format option:
 
 To display the list of available commands, please use the list command.
 
-### Arguments
+### Application-level Arguments
 
-#### `command_name`
+#### `command`
 
-The command name
+The command to execute
 
-* Is required: no
+* Is required: yes
 * Is array: no
-* Default: `'help'`
+* Default: `NULL`
 
-### Options
-
-#### `--format`
-
-The output format (txt, xml, json, or md)
-
-* Accept value: yes
-* Is value required: yes
-* Is multiple: no
-* Is negatable: no
-* Default: `'txt'`
-
-#### `--raw`
-
-To output raw command help
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -206,6 +198,38 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+### Command-level Arguments
+
+#### `command_name`
+
+The command name
+
+* Is required: no
+* Is array: no
+* Default: `'help'`
+
+### Command-level Options
+
+#### `--format`
+
+The output format (txt, xml, json, or md)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `'txt'`
+
+#### `--raw`
+
+To output raw command help
 
 * Accept value: no
 * Is value required: no
@@ -238,7 +262,79 @@ It's also possible to get raw list of commands (useful for embedding command run
 
   %%PHP_SELF%% list --raw
 
-### Arguments
+### Application-level Arguments
+
+#### `command`
+
+The command to execute
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Application-level Options
+
+#### `--help|-h`
+
+Display help for the given command. When no command is given display help for the list command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--ansi|--no-ansi`
+
+Force (or disable --no-ansi) ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: yes
+* Default: `NULL`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+### Command-level Arguments
 
 #### `namespace`
 
@@ -248,7 +344,7 @@ The namespace name
 * Is array: no
 * Default: `NULL`
 
-### Options
+### Command-level Options
 
 #### `--raw`
 
@@ -280,66 +376,6 @@ To skip describing commands' arguments
 * Is negatable: no
 * Default: `false`
 
-#### `--help|-h`
-
-Display help for the given command. When no command is given display help for the list command
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
-
-#### `--quiet|-q`
-
-Do not output any message
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
-
-#### `--verbose|-v|-vv|-vvv`
-
-Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
-
-#### `--version|-V`
-
-Display this application version
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
-
-#### `--ansi|--no-ansi`
-
-Force (or disable --no-ansi) ANSI output
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: yes
-* Default: `NULL`
-
-#### `--no-interaction|-n`
-
-Do not ask any interactive question
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
-
 `descriptor:åèä`
 ----------------
 
@@ -353,23 +389,17 @@ command åèä description
 
 command åèä help
 
-### Arguments
+### Application-level Arguments
 
-#### `argument_åèä`
+#### `command`
+
+The command to execute
 
 * Is required: yes
 * Is array: no
 * Default: `NULL`
 
-### Options
-
-#### `--option_åèä|-o`
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
+### Application-level Options
 
 #### `--help|-h`
 
@@ -424,6 +454,24 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+### Command-level Arguments
+
+#### `argument_åèä`
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Command-level Options
+
+#### `--option_åèä|-o`
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -4,19 +4,24 @@ Description:
 Usage:
   list [options] [--] [<namespace>]
 
-Arguments:
-  namespace             The namespace name
+Application-level Arguments:
+  command               The command to execute [default: "list"]
 
-Options:
-      --raw             To output raw command list
-      --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
-      --short           To skip describing commands' arguments
+Application-level Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+Command-level Arguments:
+  namespace            The namespace name
+
+Command-level Options:
+      --raw            To output raw command list
+      --format=FORMAT  The output format (txt, xml, json, or md) [default: "txt"]
+      --short          To skip describing commands' arguments
 
 Help:
   The list command lists all commands:

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -4,19 +4,24 @@ Description:
 Usage:
   list [options] [--] [<namespace>]
 
-Arguments:
-  namespace             The namespace name
+Application-level Arguments:
+  command               The command to execute [default: "list"]
 
-Options:
-      --raw             To output raw command list
-      --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
-      --short           To skip describing commands' arguments
+Application-level Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+Command-level Arguments:
+  namespace            The namespace name
+
+Command-level Options:
+      --raw            To output raw command list
+      --format=FORMAT  The output format (txt, xml, json, or md) [default: "txt"]
+      --short          To skip describing commands' arguments
 
 Help:
   The list command lists all commands:

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
@@ -4,18 +4,23 @@ Description:
 Usage:
   help [options] [--] [<command_name>]
 
-Arguments:
-  command_name          The command name [default: "help"]
+Application-level Arguments:
+  command               The command to execute [default: "list"]
 
-Options:
-      --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
-      --raw             To output raw command help
+Application-level Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+Command-level Arguments:
+  command_name         The command name [default: "help"]
+
+Command-level Options:
+      --format=FORMAT  The output format (txt, xml, json, or md) [default: "txt"]
+      --raw            To output raw command help
 
 Help:
   The help command displays help for a given command:

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.json
@@ -9,7 +9,5 @@
     "description": "command 1 description",
     "help": "command 1 help",
     "definition": {
-        "arguments": [],
-        "options": []
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.xml
@@ -7,6 +7,4 @@
   </usages>
   <description>command 1 description</description>
   <help>command 1 help</help>
-  <arguments/>
-  <options/>
 </command>

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.json
@@ -9,7 +9,7 @@
     "description": "command 2 description",
     "help": "command 2 help",
     "definition": {
-        "arguments": {
+        "command-level arguments": {
             "argument_name": {
                 "name": "argument_name",
                 "is_required": true,
@@ -18,7 +18,7 @@
                 "default": null
             }
         },
-        "options": {
+        "command-level options": {
             "option_name": {
                 "name": "--option_name",
                 "shortcut": "-o",

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.md
@@ -11,7 +11,7 @@ command 2 description
 
 command 2 help
 
-### Arguments
+### Command-level Arguments
 
 #### `argument_name`
 
@@ -19,7 +19,7 @@ command 2 help
 * Is array: no
 * Default: `NULL`
 
-### Options
+### Command-level Options
 
 #### `--option_name|-o`
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
@@ -6,10 +6,10 @@
   descriptor:command2 -o|--option_name \<argument_name\>
   descriptor:command2 \<argument_name\>
 
-<comment>Arguments:</comment>
+<comment>Command-level Arguments:</comment>
   <info>argument_name</info>      
 
-<comment>Options:</comment>
+<comment>Command-level Options:</comment>
   <info>-o, --option_name</info>  
 
 <comment>Help:</comment>

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.xml
@@ -7,13 +7,13 @@
   </usages>
   <description>command 2 description</description>
   <help>command 2 help</help>
-  <arguments>
+  <arguments type="command-level">
     <argument name="argument_name" is_required="1" is_array="0">
       <description></description>
       <defaults/>
     </argument>
   </arguments>
-  <options>
+  <options type="command-level">
     <option name="--option_name" shortcut="-o" accept_value="0" is_value_required="0" is_multiple="0">
       <description></description>
     </option>

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.md
@@ -11,7 +11,7 @@ command åèä description
 
 command åèä help
 
-### Arguments
+### Command-level Arguments
 
 #### `argument_åèä`
 
@@ -19,7 +19,7 @@ command åèä help
 * Is array: no
 * Default: `NULL`
 
-### Options
+### Command-level Options
 
 #### `--option_åèä|-o`
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
@@ -6,10 +6,10 @@
   descriptor:åèä -o|--option_name \<argument_name\>
   descriptor:åèä \<argument_name\>
 
-<comment>Arguments:</comment>
+<comment>Command-level Arguments:</comment>
   <info>argument_åèä</info>   
 
-<comment>Options:</comment>
+<comment>Command-level Options:</comment>
   <info>-o, --option_åèä</info>  
 
 <comment>Help:</comment>

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_1.xml
@@ -1,5 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definition>
-  <arguments/>
-  <options/>
-</definition>
+<definition/>

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_2.xml
@@ -6,5 +6,4 @@
       <defaults/>
     </argument>
   </arguments>
-  <options/>
 </definition>

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_3.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_3.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definition>
-  <arguments/>
   <options>
     <option name="--option_name" shortcut="-o" accept_value="0" is_value_required="0" is_multiple="0">
       <description></description>

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
@@ -27,7 +27,7 @@ require $vendor.'/vendor/autoload.php';
 Usage:
   %s
 
-Options:
+Application-level Options:
   -h, --help            Display help for the given command. When no command is given display help for the %s command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #42765 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
| BC Break     | I think yes

Create a file in the root directory of a Symfony project with the following code, then run `php FILENAME echo --help --format FORMAT`
```php
#!/usr/bin/env php
<?php

require __DIR__ . '/vendor/autoload.php';

use Symfony\Component\Console\Application;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Input\InputOption;
use Symfony\Component\Console\Output\OutputInterface;

$application = new Application('jlslew', '1.0.0');

$application->add(new class extends Command {
    protected function configure(): void
    {
        $this->setName('echo')
            ->setDescription('The description of the command')
            ->addArgument('argument', InputArgument::REQUIRED, 'The argument to execute')
            ->addOption('option', mode: InputOption::VALUE_REQUIRED, description: 'The option to execute');
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        $output->writeln('Hello World!');
        return 0;
    }
});

$application->run();
```

EDIT: It might break BC because methods' signature has been changed (Added an argument with a default value)