### PR TITLE
[HttpFoundation] Every second request fails for BinaryFileResponse and non-modified file

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -206,6 +206,10 @@ class BinaryFileResponse extends Response
      */
     public function prepare(Request $request)
     {
+        if (\in_array($this->getStatusCode(), [self::HTTP_NO_CONTENT, self::HTTP_NOT_MODIFIED])) {
+            return $this;
+        }
+        
         if (!$this->headers->has('Content-Type')) {
             $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #47473 @naitsirch
| License       | MIT

Proposed Fix for #47473 in a PR. 

I cannot replicate the problem in macOS Safari, but I can replicate it in Google Chrome (on Mac) - applying this fix, fixes the problem when it can be replicated. 
