### PR TITLE
[Mime] Simplify adding Parts to an Email

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -74,10 +74,16 @@ class TemplatedEmailTest extends TestCase
     "htmlCharset": null,
     "attachments": [
         {
+            "filename": "test.txt",
+            "mediaType": "application",
             "body": "Some Text file",
+            "charset": null,
+            "subtype": "octet-stream",
+            "disposition": "attachment",
             "name": "test.txt",
-            "content-type": null,
-            "inline": false
+            "encoding": "base64",
+            "headers": [],
+            "class": "Symfony\\\Component\\\Mime\\\Part\\\DataPart"
         }
     ],
     "headers": {

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -43,7 +43,7 @@
         "symfony/security-core": "^5.4|^6.0",
         "symfony/security-csrf": "^5.4|^6.0",
         "symfony/security-http": "^5.4|^6.0",
-        "symfony/serializer": "^5.4|^6.0",
+        "symfony/serializer": "^6.2",
         "symfony/stopwatch": "^5.4|^6.0",
         "symfony/console": "^5.4|^6.0",
         "symfony/expression-language": "^5.4|^6.0",

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -21,7 +21,7 @@
         "psr/event-dispatcher": "^1",
         "psr/log": "^1|^2|^3",
         "symfony/event-dispatcher": "^5.4|^6.0",
-        "symfony/mime": "^5.4|^6.0",
+        "symfony/mime": "^6.2",
         "symfony/service-contracts": "^1.1|^2|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Mime/MessageConverter.php
+++ b/src/Symfony/Component/Mime/MessageConverter.php
@@ -114,10 +114,7 @@ final class MessageConverter
                 throw new RuntimeException(sprintf('Unable to create an Email from an instance of "%s" as the body is too complex.', get_debug_type($email)));
             }
 
-            $headers = $part->getPreparedHeaders();
-            $method = 'inline' === $headers->getHeaderBody('Content-Disposition') ? 'embed' : 'attach';
-            $name = $headers->getHeaderParameter('Content-Disposition', 'filename');
-            $email->$method($part->getBody(), $name, $part->getMediaType().'/'.$part->getMediaSubtype());
+            $email->attachPart($part);
         }
 
         return $email;

--- a/src/Symfony/Component/Mime/Part/BodyFile.php
+++ b/src/Symfony/Component/Mime/Part/BodyFile.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Part;
+
+use Symfony\Component\Mime\MimeTypes;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class BodyFile
+{
+    private static $mimeTypes;
+
+    public function __construct(
+        private string $path,
+    ) {
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getContentType(): string
+    {
+        $ext = strtolower(pathinfo($this->path, \PATHINFO_EXTENSION));
+        if (null === self::$mimeTypes) {
+            self::$mimeTypes = new MimeTypes();
+        }
+
+        return self::$mimeTypes->getMimeTypes($ext)[0] ?? 'application/octet-stream';
+    }
+}

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -504,7 +504,9 @@ class EmailTest extends TestCase
         $expected = clone $e;
         $n = unserialize(serialize($e));
         $this->assertEquals($expected->getHeaders(), $n->getHeaders());
-        $this->assertEquals($e->getBody(), $n->getBody());
+        $a = preg_replace(["{boundary=.+\r\n}", "{^\-\-.+\r\n}m"], ['boundary=x', '--x'], $e->getBody()->toString());
+        $b = preg_replace(["{boundary=.+\r\n}", "{^\-\-.+\r\n}m"], ['boundary=x', '--x'], $n->getBody()->toString());
+        $this->assertSame($a, $b);
     }
 
     public function testSymfonySerialize()
@@ -525,10 +527,16 @@ class EmailTest extends TestCase
     "htmlCharset": "utf-8",
     "attachments": [
         {
+            "filename": "test.txt",
+            "mediaType": "application",
             "body": "Some Text file",
+            "charset": null,
+            "subtype": "octet-stream",
+            "disposition": "attachment",
             "name": "test.txt",
-            "content-type": null,
-            "inline": false
+            "encoding": "base64",
+            "headers": [],
+            "class": "Symfony\\\Component\\\Mime\\\Part\\\DataPart"
         }
     ],
     "headers": {
@@ -587,7 +595,7 @@ EOF;
     public function testAttachBodyExpectStringOrResource()
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('The body must be a string or a resource (got "bool").');
+        $this->expectExceptionMessage('The body of "Symfony\Component\Mime\Part\TextPart" must be a string, a resource, or an instance of "Symfony\Component\Mime\Part\BodyFile" (got "bool").');
 
         (new Email())->attach(false);
     }
@@ -595,7 +603,7 @@ EOF;
     public function testEmbedBodyExpectStringOrResource()
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('The body must be a string or a resource (got "bool").');
+        $this->expectExceptionMessage('The body of "Symfony\Component\Mime\Part\TextPart" must be a string, a resource, or an instance of "Symfony\Component\Mime\Part\BodyFile" (got "bool").');
 
         (new Email())->embed(false);
     }

--- a/src/Symfony/Component/Mime/Tests/Fixtures/content.txt
+++ b/src/Symfony/Component/Mime/Tests/Fixtures/content.txt
@@ -1,0 +1,1 @@
+content

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -202,7 +202,6 @@ EOF;
                         "disposition": null,
                         "name": null,
                         "encoding": "quoted-printable",
-                        "seekable": null,
                         "headers": [],
                         "class": "Symfony\\\\Component\\\\Mime\\\\Part\\\TextPart"
                     },
@@ -213,7 +212,6 @@ EOF;
                         "disposition": null,
                         "name": null,
                         "encoding": "quoted-printable",
-                        "seekable": null,
                         "headers": [],
                         "class": "Symfony\\\\Component\\\\Mime\\\\Part\\\\TextPart"
                     }
@@ -224,15 +222,12 @@ EOF;
             {
                 "filename": "text.txt",
                 "mediaType": "application",
-                "cid": null,
-                "handle": null,
                 "body": "text data",
                 "charset": null,
                 "subtype": "octet-stream",
                 "disposition": "attachment",
                 "name": "text.txt",
                 "encoding": "base64",
-                "seekable": null,
                 "headers": [],
                 "class": "Symfony\\\\Component\\\\Mime\\\\Part\\\\DataPart"
             }

--- a/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\ParameterizedHeader;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
+use Symfony\Component\Mime\Part\BodyFile;
 use Symfony\Component\Mime\Part\TextPart;
 
 class TextPartTest extends TestCase
@@ -44,6 +45,14 @@ class TextPartTest extends TestCase
         $this->assertEquals('content', $p->bodyToString());
         $this->assertEquals('content', implode('', iterator_to_array($p->bodyToIterable())));
         fclose($f);
+    }
+
+    public function testConstructorWithBodyFile()
+    {
+        $p = new TextPart(new BodyFile(\dirname(__DIR__).'/Fixtures/content.txt'));
+        $this->assertSame('content', $p->getBody());
+        $this->assertSame('content', $p->bodyToString());
+        $this->assertSame('content', implode('', iterator_to_array($p->bodyToIterable())));
     }
 
     public function testConstructorWithNonStringOrResource()

--- a/src/Symfony/Component/Mime/composer.json
+++ b/src/Symfony/Component/Mime/composer.json
@@ -27,7 +27,7 @@
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/property-access": "^5.4|^6.0",
         "symfony/property-info": "^5.4|^6.0",
-        "symfony/serializer": "^5.4|^6.0"
+        "symfony/serializer": "^6.2"
     },
     "conflict": {
         "egulias/email-validator": "~3.0.0",

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -62,6 +62,7 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         if ($object instanceof AbstractPart) {
             $ret = $this->normalizer->normalize($object, $format, $context);
             $ret['class'] = $object::class;
+            unset($ret['seekable'], $ret['cid']);
 
             return $ret;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

While fixing some MIME bugs, I realized we have a substantial cyclomatic complexity due to the attach/attachFromPath/embed/embedFromPath/attachPart methods on the Email class.

This PR simplifies all of that and introduces a way to have a file for TextPart as well (via the new `file://` notation) and it keeps the lazy-loading feature which was why those methods were introduced in the first place.

From now, I've kept all the methods, but I'm wondering if we should deprecate all of them and only keep `attachPart()` (which I would like to rename `addPart()`).
