### PR TITLE
[HttpKernel] Regression when ArgumentResolver::getArguments() passes an empty array of reflectors to ArgumentMetadataFactory::createArgumentMetadata()

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -43,7 +43,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
     public function getArguments(Request $request, callable $controller): array
     {
         $arguments = [];
-        $reflectors = $request->attributes->get('_controller_reflectors') ?? [];
+        $reflectors = $request->attributes->get('_controller_reflectors') ?? NULL;
 
         foreach ($this->argumentMetadataFactory->createArgumentMetadata($controller, ...$reflectors) as $metadata) {
             foreach ($this->argumentValueResolvers as $resolver) {

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
@@ -21,10 +21,6 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
     public function createArgumentMetadata(string|object|array $controller, \ReflectionClass $class = null, \ReflectionFunctionAbstract $reflection = null): array
     {
         $arguments = [];
-        if (\is_array($controller)) {
-            $reflection = new \ReflectionMethod($controller[0], $controller[1]);
-            $class = $reflection->class;
-        }
 
         if (null === $reflection) {
             $reflection = new \ReflectionFunction($controller(...));

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
@@ -21,6 +21,10 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
     public function createArgumentMetadata(string|object|array $controller, \ReflectionClass $class = null, \ReflectionFunctionAbstract $reflection = null): array
     {
         $arguments = [];
+        if (\is_array($controller)) {
+            $reflection = new \ReflectionMethod($controller[0], $controller[1]);
+            $class = $reflection->class;
+        }
 
         if (null === $reflection) {
             $reflection = new \ReflectionFunction($controller(...));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

We're in the progress of preparing Drupal 10 for Symfony 6.2 compatibility and found a regression caused by https://github.com/symfony/symfony/pull/46001

Drupal issue is https://www.drupal.org/project/drupal/issues/3284422 (no dedicated issue for this yet)

Easiest way to see this is the original diff from that MR, i.e. https://github.com/symfony/symfony/pull/46001/files#diff-d3747dd395ddb12ee6fd6bdd911faa1cab4e10cfa69489918bf443fc2d25ba2fL28

Restoring the specific handling for $controller as array seems to be enough to fix things on our end, although maybe the call to ReflectionFunction can be changed to handle it too. Just trying to get this up quickly for discussion.

The symptom of this is that the arguments don't get passed to the controller, which is fatal errors everywhere.