### PR TITLE
[Messenger] Separate WorkerRunningEvent into WorkerBusyEvent and WorkerIdleEvent

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -32,6 +32,7 @@ CHANGELOG
  * Add `WrappedExceptionsInterface` interface for exceptions that hold multiple individual exceptions
  * Deprecate `HandlerFailedException::getNestedExceptions()`, `HandlerFailedException::getNestedExceptionsOfClass()`
    and `DelayedMessageHandlingException::getExceptions()` which are replaced by a new `getWrappedExceptions()` method
+ * Separate `WorkerRunningEvent` into `WorkerBusyEvent` and `WorkerIdleEvent`
 
 6.3
 ---

--- a/src/Symfony/Component/Messenger/Event/WorkerBusyEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerBusyEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\Messenger\Worker;
+
+/**
+ * Dispatched after the worker processed a message.
+ *
+ * @author Jeroen Spee <https://github.com/Jeroeny>
+ */
+final class WorkerBusyEvent extends WorkerRunningEvent
+{
+    public function __construct(Worker $worker)
+    {
+        parent::__construct($worker, false);
+    }
+}

--- a/src/Symfony/Component/Messenger/Event/WorkerIdleEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerIdleEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\Messenger\Worker;
+
+/**
+ * Dispatched after the worker didn't receive any message from its receivers.
+ *
+ * @author Jeroen Spee <https://github.com/Jeroeny>
+ */
+final class WorkerIdleEvent extends WorkerRunningEvent
+{
+    public function __construct(Worker $worker)
+    {
+        parent::__construct($worker, true);
+    }
+}

--- a/src/Symfony/Component/Messenger/Event/WorkerRunningEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerRunningEvent.php
@@ -14,11 +14,11 @@ namespace Symfony\Component\Messenger\Event;
 use Symfony\Component\Messenger\Worker;
 
 /**
- * Dispatched after the worker processed a message or didn't receive a message at all.
+ * Events that are dispatched after the worker processed a message or didn't receive a message at all.
  *
  * @author Tobias Schultze <http://tobion.de>
  */
-final class WorkerRunningEvent
+class WorkerRunningEvent
 {
     private Worker $worker;
     private bool $isWorkerIdle;

--- a/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Messenger\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 
 /**
@@ -28,11 +28,9 @@ class ResetServicesListener implements EventSubscriberInterface
         $this->servicesResetter = $servicesResetter;
     }
 
-    public function resetServices(WorkerRunningEvent $event): void
+    public function resetServices(WorkerBusyEvent $event): void
     {
-        if (!$event->isWorkerIdle()) {
-            $this->servicesResetter->reset();
-        }
+        $this->servicesResetter->reset();
     }
 
     public function resetServicesAtStop(WorkerStoppedEvent $event): void
@@ -43,7 +41,7 @@ class ResetServicesListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            WorkerRunningEvent::class => ['resetServices', -1024],
+            WorkerBusyEvent::class => ['resetServices', -1024],
             WorkerStoppedEvent::class => ['resetServicesAtStop', -1024],
         ];
     }

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnFailureLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnFailureLimitListener.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\Messenger\EventListener;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 
 /**
@@ -41,9 +41,9 @@ class StopWorkerOnFailureLimitListener implements EventSubscriberInterface
         ++$this->failedMessages;
     }
 
-    public function onWorkerRunning(WorkerRunningEvent $event): void
+    public function onWorkerBusy(WorkerBusyEvent $event): void
     {
-        if (!$event->isWorkerIdle() && $this->failedMessages >= $this->maximumNumberOfFailures) {
+        if ($this->failedMessages >= $this->maximumNumberOfFailures) {
             $this->failedMessages = 0;
             $event->getWorker()->stop();
 
@@ -55,7 +55,7 @@ class StopWorkerOnFailureLimitListener implements EventSubscriberInterface
     {
         return [
             WorkerMessageFailedEvent::class => 'onMessageFailed',
-            WorkerRunningEvent::class => 'onWorkerRunning',
+            WorkerBusyEvent::class => 'onWorkerBusy',
         ];
     }
 }

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnMessageLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnMessageLimitListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Messenger\EventListener;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 
 /**
@@ -36,9 +36,9 @@ class StopWorkerOnMessageLimitListener implements EventSubscriberInterface
         }
     }
 
-    public function onWorkerRunning(WorkerRunningEvent $event): void
+    public function onWorkerBusy(WorkerBusyEvent $event): void
     {
-        if (!$event->isWorkerIdle() && ++$this->receivedMessages >= $this->maximumNumberOfMessages) {
+        if (++$this->receivedMessages >= $this->maximumNumberOfMessages) {
             $this->receivedMessages = 0;
             $event->getWorker()->stop();
 
@@ -49,7 +49,7 @@ class StopWorkerOnMessageLimitListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            WorkerRunningEvent::class => 'onWorkerRunning',
+            WorkerBusyEvent::class => 'onWorkerBusy',
         ];
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnCustomStopExceptionListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnCustomStopExceptionListenerTest.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnCustomStopExceptionListener;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\StopWorkerException;
@@ -50,7 +50,7 @@ class StopWorkerOnCustomStopExceptionListenerTest extends TestCase
 
         $worker = $this->createMock(Worker::class);
         $worker->expects($shouldStop ? $this->once() : $this->never())->method('stop');
-        $runningEvent = new WorkerRunningEvent($worker, false);
+        $runningEvent = new WorkerBusyEvent($worker);
 
         $listener->onWorkerRunning($runningEvent);
     }

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnFailureLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnFailureLimitListenerTest.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnFailureLimitListener;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Worker;
@@ -31,17 +31,17 @@ class StopWorkerOnFailureLimitListenerTest extends TestCase
         $worker->expects($shouldStop ? $this->atLeastOnce() : $this->never())->method('stop');
 
         $failedEvent = $this->createFailedEvent();
-        $runningEvent = new WorkerRunningEvent($worker, false);
+        $runningEvent = new WorkerBusyEvent($worker);
 
         $failureLimitListener = new StopWorkerOnFailureLimitListener($max);
         // simulate three messages (of which 2 failed)
         $failureLimitListener->onMessageFailed($failedEvent);
-        $failureLimitListener->onWorkerRunning($runningEvent);
+        $failureLimitListener->onWorkerBusy($runningEvent);
 
-        $failureLimitListener->onWorkerRunning($runningEvent);
+        $failureLimitListener->onWorkerBusy($runningEvent);
 
         $failureLimitListener->onMessageFailed($failedEvent);
-        $failureLimitListener->onWorkerRunning($runningEvent);
+        $failureLimitListener->onWorkerBusy($runningEvent);
     }
 
     public static function countProvider(): iterable
@@ -62,11 +62,11 @@ class StopWorkerOnFailureLimitListenerTest extends TestCase
             );
 
         $worker = $this->createMock(Worker::class);
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerBusyEvent($worker);
 
         $failureLimitListener = new StopWorkerOnFailureLimitListener(1, $logger);
         $failureLimitListener->onMessageFailed($this->createFailedEvent());
-        $failureLimitListener->onWorkerRunning($event);
+        $failureLimitListener->onWorkerBusy($event);
     }
 
     private function createFailedEvent(): WorkerMessageFailedEvent

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnMemoryLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnMemoryLimitListenerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMemoryLimitListener;
 use Symfony\Component\Messenger\Worker;
 
@@ -28,7 +28,7 @@ class StopWorkerOnMemoryLimitListenerTest extends TestCase
 
         $worker = $this->createMock(Worker::class);
         $worker->expects($shouldStop ? $this->once() : $this->never())->method('stop');
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerBusyEvent($worker);
 
         $memoryLimitListener = new StopWorkerOnMemoryLimitListener($memoryLimit, null, $memoryResolver);
         $memoryLimitListener->onWorkerRunning($event);
@@ -50,7 +50,7 @@ class StopWorkerOnMemoryLimitListenerTest extends TestCase
         $memoryResolver = fn () => 70;
 
         $worker = $this->createMock(Worker::class);
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerBusyEvent($worker);
 
         $memoryLimitListener = new StopWorkerOnMemoryLimitListener(64, $logger, $memoryResolver);
         $memoryLimitListener->onWorkerRunning($event);

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnMessageLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnMessageLimitListenerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\Worker;
 
@@ -26,13 +26,13 @@ class StopWorkerOnMessageLimitListenerTest extends TestCase
     {
         $worker = $this->createMock(Worker::class);
         $worker->expects($shouldStop ? $this->atLeastOnce() : $this->never())->method('stop');
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerBusyEvent($worker);
 
         $maximumCountListener = new StopWorkerOnMessageLimitListener($max);
         // simulate three messages processed
-        $maximumCountListener->onWorkerRunning($event);
-        $maximumCountListener->onWorkerRunning($event);
-        $maximumCountListener->onWorkerRunning($event);
+        $maximumCountListener->onWorkerBusy($event);
+        $maximumCountListener->onWorkerBusy($event);
+        $maximumCountListener->onWorkerBusy($event);
     }
 
     public static function countProvider(): iterable
@@ -53,9 +53,9 @@ class StopWorkerOnMessageLimitListenerTest extends TestCase
             );
 
         $worker = $this->createMock(Worker::class);
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerBusyEvent($worker);
 
         $maximumCountListener = new StopWorkerOnMessageLimitListener(1, $logger);
-        $maximumCountListener->onWorkerRunning($event);
+        $maximumCountListener->onWorkerBusy($event);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\Worker;
 
@@ -36,7 +36,7 @@ class StopWorkerOnRestartSignalListenerTest extends TestCase
 
         $worker = $this->createMock(Worker::class);
         $worker->expects($shouldStop ? $this->once() : $this->never())->method('stop');
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerBusyEvent($worker);
 
         $stopOnSignalListener = new StopWorkerOnRestartSignalListener($cachePool);
         $stopOnSignalListener->onWorkerStarted();
@@ -60,7 +60,7 @@ class StopWorkerOnRestartSignalListenerTest extends TestCase
 
         $worker = $this->createMock(Worker::class);
         $worker->expects($this->never())->method('stop');
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerBusyEvent($worker);
 
         $stopOnSignalListener = new StopWorkerOnRestartSignalListener($cachePool);
         $stopOnSignalListener->onWorkerStarted();

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnTimeLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnTimeLimitListenerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnTimeLimitListener;
 use Symfony\Component\Messenger\Worker;
 
@@ -30,7 +30,7 @@ class StopWorkerOnTimeLimitListenerTest extends TestCase
 
         $worker = $this->createMock(Worker::class);
         $worker->expects($this->once())->method('stop');
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerBusyEvent($worker);
 
         $timeoutListener = new StopWorkerOnTimeLimitListener(1, $logger);
         $timeoutListener->onWorkerStarted();

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Clock\MockClock;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerBusyEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
@@ -81,8 +82,8 @@ class WorkerTest extends TestCase
 
             public function dispatch(object $event): object
             {
-                if ($event instanceof WorkerRunningEvent) {
-                    $this->listener->onWorkerRunning($event);
+                if ($event instanceof WorkerBusyEvent) {
+                    $this->listener->onWorkerBusy($event);
                 }
 
                 return $event;
@@ -141,7 +142,7 @@ class WorkerTest extends TestCase
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new ResetServicesListener(new ServicesResetter(new \ArrayIterator([$resettableReceiver]), ['reset'])));
-        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) {
+        $dispatcher->addListener(WorkerBusyEvent::class, function (WorkerBusyEvent $event) {
             $event->getWorker()->stop();
         });
 
@@ -201,10 +202,11 @@ class WorkerTest extends TestCase
             $this->isInstanceOf(WorkerMessageReceivedEvent::class),
             $this->isInstanceOf(WorkerMessageHandledEvent::class),
             $this->isInstanceOf(WorkerRunningEvent::class),
+            $this->isInstanceOf(WorkerBusyEvent::class),
             $this->isInstanceOf(WorkerStoppedEvent::class),
         ];
 
-        $eventDispatcher->expects($this->exactly(5))
+        $eventDispatcher->expects($this->exactly(6))
             ->method('dispatch')
             ->willReturnCallback(function ($event) use (&$series) {
                 array_shift($series)->evaluate($event);
@@ -255,10 +257,11 @@ class WorkerTest extends TestCase
             $this->isInstanceOf(WorkerMessageReceivedEvent::class),
             $this->isInstanceOf(WorkerMessageFailedEvent::class),
             $this->isInstanceOf(WorkerRunningEvent::class),
+            $this->isInstanceOf(WorkerBusyEvent::class),
             $this->isInstanceOf(WorkerStoppedEvent::class),
         ];
 
-        $eventDispatcher->expects($this->exactly(5))
+        $eventDispatcher->expects($this->exactly(6))
             ->method('dispatch')
             ->willReturnCallback(function ($event) use (&$series) {
                 array_shift($series)->evaluate($event);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | maybe
| License       | MIT

A common usecase for WorkerRunning listeners seems to be that they perform logic based on `$event->isWorkerIdle()`. E.g. sometimes services only need to reset if a message has been processed. Or non-critical logic needs to happen when the worker is not busy, to keep the processing performant (like keeping a cache warm or sending buffered metrics). 
Right now each of those listeners need to be called, upon which they check themselves if the worker is busy. To increase performance, the WorkerRunning event can be split into `WorkerBusyEvent` and `WorkerIdleEvent`.  This way listeners can be explicit about when they want to act. Since these events are emitted in a loop, this could make a difference. 

There doesn't seem to be a way to deprecate an event, so I think the `WorkerRunning` event remains.   
Though `WorkerRunning::isWorkerIdle()` could be deprecated to stimulate the usage of the new events.
