### PR TITLE
[DotEnv] Populate HTTP_* vars if it does not exist on $_SERVER

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -150,7 +150,7 @@ final class Dotenv
             }
 
             $_ENV[$name] = $value;
-            if ($notHttpName) {
+            if ($notHttpName || false === \array_key_exists($name, $_SERVER)) {
                 $_SERVER[$name] = $value;
             }
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -362,11 +362,15 @@ class DotenvTest extends TestCase
         $_SERVER['HTTP_TEST_ENV_VAR'] = 'http_value';
 
         $dotenv = new Dotenv(true);
-        $dotenv->populate(['HTTP_TEST_ENV_VAR' => 'env_value']);
+        $dotenv->populate(['HTTP_TEST_ENV_VAR' => 'env_value', 'HTTP_FOO' => 'bar']);
 
         $this->assertSame('env_value', getenv('HTTP_TEST_ENV_VAR'));
         $this->assertSame('env_value', $_ENV['HTTP_TEST_ENV_VAR']);
         $this->assertSame('http_value', $_SERVER['HTTP_TEST_ENV_VAR']);
+
+        $this->assertSame('bar', getenv('HTTP_FOO'));
+        $this->assertSame('bar', $_ENV['HTTP_FOO']);
+        $this->assertSame('bar', $_SERVER['HTTP_FOO']);
     }
 
     public function testEnvVarIsOverriden()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Hello,

On my .env file with SF6.1 I've got a var named HTTP_HOST and when I use the command `debug:dotenv` I've got this error : 

> In DebugCommand.php line 100:
> [ErrorException]                                   
> Warning: Undefined array key "HTTP_HOST"

After some research I've found we did not put value into `$_SERVER` and when we dump the values with the command `$realValue = $_SERVER[$var]` (L100) the key `$var` does not exist.

So I propose this minor fix. If the key does not already exists on `$_SERVER`, so we set the value.

Have a nice day.

