### PR TITLE
[Ldap] Do not run ldap_set_option on failed connection

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -159,16 +159,16 @@ class Connection extends AbstractConnection
             }
         }
 
-        $this->connection = ldap_connect($this->config['connection_string']);
+        if (false === $connection = ldap_connect($this->config['connection_string'])) {
+            throw new LdapException('Invalid connection string: '.$this->config['connection_string']);
+        } else {
+            $this->connection = $connection;
+        }
 
         foreach ($this->config['options'] as $name => $value) {
             if (!\in_array(ConnectionOptions::getOption($name), self::PRECONNECT_OPTIONS, true)) {
                 $this->setOption($name, $value);
             }
-        }
-
-        if (false === $this->connection) {
-            throw new LdapException('Could not connect to Ldap server: '.ldap_error($this->connection));
         }
 
         if ('tls' === $this->config['encryption'] && false === @ldap_start_tls($this->connection)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

ldap_set_option should only be called on null (first time setOption is run) or on an LDAP\Connection instance. When ldap_connect fails, it returns a boolean. ldap_set_option fails on this, which results in an early TypeError instead of the LdapException with the real issue: 'Could not connect to Ldap server'. So, the result of ldap_connect should be checked earlier.