### PR TITLE
[Cache] Add support for a tag lifetime in the RedisTagAwareAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
@@ -28,15 +28,56 @@ class RedisTagAwareAdapterTest extends RedisAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool(int $defaultLifetime = 0, string $testMethod = null): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0, string $testMethod = null, $tagLifetime = null): CacheItemPoolInterface
     {
         if ('testClearWithPrefix' === $testMethod && \defined('Redis::SCAN_PREFIX')) {
             self::$redis->setOption(\Redis::OPT_SCAN, \Redis::SCAN_PREFIX);
         }
 
         $this->assertInstanceOf(RedisProxy::class, self::$redis);
-        $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+        $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime, null, $tagLifetime);
 
         return $adapter;
+    }
+
+    public function testTagExpiry()
+    {
+        $pool = $this->createCachePool(10, null, true);
+
+        $item = $pool->getItem('tag_item_expiry');
+        $item->tag(['tag_item_expiry_tag']);
+        $item->expiresAfter(5);
+
+        $pool->save($item);
+
+        sleep(7);
+
+        $redis = self::$redis;
+
+        $keys = $redis->keys('*tag_item_expiry*');
+        $this->assertCount(0, $keys);
+    }
+
+    public function testTagExpirySeparateLifetime()
+    {
+        $pool = $this->createCachePool(10, null, 10);
+
+        $item = $pool->getItem('tag_expiry');
+        $item->tag(['tag_expiry_tag']);
+        $item->expiresAfter(5);
+
+        $pool->save($item);
+
+        sleep(7);
+
+        $redis = self::$redis;
+
+        $keys = $redis->keys('*tag_expiry*');
+        $this->assertCount(1, $keys);
+
+        sleep(5);
+
+        $keys = $redis->keys('*tag_expiry*');
+        $this->assertCount(0, $keys);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes 
| New feature?  | maybe (see below)
| Deprecations? |no
| Discussion | https://github.com/symfony/symfony/discussions/45507
| License       | MIT

We use the `RedisTagAwareAdapter` cache to tag cached auth tokens for a specific user. These cached tokens have a rather short lifetime of 5 minutes. 
By tagging those token caches, we can invalidate all token caches if the user (e.g.) is disabled/deleted. However, since the tag itself never expires (and some users don't come back for months), we see a constant increase of non-expiring keys in our redis database, which also increases the memory usage. Changing the eviction policy to `allkeys-lru` or `allkeys-lfu` might fix this, but these policies [are not allowed](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php#L96) to be used with the `RedisTagAwareAdapter` and thus are not an option.

To fix this, I added a new parameter to the `RedisTagAwareAdapter` where you can specify a potential tag lifetime. This parameter can have the following values:

* `null` (default) -> same behaviour as before, the tags will not expire
* `true` -> use the lifetime from the item itself
* `numeric` -> explicitly define the tag lifetime

From our point of view this is more of a bug fix and I think it would make sense to backport this parameter to the oldest supported version (in this case 4.4). But I also can see that this might be more of a new feature, so if you think it makes more sense to only add it to the `6.2` branch, I'll adjust the base branch (and code) accordingly.

Based on how we agree on this, I'll update the changelog and add a proper documentation PR.
