### PR TITLE
[HttpFoundation] Use identical comparison for scheme validation

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -983,7 +983,7 @@ class Request
         $scheme = $this->getScheme();
         $port = $this->getPort();
 
-        if (('http' == $scheme && 80 == $port) || ('https' == $scheme && 443 == $port)) {
+        if (('http' === $scheme && 80 == $port) || ('https' === $scheme && 443 == $port)) {
             return $this->getHost();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Since the method `getScheme` will always return a `string`, an _identical comparison_ should be used as described by the [Symfony Code Standard Documentation](https://symfony.com/doc/current/contributing/code/standards.html#structure).
