### PR TITLE
[Mime] remove unused getDisposition() method

### DIFF
--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -89,11 +89,6 @@ class TextPart extends AbstractPart
         return $this;
     }
 
-    public function getDisposition(): ?string
-    {
-        return $this->disposition;
-    }
-
     /**
      * Sets the name of the file (used by FormDataPart).
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

This method was introduced in #47034, but its usage was removed again when merging #47437 up into the 6.2 branch.