### PR TITLE
[WebProfilerBundle] Update the mailer panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -24,43 +24,6 @@
     {% endif %}
 {% endblock %}
 
-{% block head %}
-    {{ parent() }}
-    <style type="text/css">
-        /* utility classes */
-        .m-t-0 { margin-top: 0 !important; }
-        .m-t-10 { margin-top: 10px !important; }
-
-        /* basic grid */
-        .row {
-            display: flex;
-            flex-wrap: wrap;
-            margin-right: -15px;
-            margin-left: -15px;
-        }
-        .col {
-            flex-basis: 0;
-            flex-grow: 1;
-            max-width: 100%;
-            position: relative;
-            width: 100%;
-            min-height: 1px;
-            padding-right: 15px;
-            padding-left: 15px;
-        }
-        .col-4 {
-            flex: 0 0 33.333333%;
-            max-width: 33.333333%;
-        }
-
-        /* small tabs */
-        .sf-tabs-sm .tab-navigation li {
-            font-size: 14px;
-            padding: .3em .5em;
-        }
-    </style>
-{% endblock %}
-
 {% block menu %}
     {% set events = collector.events %}
 
@@ -78,7 +41,6 @@
 
 {% block panel %}
     {% set events = collector.events %}
-
     <h2>Emails</h2>
 
     {% if not events.messages|length %}
@@ -101,135 +63,202 @@
         </div>
     {% endif %}
 
-    {% for transport in events.transports %}
-        <div class="card-block">
-            <div class="sf-tabs sf-tabs-sm">
-                {% for event in events.events(transport) %}
-                    {% set message = event.message %}
-                    <div class="tab">
-                        <h3 class="tab-title">Email {{ event.isQueued() ? 'queued' : 'sent via ' ~ transport }}</h3>
-                        <div class="tab-content">
-                            <div class="card">
-                                {% if message.headers is not defined %}
-                                    {# RawMessage instance #}
-                                    <div class="card-block">
-                                        <pre class="prewrap" style="max-height: 600px">{{ message.toString() }}</pre>
-                                    </div>
-                                {% else %}
-                                    {# Message instance #}
-                                    <div class="card-block">
-                                        <div class="sf-tabs sf-tabs-sm">
-                                            <div class="tab">
-                                                <h3 class="tab-title">Headers</h3>
-                                                <div class="tab-content">
-                                                    <span class="label">Subject</span>
-                                                    <h2 class="m-t-10">{{ message.headers.get('subject').bodyAsString() ?? '(empty)' }}</h2>
-                                                    <div class="row">
-                                                        <div class="col col-4">
-                                                            <span class="label">From</span>
-                                                            <pre class="prewrap">{{ (message.headers.get('from').bodyAsString() ?? '(empty)')|replace({'From:': ''}) }}</pre>
+    {% if events.transports|length > 1 %}
+        {% for transport in events.transports %}
+            <h2><code>{{ transport }}</code> transport</h2>
+            {{ _self.render_transport_details(collector, transport) }}
+        {% endfor %}
+    {% else %}
+        {{ _self.render_transport_details(collector, events.transports|first, true) }}
+    {% endif %}
 
-                                                            <span class="label">To</span>
-                                                            <pre class="prewrap">{{ (message.headers.get('to').bodyAsString() ?? '(empty)')|replace({'To:': ''}) }}</pre>
+    {% macro render_transport_details(collector, transport, show_transport_name = false) %}
+        <div class="card">
+            {% set num_emails = collector.events.events(transport)|length %}
+            {% if num_emails > 1 %}
+                <div class="mailer-email-summary-table-wrapper">
+                    <table class="mailer-email-summary-table">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Subject</th>
+                                <th>To</th>
+                                <th class="visually-hidden">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for event in collector.events.events(transport) %}
+                                <tr class="mailer-email-summary-table-row {{ loop.first ? 'active' }}" data-target="#email-{{ loop.index }}">
+                                    <td>{{ loop.index }}</td>
+                                    <td>{{ event.message.headers.get('subject').bodyAsString() ?? '(No subject)' }}</td>
+                                    <td>{{ (event.message.headers.get('to').bodyAsString() ?? '(empty)')|replace({'To:': ''}) }}</td>
+                                    <td class="visually-hidden"><button class="mailer-email-summary-table-row-button" data-target="#email-{{ loop.index }}">View email details</button></td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
 
-                                                            {% if event.envelope.recipients|length > 0 %}
-                                                                <span class="label">Recipients</span>
-                                                                {% for recipient in event.envelope.recipients %}
-                                                                    <pre class="prewrap">{{ recipient.address }}</pre>
-                                                                {% endfor %}
-                                                            {% endif %}
-                                                        </div>
-                                                        <div class="col">
-                                                            <span class="label">Headers</span>
-                                                            <pre class="prewrap">{% for header in message.headers.all|filter(header => (header.name ?? '') not in ['Subject', 'From', 'To']) %}
-                                                                {{- header.toString }}
-                                                            {%~ endfor %}</pre>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            {% if message.htmlBody is defined %}
-                                                {# Email instance #}
-                                                {% set htmlBody = message.htmlBody() %}
-                                                {% if htmlBody is not null %}
-                                                    <div class="tab">
-                                                        <h3 class="tab-title">HTML Preview</h3>
-                                                        <div class="tab-content">
-                                                            <pre class="prewrap" style="max-height: 600px">
-                                                                <iframe
-                                                                    src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}"
-                                                                    style="height: 80vh;width: 100%;"
-                                                                >
-                                                                </iframe>
-                                                            </pre>
-                                                        </div>
-                                                    </div>
-                                                    <div class="tab">
-                                                        <h3 class="tab-title">HTML Content</h3>
-                                                        <div class="tab-content">
-                                                            <pre class="prewrap" style="max-height: 600px">
-                                                                {%- if message.htmlCharset() %}
-                                                                    {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
-                                                                {%- else %}
-                                                                    {{- htmlBody }}
-                                                                {%- endif -%}
-                                                            </pre>
-                                                        </div>
-                                                    </div>
-                                                {% endif %}
-                                                {% set textBody = message.textBody() %}
-                                                {% if textBody is not null %}
-                                                    <div class="tab">
-                                                        <h3 class="tab-title">Text Content</h3>
-                                                        <div class="tab-content">
-                                                            <pre class="prewrap" style="max-height: 600px">
-                                                                {%- if message.textCharset() %}
-                                                                    {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
-                                                                {%- else %}
-                                                                    {{- textBody }}
-                                                                {%- endif -%}
-                                                            </pre>
-                                                        </div>
-                                                    </div>
-                                                {% endif %}
-                                                {% for attachment in message.attachments %}
-                                                    <div class="tab">
-                                                        <h3 class="tab-title">Attachment #{{ loop.index }}</h3>
-                                                        <div class="tab-content">
-                                                            <p>
-                                                                <a href="data:{{ attachment.contentType|default('application/octet-stream') }};base64,{{ collector.base64Encode(attachment.body) }}" download="{{ attachment.filename|default('attachment') }}">
-                                                                    {% if attachment.filename|default %}
-                                                                        {{ attachment.filename }}
-                                                                    {% else %}
-                                                                        <em>(no filename)</em>
-                                                                    {% endif %}
-                                                                </a>
-                                                            </p>
-                                                            <pre class="prewrap" style="max-height: 600px">{{ attachment.toString() }}</pre>
-                                                        </div>
-                                                    </div>
-                                                {% endfor %}
-                                            {% endif %}
-                                            <div class="tab">
-                                                <h3 class="tab-title">Parts Hierarchy</h3>
-                                                <div class="tab-content">
-                                                    <pre class="prewrap" style="max-height: 600px">{{ message.body().asDebugString() }}</pre>
-                                                </div>
-                                            </div>
-                                            <div class="tab">
-                                                <h3 class="tab-title">Raw</h3>
-                                                <div class="tab-content">
-                                                    <pre class="prewrap" style="max-height: 600px">{{ message.toString() }}</pre>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                {% endif %}
-                            </div>
-                        </div>
+                {% for event in collector.events.events(transport) %}
+                    <div class="mailer-email-details {{ loop.first ? 'active' }}" id="email-{{ loop.index }}">
+                        {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
                     </div>
                 {% endfor %}
-            </div>
+
+                <script>Sfjs.initializeMailerTable();</script>
+            {% else %}
+                {% set event = (collector.events.events(transport)|first) %}
+                {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
+            {% endif %}
         </div>
-    {% endfor %}
+    {% endmacro %}
+
+    {% macro render_email_details(collector, transport, message, message_is_queued, show_transport_name = false) %}
+        {% if show_transport_name %}
+            <p class="mailer-transport-information">
+                <strong>Status:</strong> <span class="badge badge-{{ message_is_queued ? 'warning' : 'success' }}">{{ message_is_queued ? 'Queued' : 'Sent' }}</span>
+                &bull;
+                <strong>Transport:</strong> <code>{{ transport }}</code>
+            </p>
+        {% endif %}
+
+        {% if message.headers is not defined %}
+            {# render the raw message contents #}
+            <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
+                {{ source('@WebProfiler/Icon/download.svg') }}
+                Download as EML file
+            </a>
+
+            <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+        {% else %}
+            <div class="sf-tabs">
+                <div class="tab">
+                    <h3 class="tab-title">Email contents</h3>
+                    <div class="tab-content">
+                        <div class="card-block">
+                            <p class="mailer-message-subject">
+                                {{ message.headers.get('subject').bodyAsString() ?? '(No subject)' }}
+                            </p>
+                            <div class="mailer-message-headers">
+                                <p><strong>From:</strong> {{ (message.headers.get('from').bodyAsString() ?? '(empty)')|replace({'From:': ''}) }}</p>
+                                <p><strong>To:</strong> {{ (message.headers.get('to').bodyAsString() ?? '(empty)')|replace({'To:': ''}) }}</p>
+                                {% for header in message.headers.all|filter(header => (header.name ?? '') not in ['Subject', 'From', 'To']) %}
+                                    <p class="mailer-message-header-secondary">{{ header.toString }}</p>
+                                {% endfor %}
+                            </div>
+                        </div>
+
+                        {% if message.attachments %}
+                            <div class="card-block">
+                                {% set num_of_attachments = message.attachments|length %}
+                                {% set total_attachments_size_in_bytes = message.attachments|reduce((total_size, attachment) => total_size + attachment.body|length) %}
+                                <p class="mailer-message-attachments-title">
+                                    {{ source('@WebProfiler/Icon/attachment.svg') }}
+                                    Attachments <span>({{ num_of_attachments }} file{{ num_of_attachments > 1 ? 's' }} / {{ _self.render_file_size_humanized(total_attachments_size_in_bytes) }})</span>
+                                </p>
+
+                                <ul class="mailer-message-attachments-list">
+                                    {% for attachment in message.attachments %}
+                                        <li>
+                                            {{ source('@WebProfiler/Icon/file.svg') }}
+
+                                            {% if attachment.filename|default %}
+                                                {{ attachment.filename }}
+                                            {% else %}
+                                                <em>(no filename)</em>
+                                            {% endif %}
+
+                                            ({{ _self.render_file_size_humanized(attachment.body|length) }})
+
+                                            <a href="data:{{ attachment.contentType|default('application/octet-stream') }};base64,{{ collector.base64Encode(attachment.body) }}" download="{{ attachment.filename|default('attachment') }}">Download</a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        {% endif %}
+
+                        {% if message.htmlBody or message.textBody %}
+                            <div class="card-block">
+                                <div class="sf-tabs sf-tabs-sm">
+                                    {% if message.htmlBody %}
+                                        {% set htmlBody = message.htmlBody() %}
+                                        <div class="tab">
+                                            <h3 class="tab-title">HTML content</h3>
+                                            <div class="tab-content">
+                                                <pre class="prewrap" style="max-height: 600px">
+                                                    {%- if message.htmlCharset() %}
+                                                        {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
+                                                    {%- else %}
+                                                        {{- htmlBody }}
+                                                    {%- endif -%}
+                                                </pre>
+                                            </div>
+                                        </div>
+
+                                        <div class="tab">
+                                            <h3 class="tab-title">HTML preview</h3>
+                                            <div class="tab-content">
+                                                <pre class="prewrap" style="max-height: 600px">
+                                                    <iframe
+                                                        src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}"
+                                                        style="height: 80vh;width: 100%;"
+                                                    >
+                                                    </iframe>
+                                                </pre>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+
+                                    {% if message.textBody %}
+                                        {% set textBody = message.textBody() %}
+                                        <div class="tab">
+                                            <h3 class="tab-title">Text content</h3>
+                                            <div class="tab-content">
+                                                <pre class="prewrap" style="max-height: 600px">
+                                                    {%- if message.textCharset() %}
+                                                        {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
+                                                    {%- else %}
+                                                        {{- textBody }}
+                                                    {%- endif -%}
+                                                </pre>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="tab">
+                    <h3 class="tab-title">MIME parts</h3>
+                    <div class="tab-content">
+                        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.body().asDebugString() }}</pre>
+                    </div>
+                </div>
+
+                <div class="tab">
+                    <h3 class="tab-title">Raw Message</h3>
+                    <div class="tab-content">
+                        <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
+                            {{ source('@WebProfiler/Icon/download.svg') }}
+                            Download as EML file
+                        </a>
+
+                        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    {% endmacro %}
+
+    {% macro render_file_size_humanized(bytes) %}
+        {%- if bytes < 1000 -%}
+            {{- bytes ~ ' bytes' -}}
+        {%- elseif bytes < 1000 ** 2 -%}
+            {{- (bytes / 1000)|number_format(2) ~ ' kB' -}}
+        {%- else -%}
+            {{- (bytes / 1000 ** 2)|number_format(2) ~ ' MB' -}}
+        {%- endif -%}
+    {% endmacro %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/attachment.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/attachment.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-paperclip" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <path d="M15 7l-6.5 6.5a1.5 1.5 0 0 0 3 3l6.5 -6.5a3 3 0 0 0 -6 -6l-6.5 6.5a4.5 4.5 0 0 0 9 9l6.5 -6.5"></path>
+</svg>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/download.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/download.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-download" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"></path>
+    <polyline points="7 11 12 16 17 11"></polyline>
+    <line x1="12" y1="4" x2="12" y2="16"></line>
+</svg>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/file.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/file.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-file" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <path d="M14 3v4a1 1 0 0 0 1 1h4"></path>
+    <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"></path>
+</svg>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/mailer.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/mailer.svg
@@ -3,3 +3,4 @@
     <rect x="3" y="5" width="18" height="14" rx="2"></rect>
     <polyline points="3 7 12 13 21 7"></polyline>
 </svg>
+

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -834,6 +834,22 @@ if (typeof Sfjs === 'undefined' || typeof Sfjs.loadToolbar === 'undefined') {
                 });
             },
 
+            initializeMailerTable: function() {
+                const emailRows = document.querySelectorAll('.mailer-email-summary-table-row');
+
+                emailRows.forEach((emailRow) => {
+                    emailRow.addEventListener('click', () => {
+                        emailRow.addEventListener('click', () => {
+                            emailRows.forEach((row) => row.classList.remove('active'));
+                            emailRow.classList.add('active');
+
+                            document.querySelectorAll('.mailer-email-details').forEach((emailDetails) => emailDetails.style.display = 'none');
+                            document.querySelector(emailRow.getAttribute('data-target')).style.display = 'block';
+                        });
+                    });
+                });
+            },
+
             updateLogsTable: function() {
                 const selectedType = document.querySelector('#log-filter-type input:checked').value;
                 const priorities = document.querySelectorAll('#log-filter-priority input');

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -96,6 +96,7 @@ button,hr,input{overflow:visible}progress,sub,sup{vertical-align:baseline}[type=
     --color-warning: var(--yellow-700);
     --color-error: var(--red-600);
     --h2-border-color: var(--gray-200);
+    --heading-code-background: var(--gray-100);
     --form-input-border-color: var(--gray-300);
     --button-background: var(--gray-100);
     --button-border-color: var(--gray-300);
@@ -151,6 +152,9 @@ button,hr,input{overflow:visible}progress,sub,sup{vertical-align:baseline}[type=
     --shadow: 0px 0px 1px rgba(128, 128, 128, .2);
     --border: 1px solid #e0e0e0;
     --background-error: var(--color-error);
+    --mailer-email-table-wrapper-background: var(--gray-100);
+    --mailer-email-table-active-row-background: #dbeafe;
+    --mailer-email-table-active-row-color: var(--color-text);
 
     --highlight-variable: #e36209;
     --highlight-string: #22863a;
@@ -220,6 +224,7 @@ button,hr,input{overflow:visible}progress,sub,sup{vertical-align:baseline}[type=
     --header-error-status-text-color: var(--red-200);
 
     --h2-border-color: var(--gray-500);
+    --heading-code-background: var(--gray-600);
     --form-input-border-color: var(--gray-400);
     --button-background: var(--gray-300);
     --button-border-color: var(--gray-500);
@@ -273,6 +278,9 @@ button,hr,input{overflow:visible}progress,sub,sup{vertical-align:baseline}[type=
     --shadow: 0px 0px 1px rgba(32, 32, 32, .2);
     --border: 1px solid #666;
     --background-error: #b0413e;
+    --mailer-email-table-wrapper-background: var(--gray-900);
+    --mailer-email-table-active-row-background: var(--gray-300);
+    --mailer-email-table-active-row-color: var(--gray-800);
     --highlight-variable: #ffa657;
     --highlight-string: #7ee787;
     --highlight-comment: #8b949e;
@@ -402,6 +410,16 @@ code, pre {
     font-family: var(--font-family-monospace);
     font-size: 14px;
 }
+h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
+    color: inherit;
+    font-weight: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    background: var(--heading-code-background);
+    border-radius: 4px;
+    padding: 0 3px;
+    word-break: break-word;
+}
 
 input, select {
     background-color: var(--page-background);
@@ -413,6 +431,19 @@ input, select {
 }
 input[type="radio"], input[type="checkbox"] {
     box-shadow: none;
+}
+
+/* Used to hide elements added for accessibility reasons (the !important modifier is needed here) */
+.visually-hidden {
+    border: 0 !important;
+    clip: rect(0, 0, 0, 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+    white-space: nowrap !important;
 }
 
 {# Buttons (the colors of this element don't change based on the selected theme)
@@ -646,7 +677,7 @@ table tbody td.num-col {
 .metrics {
     align-items: flex-start;
     display: flex;
-    margin: 1em 0 0;
+    margin: 1em 0;
     flex-wrap: wrap;
 }
 .metrics .metric {
@@ -658,7 +689,7 @@ table tbody td.num-col {
     box-shadow: inset 0 0 0 1px var(--metric-border-color), 0 0 0 5px var(--page-background);
     border-radius: 6px;
     color: var(--metric-value-color);
-    display: flex;
+    display: inline-flex;
     flex-direction: column-reverse;
     min-width: 60px;
     padding: 10px 15px;
@@ -758,7 +789,7 @@ table tbody td.num-col {
 }
 
 .metric-divider {
-    float: left;
+    display: inline-flex;
     margin: 0 10px;
     min-height: 1px; {# required to apply 'margin' to an empty 'div' #}
 }
@@ -771,6 +802,7 @@ table tbody td.num-col {
     box-shadow: inset 0 0 0 1px var(--form-input-border-color), 0 0 0 5px var(--page-background);
     margin: 1em 0;
     padding: 10px;
+    overflow-y: auto;
 }
 .card-block + .card-block {
     border-top: 1px solid var(--form-input-border-color);
@@ -1469,11 +1501,14 @@ tr.status-warning td {
     box-shadow: inset 0 0 0 1px var(--tab-border-color), 0 0 0 5px var(--page-background);
     display: inline-flex;
     flex-wrap: wrap;
-    font-size: 13px;
     margin: 0 0 15px;
     padding: 2px;
     user-select: none;
     -webkit-user-select: none;
+}
+.sf-tabs-sm .tab-navigation {
+    box-shadow: inset 0 0 0 1px var(--tab-border-color), 0 0 0 4px var(--page-background);
+    margin: 0 0 10px;
 }
 .tab-navigation li {
     cursor: pointer;
@@ -1484,6 +1519,10 @@ tr.status-warning td {
     position: relative;
     text-align: center;
     z-index: 1;
+}
+.sf-tabs-sm .tab-navigation li {
+    font-size: 13px;
+    padding: 2.5px 10px;
 }
 .tab-navigation li:before {
     background: var(--tab-border-color);
@@ -1641,6 +1680,10 @@ tr.status-warning td {
     font-size: 12px;
     font-weight: bold;
     padding: 1px 4px;
+}
+.badge-success {
+    background: var(--badge-success-background);
+    color: var(--badge-success-color);
 }
 .badge-warning {
     background: var(--badge-warning-background);
@@ -1843,6 +1886,129 @@ tr.log-status-silenced > td:first-child:before {
 }
 .container-compilation-logs summary p {
     margin: 0;
+}
+
+{# Mailer panel
+   ========================================================================= #}
+.mailer-email-summary-table-wrapper {
+    background: var(--mailer-email-table-wrapper-background);
+    border-bottom: 4px double var(--table-border-color);
+    border-radius: inherit;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    margin: 0 -9px 10px -9px;
+    padding-bottom: 10px;
+    transform: translateY(-9px);
+    max-height: 265px;
+    overflow-y: auto;
+}
+.mailer-email-summary-table,
+.mailer-email-summary-table tr,
+.mailer-email-summary-table td {
+    border: 0;
+    border-radius: inherit;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    box-shadow: none;
+}
+.mailer-email-summary-table th {
+    color: var(--color-muted);
+    font-size: 13px;
+    padding: 4px 10px;
+}
+.mailer-email-summary-table tr td,
+.mailer-email-summary-table tr:last-of-type td {
+    border: solid var(--table-border-color);
+    border-width: 1px 0;
+}
+.mailer-email-summary-table-row {
+    margin: 5px 0;
+}
+.mailer-email-summary-table-row:hover {
+    cursor: pointer;
+}
+.mailer-email-summary-table-row.active {
+    background: var(--mailer-email-table-active-row-background);
+    color: var(--mailer-email-table-active-row-color);
+}
+.mailer-email-summary-table-row td {
+    font-family: var(--font-family-system);
+    font-size: inherit;
+}
+.mailer-email-details {
+    display: none;
+}
+.mailer-email-details.active {
+    display: block;
+}
+.mailer-transport-information {
+    border-bottom: 1px solid var(--form-input-border-color);
+    padding-bottom: 5px;
+    font-size: 14px;
+    margin: 5px 0 10px 5px;
+}
+.mailer-transport-information .badge {
+    font-size: inherit;
+    font-weight: inherit;
+}
+.mailer-message-subject {
+    font-size: 21px;
+    font-weight: bold;
+    margin: 5px;
+}
+.mailer-message-headers {
+    margin-bottom: 10px;
+}
+.mailer-message-headers p {
+    font-size: 14px;
+    margin: 2px 5px;
+}
+.mailer-message-header-secondary {
+    color: var(--color-muted);
+}
+.mailer-message-attachments-title {
+    align-items: center;
+    display: flex;
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 10px;
+}
+.mailer-message-attachments-title svg {
+    color: var(--color-muted);
+    margin-right: 5px;
+    height: 18px;
+    width: 18px;
+}
+.mailer-message-attachments-title span {
+    font-weight: normal;
+    margin-left: 4px;
+}
+.mailer-message-attachments-list {
+    list-style: none;
+    margin: 0 0 5px 20px;
+    padding: 0;
+}
+.mailer-message-attachments-list li {
+    align-items: center;
+    display: flex;
+}
+.mailer-message-attachments-list li svg {
+    margin-right: 5px;
+    height: 18px;
+    width: 18px;
+}
+.mailer-message-attachments-list li a {
+    margin-left: 5px;
+}
+.mailer-message-download-raw {
+    align-items: center;
+    display: flex;
+    padding: 5px 0 0 5px;
+}
+.mailer-message-download-raw svg {
+    height: 18px;
+    width: 18px;
+    margin-right: 3px;
 }
 
 {# Doctrine panel

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -87,6 +87,9 @@
     letter-spacing: normal;
     width: auto;
 }
+.sf-toolbarreset svg rect {
+    width: inherit;
+}
 
 .sf-toolbarreset {
     background-color: var(--sf-toolbar-gray-800);
@@ -313,7 +316,7 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
 
 .sf-toolbar-block-request .sf-toolbar-status {
     border-radius: 6px;
-    color: var(--white);
+    color: #fff;
     display: inline-block;
     flex-shrink: 0;
     font-size: 13px;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Related to #47148, this updates one of the panels which weren't updated in that other PR.

### Before - 1 email sent

![before-1-email](https://user-images.githubusercontent.com/73419/191480458-a49d6f21-4119-47a7-9bb6-79f583e5cdc3.jpg)

### Before - Multiple emails sent

![before-multiple-emails](https://user-images.githubusercontent.com/73419/191480487-9c177e2c-e340-4b67-b0e3-9cc0fd6e4256.jpg)

### Before - Email attachments

![before-attachment](https://user-images.githubusercontent.com/73419/191480510-597b4e3c-8846-4ad3-b2c4-d8600abc15d6.jpg)

-----

### After - 1 email sent

![after-1-email](https://user-images.githubusercontent.com/73419/191480683-8849eeae-e034-414b-aa44-c6a9f25684c9.jpg)

Comments:

* All email contents are displayed on the same place, to make debugging quicker
* All headers are displayed too; this can be long in some cases, but I think it's better to display them all to spot errors easier and quicker
* Attachments now display file name, file size and a link to download them as files. We no longer display the base64-encoded contents of the file

### After - Multiple emails sent

![after-multiple-emails](https://user-images.githubusercontent.com/73419/191481013-c245f0d4-4702-49c6-b723-16208dbce20e.jpg)

Comments:

* When there's more than 1 email sent/queued, we display the "Email 1", "Email 2", etc. navigation (which is hidden when there's only 1 email to make design more efficient)

### After - MIME parts

![after-mime-parts](https://user-images.githubusercontent.com/73419/191481239-7e056578-17d1-42ba-91e9-e734fcf92f14.jpg)

Comments:

* This is the same as before

### After - Raw message

![after-raw-message](https://user-images.githubusercontent.com/73419/191481300-3275b0de-0108-4195-a1b5-19a8986c762f.jpg)

Comments:

* We now include a link to download the raw email as a `*.eml` file
