### PR TITLE
[Validator] Rename Uuid::V7_SORTABLE to Uuid::V7_MONOTONIC

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Uuid.php
+++ b/src/Symfony/Component/Validator/Constraints/Uuid.php
@@ -51,7 +51,7 @@ class Uuid extends Constraint
     public const V4_RANDOM = 4;
     public const V5_SHA1 = 5;
     public const V6_SORTABLE = 6;
-    public const V7_SORTABLE = 7;
+    public const V7_MONOTONIC = 7;
     public const V8_CUSTOM = 8;
 
     public const ALL_VERSIONS = [
@@ -61,7 +61,7 @@ class Uuid extends Constraint
         self::V4_RANDOM,
         self::V5_SHA1,
         self::V6_SORTABLE,
-        self::V7_SORTABLE,
+        self::V7_MONOTONIC,
         self::V8_CUSTOM,
     ];
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
@@ -82,7 +82,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
             ['456daEFb-5AA6-41B5-8DBC-068B05A8B201'], // Version 4 UUID in mixed case
             ['456daEFb-5AA6-41B5-8DBC-068B05A8B201', [Uuid::V4_RANDOM]],
             ['1eb01932-4c0b-6570-aa34-d179cdf481ae', [Uuid::V6_SORTABLE]],
-            ['216fff40-98d9-71e3-a5e2-0800200c9a66', [Uuid::V7_SORTABLE]],
+            ['216fff40-98d9-71e3-a5e2-0800200c9a66', [Uuid::V7_MONOTONIC]],
             ['216fff40-98d9-81e3-a5e2-0800200c9a66', [Uuid::V8_CUSTOM]],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Renaming a not-yet released const. Might be more specific/clear.