### PR TITLE
Removed unused $event param of onKernelFinishRequest from RouterListener

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -83,7 +83,7 @@ class RouterListener implements EventSubscriberInterface
      * After a sub-request is done, we need to reset the routing context to the parent request so that the URL generator
      * operates on the correct context again.
      */
-    public function onKernelFinishRequest(FinishRequestEvent $event)
+    public function onKernelFinishRequest()
     {
         $this->setCurrentRequest($this->requestStack->getParentRequest());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| License       | MIT

The `$event` parameter in the `onKernelFinishRequest` for the `RouterListener` class seems to not be used. Other listeners such as `LocaleAwareListener`, `Firewall` and `FirewallListener` all takes advantage of this $event parameter.

`Symfony\Component\HttpKernel\EventListener\LocaleAwareListener`:
![image](https://user-images.githubusercontent.com/5428251/188231452-d5cd0772-0cc2-4e94-85d9-cea7f34edf95.png)


`Symfony\Component\Security\Http\Firewall`:
![image](https://user-images.githubusercontent.com/5428251/188230787-9e4a35cf-8c7f-45ab-93de-8d1d8a35bbc4.png)


`Symfony\Bundle\SecurityBundle\EventListener\FirewallListener`:
![image](https://user-images.githubusercontent.com/5428251/188231264-2d99f76e-f2f4-4c21-af37-196e3f21f788.png)


Plus, I could not find any Interface that ensures any contract over this method to all these classes above.