### PR TITLE
[ExpressionLanguage] Fix coalescing operator deep nested properties

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -69,6 +69,10 @@ class GetAttrNode extends Node
     {
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
+                if ($this->nodes['node'] instanceof GetAttrNode) {
+                    $this->nodes['node']->attributes['is_null_coalesce'] = $this->attributes['is_null_coalesce'];
+                }
+
                 $obj = $this->nodes['node']->evaluate($functions, $values);
                 if (null === $obj && ($this->nodes['attribute']->isNullSafe || $this->attributes['is_null_coalesce'])) {
                     $this->attributes['is_short_circuited'] = true;

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -344,6 +344,7 @@ class ExpressionLanguageTest extends TestCase
 
         yield ['foo.bar ?? "default"', null];
         yield ['foo.bar.baz ?? "default"', (object) ['bar' => null]];
+        yield ['foo.bar.baz.bam ?? "default"', (object) ['bar' => null]];
         yield ['foo.bar ?? foo.baz ?? "default"', null];
         yield ['foo[0] ?? "default"', []];
         yield ['foo["bar"] ?? "default"', ['bar' => null]];


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47192 
| License       | MIT

This is a fix for issue #47192 which consist of dealing with nested object's properties evalution problem occuring for levels 3 and above.
