### PR TITLE
Add warning for possibly truncated inputs in QuestionHelper (#47586)

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -430,6 +430,11 @@ class QuestionHelper extends Helper
 
         $value = fgets($inputStream, 4096);
 
+        if (4095 === strlen($value)) {
+            $errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+            $errOutput->warning('The value was possibly truncated by your shell or terminal emulator');
+        }
+
         if (self::$stty && Terminal::hasSttyAvailable()) {
             shell_exec('stty '.$sttyMode);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| Tickets       | Fix #47586
| License       | MIT

Adds a warning for possibly truncated inputs in `QuestionHelper`.

