### PR TITLE
[HttpFoundation] Add `StreamedJsonResponse` for efficient JSON streaming

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 6.2
 ---
 
+ * Add `StreamedJsonResponse` class for efficient JSON streaming
  * The HTTP cache store uses the `xxh128` algorithm
  * Deprecate calling `JsonResponse::setCallback()`, `Response::setExpires/setLastModified/setEtag()`, `MockArraySessionStorage/NativeSessionStorage::setMetadataBag()`, `NativeSessionStorage::setSaveHandler()` without arguments
  * Add request matchers under the `Symfony\Component\HttpFoundation\RequestMatcher` namespace

--- a/src/Symfony/Component/HttpFoundation/StreamedJsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedJsonResponse.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * StreamedJsonResponse represents a streamed HTTP response for JSON.
+ *
+ * A StreamedJsonResponse uses a structure and generics to create an
+ * efficient resource-saving JSON response.
+ *
+ * It is recommended to use flush() function after a specific number of items to directly stream the data.
+ *
+ * @see flush()
+ *
+ * @author Alexander Schranz <alexander@sulu.io>
+ *
+ * Example usage:
+ *
+ *     function loadArticles(): \Generator
+ *         // some streamed loading
+ *         yield ['title' => 'Article 1'];
+ *         yield ['title' => 'Article 2'];
+ *         yield ['title' => 'Article 3'];
+ *         // recommended to use flush() after every specific number of items
+ *     }),
+ *
+ *     $response = new StreamedJsonResponse(
+ *         // json structure with generators in which will be streamed
+ *         [
+ *             '_embedded' => [
+ *                 'articles' => loadArticles(), // any generator which you want to stream as list of data
+ *             ],
+ *         ],
+ *     );
+ */
+class StreamedJsonResponse extends StreamedResponse
+{
+    private const PLACEHOLDER = '__symfony_json__';
+
+    /**
+     * @param mixed[]                        $data            JSON Data containing PHP generators which will be streamed as list of data
+     * @param int                            $status          The HTTP status code (200 "OK" by default)
+     * @param array<string, string|string[]> $headers         An array of HTTP headers
+     * @param int                            $encodingOptions Flags for the json_encode() function
+     */
+    public function __construct(
+        private readonly array $data,
+        int $status = 200,
+        array $headers = [],
+        private int $encodingOptions = JsonResponse::DEFAULT_ENCODING_OPTIONS,
+    ) {
+        parent::__construct($this->stream(...), $status, $headers);
+
+        if (!$this->headers->get('Content-Type')) {
+            $this->headers->set('Content-Type', 'application/json');
+        }
+    }
+
+    private function stream(): void
+    {
+        $generators = [];
+        $structure = $this->data;
+
+        array_walk_recursive($structure, function (&$item, $key) use (&$generators) {
+            if (self::PLACEHOLDER === $key) {
+                // if the placeholder is already in the structure it should be replaced with a new one that explode
+                // works like expected for the structure
+                $generators[] = $key;
+            }
+
+            // generators should be used but for better DX all kind of Traversable and objects are supported
+            if (\is_object($item)) {
+                $generators[] = $item;
+                $item = self::PLACEHOLDER;
+            } elseif (self::PLACEHOLDER === $item) {
+                // if the placeholder is already in the structure it should be replaced with a new one that explode
+                // works like expected for the structure
+                $generators[] = $item;
+            }
+        });
+
+        $jsonEncodingOptions = \JSON_THROW_ON_ERROR | $this->encodingOptions;
+        $keyEncodingOptions = $jsonEncodingOptions & ~\JSON_NUMERIC_CHECK;
+
+        $jsonParts = explode('"'.self::PLACEHOLDER.'"', json_encode($structure, $jsonEncodingOptions));
+
+        foreach ($generators as $index => $generator) {
+            // send first and between parts of the structure
+            echo $jsonParts[$index];
+
+            if ($generator instanceof \JsonSerializable || !$generator instanceof \Traversable) {
+                // the placeholders, JsonSerializable and none traversable items in the structure are rendered here
+                echo json_encode($generator, $jsonEncodingOptions);
+
+                continue;
+            }
+
+            $isFirstItem = true;
+            $startTag = '[';
+
+            foreach ($generator as $key => $item) {
+                if ($isFirstItem) {
+                    $isFirstItem = false;
+                    // depending on the first elements key the generator is detected as a list or map
+                    // we can not check for a whole list or map because that would hurt the performance
+                    // of the streamed response which is the main goal of this response class
+                    if (0 !== $key) {
+                        $startTag = '{';
+                    }
+
+                    echo $startTag;
+                } else {
+                    // if not first element of the generic, a separator is required between the elements
+                    echo ',';
+                }
+
+                if ('{' === $startTag) {
+                    echo json_encode((string) $key, $keyEncodingOptions).':';
+                }
+
+                echo json_encode($item, $jsonEncodingOptions);
+            }
+
+            echo '[' === $startTag ? ']' : '}';
+        }
+
+        // send last part of the structure
+        echo $jsonParts[array_key_last($jsonParts)];
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedJsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedJsonResponseTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\StreamedJsonResponse;
+
+class StreamedJsonResponseTest extends TestCase
+{
+    public function testResponseSimpleList()
+    {
+        $content = $this->createSendResponse(
+            [
+                '_embedded' => [
+                    'articles' => $this->generatorSimple('Article'),
+                    'news' => $this->generatorSimple('News'),
+                ],
+            ],
+        );
+
+        $this->assertSame('{"_embedded":{"articles":["Article 1","Article 2","Article 3"],"news":["News 1","News 2","News 3"]}}', $content);
+    }
+
+    public function testResponseObjectsList()
+    {
+        $content = $this->createSendResponse(
+            [
+                '_embedded' => [
+                    'articles' => $this->generatorArray('Article'),
+                ],
+            ],
+        );
+
+        $this->assertSame('{"_embedded":{"articles":[{"title":"Article 1"},{"title":"Article 2"},{"title":"Article 3"}]}}', $content);
+    }
+
+    public function testResponseWithoutGenerator()
+    {
+        // while it is not the intended usage, all kind of iterables should be supported for good DX
+        $content = $this->createSendResponse(
+            [
+                '_embedded' => [
+                    'articles' => ['Article 1', 'Article 2', 'Article 3'],
+                ],
+            ],
+        );
+
+        $this->assertSame('{"_embedded":{"articles":["Article 1","Article 2","Article 3"]}}', $content);
+    }
+
+    public function testResponseWithPlaceholder()
+    {
+        // the placeholder must not conflict with generator injection
+        $content = $this->createSendResponse(
+            [
+                '_embedded' => [
+                    'articles' => $this->generatorArray('Article'),
+                    'placeholder' => '__symfony_json__',
+                    'news' => $this->generatorSimple('News'),
+                ],
+                'placeholder' => '__symfony_json__',
+            ],
+        );
+
+        $this->assertSame('{"_embedded":{"articles":[{"title":"Article 1"},{"title":"Article 2"},{"title":"Article 3"}],"placeholder":"__symfony_json__","news":["News 1","News 2","News 3"]},"placeholder":"__symfony_json__"}', $content);
+    }
+
+    public function testResponseWithMixedKeyType()
+    {
+        $content = $this->createSendResponse(
+            [
+                '_embedded' => [
+                    'list' => (function (): \Generator {
+                        yield 0 => 'test';
+                        yield 'key' => 'value';
+                    })(),
+                    'map' => (function (): \Generator {
+                        yield 'key' => 'value';
+                        yield 0 => 'test';
+                    })(),
+                    'integer' => (function (): \Generator {
+                        yield 1 => 'one';
+                        yield 3 => 'three';
+                    })(),
+                ],
+            ]
+        );
+
+        $this->assertSame('{"_embedded":{"list":["test","value"],"map":{"key":"value","0":"test"},"integer":{"1":"one","3":"three"}}}', $content);
+    }
+
+    public function testResponseOtherTraversable()
+    {
+        $arrayObject = new \ArrayObject(['__symfony_json__' => '__symfony_json__']);
+
+        $iteratorAggregate = new class() implements \IteratorAggregate {
+            public function getIterator(): \Traversable
+            {
+                return new \ArrayIterator(['__symfony_json__']);
+            }
+        };
+
+        $jsonSerializable = new class() implements \IteratorAggregate, \JsonSerializable {
+            public function getIterator(): \Traversable
+            {
+                return new \ArrayIterator(['This should be ignored']);
+            }
+
+            public function jsonSerialize(): mixed
+            {
+                return ['__symfony_json__' => '__symfony_json__'];
+            }
+        };
+
+        // while Generators should be used for performance reasons, the object should also work with any Traversable
+        // to make things easier for a developer
+        $content = $this->createSendResponse(
+            [
+                'arrayObject' => $arrayObject,
+                'iteratorAggregate' => $iteratorAggregate,
+                'jsonSerializable' => $jsonSerializable,
+                // add a Generator to make sure it still work in combination with other Traversable objects
+                'articles' => $this->generatorArray('Article'),
+            ],
+        );
+
+        $this->assertSame('{"arrayObject":{"__symfony_json__":"__symfony_json__"},"iteratorAggregate":["__symfony_json__"],"jsonSerializable":{"__symfony_json__":"__symfony_json__"},"articles":[{"title":"Article 1"},{"title":"Article 2"},{"title":"Article 3"}]}', $content);
+    }
+
+    public function testPlaceholderAsKeyAndValueInStructure()
+    {
+        $content = $this->createSendResponse(
+            [
+                '__symfony_json__' => '__symfony_json__',
+                'articles' => $this->generatorArray('Article'),
+            ],
+        );
+
+        $this->assertSame('{"__symfony_json__":"__symfony_json__","articles":[{"title":"Article 1"},{"title":"Article 2"},{"title":"Article 3"}]}', $content);
+    }
+
+    public function testResponseStatusCode()
+    {
+        $response = new StreamedJsonResponse([], 201);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    public function testPlaceholderAsObjectStructure()
+    {
+        $object = new class() {
+            public $__symfony_json__ = 'foo';
+            public $bar = '__symfony_json__';
+        };
+
+        $content = $this->createSendResponse(
+            [
+                'object' => $object,
+                // add a Generator to make sure it still work in combination with other object holding placeholders
+                'articles' => $this->generatorArray('Article'),
+            ],
+        );
+
+        $this->assertSame('{"object":{"__symfony_json__":"foo","bar":"__symfony_json__"},"articles":[{"title":"Article 1"},{"title":"Article 2"},{"title":"Article 3"}]}', $content);
+    }
+
+    public function testResponseHeaders()
+    {
+        $response = new StreamedJsonResponse([], 200, ['X-Test' => 'Test']);
+
+        $this->assertSame('Test', $response->headers->get('X-Test'));
+    }
+
+    public function testCustomContentType()
+    {
+        $response = new StreamedJsonResponse([], 200, ['Content-Type' => 'application/json+stream']);
+
+        $this->assertSame('application/json+stream', $response->headers->get('Content-Type'));
+    }
+
+    public function testEncodingOptions()
+    {
+        $response = new StreamedJsonResponse([
+            '_embedded' => [
+                'count' => '2', // options are applied to the initial json encode
+                'values' => (function (): \Generator {
+                    yield 'with/unescaped/slash' => 'With/a/slash'; // options are applied to key and values
+                    yield '3' => '3'; // numeric check for value, but not for the key
+                })(),
+            ],
+        ], encodingOptions: \JSON_UNESCAPED_SLASHES | \JSON_NUMERIC_CHECK);
+
+        ob_start();
+        $response->send();
+        $content = ob_get_clean();
+
+        $this->assertSame('{"_embedded":{"count":2,"values":{"with/unescaped/slash":"With/a/slash","3":3}}}', $content);
+    }
+
+    /**
+     * @param mixed[] $data
+     */
+    private function createSendResponse(array $data): string
+    {
+        $response = new StreamedJsonResponse($data);
+
+        ob_start();
+        $response->send();
+
+        return ob_get_clean();
+    }
+
+    /**
+     * @return \Generator<int, string>
+     */
+    private function generatorSimple(string $test): \Generator
+    {
+        yield $test.' 1';
+        yield $test.' 2';
+        yield $test.' 3';
+    }
+
+    /**
+     * @return \Generator<int, array{title: string}>
+     */
+    private function generatorArray(string $test): \Generator
+    {
+        yield ['title' => $test.' 1'];
+        yield ['title' => $test.' 2'];
+        yield ['title' => $test.' 3'];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/17301

When big data are streamed via JSON API it can sometimes be difficult to keep the resources usages low. For this I experimented with a different way of streaming data for JSON responses. It uses combination of `structured array` and `generics` which did result in a lot better result.

More can be read about here: [https://github.com/alexander-schranz/efficient-json-streaming-with-symfony-doctrine](https://github.com/alexander-schranz/efficient-json-streaming-with-symfony-doctrine).

I thought it maybe can be a great addition to Symfony itself to make this kind of responses easier and that APIs can be made more performant.

## Usage

<details><summary>First Version (replaced)</summary>

```php
class ArticleListAction {
    public function __invoke(EntityManagerInterface  $entityManager): Response
    {
        $articles = $this->findArticles($entityManager);

        return new StreamedJsonResponse(
            // json structure with replacers identifiers
            [
                '_embedded' => [
                    'articles' => '__articles__',
                ],
            ],
            // array of generator replacer identifier used as key
            [
                '__articles__' => $this->findArticles('Article'),
            ]
        );
    }

    private function findArticles(EntityManagerInterface  $entityManager): \Generator
    {
        $queryBuilder = $entityManager->createQueryBuilder();
        $queryBuilder->from(Article::class, 'article');
        $queryBuilder->select('article.id')
            ->addSelect('article.title')
            ->addSelect('article.description');

        return $queryBuilder->getQuery()->toIterable();
    }
}
```

</details>

Update Version (thx to @ro0NL for the idea):

```php
class ArticleListAction {
    public function __invoke(EntityManagerInterface  $entityManager): Response
    {
        $articles = $this->findArticles($entityManager);

        return new StreamedJsonResponse(
            // json structure with generators in it which are streamed
            [
                '_embedded' => [
                    'articles' => $this->findArticles('Article'), // returns a generator which is streamed
                ],
            ],
        );
    }

    private function findArticles(EntityManagerInterface  $entityManager): \Generator
    {
        $queryBuilder = $entityManager->createQueryBuilder();
        $queryBuilder->from(Article::class, 'article');
        $queryBuilder->select('article.id')
            ->addSelect('article.title')
            ->addSelect('article.description');

        return $queryBuilder->getQuery()->toIterable();
    }
}
```

----

As proposed by  @OskarStark the Full Content of Blog about ["Efficient JSON Streaming with Symfony and Doctrine"](https://github.com/alexander-schranz/efficient-json-streaming-with-symfony-doctrine/edit/main/README.md):

# Efficient JSON Streaming with Symfony and Doctrine

After reading a tweet about we provide only a few items (max. 100) over our
JSON APIs but providing 4k images for our websites.  I did think about why is 
this the case.

The main difference first we need to know about how images are streamed.
On webservers today is mostly the sendfile feature used. Which is very
efficient as it can stream a file chunk by chunk and don't  need to load
the whole data.

So I'm asking myself how we can achieve the same mechanisms for our
JSON APIs, with a little experiment.

As an example we will have a look at a basic entity which has the
following fields defined:

 - id: int
 - title: string
 - description: text

The response of our API should look like the following:

```json
{
  "_embedded": {
    "articles": [
      {
        "id": 1,
        "title": "Article 1",
        "description": "Description 1\nMore description text ...",
      },
      ...
    ]
  } 
}
```

Normally to provide this API we would do something like this:

```php
<?php

namespace App\Controller;

use App\Entity\Article;
use Doctrine\ORM\EntityManagerInterface;
use Symfony\Component\HttpFoundation\JsonResponse;
use Symfony\Component\HttpFoundation\Response;

class ArticleListAction
{
    public function __invoke(EntityManagerInterface $entityManager): Response
    {
        $articles = $this->findArticles($entityManager);

        return JsonResponse::fromJsonString(json_encode([
            'embedded' => [
                'articles' => $articles,
            ],
            'total' => 100_000,
        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
    }

    // normally this method would live in a repository
    private function findArticles(EntityManagerInterface  $entityManager): iterable
    {
        $queryBuilder = $entityManager->createQueryBuilder();
        $queryBuilder->from(Article::class, 'article');
        $queryBuilder->select('article.id')
            ->addSelect('article.title')
            ->addSelect('article.description');

        return $queryBuilder->getQuery()->getResult();
    }
}
```

In most cases we will add some pagination to the endpoint so our response are not too big.

## Making the api more efficient

But there is also a way how we can stream this response in an efficient way.

First of all we need to adjust how we load the articles. This can be done by replace
the `getResult` with the more efficient [`toIterable`](https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/reference/batch-processing.html#iterating-results):

```diff
-        return $queryBuilder->getQuery()->getResult();
+        return $queryBuilder->getQuery()->toIterable();
```

Still the whole JSON need to be in the memory to send it. So we need also refactoring
how we are creating our response. We will replace our `JsonResponse` with the 
[`StreamedResponse`](https://symfony.com/doc/6.0/components/http_foundation.html#streaming-a-response) object.

```php
return new StreamedResponse(function() use ($articles) {
    // stream json
}, 200, ['Content-Type' => 'application/json']);
```

But the `json` format is not the best format for streaming, so we need to add some hacks
so we can make it streamable.

First we will create will define the basic structure of our JSON this way:

```php
$jsonStructure = json_encode([
    'embedded' => [
        'articles' => ['__REPLACES_ARTICLES__'],
    ],
    'total' => 100_000,
], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
```

Instead of the `$articles` we are using a placeholder which we use to split the string into
a `$before` and `$after` variable:

```php
[$before, $after] = explode('"__REPLACES_ARTICLES__"', $jsonStructure, 2);
```

Now we are first sending the `$before`:

```php
echo $before . PHP_EOL;
```

Then we stream the articles one by one to it here we need to keep the comma in mind which
we need to add after every article but not the last one:

```php
foreach ($articles as $count => $article) {
    if ($count !== 0) {
        echo ',' . PHP_EOL; // if not first element we need a separator
    }

    echo json_encode($article, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
}
```

Also we will add an additional `flush` after every 500 elements:

```php
if ($count % 500 === 0 && $count !== 100_000) { // flush response after every 500
    flush();
}
```

After that we will also send the `$after` part:

```php
echo PHP_EOL;
echo $after;
```

## The result

So at the end the whole action looks like the following:

```php
<?php

namespace App\Controller;

use App\Entity\Article;
use Doctrine\ORM\EntityManagerInterface;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\HttpFoundation\StreamedResponse;

class ArticleListAction
{
    public function __invoke(EntityManagerInterface  $entityManager): Response
    {
        $articles = $this->findArticles($entityManager);

        return new StreamedResponse(function() use ($articles) {
            // defining our json structure but replaces the articles with a placeholder
            $jsonStructure = json_encode([
                'embedded' => [
                    'articles' => ['__REPLACES_ARTICLES__'],
                ],
                'total' => 100_000,
            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);

            // split by placeholder
            [$before, $after] = explode('"__REPLACES_ARTICLES__"', $jsonStructure, 2);

            // send first before part of the json
            echo $before . PHP_EOL;

            // stream article one by one as own json
            foreach ($articles as $count => $article) {
                if ($count !== 0) {
                    echo ',' . PHP_EOL; // if not first element we need a separator
                }

                if ($count % 500 === 0 && $count !== 100_000) { // flush response after every 500
                    flush();
                }

                echo json_encode($article, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
            }

            // send the after part of the json as last
            echo PHP_EOL;
            echo $after;
        }, 200, ['Content-Type' => 'application/json']);
    }

    private function findArticles(EntityManagerInterface  $entityManager): iterable
    {
        $queryBuilder = $entityManager->createQueryBuilder();
        $queryBuilder->from(Article::class, 'article');
        $queryBuilder->select('article.id')
            ->addSelect('article.title')
            ->addSelect('article.description');

        return $queryBuilder->getQuery()->toIterable();
    }
}
```

The metrics for 100000 Articles (nginx + php-fpm 7.4 - Macbook Pro 2013):

|                           | Old Implementation | New Implementation |
|---------------------------|--------------------|--------------------|
| Memory Usage              | 49.53 MB           | 2.10 MB            |
| Memory Usage Peak         | 59.21 MB           | 2.10 MB            |
| Time to first Byte        | 478ms              | 28ms               |
| Time                      | 2.335 s            | 0.584 s            |

This way we did not only reduce the memory usage on our server
also we did make the response faster. The memory usage was
measured here with `memory_get_usage` and `memory_get_peak_usage`.
The "Time to first Byte" by the browser value and response times
over curl.

**Updated 2022-10-02 - (symfony serve + php-fpm 8.1 - Macbook Pro 2021)**

|                           | Old Implementation | New Implementation |
|---------------------------|--------------------|--------------------|
| Memory Usage              | 64.21 MB           | 2.10 MB            |
| Memory Usage Peak         | 73.89 MB           | 2.10 MB            |
| Time to first Byte        | 0.203 s            | 0.049 s            |
| Updated Time (2022-10-02) | 0.233 s            | 0.232 s            |

While there is not much different for a single response in the time, 
the real performance is the lower memory usage. Which will kick in when
you have a lot of simultaneously requests. On my machine >150 simultaneously
requests - which is a high value but will on a normal server be a lot lower.

While 150 simultaneously requests crashes in the old implementation
the new implementation still works with 220 simultaneously requests. Which
means we got about ~46% more requests possible.

## Reading Data in javascript

As we stream the data we should also make our JavaScript on the other
end the same way - so data need to read in streamed way.

Here I'm just following the example from the [Fetch API Processing a text file line by line](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#processing_a_text_file_line_by_line)

So if we look at our [`script.js`](public/script.js) we split the object
line by line and append it to our table. This method is definitely not the
way how JSON should be read and parsed. It should only be shown as example
how the response could be read from a stream.

## Conclusion

The implementation looks a little hacky for maintainability it could
be moved into its own Factory which creates this kind of response.

Example:

```php
return StreamedResponseFactory::create(
    [
        'embedded' => [
            'articles' => ['__REPLACES_ARTICLES__'],
        ],
        'total' => 100_000,
    ],
    ['____REPLACES_ARTICLES__' => $articles]
);
```

The JavaScript part something is definitely not ready for production
and if used you should probably creating your own content-type e.g.:
`application/json+stream`.  So you are parsing the json this way 
only when you know it is really in this line by line format.
There maybe better libraries like [`JSONStream`](https://www.npmjs.com/package/JSONStream)
to read data but at current state did test them out. Let me know
if somebody has experience with that and has solutions for it.

Atleast what I think everybody should use for providing lists
is to use [`toIterable`](https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/reference/batch-processing.html#iterating-results) when possible for your lists when loading
your data via Doctrine and and select specific fields instead
of using the `ORM` to avoid hydration process to object. 

Let me know what you think about this experiment and how you currently are
providing your JSON data.

The whole experiment here can be checked out and test yourself via [this repository](https://github.com/alexander-schranz/efficient-json-streaming-with-symfony-doctrine).

Attend the discussion about this on [Twitter](https://twitter.com/alex_s_/status/1488314080381313025).

## Update 2022-09-27

Added a [StreamedJsonRepsonse](src/Controller/StreamedJsonResponse.php) class and
try to contribute this implementation to the Symfony core.

[https://github.com/symfony/symfony/pull/47709](https://github.com/symfony/symfony/pull/47709)

## Update 2022-10-02

Updated some statistics with new machine and apache benchmark tests for concurrency requests.



