### PR TITLE
[HttpClient] Fix computing retry delay when using RetryableHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/RetryableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/RetryableHttpClient.php
@@ -138,7 +138,7 @@ class RetryableHttpClient implements HttpClientInterface, ResetInterface
     {
         if (null !== $after = $headers['retry-after'][0] ?? null) {
             if (is_numeric($after)) {
-                return (int) $after * 1000;
+                return (int) ($after * 1000);
             }
 
             if (false !== $time = strtotime($after)) {

--- a/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
@@ -187,4 +187,42 @@ class RetryableHttpClientTest extends TestCase
             $response->cancel();
         }
     }
+
+    public function testRetryWithDelay()
+    {
+        $retryAfter = '0.46';
+
+        $client = new RetryableHttpClient(
+            new MockHttpClient([
+                new MockResponse('', [
+                    'http_code' => 503,
+                    'response_headers' => [
+                        'retry-after' => $retryAfter,
+                    ],
+                ]),
+                new MockResponse('', [
+                    'http_code' => 200,
+                ]),
+            ]),
+            new GenericRetryStrategy(),
+            1,
+            $logger = new class() extends TestLogger {
+                public array $context = [];
+
+                public function log($level, $message, array $context = []): void
+                {
+                    $this->context = $context;
+                    parent::log($level, $message, $context);
+                }
+            },
+        );
+
+        $client->request('GET', 'http://example.com/foo-bar')->getContent();
+
+        $delay = $logger->context['delay'] ?? null;
+
+        $this->assertArrayHasKey('delay', $logger->context);
+        $this->assertNotNull($delay);
+        $this->assertSame((int) ($retryAfter * 1000), $delay);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #47430 
| License       | MIT

