### PR TITLE
[DependencyInjection] EnvPlaceholderParameterBag::get() can't return UnitEnum

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -29,7 +29,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
     /**
      * {@inheritdoc}
      */
-    public function get(string $name): array|bool|string|int|float|null
+    public function get(string $name): array|bool|string|int|float|\UnitEnum|null
     {
         if (str_starts_with($name, 'env(') && str_ends_with($name, ')') && 'env()' !== $name) {
             $env = substr($name, 4, -1);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StringBackedEnum.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StringBackedEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+enum StringBackedEnum: string
+{
+    case Bar = 'bar';
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\StringBackedEnum;
 
 class EnvPlaceholderParameterBagTest extends TestCase
 {
@@ -195,5 +196,13 @@ class EnvPlaceholderParameterBagTest extends TestCase
         $bag = new EnvPlaceholderParameterBag();
         $bag->resolve();
         $this->assertStringMatchesFormat('env_%s_key_a_b_c_FOO_%s', $bag->get('env(key:a.b-c:FOO)'));
+    }
+
+    public function testGetEnum()
+    {
+        $bag = new EnvPlaceholderParameterBag();
+        $bag->set('ENUM_VAR', StringBackedEnum::Bar);
+        $this->assertInstanceOf(StringBackedEnum::class, $bag->get('ENUM_VAR'));
+        $this->assertEquals(StringBackedEnum::Bar, $bag->get('ENUM_VAR'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | - 
| License       | MIT
| Doc PR        | - 

This PR allows to get enums from container in the next situation:

```
parameters:
    app.someEnum.yes !php/const \App\Context\SomeEnum::YES
```

Currently, we'll have an error:

```
[critical] Uncaught Error: Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag::get(): Return value must be of type array|string|int|float|bool|null, \App\Context\SomeEnum returned
```

This bugfix fixes this error.

`EnvPlaceholderParameterBag::get()` has a signature:  array|bool|string|int|float|null
`ParameterBag::get()` has another signature: array|bool|string|int|float|**\UnitEnum**|null

Why do we need this fix?
To make the results of two dependent methods consistent.

`EnvPlaceholderParameterBag::get()` call `ParameterBag::get()` here: https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php#L61

This PR makes it consistent and adding UnitEnum to `EnvPlaceholderParameterBag::get()` result.