### PR TITLE
[WebProfilerBundle] [WebProfilerPanel] Update the configuration panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -118,7 +118,13 @@
 
     <div class="metrics">
         <div class="metric">
-            <span class="value">{{ collector.symfonyversion }}</span>
+            <span class="value">
+                {{ collector.symfonyversion }}
+
+                {% if collector.symfonylts %}
+                    <abbr class="config-symfony-version-lts" title="This is a Long-Term Support version">(LTS)</abbr>
+                {% endif %}
+            </span>
             <span class="label">Symfony version</span>
         </div>
 
@@ -137,33 +143,39 @@
         {% endif %}
     </div>
 
-    {% set symfony_status = { dev: 'Unstable Version', stable: 'Stable Version', eom: 'Maintenance Ended', eol: 'Version Expired' } %}
+    {% set symfony_status = { dev: 'In Development', stable: 'Maintained', eom: 'Security Fixes Only', eol: 'Unmaintained' } %}
     {% set symfony_status_class = { dev: 'warning', stable: 'success', eom: 'warning', eol: 'error' } %}
-    <table>
-        <thead class="small">
-            <tr>
-                <th>Symfony Status</th>
-                <th>Bugs {{ collector.symfonystate in ['eom', 'eol'] ? 'were' : 'are' }} fixed until</th>
-                <th>Security issues {{ collector.symfonystate == 'eol' ? 'were' : 'are' }} fixed until</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td class="font-normal">
-                    <span class="label status-{{ symfony_status_class[collector.symfonystate] }}">{{ symfony_status[collector.symfonystate]|upper }}</span>
-                    {% if collector.symfonylts %}
-                        &nbsp; <span class="label status-success">Long-Term Support</span>
-                    {% endif %}
-                </td>
-                <td class="font-normal">{{ collector.symfonyeom }}</td>
-                <td class="font-normal">{{ collector.symfonyeol }}</td>
-                <td class="font-normal">
-                    <a href="https://symfony.com/releases/{{ collector.symfonyminorversion }}#release-checker">View roadmap</a>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+
+    <div class="metrics">
+        <div class="metric-group">
+            <div class="metric">
+                <span class="value">
+                    <span class="config-symfony-version-status-badge status-{{ symfony_status_class[collector.symfonystate] }}">{{ symfony_status[collector.symfonystate]|upper }}</span>
+                </span>
+                <span class="label">Your Symfony version status</span>
+            </div>
+
+            {% if collector.symfonylts %}
+                <div class="metric">
+                    <span class="value config-symfony-eol">
+                        {{ collector.symfonyeom }}
+                    </span>
+                    <span class="label">Bug fixes {{ collector.symfonystate in ['eom', 'eol'] ? 'ended on' : 'until' }}</span>
+                </div>
+            {% endif %}
+
+            <div class="metric">
+                <span class="value config-symfony-eol">
+                    {{ collector.symfonyeol }}
+                </span>
+                <span class="label">
+                    {{ collector.symfonylts ? 'Security fixes' : 'Bug fixes and security fixes' }}
+                    {{ 'eol' == collector.symfonystate ? 'ended on' : 'until' }}</span>
+            </div>
+        </div>
+    </div>
+
+    <a class="config-symfony-version-roadmap-link" href="https://symfony.com/releases/{{ collector.symfonyminorversion }}">View Symfony {{ collector.symfonyversion }} release details</a>
 
     <h2>PHP Configuration</h2>
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -665,6 +665,7 @@ table tbody td.num-col {
     text-align: center;
 }
 .metric-group {
+    align-items: stretch;
     flex-direction: row;
     padding: 10px 0;
 }
@@ -673,6 +674,7 @@ table tbody td.num-col {
     border: none;
     border-radius: 0;
     box-shadow: none;
+    justify-content: flex-end;
     margin: 0;
     min-height: auto;
     padding: 0 15px;
@@ -2048,6 +2050,48 @@ pre.sf-dump, pre.sf-dump .sf-dump-default {
 }
 .form-type-class .sf-dump .sf-dump-str:hover {
     text-decoration: none;
+}
+
+{# Configuration panel
+   ========================================================================= #}
+.config-symfony-version-lts {
+    border: 0;
+    color: var(--color-muted);
+    font-size: 21px;
+    line-height: 33px;
+}
+.config-symfony-version-lts[title] {
+    text-decoration: none;
+}
+.config-symfony-version-status-badge {
+    background-color: var(--badge-background);
+    border-radius: 4px;
+    color: var(--badge-color);
+    display: inline-block;
+    font-size: 15px;
+    font-weight: bold;
+    margin: 10px 0 5px;
+    padding: 3px 7px;
+    white-space: nowrap;
+}
+.config-symfony-version-status-badge.status-success {
+    background-color: var(--badge-success-background);
+    color: var(--badge-success-color);
+}
+.config-symfony-version-status-badge.status-warning {
+    background-color: var(--badge-warning-background);
+    color: var(--badge-warning-color);
+}
+.config-symfony-version-status-badge.status-error {
+    background-color: var(--badge-danger-background);
+    color: var(--badge-danger-color);
+}
+.config-symfony-version-roadmap-link {
+    display: inline-block;
+    margin: 10px 5px 5px;
+}
+.config-symfony-eol {
+    margin-top: 5px;
 }
 
 {# Search Results page


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR proposes to update the "Symfony status" information in the "Config" panel of the Symfony Profiler. Today it's displayed as a table:

<img width="1238" alt="config-panel-before" src="https://user-images.githubusercontent.com/73419/191730115-41988e01-4366-40d1-ab98-eabf8d201742.png">

I'd prefer to display that information more visually:

<img width="1239" alt="config-panel-after" src="https://user-images.githubusercontent.com/73419/191739064-15276fa3-8dff-4c44-8981-5b2b2785238c.png">

The wording has been updated a bit too ("In development" vs "Unstable version") to better match the wording used at https://symfony.com/releases/6.2

Here's the case of a LTS version:

<img width="1240" alt="config-panel-after-lts" src="https://user-images.githubusercontent.com/73419/191739099-613eae03-df1e-4ca9-adbf-7e6007f318cd.png">

And for an unmaintained version:

<img width="1240" alt="config-panel-after-unmaintained" src="https://user-images.githubusercontent.com/73419/191739155-a516713c-c6d7-4a32-8e59-24ed4b355d81.png">
