### PR TITLE
[Dotenv] Start using virtual filesystem in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,7 +145,8 @@
         "symfony/security-acl": "~2.8|~3.0",
         "twig/cssinliner-extra": "^2.12|^3",
         "twig/inky-extra": "^2.12|^3",
-        "twig/markdown-extra": "^2.12|^3"
+        "twig/markdown-extra": "^2.12|^3",
+        "mikey179/vfsstream": "^1.6"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Dotenv\Tests;
 
+use bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Dotenv\Exception\FormatException;
@@ -201,10 +202,10 @@ class DotenvTest extends TestCase
         putenv('FOO');
         putenv('BAR');
 
-        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $tmpdir = vfsStream::setup()->url();
 
-        $path1 = tempnam($tmpdir, 'sf-');
-        $path2 = tempnam($tmpdir, 'sf-');
+        $path1 = "$tmpdir/file1";
+        $path2 = "$tmpdir/file2";
 
         file_put_contents($path1, 'FOO=BAR');
         file_put_contents($path2, 'BAR=BAZ');
@@ -216,9 +217,6 @@ class DotenvTest extends TestCase
 
         putenv('FOO');
         putenv('BAR');
-        unlink($path1);
-        unlink($path2);
-        rmdir($tmpdir);
 
         $this->assertSame('BAR', $foo);
         $this->assertSame('BAZ', $bar);
@@ -241,9 +239,7 @@ class DotenvTest extends TestCase
             putenv('EXISTING_KEY=EXISTING_VALUE');
         };
 
-        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
-
-        $path = tempnam($tmpdir, 'sf-');
+        $path = vfsStream::setup()->url().'/sf';
 
         // .env
         file_put_contents($path, "FOO=BAR\nEXISTING_KEY=NEW_VALUE");
@@ -347,7 +343,6 @@ class DotenvTest extends TestCase
         $resetContext();
         unset($_ENV['EXISTING_KEY'], $_SERVER['EXISTING_KEY']);
         putenv('EXISTING_KEY');
-        rmdir($tmpdir);
     }
 
     public function testOverload()
@@ -362,10 +357,10 @@ class DotenvTest extends TestCase
         $_ENV['FOO'] = 'initial_foo_value';
         $_ENV['BAR'] = 'initial_bar_value';
 
-        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $tmpdir = vfsStream::setup()->url();
 
-        $path1 = tempnam($tmpdir, 'sf-');
-        $path2 = tempnam($tmpdir, 'sf-');
+        $path1 = "$tmpdir/file1";
+        $path2 = "$tmpdir/file2";
 
         file_put_contents($path1, 'FOO=BAR');
         file_put_contents($path2, 'BAR=BAZ');
@@ -377,9 +372,6 @@ class DotenvTest extends TestCase
 
         putenv('FOO');
         putenv('BAR');
-        unlink($path1);
-        unlink($path2);
-        rmdir($tmpdir);
 
         $this->assertSame('BAR', $foo);
         $this->assertSame('BAZ', $bar);
@@ -389,7 +381,7 @@ class DotenvTest extends TestCase
     {
         $this->expectException(PathException::class);
         $dotenv = new Dotenv();
-        $dotenv->load(__DIR__);
+        $dotenv->load(vfsStream::setup()->url());
     }
 
     public function testServerSuperglobalIsNotOverridden()
@@ -560,8 +552,7 @@ class DotenvTest extends TestCase
             $_ENV['EXISTING_KEY'] = $_SERVER['EXISTING_KEY'] = 'EXISTING_VALUE';
         };
 
-        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
-        $path = tempnam($tmpdir, 'sf-');
+        $path = vfsStream::setup()->url().'/file';
 
         file_put_contents($path, "FOO=BAR\nEXISTING_KEY=NEW_VALUE");
         $resetContext();
@@ -597,6 +588,5 @@ class DotenvTest extends TestCase
         unlink($path.'.local.php');
 
         $resetContext();
-        rmdir($tmpdir);
     }
 }

--- a/src/Symfony/Component/Dotenv/composer.json
+++ b/src/Symfony/Component/Dotenv/composer.json
@@ -20,7 +20,8 @@
     },
     "require-dev": {
         "symfony/console": "^5.4|^6.0",
-        "symfony/process": "^5.4|^6.0"
+        "symfony/process": "^5.4|^6.0",
+        "mikey179/vfsstream": "^1.6"
     },
     "conflict": {
         "symfony/console": "<5.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

During the work on Dotenv I was always running into an issue that when I cause test to fail, file/directory cleanup mechanism does not run. Since in such cases file persists between test runs, this causes tests to be permanently broken even after fixing the bug, until file/folder is removed manually. Situation is complicating also a fact that temporary directory is used, which is pretty much non-accessible and completely random on my dev machine (macos).

So I was thinking, why not using VFS? This is precisely what it's designed for, see https://github.com/bovigo/vfsStream/wiki/Example and https://github.com/bovigo/vfs-stream-examples/tree/master/src/part01. Nothing is persisted between tests no matter what, since all the files are in memory. And it might also be faster, since it eliminates I/O.

As for library used, it is pretty mature as I remember it was used back in the days when I was using CodeIgniter 2 and it's still used by them. It has no dependencies, in latest version it supports PHP versions from 7.2 up to 8.2 and is used by projects such as:
- php-cs-fixer
- Zend/Laminas
- CodeIgniter
- Magento
- CakePHP
- JMS
- phpmd
- Gaufrette
- Phing
- Yasumi

[and more](https://packagist.org/packages/mikey179/vfsstream/dependents?order_by=downloads&page=1)

I'm targetting 5.4 because there are 0 changes between 5.4 and 6.2 in DotenvTest class, unlike when comparing with 4.4.

As this library wasn't used and I wasn't sure this change is welcome, I've added it to one component only (DotEnv). However, lot of tests in lot of other Symfony components would benefit from this as well.