### PR TITLE
[HttpKernel] Make Logger implement DebugLoggerInterface

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -33,7 +33,7 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
 
     private function doInvoke(array|LogRecord $record): array|LogRecord
     {
-        $hash = $this->requestStack && ($request = $this->requestStack->getCurrentRequest()) ? spl_object_hash($request) : '';
+        $key = $this->requestStack && ($request = $this->requestStack->getCurrentRequest()) ? spl_object_id($request) : '';
 
         $timestamp = $timestampRfc3339 = false;
         if ($record['datetime'] instanceof \DateTimeInterface) {
@@ -43,7 +43,7 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
             $timestampRfc3339 = (new \DateTimeImmutable($record['datetime']))->format(\DateTimeInterface::RFC3339_EXTENDED);
         }
 
-        $this->records[$hash][] = [
+        $this->records[$key][] = [
             'timestamp' => $timestamp,
             'timestamp_rfc3339' => $timestampRfc3339,
             'message' => $record['message'],
@@ -53,8 +53,8 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
             'channel' => $record['channel'] ?? '',
         ];
 
-        if (!isset($this->errorCount[$hash])) {
-            $this->errorCount[$hash] = 0;
+        if (!isset($this->errorCount[$key])) {
+            $this->errorCount[$key] = 0;
         }
 
         switch ($record['level']) {
@@ -62,7 +62,7 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
             case Logger::CRITICAL:
             case Logger::ALERT:
             case Logger::EMERGENCY:
-                ++$this->errorCount[$hash];
+                ++$this->errorCount[$key];
         }
 
         return $record;
@@ -71,7 +71,7 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
     public function getLogs(Request $request = null): array
     {
         if (null !== $request) {
-            return $this->records[spl_object_hash($request)] ?? [];
+            return $this->records[spl_object_id($request)] ?? [];
         }
 
         if (0 === \count($this->records)) {
@@ -84,7 +84,7 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
     public function countErrors(Request $request = null): int
     {
         if (null !== $request) {
-            return $this->errorCount[spl_object_hash($request)] ?? 0;
+            return $this->errorCount[spl_object_id($request)] ?? 0;
         }
 
         return array_sum($this->errorCount);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Log\Logger;
 
 class AddDebugLogProcessorPass implements CompilerPassInterface
 {
@@ -22,22 +23,38 @@ class AddDebugLogProcessorPass implements CompilerPassInterface
         if (!$container->hasDefinition('profiler')) {
             return;
         }
-        if (!$container->hasDefinition('monolog.logger_prototype')) {
-            return;
-        }
-        if (!$container->hasDefinition('debug.log_processor')) {
+
+        if ($container->hasDefinition('monolog.logger_prototype') && $container->hasDefinition('debug.log_processor')) {
+            $container->getDefinition('monolog.logger_prototype')
+                ->setConfigurator([__CLASS__, 'configureMonologLogger'])
+                ->addMethodCall('pushProcessor', [new Reference('debug.log_processor')])
+            ;
+
             return;
         }
 
-        $definition = $container->getDefinition('monolog.logger_prototype');
-        $definition->setConfigurator([__CLASS__, 'configureLogger']);
-        $definition->addMethodCall('pushProcessor', [new Reference('debug.log_processor')]);
+        if (!$container->hasDefinition('logger')) {
+            return;
+        }
+
+        $loggerDefinition = $container->getDefinition('logger');
+
+        if (Logger::class === $loggerDefinition->getClass()) {
+            $loggerDefinition->setConfigurator([__CLASS__, 'configureHttpKernelLogger']);
+        }
     }
 
-    public static function configureLogger(mixed $logger)
+    public static function configureMonologLogger(mixed $logger)
     {
-        if (\is_object($logger) && method_exists($logger, 'removeDebugLogger') && \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
+        if (\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && \is_object($logger) && method_exists($logger, 'removeDebugLogger')) {
             $logger->removeDebugLogger();
+        }
+    }
+
+    public static function configureHttpKernelLogger(Logger $logger)
+    {
+        if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && method_exists($logger, 'enableDebug')) {
+            $logger->enableDebug();
         }
     }
 }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\HttpKernel\DependencyInjection;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Log\Logger;
 
 /**
@@ -33,6 +35,7 @@ class LoggerPass implements CompilerPassInterface
         }
 
         $container->register('logger', Logger::class)
+            ->setArguments([null, null, null, new Reference(RequestStack::class)])
             ->setPublic(false);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Log/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Log/Logger.php
@@ -14,13 +14,15 @@ namespace Symfony\Component\HttpKernel\Log;
 use Psr\Log\AbstractLogger;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LogLevel;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Minimalist PSR-3 logger designed to write in stderr or any other stream.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class Logger extends AbstractLogger
+class Logger extends AbstractLogger implements DebugLoggerInterface
 {
     private const LEVELS = [
         LogLevel::DEBUG => 0,
@@ -32,9 +34,22 @@ class Logger extends AbstractLogger
         LogLevel::ALERT => 6,
         LogLevel::EMERGENCY => 7,
     ];
+    private const PRIORITIES = [
+        LogLevel::DEBUG => 100,
+        LogLevel::INFO => 200,
+        LogLevel::NOTICE => 250,
+        LogLevel::WARNING => 300,
+        LogLevel::ERROR => 400,
+        LogLevel::CRITICAL => 500,
+        LogLevel::ALERT => 550,
+        LogLevel::EMERGENCY => 600,
+    ];
 
     private int $minLevelIndex;
     private \Closure $formatter;
+    private bool $debug = false;
+    private array $logs = [];
+    private array $errorCount = [];
 
     /** @var resource|null */
     private $handle;
@@ -42,7 +57,7 @@ class Logger extends AbstractLogger
     /**
      * @param string|resource|null $output
      */
-    public function __construct(string $minLevel = null, $output = null, callable $formatter = null)
+    public function __construct(string $minLevel = null, $output = null, callable $formatter = null, private readonly ?RequestStack $requestStack = null)
     {
         if (null === $minLevel) {
             $minLevel = null === $output || 'php://stdout' === $output || 'php://stderr' === $output ? LogLevel::ERROR : LogLevel::WARNING;
@@ -69,6 +84,11 @@ class Logger extends AbstractLogger
         }
     }
 
+    public function enableDebug(): void
+    {
+        $this->debug = true;
+    }
+
     public function log($level, $message, array $context = []): void
     {
         if (!isset(self::LEVELS[$level])) {
@@ -85,6 +105,34 @@ class Logger extends AbstractLogger
         } else {
             error_log($formatter($level, $message, $context, false));
         }
+
+        if ($this->debug && $this->requestStack) {
+            $this->record($level, $message, $context);
+        }
+    }
+
+    public function getLogs(Request $request = null): array
+    {
+        if ($request) {
+            return $this->logs[spl_object_id($request)] ?? [];
+        }
+
+        return array_merge(...array_values($this->logs));
+    }
+
+    public function countErrors(Request $request = null): int
+    {
+        if ($request) {
+            return $this->errorCount[spl_object_id($request)] ?? 0;
+        }
+
+        return array_sum($this->errorCount);
+    }
+
+    public function clear(): void
+    {
+        $this->logs = [];
+        $this->errorCount = [];
     }
 
     private function format(string $level, string $message, array $context, bool $prefixDate = true): string
@@ -112,5 +160,30 @@ class Logger extends AbstractLogger
         }
 
         return $log;
+    }
+
+    private function record($level, $message, array $context): void
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $key = $request ? spl_object_id($request) : '';
+
+        $this->logs[$key][] = [
+            'channel' => null,
+            'context' => $context,
+            'message' => $message,
+            'priority' => self::PRIORITIES[$level],
+            'priorityName' => $level,
+            'timestamp' => time(),
+            'timestamp_rfc3339' => date(\DATE_RFC3339_EXTENDED),
+        ];
+
+        $this->errorCount[$key] ??= 0;
+        switch ($level) {
+            case LogLevel::ERROR:
+            case LogLevel::CRITICAL:
+            case LogLevel::ALERT:
+            case LogLevel::EMERGENCY:
+                ++$this->errorCount[$key];
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When starting a new project from a skeleton I was surprised not to see any log in the profiler and error pages. Turns out this depends of the logger implementing `DebugLoggerInterface` but AFAIK this only happen in Monolog’s bridge.

Given the API makes it weird to implement it in userland (see https://github.com/symfony/symfony/issues/47396) would it make sense to provide one by default?