### PR TITLE
[VarExporter] Allow creating lazy-loading classes using constructors

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
@@ -61,7 +61,7 @@ class LazyObjectRegistry
         }
 
         foreach ($propertyScopes as $key => [$scope, $name, $readonlyScope]) {
-            $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0*\0$name"] ?? $k = null !== $readonlyScope ? $name : null;
+            $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0*\0$name"] ?? $k = $name;
 
             if ($k === $key && "\0$class\0lazyObjectId" !== $k) {
                 $classProperties[$readonlyScope ?? $scope][$name] = $key;
@@ -146,6 +146,6 @@ class LazyObjectRegistry
             return null;
         }
 
-        return $scope;
+        return \ReflectionProperty::class === $scope ? $class : $scope;
     }
 }

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -27,15 +27,15 @@ trait LazyGhostTrait
      * @param array<string, true> $skippedProperties An array indexed by the properties to skip,
      *                                               aka the ones that the initializer doesn't set
      */
-    public static function createLazyGhost(\Closure $initializer, array $skippedProperties = []): static
+    public static function createLazyGhost(\Closure $initializer, array $skippedProperties = [], self $instance = null): static
     {
-        if (self::class !== $class = static::class) {
+        if (self::class !== $class = $instance ? $instance::class : static::class) {
             $skippedProperties["\0".self::class."\0lazyObjectId"] = true;
         } elseif (\defined($class.'::LAZY_OBJECT_PROPERTY_SCOPES')) {
             Hydrator::$propertyScopes[$class] ??= $class::LAZY_OBJECT_PROPERTY_SCOPES;
         }
 
-        $instance = (Registry::$classReflectors[$class] ??= new \ReflectionClass($class))->newInstanceWithoutConstructor();
+        $instance ??= (Registry::$classReflectors[$class] ??= new \ReflectionClass($class))->newInstanceWithoutConstructor();
         Registry::$defaultProperties[$class] ??= (array) $instance;
         $instance->lazyObjectId = $id = spl_object_id($instance);
         Registry::$states[$id] = new LazyObjectState($initializer, $skippedProperties);
@@ -56,11 +56,22 @@ trait LazyGhostTrait
             return true;
         }
 
-        if (LazyObjectState::STATUS_INITIALIZED_PARTIAL === $state->status) {
-            return \count($state->preInitSetProperties) !== \count((array) $this);
+        if (LazyObjectState::STATUS_INITIALIZED_PARTIAL !== $state->status) {
+            return LazyObjectState::STATUS_INITIALIZED_FULL === $state->status;
         }
 
-        return LazyObjectState::STATUS_INITIALIZED_FULL === $state->status;
+        $class = static::class;
+        $properties = (array) $this;
+        $propertyScopes = Hydrator::$propertyScopes[$class] ??= Hydrator::getPropertyScopes($class);
+        foreach ($propertyScopes as $key => [$scope, $name]) {
+            $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0".($scope = '*')."\0$name"] ?? $k = $name;
+
+            if ($k === $key && !\array_key_exists($k, $properties) && !isset($state->unsetProperties[$scope][$name])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -69,6 +80,18 @@ trait LazyGhostTrait
     public function initializeLazyObject(): static
     {
         if (!$state = Registry::$states[$this->lazyObjectId ?? ''] ?? null) {
+            return $this;
+        }
+
+        if (!$state->status) {
+            $state->initialize($this, null, null);
+        }
+
+        if (LazyObjectState::STATUS_INITIALIZED_PARTIAL !== $state->status) {
+            if (LazyObjectState::STATUS_UNINITIALIZED_FULL === $state->status) {
+                $state->initialize($this, '', null);
+            }
+
             return $this;
         }
 
@@ -105,7 +128,7 @@ trait LazyGhostTrait
 
         $class = static::class;
         $propertyScopes = Hydrator::$propertyScopes[$class] ??= Hydrator::getPropertyScopes($class);
-        $skippedProperties = $state->preInitSetProperties;
+        $skippedProperties = $state->skippedProperties + $state->preInitSetProperties;
         foreach ($propertyScopes as $key => [$scope, $name, $readonlyScope]) {
             $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0*\0$name"] ?? $k = $name;
 

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -25,15 +25,15 @@ trait LazyProxyTrait
     /**
      * @param \Closure():object $initializer Returns the proxied object
      */
-    public static function createLazyProxy(\Closure $initializer): static
+    public static function createLazyProxy(\Closure $initializer, self $instance = null): static
     {
-        if (self::class !== $class = static::class) {
+        if (self::class !== $class = $instance ? $instance::class : static::class) {
             $skippedProperties = ["\0".self::class."\0lazyObjectId" => true];
         } elseif (\defined($class.'::LAZY_OBJECT_PROPERTY_SCOPES')) {
             Hydrator::$propertyScopes[$class] ??= $class::LAZY_OBJECT_PROPERTY_SCOPES;
         }
 
-        $instance = (Registry::$classReflectors[$class] ??= new \ReflectionClass($class))->newInstanceWithoutConstructor();
+        $instance ??= (Registry::$classReflectors[$class] ??= new \ReflectionClass($class))->newInstanceWithoutConstructor();
         $instance->lazyObjectId = $id = spl_object_id($instance);
         Registry::$states[$id] = new LazyObjectState($initializer);
 

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/LazyClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/LazyClass.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
+
+use Symfony\Component\VarExporter\LazyGhostTrait;
+
+class LazyClass
+{
+    use LazyGhostTrait {
+        createLazyGhost as private;
+    }
+
+    private int $lazyObjectId;
+    public int $public;
+
+    public function __construct(\Closure $initializer)
+    {
+        self::createLazyGhost($initializer, [], $this);
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarExporter\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Component\VarExporter\ProxyHelper;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\FinalPublicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\ReadOnlyClass;
@@ -239,6 +240,25 @@ class LazyProxyTraitTest extends TestCase
         $proxy = $this->createLazyProxy(ReadOnlyClass::class, fn () => new ReadOnlyClass(123));
 
         $this->assertSame(123, $proxy->foo);
+    }
+
+    public function testLazyDecoratorClass()
+    {
+        $obj = new class() extends TestClass {
+            use LazyProxyTrait {
+                createLazyProxy as private;
+            }
+
+            private int $lazyObjectId;
+            private parent $lazyObjectReal;
+
+            public function __construct()
+            {
+                self::createLazyProxy(fn () => new TestClass((object) ['foo' => 123]), $this);
+            }
+        };
+
+        $this->assertSame(['foo' => 123], (array) $obj->getDep());
     }
 
     /**

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -33,7 +33,7 @@ class ProxyHelperTest extends TestCase
 
         foreach ($methods as $method) {
             $expected = substr($source[$method->getStartLine() - 1], $method->isAbstract() ? 13 : 4, -(1 + $method->isAbstract()));
-            $expected = str_replace(['.', ' .  .  . ', '"', '\0'], [' . ', '...', "'", '\'."\0".\''], $expected);
+            $expected = str_replace(['.', ' .  .  . ', '\'$a\', \'$a\n\', "\$a\n"'], [' . ', '...', '\'$a\', "\$a\\\n", "\$a\n"'], $expected);
             $expected = str_replace('Bar', '\\'.Bar::class, $expected);
             $expected = str_replace('self', '\\'.TestForProxyHelper::class, $expected);
 
@@ -226,6 +226,10 @@ abstract class TestForProxyHelper
     abstract protected function foo7();
 
     public static function foo8()
+    {
+    }
+
+    public function foo9($a = self::BOB, $b = ['$a', '$a\n', "\$a\n"], $c = ['$a', '$a\n', "\$a\n", new \stdClass()])
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR enables instantiating lazy objects using a constructor instead of the `createLazy*()` methods.

It also fixes:
- setting properties via `ReflectionProperty::setValue()`
- resetting typed public properties
- calls to `isLazyObjectInitialized()`