### PR TITLE
[Clock] sleep in test, 1millisecond to ensure time has changed on fast computers

### DIFF
--- a/src/Symfony/Component/Clock/Tests/MockClockTest.php
+++ b/src/Symfony/Component/Clock/Tests/MockClockTest.php
@@ -43,6 +43,7 @@ class MockClockTest extends TestCase
     {
         $before = new \DateTimeImmutable();
         $clock = new MockClock();
+        usleep(1);
         $after = new \DateTimeImmutable();
 
         $this->assertGreaterThan($before, $clock->now());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

So... Im "one of those" people that bought a Mac Studio Mac with a Apple M1 Ultra CPU and 128Gb RAM

When running the unit tests for the new Clock Component there is a test that compares before and after with 

```php
$before = new \DateTimeImmutable();
$clock = new MockClock();
$after = new \DateTimeImmutable();
```

**50% of the tuns the unit tests fail**, when run on this blazingly fast Mac, fail with message:

<img width="1041" alt="Screen Shot 2022-09-03 at 01 28 01" src="https://user-images.githubusercontent.com/400092/188248812-80ca31f3-3b54-4b5b-a44f-5346f85fa3a8.png">

As you can see the timestamps are exactly the same. 

Adding a one millionth of  second delay ensures that on blazingly fast computers (And I DO UNDERSTAND that GitHub action runners/AppVeyor is never going be fast haha) that the tests pass 100% of the time instead of giving false failures. 

I appreciate this might be an edge case but computers are only getting faster :) and one day a Mac like this might not cost £6000! 
