### PR TITLE
[Security] Ban \DateTime from Security component

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
@@ -31,7 +31,7 @@ class InMemoryTokenProvider implements TokenProviderInterface
         return $this->tokens[$series];
     }
 
-    public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed)
+    public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed)
     {
         if (!isset($this->tokens[$series])) {
             throw new TokenNotFoundException('No token found.');

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
@@ -22,9 +22,9 @@ final class PersistentToken implements PersistentTokenInterface
     private string $userIdentifier;
     private string $series;
     private string $tokenValue;
-    private \DateTime $lastUsed;
+    private \DateTimeInterface $lastUsed;
 
-    public function __construct(string $class, string $userIdentifier, string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed)
+    public function __construct(string $class, string $userIdentifier, string $series, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed)
     {
         if (empty($class)) {
             throw new \InvalidArgumentException('$class must not be empty.');
@@ -37,6 +37,10 @@ final class PersistentToken implements PersistentTokenInterface
         }
         if (empty($tokenValue)) {
             throw new \InvalidArgumentException('$tokenValue must not be empty.');
+        }
+
+        if ($lastUsed instanceof \DateTime) {
+            trigger_deprecation('symfony/security-core', '6.2', 'usage of \DateTime is deprecated use \DateTimeImmutable instead.');
         }
 
         $this->class = $class;
@@ -66,7 +70,7 @@ final class PersistentToken implements PersistentTokenInterface
         return $this->tokenValue;
     }
 
-    public function getLastUsed(): \DateTime
+    public function getLastUsed(): \DateTimeInterface
     {
         return $this->lastUsed;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
@@ -37,7 +37,7 @@ interface PersistentTokenInterface
     /**
      * Returns the time the token was last used.
      */
-    public function getLastUsed(): \DateTime;
+    public function getLastUsed(): \DateTimeInterface;
 
     /**
      * Returns the identifier used to authenticate (e.g. their email address or username).

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
@@ -39,7 +39,7 @@ interface TokenProviderInterface
      *
      * @throws TokenNotFoundException if the token is not found
      */
-    public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTime $lastUsed);
+    public function updateToken(string $series, #[\SensitiveParameter] string $tokenValue, \DateTimeInterface $lastUsed);
 
     /**
      * Creates a new token.

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/CacheTokenVerifierTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/CacheTokenVerifierTest.php
@@ -21,23 +21,23 @@ class CacheTokenVerifierTest extends TestCase
     public function testVerifyCurrentToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTime());
+        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable());
         $this->assertTrue($verifier->verifyToken($token, 'value'));
     }
 
     public function testVerifyFailsInvalidToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTime());
+        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable());
         $this->assertFalse($verifier->verifyToken($token, 'wrong-value'));
     }
 
     public function testVerifyOutdatedToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $outdatedToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTime());
-        $newToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'newvalue', new \DateTime());
-        $verifier->updateExistingToken($outdatedToken, 'newvalue', new \DateTime());
+        $outdatedToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable());
+        $newToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'newvalue', new \DateTimeImmutable());
+        $verifier->updateExistingToken($outdatedToken, 'newvalue', new \DateTimeImmutable());
         $this->assertTrue($verifier->verifyToken($newToken, 'value'));
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/InMemoryTokenProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/InMemoryTokenProviderTest.php
@@ -22,7 +22,7 @@ class InMemoryTokenProviderTest extends TestCase
     {
         $provider = new InMemoryTokenProvider();
 
-        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTime());
+        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable());
         $provider->createNewToken($token);
 
         $this->assertSame($provider->loadTokenBySeries('foo'), $token);
@@ -39,9 +39,9 @@ class InMemoryTokenProviderTest extends TestCase
     {
         $provider = new InMemoryTokenProvider();
 
-        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTime());
+        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable());
         $provider->createNewToken($token);
-        $provider->updateToken('foo', 'newFoo', $lastUsed = new \DateTime());
+        $provider->updateToken('foo', 'newFoo', $lastUsed = new \DateTimeImmutable());
         $token = $provider->loadTokenBySeries('foo');
 
         $this->assertEquals('newFoo', $token->getTokenValue());
@@ -53,7 +53,7 @@ class InMemoryTokenProviderTest extends TestCase
         $this->expectException(TokenNotFoundException::class);
         $provider = new InMemoryTokenProvider();
 
-        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTime());
+        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable());
         $provider->createNewToken($token);
         $provider->deleteTokenBySeries('foo');
         $provider->loadTokenBySeries('foo');

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/PersistentTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/PersistentTokenTest.php
@@ -18,7 +18,7 @@ class PersistentTokenTest extends TestCase
 {
     public function testConstructor()
     {
-        $lastUsed = new \DateTime();
+        $lastUsed = new \DateTimeImmutable();
         $token = new PersistentToken('fooclass', 'fooname', 'fooseries', 'footokenvalue', $lastUsed);
 
         $this->assertEquals('fooclass', $token->getClass());

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -52,7 +52,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
     {
         $series = base64_encode(random_bytes(64));
         $tokenValue = $this->generateHash(base64_encode(random_bytes(64)));
-        $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $tokenValue, new \DateTime());
+        $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable());
 
         $this->tokenProvider->createNewToken($token);
         $this->createCookie(RememberMeDetails::fromPersistentToken($token, time() + $this->options['lifetime']));
@@ -84,7 +84,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         // if multiple concurrent requests reauthenticate a user we do not want to update the token several times
         if ($persistentToken->getLastUsed()->getTimestamp() + 60 < time()) {
             $tokenValue = $this->generateHash(base64_encode(random_bytes(64)));
-            $tokenLastUsed = new \DateTime();
+            $tokenLastUsed = new \DateTimeImmutable();
             $this->tokenVerifier?->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
             $this->tokenProvider->updateToken($series, $tokenValue, $tokenLastUsed);
 

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -107,7 +107,7 @@ class LoginLinkHandlerTest extends TestCase
         ];
 
         yield [
-            new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash', new \DateTime('2020-06-01 00:00:00', new \DateTimeZone('+0000'))),
+            new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash', new \DateTimeImmutable('2020-06-01 00:00:00', new \DateTimeZone('+0000'))),
             ['lastAuthenticatedAt' => '2020-06-01T00:00:00+00:00'],
         ];
     }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -80,7 +80,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
             ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('-10 min')))
+            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min')))
         ;
 
         $this->tokenProvider->expects($this->once())->method('updateToken')->with('series1');
@@ -108,7 +108,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $verifier = $this->createMock(TokenVerifierInterface::class);
         $handler = new PersistentRememberMeHandler($this->tokenProvider, 'secret', $this->userProvider, $this->requestStack, [], null, $verifier);
 
-        $persistentToken = new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('30 seconds'));
+        $persistentToken = new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('30 seconds'));
 
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
@@ -135,7 +135,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
             ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue1', new \DateTime('-10 min')));
+            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue1', new \DateTimeImmutable('-10 min')));
 
         $this->tokenProvider->expects($this->never())->method('updateToken')->with('series1');
 
@@ -150,7 +150,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
             ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('@'.(time() - (31536000 + 1)))));
+            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('@'.(time() - (31536000 + 1)))));
 
         $this->tokenProvider->expects($this->never())->method('updateToken')->with('series1');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       |  #47580
| License       | MIT

This PR is next to: #47730

The purpose here is to remove the use of \DateTime in the security component. I don't think we can remove it completely without leading any BC break. So I propose to use DateTimeInterface with a deprecation notice.
Feel free to discuss! 