### PR TITLE
Add warning for possibly truncated inputs in SecretsSetCommand (#47586)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
@@ -104,7 +104,7 @@ EOF
             }
 
             if (4095 === strlen($value)) {
-                $io->warning('Value has exactly 4095 characters: it possibly was truncated by your shell or terminal emulator');
+                $io->warning('The value was possibly truncated by your shell or terminal emulator');
             }
         } elseif ('-' === $file) {
             $value = file_get_contents('php://stdin');

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
@@ -102,6 +102,10 @@ EOF
                 $io->warning('No value provided: using empty string');
                 $value = '';
             }
+
+            if (4095 === strlen($value)) {
+                $io->warning('Value has exactly 4095 characters: it possibly was truncated by your shell or terminal emulator');
+            }
         } elseif ('-' === $file) {
             $value = file_get_contents('php://stdin');
         } elseif (is_file($file) && is_readable($file)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features / 4.4, 5.4, 6.0 or 6.1 for bug fixes <!-- see below -->
| Bug fix?      | yes
| Tickets       | Fix #47586
| License       | MIT

Adds a warning for possibly truncated inputs in `SecretsSetCommand`.

