### PR TITLE
[Messenger] [amqp-messenger] When heartbeat expired, disconnect to force a reconnect

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -102,6 +102,9 @@ class Connection
      */
     private $amqpDelayExchange;
 
+    /** @var int */
+    private $lastActivityTime = 0;
+
     public function __construct(array $connectionOptions, array $exchangeOptions, array $queuesOptions, AmqpFactory $amqpFactory = null)
     {
         if (!\extension_loaded('amqp')) {
@@ -347,6 +350,8 @@ class Connection
         $attributes['delivery_mode'] = $attributes['delivery_mode'] ?? 2;
         $attributes['timestamp'] = $attributes['timestamp'] ?? time();
 
+        $this->lastActivityTime = time();
+
         $exchange->publish(
             $body,
             $routingKey,
@@ -510,6 +515,11 @@ class Connection
                     }
                 );
             }
+
+            $this->lastActivityTime = time();
+        } elseif (!empty($this->connectionOptions['heartbeat']) && time() > $this->lastActivityTime + ($this->connectionOptions['heartbeat'] * 2)) {
+            $disconnectMethod = 'true' === ($this->connectionOptions['persistent'] ?? 'false') ? 'pdisconnect' : 'disconnect';
+            $this->amqpChannel->getConnection()->{$disconnectMethod}();
         }
 
         return $this->amqpChannel;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      | 5.4
| Bug fix?      | yes
| License       | MIT

Network can fail in many ways, sometimes pretty subtle.

To avoid error messages "Library error: a socket error occurred", we detect when heartbeat as expired, and disconnect the chanmel connection, and force a reconnect.

Here a explaination to justify the condition :
https://www.rabbitmq.com/heartbeats.html#:~:text=Heartbeat%20frames%20are%20sent%20about,TCP%20connection%20will%20be%20closed.