### PR TITLE
[TwigBridge] Avoid double render when an exception is thrown in !debug

### DIFF
--- a/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
+++ b/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
@@ -41,17 +41,17 @@ class TwigErrorRenderer implements ErrorRendererInterface
 
     public function render(\Throwable $exception): FlattenException
     {
-        $exception = $this->fallbackErrorRenderer->render($exception);
-        $debug = \is_bool($this->debug) ? $this->debug : ($this->debug)($exception);
+        $flattenException = FlattenException::createFromThrowable($exception);
+        $debug = \is_bool($this->debug) ? $this->debug : ($this->debug)($flattenException);
 
-        if ($debug || !$template = $this->findTemplate($exception->getStatusCode())) {
-            return $exception;
+        if ($debug || !$template = $this->findTemplate($flattenException->getStatusCode())) {
+            return $this->fallbackErrorRenderer->render($exception);
         }
 
-        return $exception->setAsString($this->twig->render($template, [
-            'exception' => $exception,
-            'status_code' => $exception->getStatusCode(),
-            'status_text' => $exception->getStatusText(),
+        return $flattenException->setAsString($this->twig->render($template, [
+            'exception' => $flattenException,
+            'status_code' => $flattenException->getStatusCode(),
+            'status_text' => $flattenException->getStatusText(),
         ]));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

In !debug, the error is rendered a first time in `TwigErrorRenderer::render()`
via `$exception = $this->fallbackErrorRenderer->render($exception);` But
in !debug, the error is rendered another time with twig.
