### PR TITLE
[Mailer][Mailjet] Apply the default value of 512 for max depths

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -201,7 +201,7 @@ class MailjetApiTransport extends AbstractApiTransport
         return match ($type) {
             'bool' => filter_var($value, \FILTER_VALIDATE_BOOLEAN),
             'int' => (int) $value,
-            'json' => json_decode($value, true, 2, \JSON_THROW_ON_ERROR),
+            'json' => json_decode($value, true, 512, \JSON_THROW_ON_ERROR),
             'string' => $value,
         };
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47701 
| License       | MIT
| Doc PR        | n/a

Applies the default value of 512 for max depths when using PHP's json_decode() function.

See symfony#47701 for more details.