### PR TITLE
[VarExporter] Add LazyObjectInterface::isLazyObjectInitialized()

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -48,6 +48,22 @@ trait LazyGhostTrait
     }
 
     /**
+     * Returns whether the object is initialized.
+     */
+    public function isLazyObjectInitialized(): bool
+    {
+        if (!$state = Registry::$states[$this->lazyObjectId ?? ''] ?? null) {
+            return true;
+        }
+
+        if (LazyObjectState::STATUS_INITIALIZED_PARTIAL === $state->status) {
+            return \count($state->preInitSetProperties) !== \count((array) $this);
+        }
+
+        return LazyObjectState::STATUS_INITIALIZED_FULL === $state->status;
+    }
+
+    /**
      * Forces initialization of a lazy object and returns it.
      */
     public function initializeLazyObject(): static

--- a/src/Symfony/Component/VarExporter/LazyObjectInterface.php
+++ b/src/Symfony/Component/VarExporter/LazyObjectInterface.php
@@ -14,6 +14,11 @@ namespace Symfony\Component\VarExporter;
 interface LazyObjectInterface
 {
     /**
+     * Returns whether the object is initialized.
+     */
+    public function isLazyObjectInitialized(): bool;
+
+    /**
      * Forces initialization of a lazy object and returns it.
      */
     public function initializeLazyObject(): object;

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -45,6 +45,18 @@ trait LazyProxyTrait
     }
 
     /**
+     * Returns whether the object is initialized.
+     */
+    public function isLazyObjectInitialized(): bool
+    {
+        if (0 >= ($this->lazyObjectId ?? 0)) {
+            return true;
+        }
+
+        return \array_key_exists("\0".self::class."\0lazyObjectReal", (array) $this);
+    }
+
+    /**
      * Forces initialization of a lazy object and returns it.
      */
     public function initializeLazyObject(): parent

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -98,6 +98,7 @@ class LazyGhostTraitTest extends TestCase
         unset($expected["\0".TestClass::class."\0lazyObjectId"]);
         $this->assertSame(array_keys($expected), array_keys((array) $clone));
         $this->assertFalse($clone->resetLazyObject());
+        $this->assertTrue($clone->isLazyObjectInitialized());
     }
 
     /**
@@ -162,6 +163,7 @@ class LazyGhostTraitTest extends TestCase
 
         $instance->foo = 234;
         $this->assertTrue($instance->resetLazyObject());
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame('bar', $instance->foo);
     }
 
@@ -173,7 +175,9 @@ class LazyGhostTraitTest extends TestCase
             $ghost->__construct();
         });
 
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertTrue(isset($instance->public));
+        $this->assertTrue($instance->isLazyObjectInitialized());
         $this->assertSame(-4, $instance->public);
         $this->assertSame(4, $instance->publicReadonly);
         $this->assertSame(1, $counter);
@@ -198,7 +202,9 @@ class LazyGhostTraitTest extends TestCase
         });
 
         $this->assertSame(["\0".TestClass::class."\0lazyObjectId"], array_keys((array) $instance));
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(123, $instance->public);
+        $this->assertTrue($instance->isLazyObjectInitialized());
         $this->assertSame(["\0".TestClass::class."\0lazyObjectId", 'public'], array_keys((array) $instance));
         $this->assertSame(1, $counter);
 
@@ -221,7 +227,9 @@ class LazyGhostTraitTest extends TestCase
 
         $instance->public = 123;
 
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(234, $instance->publicReadonly);
+        $this->assertTrue($instance->isLazyObjectInitialized());
         $this->assertSame(123, $instance->public);
 
         $this->assertTrue($instance->resetLazyObject());

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -33,8 +33,10 @@ class LazyProxyTraitTest extends TestCase
 
         $this->assertInstanceOf(TestClass::class, $proxy);
         $this->assertSame(0, $initCounter);
+        $this->assertFalse($proxy->isLazyObjectInitialized());
 
         $dep1 = $proxy->getDep();
+        $this->assertTrue($proxy->isLazyObjectInitialized());
         $this->assertSame(1, $initCounter);
 
         $this->assertTrue($proxy->resetLazyObject());
@@ -55,8 +57,10 @@ class LazyProxyTraitTest extends TestCase
         });
 
         $this->assertSame(0, $initCounter);
+        $this->assertFalse($proxy->isLazyObjectInitialized());
 
         $proxy->initializeLazyObject();
+        $this->assertTrue($proxy->isLazyObjectInitialized());
         $this->assertSame(1, $initCounter);
 
         $proxy->initializeLazyObject();
@@ -98,6 +102,8 @@ class LazyProxyTraitTest extends TestCase
 
         $copy = unserialize(serialize($proxy));
         $this->assertSame(1, $initCounter);
+        $this->assertTrue($copy->isLazyObjectInitialized());
+        $this->assertTrue($proxy->isLazyObjectInitialized());
 
         $this->assertFalse($copy->resetLazyObject());
         $this->assertTrue($copy->getDep()->wokeUp);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no (amending a new feat)
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

After reviewing a few existing use cases of lazy proxies, it looks like we should provide a way to know whether a lazy object is initialized.

Typically, Doctrine uses that to know if an object needs to be populated or not in its UnitOfWork.