### PR TITLE
[Cache] Add support for saving cache item in PSR-6 pool without having to fetch it first

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -45,8 +45,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
         }
         self::$createCacheItem ?? self::$createCacheItem = \Closure::bind(
             static function ($key, $value, $isHit) {
-                $item = new CacheItem();
-                $item->key = $key;
+                $item = new CacheItem($key);
                 $item->value = $v = $value;
                 $item->isHit = $isHit;
                 $item->unpack();

--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -46,8 +46,7 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
         }
         self::$createCacheItem ?? self::$createCacheItem = \Closure::bind(
             static function ($key, $value, $isHit) {
-                $item = new CacheItem();
-                $item->key = $key;
+                $item = new CacheItem($key);
                 $item->isTaggable = true;
                 // If structure does not match what we expect return item as is (no value and not a hit)
                 if (!\is_array($value) || !\array_key_exists('value', $value)) {

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -59,8 +59,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
         $this->maxItems = $maxItems;
         self::$createCacheItem ?? self::$createCacheItem = \Closure::bind(
             static function ($key, $value, $isHit, $tags) {
-                $item = new CacheItem();
-                $item->key = $key;
+                $item = new CacheItem($key);
                 $item->value = $value;
                 $item->isHit = $isHit;
                 if (null !== $tags) {

--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -26,8 +26,7 @@ class NullAdapter implements AdapterInterface, CacheInterface
     {
         self::$createCacheItem ?? self::$createCacheItem = \Closure::bind(
             static function ($key) {
-                $item = new CacheItem();
-                $item->key = $key;
+                $item = new CacheItem($key);
                 $item->isHit = false;
 
                 return $item;

--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -51,8 +51,7 @@ class PhpArrayAdapter implements AdapterInterface, CacheInterface, PruneableInte
         $this->pool = $fallbackPool;
         self::$createCacheItem ?? self::$createCacheItem = \Closure::bind(
             static function ($key, $value, $isHit) {
-                $item = new CacheItem();
-                $item->key = $key;
+                $item = new CacheItem($key);
                 $item->value = $value;
                 $item->isHit = $isHit;
 

--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -48,8 +48,7 @@ class ProxyAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
         $this->defaultLifetime = $defaultLifetime;
         self::$createCacheItem ??= \Closure::bind(
             static function ($key, $innerItem, $poolHash) {
-                $item = new CacheItem();
-                $item->key = $key;
+                $item = new CacheItem($key);
 
                 if (null === $innerItem) {
                     return $item;

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Add support for saving cache item in PSR-6 pool without having to fetch it first
+
 6.1
 ---
 

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -24,7 +24,6 @@ final class CacheItem implements ItemInterface
     private const METADATA_EXPIRY_OFFSET = 1527506807;
     private const VALUE_WRAPPER = "\xA9";
 
-    protected string $key;
     protected mixed $value = null;
     protected bool $isHit = false;
     protected float|int|null $expiry = null;
@@ -33,6 +32,10 @@ final class CacheItem implements ItemInterface
     protected ?ItemInterface $innerItem = null;
     protected ?string $poolHash = null;
     protected bool $isTaggable = false;
+
+    public function __construct(protected string $key = '')
+    {
+    }
 
     public function getKey(): string
     {

--- a/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TraceableAdapter;
+use Symfony\Component\Cache\CacheItem;
 
 /**
  * @group time-sensitive
@@ -155,6 +156,13 @@ class TraceableAdapterTest extends AdapterTestCase
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
+    }
+
+    public function testSaveWithoutFetchTrace()
+    {
+        $pool = $this->createCachePool();
+        $pool->save((new CacheItem('k'))->set('v'));
+        $this->assertCount(1, $pool->getCalls());
     }
 
     public function testSaveDeferredTrace()

--- a/src/Symfony/Component/Cache/Tests/CacheItemTest.php
+++ b/src/Symfony/Component/Cache/Tests/CacheItemTest.php
@@ -89,10 +89,7 @@ class CacheItemTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cache item "foo" comes from a non tag-aware pool: you cannot tag it.');
-        $item = new CacheItem();
-        $r = new \ReflectionProperty($item, 'key');
-        $r->setValue($item, 'foo');
-
+        $item = new CacheItem('foo');
         $item->tag([]);
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

At the moment it's unfortunately not possible (well, without "illegal" encapsulation breakage) to save a cache item without fetching it first. We have a use case where application A is always saving the item and application B is always reading it. At the moment, application A is always completely unnecessary fetching the data from cache storage.

This is one of the reasons why Doctrine team initially rejected PSR-6 in favor of PSR-16 ([see also benchmarks that were created for that opportunity](https://github.com/lcobucci/cache-mess/blob/master/bench/SingleSaveWithTTL.php)). However, it can be done - with slight modification. We need to make CacheItem constructable by end users.