### PR TITLE
Guard scripts from being run in non-CLI contexts

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -12,6 +12,10 @@
 // Please update when phpunit needs to be reinstalled with fresh deps:
 // Cache-Id: 2021-02-04 11:00 UTC
 
+if ('cli' !== \PHP_SAPI && 'phpdbg' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 error_reporting(-1);
 
 global $argv, $argc;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/bin/check-unused-known-tags.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/bin/check-unused-known-tags.php
@@ -9,6 +9,10 @@
  * file that was distributed with this source code.
  */
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 require dirname(__DIR__, 6).'/vendor/autoload.php';
 
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\UnusedTagsPassUtils;

--- a/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
+++ b/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
@@ -9,6 +9,10 @@
  * file that was distributed with this source code.
  */
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 $operators = ['not', '!', 'or', '||', '&&', 'and', '|', '^', '&', '==', '===', '!=', '!==', '<', '>', '>=', '<=', 'not in', 'in', '..', '+', '-', '~', '*', '/', '%', 'matches', '**'];
 $operators = array_combine($operators, array_map('strlen', $operators));
 arsort($operators);

--- a/src/Symfony/Component/Intl/Resources/bin/common.php
+++ b/src/Symfony/Component/Intl/Resources/bin/common.php
@@ -9,6 +9,10 @@
  * file that was distributed with this source code.
  */
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 define('LINE_WIDTH', 75);
 
 define('LINE', str_repeat('-', LINE_WIDTH)."\n");

--- a/src/Symfony/Component/Intl/Resources/bin/update-data.php
+++ b/src/Symfony/Component/Intl/Resources/bin/update-data.php
@@ -23,6 +23,10 @@ use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\Locale;
 use Symfony\Component\Intl\Util\GitRepository;
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 require_once __DIR__.'/common.php';
 require_once __DIR__.'/autoload.php';
 

--- a/src/Symfony/Component/Mime/Resources/bin/update_mime_types.php
+++ b/src/Symfony/Component/Mime/Resources/bin/update_mime_types.php
@@ -9,6 +9,10 @@
  * file that was distributed with this source code.
  */
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 // load new map
 $data = file_get_contents('https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types');
 $new = [];

--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -9,6 +9,10 @@
  * file that was distributed with this source code.
  */
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 $usageInstructions = <<<END
 
   Usage instructions

--- a/src/Symfony/Component/VarDumper/Resources/bin/var-dump-server
+++ b/src/Symfony/Component/VarDumper/Resources/bin/var-dump-server
@@ -10,6 +10,10 @@
  * file that was distributed with this source code.
  */
 
+if ('cli' !== PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 /**
  * Starts a dump server to collect and output dumps on a single place with multiple formats support.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Although exposing those scripts on the web would be a mistake, let's disallow running them but from the CLI.