### PR TITLE
[HttpFoundation] Prevent BinaryFileResponse::prepare from adding content type if no content is sent

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -201,15 +201,17 @@ class BinaryFileResponse extends Response
      */
     public function prepare(Request $request)
     {
+        parent::prepare($request);
+
+        if ($this->isInformational() || $this->isEmpty()) {
+            $this->maxlen = 0;
+
+            return $this;
+        }
+
         if (!$this->headers->has('Content-Type')) {
             $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');
         }
-
-        if ('HTTP/1.0' !== $request->server->get('SERVER_PROTOCOL')) {
-            $this->setProtocolVersion('1.1');
-        }
-
-        $this->ensureIEOverSSLCompatibility($request);
 
         $this->offset = 0;
         $this->maxlen = -1;
@@ -217,6 +219,7 @@ class BinaryFileResponse extends Response
         if (false === $fileSize = $this->file->getSize()) {
             return $this;
         }
+        $this->headers->remove('Transfer-Encoding');
         $this->headers->set('Content-Length', $fileSize);
 
         if (!$this->headers->has('Accept-Ranges')) {
@@ -286,6 +289,10 @@ class BinaryFileResponse extends Response
             }
         }
 
+        if ($request->isMethod('HEAD')) {
+            $this->maxlen = 0;
+        }
+
         return $this;
     }
 
@@ -309,40 +316,42 @@ class BinaryFileResponse extends Response
      */
     public function sendContent()
     {
-        if (!$this->isSuccessful()) {
-            return parent::sendContent();
-        }
-
-        if (0 === $this->maxlen) {
-            return $this;
-        }
-
-        $out = fopen('php://output', 'w');
-        $file = fopen($this->file->getPathname(), 'r');
-
-        ignore_user_abort(true);
-
-        if (0 !== $this->offset) {
-            fseek($file, $this->offset);
-        }
-
-        $length = $this->maxlen;
-        while ($length && !feof($file)) {
-            $read = ($length > $this->chunkSize) ? $this->chunkSize : $length;
-            $length -= $read;
-
-            stream_copy_to_stream($file, $out, $read);
-
-            if (connection_aborted()) {
-                break;
+        try {
+            if (!$this->isSuccessful()) {
+                return parent::sendContent();
             }
-        }
 
-        fclose($out);
-        fclose($file);
+            if (0 === $this->maxlen) {
+                return $this;
+            }
 
-        if ($this->deleteFileAfterSend && file_exists($this->file->getPathname())) {
-            unlink($this->file->getPathname());
+            $out = fopen('php://output', 'w');
+            $file = fopen($this->file->getPathname(), 'r');
+
+            ignore_user_abort(true);
+
+            if (0 !== $this->offset) {
+                fseek($file, $this->offset);
+            }
+
+            $length = $this->maxlen;
+            while ($length && !feof($file)) {
+                $read = ($length > $this->chunkSize) ? $this->chunkSize : $length;
+                $length -= $read;
+
+                stream_copy_to_stream($file, $out, $read);
+
+                if (connection_aborted()) {
+                    break;
+                }
+            }
+
+            fclose($out);
+            fclose($file);
+        } finally {
+            if ($this->deleteFileAfterSend && file_exists($this->file->getPathname())) {
+                unlink($this->file->getPathname());
+            }
         }
 
         return $this;

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -373,6 +373,21 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertNull($response->headers->get('Content-Length'));
     }
 
+    public function testPrepareNotAddingContentTypeHeaderIfNoContentResponse()
+    {
+        $request = Request::create('/');
+        $request->headers->set('If-Modified-Since', date('D, d M Y H:i:s').' GMT');
+
+        $response = new BinaryFileResponse(__DIR__.'/File/Fixtures/test.gif', 200, ['Content-Type' => 'application/octet-stream']);
+        $response->setLastModified(new \DateTimeImmutable('-1 day'));
+        $response->isNotModified($request);
+
+        $response->prepare($request);
+
+        $this->assertSame(BinaryFileResponse::HTTP_NOT_MODIFIED, $response->getStatusCode());
+        $this->assertFalse($response->headers->has('Content-Type'));
+    }
+
     protected function provideResponse()
     {
         return new BinaryFileResponse(__DIR__.'/../README.md', 200, ['Content-Type' => 'application/octet-stream']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47473
| License       | MIT
| Doc PR        | -

Until now, `BinaryFileResponse::prepare()` adds `Content-Type` and other content related header even if no content is sent. This happens for example if the provided file's modification date is not older than the cached version of the client and http status 304 is sent. See issue #47473

