### PR TITLE
[DependencyInjection] [Bugfix] EnvPlaceholderParameterBag::get() can't return UnitEnum

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -26,7 +26,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
 
     private static int $counter = 0;
 
-    public function get(string $name): array|bool|string|int|float|null
+    public function get(string $name): array|bool|string|int|float|\UnitEnum|null
     {
         if (str_starts_with($name, 'env(') && str_ends_with($name, ')') && 'env()' !== $name) {
             $env = substr($name, 4, -1);

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -42,7 +42,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
                 }
             }
             if (!preg_match('/^(?:[-.\w\\\\]*+:)*+\w++$/', $env)) {
-                throw new InvalidArgumentException(sprintf('Invalid %s name: only "word" characters are allowed.', $name));
+                throw new InvalidArgumentException(sprintf('Invalid "%s" name: only "word" characters are allowed.', $name));
             }
             if ($this->has($name) && null !== ($defaultValue = parent::get($name)) && !\is_string($defaultValue)) {
                 throw new RuntimeException(sprintf('The default value of an env() parameter must be a string or null, but "%s" given to "%s".', get_debug_type($defaultValue), $name));

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -206,4 +206,14 @@ class EnvPlaceholderParameterBagTest extends TestCase
         $bag->resolve();
         $this->assertStringMatchesFormat('env_%s_key_a_b_c_FOO_%s', $bag->get('env(key:a.b-c:FOO)'));
     }
+
+    public function testGetEnum()
+    {
+        $bag = new EnvPlaceholderParameterBag();
+        $bag->set('ENUM_VAR', StringBackedEnum::Bar);
+        $value = $bag->get('ENUM_VAR');
+
+        $this->assertInstanceOf(StringBackedEnum::class, $value);
+        $this->assertEquals(StringBackedEnum::Bar, $value);
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -211,9 +211,7 @@ class EnvPlaceholderParameterBagTest extends TestCase
     {
         $bag = new EnvPlaceholderParameterBag();
         $bag->set('ENUM_VAR', StringBackedEnum::Bar);
-        $value = $bag->get('ENUM_VAR');
-
-        $this->assertInstanceOf(StringBackedEnum::class, $value);
-        $this->assertEquals(StringBackedEnum::Bar, $value);
+        $this->assertInstanceOf(StringBackedEnum::class, $bag->get('ENUM_VAR'));
+        $this->assertEquals(StringBackedEnum::Bar, $bag->get('ENUM_VAR'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2  
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | - 
| License       | MIT
| Doc PR        | - 

This PR allows to get enums from container in the next situation:

```
parameters:
    app.someEnum.yes !php/const \App\Context\SomeEnum::YES
```

Currently, we'll have an error:

```
[critical] Uncaught Error: Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag::get(): Return value must be of type array|string|int|float|bool|null, \App\Context\SomeEnum returned
```

This bugfix fixes this error.

`EnvPlaceholderParameterBag::get()` has a signature:  array|bool|string|int|float|null
`ParameterBag::get()` has another signature: array|bool|string|int|float|**\UnitEnum**|null

Why do we need this fix?
To make the results of two dependent methods consistent.

`EnvPlaceholderParameterBag::get()` call `ParameterBag::get()` here: https://github.com/symfony/symfony/blob/b7ce8f23d3854d5417eacefa99af8e20e0841a52/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php#L58


This PR makes it consistent and adding UnitEnum to `EnvPlaceholderParameterBag::get()` result.