### PR TITLE
[Console] Console: Fix `proc_close()` function is undefinded

### DIFF
--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -198,7 +198,7 @@ class Terminal
         $info = stream_get_contents($pipes[1]);
         fclose($pipes[1]);
         fclose($pipes[2]);
-        proc_close($process);
+        \proc_close($process);
 
         return $info;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | latest for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

![Screenshot 2022-09-07 at 20 21 38](https://user-images.githubusercontent.com/56961917/188890634-cfc00c7a-ac5f-474d-b35c-d752d53d19ca.png)

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
