### PR TITLE
[Messenger] [WIP]  Be able to start a worker for multiple queues with custom consumption priorities

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2183,6 +2183,11 @@ class FrameworkExtension extends Extension
 
         $sendersServiceLocator = ServiceLocatorTagPass::register($container, $senderReferences);
 
+        $workerExecutionStrategyRegistry = $container->getDefinition('messenger.worker_execution_strategy.registry');
+        foreach ($container->findTaggedServiceIds('messenger.worker_execution_strategy', true) as $serviceId => $unused) {
+            $workerExecutionStrategyRegistry->addMethodCall('registerStrategy', [$container->findDefinition($serviceId)->getClass()]);
+        }
+
         $container->getDefinition('messenger.senders_locator')
             ->replaceArgument(0, $messageToSendersMapping)
             ->replaceArgument(1, $sendersServiceLocator)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -156,6 +156,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('Routable message bus'),
                 service('messenger.receiver_locator'),
                 service('event_dispatcher'),
+                service('messenger.worker_execution_strategy.registry'),
                 service('logger')->nullOnInvalid(),
                 [], // Receiver names
                 service('messenger.listener.reset_services')->nullOnInvalid(),

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -43,6 +43,9 @@ use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory;
 use Symfony\Component\Messenger\Transport\TransportFactory;
+use Symfony\Component\Messenger\WorkerExecution\DefaultWorkerExecutionStrategy;
+use Symfony\Component\Messenger\WorkerExecution\RankedWorkerExecutionStrategy;
+use Symfony\Component\Messenger\WorkerExecution\WorkerExecutionStrategyRegistry;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -216,5 +219,13 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('message bus locator'),
                 service('messenger.default_bus'),
             ])
+
+        ->set('messenger.worker_execution_strategy.registry', WorkerExecutionStrategyRegistry::class)
+
+        ->set('messenger.worker_execution_strategy.default', DefaultWorkerExecutionStrategy::class)
+        ->tag('messenger.worker_execution_strategy')
+
+        ->set('messenger.worker_execution_strategy.ranked', RankedWorkerExecutionStrategy::class)
+        ->tag('messenger.worker_execution_strategy')
     ;
 };

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -295,9 +295,9 @@ class MessengerPass implements CompilerPassInterface
                 $consumeCommandDefinition->replaceArgument(0, new Reference('messenger.routable_message_bus'));
             }
 
-            $consumeCommandDefinition->replaceArgument(4, array_values($receiverNames));
+            $consumeCommandDefinition->replaceArgument(5, array_values($receiverNames));
             try {
-                $consumeCommandDefinition->replaceArgument(6, $busIds);
+                $consumeCommandDefinition->replaceArgument(7, $busIds);
             } catch (OutOfBoundsException) {
                 // ignore to preserve compatibility with symfony/framework-bundle < 5.4
             }

--- a/src/Symfony/Component/Messenger/WorkerExecution/DefaultWorkerExecutionStrategy.php
+++ b/src/Symfony/Component/Messenger/WorkerExecution/DefaultWorkerExecutionStrategy.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Symfony\Component\Messenger\WorkerExecution;
+
+final class DefaultWorkerExecutionStrategy implements WorkerExecutionStrategyInterface
+{
+    public function __construct(array $options)
+    {
+    }
+
+    public static function getAlias(): string
+    {
+        return 'default';
+    }
+
+    public function processQueueTasks(WorkerExecutionStrategyContext $context): WorkerExecutionStrategyResult
+    {
+        $envelopeHandled = false;
+
+        foreach ($context->getReceivers() as $transportName => $receiver) {
+            if ($context->getQueueNames()) {
+                $envelopes = $receiver->getFromQueues($context->getQueueNames());
+            } else {
+                $envelopes = $receiver->get();
+            }
+
+            foreach ($envelopes as $envelope) {
+                $envelopeHandled = true;
+
+                $result = $context->handleMessage($envelope, $transportName);
+
+                if ($result->shouldStop) {
+                    break 2;
+                }
+            }
+
+            // after handling a single receiver, quit and start the loop again
+            // this should prevent multiple lower priority receivers from
+            // blocking too long before the higher priority are checked
+            if ($envelopeHandled) {
+                break;
+            }
+        }
+
+        return new WorkerExecutionStrategyResult($envelopeHandled);
+    }
+}

--- a/src/Symfony/Component/Messenger/WorkerExecution/RankedWorkerExecutionStrategy.php
+++ b/src/Symfony/Component/Messenger/WorkerExecution/RankedWorkerExecutionStrategy.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Symfony\Component\Messenger\WorkerExecution;
+
+use RuntimeException;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+
+/**
+ * Example worker command:
+ *
+ *   bin/console messenger:consume queue_a queue_b queue_b_low queue_b_lowest queue_c \
+ *     --strategy="com.symfony.ranked" \
+ *     --strategy-config="{\"ranks\": [1, 1, 2, 3, 1]}"
+ *
+ * The command above will result in the following execution pattern:
+ *
+ *  1. (queue_a, queue_b, queue_c)
+ *  2. queue_b_low
+ *  3. queue_b_lowest
+ */
+final class RankedWorkerExecutionStrategy implements WorkerExecutionStrategyInterface
+{
+    /**
+     * * ranks: int[]. Queue receivers with the same rank integer value will form a single group. Groups are executed
+     *      from lowest to highest integer value.
+     */
+    private array $options;
+
+    public function __construct(array $options)
+    {
+        $this->options = $options;
+
+        $this->validateOptions($options);
+    }
+
+    private function validateOptions(array $options): void
+    {
+        if (!array_key_exists('ranks', $options) || !is_array($options['ranks'])) {
+            throw new RuntimeException('Invalid worker ranked strategy options. Missing key "ranks" or it is not an array');
+        }
+
+        foreach ($options['ranks'] as $rankNumber) {
+            if (!is_int($rankNumber)) {
+                throw new RuntimeException('Invalid worker ranked strategy options. One of the ranks is not an integer');
+            }
+        }
+    }
+
+    public static function getAlias(): string
+    {
+        return 'com.symfony.ranked';
+    }
+
+    public function processQueueTasks(WorkerExecutionStrategyContext $context): WorkerExecutionStrategyResult
+    {
+        $envelopeHandled = false;
+
+        foreach ($this->groupReceiversByRanks($context->getReceivers()) as $receiversGroup) {
+            foreach ($receiversGroup as $transportName => $receiver) {
+                if ($context->getQueueNames()) {
+                    $envelopes = $receiver->getFromQueues($context->getQueueNames());
+                } else {
+                    $envelopes = $receiver->get();
+                }
+
+                foreach ($envelopes as $envelope) {
+                    $envelopeHandled = true;
+
+                    $result = $context->handleMessage($envelope, $transportName);
+
+                    if ($result->shouldStop) {
+                        break 3;
+                    }
+                }
+            }
+
+            // after handling a single grouped rank of receivers, quit and start the loop again
+            // this should prevent multiple lower priority receivers from
+            // blocking too long before the higher priority are checked
+            if ($envelopeHandled) {
+                break;
+            }
+        }
+
+        return new WorkerExecutionStrategyResult($envelopeHandled);
+    }
+
+    /**
+     * @param ReceiverInterface[] $receivers Where the key is the transport name
+     * @return array<int, array<string, ReceiverInterface>> Ordered groups of receivers by ranks number
+     */
+    private function groupReceiversByRanks(array $receivers): array
+    {
+        $receiversRanks = $this->options['ranks'];
+        $receiversValues = array_values($receivers);
+        $receiversKeys = array_keys($receivers);
+
+        if (count($receiversRanks) !== count($receivers)) {
+            throw new RuntimeException('Worker ranked strategy: The count of queue receivers does not match the count of their ranks');
+        }
+
+        /**
+         * @var array<int, array<string, ReceiverInterface>> $receiversGroupedByRanks
+         */
+        $receiversGroupedByRanks = [];
+        foreach ($receiversValues as $index => $receiver) {
+            $receiversGroupedByRanks[(int) $receiversRanks[$index]][$receiversKeys[$index]] = $receiver;
+        }
+
+        uksort($receiversGroupedByRanks, static function ($rankA, $rankB) {
+            return $rankA <=> $rankB;
+        });
+
+        return $receiversGroupedByRanks;
+    }
+}

--- a/src/Symfony/Component/Messenger/WorkerExecution/WorkerExecutionStrategyContext.php
+++ b/src/Symfony/Component/Messenger/WorkerExecution/WorkerExecutionStrategyContext.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Component\Messenger\WorkerExecution;
+
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Worker;
+
+final class WorkerExecutionStrategyContext
+{
+    private Worker $worker;
+
+    /** @var string[] */
+    private array $queueNames;
+
+    public function __construct(Worker $worker, array $queueNames)
+    {
+        $this->worker = $worker;
+        $this->queueNames = $queueNames;
+    }
+
+    /**
+     * @return ReceiverInterface[] Where the key is the transport name
+     */
+    public function getReceivers(): array
+    {
+        return $this->worker->getReceivers();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getQueueNames(): array
+    {
+        return $this->queueNames;
+    }
+
+    /**
+     * The strategy *must* stop executing and return immediately if the result of this function
+     * requests so.
+     */
+    public function handleMessage(mixed $envelope, int|string $transportName): WorkerMessageHandlingResult
+    {
+        $this->worker->rateLimit($transportName);
+        $this->worker->handleMessage($envelope, $transportName);
+        $this->worker->getEventDispatcher()?->dispatch(new WorkerRunningEvent($this->worker, false));
+
+        return new WorkerMessageHandlingResult($this->worker->getShouldStop());
+    }
+}

--- a/src/Symfony/Component/Messenger/WorkerExecution/WorkerExecutionStrategyInterface.php
+++ b/src/Symfony/Component/Messenger/WorkerExecution/WorkerExecutionStrategyInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Messenger\WorkerExecution;
+
+interface WorkerExecutionStrategyInterface
+{
+    public function __construct(array $options);
+
+    /**
+     * Get a unique alias under which the strategy will be registered in the registry.
+     *
+     * @see WorkerExecutionStrategyRegistry::registerStrategy()
+     */
+    public static function getAlias(): string;
+
+    public function processQueueTasks(WorkerExecutionStrategyContext $context): WorkerExecutionStrategyResult;
+}

--- a/src/Symfony/Component/Messenger/WorkerExecution/WorkerExecutionStrategyRegistry.php
+++ b/src/Symfony/Component/Messenger/WorkerExecution/WorkerExecutionStrategyRegistry.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\Messenger\WorkerExecution;
+
+use RuntimeException;
+
+final class WorkerExecutionStrategyRegistry
+{
+    /** @var array<string, class-string<WorkerExecutionStrategyInterface>> */
+    private array $strategies = [];
+
+    /**
+     * @param class-string<WorkerExecutionStrategyInterface> $strategyClass
+     */
+    public function registerStrategy(string $strategyClass): void
+    {
+        $this->strategies[$strategyClass::getAlias()] = $strategyClass;
+    }
+
+    public function createStrategy(mixed $strategyAlias, mixed $strategyConfig): WorkerExecutionStrategyInterface
+    {
+        $strategyClass = $this->strategies[$strategyAlias] ?? null;
+        if (!$strategyClass) {
+            throw new RuntimeException("Unknown strategy alias: '{$strategyAlias}'");
+        }
+
+        return new $strategyClass($strategyConfig);
+    }
+}

--- a/src/Symfony/Component/Messenger/WorkerExecution/WorkerExecutionStrategyResult.php
+++ b/src/Symfony/Component/Messenger/WorkerExecution/WorkerExecutionStrategyResult.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Messenger\WorkerExecution;
+
+final class WorkerExecutionStrategyResult
+{
+    public readonly bool $wereEnvelopesHandled;
+
+    public function __construct(bool $wereEnvelopesHandled)
+    {
+        $this->wereEnvelopesHandled = $wereEnvelopesHandled;
+    }
+}

--- a/src/Symfony/Component/Messenger/WorkerExecution/WorkerMessageHandlingResult.php
+++ b/src/Symfony/Component/Messenger/WorkerExecution/WorkerMessageHandlingResult.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Messenger\WorkerExecution;
+
+final class WorkerMessageHandlingResult
+{
+    public readonly bool $shouldStop;
+
+    public function __construct(bool $shouldStop)
+    {
+        $this->shouldStop = $shouldStop;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | Fix #45882 -->
| License       | MIT
| Doc PR        | todo

- [ ] fix the tests as they have not been updated yet
- [ ] submit changes to the documentation
- [ ] document the BC breaks
- [ ] finish the code
- [ ] gather feedback for my changes

This PR adds a way to run the messenger worker with different, potentially custom execution strategies. Beside extracting the current "execution strategy", it also adds a new one: "com.symfony.ranked", which satisfies the requirements described in the related ticket: #45882. 

An example that demonstrates the entire feature:
```bash
bin/console messenger:consume queue_a queue_b queue_b_low queue_b_lowest queue_c \
  --strategy="com.symfony.ranked" \
  --strategy-config="{\"ranks\": [1, 1, 2, 3, 1]}"
```

At present, I would like to gather feedback for my changes before I go ahead and fix/write tests, etc. The code does work, however, as I integration-tested it in my test project.

Regarding BC, the feature might be breaking the compatibility because it adds a new required `__construct()` argument to the following classes: `ConsumeMessagesCommand`, `Worker` (this one is, however, annotated as final, so perhaps BC might not be a concern here). Please let me know if this indeed is a BC break. If yes, I'd appreciate a proposition on how to work around it (perhaps setter injection could be used instead, but it has its own downsides).
