### PR TITLE
[Notifier] [RocketChat] Updated RocketChatOptions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
    `workflow.state_machine`
  * Add `rate_limiter` configuration option to `messenger.transport` to allow rate limited transports using the RateLimiter component
  * Remove `@internal` tag from secret vaults to allow them to be used directly outside the framework bundle and custom vaults to be added
+ * Deprecate "framework.form.legacy_error_messages" config node
 
 6.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -237,8 +237,9 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('field_name')->defaultValue('_token')->end()
                             ->end()
                         ->end()
-                        // to be deprecated in Symfony 6.1
-                        ->booleanNode('legacy_error_messages')->end()
+                        ->booleanNode('legacy_error_messages')
+                            ->setDeprecated('symfony/framework-bundle', '6.2')
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_default_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_default_csrf.php
@@ -2,9 +2,6 @@
 
 $container->loadFromExtension('framework', [
     'http_method_override' => false,
-    'form' => [
-        'legacy_error_messages' => false,
-    ],
     'session' => [
         'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
@@ -8,7 +8,6 @@
 
     <framework:config http-method-override="false">
         <framework:csrf-protection />
-        <framework:form legacy-error-messages="false" />
         <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
@@ -9,6 +9,5 @@
     <framework:config http-method-override="false">
         <framework:csrf-protection field-name="_custom" />
         <framework:session storage-factory-id="session.storage.factory.native" />
-        <framework:form legacy-error-messages="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
@@ -8,7 +8,6 @@
 
     <framework:config http-method-override="false">
         <framework:csrf-protection field-name="_custom_form" />
-        <framework:form legacy-error-messages="false" />
         <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_default_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_default_csrf.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
-        <framework:form enabled="true" legacy-error-messages="false" />
+        <framework:form enabled="true" />
         <framework:session storage-factory-id="session.storage.factory.native" handler-id="null"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
-        <framework:form enabled="true" legacy-error-messages="false">
+        <framework:form enabled="true">
             <framework:csrf-protection enabled="false" />
         </framework:form>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -10,7 +10,7 @@
         <framework:enabled-locale>fr</framework:enabled-locale>
         <framework:enabled-locale>en</framework:enabled-locale>
         <framework:csrf-protection />
-        <framework:form legacy-error-messages="false">
+        <framework:form>
             <framework:csrf-protection field-name="_csrf"/>
         </framework:form>
         <framework:esi enabled="true" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_default_csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_default_csrf.yml
@@ -1,7 +1,5 @@
 framework:
     http_method_override: false
-    form:
-        legacy_error_messages: false
     session:
         storage_factory_id: session.storage.factory.native
         handler_id: null

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -256,7 +256,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $requestMatcherId = 'My\Test\RequestMatcher';
-        $requestMatcher = new RequestMatcher('/');
+        $requestMatcher = new PathRequestMatcher('/');
         $container->set($requestMatcherId, $requestMatcher);
 
         $container->loadFromExtension('security', [
@@ -291,7 +291,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $requestMatcherId = 'My\Test\RequestMatcher';
-        $requestMatcher = new RequestMatcher('/');
+        $requestMatcher = new PathRequestMatcher('/');
         $container->set($requestMatcherId, $requestMatcher);
 
         $container->loadFromExtension('security', [

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/dependency-injection": "^6.2",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/http-kernel": "^6.2",
-        "symfony/http-foundation": "^5.4|^6.0",
+        "symfony/http-foundation": "^6.2",
         "symfony/password-hasher": "^5.4|^6.0",
         "symfony/security-core": "^6.2",
         "symfony/security-csrf": "^5.4|^6.0",

--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -102,7 +102,7 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
         return $this->lazyObjectReal->bgrewriteaof(...\func_get_args());
     }
 
-    public function bitcount($key, $start = 0, $end = -1)
+    public function bitcount($key, $start = 0, $end = -1, $bybit = false)
     {
         return $this->lazyObjectReal->bitcount(...\func_get_args());
     }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @implements DataTransformerInterface<string, string>
+ * @implements DataTransformerInterface<mixed, string>
  */
 class ChoiceToValueTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -179,15 +179,17 @@ class BinaryFileResponse extends Response
 
     public function prepare(Request $request): static
     {
+        parent::prepare($request);
+
+        if ($this->isInformational() || $this->isEmpty()) {
+            $this->maxlen = 0;
+
+            return $this;
+        }
+
         if (!$this->headers->has('Content-Type')) {
             $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');
         }
-
-        if ('HTTP/1.0' !== $request->server->get('SERVER_PROTOCOL')) {
-            $this->setProtocolVersion('1.1');
-        }
-
-        $this->ensureIEOverSSLCompatibility($request);
 
         $this->offset = 0;
         $this->maxlen = -1;
@@ -195,6 +197,7 @@ class BinaryFileResponse extends Response
         if (false === $fileSize = $this->file->getSize()) {
             return $this;
         }
+        $this->headers->remove('Transfer-Encoding');
         $this->headers->set('Content-Length', $fileSize);
 
         if (!$this->headers->has('Accept-Ranges')) {
@@ -264,6 +267,10 @@ class BinaryFileResponse extends Response
             }
         }
 
+        if ($request->isMethod('HEAD')) {
+            $this->maxlen = 0;
+        }
+
         return $this;
     }
 
@@ -282,40 +289,42 @@ class BinaryFileResponse extends Response
 
     public function sendContent(): static
     {
-        if (!$this->isSuccessful()) {
-            return parent::sendContent();
-        }
-
-        if (0 === $this->maxlen) {
-            return $this;
-        }
-
-        $out = fopen('php://output', 'w');
-        $file = fopen($this->file->getPathname(), 'r');
-
-        ignore_user_abort(true);
-
-        if (0 !== $this->offset) {
-            fseek($file, $this->offset);
-        }
-
-        $length = $this->maxlen;
-        while ($length && !feof($file)) {
-            $read = ($length > $this->chunkSize) ? $this->chunkSize : $length;
-            $length -= $read;
-
-            stream_copy_to_stream($file, $out, $read);
-
-            if (connection_aborted()) {
-                break;
+        try {
+            if (!$this->isSuccessful()) {
+                return parent::sendContent();
             }
-        }
 
-        fclose($out);
-        fclose($file);
+            if (0 === $this->maxlen) {
+                return $this;
+            }
 
-        if ($this->deleteFileAfterSend && is_file($this->file->getPathname())) {
-            unlink($this->file->getPathname());
+            $out = fopen('php://output', 'w');
+            $file = fopen($this->file->getPathname(), 'r');
+
+            ignore_user_abort(true);
+
+            if (0 !== $this->offset) {
+                fseek($file, $this->offset);
+            }
+
+            $length = $this->maxlen;
+            while ($length && !feof($file)) {
+                $read = ($length > $this->chunkSize) ? $this->chunkSize : $length;
+                $length -= $read;
+
+                stream_copy_to_stream($file, $out, $read);
+
+                if (connection_aborted()) {
+                    break;
+                }
+            }
+
+            fclose($out);
+            fclose($file);
+        } finally {
+            if ($this->deleteFileAfterSend && is_file($this->file->getPathname())) {
+                unlink($this->file->getPathname());
+            }
         }
 
         return $this;

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 
  * The HTTP cache store uses the `xxh128` algorithm
  * Deprecate calling `JsonResponse::setCallback()`, `Response::setExpires/setLastModified/setEtag()`, `MockArraySessionStorage/NativeSessionStorage::setMetadataBag()`, `NativeSessionStorage::setSaveHandler()` without arguments
+ * Add request matchers under the `Symfony\Component\HttpFoundation\RequestMatcher` namespace
+ * Deprecate `RequestMatcher` in favor of `ChainRequestMatcher`
+ * Deprecate `Symfony\Component\HttpFoundation\ExpressionRequestMatcher` in favor of `Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher`
 
 6.1
 ---

--- a/src/Symfony/Component/HttpFoundation/ChainRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/ChainRequestMatcher.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * ChainRequestMatcher verifies that all checks match against a Request instance.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ChainRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @param iterable<RequestMatcherInterface> $matchers
+     */
+    public function __construct(private iterable $matchers)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        foreach ($this->matchers as $matcher) {
+            if (!$matcher->matches($request)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/ExpressionRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/ExpressionRequestMatcher.php
@@ -13,11 +13,16 @@ namespace Symfony\Component\HttpFoundation;
 
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher as NewExpressionRequestMatcher;
+
+trigger_deprecation('symfony/http-foundation', '6.2', 'The "%s" class is deprecated, use "%s" instead.', ExpressionRequestMatcher::class, NewExpressionRequestMatcher::class);
 
 /**
  * ExpressionRequestMatcher uses an expression to match a Request.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 6.2, use "Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher" instead
  */
 class ExpressionRequestMatcher extends RequestMatcher
 {

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\HttpFoundation;
 
+trigger_deprecation('symfony/http-foundation', '6.2', 'The "%s" class is deprecated, use "%s" instead.', RequestMatcher::class, ChainRequestMatcher::class);
+
 /**
  * RequestMatcher compares a pre-defined set of checks against a Request instance.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 6.2, use ChainRequestMatcher instead
  */
 class RequestMatcher implements RequestMatcherInterface
 {

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/AttributesRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/AttributesRequestMatcher.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the Request attributes matches all regular expressions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AttributesRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @param array<string, string> $regexps
+     */
+    public function __construct(private array $regexps)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        foreach ($this->regexps as $key => $regexp) {
+            $attribute = $request->attributes->get($key);
+            if (!\is_string($attribute)) {
+                return false;
+            }
+            if (!preg_match('{'.$regexp.'}', $attribute)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/ExpressionRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/ExpressionRequestMatcher.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * ExpressionRequestMatcher uses an expression to match a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ExpressionRequestMatcher implements RequestMatcherInterface
+{
+    public function __construct(
+        private ExpressionLanguage $language,
+        private Expression|string $expression,
+    ) {
+    }
+
+    public function matches(Request $request): bool
+    {
+        return $this->language->evaluate($this->expression, [
+            'request' => $request,
+            'method' => $request->getMethod(),
+            'path' => rawurldecode($request->getPathInfo()),
+            'host' => $request->getHost(),
+            'ip' => $request->getClientIp(),
+            'attributes' => $request->attributes->all(),
+        ]);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/HostRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/HostRequestMatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the Request URL host name matches a regular expression.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HostRequestMatcher implements RequestMatcherInterface
+{
+    public function __construct(private string $regexp)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        return preg_match('{'.$this->regexp.'}i', $request->getHost());
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/IpsRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/IpsRequestMatcher.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\IpUtils;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the client IP of a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class IpsRequestMatcher implements RequestMatcherInterface
+{
+    private array $ips;
+
+    /**
+     * @param string[]|string $ips A specific IP address or a range specified using IP/netmask like 192.168.1.0/24
+     *                             Strings can contain a comma-delimited list of IPs/ranges
+     */
+    public function __construct(array|string $ips)
+    {
+        $this->ips = array_reduce((array) $ips, static function (array $ips, string $ip) {
+            return array_merge($ips, preg_split('/\s*,\s*/', $ip));
+        }, []);
+    }
+
+    public function matches(Request $request): bool
+    {
+        if (!$this->ips) {
+            return true;
+        }
+
+        return IpUtils::checkIp($request->getClientIp() ?? '', $this->ips);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/IsJsonRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/IsJsonRequestMatcher.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the Request content is valid JSON.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class IsJsonRequestMatcher implements RequestMatcherInterface
+{
+    public function matches(Request $request): bool
+    {
+        try {
+            json_decode($request->getContent(), true, 512, \JSON_BIGINT_AS_STRING | \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/MethodRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/MethodRequestMatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the HTTP method of a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class MethodRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @var string[]
+     */
+    private array $methods = [];
+
+    /**
+     * @param string[]|string $methods An HTTP method or an array of HTTP methods
+     *                                 Strings can contain a comma-delimited list of methods
+     */
+    public function __construct(array|string $methods)
+    {
+        $this->methods = array_reduce(array_map('strtoupper', (array) $methods), static function (array $methods, string $method) {
+            return array_merge($methods, preg_split('/\s*,\s*/', $method));
+        }, []);
+    }
+
+    public function matches(Request $request): bool
+    {
+        if (!$this->methods) {
+            return true;
+        }
+
+        return \in_array($request->getMethod(), $this->methods, true);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/PathRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/PathRequestMatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the Request URL path info matches a regular expression.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class PathRequestMatcher implements RequestMatcherInterface
+{
+    public function __construct(private string $regexp)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        return preg_match('{'.$this->regexp.'}', rawurldecode($request->getPathInfo()));
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/PortRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/PortRequestMatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the HTTP port of a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class PortRequestMatcher implements RequestMatcherInterface
+{
+    public function __construct(private int $port)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        return $request->getPort() === $this->port;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/SchemeRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/SchemeRequestMatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the HTTP scheme of a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class SchemeRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @var string[]
+     */
+    private array $schemes;
+
+    /**
+     * @param string[]|string $schemes A scheme or a list of schemes
+     *                                 Strings can contain a comma-delimited list of schemes
+     */
+    public function __construct(array|string $schemes)
+    {
+        $this->schemes = array_reduce(array_map('strtolower', (array) $schemes), static function (array $schemes, string $scheme) {
+            return array_merge($schemes, preg_split('/\s*,\s*/', $scheme));
+        }, []);
+    }
+
+    public function matches(Request $request): bool
+    {
+        if (!$this->schemes) {
+            return true;
+        }
+
+        return \in_array($request->getScheme(), $this->schemes, true);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -372,6 +372,21 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertNull($response->headers->get('Content-Length'));
     }
 
+    public function testPrepareNotAddingContentTypeHeaderIfNoContentResponse()
+    {
+        $request = Request::create('/');
+        $request->headers->set('If-Modified-Since', date('D, d M Y H:i:s').' GMT');
+
+        $response = new BinaryFileResponse(__DIR__.'/File/Fixtures/test.gif', 200, ['Content-Type' => 'application/octet-stream']);
+        $response->setLastModified(new \DateTimeImmutable('-1 day'));
+        $response->isNotModified($request);
+
+        $response->prepare($request);
+
+        $this->assertSame(BinaryFileResponse::HTTP_NOT_MODIFIED, $response->getStatusCode());
+        $this->assertFalse($response->headers->has('Content-Type'));
+    }
+
     protected function provideResponse()
     {
         return new BinaryFileResponse(__DIR__.'/../README.md', 200, ['Content-Type' => 'application/octet-stream']);

--- a/src/Symfony/Component/HttpFoundation/Tests/ExpressionRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ExpressionRequestMatcherTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\ExpressionRequestMatcher;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @group legacy
+ */
 class ExpressionRequestMatcherTest extends TestCase
 {
     public function testWhenNoExpressionIsSet()

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/AttributesRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/AttributesRequestMatcherTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\AttributesRequestMatcher;
+use Symfony\Component\HttpFoundation\Response;
+
+class AttributesRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(string $key, string $regexp, bool $expected)
+    {
+        $matcher = new AttributesRequestMatcher([$key => $regexp]);
+        $request = Request::create('/admin/foo');
+        $request->attributes->set('foo', 'foo_bar');
+        $request->attributes->set('_controller', function () {
+            return new Response('foo');
+        });
+        $this->assertSame($expected, $matcher->matches($request));
+    }
+
+    public function getData(): array
+    {
+        return [
+            ['foo', 'foo_.*', true],
+            ['foo', 'foo', true],
+            ['foo', '^foo_bar$', true],
+            ['foo', 'babar', false],
+            'with-closure' => ['_controller', 'babar', false],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/ExpressionRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/ExpressionRequestMatcherTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher;
+
+class ExpressionRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider provideExpressions
+     */
+    public function testMatchesWhenParentMatchesIsTrue($expression, $expected)
+    {
+        $request = Request::create('/foo');
+        $expressionRequestMatcher = new ExpressionRequestMatcher(new ExpressionLanguage(), $expression);
+        $this->assertSame($expected, $expressionRequestMatcher->matches($request));
+    }
+
+    public function provideExpressions()
+    {
+        return [
+            ['request.getMethod() == method', true],
+            ['request.getPathInfo() == path', true],
+            ['request.getHost() == host', true],
+            ['request.getClientIp() == ip', true],
+            ['request.attributes.all() == attributes', true],
+            ['request.getMethod() == method && request.getPathInfo() == path && request.getHost() == host && request.getClientIp() == ip &&  request.attributes.all() == attributes', true],
+            ['request.getMethod() != method', false],
+            ['request.getMethod() != method && request.getPathInfo() == path && request.getHost() == host && request.getClientIp() == ip &&  request.attributes.all() == attributes', false],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/HostRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/HostRequestMatcherTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\HostRequestMatcher;
+
+class HostRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test($pattern, $isMatch)
+    {
+        $matcher = new HostRequestMatcher($pattern);
+        $request = Request::create('', 'get', [], [], [], ['HTTP_HOST' => 'foo.example.com']);
+        $this->assertSame($isMatch, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            ['.*\.example\.com', true],
+            ['\.example\.com$', true],
+            ['^.*\.example\.com$', true],
+            ['.*\.sensio\.com', false],
+            ['.*\.example\.COM', true],
+            ['\.example\.COM$', true],
+            ['^.*\.example\.COM$', true],
+            ['.*\.sensio\.COM', false],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/IpsRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/IpsRequestMatcherTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IpsRequestMatcher;
+
+class IpsRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test($ips, bool $expected)
+    {
+        $matcher = new IpsRequestMatcher($ips);
+        $request = Request::create('', 'GET', [], [], [], ['REMOTE_ADDR' => '127.0.0.1']);
+        $this->assertSame($expected, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            [[], true],
+            ['127.0.0.1', true],
+            ['192.168.0.1', false],
+            ['127.0.0.1', true],
+            ['127.0.0.1, ::1', true],
+            ['192.168.0.1, ::1', false],
+            [['127.0.0.1', '::1'], true],
+            [['192.168.0.1', '::1'], false],
+            [['1.1.1.1', '2.2.2.2', '127.0.0.1, ::1'], true],
+            [['1.1.1.1', '2.2.2.2', '192.168.0.1, ::1'], false],
+            [['192.168.1.0/24'], false],
+            [['127.0.0.1/32'], true],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/IsJsonRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/IsJsonRequestMatcherTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
+
+class IsJsonRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test($json, bool $isValid)
+    {
+        $matcher = new IsJsonRequestMatcher();
+        $request = Request::create('', 'GET', [], [], [], [], $json);
+        $this->assertSame($isValid, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            ['not json', false],
+            ['"json_string"', true],
+            ['11', true],
+            ['["json", "array"]', true],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/MethodRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/MethodRequestMatcherTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
+
+class MethodRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(string $requestMethod, array|string $matcherMethod, bool $isMatch)
+    {
+        $matcher = new MethodRequestMatcher($matcherMethod);
+        $request = Request::create('', $requestMethod);
+        $this->assertSame($isMatch, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            ['get', 'get', true],
+            ['get', 'post,get', true],
+            ['get', 'post, get', true],
+            ['get', 'post,GET', true],
+            ['get', ['get', 'post'], true],
+            ['get', 'post', false],
+            ['get', 'GET', true],
+            ['get', ['GET', 'POST'], true],
+            ['get', 'POST', false],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/PathRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/PathRequestMatcherTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
+
+class PathRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(string $regexp, bool $expected)
+    {
+        $matcher = new PathRequestMatcher($regexp);
+        $request = Request::create('/admin/foo');
+        $this->assertSame($expected, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            ['/admin/.*', true],
+            ['/admin', true],
+            ['^/admin/.*$', true],
+            ['/blog/.*', false],
+        ];
+    }
+
+    public function testWithLocaleIsNotSupported()
+    {
+        $matcher = new PathRequestMatcher('^/{_locale}/login$');
+        $request = Request::create('/en/login');
+        $request->setLocale('en');
+        $this->assertFalse($matcher->matches($request));
+    }
+
+    public function testWithEncodedCharacters()
+    {
+        $matcher = new PathRequestMatcher('^/admin/fo o*$');
+        $request = Request::create('/admin/fo%20o');
+        $this->assertTrue($matcher->matches($request));
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/PortRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/PortRequestMatcherTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\PortRequestMatcher;
+
+class PortRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(int $port, bool $expected)
+    {
+        $matcher = new PortRequestMatcher($port);
+        $request = Request::create('', 'get', [], [], [], ['HTTP_HOST' => null, 'SERVER_PORT' => 8000]);
+        $this->assertSame($expected, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            [8000, true],
+            [9000, false],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/SchemeRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/SchemeRequestMatcherTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\SchemeRequestMatcher;
+
+class SchemeRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(string $requestScheme, array|string $matcherScheme, bool $isMatch)
+    {
+        $httpRequest = Request::create('');
+        $httpsRequest = Request::create('', 'get', [], [], [], ['HTTPS' => 'on']);
+
+        if ($isMatch) {
+            if ('https' === $requestScheme) {
+                $matcher = new SchemeRequestMatcher($matcherScheme);
+                $this->assertFalse($matcher->matches($httpRequest));
+                $this->assertTrue($matcher->matches($httpsRequest));
+            } else {
+                $matcher = new SchemeRequestMatcher($matcherScheme);
+                $this->assertFalse($matcher->matches($httpsRequest));
+                $this->assertTrue($matcher->matches($httpRequest));
+            }
+        } else {
+            $matcher = new SchemeRequestMatcher($matcherScheme);
+            $this->assertFalse($matcher->matches($httpRequest));
+            $this->assertFalse($matcher->matches($httpsRequest));
+        }
+    }
+
+    public function getData()
+    {
+        return [
+            ['http', 'http', true],
+            ['http', 'HTTP', true],
+            ['https', 'https', true],
+            ['http', 'ftp', false],
+            ['http', 'ftp, http', true],
+            ['http', 'FTP, HTTP', true],
+            ['http', ['http', 'ftp'], true],
+            ['http', ['http,ftp'], true],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcherTest.php
@@ -14,7 +14,11 @@ namespace Symfony\Component\HttpFoundation\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group legacy
+ */
 class RequestMatcherTest extends TestCase
 {
     /**
@@ -46,8 +50,8 @@ class RequestMatcherTest extends TestCase
 
     public function testScheme()
     {
-        $httpRequest = $request = $request = Request::create('');
-        $httpsRequest = $request = $request = Request::create('', 'get', [], [], [], ['HTTPS' => 'on']);
+        $httpRequest = Request::create('');
+        $httpsRequest = Request::create('', 'get', [], [], [], ['HTTPS' => 'on']);
 
         $matcher = new RequestMatcher();
         $matcher->matchScheme('https');

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -221,15 +221,20 @@ class MessengerPass implements CompilerPassInterface
 
         if ($type instanceof \ReflectionUnionType) {
             $types = [];
+            $invalidTypes = [];
             foreach ($type->getTypes() as $type) {
                 if (!$type->isBuiltin()) {
                     $types[] = (string) $type;
+                } else {
+                    $invalidTypes[] = (string) $type;
                 }
             }
 
             if ($types) {
-                return $types;
+                return ('__invoke' === $methodName) ? $types : array_fill_keys($types, $methodName);
             }
+
+            throw new RuntimeException(sprintf('Invalid handler service "%s": type-hint of argument "$%s" in method "%s::__invoke()" must be a class , "%s" given.', $serviceId, $parameters[0]->getName(), $handlerClass->getName(), implode('|', $invalidTypes)));
         }
 
         if ($type->isBuiltin()) {

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommand;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyHandlerWithCustomMethods;
@@ -49,6 +50,11 @@ use Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler;
 use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\TaggedDummyHandler;
+use Symfony\Component\Messenger\Tests\Fixtures\TaggedDummyHandlerWithUnionTypes;
+use Symfony\Component\Messenger\Tests\Fixtures\UnionBuiltinTypeArgumentHandler;
+use Symfony\Component\Messenger\Tests\Fixtures\UnionTypeArgumentHandler;
+use Symfony\Component\Messenger\Tests\Fixtures\UnionTypeOneMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\UnionTypeTwoMessage;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 class MessengerPassTest extends TestCase
@@ -177,6 +183,54 @@ class MessengerPassTest extends TestCase
             $handlerDescriptionMapping,
             SecondMessage::class,
             [[TaggedDummyHandler::class, 'handleSecondMessage']]
+        );
+    }
+
+    public function testTaggedMessageHandlerWithUnionTypes()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container->registerAttributeForAutoconfiguration(AsMessageHandler::class, static function (ChildDefinition $definition, AsMessageHandler $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
+            $tagAttributes = get_object_vars($attribute);
+            $tagAttributes['from_transport'] = $tagAttributes['fromTransport'];
+            unset($tagAttributes['fromTransport']);
+            if ($reflector instanceof \ReflectionMethod) {
+                if (isset($tagAttributes['method'])) {
+                    throw new LogicException(sprintf('AsMessageHandler attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
+                }
+                $tagAttributes['method'] = $reflector->getName();
+            }
+
+            $definition->addTag('messenger.message_handler', $tagAttributes);
+        });
+        $container
+            ->register(TaggedDummyHandlerWithUnionTypes::class, TaggedDummyHandlerWithUnionTypes::class)
+            ->setAutoconfigured(true)
+        ;
+
+        (new AttributeAutoconfigurationPass())->process($container);
+        (new ResolveInstanceofConditionalsPass())->process($container);
+        (new MessengerPass())->process($container);
+
+        $handlersLocatorDefinition = $container->getDefinition($busId.'.messenger.handlers_locator');
+        $this->assertSame(HandlersLocator::class, $handlersLocatorDefinition->getClass());
+
+        $handlerDescriptionMapping = $handlersLocatorDefinition->getArgument(0);
+
+        $this->assertCount(4, $handlerDescriptionMapping);
+
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, [TaggedDummyHandlerWithUnionTypes::class], [[]]);
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, SecondMessage::class, [TaggedDummyHandlerWithUnionTypes::class], [[]]);
+        $this->assertHandlerDescriptor(
+            $container,
+            $handlerDescriptionMapping,
+            UnionTypeOneMessage::class,
+            [[TaggedDummyHandlerWithUnionTypes::class, 'handleUnionTypeMessage']]
+        );
+        $this->assertHandlerDescriptor(
+            $container,
+            $handlerDescriptionMapping,
+            UnionTypeTwoMessage::class,
+            [[TaggedDummyHandlerWithUnionTypes::class, 'handleUnionTypeMessage']]
         );
     }
 
@@ -578,6 +632,37 @@ class MessengerPassTest extends TestCase
         $container = $this->getContainerBuilder();
         $container
             ->register(BuiltinArgumentTypeHandler::class, BuiltinArgumentTypeHandler::class)
+            ->addTag('messenger.message_handler')
+        ;
+
+        (new MessengerPass())->process($container);
+    }
+
+    public function testUnionTypeArgumentsTypeHandler()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container
+            ->register(UnionTypeArgumentHandler::class, UnionTypeArgumentHandler::class)
+            ->addTag('messenger.message_handler')
+        ;
+
+        (new MessengerPass())->process($container);
+
+        $handlersMapping = $container->getDefinition($busId.'.messenger.handlers_locator')->getArgument(0);
+
+        $this->assertArrayHasKey(ChildDummyMessage::class, $handlersMapping);
+        $this->assertArrayHasKey(DummyMessage::class, $handlersMapping);
+        $this->assertHandlerDescriptor($container, $handlersMapping, ChildDummyMessage::class, [UnionTypeArgumentHandler::class]);
+        $this->assertHandlerDescriptor($container, $handlersMapping, DummyMessage::class, [UnionTypeArgumentHandler::class]);
+    }
+
+    public function testUnionBuiltinArgumentTypeHandler()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('Invalid handler service "%s": type-hint of argument "$message" in method "%s::__invoke()" must be a class , "string|int" given.', UnionBuiltinTypeArgumentHandler::class, UnionBuiltinTypeArgumentHandler::class));
+        $container = $this->getContainerBuilder();
+        $container
+            ->register(UnionBuiltinTypeArgumentHandler::class, UnionBuiltinTypeArgumentHandler::class)
             ->addTag('messenger.message_handler')
         ;
 

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandlerWithUnionTypes.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/TaggedDummyHandlerWithUnionTypes.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class TaggedDummyHandlerWithUnionTypes
+{
+    public function __invoke(DummyMessage|SecondMessage $message)
+    {
+    }
+
+    #[AsMessageHandler]
+    public function handleUnionTypeMessage(UnionTypeOneMessage|UnionTypeTwoMessage $message)
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/UnionBuiltinTypeArgumentHandler.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/UnionBuiltinTypeArgumentHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class UnionBuiltinTypeArgumentHandler
+{
+    public function __invoke(string|int $message): void
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeArgumentHandler.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeArgumentHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class UnionTypeArgumentHandler
+{
+    public function __invoke(ChildDummyMessage|DummyMessage $message): void
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeOneMessage.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeOneMessage.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class UnionTypeOneMessage
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeTwoMessage.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/UnionTypeTwoMessage.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class UnionTypeTwoMessage
+{
+}

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Add the ability to send multiple attachments in a message
+ * Add the ability to send custom payload data to Rocket.Chat webhooks
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/README.md
@@ -11,8 +11,76 @@ ROCKETCHAT_DSN=rocketchat://ACCESS_TOKEN@default?channel=CHANNEL
 ```
 
 where:
- - `ACCESS_TOKEN` is your RocketChat access token
- - `CHANNEL` is your RocketChat channel
+ - `ACCESS_TOKEN` is your RocketChat webhook token
+ - `CHANNEL` is your RocketChat channel, it may be overridden in the payload
+
+Example (be sure to escape the middle slash with %2F):
+
+```
+# Webhook URL: https://rocketchathost/hooks/a847c392165c41f7bc5bbf273dd701f3/9343289d1c33464bb15ef132b5a7628d
+ROCKETCHAT_DSN=rocketchat://a847c392165c41f7bc5bbf273dd701f3%2F9343289d1c33464bb15ef132b5a7628d@rocketchathost?channel=channel
+```
+
+Attachments and Payload
+-----------------------
+
+When creating a `ChatMessage`, you can add payload and multiple attachments to
+`RocketChatOptions`. These enable you to customize the name or the avatar of the
+bot posting the message, and to add files to it.
+
+The payload can contain any data you want; its data is processed by a
+Rocket.Chat Incoming Webhook Script which you can write to best suit your needs.
+For example, you can use this script to send the raw payload to Rocket.Chat:
+
+```javascript
+ class Script {
+     process_incoming_request({ request }) {
+         return {
+             request.content
+         };
+     }
+}
+```
+
+When using this script, the Payload must be indexed following Rocket.Chat
+Payload convention:
+
+```php
+$payload = [
+   'alias' => 'Bot Name',
+   'emoji' => ':joy:', // Emoji used as avatar
+   'avatar' => 'http://site.com/logo.png', // Overridden by emoji if provided
+   'channel' => '#myChannel', // Overrides the DSN's channel setting
+];
+
+$attachement1 = [
+    'color' => '#ff0000',
+    'title' => 'My title',
+    'text' => 'My text',
+    // ...
+];
+
+$attachement2 = [
+    'color' => '#ff0000',
+    'title' => 'My title',
+    'text' => 'My text',
+    // ...
+];
+
+// For backward compatibility reasons, both usages are valid
+$rocketChatOptions = new RocketChatOptions($attachement1, $payload);
+$rocketChatOptions = new RocketChatOptions([$attachement1, $attachement2], $payload);
+```
+
+**Note:** the `text` and `attachments` keys of the payload will be overridden
+respectively by the ChatMessage's subject and the attachments provided in
+RocketChatOptions' constructor.
+
+See Also
+--------
+
+ * [Rocket.Chat Webhook Integration](https://docs.rocket.chat/guides/administration/admin-panel/integrations)
+ * [Rocket.Chat Message Payload](https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/postmessage#payload)
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatOptions.php
@@ -17,28 +17,36 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
  * @author Jeroen Spee <https://github.com/Jeroeny>
  *
  * @see https://rocket.chat/docs/administrator-guides/integrations/
+ * @see https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/postmessage
  */
 final class RocketChatOptions implements MessageOptionsInterface
 {
     /** prefix with '@' for personal messages */
     private ?string $channel = null;
 
-    /** @var mixed[] */
+    /** @var string[]|string[][] */
     private array $attachments;
 
+    /** @var string[] */
+    private array $payload;
+
     /**
-     * @param string[] $attachments
+     * @param string[]|string[][] $attachments
+     * @param string[]            $payload
      */
-    public function __construct(array $attachments = [])
+    public function __construct(array $attachments = [], array $payload = [])
     {
         $this->attachments = $attachments;
+        $this->payload = $payload;
     }
 
     public function toArray(): array
     {
-        return [
-            'attachments' => [$this->attachments],
-        ];
+        if ($this->attachments) {
+            return $this->payload + ['attachments' => array_is_list($this->attachments) ? $this->attachments : [$this->attachments]];
+        }
+
+        return $this->payload;
     }
 
     public function getRecipientId(): ?string

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.nb.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.nb.xlf
@@ -70,6 +70,14 @@
                 <source>Invalid or expired login link.</source>
                 <target>Ugyldig eller utløpt påloggingskobling.</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutt.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+                <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutter.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.no.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.no.xlf
@@ -70,6 +70,14 @@
                 <source>Invalid or expired login link.</source>
                 <target>Ugyldig eller utløpt påloggingskobling.</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutt.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+                <target>For mange mislykkede påloggingsforsøk, prøv igjen om %minutes% minutter.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Http\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
 use Symfony\Component\Security\Http\FirewallMap;
 
@@ -25,7 +25,7 @@ class FirewallMapTest extends TestCase
 
         $request = new Request();
 
-        $notMatchingMatcher = $this->createMock(RequestMatcher::class);
+        $notMatchingMatcher = $this->createMock(RequestMatcherInterface::class);
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
@@ -35,7 +35,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($notMatchingMatcher, [function () {}]);
 
-        $matchingMatcher = $this->createMock(RequestMatcher::class);
+        $matchingMatcher = $this->createMock(RequestMatcherInterface::class);
         $matchingMatcher
             ->expects($this->once())
             ->method('matches')
@@ -47,7 +47,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($matchingMatcher, [$theListener], $theException);
 
-        $tooLateMatcher = $this->createMock(RequestMatcher::class);
+        $tooLateMatcher = $this->createMock(RequestMatcherInterface::class);
         $tooLateMatcher
             ->expects($this->never())
             ->method('matches')
@@ -67,7 +67,7 @@ class FirewallMapTest extends TestCase
 
         $request = new Request();
 
-        $notMatchingMatcher = $this->createMock(RequestMatcher::class);
+        $notMatchingMatcher = $this->createMock(RequestMatcherInterface::class);
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
@@ -82,7 +82,7 @@ class FirewallMapTest extends TestCase
 
         $map->add(null, [$theListener], $theException);
 
-        $tooLateMatcher = $this->createMock(RequestMatcher::class);
+        $tooLateMatcher = $this->createMock(RequestMatcherInterface::class);
         $tooLateMatcher
             ->expects($this->never())
             ->method('matches')
@@ -102,7 +102,7 @@ class FirewallMapTest extends TestCase
 
         $request = new Request();
 
-        $notMatchingMatcher = $this->createMock(RequestMatcher::class);
+        $notMatchingMatcher = $this->createMock(RequestMatcherInterface::class);
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -451,7 +451,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                             }
                             break;
                         case Type::BUILTIN_TYPE_INT:
-                            if (ctype_digit($data) || '-' === $data[0] && ctype_digit(substr($data, 1))) {
+                            if (ctype_digit('-' === $data[0] ? substr($data, 1) : $data)) {
                                 $data = (int) $data;
                             } else {
                                 throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('The type of the "%s" attribute for class "%s" must be int ("%s" given).', $attribute, $currentClass, $data), $data, [Type::BUILTIN_TYPE_INT], $context['deserialization_path'] ?? null);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1183,9 +1183,6 @@ class SerializerTest extends TestCase
         $this->assertSame($expected, $exceptionsAsArray);
     }
 
-    /**
-     * @requires PHP 8.1
-     */
     public function testCollectDenormalizationErrorsWithEnumConstructor()
     {
         $serializer = new Serializer(
@@ -1223,9 +1220,6 @@ class SerializerTest extends TestCase
         $this->assertSame($expected, $exceptionsAsArray);
     }
 
-    /**
-     * @requires PHP 8.1
-     */
     public function testNoCollectDenormalizationErrorsWithWrongEnum()
     {
         $serializer = new Serializer(

--- a/src/Symfony/Component/Validator/Constraints/WhenValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/WhenValidator.php
@@ -19,16 +19,10 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 final class WhenValidator extends ConstraintValidator
 {
-    private ?ExpressionLanguage $expressionLanguage;
-
-    public function __construct(ExpressionLanguage $expressionLanguage = null)
+    public function __construct(private ?ExpressionLanguage $expressionLanguage = null)
     {
-        $this->expressionLanguage = $expressionLanguage;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof When) {
@@ -48,14 +42,10 @@ final class WhenValidator extends ConstraintValidator
 
     private function getExpressionLanguage(): ExpressionLanguage
     {
-        if (null !== $this->expressionLanguage) {
-            return $this->expressionLanguage;
-        }
-
         if (!class_exists(ExpressionLanguage::class)) {
             throw new LogicException(sprintf('The "symfony/expression-language" component is required to use the "%s" validator. Try running "composer require symfony/expression-language".', __CLASS__));
         }
 
-        return $this->expressionLanguage = new ExpressionLanguage();
+        return $this->expressionLanguage ??= new ExpressionLanguage();
     }
 }

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
@@ -386,6 +386,22 @@
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
                 <target>Denne verdien er ikke et gyldig International Securities Identification Number (ISIN).</target>
             </trans-unit>
+            <trans-unit id="100">
+                <source>This value should be a valid expression.</source>
+                <target>Denne verdien skal være et gyldig uttrykk.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>This value is not a valid CSS color.</source>
+                <target>Denne verdien er ikke en gyldig CSS-farge.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Denne verdien er ikke en gyldig CIDR-notasjon.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>Verdien på nettmasken skal være mellom {{ min }} og {{ max }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
@@ -386,6 +386,22 @@
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
                 <target>Denne verdien er ikke et gyldig International Securities Identification Number (ISIN).</target>
             </trans-unit>
+            <trans-unit id="100">
+                <source>This value should be a valid expression.</source>
+                <target>Denne verdien skal være et gyldig uttrykk.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>This value is not a valid CSS color.</source>
+                <target>Denne verdien er ikke en gyldig CSS-farge.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Denne verdien er ikke en gyldig CIDR-notasjon.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>Verdien på nettmasken skal være mellom {{ min }} og {{ max }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
@@ -35,9 +35,6 @@ class ValidTest extends TestCase
         $this->assertNull($constraint->groups);
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testAttributes()
     {
         $metadata = new ClassMetaData(ValidDummy::class);

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -48,6 +48,22 @@ trait LazyGhostTrait
     }
 
     /**
+     * Returns whether the object is initialized.
+     */
+    public function isLazyObjectInitialized(): bool
+    {
+        if (!$state = Registry::$states[$this->lazyObjectId ?? ''] ?? null) {
+            return true;
+        }
+
+        if (LazyObjectState::STATUS_INITIALIZED_PARTIAL === $state->status) {
+            return \count($state->preInitSetProperties) !== \count((array) $this);
+        }
+
+        return LazyObjectState::STATUS_INITIALIZED_FULL === $state->status;
+    }
+
+    /**
      * Forces initialization of a lazy object and returns it.
      */
     public function initializeLazyObject(): static
@@ -308,7 +324,7 @@ trait LazyGhostTrait
 
     public function __destruct()
     {
-        $state = Registry::$states[$this->lazyObjectId ?? null] ?? null;
+        $state = Registry::$states[$this->lazyObjectId ?? ''] ?? null;
 
         try {
             if ($state && !\in_array($state->status, [LazyObjectState::STATUS_INITIALIZED_FULL, LazyObjectState::STATUS_INITIALIZED_PARTIAL], true)) {

--- a/src/Symfony/Component/VarExporter/LazyObjectInterface.php
+++ b/src/Symfony/Component/VarExporter/LazyObjectInterface.php
@@ -14,6 +14,11 @@ namespace Symfony\Component\VarExporter;
 interface LazyObjectInterface
 {
     /**
+     * Returns whether the object is initialized.
+     */
+    public function isLazyObjectInitialized(): bool;
+
+    /**
      * Forces initialization of a lazy object and returns it.
      */
     public function initializeLazyObject(): object;

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -45,6 +45,18 @@ trait LazyProxyTrait
     }
 
     /**
+     * Returns whether the object is initialized.
+     */
+    public function isLazyObjectInitialized(): bool
+    {
+        if (0 >= ($this->lazyObjectId ?? 0)) {
+            return true;
+        }
+
+        return \array_key_exists("\0".self::class."\0lazyObjectReal", (array) $this);
+    }
+
+    /**
      * Forces initialization of a lazy object and returns it.
      */
     public function initializeLazyObject(): parent
@@ -84,7 +96,8 @@ trait LazyProxyTrait
             if (null === $scope || isset($propertyScopes["\0$scope\0$name"])) {
                 if (isset($this->lazyObjectId)) {
                     if ('lazyObjectReal' === $name && self::class === $scope) {
-                        $this->lazyObjectReal = (Registry::$states[$this->lazyObjectId]->initializer)();
+                        $state = Registry::$states[$this->lazyObjectId] ?? null;
+                        $this->lazyObjectReal = $state ? ($state->initializer)() : null;
 
                         return $this->lazyObjectReal;
                     }
@@ -184,7 +197,9 @@ trait LazyProxyTrait
             if (null === $scope || isset($propertyScopes["\0$scope\0$name"])) {
                 if (isset($this->lazyObjectId)) {
                     if ('lazyObjectReal' === $name && self::class === $scope) {
-                        return null !== $this->lazyObjectReal = (Registry::$states[$this->lazyObjectId]->initializer)();
+                        $state = Registry::$states[$this->lazyObjectId] ?? null;
+
+                        return null !== $this->lazyObjectReal = $state ? ($state->initializer)() : null;
                     }
                     if (isset($this->lazyObjectReal)) {
                         $instance = $this->lazyObjectReal;

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -98,6 +98,7 @@ class LazyGhostTraitTest extends TestCase
         unset($expected["\0".TestClass::class."\0lazyObjectId"]);
         $this->assertSame(array_keys($expected), array_keys((array) $clone));
         $this->assertFalse($clone->resetLazyObject());
+        $this->assertTrue($clone->isLazyObjectInitialized());
     }
 
     /**
@@ -162,6 +163,7 @@ class LazyGhostTraitTest extends TestCase
 
         $instance->foo = 234;
         $this->assertTrue($instance->resetLazyObject());
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame('bar', $instance->foo);
     }
 
@@ -173,7 +175,9 @@ class LazyGhostTraitTest extends TestCase
             $ghost->__construct();
         });
 
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertTrue(isset($instance->public));
+        $this->assertTrue($instance->isLazyObjectInitialized());
         $this->assertSame(-4, $instance->public);
         $this->assertSame(4, $instance->publicReadonly);
         $this->assertSame(1, $counter);
@@ -198,7 +202,9 @@ class LazyGhostTraitTest extends TestCase
         });
 
         $this->assertSame(["\0".TestClass::class."\0lazyObjectId"], array_keys((array) $instance));
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(123, $instance->public);
+        $this->assertTrue($instance->isLazyObjectInitialized());
         $this->assertSame(["\0".TestClass::class."\0lazyObjectId", 'public'], array_keys((array) $instance));
         $this->assertSame(1, $counter);
 
@@ -221,7 +227,9 @@ class LazyGhostTraitTest extends TestCase
 
         $instance->public = 123;
 
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(234, $instance->publicReadonly);
+        $this->assertTrue($instance->isLazyObjectInitialized());
         $this->assertSame(123, $instance->public);
 
         $this->assertTrue($instance->resetLazyObject());

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -33,8 +33,10 @@ class LazyProxyTraitTest extends TestCase
 
         $this->assertInstanceOf(TestClass::class, $proxy);
         $this->assertSame(0, $initCounter);
+        $this->assertFalse($proxy->isLazyObjectInitialized());
 
         $dep1 = $proxy->getDep();
+        $this->assertTrue($proxy->isLazyObjectInitialized());
         $this->assertSame(1, $initCounter);
 
         $this->assertTrue($proxy->resetLazyObject());
@@ -55,8 +57,10 @@ class LazyProxyTraitTest extends TestCase
         });
 
         $this->assertSame(0, $initCounter);
+        $this->assertFalse($proxy->isLazyObjectInitialized());
 
         $proxy->initializeLazyObject();
+        $this->assertTrue($proxy->isLazyObjectInitialized());
         $this->assertSame(1, $initCounter);
 
         $proxy->initializeLazyObject();
@@ -98,6 +102,8 @@ class LazyProxyTraitTest extends TestCase
 
         $copy = unserialize(serialize($proxy));
         $this->assertSame(1, $initCounter);
+        $this->assertTrue($copy->isLazyObjectInitialized());
+        $this->assertTrue($proxy->isLazyObjectInitialized());
 
         $this->assertFalse($copy->resetLazyObject());
         $this->assertTrue($copy->getDep()->wokeUp);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

**This PR adds payloads to RocketChatOptions and the ability to send multiple attachments.**

When creating a `ChatMessage`, you can now add Payload and multiple Attachments to `RocketChatOptions`.
These enable you to customize the name or the avatar of the bot posting the message, and to add files to it.

The Payload can contain any data you want ; its data is processed by a Rocket.Chat Incoming Webhook Script which you can write to best suit your needs.
For example, you can use this script to send the raw payload to Rocket.Chat:
```javascript
 class Script {
     process_incoming_request({ request }) {
         return {
             request.content
         };
     }
}
```

When using this script, the Payload must be indexed following Rocket.Chat Payload convention:
```php
$payload = [
   'alias' => 'Bot Name',
   'emoji' => ':joy:', // Emoji used as avatar
   'avatar' => 'http://site.com/logo.png', // Overridden by emoji if provided
   'channel' => '#myChannel', // Overrides the DSN's channel setting
];

$attachement1 = [
    'color' => '#ff0000',
    'title' => 'My title',
    'text' => 'My text',
    // ...
];
$attachement2 = [
    'color' => '#ff0000',
    'title' => 'My title',
    'text' => 'My text',
    // ...
];

// For backward compatibility reasons, both usages are valid
$rocketChatOptions = new RocketChatOptions($attachment1, $payload);
$rocketChatOptions = new RocketChatOptions([$attachment1, $attachment2], $payload);
```

**Note:** the `text` and `attachments` keys of the payload will be overridden respectively by the ChatMessage's subject and the attachments provided in RocketChatOptions' constructor.