### PR TITLE
remove conflict with phpunit/phpunit < 5.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -156,8 +156,7 @@
         "masterminds/html5": "<2.6",
         "phpdocumentor/reflection-docblock": "<5.2",
         "phpdocumentor/type-resolver": "<1.5.1",
-        "ocramius/proxy-manager": "<2.1",
-        "phpunit/phpunit": "<5.4.3"
+        "ocramius/proxy-manager": "<2.1"
     },
     "config": {
         "allow-plugins": {

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -53,7 +53,6 @@
         "doctrine/dbal": "<2.13.1",
         "doctrine/lexer": "<1.1",
         "doctrine/orm": "<2.7.4",
-        "phpunit/phpunit": "<5.4.3",
         "symfony/cache": "<5.4",
         "symfony/dependency-injection": "<5.4",
         "symfony/form": "<5.4",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -74,7 +74,6 @@
         "doctrine/persistence": "<1.3",
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<1.4.0",
-        "phpunit/phpunit": "<5.4.3",
         "symfony/asset": "<5.4",
         "symfony/console": "<5.4",
         "symfony/dotenv": "<5.4",

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -43,7 +43,6 @@
         "symfony/uid": "^5.4|^6.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<5.4.3",
         "symfony/console": "<5.4",
         "symfony/dependency-injection": "<5.4",
         "symfony/doctrine-bridge": "<5.4",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -44,7 +44,6 @@
     "conflict": {
         "doctrine/annotations": "<1.13",
         "doctrine/lexer": "<1.1",
-        "phpunit/phpunit": "<5.4.3",
         "symfony/dependency-injection": "<5.4",
         "symfony/expression-language": "<5.4",
         "symfony/http-kernel": "<5.4",

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -27,7 +27,6 @@
         "twig/twig": "^2.13|^3.0.4"
     },
     "conflict": {
-        "phpunit/phpunit": "<5.4.3",
         "symfony/console": "<5.4"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

[PHPUnit 5.4.3](https://packagist.org/packages/phpunit/phpunit#5.4.3) requires PHP `^5.6` or `^7.0`. Therefore it can't be installed alongside Symfony 6.2 which require PHP `>=PHP 8.1`. So we can remove it from the `conflict` conf.