### PR TITLE
[HttpFoundation] Extract request matchers for better reusability

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -256,7 +256,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $requestMatcherId = 'My\Test\RequestMatcher';
-        $requestMatcher = new RequestMatcher('/');
+        $requestMatcher = new PathRequestMatcher('/');
         $container->set($requestMatcherId, $requestMatcher);
 
         $container->loadFromExtension('security', [
@@ -291,7 +291,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $requestMatcherId = 'My\Test\RequestMatcher';
-        $requestMatcher = new RequestMatcher('/');
+        $requestMatcher = new PathRequestMatcher('/');
         $container->set($requestMatcherId, $requestMatcher);
 
         $container->loadFromExtension('security', [

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/dependency-injection": "^6.2",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/http-kernel": "^6.2",
-        "symfony/http-foundation": "^5.4|^6.0",
+        "symfony/http-foundation": "^6.2",
         "symfony/password-hasher": "^5.4|^6.0",
         "symfony/security-core": "^6.2",
         "symfony/security-csrf": "^5.4|^6.0",

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 
  * The HTTP cache store uses the `xxh128` algorithm
  * Deprecate calling `JsonResponse::setCallback()`, `Response::setExpires/setLastModified/setEtag()`, `MockArraySessionStorage/NativeSessionStorage::setMetadataBag()`, `NativeSessionStorage::setSaveHandler()` without arguments
+ * Add request matchers under the `Symfony\Component\HttpFoundation\RequestMatcher` namespace
+ * Deprecate `RequestMatcher` in favor of `ChainRequestMatcher`
+ * Deprecate `Symfony\Component\HttpFoundation\ExpressionRequestMatcher` in favor of `Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher`
 
 6.1
 ---

--- a/src/Symfony/Component/HttpFoundation/ChainRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/ChainRequestMatcher.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * ChainRequestMatcher verifies that all checks match against a Request instance.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ChainRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @param iterable<RequestMatcherInterface> $matchers
+     */
+    public function __construct(private iterable $matchers)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        foreach ($this->matchers as $matcher) {
+            if (!$matcher->matches($request)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/ExpressionRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/ExpressionRequestMatcher.php
@@ -13,11 +13,16 @@ namespace Symfony\Component\HttpFoundation;
 
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher as NewExpressionRequestMatcher;
+
+trigger_deprecation('symfony/http-foundation', '6.2', 'The "%s" class is deprecated, use "%s" instead.', ExpressionRequestMatcher::class, NewExpressionRequestMatcher::class);
 
 /**
  * ExpressionRequestMatcher uses an expression to match a Request.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 6.2, use "Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher" instead
  */
 class ExpressionRequestMatcher extends RequestMatcher
 {

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\HttpFoundation;
 
+trigger_deprecation('symfony/http-foundation', '6.2', 'The "%s" class is deprecated, use "%s" instead.', RequestMatcher::class, ChainRequestMatcher::class);
+
 /**
  * RequestMatcher compares a pre-defined set of checks against a Request instance.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 6.2, use ChainRequestMatcher instead
  */
 class RequestMatcher implements RequestMatcherInterface
 {

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/AttributesRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/AttributesRequestMatcher.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the Request attributes matches all regular expressions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AttributesRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @param array<string, string> $regexps
+     */
+    public function __construct(private array $regexps)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        foreach ($this->regexps as $key => $regexp) {
+            $attribute = $request->attributes->get($key);
+            if (!\is_string($attribute)) {
+                return false;
+            }
+            if (!preg_match('{'.$regexp.'}', $attribute)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/ExpressionRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/ExpressionRequestMatcher.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * ExpressionRequestMatcher uses an expression to match a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ExpressionRequestMatcher implements RequestMatcherInterface
+{
+    public function __construct(
+        private ExpressionLanguage $language,
+        private Expression|string $expression,
+    ) {
+    }
+
+    public function matches(Request $request): bool
+    {
+        return $this->language->evaluate($this->expression, [
+            'request' => $request,
+            'method' => $request->getMethod(),
+            'path' => rawurldecode($request->getPathInfo()),
+            'host' => $request->getHost(),
+            'ip' => $request->getClientIp(),
+            'attributes' => $request->attributes->all(),
+        ]);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/HostRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/HostRequestMatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the Request URL host name matches a regular expression.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HostRequestMatcher implements RequestMatcherInterface
+{
+    public function __construct(private string $regexp)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        return preg_match('{'.$this->regexp.'}i', $request->getHost());
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/IpsRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/IpsRequestMatcher.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\IpUtils;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the client IP of a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class IpsRequestMatcher implements RequestMatcherInterface
+{
+    private array $ips;
+
+    /**
+     * @param string[]|string $ips A specific IP address or a range specified using IP/netmask like 192.168.1.0/24
+     *                             Strings can contain a comma-delimited list of IPs/ranges
+     */
+    public function __construct(array|string $ips)
+    {
+        $this->ips = array_reduce((array) $ips, static function (array $ips, string $ip) {
+            return array_merge($ips, preg_split('/\s*,\s*/', $ip));
+        }, []);
+    }
+
+    public function matches(Request $request): bool
+    {
+        if (!$this->ips) {
+            return true;
+        }
+
+        return IpUtils::checkIp($request->getClientIp() ?? '', $this->ips);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/IsJsonRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/IsJsonRequestMatcher.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the Request content is valid JSON.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class IsJsonRequestMatcher implements RequestMatcherInterface
+{
+    public function matches(Request $request): bool
+    {
+        try {
+            json_decode($request->getContent(), true, 512, \JSON_BIGINT_AS_STRING | \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/MethodRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/MethodRequestMatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the HTTP method of a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class MethodRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @var string[]
+     */
+    private array $methods = [];
+
+    /**
+     * @param string[]|string $methods An HTTP method or an array of HTTP methods
+     *                                 Strings can contain a comma-delimited list of methods
+     */
+    public function __construct(array|string $methods)
+    {
+        $this->methods = array_reduce(array_map('strtoupper', (array) $methods), static function (array $methods, string $method) {
+            return array_merge($methods, preg_split('/\s*,\s*/', $method));
+        }, []);
+    }
+
+    public function matches(Request $request): bool
+    {
+        if (!$this->methods) {
+            return true;
+        }
+
+        return \in_array($request->getMethod(), $this->methods, true);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/PathRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/PathRequestMatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the Request URL path info matches a regular expression.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class PathRequestMatcher implements RequestMatcherInterface
+{
+    public function __construct(private string $regexp)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        return preg_match('{'.$this->regexp.'}', rawurldecode($request->getPathInfo()));
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/PortRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/PortRequestMatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the HTTP port of a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class PortRequestMatcher implements RequestMatcherInterface
+{
+    public function __construct(private int $port)
+    {
+    }
+
+    public function matches(Request $request): bool
+    {
+        return $request->getPort() === $this->port;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/SchemeRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/SchemeRequestMatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Checks the HTTP scheme of a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class SchemeRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @var string[]
+     */
+    private array $schemes;
+
+    /**
+     * @param string[]|string $schemes A scheme or a list of schemes
+     *                                 Strings can contain a comma-delimited list of schemes
+     */
+    public function __construct(array|string $schemes)
+    {
+        $this->schemes = array_reduce(array_map('strtolower', (array) $schemes), static function (array $schemes, string $scheme) {
+            return array_merge($schemes, preg_split('/\s*,\s*/', $scheme));
+        }, []);
+    }
+
+    public function matches(Request $request): bool
+    {
+        if (!$this->schemes) {
+            return true;
+        }
+
+        return \in_array($request->getScheme(), $this->schemes, true);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/AttributesRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/AttributesRequestMatcherTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\AttributesRequestMatcher;
+use Symfony\Component\HttpFoundation\Response;
+
+class AttributesRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(string $key, string $regexp, bool $expected)
+    {
+        $matcher = new AttributesRequestMatcher([$key => $regexp]);
+        $request = Request::create('/admin/foo');
+        $request->attributes->set('foo', 'foo_bar');
+        $request->attributes->set('_controller', function () {
+            return new Response('foo');
+        });
+        $this->assertSame($expected, $matcher->matches($request));
+    }
+
+    public function getData(): array
+    {
+        return [
+            ['foo', 'foo_.*', true],
+            ['foo', 'foo', true],
+            ['foo', '^foo_bar$', true],
+            ['foo', 'babar', false],
+            'with-closure' => ['_controller', 'babar', false],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/ExpressionRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/ExpressionRequestMatcherTest.php
@@ -9,49 +9,23 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\HttpFoundation\Tests;
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
-use Symfony\Component\HttpFoundation\ExpressionRequestMatcher;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher;
 
-/**
- * @group legacy
- */
 class ExpressionRequestMatcherTest extends TestCase
 {
-    public function testWhenNoExpressionIsSet()
-    {
-        $this->expectException(\LogicException::class);
-        $expressionRequestMatcher = new ExpressionRequestMatcher();
-        $expressionRequestMatcher->matches(new Request());
-    }
-
     /**
      * @dataProvider provideExpressions
      */
     public function testMatchesWhenParentMatchesIsTrue($expression, $expected)
     {
         $request = Request::create('/foo');
-        $expressionRequestMatcher = new ExpressionRequestMatcher();
-
-        $expressionRequestMatcher->setExpression(new ExpressionLanguage(), $expression);
+        $expressionRequestMatcher = new ExpressionRequestMatcher(new ExpressionLanguage(), $expression);
         $this->assertSame($expected, $expressionRequestMatcher->matches($request));
-    }
-
-    /**
-     * @dataProvider provideExpressions
-     */
-    public function testMatchesWhenParentMatchesIsFalse($expression)
-    {
-        $request = Request::create('/foo');
-        $request->attributes->set('foo', 'foo');
-        $expressionRequestMatcher = new ExpressionRequestMatcher();
-        $expressionRequestMatcher->matchAttribute('foo', 'bar');
-
-        $expressionRequestMatcher->setExpression(new ExpressionLanguage(), $expression);
-        $this->assertFalse($expressionRequestMatcher->matches($request));
     }
 
     public function provideExpressions()

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/HostRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/HostRequestMatcherTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\HostRequestMatcher;
+
+class HostRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test($pattern, $isMatch)
+    {
+        $matcher = new HostRequestMatcher($pattern);
+        $request = Request::create('', 'get', [], [], [], ['HTTP_HOST' => 'foo.example.com']);
+        $this->assertSame($isMatch, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            ['.*\.example\.com', true],
+            ['\.example\.com$', true],
+            ['^.*\.example\.com$', true],
+            ['.*\.sensio\.com', false],
+            ['.*\.example\.COM', true],
+            ['\.example\.COM$', true],
+            ['^.*\.example\.COM$', true],
+            ['.*\.sensio\.COM', false],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/IpsRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/IpsRequestMatcherTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IpsRequestMatcher;
+
+class IpsRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test($ips, bool $expected)
+    {
+        $matcher = new IpsRequestMatcher($ips);
+        $request = Request::create('', 'GET', [], [], [], ['REMOTE_ADDR' => '127.0.0.1']);
+        $this->assertSame($expected, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            [[], true],
+            ['127.0.0.1', true],
+            ['192.168.0.1', false],
+            ['127.0.0.1', true],
+            ['127.0.0.1, ::1', true],
+            ['192.168.0.1, ::1', false],
+            [['127.0.0.1', '::1'], true],
+            [['192.168.0.1', '::1'], false],
+            [['1.1.1.1', '2.2.2.2', '127.0.0.1, ::1'], true],
+            [['1.1.1.1', '2.2.2.2', '192.168.0.1, ::1'], false],
+            [['192.168.1.0/24'], false],
+            [['127.0.0.1/32'], true],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/IsJsonRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/IsJsonRequestMatcherTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
+
+class IsJsonRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test($json, bool $isValid)
+    {
+        $matcher = new IsJsonRequestMatcher();
+        $request = Request::create('', 'GET', [], [], [], [], $json);
+        $this->assertSame($isValid, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            ['not json', false],
+            ['"json_string"', true],
+            ['11', true],
+            ['["json", "array"]', true],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/MethodRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/MethodRequestMatcherTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
+
+class MethodRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(string $requestMethod, array|string $matcherMethod, bool $isMatch)
+    {
+        $matcher = new MethodRequestMatcher($matcherMethod);
+        $request = Request::create('', $requestMethod);
+        $this->assertSame($isMatch, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            ['get', 'get', true],
+            ['get', 'post,get', true],
+            ['get', 'post, get', true],
+            ['get', 'post,GET', true],
+            ['get', ['get', 'post'], true],
+            ['get', 'post', false],
+            ['get', 'GET', true],
+            ['get', ['GET', 'POST'], true],
+            ['get', 'POST', false],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/PathRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/PathRequestMatcherTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
+
+class PathRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(string $regexp, bool $expected)
+    {
+        $matcher = new PathRequestMatcher($regexp);
+        $request = Request::create('/admin/foo');
+        $this->assertSame($expected, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            ['/admin/.*', true],
+            ['/admin', true],
+            ['^/admin/.*$', true],
+            ['/blog/.*', false],
+        ];
+    }
+
+    public function testWithLocaleIsNotSupported()
+    {
+        $matcher = new PathRequestMatcher('^/{_locale}/login$');
+        $request = Request::create('/en/login');
+        $request->setLocale('en');
+        $this->assertFalse($matcher->matches($request));
+    }
+
+    public function testWithEncodedCharacters()
+    {
+        $matcher = new PathRequestMatcher('^/admin/fo o*$');
+        $request = Request::create('/admin/fo%20o');
+        $this->assertTrue($matcher->matches($request));
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/PortRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/PortRequestMatcherTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\PortRequestMatcher;
+
+class PortRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(int $port, bool $expected)
+    {
+        $matcher = new PortRequestMatcher($port);
+        $request = Request::create('', 'get', [], [], [], ['HTTP_HOST' => null, 'SERVER_PORT' => 8000]);
+        $this->assertSame($expected, $matcher->matches($request));
+    }
+
+    public function getData()
+    {
+        return [
+            [8000, true],
+            [9000, false],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/SchemeRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcher/SchemeRequestMatcherTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\RequestMatcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\SchemeRequestMatcher;
+
+class SchemeRequestMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function test(string $requestScheme, array|string $matcherScheme, bool $isMatch)
+    {
+        $httpRequest = Request::create('');
+        $httpsRequest = Request::create('', 'get', [], [], [], ['HTTPS' => 'on']);
+
+        if ($isMatch) {
+            if ('https' === $requestScheme) {
+                $matcher = new SchemeRequestMatcher($matcherScheme);
+                $this->assertFalse($matcher->matches($httpRequest));
+                $this->assertTrue($matcher->matches($httpsRequest));
+            } else {
+                $matcher = new SchemeRequestMatcher($matcherScheme);
+                $this->assertFalse($matcher->matches($httpsRequest));
+                $this->assertTrue($matcher->matches($httpRequest));
+            }
+        } else {
+            $matcher = new SchemeRequestMatcher($matcherScheme);
+            $this->assertFalse($matcher->matches($httpRequest));
+            $this->assertFalse($matcher->matches($httpsRequest));
+        }
+    }
+
+    public function getData()
+    {
+        return [
+            ['http', 'http', true],
+            ['http', 'HTTP', true],
+            ['https', 'https', true],
+            ['http', 'ftp', false],
+            ['http', 'ftp, http', true],
+            ['http', 'FTP, HTTP', true],
+            ['http', ['http', 'ftp'], true],
+            ['http', ['http,ftp'], true],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcherTest.php
@@ -14,7 +14,11 @@ namespace Symfony\Component\HttpFoundation\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group legacy
+ */
 class RequestMatcherTest extends TestCase
 {
     /**
@@ -46,8 +50,8 @@ class RequestMatcherTest extends TestCase
 
     public function testScheme()
     {
-        $httpRequest = $request = $request = Request::create('');
-        $httpsRequest = $request = $request = Request::create('', 'get', [], [], [], ['HTTPS' => 'on']);
+        $httpRequest = Request::create('');
+        $httpsRequest = Request::create('', 'get', [], [], [], ['HTTPS' => 'on']);
 
         $matcher = new RequestMatcher();
         $matcher->matchScheme('https');

--- a/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Http\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
 use Symfony\Component\Security\Http\FirewallMap;
 
@@ -25,7 +25,7 @@ class FirewallMapTest extends TestCase
 
         $request = new Request();
 
-        $notMatchingMatcher = $this->createMock(RequestMatcher::class);
+        $notMatchingMatcher = $this->createMock(RequestMatcherInterface::class);
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
@@ -35,7 +35,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($notMatchingMatcher, [function () {}]);
 
-        $matchingMatcher = $this->createMock(RequestMatcher::class);
+        $matchingMatcher = $this->createMock(RequestMatcherInterface::class);
         $matchingMatcher
             ->expects($this->once())
             ->method('matches')
@@ -47,7 +47,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($matchingMatcher, [$theListener], $theException);
 
-        $tooLateMatcher = $this->createMock(RequestMatcher::class);
+        $tooLateMatcher = $this->createMock(RequestMatcherInterface::class);
         $tooLateMatcher
             ->expects($this->never())
             ->method('matches')
@@ -67,7 +67,7 @@ class FirewallMapTest extends TestCase
 
         $request = new Request();
 
-        $notMatchingMatcher = $this->createMock(RequestMatcher::class);
+        $notMatchingMatcher = $this->createMock(RequestMatcherInterface::class);
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
@@ -82,7 +82,7 @@ class FirewallMapTest extends TestCase
 
         $map->add(null, [$theListener], $theException);
 
-        $tooLateMatcher = $this->createMock(RequestMatcher::class);
+        $tooLateMatcher = $this->createMock(RequestMatcherInterface::class);
         $tooLateMatcher
             ->expects($this->never())
             ->method('matches')
@@ -102,7 +102,7 @@ class FirewallMapTest extends TestCase
 
         $request = new Request();
 
-        $notMatchingMatcher = $this->createMock(RequestMatcher::class);
+        $notMatchingMatcher = $this->createMock(RequestMatcherInterface::class);
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

The `RequestMatcher` class hardcodes its matchers. This PR extracts those into their own classes so that we can compose a `RequestMatcher` and allow better reusability.
