### PR TITLE
[FrameworkBundle] Add BC layer and FormView handling after #46854

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Add `resolve-env` option to `debug:config` command to display actual values of environment variables in dumped configuration
  * Add `NotificationAssertionsTrait`
  * Add option `framework.catch_all_throwables` to allow `Symfony\Component\HttpKernel\HttpKernel` to catch all kinds of `Throwable`
- * Make `AbstractController::render()` able to deal with forms and deprecate `renderForm()`
+ * Make `AbstractController::render()` able to deal with forms and deprecate `renderForm()` when `framework.form.controllers_render_form_views` is `true`
  * Deprecate the `Symfony\Component\Serializer\Normalizer\ObjectNormalizer` and
    `Symfony\Component\Serializer\Normalizer\PropertyNormalizer` autowiring aliases, type-hint against
    `Symfony\Component\Serializer\Normalizer\NormalizerInterface` or implement `NormalizerAwareInterface` instead

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -240,6 +240,21 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('legacy_error_messages')
                             ->setDeprecated('symfony/framework-bundle', '6.2')
                         ->end()
+                        // to be deprecated in Symfony 7.1
+                        ->booleanNode('controllers_render_form_views')
+                            ->info('Enables "AbstractController::render()" method to convert FormInterface to FormView and setting 422 status code when invalid.')
+                            ->defaultFalse()
+                            ->validate()
+                                ->always()
+                                ->then(function ($v) {
+                                    if (false === $v) {
+                                        trigger_deprecation('symfony/framework-bundle', '6.2', 'Not setting the "framework.form.controllers_render_form_views" option to "true" is deprecated. It will have no effect as of Symfony 7.0.');
+                                    }
+
+                                    return $v;
+                                })
+                            ->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -259,6 +259,8 @@ class FrameworkExtension extends Extension
     private bool $notifierConfigEnabled = false;
     private bool $serializerConfigEnabled = false;
     private bool $propertyAccessConfigEnabled = false;
+    // To be removed in 7.0
+    private bool $controllersRenderFormViews = false;
     private static bool $lockConfigEnabled = false;
 
     /**
@@ -596,6 +598,7 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(ValueResolverInterface::class)
             ->addTag('controller.argument_value_resolver');
         $container->registerForAutoconfiguration(AbstractController::class)
+            ->addMethodCall('setRenderFormViews', [$this->controllersRenderFormViews])
             ->addTag('controller.service_arguments');
         $container->registerForAutoconfiguration(DataCollectorInterface::class)
             ->addTag('data_collector');
@@ -746,6 +749,8 @@ class FrameworkExtension extends Extension
                 ->clearTag('kernel.reset')
             ;
         }
+
+        $this->controllersRenderFormViews = $config['form']['controllers_render_form_views'];
     }
 
     private function registerHttpCacheConfiguration(array $config, ContainerBuilder $container, bool $httpMethodOverride)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -453,6 +453,7 @@ class ConfigurationTest extends TestCase
                     'enabled' => null, // defaults to csrf_protection.enabled
                     'field_name' => '_token',
                 ],
+                'controllers_render_form_views' => false,
             ],
             'esi' => ['enabled' => false],
             'ssi' => ['enabled' => false],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes (potential BC break)
| New feature?  | yes
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/pull/46854#discussion_r914624291
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16948

#46854 may have introduce a BC break by changing the type of template vars when decorators or templates may expect an instance of `FormInterface`.
Before the feature was opt-in by using an explicit method `renderForm()`.

Furthermore, this PR improves the feature by handling instances of `FormView` to change the response status code, enabling the same logic without any required changes in user land code.

We may want to define the new config option as `true` by default in new projects, I can send a PR on `symfony/recipes` to do so if this one is accepted.