### PR TITLE
[Validator] Unique should support objects fields

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -12,9 +12,11 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\LogicException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
@@ -100,9 +102,12 @@ class UniqueValidator extends ConstraintValidator
         return $output;
     }
 
-    private function getPropertyAccessor(): PropertyAccessorInterface
+    private function getPropertyAccessor(): PropertyAccessor
     {
         if (null === $this->propertyAccessor) {
+            if (!class_exists(PropertyAccess::class)) {
+                throw new LogicException('Unable to use property path as the Symfony PropertyAccess component is not installed.');
+            }
             $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
         }
 

--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -21,6 +23,13 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
  */
 class UniqueValidator extends ConstraintValidator
 {
+    private ?PropertyAccessorInterface $propertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $propertyAccessor = null)
+    {
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
     public function validate(mixed $value, Constraint $constraint)
     {
         if (!$constraint instanceof Unique) {
@@ -69,18 +78,34 @@ class UniqueValidator extends ConstraintValidator
         return $unique->normalizer;
     }
 
-    private function reduceElementKeys(array $fields, array $element): array
+    private function reduceElementKeys(array $fields, array|object $element): array
     {
         $output = [];
         foreach ($fields as $field) {
             if (!\is_string($field)) {
                 throw new UnexpectedTypeException($field, 'string');
             }
-            if (isset($element[$field])) {
-                $output[$field] = $element[$field];
+
+            // For no BC, because PropertyAccessor require brackets for array keys
+            // Previous implementation, only check in array
+            if (\is_array($element) && !str_contains($field, '[')) {
+                $field = "[{$field}]";
+            }
+
+            if (null !== $value = $this->getPropertyAccessor()->getValue($element, $field)) {
+                $output[$field] = $value;
             }
         }
 
         return $output;
+    }
+
+    private function getPropertyAccessor(): PropertyAccessorInterface
+    {
+        if (null === $this->propertyAccessor) {
+            $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        }
+
+        return $this->propertyAccessor;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -280,6 +280,10 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
                 ['id' => 1, 'email' => 'bar@email.com'],
                 ['id' => 1, 'email' => 'foo@email.com'],
             ], ['id']],
+            'unique string sub array' => [[
+                ['id' => 1, 'translation' => ['lang' => 'eng', 'translation' => 'hi']],
+                ['id' => 2, 'translation' => ['lang' => 'eng', 'translation' => 'hello']],
+            ], ['[translation][lang]']],
             'unique string attribute' => [[
                 (object) ['lang' => 'eng', 'translation' => 'hi'],
                 (object) ['lang' => 'eng', 'translation' => 'hello'],
@@ -293,6 +297,10 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
                 (object) ['id' => 1, 'email' => 'bar@email.com'],
                 (object) ['id' => 1, 'email' => 'foo@email.com'],
             ], ['id']],
+            'unique string sub object attribute' => [[
+                (object) ['id' => 1, 'translation' => (object) ['lang' => 'eng', 'translation' => 'hi']],
+                (object) ['id' => 2, 'translation' => (object) ['lang' => 'eng', 'translation' => 'hello']],
+            ], ['translation.lang']],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -280,6 +280,19 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
                 ['id' => 1, 'email' => 'bar@email.com'],
                 ['id' => 1, 'email' => 'foo@email.com'],
             ], ['id']],
+            'unique string attribute' => [[
+                (object) ['lang' => 'eng', 'translation' => 'hi'],
+                (object) ['lang' => 'eng', 'translation' => 'hello'],
+            ], ['lang']],
+            'unique float attribute' => [[
+                (object) ['latitude' => 51.509865, 'longitude' => -0.118092, 'poi' => 'capital'],
+                (object) ['latitude' => 52.520008, 'longitude' => 13.404954],
+                (object) ['latitude' => 51.509865, 'longitude' => -0.118092],
+            ], ['latitude', 'longitude']],
+            'unique int attribute' => [[
+                (object) ['id' => 1, 'email' => 'bar@email.com'],
+                (object) ['id' => 1, 'email' => 'foo@email.com'],
+            ], ['id']],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The Unique validator have a `fields` options, to define which `fields` of an array should be compared (if not set, the entire object or array is compared).

But the `fields` option do not work if we defined object attributes (not the original implementation behavior), but should be logic to work with array and object.
