### PR TITLE
[Mime] deprecate attach/embed methods in favor of Email::addPart()

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Twig\Mime;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Part\AbstractPart;
+use Symfony\Component\Mime\Part\DataPart;
 use Twig\Extra\CssInliner\CssInlinerExtension;
 use Twig\Extra\Inky\InkyExtension;
 use Twig\Extra\Markdown\MarkdownExtension;
@@ -134,7 +135,7 @@ class NotificationEmail extends TemplatedEmail
         $exceptionAsString = $this->getExceptionAsString($exception);
 
         $this->context['exception'] = true;
-        $this->attach($exceptionAsString, 'exception.txt', 'text/plain');
+        $this->addPart(new DataPart($exceptionAsString, 'exception.txt', 'text/plain'));
         $this->importance(self::IMPORTANCE_URGENT);
 
         if (!$this->getSubject()) {

--- a/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bridge\Twig\Mime;
 
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Part\BodyFile;
+use Symfony\Component\Mime\Part\DataPart;
 use Twig\Environment;
 
 /**
@@ -38,11 +40,8 @@ final class WrappedTemplatedEmail
     public function image(string $image, string $contentType = null): string
     {
         $file = $this->twig->getLoader()->getSourceContext($image);
-        if ($path = $file->getPath()) {
-            $this->message->embedFromPath($path, $image, $contentType);
-        } else {
-            $this->message->embed($file->getCode(), $image, $contentType);
-        }
+        $body = $file->getPath() ? new BodyFile($file->getPath()) : $file->getCode();
+        $this->message->addPart((new DataPart($body, $image, $contentType))->asInline());
 
         return 'cid:'.$image;
     }
@@ -50,11 +49,8 @@ final class WrappedTemplatedEmail
     public function attach(string $file, string $name = null, string $contentType = null): void
     {
         $file = $this->twig->getLoader()->getSourceContext($file);
-        if ($path = $file->getPath()) {
-            $this->message->attachFromPath($path, $name, $contentType);
-        } else {
-            $this->message->attach($file->getCode(), $name, $contentType);
-        }
+        $body = $file->getPath() ? new BodyFile($file->getPath()) : $file->getCode();
+        $this->message->addPart(new DataPart($body, $name, $contentType));
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Tests\Mime;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
@@ -58,7 +59,7 @@ class TemplatedEmailTest extends TestCase
         $e->textTemplate('email.txt.twig');
         $e->htmlTemplate('email.html.twig');
         $e->context(['foo' => 'bar']);
-        $e->attach('Some Text file', 'test.txt');
+        $e->addPart(new DataPart('Some Text file', 'test.txt'));
         $expected = clone $e;
 
         $expectedJson = <<<EOF

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/EmailController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/EmailController.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 
 class EmailController
 {
@@ -25,7 +26,7 @@ class EmailController
             ->addCc('cc@symfony.com')
             ->text('Bar!')
             ->html('<p>Foo</p>')
-            ->attach(file_get_contents(__FILE__), 'foobar.php')
+            ->addPart(new DataPart(file_get_contents(__FILE__), 'foobar.php'))
         );
 
         $mailer->send((new Email())->to('fabien@symfony.com', 'thomas@symfony.com')->from('fabien@symfony.com')->subject('Foo')
@@ -33,7 +34,7 @@ class EmailController
             ->addCc('cc@symfony.com')
             ->text('Bar!')
             ->html('<p>Foo</p>')
-            ->attach(file_get_contents(__FILE__), 'foobar.php')
+            ->addPart(new DataPart(file_get_contents(__FILE__), 'foobar.php'))
         );
 
         return new Response();

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class InfobipApiTransportTest extends TestCase
@@ -206,8 +207,8 @@ class InfobipApiTransportTest extends TestCase
     {
         $email = $this->basicValidEmail()
             ->text('foobar')
-            ->attach('some attachment', 'attachment.txt', 'text/plain')
-            ->embed('some inline attachment', 'inline.txt', 'text/plain')
+            ->addPart(new DataPart('some attachment', 'attachment.txt', 'text/plain'))
+            ->addPart((new DataPart('some inline attachment', 'inline.txt', 'text/plain'))->asInline())
         ;
 
         $this->transport->send($email);
@@ -320,8 +321,8 @@ class InfobipApiTransportTest extends TestCase
     {
         $email = $this->basicValidEmail()
             ->text('foobar')
-            ->attach('some attachment', 'attachment.txt', 'text/plain')
-            ->embed('some inline attachment', 'inline.txt', 'text/plain')
+            ->addPart(new DataPart('some attachment', 'attachment.txt', 'text/plain'))
+            ->addPart((new DataPart('some inline attachment', 'inline.txt', 'text/plain'))->asInline())
         ;
 
         $sentMessage = $this->transport->send($email);

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/composer.json
@@ -27,6 +27,9 @@
     "require-dev": {
         "symfony/http-client": "^6.1"
     },
+    "conflict": {
+        "symfony/mime": "<6.2"
+    },
     "autoload": {
         "psr-4": {
             "Symfony\\Component\\Mailer\\Bridge\\Infobip\\": ""

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -107,7 +108,7 @@ class SendgridApiTransportTest extends TestCase
         $email->from('foo@example.com')
             ->to('bar@example.com')
             // even if content doesn't include new lines, the base64 encoding performed later may add them
-            ->attach('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod', 'lorem.txt');
+            ->addPart(new DataPart('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod', 'lorem.txt'));
 
         $response = $this->createMock(ResponseInterface::class);
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-client": "^5.4|^6.0"
     },
+    "conflict": {
+        "symfony/mime": "<6.2"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Sendgrid\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueApiTransportTest.php
@@ -130,7 +130,6 @@ class SendinblueApiTransportTest extends TestCase
         $transport = new SendinblueApiTransport('ACCESS_KEY', $client);
         $transport->setPort(8984);
 
-        $dataPart = new DataPart('body');
         $mail = new Email();
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
@@ -140,7 +139,7 @@ class SendinblueApiTransportTest extends TestCase
             ->addCc('foo@bar.fr')
             ->addBcc('foo@bar.fr')
             ->addReplyTo('foo@bar.fr')
-            ->attachPart($dataPart)
+            ->addPart(new DataPart('body'))
         ;
 
         $message = $transport->send($mail);

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-client": "^5.4|^6.0"
     },
+    "conflict": {
+        "symfony/mime": "<6.2"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Sendinblue\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Exception\InvalidArgumentException;
+use Symfony\Component\Mime\Part\BodyFile;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\RawMessage;
 
 /**
@@ -103,7 +105,7 @@ class SmtpTransportTest extends TestCase
         $message = new Email();
         $message->to('recipient@example.org');
         $message->from('sender@example.org');
-        $message->attachFromPath('/does_not_exists');
+        $message->addPart(new DataPart(new BodyFile('/does_not_exists')));
 
         try {
             $transport->send($message);

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -31,7 +31,8 @@
     },
     "conflict": {
         "symfony/http-kernel": "<5.4",
-        "symfony/messenger": "<6.2"
+        "symfony/messenger": "<6.2",
+        "symfony/mime": "<6.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\": "" },

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -327,7 +327,7 @@ class Email extends Message
      */
     public function attach($body, string $name = null, string $contentType = null): static
     {
-        return $this->attachPart(new DataPart($body, $name, $contentType));
+        return $this->addPart(new DataPart($body, $name, $contentType));
     }
 
     /**
@@ -335,7 +335,7 @@ class Email extends Message
      */
     public function attachFromPath(string $path, string $name = null, string $contentType = null): static
     {
-        return $this->attachPart(new DataPart(new BodyFile($path), $name, $contentType));
+        return $this->addPart(new DataPart(new BodyFile($path), $name, $contentType));
     }
 
     /**
@@ -345,7 +345,7 @@ class Email extends Message
      */
     public function embed($body, string $name = null, string $contentType = null): static
     {
-        return $this->attachPart((new DataPart($body, $name, $contentType))->asInline());
+        return $this->addPart((new DataPart($body, $name, $contentType))->asInline());
     }
 
     /**
@@ -353,13 +353,25 @@ class Email extends Message
      */
     public function embedFromPath(string $path, string $name = null, string $contentType = null): static
     {
-        return $this->attachPart((new DataPart(new BodyFile($path), $name, $contentType))->asInline());
+        return $this->addPart((new DataPart(new BodyFile($path), $name, $contentType))->asInline());
+    }
+
+    /**
+     * @return $this
+     *
+     * @deprecated since Symfony 6.2, use addPart() instead
+     */
+    public function attachPart(DataPart $part): static
+    {
+        @trigger_deprecation('symfony/mime', '6.2', 'The "%s()" method is deprecated, use "addPart()" instead.', __METHOD__);
+
+        return $this->addPart($part);
     }
 
     /**
      * @return $this
      */
-    public function attachPart(DataPart $part): static
+    public function addPart(DataPart $part): static
     {
         $this->cachedBody = null;
         $this->attachments[] = $part;

--- a/src/Symfony/Component/Mime/MessageConverter.php
+++ b/src/Symfony/Component/Mime/MessageConverter.php
@@ -58,7 +58,7 @@ final class MessageConverter
                 throw new RuntimeException(sprintf('Unable to create an Email from an instance of "%s" as the body is too complex.', get_debug_type($message)));
             }
 
-            return self::attachParts($email, \array_slice($parts, 1));
+            return self::addParts($email, \array_slice($parts, 1));
         }
 
         throw new RuntimeException(sprintf('Unable to create an Email from an instance of "%s" as the body is too complex.', get_debug_type($message)));
@@ -104,17 +104,17 @@ final class MessageConverter
             throw new RuntimeException(sprintf('Unable to create an Email from an instance of "%s" as the body is too complex.', get_debug_type($message)));
         }
 
-        return self::attachParts($email, \array_slice($parts, 1));
+        return self::addParts($email, \array_slice($parts, 1));
     }
 
-    private static function attachParts(Email $email, array $parts): Email
+    private static function addParts(Email $email, array $parts): Email
     {
         foreach ($parts as $part) {
             if (!$part instanceof DataPart) {
                 throw new RuntimeException(sprintf('Unable to create an Email from an instance of "%s" as the body is too complex.', get_debug_type($email)));
             }
 
-            $email->attachPart($part);
+            $email->addPart($part);
         }
 
         return $email;

--- a/src/Symfony/Component/Mime/Tests/Crypto/SMimeSignerTest.php
+++ b/src/Symfony/Component/Mime/Tests/Crypto/SMimeSignerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Mime\Crypto\SMimeSigner;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\TextPart;
 
 /**
@@ -120,8 +121,8 @@ class SMimeSignerTest extends SMimeTestCase
         );
         $message->html('html content <img src="cid:test.gif">');
         $message->text('text content');
-        $message->attach(fopen(__DIR__.'/../Fixtures/mimetypes/test', 'r'));
-        $message->attach(fopen(__DIR__.'/../Fixtures/mimetypes/test.gif', 'r'), 'test.gif');
+        $message->addPart(new DataPart(fopen(__DIR__.'/../Fixtures/mimetypes/test', 'r')));
+        $message->addPart(new DataPart(fopen(__DIR__.'/../Fixtures/mimetypes/test.gif', 'r'), 'test.gif'));
 
         $signer = new SMimeSigner($this->samplesDir.'sign.crt', $this->samplesDir.'sign.key');
 

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\BodyFile;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
 use Symfony\Component\Mime\Part\Multipart\MixedPart;
@@ -295,7 +296,7 @@ class EmailTest extends TestCase
     {
         [$text, $html, $filePart, $file, $imagePart, $image] = $this->generateSomeParts();
         $e = (new Email())->from('me@example.com')->to('you@example.com');
-        $e->attach($file);
+        $e->addPart(new DataPart($file));
         $e->text('text content');
         $this->assertEquals(new MixedPart($text, $filePart), $e->getBody());
     }
@@ -304,7 +305,7 @@ class EmailTest extends TestCase
     {
         [$text, $html, $filePart, $file, $imagePart, $image] = $this->generateSomeParts();
         $e = (new Email())->from('me@example.com')->to('you@example.com');
-        $e->attach($file);
+        $e->addPart(new DataPart($file));
         $e->html('html content');
         $this->assertEquals(new MixedPart($html, $filePart), $e->getBody());
     }
@@ -315,7 +316,7 @@ class EmailTest extends TestCase
         $imagePart = new DataPart($image = fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'));
         $imagePart->asInline();
         $e = (new Email())->from('me@example.com')->to('you@example.com');
-        $e->embed($image);
+        $e->addPart((new DataPart($image))->asInline());
         $e->html('html content');
         $this->assertEquals(new MixedPart($html, $imagePart), $e->getBody());
     }
@@ -324,7 +325,7 @@ class EmailTest extends TestCase
     {
         [$text, $html, $filePart, $file, $imagePart, $image] = $this->generateSomeParts();
         $e = (new Email())->from('me@example.com')->to('you@example.com');
-        $e->attach($file);
+        $e->addPart(new DataPart($file));
         $this->assertEquals(new MixedPart($filePart), $e->getBody());
     }
 
@@ -333,7 +334,7 @@ class EmailTest extends TestCase
         $imagePart = new DataPart($image = fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'));
         $imagePart->asInline();
         $e = (new Email())->from('me@example.com')->to('you@example.com');
-        $e->embed($image);
+        $e->addPart((new DataPart($image))->asInline());
         $this->assertEquals(new MixedPart($imagePart), $e->getBody());
     }
 
@@ -341,7 +342,7 @@ class EmailTest extends TestCase
     {
         $imagePart = new DataPart($image = fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'));
         $e = (new Email())->from('me@example.com')->to('you@example.com');
-        $e->embed($image);
+        $e->addPart((new DataPart($image))->asInline());
         $imagePart->asInline();
         $this->assertEquals(new MixedPart($imagePart), $e->getBody());
     }
@@ -352,7 +353,7 @@ class EmailTest extends TestCase
         $e = (new Email())->from('me@example.com')->to('you@example.com');
         $e->html('html content');
         $e->text('text content');
-        $e->attach($file);
+        $e->addPart(new DataPart($file));
         $this->assertEquals(new MixedPart(new AlternativePart($text, $html), $filePart), $e->getBody());
     }
 
@@ -362,8 +363,8 @@ class EmailTest extends TestCase
         $e = (new Email())->from('me@example.com')->to('you@example.com');
         $e->html('html content');
         $e->text('text content');
-        $e->attach($file);
-        $e->attach($image, 'test.gif');
+        $e->addPart(new DataPart($file));
+        $e->addPart(new DataPart($image, 'test.gif'));
         $this->assertEquals(new MixedPart(new AlternativePart($text, $html), $filePart, $imagePart), $e->getBody());
     }
 
@@ -372,8 +373,8 @@ class EmailTest extends TestCase
         [$text, $html, $filePart, $file, $imagePart, $image] = $this->generateSomeParts();
         $e = (new Email())->from('me@example.com')->to('you@example.com');
         $e->text('text content');
-        $e->attach($file);
-        $e->attach($image, 'test.gif');
+        $e->addPart(new DataPart($file));
+        $e->addPart(new DataPart($image, 'test.gif'));
         $this->assertEquals(new MixedPart($text, $filePart, $imagePart), $e->getBody());
     }
 
@@ -383,8 +384,8 @@ class EmailTest extends TestCase
         $e = (new Email())->from('me@example.com')->to('you@example.com');
         $e->html($content = 'html content <img src="test.gif">');
         $e->text('text content');
-        $e->attach($file);
-        $e->attach($image, 'test.gif');
+        $e->addPart(new DataPart($file));
+        $e->addPart(new DataPart($image, 'test.gif'));
         $fullhtml = new TextPart($content, 'utf-8', 'html');
         $this->assertEquals(new MixedPart(new AlternativePart($text, $fullhtml), $filePart, $imagePart), $e->getBody());
     }
@@ -395,27 +396,8 @@ class EmailTest extends TestCase
         $e = (new Email())->from('me@example.com')->to('you@example.com');
         $e->html($content = 'html content <img src="cid:test.gif">');
         $e->text('text content');
-        $e->attach($file);
-        $e->attach($image, 'test.gif');
-        $body = $e->getBody();
-        $this->assertInstanceOf(MixedPart::class, $body);
-        $this->assertCount(2, $related = $body->getParts());
-        $this->assertInstanceOf(RelatedPart::class, $related[0]);
-        $this->assertEquals($filePart, $related[1]);
-        $this->assertCount(2, $parts = $related[0]->getParts());
-        $this->assertInstanceOf(AlternativePart::class, $parts[0]);
-        $generatedHtml = $parts[0]->getParts()[1];
-        $this->assertStringContainsString('cid:'.$parts[1]->getContentId(), $generatedHtml->getBody());
-    }
-
-    public function testGenerateBodyWithTextAndHtmlAndAttachedFileAndAttachedImagePartAsInlineReferencedViaCid()
-    {
-        [$text, $html, $filePart, $file, $imagePart, $image] = $this->generateSomeParts();
-        $e = (new Email())->from('me@example.com')->to('you@example.com');
-        $e->html($content = 'html content <img src="cid:test.gif">');
-        $e->text('text content');
-        $e->attach($file);
-        $e->attachPart((new DataPart($image, 'test.gif'))->asInline());
+        $e->addPart(new DataPart($file));
+        $e->addPart(new DataPart($image, 'test.gif'));
         $body = $e->getBody();
         $this->assertInstanceOf(MixedPart::class, $body);
         $this->assertCount(2, $related = $body->getParts());
@@ -439,8 +421,8 @@ class EmailTest extends TestCase
         $e->html($r);
         // embedding the same image twice results in one image only in the email
         $image = fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r');
-        $e->embed($image, 'test.gif');
-        $e->embed($image, 'test.gif');
+        $e->addPart((new DataPart($image, 'test.gif'))->asInline());
+        $e->addPart((new DataPart($image, 'test.gif'))->asInline());
         $body = $e->getBody();
         $this->assertInstanceOf(RelatedPart::class, $body);
         // 2 parts only, not 3 (text + embedded image once)
@@ -449,7 +431,7 @@ class EmailTest extends TestCase
 
         $e = (new Email())->from('me@example.com')->to('you@example.com');
         $e->html('<div background="cid:test.gif"></div>');
-        $e->embed($image, 'test.gif');
+        $e->addPart((new DataPart($image, 'test.gif'))->asInline());
         $body = $e->getBody();
         $this->assertInstanceOf(RelatedPart::class, $body);
         $this->assertCount(2, $parts = $body->getParts());
@@ -473,16 +455,16 @@ class EmailTest extends TestCase
         $att = new DataPart($file = fopen($name, 'r'), 'test');
         $inline = (new DataPart($contents, 'test'))->asInline();
         $e = new Email();
-        $e->attach($file, 'test');
-        $e->embed($contents, 'test');
+        $e->addPart(new DataPart($file, 'test'));
+        $e->addPart((new DataPart($contents, 'test'))->asInline());
         $this->assertEquals([$att, $inline], $e->getAttachments());
 
         // inline part from path
         $att = DataPart::fromPath($name, 'test');
         $inline = DataPart::fromPath($name, 'test')->asInline();
         $e = new Email();
-        $e->attachFromPath($name);
-        $e->embedFromPath($name);
+        $e->addPart(new DataPart(new BodyFile($name)));
+        $e->addPart((new DataPart(new BodyFile($name)))->asInline());
         $this->assertEquals([$att->bodyToString(), $inline->bodyToString()], array_map(function (DataPart $a) { return $a->bodyToString(); }, $e->getAttachments()));
         $this->assertEquals([$att->getPreparedHeaders(), $inline->getPreparedHeaders()], array_map(function (DataPart $a) { return $a->getPreparedHeaders(); }, $e->getAttachments()));
     }
@@ -500,7 +482,7 @@ class EmailTest extends TestCase
         $e->html($r);
         $name = __DIR__.'/Fixtures/mimetypes/test';
         $file = fopen($name, 'r');
-        $e->attach($file, 'test');
+        $e->addPart(new DataPart($file, 'test'));
         $expected = clone $e;
         $n = unserialize(serialize($e));
         $this->assertEquals($expected->getHeaders(), $n->getHeaders());
@@ -516,7 +498,7 @@ class EmailTest extends TestCase
         $e->to('you@example.com');
         $e->text('Text content');
         $e->html('HTML <b>content</b>');
-        $e->attach('Some Text file', 'test.txt');
+        $e->addPart(new DataPart('Some Text file', 'test.txt'));
         $expected = clone $e;
 
         $expectedJson = <<<EOF
@@ -590,22 +572,6 @@ EOF;
         $e = new Email();
         $emailHeaderSame = new EmailHeaderSame('foo', 'bar');
         $emailHeaderSame->evaluate($e);
-    }
-
-    public function testAttachBodyExpectStringOrResource()
-    {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('The body of "Symfony\Component\Mime\Part\TextPart" must be a string, a resource, or an instance of "Symfony\Component\Mime\Part\BodyFile" (got "bool").');
-
-        (new Email())->attach(false);
-    }
-
-    public function testEmbedBodyExpectStringOrResource()
-    {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('The body of "Symfony\Component\Mime\Part\TextPart" must be a string, a resource, or an instance of "Symfony\Component\Mime\Part\BodyFile" (got "bool").');
-
-        (new Email())->embed(false);
     }
 
     public function testHtmlBodyExpectStringOrResourceOrNull()

--- a/src/Symfony/Component/Mime/Tests/MessageConverterTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\MessageConverter;
+use Symfony\Component\Mime\Part\DataPart;
 
 class MessageConverterTest extends TestCase
 {
@@ -33,34 +34,34 @@ class MessageConverterTest extends TestCase
         $this->assertConversion((clone $email)
             ->text('text content')
             ->html('HTML content <img src="cid:test.jpg" />')
-            ->embed($file, 'test.jpg', 'image/gif')
+            ->addPart((new DataPart($file, 'test.jpg', 'image/gif'))->asInline())
         );
         $this->assertConversion((clone $email)
             ->text('text content')
             ->html('HTML content <img src="cid:test.jpg" />')
-            ->attach($file, 'test_attached.jpg', 'image/gif')
+            ->addPart(new DataPart($file, 'test_attached.jpg', 'image/gif'))
         );
         $this->assertConversion((clone $email)
             ->text('text content')
             ->html('HTML content <img src="cid:test.jpg" />')
-            ->embed($file, 'test.jpg', 'image/gif')
-            ->attach($file, 'test_attached.jpg', 'image/gif')
+            ->addPart((new DataPart($file, 'test.jpg', 'image/gif'))->asInline())
+            ->addPart(new DataPart($file, 'test_attached.jpg', 'image/gif'))
         );
         $this->assertConversion((clone $email)
             ->text('text content')
-            ->attach($file, 'test_attached.jpg', 'image/gif')
+            ->addPart(new DataPart($file, 'test_attached.jpg', 'image/gif'))
         );
         $this->assertConversion((clone $email)
             ->html('HTML content <img src="cid:test.jpg" />')
-            ->attach($file, 'test_attached.jpg', 'image/gif')
+            ->addPart(new DataPart($file, 'test_attached.jpg', 'image/gif'))
         );
         $this->assertConversion((clone $email)
             ->html('HTML content <img src="cid:test.jpg" />')
-            ->embed($file, 'test.jpg', 'image/gif')
+            ->addPart((new DataPart($file, 'test.jpg', 'image/gif'))->asInline())
         );
         $this->assertConversion((clone $email)
             ->text('text content')
-            ->embed($file, 'test_attached.jpg', 'image/gif')
+            ->addPart((new DataPart($file, 'test_attached.jpg', 'image/gif'))->asInline())
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | -

#47462 follow-up
