### PR TITLE
[Messenger] [Amqp-messenger] Support content encoding and compression

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2016,6 +2016,7 @@ class FrameworkExtension extends Extension
                 ['id' => 'failed_message_processing_middleware'],
             ],
             'after' => [
+                ['id' => 'compress_middleware'],
                 ['id' => 'send_message'],
                 ['id' => 'handle_message'],
             ],

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -25,6 +25,7 @@ use Symfony\Component\Messenger\EventListener\StopWorkerOnCustomStopExceptionLis
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnSigtermSignalListener;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+use Symfony\Component\Messenger\Middleware\CompressMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
@@ -109,6 +110,9 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('router'),
             ])
+
+        ->set('messenger.middleware.compress_middleware', CompressMiddleware::class)
+            ->abstract()
 
         // Discovery
         ->set('messenger.receiver_locator', ServiceLocator::class)

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/CompressorFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/CompressorFactory.php
@@ -17,12 +17,10 @@ class CompressorFactory
 {
     public static function createCompressor(string $mimeContentEncoding)
     {
-        if ('gzip' === $mimeContentEncoding) {
-            return new Gzip();
-        } elseif ('deflate') {
-            return new Deflate();
-        }
-
-        throw new InvalidArgumentException(sprintf('The MIME content encoding of the message cannot be decompressed "%s".', $mimeContentEncoding));
+        return match ($mimeContentEncoding) {
+            Gzip::CONTENT_ENCODING => new Gzip(),
+            Deflate::CONTENT_ENCODING => new Deflate(),
+            default => throw new InvalidArgumentException(sprintf('The MIME content encoding of the message cannot be decompressed "%s".', $mimeContentEncoding)),
+        };
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/CompressorFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/CompressorFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Amqp\Compressor;
+
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+
+class CompressorFactory
+{
+    public static function createCompressor(string $mimeContentEncoding)
+    {
+        if ('gzip' === $mimeContentEncoding) {
+            return new Gzip();
+        } elseif ('deflate') {
+            return new Deflate();
+        }
+
+        throw new InvalidArgumentException(sprintf('The MIME content encoding of the message cannot be decompressed "%s".', $mimeContentEncoding));
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/CompressorInterface.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/CompressorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Amqp\Compressor;
+
+interface CompressorInterface
+{
+    public function compress(mixed $data): string;
+
+    public function decompress(mixed $data): mixed;
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/Deflate.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/Deflate.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Amqp\Compressor;
+
+class Deflate implements CompressorInterface
+{
+    public function compress(mixed $data): string
+    {
+        return gzdeflate($data);
+    }
+
+    public function decompress(mixed $data): mixed
+    {
+        $decompressData = gzinflate($data);
+        if (false === $decompressData) {
+            return $data;
+        }
+
+        return $decompressData;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/Deflate.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/Deflate.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Messenger\Bridge\Amqp\Compressor;
 
 class Deflate implements CompressorInterface
 {
+    public const CONTENT_ENCODING = 'deflate';
+
     public function compress(mixed $data): string
     {
         return gzdeflate($data);
@@ -20,11 +22,10 @@ class Deflate implements CompressorInterface
 
     public function decompress(mixed $data): mixed
     {
-        $decompressData = gzinflate($data);
-        if (false === $decompressData) {
-            return $data;
+        if (\function_exists('gzinflate')) {
+            return @gzinflate($data) ?: $data;
         }
 
-        return $decompressData;
+        return $data;
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/Gzip.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/Gzip.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Messenger\Bridge\Amqp\Compressor;
 
 class Gzip implements CompressorInterface
 {
+    public const CONTENT_ENCODING = 'gzip';
+
     public function compress(mixed $data): string
     {
         return gzencode($data);
@@ -20,11 +22,10 @@ class Gzip implements CompressorInterface
 
     public function decompress(mixed $data): mixed
     {
-        $decompressData = gzdecode($data);
-        if (false === $decompressData) {
-            return $data;
+        if (\function_exists('gzdecode')) {
+            return @gzdecode($data) ?: $data;
         }
 
-        return $decompressData;
+        return $data;
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/Gzip.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Compressor/Gzip.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Amqp\Compressor;
+
+class Gzip implements CompressorInterface
+{
+    public function compress(mixed $data): string
+    {
+        return gzencode($data);
+    }
+
+    public function decompress(mixed $data): mixed
+    {
+        $decompressData = gzdecode($data);
+        if (false === $decompressData) {
+            return $data;
+        }
+
+        return $decompressData;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Compressor/DeflateTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Compressor/DeflateTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Compressor;
+
+use Symfony\Component\Messenger\Bridge\Amqp\Compressor\Deflate;
+use PHPUnit\Framework\TestCase;
+
+class DeflateTest extends TestCase
+{
+    public function testDecompress()
+    {
+        $compressor = new Deflate();
+
+        $actual = $compressor->decompress('string no compressed');
+        $this->assertEquals('string no compressed', $actual);
+
+        $actual = $compressor->decompress(gzdeflate('string compressed'));
+        $this->assertEquals('string compressed', $actual);
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Compressor/GzipTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Compressor/GzipTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Compressor;
+
+use Symfony\Component\Messenger\Bridge\Amqp\Compressor\Gzip;
+use PHPUnit\Framework\TestCase;
+
+class GzipTest extends TestCase
+{
+    public function testDecompress()
+    {
+        $compressor = new Gzip();
+
+        $actual = $compressor->decompress('string no compressed');
+        $this->assertEquals('string no compressed', $actual);
+
+        $actual = $compressor->decompress(gzencode('string compressed'));
+        $this->assertEquals('string compressed', $actual);
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -64,11 +64,13 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
         $body = $amqpEnvelope->getBody();
 
         try {
+            /*
             $contentEncoding = $amqpEnvelope->getContentEncoding();
             if ($contentEncoding) {
                 $compressor = CompressorFactory::createCompressor($contentEncoding);
                 $body = $compressor->decompress($body);
             }
+            */
 
             $envelope = $this->serializer->decode([
                 'body' => false === $body ? '' : $body, // workaround https://github.com/pdezwart/php-amqp/issues/351

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\Amqp\Transport;
 
+use Symfony\Component\Messenger\Bridge\Amqp\Compressor\CompressorFactory;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\LogicException;
 
@@ -334,6 +335,11 @@ class Connection
         $attributes['timestamp'] ??= time();
 
         $this->lastActivityTime = time();
+
+        if (isset($attributes['content_encoding'])) {
+            $compressor = CompressorFactory::createCompressor($attributes['content_encoding']);
+            $body = $compressor->compress($body);
+        }
 
         $exchange->publish(
             $body,

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -335,12 +335,12 @@ class Connection
         $attributes['timestamp'] ??= time();
 
         $this->lastActivityTime = time();
-
+        /*
         if (isset($attributes['content_encoding'])) {
             $compressor = CompressorFactory::createCompressor($attributes['content_encoding']);
             $body = $compressor->compress($body);
         }
-
+        */
         $exchange->publish(
             $body,
             $routingKey,

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
@@ -24,7 +24,8 @@
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/process": "^5.4|^6.0",
         "symfony/property-access": "^5.4|^6.0",
-        "symfony/serializer": "^5.4|^6.0"
+        "symfony/serializer": "^5.4|^6.0",
+        "ext-zlib": "*"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Messenger\\Bridge\\Amqp\\": "" },

--- a/src/Symfony/Component/Messenger/Middleware/CompressMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/CompressMiddleware.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceivedStamp;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpStamp;
+use Symfony\Component\Messenger\Envelope;
+
+class CompressMiddleware implements MiddlewareInterface
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if ($amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class)) {
+            $contentEncoding ??= $amqpReceivedStamp->getAmqpEnvelope()->getContentEncoding();
+            if (!$contentEncoding) {
+                return $stack->next()->handle($envelope, $stack);
+            }
+
+            $message = $envelope->getMessage();
+            $compress = $this->decompress($contentEncoding, $message);
+            $envelope = new Envelope(
+                $compress,
+                $envelope->all()
+            );
+        } else {
+            $amqpStamp = $envelope->last(AmqpStamp::class);
+            $contentEncoding = $amqpStamp->getAttributes()['content_encoding'] ?? null;
+            if (!$contentEncoding) {
+                return $stack->next()->handle($envelope, $stack);
+            }
+            $message = $envelope->getMessage();
+            // We need a string, but in this point we have an object
+            $compress = $this->compress($contentEncoding, $message);
+            $envelope = new Envelope(
+                $compress,
+                $envelope->all()
+            );
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+
+    public function compress(string $contentEncoding, mixed $data): string
+    {
+        return match ($contentEncoding) {
+            'gzip' => gzencode($data),
+            'deflate' => gzdeflate($data),
+            default => throw new InvalidArgumentException(sprintf('The MIME content encoding of the message cannot be decompressed "%s".', $contentEncoding)),
+        };
+    }
+
+    public function decompress(string $contentEncoding, mixed $data): mixed
+    {
+        return match ($contentEncoding) {
+            'gzip' => gzdecode($data) ?: $data,
+            'deflate' => gzinflate($data) ?: $data,
+        };
+
+        return $data;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | TODO
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

When I send a message using the AMQP transport together with the *AmqpStamp* and the *content-encoding* property, the message is not compressed.

The [AMQP protocol](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-properties), allow through the *content-encoding* property, to “indicate what additional content encodings have been applied to the *application-data*, and thus what decoding mechanisms need to be applied in order to obtain the media-type referenced by the content-type header field”.

The values admitted according to the protocol are: **gzip, compress, deflate, identity**, etc.

I expect that the body of the message will be compressed and decompressed respectively by the publisher 
and the subscriber.

For example, we can send a messages:

```php
$bus->dispatch(new DummyMessage('Foo bar'), [
    new AmqpStamp(attributes: [
        'content_encoding' => 'gzip'
    ]),
]);
```

and, With the current code the body message (payload) is not compress using gzip:

```bash
$ rabbitmqadmin get queue=messages -f pretty_json 
[
  {
    "exchange": "messages",
    "message_count": 0,
    "payload": "{\"name\":\"Foo bar\"}",
    "payload_bytes": 18,
    "payload_encoding": "string",
    "properties": {
      "content_encoding": "gzip",
      "content_type": "application/json",
      "delivery_mode": 2,
      "headers": {
        "X-Message-Stamp-Symfony\\Component\\Messenger\\Stamp\\BusNameStamp": "[{\"busName\":\"messenger.bus.default\"}]",
        "type": "App\\Message\\DummyMessage"
      },
      "timestamp": 1662922329
    },
    "redelivered": true,
    "routing_key": ""
  }
]
```

but, if we are aware of the value of the *content_encoding* property we should compress the body message.

```bash
$ rabbitmqadmin get queue=messages -f pretty_json 
[
  {
    "exchange": "messages",
    "message_count": 0,
    "payload": "H4sIAAAAAAAAA6tWysxNTE8NyC8u8UxRsrI0qwUAri6HchIAAAA=",
    "payload_bytes": 38,
    "payload_encoding": "base64",
    "properties": {
      "content_encoding": "gzip",
      "content_type": "application/json",
      "delivery_mode": 2,
      "headers": {
        "X-Message-Stamp-App\\Messenger\\UniqueIdStamp": "[{\"uniqueId\":\"631e4bdc3ad3b\"}]",
        "X-Message-Stamp-Symfony\\Component\\Messenger\\Stamp\\BusNameStamp": "[{\"busName\":\"messenger.bus.default\"}]",
        "type": "App\\Message\\AddPonkaToImage"
      },
      "timestamp": 1662929884
    },
    "redelivered": true,
    "routing_key": ""
  }
]
```

Finally, the subscriber must be able to uncompressed the body message. I made some changes in order to figure out how
this can be accomplished.

Thanks!, I should be grateful for any comments.

*Postscriptum*: I closed the PR [47545](https://github.com/symfony/symfony/pull/47545)  by mistake :).