### PR TITLE
[Console] [WIP]  Handle case where user tries to complete more arguments than there are available

### DIFF
--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -109,6 +109,7 @@ final class CompletionInput extends ArgvInput
         // complete argument value
         $this->completionType = self::TYPE_ARGUMENT_VALUE;
 
+        $acceptedIndex = 0;
         foreach ($this->definition->getArguments() as $argumentName => $argument) {
             if (!isset($this->arguments[$argumentName])) {
                 break;
@@ -118,8 +119,10 @@ final class CompletionInput extends ArgvInput
             $this->completionName = $argumentName;
             if (\is_array($argumentValue)) {
                 $this->completionValue = $argumentValue ? $argumentValue[array_key_last($argumentValue)] : null;
+                $acceptedIndex += \count($argumentValue);
             } else {
                 $this->completionValue = $argumentValue;
+                ++$acceptedIndex;
             }
         }
 
@@ -133,6 +136,15 @@ final class CompletionInput extends ArgvInput
                 $this->completionName = null;
                 $this->completionValue = '';
             }
+
+            return;
+        }
+
+        if ($this->currentIndex > $acceptedIndex) {
+            // edge case: the user is trying to complete more arguments than the command accepts, stop suggesting anything
+            $this->completionType = self::TYPE_NONE;
+            $this->completionName = null;
+            $this->completionValue = '';
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
@@ -72,6 +72,7 @@ class CompletionInputTest extends TestCase
 
         // end of definition
         yield 'end' => [CompletionInput::fromTokens(['bin/console', 'symfony', 'sensiolabs'], 3), CompletionInput::TYPE_NONE, null, ''];
+        yield 'end-with-value' => [CompletionInput::fromTokens(['bin/console', 'symfony', 'sensiolabs', 'am'], 3), CompletionInput::TYPE_NONE, null, ''];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Related to #47432
| License       | MIT
| Doc PR        | n/a

Imagine a command with 1 argument. If the user tried to complete 2 arguments (e.g. `bin/console some:cmd first sec|`), the current CompletionInput will always suggest new values for the first argument.

This PR fixes it by taking a count of the accepted tokens. If there are less tokens accepted then provided, the user is doing something bad (providing too many arguments) and we should stop providing suggestions.

This fix is required for https://github.com/symfony/symfony/pull/47432 to work correctly.
