### PR TITLE
[Uid][Validator] Stop to first ULID format violation

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UlidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UlidValidator.php
@@ -48,6 +48,8 @@ class UlidValidator extends ConstraintValidator
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(26 > \strlen($value) ? Ulid::TOO_SHORT_ERROR : Ulid::TOO_LONG_ERROR)
                 ->addViolation();
+
+            return;
         }
 
         if (\strlen($value) !== strspn($value, '0123456789ABCDEFGHJKMNPQRSTVWXYZabcdefghjkmnpqrstvwxyz')) {
@@ -55,6 +57,8 @@ class UlidValidator extends ConstraintValidator
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Ulid::INVALID_CHARACTERS_ERROR)
                 ->addViolation();
+
+            return;
         }
 
         // Largest valid ULID is '7ZZZZZZZZZZZZZZZZZZZZZZZZZ'

--- a/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
@@ -78,6 +78,7 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
             ['01ARZ3NDEKTSV4RRFFQ69G5FAVA', Ulid::TOO_LONG_ERROR],
             ['01ARZ3NDEKTSV4RRFFQ69G5FAO', Ulid::INVALID_CHARACTERS_ERROR],
             ['Z1ARZ3NDEKTSV4RRFFQ69G5FAV', Ulid::TOO_LARGE_ERROR],
+            ['not-even-ulid-like', Ulid::TOO_SHORT_ERROR],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Unlike the UUID validator, the ULID validator does not stop on the first violation raised, but continues adding a violation for each ULID format infringement.
Which might make sense in some situations, but the same error message is set for each.
In case of a string like `not-even-ulid-like`, you'll get 3 violations with the same message.

IIMHO, 95% of the use-cases will consist of exposing the violation messages directly, so displaying 3 times the same message is unexpected.

(getting different messages per violation type could be added as a new feature if needed)