### PR TITLE
[Security] Fix AbstractFormLoginAuthenticator return types

### DIFF
--- a/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Guard\Authenticator;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
@@ -34,7 +35,7 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
     /**
      * Override to change what happens after a bad username/password is submitted.
      *
-     * @return RedirectResponse
+     * @return Response
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
@@ -56,7 +57,7 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
      * Override to control what happens when the user hits a secure page
      * but isn't logged in yet.
      *
-     * @return RedirectResponse
+     * @return Response
      */
     public function start(Request $request, AuthenticationException $authException = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47571
| License       | MIT
| Doc PR        | NA

Children of AbstractFormLoginAuthenticator should be allowed to return a `Response` instead of being required to return a `RedirectResponse`. This change matches the return types in the newer `AbstractLoginFormAuthenticator`.

Not sure if tests are needed for this, but if they're desired I could use a bit of direction on how to go about it, since it's really only an issue for static analysis.