### PR TITLE
Using identical comparison for path validation

### DIFF
--- a/src/Symfony/Component/Asset/VersionStrategy/StaticVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/StaticVersionStrategy.php
@@ -46,7 +46,7 @@ class StaticVersionStrategy implements VersionStrategyInterface
     {
         $versionized = sprintf($this->format, ltrim($path, '/'), $this->getVersion($path));
 
-        if ($path && '/' == $path[0]) {
+        if ($path && '/' === $path[0]) {
             return '/'.$versionized;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| License       | MIT

As pointed out by the [Symfony Code Standard Documentation](https://symfony.com/doc/current/contributing/code/standards.html#structure), always use `identical comparison` (unless type juggling is required) (~ I do not see a case for it in here):

_Always use [identical comparison](https://www.php.net/manual/en/language.operators.comparison.php) unless you need type juggling;_
