### PR TITLE
[Cache] Sync `Redis6Proxy::lPos()` return type

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -527,7 +527,7 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
         return $this->lazyObjectReal->lPop(...\func_get_args());
     }
 
-    public function lPos($key, $value, $options = null): array|bool|int
+    public function lPos($key, $value, $options = null): array|bool|int|null
     {
         return $this->lazyObjectReal->lPos(...\func_get_args());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | not released
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

According to https://github.com/phpredis/phpredis/pull/2151