### PR TITLE
Remove `size` FormView variable

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -103,7 +103,6 @@ class FormType extends BaseType
             'value' => $form->getViewData(),
             'data' => $form->getNormData(),
             'required' => $form->isRequired(),
-            'size' => null,
             'label_attr' => $options['label_attr'],
             'help' => $options['help'],
             'help_attr' => $options['help_attr'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

While [adding `FormView::$vars` support in the Psalm Plugin for Symfony](https://github.com/psalm/psalm-plugin-symfony/pull/271), I came across the `size` key.

I tried to figure out the meaning of the setting, but it is not documented, seems to be used nowhere, and has been around since the early days of the Form Component a decade ago.

So, my assumption is that is has no meaning/relevance and thus my suggestion is to remove it.