### PR TITLE
[Form] Removing self-closing slash from `<input>`

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -14,7 +14,7 @@
         {# Attribute "required" is not supported #}
         {%- set required = false -%}
     {%- endif -%}
-    <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+    <input type="{{ type }}" {{ block('widget_attributes') }}{% if value is not empty %} value="{{ value }}"{% endif %}>
 {%- endblock form_widget_simple -%}
 
 {%- block form_widget_compound -%}
@@ -91,11 +91,11 @@
 {%- endblock choice_widget_options -%}
 
 {%- block checkbox_widget -%}
-    <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}>
 {%- endblock checkbox_widget -%}
 
 {%- block radio_widget -%}
-    <input type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    <input type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}>
 {%- endblock radio_widget -%}
 
 {%- block datetime_widget -%}
@@ -402,7 +402,7 @@
     {%- endif -%}
     <form{% if name != '' %} name="{{ name }}"{% endif %} method="{{ form_method|lower }}"{% if action != '' %} action="{{ action }}"{% endif %}{{ block('attributes') }}{% if multipart %} enctype="multipart/form-data"{% endif %}>
     {%- if form_method != method -%}
-        <input type="hidden" name="_method" value="{{ method }}" />
+        <input type="hidden" name="_method" value="{{ method }}">
     {%- endif -%}
 {%- endblock form_start -%}
 
@@ -440,7 +440,7 @@
         {%- endif -%}
 
         {%- if form_method != method -%}
-            <input type="hidden" name="_method" value="{{ method }}" />
+            <input type="hidden" name="_method" value="{{ method }}">
         {%- endif -%}
     {% endif -%}
 {% endblock form_rest %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
@@ -2772,7 +2772,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
         $html = $this->renderWidget($form->createView());
 
         // compare plain HTML to check the whitespace
-        $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" readonly="readonly" maxlength="10" pattern="\d+" class="foobar form-control" data-foo="bar" value="value" />', $html);
+        $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" readonly="readonly" maxlength="10" pattern="\d+" class="foobar form-control" data-foo="bar" value="value">', $html);
     }
 
     public function testWidgetAttributeNameRepeatedIfTrue()
@@ -2784,7 +2784,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
         $html = $this->renderWidget($form->createView());
 
         // foo="foo"
-        $this->assertSame('<input type="text" id="text" name="text" required="required" foo="foo" class="form-control" value="value" />', $html);
+        $this->assertSame('<input type="text" id="text" name="text" required="required" foo="foo" class="form-control" value="value">', $html);
     }
 
     public function testButtonAttributes()

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -72,6 +72,9 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
     protected function assertMatchesXpath($html, $expression, $count = 1)
     {
         $dom = new \DOMDocument('UTF-8');
+
+        $html = preg_replace('/(<input [^>]+)(?<!\/)>/', '$1/>', $html);
+
         try {
             // Wrap in <root> node so we can load HTML with multiple tags at
             // the top level
@@ -2511,7 +2514,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
         $html = $this->renderWidget($form->createView());
 
         // compare plain HTML to check the whitespace
-        $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" readonly="readonly" maxlength="10" pattern="\d+" class="foobar" data-foo="bar" value="value" />', $html);
+        $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" readonly="readonly" maxlength="10" pattern="\d+" class="foobar" data-foo="bar" value="value">', $html);
     }
 
     public function testWidgetAttributeNameRepeatedIfTrue()
@@ -2523,7 +2526,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
         $html = $this->renderWidget($form->createView());
 
         // foo="foo"
-        $this->assertSame('<input type="text" id="text" name="text" required="required" foo="foo" value="value" />', $html);
+        $this->assertSame('<input type="text" id="text" name="text" required="required" foo="foo" value="value">', $html);
     }
 
     public function testWidgetAttributeHiddenIfFalse()

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme.html.twig
@@ -1,4 +1,4 @@
 {% block form_widget_simple %}
     {%- set type = type|default('text') -%}
-    <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" rel="theme" />
+    <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" rel="theme">
 {%- endblock form_widget_simple %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme_extends.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme_extends.html.twig
@@ -2,5 +2,5 @@
 
 {% block form_widget_simple %}
     {%- set type = type|default('text') -%}
-    <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" rel="theme" />
+    <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" rel="theme">
 {%- endblock form_widget_simple %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme_use.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme_use.html.twig
@@ -2,5 +2,5 @@
 
 {% block form_widget_simple %}
     {%- set type = type|default('text') -%}
-    <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" rel="theme" />
+    <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" rel="theme">
 {%- endblock form_widget_simple %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -97,7 +97,7 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTestCase
         $this->assertSame(<<<'HTML'
 <div class="input-group">
                             <span class="input-group-addon">&euro; </span>
-            <input type="text" id="name" name="name" required="required" class="form-control" />        </div>
+            <input type="text" id="name" name="name" required="required" class="form-control">        </div>
 HTML
             , trim($this->renderWidget($view)));
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -102,7 +102,7 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTestCase
         $this->assertSame(<<<'HTML'
 <div class="input-group "><div class="input-group-prepend">
                     <span class="input-group-text">&euro; </span>
-                </div><input type="text" id="name" name="name" required="required" class="form-control" /></div>
+                </div><input type="text" id="name" name="name" required="required" class="form-control"></div>
 HTML
             , trim($this->renderWidget($view)));
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
@@ -101,7 +101,7 @@ class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTestCase
             ->createView();
 
         self::assertSame(<<<'HTML'
-<div class="input-group "><span class="input-group-text">&euro; </span><input type="text" id="name" name="name" required="required" class="form-control" /></div>
+<div class="input-group "><span class="input-group-text">&euro; </span><input type="text" id="name" name="name" required="required" class="form-control"></div>
 HTML
             , trim($this->renderWidget($view)));
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -184,7 +184,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
             ->createView()
         ;
 
-        $this->assertSame('&euro; <input type="text" id="name" name="name" required="required" />', $this->renderWidget($view));
+        $this->assertSame('&euro; <input type="text" id="name" name="name" required="required">', $this->renderWidget($view));
     }
 
     public function testHelpAttr()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Resources/views/Login/after_login.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Resources/views/Login/after_login.html.twig
@@ -1,8 +1,8 @@
 {% extends "base.html.twig" %}
 
 {% block body %}
-    Hello {{ app.user.userIdentifier }}!<br /><br />
-    You're browsing to path "{{ app.request.pathInfo }}".<br /><br />
+    Hello {{ app.user.userIdentifier }}!<br><br>
+    You're browsing to path "{{ app.request.pathInfo }}".<br><br>
     <a href="{{ logout_path('default') }}">Log out</a>.
     <a href="{{ logout_url('default') }}">Log out</a>.
 {% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Resources/views/Login/login.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Resources/views/Login/login.html.twig
@@ -6,7 +6,7 @@
         {{ form_widget(form) }}
 
         {# Note: ensure the submit name does not conflict with the form's name or it may clobber field data #}
-        <input type="submit" name="login" />
+        <input type="submit" name="login">
     </form>
 
 {% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Localized/login.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Localized/login.html.twig
@@ -8,14 +8,14 @@
 
     <form action="{{ path('localized_check_path') }}" method="post">
         <label for="username">Username:</label>
-        <input type="text" id="username" name="_username" value="{{ last_username }}" />
+        <input type="text" id="username" name="_username" value="{{ last_username }}">
 
         <label for="password">Password:</label>
-        <input type="password" id="password" name="_password" />
+        <input type="password" id="password" name="_password">
 
-        <input type="hidden" name="_target_path" value="" />
+        <input type="hidden" name="_target_path" value="">
 
-        <input type="submit" name="login" />
+        <input type="submit" name="login">
     </form>
 
 {% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/after_login.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/after_login.html.twig
@@ -1,7 +1,7 @@
 {% extends "base.html.twig" %}
 
 {% block body %}
-    Hello {{ user.userIdentifier }}!<br /><br />
+    Hello {{ user.userIdentifier }}!<br><br>
     You're browsing to path "{{ app.request.pathInfo }}".
 
     <a href="{{ logout_path('default') }}">Log out</a>.

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/login.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/login.html.twig
@@ -9,14 +9,14 @@
 
     <form action="{{ path('form_login_check') }}" method="post">
         <label for="username">Username:</label>
-        <input type="text" id="username" name="_username" value="{{ last_username }}" />
+        <input type="text" id="username" name="_username" value="{{ last_username }}">
 
         <label for="password">Password:</label>
-        <input type="password" id="password" name="_password" />
+        <input type="password" id="password" name="_password">
 
-        <input type="hidden" name="_target_path" value="" />
+        <input type="hidden" name="_target_path" value="">
 
-        <input type="submit" name="login" />
+        <input type="submit" name="login">
     </form>
 
 {% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/templates/base.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/templates/base.html.twig
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="{{ _charset }}" />
+        <meta charset="{{ _charset }}">
         <title>{% block title %}Welcome!{% endblock %}</title>
         {% block stylesheets %}{% endblock %}
     </head>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
@@ -134,11 +134,11 @@
                                                     <h3 class="tab-title">Notification</h3>
                                                     <div class="tab-content">
                                                         <pre class="prewrap" style="max-height: 600px">
-                                                            {{- 'Subject: ' ~ notification.getSubject() }}<br/>
-                                                            {{- 'Content: ' ~ notification.getContent() }}<br/>
-                                                            {{- 'Importance: ' ~ notification.getImportance() }}<br/>
-                                                            {{- 'Emoji: ' ~ (notification.getEmoji() is empty ? '(empty)' : notification.getEmoji()) }}<br/>
-                                                            {{- 'Exception: ' ~ notification.getException() ?? '(empty)' }}<br/>
+                                                            {{- 'Subject: ' ~ notification.getSubject() }}<br>
+                                                            {{- 'Content: ' ~ notification.getContent() }}<br>
+                                                            {{- 'Importance: ' ~ notification.getImportance() }}<br>
+                                                            {{- 'Emoji: ' ~ (notification.getEmoji() is empty ? '(empty)' : notification.getEmoji()) }}<br>
+                                                            {{- 'Exception: ' ~ notification.getException() ?? '(empty)' }}<br>
                                                             {{- 'ExceptionAsString: ' ~ (notification.getExceptionAsString() is empty ? '(empty)' : notification.getExceptionAsString()) }}
                                                         </pre>
                                                     </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="{{ _charset }}" />
-        <meta name="robots" content="noindex,nofollow" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta charset="{{ _charset }}">
+        <meta name="robots" content="noindex,nofollow">
+        <meta name="viewport" content="width=device-width,initial-scale=1">
         <title>{% block title %}Symfony Profiler{% endblock %}</title>
 
         {% set request_collector = profile is defined ? profile.collectors.request|default(null) : null %}

--- a/src/Symfony/Component/ErrorHandler/Resources/views/error.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/error.html.php
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="<?= $this->charset; ?>" />
-    <meta name="robots" content="noindex,nofollow,noarchive" />
+    <meta charset="<?= $this->charset; ?>">
+    <meta name="robots" content="noindex,nofollow,noarchive">
     <title>An Error Occurred: <?= $statusText; ?></title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>❌</text></svg>">
     <style><?= $this->include('assets/css/error.css'); ?></style>

--- a/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
@@ -2,9 +2,9 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="<?= $this->charset; ?>" />
-        <meta name="robots" content="noindex,nofollow" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta charset="<?= $this->charset; ?>">
+        <meta name="robots" content="noindex,nofollow">
+        <meta name="viewport" content="width=device-width,initial-scale=1">
         <title><?= $_message; ?></title>
         <link rel="icon" type="image/png" href="<?= $this->include('assets/images/favicon.png.base64'); ?>">
         <style><?= $this->include('assets/css/exception.css'); ?></style>

--- a/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
+++ b/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
 <head>
-    <meta charset="UTF-8" />
-    <meta name="robots" content="noindex,nofollow,noarchive,nosnippet,noodp,notranslate,noimageindex" />
+    <meta charset="UTF-8">
+    <meta name="robots" content="noindex,nofollow,noarchive,nosnippet,noodp,notranslate,noimageindex">
     <title>Welcome to Symfony!</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>👋</text></svg>">
     <style>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | kinda
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

Switching form template from XHTML to HTML5 syntax.

https://validator.w3.org/nu/ says:

> Warning: Self-closing tag syntax in text/html documents is [widely discouraged](https://google.github.io/styleguide/htmlcssguide.html#Document_Type); it’s unnecessary and [interacts badly with other HTML features](https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=10809) (e.g., unquoted attribute values). If you’re using a tool that injects self-closing tag syntax into all void elements, [without any option to prevent it from doing so](https://github.com/prettier/prettier/issues/5246), then consider switching to a different tool.

I haven't searched for other occurrences; waiting for some feedback first.
