### PR TITLE
[VarExporter] Do initialize ghost objects when setting one of their properties

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -1094,17 +1094,6 @@ index b22d6ae609..31d1a25f9d 100644
 +    public static function prepare($values, $objectsPool, &$refsPool, &$objectsCount, &$valuesAreStatic): array
      {
          $refs = $values;
-diff --git a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
-index 6ea89bc831..01748bcfc0 100644
---- a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
-+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
-@@ -56,5 +56,5 @@ class LazyObjectState
-      * @return bool Returns true when fully-initializing, false when partial-initializing
-      */
--    public function initialize($instance, $propertyName, $propertyScope)
-+    public function initialize($instance, $propertyName, $propertyScope): bool
-     {
-         if (!$this->status) {
 diff --git a/src/Symfony/Component/Workflow/Event/Event.php b/src/Symfony/Component/Workflow/Event/Event.php
 index cd7fab7896..b340eba38e 100644
 --- a/src/Symfony/Component/Workflow/Event/Event.php

--- a/src/Symfony/Component/VarExporter/README.md
+++ b/src/Symfony/Component/VarExporter/README.md
@@ -119,10 +119,6 @@ $initializer = function (Foo $instance, string $propertyName, ?string $propertyS
 };
 ```
 
-Because lazy-initialization is not triggered when (un)setting a property, it's
-also possible to do partial initialization by calling setters on a just-created
-ghost object.
-
 ### `LazyProxyTrait`
 
 Alternatively, `LazyProxyTrait` can be used to create virtual proxies:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I thought we could allow properties to be set on lazy ghost objects without initializing them, but it turns out this adds a significant amount of complexity and edge cases that are not trivial to deal with. Let's postpone this to a maybe future iteration and make things simple for now.