### PR TITLE
[PropertyInfo] a readonly property must not be reported as being writable

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -180,7 +180,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      */
     public function isWritable($class, $property, array $context = []): ?bool
     {
-        if ($this->isAllowedProperty($class, $property)) {
+        if ($this->isAllowedProperty($class, $property, true)) {
             return true;
         }
 
@@ -389,10 +389,14 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         return false;
     }
 
-    private function isAllowedProperty(string $class, string $property): bool
+    private function isAllowedProperty(string $class, string $property, bool $writeAccessRequired = false): bool
     {
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
+
+            if (\PHP_VERSION_ID >= 80100 && $writeAccessRequired && $reflectionProperty->isReadOnly()) {
+                return false;
+            }
 
             if ($this->accessFlags & self::ALLOW_PUBLIC && $reflectionProperty->isPublic()) {
                 return true;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyExtended2;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7ParentDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -234,6 +235,7 @@ class ReflectionExtractorTest extends TestCase
 
     /**
      * @dataProvider php80TypesProvider
+     *
      * @requires PHP 8
      */
     public function testExtractPhp80Type($property, array $type = null)
@@ -257,6 +259,7 @@ class ReflectionExtractorTest extends TestCase
 
     /**
      * @dataProvider php81TypesProvider
+     *
      * @requires PHP 8.1
      */
     public function testExtractPhp81Type($property, array $type = null)
@@ -273,7 +276,16 @@ class ReflectionExtractorTest extends TestCase
     }
 
     /**
+     * @requires PHP 8.1
+     */
+    public function testReadonlyPropertiesAreNotWriteable()
+    {
+        $this->assertFalse($this->extractor->isWritable(Php81Dummy::class, 'foo'));
+    }
+
+    /**
      * @dataProvider php82TypesProvider
+     *
      * @requires PHP 8.2
      */
     public function testExtractPhp82Type($property, array $type = null)

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php81Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php81Dummy.php
@@ -13,6 +13,10 @@ namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
 
 class Php81Dummy
 {
+    public function __construct(public readonly string $foo)
+    {
+    }
+
     public function getNothing(): never
     {
         throw new \Exception('Oops');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47756
| License       | MIT
| Doc PR        | 
