### PR TITLE
remove upgrade instructions leftovers of #47150

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -42,8 +42,6 @@ Serializer
 
  * Deprecate `ContextAwareNormalizerInterface`, use `NormalizerInterface` instead
  * Deprecate `ContextAwareDenormalizerInterface`, use `DenormalizerInterface` instead
- * Deprecate `ContextAwareEncoderInterface`, use `EncoderInterface` instead
- * Deprecate `ContextAwareDecoderInterface`, use `DecoderInterface` instead
  * Deprecate supporting denormalization for `AbstractUid` in `UidNormalizer`, use one of `AbstractUid` child class instead
  * Deprecate denormalizing to an abstract class in `UidNormalizer`
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR corrects that #47150 has not been reflected in the UPGRADE doc.