### PR TITLE
[HttpFoundation] Fix BinaryFileResponse content type detection logic

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -201,9 +201,9 @@ class BinaryFileResponse extends Response
      */
     public function prepare(Request $request)
     {
-        parent::prepare($request);
-
         if ($this->isInformational() || $this->isEmpty()) {
+            parent::prepare($request);
+
             $this->maxlen = 0;
 
             return $this;
@@ -212,6 +212,8 @@ class BinaryFileResponse extends Response
         if (!$this->headers->has('Content-Type')) {
             $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');
         }
+
+        parent::prepare($request);
 
         $this->offset = 0;
         $this->maxlen = -1;

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -388,6 +388,32 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertFalse($response->headers->has('Content-Type'));
     }
 
+    public function testContentTypeIsCorrectlyDetected()
+    {
+        $response = new BinaryFileResponse(__DIR__.'/File/Fixtures/test.gif');
+
+        $request = Request::create('/');
+        $response->prepare($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/gif', $response->headers->get('Content-Type'));
+    }
+
+    public function testContentTypeIsNotGuessedWhenTheFileWasNotModified()
+    {
+        $response = new BinaryFileResponse(__DIR__.'/File/Fixtures/test.gif');
+        $response->setAutoLastModified();
+
+        $request = Request::create('/');
+        $request->headers->set('If-Modified-Since', $response->getLastModified()->format('D, d M Y H:i:s').' GMT');
+        $isNotModified = $response->isNotModified($request);
+        $this->assertTrue($isNotModified);
+        $response->prepare($request);
+
+        $this->assertSame(304, $response->getStatusCode());
+        $this->assertFalse($response->headers->has('Content-Type'));
+    }
+
     protected function provideResponse()
     {
         return new BinaryFileResponse(__DIR__.'/../README.md', 200, ['Content-Type' => 'application/octet-stream']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I've just upgraded to 5.4.13 (from 5.4.8) and a lot of my tests started failing. Upon further debugging I've found the issue to be caused by https://github.com/symfony/symfony/pull/47516

Prior to that PR

```php
        if (!$this->headers->has('Content-Type')) {
            $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');
        }
```

was called before the `parent::prepare($request);` call.

After that PR `parent::prepare($request);` was called first and that would call

```php
            // Content-type based on the Request
            if (!$headers->has('Content-Type')) {
                $format = $request->getRequestFormat(null);
                if (null !== $format && $mimeType = $request->getMimeType($format)) {
                    $headers->set('Content-Type', $mimeType);
                }
            }
```

which would set the content type from the request so by the time 


```php
        if (!$this->headers->has('Content-Type')) {
            $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');
        }
```

is executed again in the BinaryFileResponse `prepare` method that `if` statement never evaluates to `true` because the `Content-Type` header was already set (to the wrong one).

This PR fixes this issue by making sure the order of the method calls is correct.