### PR TITLE
[Serializer] fixed traceable decoration priorities

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer_debug.php
@@ -17,7 +17,7 @@ use Symfony\Component\Serializer\Debug\TraceableSerializer;
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('debug.serializer', TraceableSerializer::class)
-            ->decorate('serializer', null, 255)
+            ->decorate('serializer')
             ->args([
                 service('debug.serializer.inner'),
                 service('serializer.data_collector'),

--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -44,7 +44,7 @@ class SerializerPass implements CompilerPassInterface
         if ($container->getParameter('kernel.debug') && $container->hasDefinition('serializer.data_collector')) {
             foreach (array_keys($normalizers) as $normalizer) {
                 $container->register('debug.'.$normalizer, TraceableNormalizer::class)
-                    ->setDecoratedService($normalizer, null, 255)
+                    ->setDecoratedService($normalizer)
                     ->setArguments([new Reference('debug.'.$normalizer.'.inner'), new Reference('serializer.data_collector')]);
             }
         }
@@ -59,7 +59,7 @@ class SerializerPass implements CompilerPassInterface
         if ($container->getParameter('kernel.debug') && $container->hasDefinition('serializer.data_collector')) {
             foreach (array_keys($encoders) as $encoder) {
                 $container->register('debug.'.$encoder, TraceableEncoder::class)
-                    ->setDecoratedService($encoder, null, 255)
+                    ->setDecoratedService($encoder)
                     ->setArguments([new Reference('debug.'.$encoder.'.inner'), new Reference('serializer.data_collector')]);
             }
         }

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -108,12 +108,12 @@ class SerializerPassTest extends TestCase
         $traceableEncoderDefinition = $container->getDefinition('debug.e');
 
         $this->assertEquals(TraceableNormalizer::class, $traceableNormalizerDefinition->getClass());
-        $this->assertEquals(['n', null, 255], $traceableNormalizerDefinition->getDecoratedService());
+        $this->assertEquals(['n', null, 0], $traceableNormalizerDefinition->getDecoratedService());
         $this->assertEquals(new Reference('debug.n.inner'), $traceableNormalizerDefinition->getArgument(0));
         $this->assertEquals(new Reference('serializer.data_collector'), $traceableNormalizerDefinition->getArgument(1));
 
         $this->assertEquals(TraceableEncoder::class, $traceableEncoderDefinition->getClass());
-        $this->assertEquals(['e', null, 255], $traceableEncoderDefinition->getDecoratedService());
+        $this->assertEquals(['e', null, 0], $traceableEncoderDefinition->getDecoratedService());
         $this->assertEquals(new Reference('debug.e.inner'), $traceableEncoderDefinition->getArgument(0));
         $this->assertEquals(new Reference('serializer.data_collector'), $traceableEncoderDefinition->getArgument(1));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 

Related to https://github.com/symfony/maker-bundle/issues/1252

The decoration priority of `TraceableNormalizer` and `TraceableEncoder` is too high, therefore while it should be the last decoration applied, it is applied before userland decorations.

I've set the decoration priority to `0`, but maybe `-255` might be better.

Moreover, I've seen the very same thing for the `TraceableValidator`, is it a bug or wanted?