### PR TITLE
[DependencyInjection] Fix dumping lazy-proxy of interfaces

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -37,7 +37,7 @@ class ProxyDumper implements DumperInterface
         $this->classGenerator = new BaseGeneratorStrategy();
     }
 
-    public function isProxyCandidate(Definition $definition, bool &$asGhostObject = null): bool
+    public function isProxyCandidate(Definition $definition, bool &$asGhostObject = null, string $id = null): bool
     {
         $asGhostObject = false;
 
@@ -72,7 +72,7 @@ class ProxyDumper implements DumperInterface
 EOF;
     }
 
-    public function getProxyCode(Definition $definition): string
+    public function getProxyCode(Definition $definition, string $id = null): string
     {
         $code = $this->classGenerator->generate($this->generateProxyClass($definition));
         $code = preg_replace('/^(class [^ ]++ extends )([^\\\\])/', '$1\\\\$2', $code);

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Use lazy-loading ghost objects and virtual proxies out of the box
- * Add argument `&$asGhostObject` to LazyProxy's `DumperInterface` to allow using ghost objects for lazy loading services
+ * Add arguments `&$asGhostObject` and `$id` to LazyProxy's `DumperInterface` to allow using ghost objects for lazy loading services
  * Add `enum` env var processor
  * Add `shuffle` env var processor
  * Add `resolve-env` option to `debug:config` command to display actual values of environment variables in dumped configuration

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -550,8 +550,8 @@ EOF;
         $strip = '' === $this->docStar && method_exists(Kernel::class, 'stripComments');
         $proxyDumper = $this->getProxyDumper();
         ksort($definitions);
-        foreach ($definitions as $definition) {
-            if (!$definition = $this->isProxyCandidate($definition)) {
+        foreach ($definitions as $id => $definition) {
+            if (!$definition = $this->isProxyCandidate($definition, $asGhostObject, $id)) {
                 continue;
             }
             if (isset($alreadyGenerated[$class = $definition->getClass()])) {
@@ -560,7 +560,7 @@ EOF;
             $alreadyGenerated[$class] = true;
             // register class' reflector for resource tracking
             $this->container->getReflectionClass($class);
-            if ("\n" === $proxyCode = "\n".$proxyDumper->getProxyCode($definition)) {
+            if ("\n" === $proxyCode = "\n".$proxyDumper->getProxyCode($definition, $id)) {
                 continue;
             }
 
@@ -655,7 +655,7 @@ EOF;
         }
 
         $asGhostObject = false;
-        $isProxyCandidate = $this->isProxyCandidate($definition, $asGhostObject);
+        $isProxyCandidate = $this->isProxyCandidate($definition, $asGhostObject, $id);
         $instantiation = '';
 
         $lastWitherIndex = null;
@@ -883,7 +883,7 @@ EOF;
             }
 
             $asGhostObject = false;
-            if ($isProxyCandidate = $this->isProxyCandidate($definition, $asGhostObject)) {
+            if ($isProxyCandidate = $this->isProxyCandidate($definition, $asGhostObject, $id)) {
                 $definition = $isProxyCandidate;
 
                 if (!$definition->isShared()) {
@@ -1041,7 +1041,7 @@ EOTXT
         }
 
         $asGhostObject = false;
-        $isProxyCandidate = $this->isProxyCandidate($inlineDef, $asGhostObject);
+        $isProxyCandidate = $this->isProxyCandidate($inlineDef, $asGhostObject, $id);
 
         if (isset($this->definitionVariables[$inlineDef])) {
             $isSimpleInstance = false;
@@ -2266,7 +2266,7 @@ EOF;
         return $classes;
     }
 
-    private function isProxyCandidate(Definition $definition, bool &$asGhostObject = null): ?Definition
+    private function isProxyCandidate(Definition $definition, ?bool &$asGhostObject, string $id): ?Definition
     {
         $asGhostObject = false;
 
@@ -2279,6 +2279,6 @@ EOF;
             ->setClass($bag->resolveValue($definition->getClass()))
             ->setTags(($definition->hasTag('proxy') ? ['proxy' => $bag->resolveValue($definition->getTag('proxy'))] : []) + $definition->getTags());
 
-        return $proxyDumper->isProxyCandidate($definition, $asGhostObject) ? $definition : null;
+        return $proxyDumper->isProxyCandidate($definition, $asGhostObject, $id) ? $definition : null;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/LazyServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/LazyServiceInstantiator.php
@@ -26,7 +26,7 @@ final class LazyServiceInstantiator implements InstantiatorInterface
         $dumper = new LazyServiceDumper();
 
         if (!class_exists($proxyClass = $dumper->getProxyClass($definition, $class), false)) {
-            eval($dumper->getProxyCode($definition));
+            eval($dumper->getProxyCode($definition, $id));
         }
 
         return isset(class_uses($proxyClass)[LazyGhostTrait::class]) ? $proxyClass::createLazyGhost($realInstantiator) : $proxyClass::createLazyProxy($realInstantiator);

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
@@ -23,9 +23,10 @@ interface DumperInterface
     /**
      * Inspects whether the given definitions should produce proxy instantiation logic in the dumped container.
      *
-     * @param bool|null &$asGhostObject Set to true after the call if the proxy is a ghost object
+     * @param bool|null   &$asGhostObject Set to true after the call if the proxy is a ghost object
+     * @param string|null $id
      */
-    public function isProxyCandidate(Definition $definition/* , bool &$asGhostObject = null */): bool;
+    public function isProxyCandidate(Definition $definition/* , bool &$asGhostObject = null, string $id = null */): bool;
 
     /**
      * Generates the code to be used to instantiate a proxy in the dumped factory code.
@@ -35,5 +36,5 @@ interface DumperInterface
     /**
      * Generates the code for the lazy proxy.
      */
-    public function getProxyCode(Definition $definition): string;
+    public function getProxyCode(Definition $definition/* , string $id = null */): string;
 }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class NullDumper implements DumperInterface
 {
-    public function isProxyCandidate(Definition $definition, bool &$asGhostObject = null): bool
+    public function isProxyCandidate(Definition $definition, bool &$asGhostObject = null, string $id = null): bool
     {
         return $asGhostObject = false;
     }
@@ -32,7 +32,7 @@ class NullDumper implements DumperInterface
         return '';
     }
 
-    public function getProxyCode(Definition $definition): string
+    public function getProxyCode(Definition $definition, string $id = null): string
     {
         return '';
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
@@ -84,7 +84,7 @@ class MethodCallClass
 
 class DummyProxyDumper implements ProxyDumper
 {
-    public function isProxyCandidate(Definition $definition, bool &$asGhostObject = null): bool
+    public function isProxyCandidate(Definition $definition, bool &$asGhostObject = null, string $id = null): bool
     {
         $asGhostObject = false;
 
@@ -96,7 +96,7 @@ class DummyProxyDumper implements ProxyDumper
         return "        // lazy factory for {$definition->getClass()}\n\n";
     }
 
-    public function getProxyCode(Definition $definition): string
+    public function getProxyCode(Definition $definition, $id = null): string
     {
         return "// proxy code for {$definition->getClass()}\n";
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\LazyProxy\PhpDumper;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\LazyServiceDumper;
+
+class LazyServiceDumperTest extends TestCase
+{
+    public function testProxyInterface()
+    {
+        $dumper = new LazyServiceDumper();
+        $definition = (new Definition(ContainerInterface::class))->setLazy(true);
+
+        $this->assertTrue($dumper->isProxyCandidate($definition));
+        $this->assertStringContainsString('function get(', $dumper->getProxyCode($definition));
+    }
+}

--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -176,7 +176,7 @@ final class ProxyHelper
             $methods[$lcName] = "    {$signature}\n    {\n{$body}\n    }";
         }
 
-        $readonly = \PHP_VERSION_ID >= 80200 && $class && $class->isReadOnly() ? 'readonly ' : '';
+        $readonly = \PHP_VERSION_ID >= 80200 && $class?->isReadOnly() ? 'readonly ' : '';
         $types = $interfaces = array_unique(array_column($interfaces, 'name'));
         $interfaces[] = LazyObjectInterface::class;
         $interfaces = implode(', \\', $interfaces);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As spotted by the tests of API Platform.
Also improves exception messages a bit by giving the id of the affected services in case of error.