### PR TITLE
[Serializer] Allow getting discriminated type by class name

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
@@ -53,7 +53,7 @@ class ClassDiscriminatorMapping
     public function getMappedObjectType($object): ?string
     {
         foreach ($this->typesMapping as $type => $typeClass) {
-            if (is_a($object, $typeClass)) {
+            if (is_a($object, $typeClass, true)) {
                 return $type;
             }
         }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/ClassDiscriminatorMappingTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/ClassDiscriminatorMappingTest.php
@@ -39,6 +39,7 @@ class ClassDiscriminatorMappingTest extends TestCase
             'third' => AbstractDummyThirdChild::class,
         ]);
 
+        $this->assertEquals('first', $mapping->getMappedObjectType(AbstractDummyFirstChild::class));
         $this->assertEquals('first', $mapping->getMappedObjectType(new AbstractDummyFirstChild()));
         $this->assertNull($mapping->getMappedObjectType(new AbstractDummySecondChild()));
         $this->assertSame('third', $mapping->getMappedObjectType(new AbstractDummyThirdChild()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Fixing: `ClassDiscriminatorMapping::getMappedObjectType` allows string input but hasn't worked with class name
