### PR TITLE
[Security] Fix valid remember-me token exposure to the second consequent request

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -75,7 +75,6 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
 
         if ($this->tokenVerifier) {
             $isTokenValid = $this->tokenVerifier->verifyToken($persistentToken, $tokenValue);
-            $tokenValue = $persistentToken->getTokenValue();
         } else {
             $isTokenValid = hash_equals($persistentToken->getTokenValue(), $tokenValue);
         }
@@ -96,9 +95,9 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
                 $this->tokenVerifier->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
             }
             $this->tokenProvider->updateToken($series, $tokenValue, $tokenLastUsed);
-        }
 
-        $this->createCookie($rememberMeDetails->withValue($series.':'.$tokenValue));
+            $this->createCookie($rememberMeDetails->withValue($series.':'.$tokenValue));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -125,18 +125,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:oldTokenValue');
         $handler->consumeRememberMeCookie($rememberMeDetails);
 
-        // assert that the cookie has been updated with a new base64 encoded token value
-        $this->assertTrue($this->request->attributes->has(ResponseListener::COOKIE_ATTR_NAME));
-
-        /** @var Cookie $cookie */
-        $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
-
-        $cookieParts = explode(':', base64_decode($cookie->getValue()), 4);
-
-        $this->assertSame(InMemoryUser::class, $cookieParts[0]); // class
-        $this->assertSame(base64_encode('wouter'), $cookieParts[1]); // identifier
-        $this->assertSame('360', $cookieParts[2]); // expire
-        $this->assertSame('series1:tokenvalue', $cookieParts[3]); // value
+        $this->assertFalse($this->request->attributes->has(ResponseListener::COOKIE_ATTR_NAME));
     }
 
     public function testConsumeRememberMeCookieInvalidToken()


### PR DESCRIPTION
Close https://github.com/symfony/symfony/issues/42343
Fix https://github.com/symfony/symfony/pull/46760

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #42343, Fix #46760 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

https://github.com/symfony/symfony/pull/46760 PR together with a fix produces a security vulnerability when a malicious actor may get a **new and valid** remember me token if makes a request right after the legit user.