### PR TITLE
[Clock] Fix `sleep()` in `MockClock`

### DIFF
--- a/src/Symfony/Component/Clock/MockClock.php
+++ b/src/Symfony/Component/Clock/MockClock.php
@@ -40,21 +40,11 @@ final class MockClock implements ClockInterface
 
     public function sleep(float|int $seconds): void
     {
-        $now = explode('.', $this->now->format('U.u'));
-
-        if (0 < $s = (int) $seconds) {
-            $now[0] += $s;
-        }
-
-        if (0 < ($us = $seconds - $s) && 1E6 <= $now[1] += $us * 1E6) {
-            ++$now[0];
-            $now[1] -= 1E6;
-        }
-
-        $datetime = '@'.$now[0].'.'.str_pad($now[1], 6, '0', \STR_PAD_LEFT);
+        $now = (float) $this->now->format('Uu') + $seconds * 1e6;
+        $now = substr_replace(sprintf('@%07.0F', $now), '.', -6, 0);
         $timezone = $this->now->getTimezone();
 
-        $this->now = (new \DateTimeImmutable($datetime, $timezone))->setTimezone($timezone);
+        $this->now = (new \DateTimeImmutable($now, $timezone))->setTimezone($timezone);
     }
 
     public function withTimeZone(\DateTimeZone|string $timezone): static

--- a/src/Symfony/Component/Clock/Tests/MockClockTest.php
+++ b/src/Symfony/Component/Clock/Tests/MockClockTest.php
@@ -55,11 +55,11 @@ class MockClockTest extends TestCase
 
     public function testSleep()
     {
-        $clock = new MockClock((new \DateTimeImmutable('@123.456'))->setTimezone(new \DateTimeZone('UTC')));
+        $clock = new MockClock((new \DateTimeImmutable('2112-09-17 23:53:00.999Z'))->setTimezone(new \DateTimeZone('UTC')));
         $tz = $clock->now()->getTimezone()->getName();
 
-        $clock->sleep(4.999);
-        $this->assertSame('128.455000', $clock->now()->format('U.u'));
+        $clock->sleep(2.002001);
+        $this->assertSame('2112-09-17 23:53:03.001001', $clock->now()->format('Y-m-d H:i:s.u'));
         $this->assertSame($tz, $clock->now()->getTimezone()->getName());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

It fixes losing precision in `$us = $seconds - $s` that occurs because the `$seconds` is float.

Anyway, why so many calculation? Double precision is enough to represent any valid date and time:

```php
    public function sleep(float|int $seconds): void
    {
        $datetime = '@'. ((float)$this->now->format('U.u') + $seconds);
        $timezone = $this->now->getTimezone();

        $this->now = (new \DateTimeImmutable($datetime))->setTimezone($timezone);
    }
```

Why is cloning needed for immutable? The beauty of immutables is that they don't need to be copied.

```php
    public function now(): \DateTimeImmutable
    {
        return clone $this->now;
    }
```
