### PR TITLE
Remove conflict with phpunit/phpunit < 7.5

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -28,7 +28,7 @@
         "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
     },
     "conflict": {
-        "phpunit/phpunit": "<7.5|9.1.2"
+        "phpunit/phpunit": "9.1.2"
     },
     "autoload": {
         "files": [ "bootstrap.php" ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

[PHPUnit 7.5.0](https://packagist.org/packages/phpunit/phpunit#7.5.0) requires PHP `^7.0`. Therefore it can't be installed alongside Symfony 6.2 which require `>=PHP 8.1`. So we can remove it from the `conflict` conf.

See also #47486