### PR TITLE
[Bridge] Fix mkdir() race condition in ProxyCacheWarmer

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
@@ -49,7 +49,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
         foreach ($this->registry->getManagers() as $em) {
             // we need the directory no matter the proxy cache generation strategy
             if (!is_dir($proxyCacheDir = $em->getConfiguration()->getProxyDir())) {
-                if (false === @mkdir($proxyCacheDir, 0777, true)) {
+                if (false === @mkdir($proxyCacheDir, 0777, true) && !is_dir($proxyCacheDir)) {
                     throw new \RuntimeException(sprintf('Unable to create the Doctrine Proxy directory "%s".', $proxyCacheDir));
                 }
             } elseif (!is_writable($proxyCacheDir)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix [#47489](https://github.com/symfony/symfony/issues/47489)
| License       | MIT
| Doc PR        |  -

The race condition is appears when several processes are attempting to create a same Doctrine Proxy directory which does not yet exist and `\RuntimeException` is thrown in `\Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer`.

This PR adds an extra check to `\Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer`.




