### PR TITLE
[Console] [Completion] Make zsh completion run in non interactive mode

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.zsh
+++ b/src/Symfony/Component/Console/Resources/completion.zsh
@@ -31,7 +31,7 @@ _sf_{{ COMMAND_NAME }}() {
     fi
 
     # Prepare the command to obtain completions
-    requestComp="${words[0]} ${words[1]} _complete -szsh -a{{ VERSION }} -c$((CURRENT-1))" i=""
+    requestComp="${words[0]} ${words[1]} _complete --no-interaction -szsh -a{{ VERSION }} -c$((CURRENT-1))" i=""
     for w in ${words[@]}; do
         w=$(printf -- '%b' "$w")
         # remove quotes from typed values


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Port https://github.com/symfony/symfony/pull/47394 to 6.2 for zsh