### PR TITLE
Leverage class name literal on object

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -77,7 +77,7 @@ class DoctrineExtensionTest extends TestCase
             'SecondBundle' => 'My\SecondBundle',
         ];
 
-        $reflection = new \ReflectionClass(\get_class($this->extension));
+        $reflection = new \ReflectionClass($this->extension);
         $method = $reflection->getMethod('fixManagersAutoMappings');
 
         $method->invoke($this->extension, $emConfigs, $bundles);
@@ -165,7 +165,7 @@ class DoctrineExtensionTest extends TestCase
             'SecondBundle' => 'My\SecondBundle',
         ];
 
-        $reflection = new \ReflectionClass(\get_class($this->extension));
+        $reflection = new \ReflectionClass($this->extension);
         $method = $reflection->getMethod('fixManagersAutoMappings');
 
         $newEmConfigs = $method->invoke($this->extension, $emConfigs, $bundles);
@@ -182,7 +182,7 @@ class DoctrineExtensionTest extends TestCase
     {
         $container = $this->createContainer();
 
-        $reflection = new \ReflectionClass(\get_class($this->extension));
+        $reflection = new \ReflectionClass($this->extension);
         $method = $reflection->getMethod('detectMappingType');
 
         // The ordinary fixtures contain annotation
@@ -326,7 +326,7 @@ class DoctrineExtensionTest extends TestCase
 
         $container = $this->createContainer([], [$bundle => $bundleClassName]);
 
-        $reflection = new \ReflectionClass(\get_class($this->extension));
+        $reflection = new \ReflectionClass($this->extension);
         $method = $reflection->getMethod('getMappingDriverBundleConfigDefaults');
 
         $this->assertSame(

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -328,7 +328,7 @@ class JsonDescriptor extends Descriptor
 
             if (\is_object($callable[0])) {
                 $data['name'] = $callable[1];
-                $data['class'] = \get_class($callable[0]);
+                $data['class'] = $callable[0]::class;
             } else {
                 if (!str_starts_with($callable[1], 'parent::')) {
                     $data['name'] = $callable[1];

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -345,7 +345,7 @@ class MarkdownDescriptor extends Descriptor
 
             if (\is_object($callable[0])) {
                 $string .= "\n".sprintf('- Name: `%s`', $callable[1]);
-                $string .= "\n".sprintf('- Class: `%s`', \get_class($callable[0]));
+                $string .= "\n".sprintf('- Class: `%s`', $callable[0]::class);
             } else {
                 if (!str_starts_with($callable[1], 'parent::')) {
                     $string .= "\n".sprintf('- Name: `%s`', $callable[1]);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -602,7 +602,7 @@ class TextDescriptor extends Descriptor
     {
         if (\is_array($callable)) {
             if (\is_object($callable[0])) {
-                return sprintf('%s::%s()', \get_class($callable[0]), $callable[1]);
+                return sprintf('%s::%s()', $callable[0]::class, $callable[1]);
             }
 
             return sprintf('%s::%s()', $callable[0], $callable[1]);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -523,7 +523,7 @@ class XmlDescriptor extends Descriptor
 
             if (\is_object($callable[0])) {
                 $callableXML->setAttribute('name', $callable[1]);
-                $callableXML->setAttribute('class', \get_class($callable[0]));
+                $callableXML->setAttribute('class', $callable[0]::class);
             } else {
                 if (!str_starts_with($callable[1], 'parent::')) {
                     $callableXML->setAttribute('name', $callable[1]);

--- a/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
@@ -230,7 +230,7 @@ EOF
     {
         if (\is_array($callable)) {
             if (\is_object($callable[0])) {
-                return sprintf('%s::%s()', \get_class($callable[0]), $callable[1]);
+                return sprintf('%s::%s()', $callable[0]::class, $callable[1]);
             }
 
             return sprintf('%s::%s()', $callable[0], $callable[1]);

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -145,7 +145,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
             foreach ($decisionLog as $key => $log) {
                 $decisionLog[$key]['voter_details'] = [];
                 foreach ($log['voterDetails'] as $voterDetail) {
-                    $voterClass = \get_class($voterDetail['voter']);
+                    $voterClass = $voterDetail['voter']::class;
                     $classData = $this->hasVarDumper ? new ClassStub($voterClass) : $voterClass;
                     $decisionLog[$key]['voter_details'][] = [
                         'class' => $classData,

--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -134,12 +134,12 @@ final class CompleteCommand extends Command
                 $completionInput->bind($command->getDefinition());
 
                 if (CompletionInput::TYPE_OPTION_NAME === $completionInput->getCompletionType()) {
-                    $this->log('  Completing option names for the <comment>'.\get_class($command instanceof LazyCommand ? $command->getCommand() : $command).'</> command.');
+                    $this->log('  Completing option names for the <comment>'.($command instanceof LazyCommand ? $command->getCommand() : $command)::class.'</> command.');
 
                     $suggestions->suggestOptions($command->getDefinition()->getOptions());
                 } else {
                     $this->log([
-                        '  Completing using the <comment>'.\get_class($command instanceof LazyCommand ? $command->getCommand() : $command).'</> class.',
+                        '  Completing using the <comment>'.($command instanceof LazyCommand ? $command->getCommand() : $command)::class.'</> class.',
                         '  Completing <comment>'.$completionInput->getCompletionType().'</> for <comment>'.$completionInput->getCompletionName().'</>',
                     ]);
                     if (null !== $compval = $completionInput->getCompletionValue()) {

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -922,7 +922,7 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->register('foo')->setCode(function () {
-            throw new \InvalidArgumentException(sprintf('Dummy type "%s" is invalid.', \get_class(new class() { })));
+            throw new \InvalidArgumentException(sprintf('Dummy type "%s" is invalid.', (new class() { })::class));
         });
         $tester = new ApplicationTester($application);
 
@@ -948,7 +948,7 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->register('foo')->setCode(function () {
-            throw new \InvalidArgumentException(sprintf('Dummy type "%s" is invalid.', \get_class(new class() { })));
+            throw new \InvalidArgumentException(sprintf('Dummy type "%s" is invalid.', (new class() { })::class));
         });
         $tester = new ApplicationTester($application);
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -174,7 +174,7 @@ class GraphvizDumper extends Dumper
             }
 
             if (!$container->hasDefinition($id)) {
-                $nodes[$id] = ['class' => str_replace('\\', '\\\\', \get_class($container->get($id))), 'attributes' => $this->options['node.instance']];
+                $nodes[$id] = ['class' => str_replace('\\', '\\\\', $container->get($id)::class), 'attributes' => $this->options['node.instance']];
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
@@ -87,7 +87,7 @@ class ServiceLocator implements ServiceProviderInterface, \Countable
         }
 
         $class = debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT | \DEBUG_BACKTRACE_IGNORE_ARGS, 4);
-        $class = isset($class[3]['object']) ? \get_class($class[3]['object']) : null;
+        $class = isset($class[3]['object']) ? $class[3]['object']::class : null;
         $externalId = $this->externalId ?: $class;
 
         $msg = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -285,11 +285,11 @@ class ResolveChildDefinitionsPassTest extends TestCase
         $this->process($container);
 
         $configurator = $container->getDefinition('sibling')->getConfigurator();
-        $this->assertSame('Symfony\Component\DependencyInjection\Definition', \get_class($configurator[0]));
+        $this->assertSame('Symfony\Component\DependencyInjection\Definition', $configurator[0]::class);
         $this->assertSame('parentClass', $configurator[0]->getClass());
 
         $factory = $container->getDefinition('sibling')->getFactory();
-        $this->assertSame('Symfony\Component\DependencyInjection\Definition', \get_class($factory[0]));
+        $this->assertSame('Symfony\Component\DependencyInjection\Definition', $factory[0]::class);
         $this->assertSame('parentClass', $factory[0]->getClass());
 
         $argument = $container->getDefinition('sibling')->getArgument(0);
@@ -297,11 +297,11 @@ class ResolveChildDefinitionsPassTest extends TestCase
         $this->assertSame('parentClass', $argument->getClass());
 
         $properties = $container->getDefinition('sibling')->getProperties();
-        $this->assertSame('Symfony\Component\DependencyInjection\Definition', \get_class($properties['prop']));
+        $this->assertSame('Symfony\Component\DependencyInjection\Definition', $properties['prop']::class);
         $this->assertSame('parentClass', $properties['prop']->getClass());
 
         $methodCalls = $container->getDefinition('sibling')->getMethodCalls();
-        $this->assertSame('Symfony\Component\DependencyInjection\Definition', \get_class($methodCalls[0][1][0]));
+        $this->assertSame('Symfony\Component\DependencyInjection\Definition', $methodCalls[0][1][0]::class);
         $this->assertSame('parentClass', $methodCalls[0][1][0]->getClass());
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -79,9 +79,9 @@ class ServiceLocatorTagPassTest extends TestCase
         /** @var ServiceLocator $locator */
         $locator = $container->get('foo');
 
-        $this->assertSame(CustomDefinition::class, \get_class($locator('bar')));
-        $this->assertSame(CustomDefinition::class, \get_class($locator('baz')));
-        $this->assertSame(CustomDefinition::class, \get_class($locator('some.service')));
+        $this->assertSame(CustomDefinition::class, $locator('bar')::class);
+        $this->assertSame(CustomDefinition::class, $locator('baz')::class);
+        $this->assertSame(CustomDefinition::class, $locator('some.service')::class);
     }
 
     public function testServiceWithKeyOverwritesPreviousInheritedKey()
@@ -104,7 +104,7 @@ class ServiceLocatorTagPassTest extends TestCase
         /** @var ServiceLocator $locator */
         $locator = $container->get('foo');
 
-        $this->assertSame(TestDefinition2::class, \get_class($locator('bar')));
+        $this->assertSame(TestDefinition2::class, $locator('bar')::class);
     }
 
     public function testInheritedKeyOverwritesPreviousServiceWithKey()
@@ -128,8 +128,8 @@ class ServiceLocatorTagPassTest extends TestCase
         /** @var ServiceLocator $locator */
         $locator = $container->get('foo');
 
-        $this->assertSame(TestDefinition1::class, \get_class($locator('bar')));
-        $this->assertSame(TestDefinition2::class, \get_class($locator(16)));
+        $this->assertSame(TestDefinition1::class, $locator('bar')::class);
+        $this->assertSame(TestDefinition2::class, $locator(16)::class);
     }
 
     public function testBindingsAreCopied()
@@ -164,8 +164,8 @@ class ServiceLocatorTagPassTest extends TestCase
         /** @var ServiceLocator $locator */
         $locator = $container->get('foo');
 
-        $this->assertSame(TestDefinition1::class, \get_class($locator('bar')));
-        $this->assertSame(TestDefinition2::class, \get_class($locator('baz')));
+        $this->assertSame(TestDefinition1::class, $locator('bar')::class);
+        $this->assertSame(TestDefinition2::class, $locator('baz')::class);
     }
 
     public function testIndexedByServiceIdWithDecoration()

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -408,8 +408,8 @@ class ErrorHandlerTest extends TestCase
             ['Uncaught Exception: foo', new \Exception('foo')],
             ['Uncaught Exception: foo', new class('foo') extends \RuntimeException {
             }],
-            ['Uncaught Exception: foo stdClass@anonymous bar', new \RuntimeException('foo '.\get_class(new class() extends \stdClass {
-            }).' bar')],
+            ['Uncaught Exception: foo stdClass@anonymous bar', new \RuntimeException('foo '.(new class() extends \stdClass {
+            })::class.' bar')],
             ['Uncaught Error: bar', new \Error('bar')],
             ['Uncaught ccc', new \ErrorException('ccc')],
         ];

--- a/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
@@ -249,13 +249,13 @@ class FlattenExceptionTest extends TestCase
 
         $this->assertSame('RuntimeException@anonymous', $flattened->getClass());
 
-        $flattened->setClass(\get_class(new class('Oops') extends NotFoundHttpException {
-        }));
+        $flattened->setClass((new class('Oops') extends NotFoundHttpException {
+        })::class);
 
         $this->assertSame('Symfony\Component\HttpKernel\Exception\NotFoundHttpException@anonymous', $flattened->getClass());
 
-        $flattened = FlattenException::createFromThrowable(new \Exception(sprintf('Class "%s" blah.', \get_class(new class() extends \RuntimeException {
-        }))));
+        $flattened = FlattenException::createFromThrowable(new \Exception(sprintf('Class "%s" blah.', (new class() extends \RuntimeException {
+        })::class)));
 
         $this->assertSame('Class "RuntimeException@anonymous" blah.', $flattened->getMessage());
     }

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -134,7 +134,7 @@ final class WrappedListener
         }
 
         if (\is_object($listener[0])) {
-            return [get_debug_type($listener[0]), \get_class($listener[0])];
+            return [get_debug_type($listener[0]), $listener[0]::class];
         }
 
         return [$listener[0], $listener[0]];

--- a/src/Symfony/Component/Form/Command/DebugCommand.php
+++ b/src/Symfony/Component/Form/Command/DebugCommand.php
@@ -122,7 +122,7 @@ EOF
                 $object = $resolvedType->getOptionsResolver();
 
                 if (!$object->isDefined($option)) {
-                    $message = sprintf('Option "%s" is not defined in "%s".', $option, \get_class($resolvedType->getInnerType()));
+                    $message = sprintf('Option "%s" is not defined in "%s".', $option, $resolvedType->getInnerType()::class);
 
                     if ($alternatives = $this->findAlternatives($option, $object->getDefinedOptions())) {
                         if (1 === \count($alternatives)) {

--- a/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
@@ -169,7 +169,7 @@ abstract class Descriptor implements DescriptorInterface
 
     private function getParentOptionsResolver(ResolvedFormTypeInterface $type): OptionsResolver
     {
-        $this->parents[$class = \get_class($type->getInnerType())] = [];
+        $this->parents[$class = $type->getInnerType()::class] = [];
 
         if (null !== $type->getParent()) {
             $optionsResolver = clone $this->getParentOptionsResolver($type->getParent());

--- a/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
@@ -51,7 +51,7 @@ class JsonDescriptor extends Descriptor
         $this->sortOptions($formOptions);
 
         $data = [
-            'class' => \get_class($resolvedFormType->getInnerType()),
+            'class' => $resolvedFormType->getInnerType()::class,
             'block_prefix' => $resolvedFormType->getInnerType()->getBlockPrefix(),
             'options' => $formOptions,
             'parent_types' => $this->parents,

--- a/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
@@ -84,7 +84,7 @@ class TextDescriptor extends Descriptor
             'extension' => 'Extension options',
         ], $formOptions);
 
-        $this->output->title(sprintf('%s (Block prefix: "%s")', \get_class($resolvedFormType->getInnerType()), $resolvedFormType->getInnerType()->getBlockPrefix()));
+        $this->output->title(sprintf('%s (Block prefix: "%s")', $resolvedFormType->getInnerType()::class, $resolvedFormType->getInnerType()->getBlockPrefix()));
 
         if ($formOptions) {
             $this->output->table($tableHeaders, $this->buildTableRows($tableHeaders, $formOptions));
@@ -135,7 +135,7 @@ class TextDescriptor extends Descriptor
         }
         array_pop($rows);
 
-        $this->output->title(sprintf('%s (%s)', \get_class($options['type']), $options['option']));
+        $this->output->title(sprintf('%s (%s)', $options['type']::class, $options['option']));
         $this->output->table([], $rows);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -135,7 +135,7 @@ class FormType extends BaseType
 
         // Derive "data_class" option from passed "data" object
         $dataClass = function (Options $options) {
-            return isset($options['data']) && \is_object($options['data']) ? \get_class($options['data']) : null;
+            return isset($options['data']) && \is_object($options['data']) ? $options['data']::class : null;
         };
 
         // Derive "empty_data" closure from "data_class" option

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -58,7 +58,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             ->addEventSubscriber(new CsrfValidationListener(
                 $options['csrf_field_name'],
                 $options['csrf_token_manager'],
-                $options['csrf_token_id'] ?: ($builder->getName() ?: \get_class($builder->getType()->getInnerType())),
+                $options['csrf_token_id'] ?: ($builder->getName() ?: $builder->getType()->getInnerType()::class),
                 $options['csrf_message'],
                 $this->translator,
                 $this->translationDomain,
@@ -74,7 +74,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
     {
         if ($options['csrf_protection'] && !$view->parent && $options['compound']) {
             $factory = $form->getConfig()->getFormFactory();
-            $tokenId = $options['csrf_token_id'] ?: ($form->getName() ?: \get_class($form->getConfig()->getType()->getInnerType()));
+            $tokenId = $options['csrf_token_id'] ?: ($form->getName() ?: $form->getConfig()->getType()->getInnerType()::class);
             $data = (string) $options['csrf_token_manager']->getToken($tokenId);
 
             $csrfForm = $factory->createNamed($options['csrf_field_name'], HiddenType::class, $data, [

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -232,7 +232,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
             FormInterface::class => function (FormInterface $f, array $a) {
                 return [
                     Caster::PREFIX_VIRTUAL.'name' => $f->getName(),
-                    Caster::PREFIX_VIRTUAL.'type_class' => new ClassStub(\get_class($f->getConfig()->getType()->getInnerType())),
+                    Caster::PREFIX_VIRTUAL.'type_class' => new ClassStub($f->getConfig()->getType()->getInnerType()::class),
                 ];
             },
             FormView::class => StubCaster::cutInternals(...),

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
@@ -27,7 +27,7 @@ class FormDataExtractor implements FormDataExtractorInterface
         $data = [
             'id' => $this->buildId($form),
             'name' => $form->getName(),
-            'type_class' => \get_class($form->getConfig()->getType()->getInnerType()),
+            'type_class' => $form->getConfig()->getType()->getInnerType()::class,
             'synchronized' => $form->isSynchronized(),
             'passed_options' => [],
             'resolved_options' => [],

--- a/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
@@ -31,7 +31,7 @@ class TestExtension implements FormExtensionInterface
 
     public function addType(FormTypeInterface $type)
     {
-        $this->types[\get_class($type)] = $type;
+        $this->types[$type::class] = $type;
     }
 
     public function getType($name): FormTypeInterface

--- a/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
@@ -40,7 +40,7 @@ class FormFactoryBuilderTest extends TestCase
         $extensions = $registry->getExtensions();
 
         $this->assertCount(1, $extensions);
-        $this->assertTrue($extensions[0]->hasType(\get_class($this->type)));
+        $this->assertTrue($extensions[0]->hasType($this->type::class));
         $this->assertNull($extensions[0]->getTypeGuesser());
     }
 

--- a/src/Symfony/Component/HttpClient/RetryableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/RetryableHttpClient.php
@@ -73,7 +73,7 @@ class RetryableHttpClient implements HttpClientInterface, ResetInterface
                 if ('' !== $context->getInfo('primary_ip')) {
                     $shouldRetry = $this->strategy->shouldRetry($context, null, $exception);
                     if (null === $shouldRetry) {
-                        throw new \LogicException(sprintf('The "%s::shouldRetry()" method must not return null when called with an exception.', \get_class($this->strategy)));
+                        throw new \LogicException(sprintf('The "%s::shouldRetry()" method must not return null when called with an exception.', $this->strategy::class));
                     }
 
                     if (false === $shouldRetry) {
@@ -104,7 +104,7 @@ class RetryableHttpClient implements HttpClientInterface, ResetInterface
                 }
 
                 if (null === $shouldRetry = $this->strategy->shouldRetry($context, $content, null)) {
-                    throw new \LogicException(sprintf('The "%s::shouldRetry()" method must not return null when called with a body.', \get_class($this->strategy)));
+                    throw new \LogicException(sprintf('The "%s::shouldRetry()" method must not return null when called with a body.', $this->strategy::class));
                 }
 
                 if (false === $shouldRetry) {

--- a/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
@@ -204,7 +204,7 @@ class HttplugClientTest extends TestCase
                 return $response;
             }, function (\Exception $exception) use (&$failureCallableCalled, $client) {
                 $this->assertSame(NetworkException::class, $exception::class);
-                $this->assertSame(TransportException::class, \get_class($exception->getPrevious()));
+                $this->assertSame(TransportException::class, $exception->getPrevious()::class);
                 $failureCallableCalled = true;
 
                 return $client->sendAsyncRequest($client->createRequest('GET', 'http://localhost:8057'));

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -73,7 +73,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
             $representative = $controller;
 
             if (\is_array($representative)) {
-                $representative = sprintf('%s::%s()', \get_class($representative[0]), $representative[1]);
+                $representative = sprintf('%s::%s()', $representative[0]::class, $representative[1]);
             } elseif (\is_object($representative)) {
                 $representative = get_debug_type($representative);
             }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
@@ -42,7 +42,7 @@ final class TraceableValueResolver implements ArgumentValueResolverInterface, Va
             return true;
         }
 
-        $method = \get_class($this->inner).'::'.__FUNCTION__;
+        $method = $this->inner::class.'::'.__FUNCTION__;
         $this->stopwatch->start($method, 'controller.argument_value_resolver');
 
         $return = $this->inner->supports($request, $argument);
@@ -54,7 +54,7 @@ final class TraceableValueResolver implements ArgumentValueResolverInterface, Va
 
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
-        $method = \get_class($this->inner).'::'.__FUNCTION__;
+        $method = $this->inner::class.'::'.__FUNCTION__;
         $this->stopwatch->start($method, 'controller.argument_value_resolver');
 
         yield from $this->inner->resolve($request, $argument);

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -414,7 +414,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                     $lock = null;
                 } elseif (!is_file($cachePath) || !\is_object($this->container = include $cachePath)) {
                     $this->container = null;
-                } elseif (!$oldContainer || \get_class($this->container) !== $oldContainer->name) {
+                } elseif (!$oldContainer || $this->container::class !== $oldContainer->name) {
                     flock($lock, \LOCK_UN);
                     fclose($lock);
                     $this->container->set('kernel', $this);
@@ -504,7 +504,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $this->container = require $cachePath;
         $this->container->set('kernel', $this);
 
-        if ($oldContainer && \get_class($this->container) !== $oldContainer->name) {
+        if ($oldContainer && $this->container::class !== $oldContainer->name) {
             // Because concurrent requests might still be using them,
             // old container files are not removed immediately,
             // but on a next dump of the container.

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -98,7 +98,7 @@ class Profiler implements ResetInterface
         }
 
         if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {
-            $this->logger->warning('Unable to store the profiler information.', ['configured_storage' => \get_class($this->storage)]);
+            $this->logger->warning('Unable to store the profiler information.', ['configured_storage' => $this->storage::class]);
         }
 
         return $ret;

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -99,7 +99,7 @@ class KernelTest extends TestCase
         $kernel = new CustomProjectDirKernel();
         $kernel->boot();
 
-        $containerDir = __DIR__.'/Fixtures/var/cache/custom/'.substr(\get_class($kernel->getContainer()), 0, 16);
+        $containerDir = __DIR__.'/Fixtures/var/cache/custom/'.substr($kernel->getContainer()::class, 0, 16);
         $this->assertTrue(unlink(__DIR__.'/Fixtures/var/cache/custom/Symfony_Component_HttpKernel_Tests_CustomProjectDirKernelCustomDebugContainer.php.meta'));
         $this->assertFileExists($containerDir);
         $this->assertFileDoesNotExist($containerDir.'.legacy');
@@ -489,7 +489,7 @@ EOF
         $kernel = new CustomProjectDirKernel();
         $kernel->boot();
 
-        $containerClass = \get_class($kernel->getContainer());
+        $containerClass = $kernel->getContainer()::class;
         $containerFile = (new \ReflectionClass($kernel->getContainer()))->getFileName();
         unlink(__DIR__.'/Fixtures/var/cache/custom/Symfony_Component_HttpKernel_Tests_CustomProjectDirKernelCustomDebugContainer.php.meta');
 

--- a/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
+++ b/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
@@ -50,7 +50,7 @@ class CheckLdapCredentialsListener implements EventSubscriberInterface
         }
 
         if (!$passport->hasBadge(PasswordCredentials::class)) {
-            throw new \LogicException(sprintf('LDAP authentication requires a passport containing password credentials, authenticator "%s" does not fulfill these requirements.', \get_class($event->getAuthenticator())));
+            throw new \LogicException(sprintf('LDAP authentication requires a passport containing password credentials, authenticator "%s" does not fulfill these requirements.', $event->getAuthenticator()::class));
         }
 
         /** @var PasswordCredentials $passwordCredentials */

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
@@ -42,7 +42,7 @@ class DoctrineDbalPostgreSqlStore implements BlockingSharedLockStoreInterface, B
     {
         if ($connOrUrl instanceof Connection) {
             if (!$connOrUrl->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-                throw new InvalidArgumentException(sprintf('The adapter "%s" does not support the "%s" platform.', __CLASS__, \get_class($connOrUrl->getDatabasePlatform())));
+                throw new InvalidArgumentException(sprintf('The adapter "%s" does not support the "%s" platform.', __CLASS__, $connOrUrl->getDatabasePlatform()::class));
             }
             $this->conn = $connOrUrl;
         } else {

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Fixtures/long_receiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Fixtures/long_receiver.php
@@ -39,7 +39,7 @@ $eventDispatcher->addSubscriber(new DispatchPcntlSignalListener());
 $worker = new Worker(['the_receiver' => $receiver], new class() implements MessageBusInterface {
     public function dispatch($envelope, array $stamps = []): Envelope
     {
-        echo 'Get envelope with message: '.get_class($envelope->getMessage())."\n";
+        echo 'Get envelope with message: '.$envelope->getMessage()::class."\n";
         echo sprintf("with stamps: %s\n", json_encode(array_keys($envelope->all()), \JSON_PRETTY_PRINT));
 
         sleep(30);

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -86,7 +86,7 @@ abstract class AbstractFailedMessagesCommand extends Command
         $lastMessageDecodingFailedStamp = $envelope->last(MessageDecodingFailedStamp::class);
 
         $rows = [
-            ['Class', \get_class($envelope->getMessage())],
+            ['Class', $envelope->getMessage()::class],
         ];
 
         if (null !== $id = $this->getMessageId($envelope)) {

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -99,7 +99,7 @@ EOF
         $this->phpSerializer?->acceptPhpIncompleteClass();
         try {
             foreach ($envelopes as $envelope) {
-                $currentClassName = \get_class($envelope->getMessage());
+                $currentClassName = $envelope->getMessage()::class;
 
                 if ($classFilter && $classFilter !== $currentClassName) {
                     continue;
@@ -151,7 +151,7 @@ EOF
         $this->phpSerializer?->acceptPhpIncompleteClass();
         try {
             foreach ($envelopes as $envelope) {
-                $c = \get_class($envelope->getMessage());
+                $c = $envelope->getMessage()::class;
 
                 if (!isset($countPerClass[$c])) {
                     $countPerClass[$c] = [$c, 0];

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -61,7 +61,7 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
         );
 
         $this->logger?->info('Rejected message {class} will be sent to the failure transport {transport}.', [
-            'class' => \get_class($envelope->getMessage()),
+            'class' => $envelope->getMessage()::class,
             'transport' => $failureSender::class,
         ]);
 

--- a/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
@@ -25,7 +25,7 @@ class HandlerFailedException extends RuntimeException
     {
         $firstFailure = current($exceptions);
 
-        $message = sprintf('Handling "%s" failed: ', \get_class($envelope->getMessage()));
+        $message = sprintf('Handling "%s" failed: ', $envelope->getMessage()::class);
 
         parent::__construct(
             $message.(1 === \count($exceptions)

--- a/src/Symfony/Component/Messenger/Exception/ValidationFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/ValidationFailedException.php
@@ -26,7 +26,7 @@ class ValidationFailedException extends RuntimeException
         $this->violatingMessage = $violatingMessage;
         $this->violations = $violations;
 
-        parent::__construct(sprintf('Message of type "%s" failed validation.', \get_class($this->violatingMessage)));
+        parent::__construct(sprintf('Message of type "%s" failed validation.', $this->violatingMessage::class));
     }
 
     public function getViolatingMessage()

--- a/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
@@ -63,7 +63,7 @@ class HandlersLocator implements HandlersLocatorInterface
      */
     public static function listTypes(Envelope $envelope): array
     {
-        $class = \get_class($envelope->getMessage());
+        $class = $envelope->getMessage()::class;
 
         return [$class => $class]
             + class_parents($class)

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -44,7 +44,7 @@ class SendMessageMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         $context = [
-            'class' => \get_class($envelope->getMessage()),
+            'class' => $envelope->getMessage()::class,
         ];
 
         $sender = null;

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -101,7 +101,7 @@ class Serializer implements SerializerInterface
 
         $envelope = $envelope->withoutStampsOfType(NonSendableStampInterface::class);
 
-        $headers = ['type' => \get_class($envelope->getMessage())] + $this->encodeStamps($envelope) + $this->getContentTypeHeader();
+        $headers = ['type' => $envelope->getMessage()::class] + $this->encodeStamps($envelope) + $this->getContentTypeHeader();
 
         return [
             'body' => $serializedMessageStamp

--- a/src/Symfony/Component/Notifier/EventListener/SendFailedMessageToNotifierListener.php
+++ b/src/Symfony/Component/Notifier/EventListener/SendFailedMessageToNotifierListener.php
@@ -43,7 +43,7 @@ class SendFailedMessageToNotifierListener implements EventSubscriberInterface
         }
         $envelope = $event->getEnvelope();
         $notification = Notification::fromThrowable($throwable)->importance(Notification::IMPORTANCE_HIGH);
-        $notification->subject(sprintf('A "%s" message has just failed: %s.', \get_class($envelope->getMessage()), $notification->getSubject()));
+        $notification->subject(sprintf('A "%s" message has just failed: %s.', $envelope->getMessage()::class, $notification->getSubject()));
 
         $this->notifier->send($notification, ...$this->notifier->getAdminRecipients());
     }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -146,14 +146,14 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             // eagerly (before token storage is initialized), whereas authenticate() is called
             // lazily (after initialization).
             if (false === $authenticator->supports($request)) {
-                $this->logger?->debug('Skipping the "{authenticator}" authenticator as it did not support the request.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
+                $this->logger?->debug('Skipping the "{authenticator}" authenticator as it did not support the request.', ['authenticator' => ($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)::class]);
 
                 continue;
             }
 
             $response = $this->executeAuthenticator($authenticator, $request);
             if (null !== $response) {
-                $this->logger?->debug('The "{authenticator}" authenticator set the response. Any later authenticator will not be called', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
+                $this->logger?->debug('The "{authenticator}" authenticator set the response. Any later authenticator will not be called', ['authenticator' => ($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)::class]);
 
                 return $response;
             }
@@ -201,7 +201,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
 
             $this->eventDispatcher->dispatch(new AuthenticationSuccessEvent($authenticatedToken), AuthenticationEvents::AUTHENTICATION_SUCCESS);
 
-            $this->logger?->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
+            $this->logger?->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => ($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)::class]);
         } catch (AuthenticationException $e) {
             // oh no! Authentication failed!
             $response = $this->handleAuthenticationFailure($e, $request, $authenticator, $passport);
@@ -218,7 +218,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             return $response;
         }
 
-        $this->logger?->debug('Authenticator set no success response: request continues.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
+        $this->logger?->debug('Authenticator set no success response: request continues.', ['authenticator' => ($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)::class]);
 
         return null;
     }
@@ -243,7 +243,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
      */
     private function handleAuthenticationFailure(AuthenticationException $authenticationException, Request $request, AuthenticatorInterface $authenticator, ?Passport $passport): ?Response
     {
-        $this->logger?->info('Authenticator failed.', ['exception' => $authenticationException, 'authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
+        $this->logger?->info('Authenticator failed.', ['exception' => $authenticationException, 'authenticator' => ($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)::class]);
 
         // Avoid leaking error details in case of invalid user (e.g. user not found or invalid account status)
         // to prevent user enumeration via response content comparison
@@ -253,7 +253,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
 
         $response = $authenticator->onAuthenticationFailure($request, $authenticationException);
         if (null !== $response && null !== $this->logger) {
-            $this->logger->debug('The "{authenticator}" authenticator set the failure response.', ['authenticator' => \get_class($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)]);
+            $this->logger->debug('The "{authenticator}" authenticator set the failure response.', ['authenticator' => ($authenticator instanceof TraceableAuthenticator ? $authenticator->getAuthenticator() : $authenticator)::class]);
         }
 
         $this->eventDispatcher->dispatch($loginFailureEvent = new LoginFailureEvent($authenticationException, $authenticator, $request, $response, $this->firewallName, $passport));

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -45,7 +45,7 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
             'supports' => true,
             'passport' => $this->passport,
             'duration' => $this->duration,
-            'stub' => $this->stub ??= class_exists(ClassStub::class) ? new ClassStub(\get_class($this->authenticator)) : \get_class($this->authenticator),
+            'stub' => $this->stub ??= class_exists(ClassStub::class) ? new ClassStub($this->authenticator::class) : $this->authenticator::class,
         ];
     }
 

--- a/src/Symfony/Component/Security/Http/EventListener/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/RememberMeListener.php
@@ -47,7 +47,7 @@ class RememberMeListener implements EventSubscriberInterface
     {
         $passport = $event->getPassport();
         if (!$passport->hasBadge(RememberMeBadge::class)) {
-            $this->logger?->debug('Remember me skipped: your authenticator does not support it.', ['authenticator' => \get_class($event->getAuthenticator())]);
+            $this->logger?->debug('Remember me skipped: your authenticator does not support it.', ['authenticator' => $event->getAuthenticator()::class]);
 
             return;
         }

--- a/src/Symfony/Component/Serializer/Debug/TraceableEncoder.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableEncoder.php
@@ -44,7 +44,7 @@ class TraceableEncoder implements EncoderInterface, DecoderInterface, Serializer
         $time = microtime(true) - $startTime;
 
         if ($traceId = ($context[TraceableSerializer::DEBUG_TRACE_ID] ?? null)) {
-            $this->dataCollector->collectEncoding($traceId, \get_class($this->encoder), $time);
+            $this->dataCollector->collectEncoding($traceId, $this->encoder::class, $time);
         }
 
         return $encoded;
@@ -70,7 +70,7 @@ class TraceableEncoder implements EncoderInterface, DecoderInterface, Serializer
         $time = microtime(true) - $startTime;
 
         if ($traceId = ($context[TraceableSerializer::DEBUG_TRACE_ID] ?? null)) {
-            $this->dataCollector->collectDecoding($traceId, \get_class($this->encoder), $time);
+            $this->dataCollector->collectDecoding($traceId, $this->encoder::class, $time);
         }
 
         return $encoded;

--- a/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
@@ -46,7 +46,7 @@ class TraceableNormalizer implements NormalizerInterface, DenormalizerInterface,
         $time = microtime(true) - $startTime;
 
         if ($traceId = ($context[TraceableSerializer::DEBUG_TRACE_ID] ?? null)) {
-            $this->dataCollector->collectNormalization($traceId, \get_class($this->normalizer), $time);
+            $this->dataCollector->collectNormalization($traceId, $this->normalizer::class, $time);
         }
 
         return $normalized;
@@ -72,7 +72,7 @@ class TraceableNormalizer implements NormalizerInterface, DenormalizerInterface,
         $time = microtime(true) - $startTime;
 
         if ($traceId = ($context[TraceableSerializer::DEBUG_TRACE_ID] ?? null)) {
-            $this->dataCollector->collectDenormalization($traceId, \get_class($this->normalizer), $time);
+            $this->dataCollector->collectDenormalization($traceId, $this->normalizer::class, $time);
         }
 
         return $denormalized;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/CustomNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/CustomNormalizerTest.php
@@ -50,11 +50,11 @@ class CustomNormalizerTest extends TestCase
 
     public function testDeserialize()
     {
-        $obj = $this->normalizer->denormalize('foo', \get_class(new ScalarDummy()), 'xml');
+        $obj = $this->normalizer->denormalize('foo', (new ScalarDummy())::class, 'xml');
         $this->assertEquals('foo', $obj->xmlFoo);
         $this->assertNull($obj->foo);
 
-        $obj = $this->normalizer->denormalize('foo', \get_class(new ScalarDummy()), 'json');
+        $obj = $this->normalizer->denormalize('foo', (new ScalarDummy())::class, 'json');
         $this->assertEquals('foo', $obj->foo);
         $this->assertNull($obj->xmlFoo);
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -736,10 +736,10 @@ class ObjectNormalizerTest extends TestCase
         $normalizer = new ObjectNormalizer(null, null, null, $extractor);
         $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
 
-        $this->assertSame('bar', $serializer->denormalize(['foo' => 'bar'], \get_class(new class() {
+        $this->assertSame('bar', $serializer->denormalize(['foo' => 'bar'], (new class() {
             /** @var self::*|null */
             public $foo;
-        }))->foo);
+        })::class)->foo);
     }
 
     public function testExtractAttributesRespectsFormat()

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -66,7 +66,7 @@ class ConstraintViolation implements ConstraintViolationInterface
     public function __toString(): string
     {
         if (\is_object($this->root)) {
-            $class = 'Object('.\get_class($this->root).')';
+            $class = 'Object('.$this->root::class.')';
         } elseif (\is_array($this->root)) {
             $class = 'Array';
         } else {

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -35,7 +35,7 @@ class CallbackValidator extends ConstraintValidator
         } elseif (\is_array($method)) {
             if (!\is_callable($method)) {
                 if (isset($method[0]) && \is_object($method[0])) {
-                    $method[0] = \get_class($method[0]);
+                    $method[0] = $method[0]::class;
                 }
                 throw new ConstraintDefinitionException(json_encode($method).' targeted by Callback constraint is not a valid callable.');
             }

--- a/src/Symfony/Component/Validator/DataCollector/ValidatorDataCollector.php
+++ b/src/Symfony/Component/Validator/DataCollector/ValidatorDataCollector.php
@@ -90,7 +90,7 @@ class ValidatorDataCollector extends DataCollector implements LateDataCollectorI
             FormInterface::class => function (FormInterface $f, array $a) {
                 return [
                     Caster::PREFIX_VIRTUAL.'name' => $f->getName(),
-                    Caster::PREFIX_VIRTUAL.'type_class' => new ClassStub(\get_class($f->getConfig()->getType()->getInnerType())),
+                    Caster::PREFIX_VIRTUAL.'type_class' => new ClassStub($f->getConfig()->getType()->getInnerType()::class),
                     Caster::PREFIX_VIRTUAL.'data' => $f->getData(),
                 ];
             },

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -501,7 +501,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             ], '1'];
 
             // access FileValidator::factorizeSizes() private method to format max file size
-            $reflection = new \ReflectionClass(\get_class(new FileValidator()));
+            $reflection = new \ReflectionClass((new FileValidator()));
             $method = $reflection->getMethod('factorizeSizes');
             [, $limit, $suffix] = $method->invokeArgs(new FileValidator(), [0, UploadedFile::getMaxFilesize(), false]);
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
@@ -25,7 +25,7 @@ class FakeMetadataFactory implements MetadataFactoryInterface
 
         if (\is_object($class)) {
             $hash = spl_object_hash($class);
-            $class = \get_class($class);
+            $class = $class::class;
         }
 
         if (!\is_string($class)) {
@@ -49,7 +49,7 @@ class FakeMetadataFactory implements MetadataFactoryInterface
 
         if (\is_object($class)) {
             $hash = spl_object_hash($class);
-            $class = \get_class($class);
+            $class = $class::class;
         }
 
         if (!\is_string($class)) {

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -251,8 +251,8 @@ EODUMP;
 
     public function testAnonymous()
     {
-        $e = new \Exception(sprintf('Boo "%s" ba.', \get_class(new class('Foo') extends \Exception {
-        })));
+        $e = new \Exception(sprintf('Boo "%s" ba.', (new class('Foo') extends \Exception {
+        })::class));
 
         $expectedDump = <<<'EODUMP'
 Exception {

--- a/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
@@ -192,8 +192,8 @@ EODUMP;
 
     public function testClassStubWithAnonymousClass()
     {
-        $var = [new ClassStub(\get_class(new class() extends \Exception {
-        }))];
+        $var = [new ClassStub((new class() extends \Exception {
+        })::class)];
 
         $cloner = new VarCloner();
         $dumper = new HtmlDumper();

--- a/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
+++ b/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
@@ -30,19 +30,19 @@ class AuditTrailListener implements EventSubscriberInterface
     public function onLeave(Event $event)
     {
         foreach ($event->getTransition()->getFroms() as $place) {
-            $this->logger->info(sprintf('Leaving "%s" for subject of class "%s" in workflow "%s".', $place, \get_class($event->getSubject()), $event->getWorkflowName()));
+            $this->logger->info(sprintf('Leaving "%s" for subject of class "%s" in workflow "%s".', $place, $event->getSubject()::class, $event->getWorkflowName()));
         }
     }
 
     public function onTransition(Event $event)
     {
-        $this->logger->info(sprintf('Transition "%s" for subject of class "%s" in workflow "%s".', $event->getTransition()->getName(), \get_class($event->getSubject()), $event->getWorkflowName()));
+        $this->logger->info(sprintf('Transition "%s" for subject of class "%s" in workflow "%s".', $event->getTransition()->getName(), $event->getSubject()::class, $event->getWorkflowName()));
     }
 
     public function onEnter(Event $event)
     {
         foreach ($event->getTransition()->getTos() as $place) {
-            $this->logger->info(sprintf('Entering "%s" for subject of class "%s" in workflow "%s".', $place, \get_class($event->getSubject()), $event->getWorkflowName()));
+            $this->logger->info(sprintf('Entering "%s" for subject of class "%s" in workflow "%s".', $place, $event->getSubject()::class, $event->getWorkflowName()));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |

### Rational
[PHP RFC: Allow ::class on objects](https://wiki.php.net/rfc/class_name_literal_on_object)

More specifically
>  As it is syntactically similar to a class constant access, programmers intuitively expect the syntax $object::class to work as well and provide the same result as get_class($object). This RFC proposes to allow that syntax.


