### PR TITLE
Remove `non-empty-string` PHPDoc annotations

### DIFF
--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -721,7 +721,7 @@ final class Path
     }
 
     /**
-     * @return non-empty-string[]
+     * @return string[]
      */
     private static function findCanonicalParts(string $root, string $pathWithoutRoot): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

For consistency with the decision taken in #47648.