### PR TITLE
[VarDumper] Fix memory leak in FFI test

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/FFICasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/FFICasterTest.php
@@ -405,6 +405,8 @@ class FFICasterTest extends TestCase
           }
         }
         OUTPUT, \FFI::addr($pointer));
+
+        \FFI::free($struct);
     }
 
     public function testCastComplexType()


### PR DESCRIPTION
Unowned data must be passed to FFI::free() when no longer needed.

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As explained above :slightly_smiling_face:

https://www.php.net/manual/en/ffi.new.php

> **owned**
>
> Whether to create owned (i.e. managed) or unmanaged data. Managed data lives together with the returned [FFI\CData](https://www.php.net/manual/en/class.ffi-cdata.php) object, and is released when the last reference to that object is released by regular PHP reference counting or GC. Unmanaged data should be released by calling [FFI::free()](https://www.php.net/manual/en/ffi.free.php), when no longer needed.

Making the data owned would also work, but I wasn't sure if this test was explicitly trying to test unowned data.