### PR TITLE
[FrameworkBundle] Deprecate "legacy_error_messages" form config node

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
    `workflow.state_machine`
  * Add `rate_limiter` configuration option to `messenger.transport` to allow rate limited transports using the RateLimiter component
  * Remove `@internal` tag from secret vaults to allow them to be used directly outside the framework bundle and custom vaults to be added
+ * Deprecate "framework.form.legacy_error_messages" config node
 
 6.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -237,8 +237,9 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('field_name')->defaultValue('_token')->end()
                             ->end()
                         ->end()
-                        // to be deprecated in Symfony 6.1
-                        ->booleanNode('legacy_error_messages')->end()
+                        ->booleanNode('legacy_error_messages')
+                            ->setDeprecated('symfony/framework-bundle', '6.2')
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_default_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_default_csrf.php
@@ -2,9 +2,6 @@
 
 $container->loadFromExtension('framework', [
     'http_method_override' => false,
-    'form' => [
-        'legacy_error_messages' => false,
-    ],
     'session' => [
         'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
@@ -8,7 +8,6 @@
 
     <framework:config http-method-override="false">
         <framework:csrf-protection />
-        <framework:form legacy-error-messages="false" />
         <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
@@ -9,6 +9,5 @@
     <framework:config http-method-override="false">
         <framework:csrf-protection field-name="_custom" />
         <framework:session storage-factory-id="session.storage.factory.native" />
-        <framework:form legacy-error-messages="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
@@ -8,7 +8,6 @@
 
     <framework:config http-method-override="false">
         <framework:csrf-protection field-name="_custom_form" />
-        <framework:form legacy-error-messages="false" />
         <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_default_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_default_csrf.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
-        <framework:form enabled="true" legacy-error-messages="false" />
+        <framework:form enabled="true" />
         <framework:session storage-factory-id="session.storage.factory.native" handler-id="null"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config http-method-override="false">
-        <framework:form enabled="true" legacy-error-messages="false">
+        <framework:form enabled="true">
             <framework:csrf-protection enabled="false" />
         </framework:form>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -10,7 +10,7 @@
         <framework:enabled-locale>fr</framework:enabled-locale>
         <framework:enabled-locale>en</framework:enabled-locale>
         <framework:csrf-protection />
-        <framework:form legacy-error-messages="false">
+        <framework:form>
             <framework:csrf-protection field-name="_csrf"/>
         </framework:form>
         <framework:esi enabled="true" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_default_csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_default_csrf.yml
@@ -1,7 +1,5 @@
 framework:
     http_method_override: false
-    form:
-        legacy_error_messages: false
     session:
         storage_factory_id: session.storage.factory.native
         handler_id: null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | ~
| License       | MIT
| Doc PR        | ~