### PR TITLE
Guard scripts from being run in non-CLI contexts

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Resources/bin/extract-tentative-return-types.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/bin/extract-tentative-return-types.php
@@ -10,6 +10,10 @@
  * file that was distributed with this source code.
  */
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 // Run from the root of the php-src repository, this script generates
 // a table with all the methods that have a tentative return type.
 //

--- a/src/Symfony/Component/ErrorHandler/Resources/bin/patch-type-declarations
+++ b/src/Symfony/Component/ErrorHandler/Resources/bin/patch-type-declarations
@@ -10,6 +10,10 @@
  * file that was distributed with this source code.
  */
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 if (\in_array('-h', $argv) || \in_array('--help', $argv)) {
     echo implode(PHP_EOL, [
         ' Patches type declarations based on "@return" PHPDoc and triggers deprecations for',

--- a/src/Symfony/Component/String/Resources/bin/update-data.php
+++ b/src/Symfony/Component/String/Resources/bin/update-data.php
@@ -11,6 +11,10 @@
 
 use Symfony\Component\String\Resources\WcswidthDataGenerator;
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 error_reporting(\E_ALL);
 
 set_error_handler(static function (int $type, string $msg, string $file, int $line): void {

--- a/src/Symfony/Component/Yaml/Resources/bin/yaml-lint
+++ b/src/Symfony/Component/Yaml/Resources/bin/yaml-lint
@@ -10,6 +10,10 @@
  * file that was distributed with this source code.
  */
 
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
 /**
  * Runs the Yaml lint command.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Same as #47777 but for 5.4. I checked 6.x and we didn't add more scripts there.