### PR TITLE
[Notifier] Use local copy of stella-maris/clock when testing

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Find packages
         id: find-packages
-        run: echo "::set-output name=packages::$(php .github/get-modified-packages.php $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n' | jq -R -s -c 'split("\n")[:-1]') $(git diff --name-only origin/${{ github.base_ref }} HEAD | grep src/ | jq -R -s -c 'split("\n")[:-1]'))"
+        run: echo "::set-output name=packages::$(php .github/get-modified-packages.php $(find src/Symfony -mindepth 2 -maxdepth 6 -type f -name composer.json -printf '%h\n' | jq -R -s -c 'split("\n")[:-1]') $(git diff --name-only origin/${{ github.base_ref }} HEAD | grep src/ | jq -R -s -c 'split("\n")[:-1]'))"
 
       - name: Verify meta files are correct
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,7 +94,7 @@ jobs:
             echo SYMFONY_DEPRECATIONS_HELPER=weak >> $GITHUB_ENV
             cp composer.json composer.json.orig
             echo -e '{\n"require":{'"$(grep phpunit-bridge composer.json)"'"php":"*"},"minimum-stability":"dev"}' > composer.json
-            php .github/build-packages.php HEAD^ $SYMFONY_VERSION $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n')
+            php .github/build-packages.php HEAD^ $SYMFONY_VERSION $(find src/Symfony -mindepth 2 -maxdepth 6 -type f -name composer.json -printf '%h\n')
             mv composer.json composer.json.phpunit
             mv composer.json.orig composer.json
           fi

--- a/composer.json
+++ b/composer.json
@@ -204,6 +204,15 @@
         {
             "type": "path",
             "url": "src/Symfony/Component/Runtime"
+        },
+        {
+            "type": "path",
+            "url": "src/Symfony/Component/Notifier/Bridge/Mercure/Tests/stella-maris-clock",
+            "options": {
+                "versions": {
+                    "stella-maris/clock": "0.1.x-dev"
+                }
+            }
         }
     ],
     "minimum-stability": "dev"

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/stella-maris-clock/ClockInterface.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/stella-maris-clock/ClockInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright Andreas Heigl <andreas@heigl.org> and ClockInterfaceContributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ */
+
+namespace StellaMaris\Clock;
+
+use DateTimeImmutable;
+
+interface ClockInterface
+{
+	/**
+	 * Return the current point in time as a DateTimeImmutable object
+	 */
+	public function now() : DateTimeImmutable;
+}

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/stella-maris-clock/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/stella-maris-clock/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "stella-maris/clock",
+    "description": "A local fork to workaround gitlab failing to serve the package reliably",
+    "homepage": "https://gitlab.com/stella-maris/clock",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Andreas Heigl",
+            "role": "Maintainer"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "StellaMaris\\Clock\\": ""
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
@@ -28,5 +28,16 @@
             "/Tests/"
         ]
     },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "Tests/stella-maris-clock",
+            "options": {
+                "versions": {
+                    "stella-maris/clock": "0.1.x-dev"
+                }
+            }
+        }
+    ],
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Our CI fails too often because gitlab fails to serve the package.

See also https://gitlab.com/stella-maris/clock/-/issues/2 but let's not wait for this to resolved.