### PR TITLE
[FrameworkBundle] Make the Router `cache_dir` configurable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Add `rate_limiter` configuration option to `messenger.transport` to allow rate limited transports using the RateLimiter component
  * Remove `@internal` tag from secret vaults to allow them to be used directly outside the framework bundle and custom vaults to be added
  * Deprecate `framework.form.legacy_error_messages` config node
+ * Add a `framework.router.cache_dir` configuration option to configure the default `Router` `cache_dir` option
 
 6.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -608,6 +608,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('resource')->isRequired()->end()
                         ->scalarNode('type')->end()
+                        ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%')->end()
                         ->scalarNode('default_uri')
                             ->info('The default URI used to generate URLs in a non-HTTP context')
                             ->defaultNull()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1140,6 +1140,7 @@ class FrameworkExtension extends Extension
         }
 
         $container->setParameter('router.resource', $config['resource']);
+        $container->setParameter('router.cache_dir', $config['cache_dir']);
         $router = $container->findDefinition('router.default');
         $argument = $router->getArgument(2);
         $argument['strict_requirements'] = $config['strict_requirements'];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
@@ -101,7 +101,7 @@ return static function (ContainerConfigurator $container) {
                 service(ContainerInterface::class),
                 param('router.resource'),
                 [
-                    'cache_dir' => param('kernel.cache_dir'),
+                    'cache_dir' => param('router.cache_dir'),
                     'debug' => param('kernel.debug'),
                     'generator_class' => CompiledUrlGenerator::class,
                     'generator_dumper_class' => CompiledUrlGeneratorDumper::class,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -532,6 +532,7 @@ class ConfigurationTest extends TestCase
                 'https_port' => 443,
                 'strict_requirements' => true,
                 'utf8' => true,
+                'cache_dir' => '%kernel.cache_dir%',
             ],
             'session' => [
                 'enabled' => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#17253

This PR adds a new `framework.router.cache_dir` configuration setting. It will default to `kernel.cache_dir` as previously, but makes it possible to easily re-configure the Router's cache directory.

My intended use case is to set it to `~` (`null`) for the `test` environment because I need to modify or otherwise dynamically load routes during tests. Another use case I see for it is to have tenant-specific route configurations and caches in multi-tenancy applications.