### PR TITLE
[FrameworkBundle] Allow secrets vaults to be used directly outside Symfony

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
    tagged with `workflow.workflow`, and those with type=state_machine with
    `workflow.state_machine`
  * Add `rate_limiter` configuration option to `messenger.transport` to allow rate limited transports using the RateLimiter component
+ * Remove `@internal` tag from secret vaults to allow them to be used directly outside the framework bundle and custom vaults to be added
 
 6.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/AbstractVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/AbstractVault.php
@@ -13,8 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\Secrets;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
- *
- * @internal
  */
 abstract class AbstractVault
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
@@ -13,8 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\Secrets;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
- *
- * @internal
  */
 class DotenvVault extends AbstractVault
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
@@ -18,8 +18,6 @@ use Symfony\Component\VarExporter\VarExporter;
  * @author Tobias Schultze <http://tobion.de>
  * @author Jérémy Derussé <jeremy@derusse.com>
  * @author Nicolas Grekas <p@tchwork.com>
- *
- * @internal
  */
 class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

This PR removes the internal tag from the secrets vaults.

This allows developers to use them directly without the need to use Symfony config etc. They still have to install the whole framework bundle but that just means an overhead during download, they are still able to directly instantiate the vault using `new SodiumVault(....)` for instance.

Furthermore, by removing internal from the AbstractVault, it is possible to add a custom vault and specify it replacing the `secrets.vault` service for instance.

See ticket: https://github.com/symfony/symfony/issues/44151
and previous PR: https://github.com/symfony/symfony/pull/45571