### PR TITLE
[PropertyAccess] Implement DateTime type conversion in PropertyAccess

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -553,7 +553,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         // Only attempt coercion for specifically typed targets
         if ($targetType instanceof \ReflectionNamedType) {
             $type = $targetType->getName();
-            if ($value instanceof \DateTimeInterface && $type !== get_class($value) && $type !== \DateTimeInterface::class) {
+            if ($value instanceof \DateTimeInterface && $type !== $value::class && \DateTimeInterface::class !== $type) {
                 $value = $type::createFromInterface($value);
             }
         }

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -553,7 +553,8 @@ class PropertyAccessor implements PropertyAccessorInterface
         // Only attempt coercion for specifically typed targets
         if ($targetType instanceof \ReflectionNamedType) {
             $type = $targetType->getName();
-            if ($value instanceof \DateTimeInterface && $type !== $value::class && \DateTimeInterface::class !== $type) {
+            if ($value instanceof \DateTimeInterface && is_a($type, \DateTimeInterface::class, true)
+                    && $type !== $value::class && \DateTimeInterface::class !== $type) {
                 $value = $type::createFromInterface($value);
             }
         }

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/DateTimeConversion.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/DateTimeConversion.php
@@ -22,33 +22,21 @@ class DateTimeConversion
     private \DateTime $dateTime;
     private \DateTimeImmutable $dateTimeImmutable;
 
-    /**
-     * @return \DateTime
-     */
     public function getDateTime(): \DateTime
     {
         return $this->dateTime;
     }
 
-    /**
-     * @param \DateTime $dateTime
-     */
     public function setDateTime(\DateTime $dateTime): void
     {
         $this->dateTime = $dateTime;
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
     public function getDateTimeImmutable(): \DateTimeImmutable
     {
         return $this->dateTimeImmutable;
     }
 
-    /**
-     * @param \DateTimeImmutable $dateTimeImmutable
-     */
     public function setDateTimeImmutable(\DateTimeImmutable $dateTimeImmutable): void
     {
         $this->dateTimeImmutable = $dateTimeImmutable;

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/DateTimeConversion.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/DateTimeConversion.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+/**
+ * @author Niels Keurentjes <niels.keurentjes@omines.com>
+ */
+class DateTimeConversion
+{
+    public \DateTime $publicDateTime;
+    public \DateTimeImmutable $publicDateTimeImmutable;
+
+    private \DateTime $dateTime;
+    private \DateTimeImmutable $dateTimeImmutable;
+
+    /**
+     * @return \DateTime
+     */
+    public function getDateTime(): \DateTime
+    {
+        return $this->dateTime;
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     */
+    public function setDateTime(\DateTime $dateTime): void
+    {
+        $this->dateTime = $dateTime;
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function getDateTimeImmutable(): \DateTimeImmutable
+    {
+        return $this->dateTimeImmutable;
+    }
+
+    /**
+     * @param \DateTimeImmutable $dateTimeImmutable
+     */
+    public function setDateTimeImmutable(\DateTimeImmutable $dateTimeImmutable): void
+    {
+        $this->dateTimeImmutable = $dateTimeImmutable;
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/DateTimeConversion.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/DateTimeConversion.php
@@ -18,6 +18,7 @@ class DateTimeConversion
 {
     public \DateTime $publicDateTime;
     public \DateTimeImmutable $publicDateTimeImmutable;
+    public \DateTimeInterface $publicDateTimeInterface;
 
     private \DateTime $dateTime;
     private \DateTimeImmutable $dateTimeImmutable;

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/ExtendedUninitializedProperty.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/ExtendedUninitializedProperty.php
@@ -13,5 +13,4 @@ namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
 
 class ExtendedUninitializedProperty extends UninitializedProperty
 {
-
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -945,5 +945,9 @@ class PropertyAccessorTest extends TestCase
         $array = [$fixture];
         $this->propertyAccessor->setValue($array, '[0].publicDateTime', new \DateTimeImmutable('2023-03-03'));
         $this->assertSame($this->propertyAccessor->getValue($fixture, 'publicDateTime')->format('Y-m-d'), '2023-03-03');
+
+        // Ensure setting to an interface does not cause conversion or issues
+        $this->propertyAccessor->setValue($fixture, 'publicDateTimeInterface', $immutable);
+        $this->assertSame($fixture->publicDateTimeInterface, $immutable);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

In short
===
This PR enables implicit conversion between `\DateTime` and `\DateTimeImmutable` objects in the PropertyAccess component, allowing developers to store values of one type where the other was typed. 

Longer story
===

Since PHP introduced the `\DateTimeImmutable` type, and related to that the `\DateTimeInterface`, and afterwards added strict typing, programmers have been banging their heads over converting between 2 datetime types which essentially implement the same thing but are incompatible without helper methods. https://github.com/nelmio/alice/issues/1096 is a notable example of the frustrations this can cause, it makes no sense for a helper library like Faker to implement tons of extra methods just to support that PHP has 2 different ways of storing dates. Similar issues occur with Symfony Forms and Doctrine in certain integrations and combinations.

Which got me thinking why the PropertyAccess component, at the core of a lot of these integrations, doesn't simply support automatic conversion between the types. Conversion from a DateTime to a DateTimeImmutable is by definition harmless - the copy in the target is locked. The other way around it may not be entirely safe, as a programmer could expect a modification of the target to be reflected in the source property, however this is not a logical expectation since in that case the source was Immutable. Hence I implemented the implicit conversion both ways.

Coercion was set up to be more extensible for future similar cases, and will only be attempted for method-based and public access. Coercing values for adder/remover makes no sense as it would (nearly) always break the remover functionality. Likewise coercion is specifically not attempted for union/intersection types, only for explicitly named types.


