### PR TITLE
[Mime] Fix TextPart broken after being serialized

### DIFF
--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -197,6 +197,7 @@ class TextPart extends AbstractPart
         // convert resources to strings for serialization
         if (null !== $this->seekable) {
             $this->body = $this->getBody();
+            $this->seekable = null;
         }
 
         $this->_headers = $this->getHeaders();

--- a/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
@@ -87,6 +87,8 @@ class TextPartTest extends TestCase
         $p = new TextPart($r);
         $p->getHeaders()->addTextHeader('foo', 'bar');
         $expected = clone $p;
-        $this->assertEquals($expected->toString(), unserialize(serialize($p))->toString());
+        $n = unserialize(serialize($p));
+        $this->assertEquals($expected->toString(), $p->toString());
+        $this->assertEquals($expected->toString(), $n->toString());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

When serializing a TextPart, it's broken as we change the body to a string but we don't reset the seekable property (this property was introduced in 5.4).
