### PR TITLE
[Stopwatch] Correct compare float data in tests

### DIFF
--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
@@ -40,7 +40,7 @@ class StopwatchPeriodTest extends TestCase
     public function testGetDuration($start, $end, $useMorePrecision, $duration)
     {
         $period = new StopwatchPeriod($start, $end, $useMorePrecision);
-        $this->assertSame($duration, $period->getDuration());
+        $this->assertEqualsWithDelta($duration, $period->getDuration(), \PHP_FLOAT_EPSILON);
     }
 
     public function provideTimeValues()

--- a/src/Symfony/Component/Stopwatch/composer.json
+++ b/src/Symfony/Component/Stopwatch/composer.json
@@ -19,6 +19,9 @@
         "php": ">=7.1.3",
         "symfony/service-contracts": "^1.0|^2"
     },
+    "require-dev": {
+        "symfony/polyfill-php72": "~1.5"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Stopwatch\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Fix erorr in unit tests

```
1) Symfony\Component\Stopwatch\Tests\StopwatchPeriodTest::testGetDuration with data set #8 (2.71, 3.14, true, 0.43)
Failed asserting that 0.43000000000000016 is identical to 0.43.
```
