### PR TITLE
[FrameworkBundle] Fix passing `serializer.default_context` option to normalizers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -78,7 +78,8 @@ return static function (ContainerConfigurator $container) {
 
         // Normalizer
         ->set('serializer.normalizer.constraint_violation_list', ConstraintViolationListNormalizer::class)
-            ->args([[], service('serializer.name_converter.metadata_aware')])
+            ->args([1 => service('serializer.name_converter.metadata_aware')])
+            ->autowire(true)
             ->tag('serializer.normalizer', ['priority' => -915])
 
         ->set('serializer.normalizer.mime_message', MimeMessageNormalizer::class)
@@ -124,7 +125,6 @@ return static function (ContainerConfigurator $container) {
                 service('property_info')->ignoreOnInvalid(),
                 service('serializer.mapping.class_discriminator_resolver')->ignoreOnInvalid(),
                 null,
-                [],
             ])
             ->tag('serializer.normalizer', ['priority' => -1000])
 
@@ -137,7 +137,6 @@ return static function (ContainerConfigurator $container) {
                 service('property_info')->ignoreOnInvalid(),
                 service('serializer.mapping.class_discriminator_resolver')->ignoreOnInvalid(),
                 null,
-                [],
             ])
 
         ->alias(PropertyNormalizer::class, 'serializer.normalizer.property')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -32,6 +32,41 @@ class SerializerTest extends AbstractWebTestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @dataProvider provideNormalizersAndEncodersWithDefaultContextOption
+     */
+    public function testNormalizersAndEncodersUseDefaultContextConfigOption(string $normalizerId)
+    {
+        static::bootKernel(['test_case' => 'Serializer']);
+
+        $normalizer = static::getContainer()->get($normalizerId);
+
+        $reflectionObject = new \ReflectionObject($normalizer);
+        $property = $reflectionObject->getProperty('defaultContext');
+        $property->setAccessible(true);
+
+        $defaultContext = $property->getValue($normalizer);
+
+        self::assertArrayHasKey('fake_context_option', $defaultContext);
+        self::assertEquals('foo', $defaultContext['fake_context_option']);
+    }
+
+    public function provideNormalizersAndEncodersWithDefaultContextOption(): array
+    {
+        return [
+            ['serializer.normalizer.constraint_violation_list.alias'],
+            ['serializer.normalizer.dateinterval.alias'],
+            ['serializer.normalizer.datetime.alias'],
+            ['serializer.normalizer.json_serializable.alias'],
+            ['serializer.normalizer.problem.alias'],
+            ['serializer.normalizer.uid.alias'],
+            ['serializer.normalizer.object.alias'],
+            ['serializer.encoder.xml.alias'],
+            ['serializer.encoder.yaml.alias'],
+            ['serializer.encoder.csv.alias'],
+        ];
+    }
 }
 
 class Foo

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
@@ -6,9 +6,54 @@ framework:
         enabled: true
         default_context:
             enable_max_depth: true
+            fake_context_option: foo
     property_info: { enabled: true }
 
 services:
     serializer.alias:
         alias: serializer
+        public: true
+
+    serializer.normalizer.constraint_violation_list.alias:
+        alias: serializer.normalizer.constraint_violation_list
+        public: true
+
+    serializer.normalizer.dateinterval.alias:
+        alias: serializer.normalizer.dateinterval
+        public: true
+
+    serializer.normalizer.datetime.alias:
+        alias: serializer.normalizer.datetime
+        public: true
+
+    serializer.normalizer.json_serializable.alias:
+        alias: serializer.normalizer.json_serializable
+        public: true
+
+    serializer.normalizer.problem.alias:
+        alias: serializer.normalizer.problem
+        public: true
+
+    serializer.normalizer.uid.alias:
+        alias: serializer.normalizer.uid
+        public: true
+
+    serializer.normalizer.property.alias:
+        alias: serializer.normalizer.property
+        public: true
+
+    serializer.normalizer.object.alias:
+        alias: serializer.normalizer.object
+        public: true
+
+    serializer.encoder.xml.alias:
+        alias: serializer.encoder.xml
+        public: true
+
+    serializer.encoder.yaml.alias:
+        alias: serializer.encoder.yaml
+        public: true
+
+    serializer.encoder.csv.alias:
+        alias: serializer.encoder.csv
         public: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

The `default_context` config option under `serializer` of FrameworkBundle isn't taken into account when using `Symfony\Component\Serializer\Normalizer\ObjectNormalizer`.
Maybe it's the case for other serializers but let's fix one at a time.
