### PR TITLE
[Messenger] Allow password in redis dsn when using sockets

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -53,6 +53,61 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnOnUnixSocketWithUserAndPassword()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with(['user','password'])
+            ->willReturn(true);
+
+        $this->assertEquals(
+            new Connection(['stream' => 'queue', 'delete_after_ack' => true], [
+                'host' => '/var/run/redis/redis.sock',
+                'port' => 0,
+                'user'=> 'user',
+                'pass'=> 'password'
+            ], [], $redis),
+            Connection::fromDsn('redis://user:password@/var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
+        );
+    }
+
+    public function testFromDsnOnUnixSocketWithPassword()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with('password')
+            ->willReturn(true);
+
+        $this->assertEquals(
+            new Connection(['stream' => 'queue', 'delete_after_ack' => true], [
+                'host' => '/var/run/redis/redis.sock',
+                'port' => 0,
+                'pass'=>'password'
+            ], [], $redis),
+            Connection::fromDsn('redis://password@/var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
+        );
+    }
+
+    public function testFromDsnOnUnixSocketWithUser()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with('user')
+            ->willReturn(true);
+
+        $this->assertEquals(
+            new Connection(['stream' => 'queue', 'delete_after_ack' => true], [
+                'host' => '/var/run/redis/redis.sock',
+                'port' => 0,
+                'user' => 'user',
+            ], [], $redis),
+            Connection::fromDsn('redis://user:@/var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
+        );
+    }
+
     public function testFromDsnWithOptions()
     {
         $this->assertEquals(

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -58,15 +58,15 @@ class ConnectionTest extends TestCase
         $redis = $this->createMock(\Redis::class);
 
         $redis->expects($this->exactly(1))->method('auth')
-            ->with(['user','password'])
+            ->with(['user', 'password'])
             ->willReturn(true);
 
         $this->assertEquals(
             new Connection(['stream' => 'queue', 'delete_after_ack' => true], [
                 'host' => '/var/run/redis/redis.sock',
                 'port' => 0,
-                'user'=> 'user',
-                'pass'=> 'password'
+                'user' => 'user',
+                'pass' => 'password',
             ], [], $redis),
             Connection::fromDsn('redis://user:password@/var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
         );
@@ -84,7 +84,7 @@ class ConnectionTest extends TestCase
             new Connection(['stream' => 'queue', 'delete_after_ack' => true], [
                 'host' => '/var/run/redis/redis.sock',
                 'port' => 0,
-                'pass'=>'password'
+                'pass' => 'password',
             ], [], $redis),
             Connection::fromDsn('redis://password@/var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
         );

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -289,6 +289,7 @@ class Connection
 
                 $auth['pass'] = $m['password'];
             }
+
             return 'file:'.($m[1] ?? '');
         }, $url);
 
@@ -296,13 +297,13 @@ class Connection
             throw new InvalidArgumentException(sprintf('The given Redis DSN "%s" is invalid.', $dsn));
         }
 
-        if ($auth !== null) {
+        if (null !== $auth) {
             unset($parsedUrl['user']); // parse_url thinks //0@localhost/ is a password of "0"! doh!
             $parsedUrl = $parsedUrl + ($auth ?? []); // But don't worry as $auth array will have user, user/pass or pass as needed
         }
 
         // revert scheme now we are finished using PHP parse_url
-        if ($parsedUrl['scheme'] == 'file') {
+        if ('file' == $parsedUrl['scheme']) {
             $parsedUrl['scheme'] = $scheme;
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -298,7 +298,7 @@ class Connection
         }
 
         if (null !== $auth) {
-            unset($parsedUrl['user']); // parse_url thinks //0@localhost/ is a password of "0"! doh!
+            unset($parsedUrl['user']); // parse_url thinks //0@localhost/ is a username of "0"! doh!
             $parsedUrl = $parsedUrl + ($auth ?? []); // But don't worry as $auth array will have user, user/pass or pass as needed
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -279,16 +279,16 @@ class Connection
             $url = str_replace($scheme.':', 'file:', $dsn);
         }
 
-        $url = preg_replace_callback('#^' . $scheme . ':(//)?(?:(?:(?<user>[^:@]*+):)?(?<password>[^@]*+)@)?#', function ($m) use (&$auth) {
+        $url = preg_replace_callback('#^'.$scheme.':(//)?(?:(?:(?<user>[^:@]*+):)?(?<password>[^@]*+)@)?#', function ($m) use (&$auth) {
             if (isset($m['password'])) {
                 if (!\in_array($m['user'], ['', 'default'], true)) {
-                    $auth['user']=$m['user'];
+                    $auth['user'] = $m['user'];
                 }
 
                 $auth['pass'] = $m['password'];
             }
 
-            return 'file:' . ($m[1] ?? '');
+            return 'file:'.($m[1] ?? '');
         }, $url);
 
         if (false === $parsedUrl = parse_url($url)) {
@@ -297,7 +297,7 @@ class Connection
 
         $parsedUrl = $parsedUrl + ($auth ?? []);
 
-        if (array_key_exists('host', $parsedUrl)){
+        if (\array_key_exists('host', $parsedUrl)) {
             $parsedUrl = ['scheme' => $scheme, 'host' => $parsedUrl['host'], 'port' => $parsedUrl['port'] ?? '6379'] + $parsedUrl;
         } else {
             $parsedUrl = ['scheme' => 'unix', 'path' => $parsedUrl['path']] + $parsedUrl;

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -237,9 +237,10 @@ class Connection
             'claim_interval' => $claimInterval,
         ];
 
+        $pass = '' !== ($parsedUrl['pass'] ?? '') ? $parsedUrl['pass'] : null;
+        $user = '' !== ($parsedUrl['user'] ?? '') ? $parsedUrl['user'] : null;
+
         if (isset($parsedUrl['host'])) {
-            $pass = '' !== ($parsedUrl['pass'] ?? '') ? $parsedUrl['pass'] : null;
-            $user = '' !== ($parsedUrl['user'] ?? '') ? $parsedUrl['user'] : null;
             $connectionCredentials = [
                 'host' => $parsedUrl['host'] ?? '127.0.0.1',
                 'port' => $parsedUrl['port'] ?? 6379,
@@ -256,9 +257,6 @@ class Connection
                 $connectionCredentials['host'] = 'tls://'.$connectionCredentials['host'];
             }
         } else {
-            $pass = '' !== ($parsedUrl['pass'] ?? '') ? $parsedUrl['pass'] : null;
-            $user = '' !== ($parsedUrl['user'] ?? '') ? $parsedUrl['user'] : null;
-
             $connectionCredentials = [
                 'host' => $parsedUrl['path'],
                 'port' => 0,
@@ -275,12 +273,10 @@ class Connection
         $url = $dsn;
         $scheme = 0 === strpos($dsn, 'rediss:') ? 'rediss' : 'redis';
 
-        // if scheme:///...
         if (preg_match('#^'.$scheme.':///([^:@])+$#', $dsn)) {
             $url = str_replace($scheme.':', 'file:', $dsn);
         }
 
-        // if scheme://...
         $url = preg_replace_callback('#^'.$scheme.':(//)?(?:(?:(?<user>[^:@]*+):)?(?<password>[^@]*+)@)?#', function ($m) use (&$auth) {
             if (isset($m['password'])) {
                 if (!\in_array($m['user'], ['', 'default'], true)) {
@@ -299,11 +295,11 @@ class Connection
 
         if (null !== $auth) {
             unset($parsedUrl['user']); // parse_url thinks //0@localhost/ is a username of "0"! doh!
-            $parsedUrl = $parsedUrl + ($auth ?? []); // But don't worry as $auth array will have user, user/pass or pass as needed
+            $parsedUrl += ($auth ?? []); // But don't worry as $auth array will have user, user/pass or pass as needed
         }
 
         // revert scheme now we are finished using PHP parse_url
-        if ('file' == $parsedUrl['scheme']) {
+        if ('file' === $parsedUrl['scheme']) {
             $parsedUrl['scheme'] = $scheme;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes #47393
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #47393 @Arakmar 
| License       | MIT
| Doc PR        | 

When a messenger async transport is configured with Redis (unix socket with a password), it gives DSN parsing errors.

Using a Bunch of copy and pasted code blocks from the Redis cache adapter, this PR fixes the bug that doesn't parse a DSN such as 

`redis://password@/var/run/redis.sock`

