### PR TITLE
[Form] Aligning Interface code to follow Symfony Code Standards

### DIFF
--- a/src/Symfony/Component/Form/FormRendererEngineInterface.php
+++ b/src/Symfony/Component/Form/FormRendererEngineInterface.php
@@ -127,8 +127,6 @@ interface FormRendererEngineInterface
      * @param FormView $view      The view to render
      * @param mixed    $resource  The renderer resource
      * @param array    $variables The variables to pass to the template
-     *
-     * @return string
      */
-    public function renderBlock(FormView $view, mixed $resource, string $blockName, array $variables = []);
+    public function renderBlock(FormView $view, mixed $resource, string $blockName, array $variables = []): string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Adding return type `string` for the method `renderBlock` and removing the `@return string` PHPDoc because it does not provide any useful information as pointed out by the [Symfony Code Standard Documentation](https://symfony.com/doc/current/contributing/code/standards.html#symfony-coding-standards-in-detail):

_Add PHPDoc blocks for classes, methods, and functions only when they add relevant information that does not duplicate the name, native type declaration or context (e.g. instanceof checks);_