### PR TITLE
Fix typo in method retrySpecificEnvelopes

### DIFF
--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -150,7 +150,7 @@ EOF
                     break;
                 }
 
-                $this->retrySpecificEnvelops($envelopes, $failureTransportName, $io, $shouldForce);
+                $this->retrySpecificEnvelopes($envelopes, $failureTransportName, $io, $shouldForce);
             }
         } else {
             // get() and ask messages one-by-one
@@ -227,7 +227,7 @@ EOF
         }
     }
 
-    private function retrySpecificEnvelops(array $envelopes, string $failureTransportName, SymfonyStyle $io, bool $shouldForce)
+    private function retrySpecificEnvelopes(array $envelopes, string $failureTransportName, SymfonyStyle $io, bool $shouldForce)
     {
         $receiver = $this->getReceiver($failureTransportName);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix for https://github.com/symfony/symfony/pull/39622
| License       | MIT
