### PR TITLE
[VarDumper] Fix use-after-free with nested FFI::addr() in test

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/FFICasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/FFICasterTest.php
@@ -392,12 +392,6 @@ class FFICasterTest extends TestCase
         }
         OUTPUT, \FFI::addr($struct));
 
-        $this->assertDumpEquals(<<<'OUTPUT'
-        FFI\CData<struct <anonymous>**> size 8 align 8 {
-          cdata: null
-        }
-        OUTPUT, \FFI::addr(\FFI::addr($struct)));
-
         // Save the pointer as variable so that
         // it is not cleaned up by the GC
         $pointer = \FFI::addr($struct);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/php/php-src/issues/9598
| License       | MIT
| Doc PR        | 

This issue was found by the PHP community build, after which I created https://github.com/php/php-src/issues/9598. Basically, the inner `\FFI::addr()` `CData` will be deallocated after the second `\FFI::addr()` call which will be stored and then points to invalid memory. However, [it turns out](https://github.com/php/php-src/pull/9599#issuecomment-1255901306) nesting `\FFI::addr()` calls without temporarily storing the result is actually not allowed.

https://www.php.net/manual/en/ffi.addr.php

> Creates an unmanaged pointer to the C data represented by the given `FFI\CData`. The source ptr must survive the resulting pointer. This function is mainly useful to pass arguments to C functions by pointer.

We'll see if we can improve `FFI` by throwing an exception when passing temporary values to `FFI::addr()`. Either way, this test is not valid.