### PR TITLE
[HttpKernel] add missing allowed interface

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
@@ -24,7 +24,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 final class TraceableValueResolver implements ArgumentValueResolverInterface, ValueResolverInterface
 {
-    private ArgumentValueResolverInterface $inner;
+    private ArgumentValueResolverInterface|ValueResolverInterface $inner;
     private Stopwatch $stopwatch;
 
     public function __construct(ArgumentValueResolverInterface|ValueResolverInterface $inner, Stopwatch $stopwatch)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

In current 6.2 branch there is an error thrown:
```
Cannot assign Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver to property Symfony\Component\HttpKernel\Controller\ArgumentResolver\TraceableValueResolver::$inner of type Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface
```
This is because in TraceableValueResolver constructor, it is allowed to pass:
```
ArgumentValueResolverInterface|ValueResolverInterface $inner
```
while class field definition only allows:
```
private ArgumentValueResolverInterface $inner;
```
So when ValueResolverInterface is passed, error is thrown.

I saw that few weeks ago @nicolas-grekas merged something around this. so maybe it is something forgotten?

added [stacktrace.txt](https://github.com/symfony/symfony/files/9529458/stacktrace.txt), maybe that helps to find real problem if there is one
