### PR TITLE
[Messenger] Fix default serializer not handling DateTime objects properly

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -21,6 +21,7 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 use Symfony\Component\Serializer\SerializerInterface as SymfonySerializerInterface;
@@ -50,7 +51,7 @@ class Serializer implements SerializerInterface
         }
 
         $encoders = [new XmlEncoder(), new JsonEncoder()];
-        $normalizers = [new ArrayDenormalizer(), new ObjectNormalizer()];
+        $normalizers = [new DateTimeNormalizer(), new ArrayDenormalizer(), new ObjectNormalizer()];
         $serializer = new SymfonySerializer($normalizers, $encoders);
 
         return new self($serializer);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | --
| License       | MIT
| Doc PR        | --

I was using messenger standalone and needed to send messages in JSON format. While trying to do so using the Serializer class, I noticed that DateTime objects (present for example in RedeliveryStamp) are not serialized properly.

I fixed it by adding the proper normalizer.

I encountered it in version 5.2, but it should be applicable from version 4.4.

Before:

![before](https://user-images.githubusercontent.com/109534378/192502327-22973a95-d26c-4aa7-9a12-089109fc4185.png)

After:

![after](https://user-images.githubusercontent.com/109534378/192502452-75f36ecc-a2fe-41b7-96dc-b54b0b602206.png)

