### PR TITLE
[FrameworkBundle] Add semantic config for new terminate_on_cache_hit HttpCache option

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -269,6 +269,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('allow_revalidate')->end()
                         ->integerNode('stale_while_revalidate')->end()
                         ->integerNode('stale_if_error')->end()
+                        ->booleanNode('terminate_on_cache_hit')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -724,6 +724,7 @@
         <xsd:attribute name="allow-revalidate" type="xsd:boolean" />
         <xsd:attribute name="stale-while-revalidate" type="xsd:integer" />
         <xsd:attribute name="stale-if-error" type="xsd:integer" />
+        <xsd:attribute name="terminate-on-cache-hit" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:simpleType name="http_cache_trace_levels">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/16999

Adds the semantic configuration for the option introduced in Symfony 6.2 by https://github.com/symfony/symfony/pull/46763