### PR TITLE
[DependencyInjection] [POC] Introduce build parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -304,6 +304,14 @@ class Container implements ContainerInterface, ResetInterface
     }
 
     /**
+     * Gets parameter names that existed at compile time.
+     */
+    public function getRemovedParameters(): array
+    {
+        return [];
+    }
+
+    /**
      * Camelizes a string.
      */
     public static function camelize(string $id): string

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -684,6 +684,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         array_unshift($this->extensionConfigs[$name], $config);
     }
 
+    public function removeParameter(string $parameter): void
+    {
+        $this->parameterBag->remove($parameter);
+    }
+
     /**
      * Compiles the container.
      *

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -134,6 +134,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     private array $removedBindingIds = [];
 
+    /**
+     * @var string[]
+     */
+    private array $buildParameters = [];
+
     private const INTERNAL_TYPES = [
         'int' => true,
         'float' => true,
@@ -684,6 +689,15 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         array_unshift($this->extensionConfigs[$name], $config);
     }
 
+    /**
+     * Adds a parameter available during at compile-time only, it will be removed when dumped.
+     */
+    public function setBuildParameter(string $parameter, array|bool|string|int|float|\UnitEnum|null $value): void
+    {
+        $this->parameterBag->set($parameter, $value);
+        $this->buildParameters[] = $parameter;
+    }
+
     public function removeParameter(string $parameter): void
     {
         $this->parameterBag->remove($parameter);
@@ -739,6 +753,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             }
 
             $this->envPlaceholders = $bag->getEnvPlaceholders();
+        }
+
+        foreach ($this->buildParameters as $parameter) {
+            $this->parameterBag->remove($parameter);
         }
 
         parent::compile();

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -135,9 +135,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     private array $removedBindingIds = [];
 
     /**
-     * @var string[]
+     * @internal
+     *
+     * @var array<string, false>
      */
-    private array $buildParameters = [];
+    public array $buildParameters = [];
 
     private const INTERNAL_TYPES = [
         'int' => true,
@@ -695,7 +697,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     public function setBuildParameter(string $parameter, array|bool|string|int|float|\UnitEnum|null $value): void
     {
         $this->parameterBag->set($parameter, $value);
-        $this->buildParameters[] = $parameter;
+        $this->buildParameters[$parameter] = false;
     }
 
     public function removeParameter(string $parameter): void
@@ -753,10 +755,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             }
 
             $this->envPlaceholders = $bag->getEnvPlaceholders();
-        }
-
-        foreach ($this->buildParameters as $parameter) {
-            $this->parameterBag->remove($parameter);
         }
 
         parent::compile();

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
@@ -32,13 +32,17 @@ class ParametersConfigurator extends AbstractConfigurator
     /**
      * @return $this
      */
-    final public function set(string $name, mixed $value): static
+    final public function set(string $name, mixed $value, bool $buildOnly = false): static
     {
         if ($value instanceof Expression) {
             throw new InvalidArgumentException(sprintf('Using an expression in parameter "%s" is not allowed.', $name));
         }
 
-        $this->container->setParameter($name, static::processValue($value, true));
+        if ($buildOnly) {
+            $this->container->setBuildParameter($name, static::processValue($value, true));
+        } else {
+            $this->container->setParameter($name, static::processValue($value, true));
+        }
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
@@ -46,6 +46,16 @@ class IniFileLoader extends FileLoader
             }
         }
 
+        if (isset($result['build_parameters']) && \is_array($result['build_parameters'])) {
+            foreach ($result['build_parameters'] as $key => $value) {
+                if (\is_array($value)) {
+                    $this->container->setBuildParameter($key, array_map([$this, 'phpize'], $value));
+                } else {
+                    $this->container->setBuildParameter($key, $this->phpize($value));
+                }
+            }
+        }
+
         if ($this->env && \is_array($result['parameters@'.$this->env] ?? null)) {
             foreach ($result['parameters@'.$this->env] as $key => $value) {
                 $this->container->setParameter($key, $this->phpize($value));

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -107,8 +107,16 @@ class XmlFileLoader extends FileLoader
 
     private function parseParameters(\DOMDocument $xml, string $file, \DOMNode $root = null)
     {
-        if ($parameters = $this->getChildren($root ?? $xml->documentElement, 'parameters')) {
+        $node = $root ?? $xml->documentElement;
+
+        if ($parameters = $this->getChildren($node, 'parameters')) {
             $this->container->getParameterBag()->add($this->getArgumentsAsPhp($parameters[0], 'parameter', $file));
+        }
+
+        if ($buildParameters = $this->getChildren($node, 'build-parameters')) {
+            foreach ($this->getArgumentsAsPhp($buildParameters[0], 'parameter', $file) as $parameter => $value) {
+                $this->container->setBuildParameter($parameter, $value);
+            }
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -162,6 +162,17 @@ class YamlFileLoader extends FileLoader
             }
         }
 
+        // build parameters
+        if (isset($content['build_parameters'])) {
+            if (!\is_array($content['build_parameters'])) {
+                throw new InvalidArgumentException(sprintf('The "build_parameters" key should contain an array in "%s". Check your YAML syntax.', $path));
+            }
+
+            foreach ($content['build_parameters'] as $key => $value) {
+                $this->container->setBuildParameter($key, $this->resolveServices($value, $path, true));
+            }
+        }
+
         // extensions
         $this->loadFromExtensions($content);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -792,7 +792,7 @@ class YamlFileLoader extends FileLoader
         }
 
         foreach ($content as $namespace => $data) {
-            if (\in_array($namespace, ['imports', 'parameters', 'services']) || str_starts_with($namespace, 'when@')) {
+            if (\in_array($namespace, ['imports', 'build_parameters', 'parameters', 'services']) || str_starts_with($namespace, 'when@')) {
                 continue;
             }
 
@@ -931,7 +931,7 @@ class YamlFileLoader extends FileLoader
     private function loadFromExtensions(array $content)
     {
         foreach ($content as $namespace => $values) {
-            if (\in_array($namespace, ['imports', 'parameters', 'services']) || str_starts_with($namespace, 'when@')) {
+            if (\in_array($namespace, ['imports', 'build_parameters', 'parameters', 'services']) || str_starts_with($namespace, 'when@')) {
                 continue;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -30,6 +30,10 @@
         <xsd:group ref="foreign" />
       </xsd:sequence>
       <xsd:sequence minOccurs="0">
+        <xsd:element name="build-parameters" type="parameters" />
+        <xsd:group ref="foreign" />
+      </xsd:sequence>
+      <xsd:sequence minOccurs="0">
         <xsd:element name="parameters" type="parameters" />
         <xsd:group ref="foreign" />
       </xsd:sequence>

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
@@ -28,10 +28,19 @@ class FrozenParameterBag extends ParameterBag
      *
      * @param array $parameters An array of parameters
      */
-    public function __construct(array $parameters = [])
+    public function __construct(array $parameters = [], private array $buildParameters = [])
     {
         $this->parameters = $parameters;
         $this->resolved = true;
+    }
+
+    public function get(string $name): array|bool|string|int|float|\UnitEnum|null
+    {
+        if (isset($this->buildParameters[$name])) {
+            throw new LogicException(sprintf('Build parameter "%s" cannot be accessed at runtime.', $name));
+        }
+
+        return parent::get($name);
     }
 
     public function clear()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | TODO

We miss a way to optimise dumped container with compile-time only parameters, or ability to remove them in a straightforward/easy to discover way:
```php
// before
$containerBuilder->getParameterBag()->remove(...);
// after
$containerBuilder->removeParameter(...);
```

```php
$containerBuilder->setBuildParameter(...); // will be removed before dumping

// with configurator
$container->parameters()
    ->set('param', 'X')
    ->set('build_param', 'Y', buildOnly: true)
```
```yaml
# services.yaml
build_parameters:
    ...

parameters:
    ...
```

```xml
<!-- services.xml -->
<container ...>
    <build-parameters>
        <parameter ...>...</parameter>
    </build-parameters>

    <parameters>
        <parameter ...>...</parameter>
    </parameters>
</container>
```