### PR TITLE
Leverage First-class callable syntax

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/DebugDataHolder.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/DebugDataHolder.php
@@ -24,7 +24,7 @@ class DebugDataHolder
             'sql' => $query->getSql(),
             'params' => $query->getParams(),
             'types' => $query->getTypes(),
-            'executionMS' => [$query, 'getDuration'],  // stop() may not be called at this point
+            'executionMS' => $query->getDuration(...),  // stop() may not be called at this point
         ];
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -129,7 +129,7 @@ class MicroKernelTraitTest extends TestCase
 
             protected function configureRoutes(RoutingConfigurator $routes): void
             {
-                $routes->add('hello', '/')->controller([$this, 'helloAction']);
+                $routes->add('hello', '/')->controller($this->helloAction(...));
             }
         };
 

--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -170,7 +170,7 @@ class YamlReferenceDumper
 
             $this->writeLine('# '.$message.':', $depth * 4 + 4);
 
-            $this->writeArray(array_map([Inline::class, 'dump'], $example), $depth + 1);
+            $this->writeArray(array_map(Inline::dump(...), $example), $depth + 1);
         }
 
         if ($children) {

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -617,7 +617,7 @@ class Table
                 if (!str_contains($cell ?? '', "\n")) {
                     continue;
                 }
-                $escaped = implode("\n", array_map([OutputFormatter::class, 'escapeTrailingBackslash'], explode("\n", $cell)));
+                $escaped = implode("\n", array_map(OutputFormatter::escapeTrailingBackslash(...), explode("\n", $cell)));
                 $cell = $cell instanceof TableCell ? new TableCell($escaped, ['colspan' => $cell->getColspan()]) : $escaped;
                 $lines = explode("\n", str_replace("\n", "<fg=default;bg=default></>\n", $cell));
                 foreach ($lines as $lineKey => $line) {

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -405,7 +405,7 @@ class CommandTest extends TestCase
     public function testSetCodeWithNonClosureCallable()
     {
         $command = new \TestCommand();
-        $ret = $command->setCode([$this, 'callableMethodCommand']);
+        $ret = $command->setCode($this->callableMethodCommand(...));
         $this->assertEquals($command, $ret, '->setCode() implements a fluent interface');
         $tester = new CommandTester($command);
         $tester->execute([]);

--- a/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
@@ -39,7 +39,7 @@ class IniFileLoader extends FileLoader
         if (isset($result['parameters']) && \is_array($result['parameters'])) {
             foreach ($result['parameters'] as $key => $value) {
                 if (\is_array($value)) {
-                    $this->container->setParameter($key, array_map([$this, 'phpize'], $value));
+                    $this->container->setParameter($key, array_map($this->phpize(...), $value));
                 } else {
                     $this->container->setParameter($key, $this->phpize($value));
                 }

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -57,7 +57,7 @@ class EventDispatcherTest extends TestCase
     public function testAddListener()
     {
         $this->dispatcher->addListener('pre.foo', [$this->listener, 'preFoo']);
-        $this->dispatcher->addListener('post.foo', [$this->listener, 'postFoo']);
+        $this->dispatcher->addListener('post.foo', $this->listener->postFoo(...));
         $this->assertTrue($this->dispatcher->hasListeners());
         $this->assertTrue($this->dispatcher->hasListeners(self::preFoo));
         $this->assertTrue($this->dispatcher->hasListeners(self::postFoo));
@@ -71,21 +71,25 @@ class EventDispatcherTest extends TestCase
         $listener1 = new TestEventListener();
         $listener2 = new TestEventListener();
         $listener3 = new TestEventListener();
+        $listener4 = new TestEventListener();
         $listener1->name = '1';
         $listener2->name = '2';
         $listener3->name = '3';
+        $listener4->name = '4';
 
         $this->dispatcher->addListener('pre.foo', [$listener1, 'preFoo'], -10);
         $this->dispatcher->addListener('pre.foo', [$listener2, 'preFoo'], 10);
         $this->dispatcher->addListener('pre.foo', [$listener3, 'preFoo']);
+        $this->dispatcher->addListener('pre.foo', $listener4->preFoo(...), 20);
 
         $expected = [
+            $listener4->preFoo(...),
             [$listener2, 'preFoo'],
             [$listener3, 'preFoo'],
             [$listener1, 'preFoo'],
         ];
 
-        $this->assertSame($expected, $this->dispatcher->getListeners('pre.foo'));
+        $this->assertEquals($expected, $this->dispatcher->getListeners('pre.foo'));
     }
 
     public function testGetAllListenersSortsByPriority()
@@ -129,7 +133,7 @@ class EventDispatcherTest extends TestCase
     public function testDispatch()
     {
         $this->dispatcher->addListener('pre.foo', [$this->listener, 'preFoo']);
-        $this->dispatcher->addListener('post.foo', [$this->listener, 'postFoo']);
+        $this->dispatcher->addListener('post.foo', $this->listener->postFoo(...));
         $this->dispatcher->dispatch(new Event(), self::preFoo);
         $this->assertTrue($this->listener->preFooInvoked);
         $this->assertFalse($this->listener->postFooInvoked);
@@ -160,7 +164,7 @@ class EventDispatcherTest extends TestCase
         // be executed
         // Manually set priority to enforce $this->listener to be called first
         $this->dispatcher->addListener('post.foo', [$this->listener, 'postFoo'], 10);
-        $this->dispatcher->addListener('post.foo', [$otherListener, 'postFoo']);
+        $this->dispatcher->addListener('post.foo', $otherListener->postFoo(...));
         $this->dispatcher->dispatch(new Event(), self::postFoo);
         $this->assertTrue($this->listener->postFooInvoked);
         $this->assertFalse($otherListener->postFooInvoked);
@@ -386,7 +390,7 @@ class EventDispatcherTest extends TestCase
     {
         $testLoaded = false;
         $test = new TestEventListener();
-        $this->dispatcher->addListener('foo', [$test, 'postFoo']);
+        $this->dispatcher->addListener('foo', $test->postFoo(...));
         $this->dispatcher->addListener('foo', [function () use ($test, &$testLoaded) {
             $testLoaded = true;
 
@@ -398,7 +402,7 @@ class EventDispatcherTest extends TestCase
         $this->assertTrue($test->postFooInvoked);
         $this->assertFalse($test->preFooInvoked);
 
-        $this->assertsame(0, $this->dispatcher->getListenerPriority('foo', [$test, 'preFoo']));
+        $this->assertEquals(0, $this->dispatcher->getListenerPriority('foo', $test->postFoo(...)));
 
         $test->preFoo(new Event());
         $this->dispatcher->dispatch(new Event(), 'foo');
@@ -417,8 +421,8 @@ class EventDispatcherTest extends TestCase
         $this->assertNotSame($callback1, $callback2);
         $this->assertNotSame($callback1, $callback3);
         $this->assertNotSame($callback2, $callback3);
-        $this->assertTrue($callback1 == $callback2);
-        $this->assertFalse($callback1 == $callback3);
+        $this->assertEquals($callback1, $callback2);
+        $this->assertEquals($callback1, $callback3);
 
         $this->dispatcher->addListener('foo', $callback1, 3);
         $this->dispatcher->addListener('foo', $callback2, 2);

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -235,7 +235,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
                     Caster::PREFIX_VIRTUAL.'type_class' => new ClassStub(\get_class($f->getConfig()->getType()->getInnerType())),
                 ];
             },
-            FormView::class => [StubCaster::class, 'cutInternals'],
+            FormView::class => StubCaster::cutInternals(...),
             ConstraintViolationInterface::class => function (ConstraintViolationInterface $v, array $a) {
                 return [
                     Caster::PREFIX_VIRTUAL.'root' => $v->getRoot(),

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -141,7 +141,7 @@ class DefaultChoiceListFactoryTest extends TestCase
     {
         $list = $this->factory->createListFromChoices(
             ['A' => $this->obj1, 'B' => $this->obj2, 'C' => $this->obj3, 'D' => $this->obj4],
-            [$this, 'getValue']
+            $this->getValue(...)
         );
 
         $this->assertObjectListWithCustomValues($list);
@@ -186,7 +186,7 @@ class DefaultChoiceListFactoryTest extends TestCase
                 'Group 1' => ['A' => $this->obj1, 'B' => $this->obj2],
                 'Group 2' => ['C' => $this->obj3, 'D' => $this->obj4],
             ],
-            [$this, 'getValue']
+            $this->getValue(...)
         );
 
         $this->assertObjectListWithCustomValues($list);
@@ -335,7 +335,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             [$this->obj4, $this->obj2, $this->obj1, $this->obj3],
             null, // label
             null, // index
-            [$this, 'getGroup']
+            $this->getGroup(...)
         );
 
         $preferredLabels = array_map(static function (ChoiceGroupView $groupView): array {
@@ -380,7 +380,7 @@ class DefaultChoiceListFactoryTest extends TestCase
     {
         $view = $this->factory->createView(
             $this->list,
-            [$this, 'isPreferred']
+            $this->isPreferred(...)
         );
 
         $this->assertFlatView($view);
@@ -430,7 +430,7 @@ class DefaultChoiceListFactoryTest extends TestCase
         $view = $this->factory->createView(
             $this->list,
             [$this->obj2, $this->obj3],
-            [$this, 'getLabel']
+            $this->getLabel(...)
         );
 
         $this->assertFlatView($view);
@@ -486,7 +486,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             $this->list,
             [$this->obj2, $this->obj3],
             null, // label
-            [$this, 'getFormIndex']
+            $this->getFormIndex(...)
         );
 
         $this->assertFlatViewWithCustomIndices($view);
@@ -580,7 +580,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             [$this->obj2, $this->obj3],
             null, // label
             null, // index
-            [$this, 'getGroup']
+            $this->getGroup(...)
         );
 
         $this->assertGroupedView($view);
@@ -593,7 +593,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             [],
             null, // label
             null, // index
-            [$this, 'getGroupArray']
+            $this->getGroupArray(...)
         );
 
         $this->assertGroupedViewWithChoiceDuplication($view);
@@ -606,7 +606,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             [$this->obj2, $this->obj3],
             null, // label
             null, // index
-            [$this, 'getGroupAsObject']
+            $this->getGroupAsObject(...)
         );
 
         $this->assertGroupedView($view);
@@ -699,7 +699,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             null, // label
             null, // index
             null, // group
-            [$this, 'getAttr']
+            $this->getAttr(...)
         );
 
         $this->assertFlatViewWithAttr($view);
@@ -837,7 +837,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             null, // index
             null, // group
             null, // attr
-            [$this, 'getlabelTranslationParameters']
+            $this->getlabelTranslationParameters(...)
         );
 
         $this->assertFlatViewWithlabelTranslationParameters($view);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -423,7 +423,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
     public function testHandleCallbackValidationGroups()
     {
         $object = new \stdClass();
-        $options = ['validation_groups' => [$this, 'getValidationGroups']];
+        $options = ['validation_groups' => $this->getValidationGroups(...)];
         $form = $this->getCompoundForm($object, $options);
         $form->submit([]);
 
@@ -543,7 +543,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
     {
         $object = new \stdClass();
 
-        $parentOptions = ['validation_groups' => [$this, 'getValidationGroups']];
+        $parentOptions = ['validation_groups' => $this->getValidationGroups(...)];
         $parent = $this->getBuilder('parent', null, $parentOptions)
             ->setCompound(true)
             ->setDataMapper(new DataMapper())

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTest.php
@@ -57,7 +57,7 @@ abstract class BaseValidatorExtensionTest extends TypeTestCase
     public function testValidationGroupsCanBeSetToCallback()
     {
         $form = $this->createForm([
-            'validation_groups' => [$this, 'testValidationGroupsCanBeSetToCallback'],
+            'validation_groups' => $this->testValidationGroupsCanBeSetToCallback(...),
         ]);
 
         $this->assertIsCallable($form->getConfig()->getOption('validation_groups'));

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -207,7 +207,7 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
         $timeout += microtime(true);
         self::$delay = Loop::defer(static function () use ($timeout) {
             if (0 < $timeout -= microtime(true)) {
-                self::$delay = Loop::delay(ceil(1000 * $timeout), [Loop::class, 'stop']);
+                self::$delay = Loop::delay(ceil(1000 * $timeout), Loop::stop(...));
             } else {
                 Loop::stop();
             }
@@ -447,6 +447,6 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
             self::$delay = null;
         }
 
-        Loop::defer([Loop::class, 'stop']);
+        Loop::defer(Loop::stop(...));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -35,7 +35,7 @@ class ArgumentMetadataFactoryTest extends TestCase
 
     public function testSignature1()
     {
-        $arguments = $this->factory->createArgumentMetadata([$this, 'signature1']);
+        $arguments = $this->factory->createArgumentMetadata($this->signature1(...));
 
         $this->assertEquals([
             new ArgumentMetadata('foo', self::class, false, false, null),
@@ -46,7 +46,7 @@ class ArgumentMetadataFactoryTest extends TestCase
 
     public function testSignature2()
     {
-        $arguments = $this->factory->createArgumentMetadata([$this, 'signature2']);
+        $arguments = $this->factory->createArgumentMetadata($this->signature2(...));
 
         $this->assertEquals([
             new ArgumentMetadata('foo', self::class, false, true, null, true),
@@ -57,7 +57,7 @@ class ArgumentMetadataFactoryTest extends TestCase
 
     public function testSignature3()
     {
-        $arguments = $this->factory->createArgumentMetadata([$this, 'signature3']);
+        $arguments = $this->factory->createArgumentMetadata($this->signature3(...));
 
         $this->assertEquals([
             new ArgumentMetadata('bar', FakeClassThatDoesNotExist::class, false, false, null),
@@ -67,7 +67,7 @@ class ArgumentMetadataFactoryTest extends TestCase
 
     public function testSignature4()
     {
-        $arguments = $this->factory->createArgumentMetadata([$this, 'signature4']);
+        $arguments = $this->factory->createArgumentMetadata($this->signature4(...));
 
         $this->assertEquals([
             new ArgumentMetadata('foo', null, false, true, 'default'),
@@ -78,7 +78,7 @@ class ArgumentMetadataFactoryTest extends TestCase
 
     public function testSignature5()
     {
-        $arguments = $this->factory->createArgumentMetadata([$this, 'signature5']);
+        $arguments = $this->factory->createArgumentMetadata($this->signature5(...));
 
         $this->assertEquals([
             new ArgumentMetadata('foo', 'array', false, true, null, true),

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -123,6 +123,17 @@ class RequestDataCollectorTest extends TestCase
             ],
 
             [
+                'First-class callable closure',
+                $this->testControllerInspection(...),
+                [
+                    'class' => self::class,
+                    'method' => 'testControllerInspection',
+                    'file' => __FILE__,
+                    'line' => $r1->getStartLine(),
+                ],
+            ],
+
+            [
                 'Static callback as string',
                 __NAMESPACE__.'\RequestDataCollectorTest::staticControllerMethod',
                 [

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
@@ -30,7 +30,7 @@ class ResponseListenerTest extends TestCase
     {
         $this->dispatcher = new EventDispatcher();
         $listener = new ResponseListener('UTF-8');
-        $this->dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse']);
+        $this->dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...));
 
         $this->kernel = $this->createMock(HttpKernelInterface::class);
     }
@@ -54,7 +54,7 @@ class ResponseListenerTest extends TestCase
     public function testFilterSetsNonDefaultCharsetIfNotOverridden()
     {
         $listener = new ResponseListener('ISO-8859-15');
-        $this->dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse'], 1);
+        $this->dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...), 1);
 
         $response = new Response('foo');
 
@@ -67,7 +67,7 @@ class ResponseListenerTest extends TestCase
     public function testFilterDoesNothingIfCharsetIsOverridden()
     {
         $listener = new ResponseListener('ISO-8859-15');
-        $this->dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse'], 1);
+        $this->dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...), 1);
 
         $response = new Response('foo');
         $response->setCharset('ISO-8859-1');
@@ -81,7 +81,7 @@ class ResponseListenerTest extends TestCase
     public function testFiltersSetsNonDefaultCharsetIfNotOverriddenOnNonTextContentType()
     {
         $listener = new ResponseListener('ISO-8859-15');
-        $this->dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse'], 1);
+        $this->dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...), 1);
 
         $response = new Response('foo');
         $request = Request::create('/');
@@ -96,7 +96,7 @@ class ResponseListenerTest extends TestCase
     public function testSetContentLanguageHeaderWhenEmptyAndAtLeast2EnabledLocalesAreConfigured()
     {
         $listener = new ResponseListener('ISO-8859-15', true, ['fr', 'en']);
-        $this->dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse'], 1);
+        $this->dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...), 1);
 
         $response = new Response('content');
         $request = Request::create('/');
@@ -111,7 +111,7 @@ class ResponseListenerTest extends TestCase
     public function testNotOverrideContentLanguageHeaderWhenNotEmpty()
     {
         $listener = new ResponseListener('ISO-8859-15', true, ['de']);
-        $this->dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse'], 1);
+        $this->dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...), 1);
 
         $response = new Response('content');
         $response->headers->set('Content-Language', 'mi, en');
@@ -127,7 +127,7 @@ class ResponseListenerTest extends TestCase
     public function testNotSetContentLanguageHeaderWhenDisabled()
     {
         $listener = new ResponseListener('ISO-8859-15', false);
-        $this->dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse'], 1);
+        $this->dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...), 1);
 
         $response = new Response('content');
         $request = Request::create('/');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SurrogateListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SurrogateListenerTest.php
@@ -30,7 +30,7 @@ class SurrogateListenerTest extends TestCase
         $response = new Response('foo <esi:include src="" />');
         $listener = new SurrogateListener(new Esi());
 
-        $dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse']);
+        $dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...));
         $event = new ResponseEvent($kernel, new Request(), HttpKernelInterface::SUB_REQUEST, $response);
         $dispatcher->dispatch($event, KernelEvents::RESPONSE);
 
@@ -44,7 +44,7 @@ class SurrogateListenerTest extends TestCase
         $response = new Response('foo <esi:include src="" />');
         $listener = new SurrogateListener(new Esi());
 
-        $dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse']);
+        $dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...));
         $event = new ResponseEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST, $response);
         $dispatcher->dispatch($event, KernelEvents::RESPONSE);
 
@@ -58,7 +58,7 @@ class SurrogateListenerTest extends TestCase
         $response = new Response('foo');
         $listener = new SurrogateListener(new Esi());
 
-        $dispatcher->addListener(KernelEvents::RESPONSE, [$listener, 'onKernelResponse']);
+        $dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...));
         $event = new ResponseEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST, $response);
         $dispatcher->dispatch($event, KernelEvents::RESPONSE);
 

--- a/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
@@ -172,6 +172,6 @@ class TraceableMessageBusTest extends TestCase
 
         $this->expectExceptionObject($exception);
 
-        array_map([$traceableBus, 'dispatch'], [$message]);
+        array_map($traceableBus->dispatch(...), [$message]);
     }
 }

--- a/src/Symfony/Component/String/LazyString.php
+++ b/src/Symfony/Component/String/LazyString.php
@@ -50,7 +50,7 @@ class LazyString implements \Stringable, \JsonSerializable
     public static function fromStringable(string|int|float|bool|\Stringable $value): static
     {
         if (\is_object($value)) {
-            return static::fromCallable([$value, '__toString']);
+            return static::fromCallable($value->__toString(...));
         }
 
         $lazyString = new static();

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -162,6 +162,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
             }],
             'callable with string notation' => ['Symfony\Component\Validator\Tests\Constraints\CallableClass::execute'],
             'callable with static notation' => [[CallableClass::class, 'execute']],
+            'callable with first-class callable notation' => [CallableClass::execute(...)],
             'callable with object' => [[new CallableClass(), 'execute']],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -

### Rationale
https://wiki.php.net/rfc/first_class_callable_syntax

Mainly: 
>  The advantage is that the new syntax is accessible to static analysis, and respects the scope at the point where the callable is created.

I'd argue that it also improves readability and IDE color syntax also helps:

![image](https://user-images.githubusercontent.com/1524501/191912084-7ee933c5-dda1-4176-86f1-cd6511c58aa4.png)

I've manually reviewed each changes and discarded some of them where `[Foo::class, 'method']` was intended to be tested with this specific syntax

