### PR TITLE
[WebProfilerBundle] Add intercept redirects configuration from toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * added intercept redirects configuration from frontend toolbar
+
 6.1
 ---
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -51,6 +51,34 @@
                     <span class="sf-toolbar-status sf-toolbar-status-{{ collector.debug ? 'green' : 'red' }}">{{ collector.debug ? 'enabled' : 'disabled' }}</span>
                 </div>
             {% endif %}
+
+            <div class="sf-toolbar-info-piece">
+                <b>
+                    <label for="sf-intercept-redirects-control">
+                        Intercept Redirects
+                    </label>
+                </b>
+                <input type="checkbox" id="sf-intercept-redirects-control">
+
+                <script>
+                    {{ source('@WebProfiler/Collector/config.js') }}
+
+                    function setupInterceptRedirects() {
+                        new InterceptRedirects(
+                            document.getElementById('sf-intercept-redirects-control'),
+                            new InterceptRedirectCookie('_sf_intercept_redirects'),
+                        );
+                    }
+
+                    if (document.readyStage !== 'loading') {
+                        setupInterceptRedirects();
+                    } else {
+                        window.addEventListener('DOMContentLoaded', function onLoad() {
+                            setupInterceptRedirects();
+                        });
+                    }
+                </script>
+            </div>
         </div>
 
         <div class="sf-toolbar-info-group">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.js
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.js
@@ -1,0 +1,74 @@
+'use strict';
+
+
+class InterceptRedirectCookie {
+  /**
+   * @param {string} cookieName
+   */
+  constructor(cookieName) {
+    this.cookieName = cookieName;
+  }
+
+  /**
+   * @return {boolean|null}
+   */
+  getValue() {
+    const cookies = decodeURIComponent(document.cookie).split('; ');
+
+    for (const cookie of cookies) {
+      const cookieParts = cookie.split('=');
+
+      if (cookieParts[0] === this.cookieName) {
+        return cookieParts[1];
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * @param {boolean} enabled
+   */
+  set(enabled) {
+    document.cookie = this.cookieName + "=" + enabled;
+  }
+
+  clear() {
+    document.cookie = this.cookieName + "=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+  }
+}
+
+
+/**
+ * @param {Element} checkbox
+ * @param {InterceptRedirectCookie} cookie
+ */
+class InterceptRedirects {
+  constructor(checkbox, cookie) {
+    this.checkbox = checkbox;
+    this.cookie = cookie;
+
+    this.checkbox.checked = this.isInterceptRedirectsEnabled();
+    this.checkbox.addEventListener('change', function onChange(e) {
+      this.enableIntercept(e.target.checked);
+    }.bind(this), false);
+  }
+
+  isInterceptRedirectsEnabled() {
+    switch (this.cookie.getValue()) {
+      case null:
+      case 'no':
+        return false;
+      case 'yes':
+        return true;
+      default:
+        this.cookie.clear();
+        return false;
+    }
+  }
+
+  enableIntercept(enabled) {
+    this.cookie.set(enabled ? 'yes' : 'no');
+    this.checkbox.checked = enabled;
+  }
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -133,6 +133,7 @@ class WebDebugToolbarListenerTest extends TestCase
 
     /**
      * @depends testToolbarIsInjected
+     *
      * @dataProvider provideRedirects
      */
     public function testToolbarIsNotInjectedOnRedirection($statusCode)
@@ -355,7 +356,7 @@ class WebDebugToolbarListenerTest extends TestCase
     /**
      * @dataProvider provideInterceptRedirectCookies
      */
-    public function testSetsInterceptRedirectEnabledCookie(bool $interceptRedirects, string $cookieValue): void
+    public function testSetsInterceptRedirectEnabledCookie(bool $interceptRedirects, string $cookieValue)
     {
         $response = new Response('Some content', 200);
         $response->headers->set('X-Debug-Token', 'xxxxxxxx');
@@ -383,7 +384,7 @@ class WebDebugToolbarListenerTest extends TestCase
     /**
      * @dataProvider provideRedirects
      */
-    public function testInterceptRedirectsCookieOverwriteDisabledIntercepts(int $statusCode): void
+    public function testInterceptRedirectsCookieOverwriteDisabledIntercepts(int $statusCode)
     {
         $response = new Response('Some content', $statusCode);
         $response->headers->set('X-Debug-Token', 'xxxxxxxx');
@@ -402,7 +403,7 @@ class WebDebugToolbarListenerTest extends TestCase
     /**
      * @dataProvider provideRedirects
      */
-    public function testInterceptRedirectsCookieOverwriteEnabledIntercepts(int $statusCode): void
+    public function testInterceptRedirectsCookieOverwriteEnabledIntercepts(int $statusCode)
     {
         $response = new Response('Some content', $statusCode);
         $response->headers->set('X-Debug-Token', 'xxxxxxxx');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR adds a convenient way to override the WebProfilter *intercept_redirects* settings from the frontend toolbar.

When the need come to intercept redirect when developing applications, one need to edit the `config/packages/web_profiler.yaml` file (risking to commit it by mistake).
With this PR addition, a single click on a checkbox added to the toolbar config tab will change the `intercept_redirects` settings for the current browser session as seen in the following screenshot.

![intercept-redirects](https://user-images.githubusercontent.com/2552707/191692298-06164a91-d177-468c-a207-82662cd0e10b.png)

This feature was inspired by django's Web Debug Toolbar intercept redirect functionality which can also be triggered from the frontend part of the application.