### PR TITLE
[Console] [Completion] Make fish completion run in non interactive mode

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.fish
+++ b/src/Symfony/Component/Console/Resources/completion.fish
@@ -9,7 +9,7 @@ function _sf_{{ COMMAND_NAME }}
     set sf_cmd (commandline -o)
     set c (count (commandline -oc))
 
-    set completecmd "$sf_cmd[1]" "_complete" "-sfish" "-S{{ VERSION }}"
+    set completecmd "$sf_cmd[1]" "_complete" "--no-interaction" "-sfish" "-S{{ VERSION }}"
 
     for i in $sf_cmd
         if [ $i != "" ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Port https://github.com/symfony/symfony/pull/47394 to 6.1 for fish
