### PR TITLE
[Messenger] Move PostgreSQL LISTEN/NOTIFY blocking to worker idle event listener

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `PostgreSqlNotifyOnIdleListener` to properly support LISTEN/NOTIFY with multi-queue workers
+
 7.3
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/EventListener/PostgreSqlNotifyOnIdleListener.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/EventListener/PostgreSqlNotifyOnIdleListener.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Doctrine\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerStartedEvent;
+
+/**
+ * When the worker is idle, blocks on PostgreSQL LISTEN/NOTIFY instead of
+ * polling. This allows instant wake-up when a new message arrives while
+ * properly supporting workers that consume from multiple queues.
+ *
+ * @author d-ph <dph03292@gmail.com>
+ */
+class PostgreSqlNotifyOnIdleListener implements EventSubscriberInterface
+{
+    /** @var array<string, PostgreSqlConnection> */
+    private array $connections = [];
+    private ?PostgreSqlConnection $activeConnection = null;
+
+    public function __construct(
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    /**
+     * Registers a PostgreSQL connection candidate for LISTEN/NOTIFY.
+     *
+     * Called by {@see \Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransportFactory}
+     * during transport creation.
+     */
+    public function addConnection(string $transportName, PostgreSqlConnection $connection): void
+    {
+        $this->connections[$transportName] = $connection;
+    }
+
+    public function onWorkerStarted(WorkerStartedEvent $event): void
+    {
+        $this->activeConnection = null;
+
+        foreach ($event->getWorker()->getMetadata()->getTransportNames() as $transportName) {
+            if ($connection = $this->connections[$transportName] ?? null) {
+                $connection->listen();
+                $this->activeConnection ??= $connection;
+            }
+        }
+    }
+
+    public function onWorkerRunning(WorkerRunningEvent $event): void
+    {
+        if (!$event->isWorkerIdle() || !$this->activeConnection) {
+            return;
+        }
+
+        $config = $this->activeConnection->getConfiguration();
+
+        if (0 >= $timeout = $config['get_notify_timeout'] ?: $config['check_delayed_interval']) {
+            return;
+        }
+
+        $this->logger?->debug('Worker waiting for PostgreSQL LISTEN/NOTIFY wake-up.');
+
+        $this->activeConnection->waitForNotify($timeout);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerStartedEvent::class => 'onWorkerStarted',
+            WorkerRunningEvent::class => 'onWorkerRunning',
+        ];
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/EventListener/PostgreSqlNotifyOnIdleListenerTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/EventListener/PostgreSqlNotifyOnIdleListenerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Doctrine\Tests\EventListener;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Bridge\Doctrine\EventListener\PostgreSqlNotifyOnIdleListener;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerStartedEvent;
+use Symfony\Component\Messenger\Worker;
+use Symfony\Component\Messenger\WorkerMetadata;
+
+class PostgreSqlNotifyOnIdleListenerTest extends TestCase
+{
+    private function createPostgreSqlConnection(array $additionalConfig = []): PostgreSqlConnection
+    {
+        $driverConnection = $this->createStub(Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
+
+        return new PostgreSqlConnection($additionalConfig + ['table_name' => 'queue_table'], $driverConnection);
+    }
+
+    private function createWorkerWithTransports(array $transportNames): Worker
+    {
+        $worker = $this->createStub(Worker::class);
+        $worker->method('getMetadata')->willReturn(new WorkerMetadata(['transportNames' => $transportNames]));
+
+        return $worker;
+    }
+
+    public function testListenIsCalledOnWorkerStarted()
+    {
+        $connection = $this->createPostgreSqlConnection();
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('async', $connection);
+
+        $this->assertFalse($connection->isListening());
+
+        $listener->onWorkerStarted(new WorkerStartedEvent($this->createWorkerWithTransports(['async'])));
+
+        $this->assertTrue($connection->isListening());
+    }
+
+    public function testListenIsNotCalledForUnknownTransport()
+    {
+        $connection = $this->createPostgreSqlConnection();
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('async', $connection);
+
+        $listener->onWorkerStarted(new WorkerStartedEvent($this->createWorkerWithTransports(['other'])));
+
+        $this->assertFalse($connection->isListening());
+    }
+
+    public function testNoWaitWhenWorkerIsNotIdle()
+    {
+        $connection = $this->createPostgreSqlConnection();
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('async', $connection);
+
+        $worker = $this->createWorkerWithTransports(['async']);
+        $listener->onWorkerStarted(new WorkerStartedEvent($worker));
+
+        // isIdle=false, should not try to wait
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, false));
+
+        $this->assertTrue(true);
+    }
+
+    public function testNoWaitWhenNoPostgreSqlConnection()
+    {
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $worker = $this->createWorkerWithTransports(['other']);
+
+        $listener->onWorkerStarted(new WorkerStartedEvent($worker));
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+
+        $this->assertTrue(true);
+    }
+
+    public function testNoWaitWhenTimeoutsAreZero()
+    {
+        $connection = $this->createPostgreSqlConnection([
+            'get_notify_timeout' => 0,
+            'check_delayed_interval' => 0,
+        ]);
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('async', $connection);
+
+        $worker = $this->createWorkerWithTransports(['async']);
+        $listener->onWorkerStarted(new WorkerStartedEvent($worker));
+
+        // Both timeouts are 0: should return immediately without blocking
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+
+        $this->assertTrue(true);
+    }
+
+    public function testMultipleTransportsListenOnAllConnections()
+    {
+        $conn1 = $this->createPostgreSqlConnection();
+        $conn2 = $this->createPostgreSqlConnection();
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('high', $conn1);
+        $listener->addConnection('low', $conn2);
+
+        $listener->onWorkerStarted(new WorkerStartedEvent($this->createWorkerWithTransports(['high', 'low'])));
+
+        $this->assertTrue($conn1->isListening());
+        $this->assertTrue($conn2->isListening());
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $this->assertSame([
+            WorkerStartedEvent::class => 'onWorkerStarted',
+            WorkerRunningEvent::class => 'onWorkerRunning',
+        ], PostgreSqlNotifyOnIdleListener::getSubscribedEvents());
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportFactoryTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\Persistence\ConnectionRegistry;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Bridge\Doctrine\EventListener\PostgreSqlNotifyOnIdleListener;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransportFactory;
@@ -88,5 +89,62 @@ class DoctrineTransportFactoryTest extends TestCase
 
         $factory = new DoctrineTransportFactory($registry);
         $factory->createTransport('doctrine://default', [], $this->createStub(SerializerInterface::class));
+    }
+
+    public function testCreateTransportRegistersConnectionWithListener()
+    {
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
+        $platform = $this->createStub(PostgreSQLPlatform::class);
+        $driverConnection->method('getDatabasePlatform')->willReturn($platform);
+        $driverConnection->method('executeStatement')->willReturn(1);
+
+        $registry = $this->createStub(ConnectionRegistry::class);
+        $registry->method('getConnection')->willReturn($driverConnection);
+
+        $listener = $this->createMock(PostgreSqlNotifyOnIdleListener::class);
+        $listener->expects($this->once())
+            ->method('addConnection')
+            ->with('my_transport', $this->isInstanceOf(PostgreSqlConnection::class));
+
+        $factory = new DoctrineTransportFactory($registry, $listener);
+        $serializer = $this->createStub(SerializerInterface::class);
+
+        $factory->createTransport('doctrine://default', ['transport_name' => 'my_transport'], $serializer);
+    }
+
+    public function testCreateTransportDoesNotRegisterWithoutTransportName()
+    {
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
+        $platform = $this->createStub(PostgreSQLPlatform::class);
+        $driverConnection->method('getDatabasePlatform')->willReturn($platform);
+        $driverConnection->method('executeStatement')->willReturn(1);
+
+        $registry = $this->createStub(ConnectionRegistry::class);
+        $registry->method('getConnection')->willReturn($driverConnection);
+
+        $listener = $this->createMock(PostgreSqlNotifyOnIdleListener::class);
+        $listener->expects($this->never())->method('addConnection');
+
+        $factory = new DoctrineTransportFactory($registry, $listener);
+        $serializer = $this->createStub(SerializerInterface::class);
+
+        $factory->createTransport('doctrine://default', [], $serializer);
+    }
+
+    public function testCreateTransportWorksWithoutListener()
+    {
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
+        $platform = $this->createStub(PostgreSQLPlatform::class);
+        $driverConnection->method('getDatabasePlatform')->willReturn($platform);
+        $driverConnection->method('executeStatement')->willReturn(1);
+
+        $registry = $this->createStub(ConnectionRegistry::class);
+        $registry->method('getConnection')->willReturn($driverConnection);
+
+        $factory = new DoctrineTransportFactory($registry);
+        $serializer = $this->createStub(SerializerInterface::class);
+
+        $transport = $factory->createTransport('doctrine://default', ['transport_name' => 'my_transport'], $serializer);
+        $this->assertInstanceOf(DoctrineTransport::class, $transport);
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -50,6 +50,54 @@ class PostgreSqlConnectionTest extends TestCase
 
     public function testListenOnConnection()
     {
+        $driverConnection = $this->createStub(Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
+
+        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
+
+        $this->assertFalse($connection->isListening());
+
+        $connection->listen();
+
+        $this->assertTrue($connection->isListening());
+
+        $connection->__destruct();
+
+        $this->assertFalse($connection->isListening());
+    }
+
+    public function testWaitForNotifyCallsListenAndGetNotify()
+    {
+        $driverConnection = $this->createMock(Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
+
+        $wrappedConnection = new class {
+            public int $notifyCalls = 0;
+
+            public function getNotify()
+            {
+                ++$this->notifyCalls;
+
+                return false;
+            }
+        };
+
+        $driverConnection
+            ->expects(self::once())
+            ->method('getNativeConnection')
+            ->willReturn($wrappedConnection);
+
+        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
+
+        $result = $connection->waitForNotify(1000);
+
+        $this->assertFalse($result);
+        $this->assertTrue($connection->isListening());
+        $this->assertSame(1, $wrappedConnection->notifyCalls);
+    }
+
+    public function testGetBlocksOnNotifyWhenNoExternalListenerIsActive()
+    {
         $driverConnection = $this->createMock(Connection::class);
         $driverConnection->method('executeStatement')->willReturn(1);
 
@@ -64,18 +112,13 @@ class PostgreSqlConnectionTest extends TestCase
             ->willReturn(new QueryBuilder($driverConnection));
 
         $wrappedConnection = new class {
-            private int $notifyCalls = 0;
+            public int $notifyCalls = 0;
 
             public function getNotify()
             {
                 ++$this->notifyCalls;
 
                 return false;
-            }
-
-            public function countNotifyCalls()
-            {
-                return $this->notifyCalls;
             }
         };
 
@@ -94,17 +137,53 @@ class PostgreSqlConnectionTest extends TestCase
 
         $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
 
-        $connection->get(); // first time we have queueEmptiedAt === null, fallback on the parent implementation
+        // first get(): queueEmptiedAt === null -> parent::get(), sets queueEmptiedAt
+        $connection->get();
+        // second/third get(): queueEmptiedAt !== null -> blocks on getNotify
         $connection->get();
         $connection->get();
 
         $this->assertTrue($connection->isListening());
+        $this->assertSame(2, $wrappedConnection->notifyCalls);
+    }
 
-        $this->assertSame(2, $wrappedConnection->countNotifyCalls());
+    public function testGetSkipsBlockingWhenListenCalledExternally()
+    {
+        $driverConnection = $this->createMock(Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
 
-        $connection->__destruct();
+        $driverConnection
+            ->expects(self::any())
+            ->method('getDatabasePlatform')
+            ->willReturn(new PostgreSQLPlatform());
 
-        $this->assertFalse($connection->isListening());
+        $driverConnection
+            ->expects(self::any())
+            ->method('createQueryBuilder')
+            ->willReturn(new QueryBuilder($driverConnection));
+
+        // getNativeConnection should never be called since blocking is skipped
+        $driverConnection
+            ->expects(self::never())
+            ->method('getNativeConnection');
+
+        $driverResult = $this->createStub(DriverResult::class);
+        $driverResult->method('fetchAssociative')
+            ->willReturn(false);
+        $driverConnection
+            ->expects(self::any())
+            ->method('executeQuery')
+            ->willReturn(new Result($driverResult, $driverConnection));
+
+        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
+
+        // External listener calls listen()
+        $connection->listen();
+
+        // get() should always delegate to parent without blocking
+        $connection->get();
+        $connection->get();
+        $connection->get();
     }
 
     public function testIsListeningReturnsFalseWhenGetHasNotBeenCalled()

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\Persistence\ConnectionRegistry;
+use Symfony\Component\Messenger\Bridge\Doctrine\EventListener\PostgreSqlNotifyOnIdleListener;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
@@ -27,6 +28,7 @@ class DoctrineTransportFactory implements TransportFactoryInterface
 {
     public function __construct(
         private ConnectionRegistry $registry,
+        private ?PostgreSqlNotifyOnIdleListener $notifyOnIdleListener = null,
     ) {
     }
 
@@ -36,6 +38,7 @@ class DoctrineTransportFactory implements TransportFactoryInterface
     public function createTransport(#[\SensitiveParameter] string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
         $useNotify = $options['use_notify'] ?? true;
+        $transportName = $options['transport_name'] ?? null;
         unset($options['transport_name'], $options['use_notify']);
         // Always allow PostgreSQL-specific keys, to be able to transparently fallback to the native driver when LISTEN/NOTIFY isn't available
         $configuration = PostgreSqlConnection::buildConfiguration($dsn, $options);
@@ -48,6 +51,10 @@ class DoctrineTransportFactory implements TransportFactoryInterface
 
         if ($useNotify && $driverConnection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             $connection = new PostgreSqlConnection($configuration, $driverConnection);
+
+            if (null !== $transportName) {
+                $this->notifyOnIdleListener?->addConnection($transportName, $connection);
+            }
         } else {
             $connection = new Connection($configuration, $driverConnection);
         }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -23,6 +23,7 @@ namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 final class PostgreSqlConnection extends Connection
 {
     private bool $listening = false;
+    private bool $notifyHandledExternally = false;
 
     /**
      * * check_delayed_interval: The interval to check for delayed messages, in milliseconds. Set to 0 to disable checks. Default: 60000 (1 minute)
@@ -61,9 +62,12 @@ final class PostgreSqlConnection extends Connection
 
     public function get(): ?array
     {
-        if (null === $this->queueEmptiedAt) {
+        if ($this->notifyHandledExternally || null === $this->queueEmptiedAt) {
             return parent::get();
         }
+
+        // Fallback: when no external listener handles LISTEN/NOTIFY,
+        // block here until a notification arrives or timeout expires
 
         // This is secure because the table name must be a valid identifier:
         // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
@@ -87,6 +91,42 @@ final class PostgreSqlConnection extends Connection
         }
 
         return parent::get();
+    }
+
+    /**
+     * Registers a LISTEN on the PostgreSQL connection for the configured table.
+     *
+     * When called, also disables the internal LISTEN/NOTIFY blocking in get(),
+     * assuming an external listener (e.g. PostgreSqlNotifyOnIdleListener) handles it.
+     *
+     * Safe to call multiple times; PostgreSQL ignores duplicate LISTEN for the same channel.
+     */
+    public function listen(): void
+    {
+        // This is secure because the table name must be a valid identifier:
+        // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+        $this->executeStatement(\sprintf('LISTEN "%s"', $this->configuration['table_name']));
+        $this->listening = true;
+        $this->notifyHandledExternally = true;
+    }
+
+    /**
+     * Blocks until a PostgreSQL NOTIFY is received or the timeout expires.
+     *
+     * Automatically registers a LISTEN before waiting to handle reconnections.
+     *
+     * @param int $timeoutMs The maximum time to wait in milliseconds
+     *
+     * @return bool True if a notification was received, false on timeout
+     */
+    public function waitForNotify(int $timeoutMs): bool
+    {
+        $this->listen();
+
+        /** @var \PDO $nativeConnection */
+        $nativeConnection = $this->driverConnection->getNativeConnection();
+
+        return false !== $nativeConnection->getNotify(\PDO::FETCH_ASSOC, $timeoutMs);
     }
 
     private function unlisten(): void

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
@@ -19,6 +19,7 @@
         "php": ">=8.4",
         "doctrine/dbal": "^4.3",
         "symfony/deprecation-contracts": "^2.5|^3",
+        "symfony/event-dispatcher": "^7.4|^8.0",
         "symfony/messenger": "^7.4|^8.0",
         "symfony/service-contracts": "^2.5|^3"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #46862
| License       | MIT
| Doc PR        | -

When a Messenger worker consumes from multiple PostgreSQL-backed queues, the existing `PostgreSqlConnection::get()` blocks on `pgsqlGetNotify()` for one transport. This prevents the other transports from being polled, effectively breaking priority-based multi-queue consumption.

This PR moves the LISTEN/NOTIFY blocking from `PostgreSqlConnection::get()` into a new `PostgreSqlNotifyOnIdleListener` event subscriber. The listener hooks into the worker lifecycle:

- **`WorkerStartedEvent`**: registers `LISTEN` on all PostgreSQL connections used by the worker, so no notifications are missed from the very first loop iteration.
- **`WorkerRunningEvent`** (idle): blocks on `waitForNotify()` using the first registered connection, replacing the worker's default polling sleep with efficient LISTEN/NOTIFY wake-up.

This way, the worker's main loop can check all transports in priority order on every iteration, and only blocks *after* all queues have been found empty.

### Backwards compatibility

- `DoctrineTransportFactory` accepts an optional `?PostgreSqlNotifyOnIdleListener` second constructor argument (defaults to `null`) — fully BC.
- When no listener is wired (e.g. standalone usage without the bundle), `PostgreSqlConnection::get()` preserves the original blocking LISTEN/NOTIFY fallback behavior — no functionality is lost.
- When `listen()` is called externally (by the listener), `get()` delegates straight to `parent::get()` without blocking, letting the listener handle the idle wait instead.
- No restrictions on mixing PostgreSQL and non-PostgreSQL transports in the same worker.

### Changes

- **`PostgreSqlConnection`**: added public `listen()` and `waitForNotify()` methods; `get()` retained as fallback when no external listener is active.
- **`PostgreSqlNotifyOnIdleListener`** (new): `EventSubscriberInterface` that registers LISTEN on start and blocks on NOTIFY when idle.
- **`DoctrineTransportFactory`**: optional listener injection; registers connections when a `transport_name` is provided.