### PR TITLE
[TwigBridge] Expose current route in `AppVariable`

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -158,4 +158,25 @@ class AppVariable
 
         return $result;
     }
+
+    public function getCurrent_Route(): ?string
+    {
+        if (!isset($this->requestStack)) {
+            throw new \RuntimeException('The "app.current_route" variable is not available.');
+        }
+
+        return $this->getRequest()?->attributes->get('_route');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getCurrent_Route_Parameters(): array
+    {
+        if (!isset($this->requestStack)) {
+            throw new \RuntimeException('The "app.current_route_parameters" variable is not available.');
+        }
+
+        return $this->getRequest()?->attributes->get('_route_params') ?? [];
+    }
 }

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `form_label_content` and `form_help_content` block to form themes
  * Add `#[Template()]` to describe how to render arrays returned by controllers
  * Add support for toggle buttons in Bootstrap 5 form theme
+ * Add `app.current_route` and `app.current_route_parameters` variables
 
 6.1
 ---

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -228,6 +228,40 @@ class AppVariableTest extends TestCase
         );
     }
 
+    public function testGetCurrentRoute()
+    {
+        $this->setRequestStack(new Request(attributes: ['_route' => 'some_route']));
+
+        $this->assertSame('some_route', $this->appVariable->getCurrent_Route());
+    }
+
+    public function testGetCurrentRouteWithRequestStackNotSet()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->appVariable->getCurrent_Route();
+    }
+
+    public function testGetCurrentRouteParameters()
+    {
+        $routeParams = ['some_param' => true];
+        $this->setRequestStack(new Request(attributes: ['_route_params' => $routeParams]));
+
+        $this->assertSame($routeParams, $this->appVariable->getCurrent_Route_Parameters());
+    }
+
+    public function testGetCurrentRouteParametersWithoutAttribute()
+    {
+        $this->setRequestStack(new Request());
+
+        $this->assertSame([], $this->appVariable->getCurrent_Route_Parameters());
+    }
+
+    public function testGetCurrentRouteParametersWithRequestStackNotSet()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->appVariable->getCurrent_Route_Parameters();
+    }
+
     protected function setRequestStack($request)
     {
         $requestStackMock = $this->createMock(RequestStack::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | TODO

In my experience, a Symfony web project using Twig always comes with templates using `app.request.attributes.get('_route')`, a most common exemple:
```twig
<ul>
    <li class="{{ 'some_route' == app.request.attributes.get('_route') ? 'active' }}">...</li>
    ...
</ul>
```
(An idea of how much it can be used at: https://github.com/search?q=app.request.attributes.get%28%27_route%27%29&type=code).

The current way is somehow complex and not easy to discover, also trying to search the `current` keyword in Routing and Twig sections of the docs does not show the expected exemple.
However searching for `_route` may lead to https://symfony.com/doc/current/routing.html#getting-the-route-name-and-parameters.

I propose with this PR to introduce two small helpers in the global `AppVariable`:
```twig
{% set current_route = app.current_route %}
{% set current_params = app.current_route_parameters %}
```
