### PR TITLE
[Form] [ChoiceType] Add placeholder_disabled option

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -61,7 +61,7 @@
     {%- endif -%}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
         {%- if placeholder is not none -%}
-            <option value=""{% if required and value is empty %} selected="selected"{% endif %}{% if placeholder_disabled is same as(true) %} disabled="disabled"{% endif %}>{{ placeholder != '' ? (translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain)) }}</option>
+            <option value=""{% if required and value is empty %} selected="selected"{% endif %}{% if placeholder_disabled|default(false) is same as(true) %} disabled="disabled"{% endif %}>{{ placeholder != '' ? (translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain)) }}</option>
         {%- endif -%}
         {%- if preferred_choices|length > 0 -%}
             {% set options = preferred_choices %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -61,7 +61,7 @@
     {%- endif -%}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
         {%- if placeholder is not none -%}
-            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ placeholder != '' ? (translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain)) }}</option>
+            <option value=""{% if required and value is empty %} selected="selected"{% endif %}{% if placeholder_disabled is same as(true) %} disabled="disabled"{% endif %}>{{ placeholder != '' ? (translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain)) }}</option>
         {%- endif -%}
         {%- if preferred_choices|length > 0 -%}
             {% set options = preferred_choices %}

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG
  * Deprecate calling `Button/Form::setParent()`, `ButtonBuilder/FormConfigBuilder::setDataMapper()`, `TransformationFailedException::setInvalidMessage()` without arguments
  * Change the signature of `FormConfigBuilderInterface::setDataMapper()` to `setDataMapper(?DataMapperInterface)`
  * Change the signature of `FormInterface::setParent()` to `setParent(?self)`
- * Add a `placeholder_disabled` option to `ChoiceType` (resolves #22318, #38958)
+ * Add a `placeholder_disabled` option to `ChoiceType`
 
 6.1
 ---

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate calling `Button/Form::setParent()`, `ButtonBuilder/FormConfigBuilder::setDataMapper()`, `TransformationFailedException::setInvalidMessage()` without arguments
  * Change the signature of `FormConfigBuilderInterface::setDataMapper()` to `setDataMapper(?DataMapperInterface)`
  * Change the signature of `FormInterface::setParent()` to `setParent(?self)`
+ * Add a `placeholder_disabled` option to `ChoiceType` (resolves #22318, #38958)
 
 6.1
 ---

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -262,8 +262,8 @@ class ChoiceType extends AbstractType
         if (null !== $options['placeholder'] && !$view->vars['placeholder_in_choices']) {
             $view->vars['placeholder'] = $options['placeholder'];
         }
-		
-		$view->vars['placeholder_disabled'] = $options['placeholder_disabled'];
+
+        $view->vars['placeholder_disabled'] = $options['placeholder_disabled'];
 
         if ($options['multiple'] && !$options['expanded']) {
             // Add "[]" to the name in case a select tag with multiple options is

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -352,6 +352,7 @@ class ChoiceType extends AbstractType
             'group_by' => null,
             'empty_data' => $emptyData,
             'placeholder' => $placeholderDefault,
+            'placeholder_disabled' => false,
             'error_bubbling' => false,
             'compound' => $compound,
             // The view data is always a string or an array of strings,
@@ -377,6 +378,7 @@ class ChoiceType extends AbstractType
         $resolver->setAllowedTypes('choice_translation_parameters', ['null', 'array', 'callable', ChoiceTranslationParameters::class]);
         $resolver->setAllowedTypes('preferred_choices', ['array', \Traversable::class, 'callable', 'string', PropertyPath::class, PreferredChoice::class]);
         $resolver->setAllowedTypes('group_by', ['null', 'callable', 'string', PropertyPath::class, GroupBy::class]);
+        $resolver->setAllowedTypes('placeholder_disabled', ['bool']);
     }
 
     public function getBlockPrefix(): string

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -262,6 +262,8 @@ class ChoiceType extends AbstractType
         if (null !== $options['placeholder'] && !$view->vars['placeholder_in_choices']) {
             $view->vars['placeholder'] = $options['placeholder'];
         }
+		
+		$view->vars['placeholder_disabled'] = $options['placeholder_disabled'];
 
         if ($options['multiple'] && !$options['expanded']) {
             // Add "[]" to the name in case a select tag with multiple options is

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -16,6 +16,7 @@
             "group_by",
             "multiple",
             "placeholder",
+            "placeholder_disabled",
             "preferred_choices"
         ],
         "overridden": {

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -19,8 +19,7 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   multiple                                             disabled                                              
   placeholder                                          form_attr                                             
   placeholder_disabled                                 getter                                                
-  preferred_choices                                    getter                                                
-                                                       help                                                  
+  preferred_choices                                    help                                                  
                                                        help_attr                                             
                                                        help_html                                             
                                                        help_translation_parameters                           

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -18,6 +18,7 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   group_by                                             data                                                  
   multiple                                             disabled                                              
   placeholder                                          form_attr                                             
+  placeholder_disabled                                 getter                                                
   preferred_choices                                    getter                                                
                                                        help                                                  
                                                        help_attr                                             


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Implements #22318, #38958
| License       | MIT
| Doc PR        | symfony/symfony-docs#17266

Adds a `placeholder_disabled` option for ChoiceType, which disables the placeholder on select lists.
