### PR TITLE
[Console] Fix `Helper::removeDecoration` hyperlink bug

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -135,6 +135,8 @@ abstract class Helper implements HelperInterface
         $string = $formatter->format($string);
         // remove already formatted characters
         $string = preg_replace("/\033\[[^m]*m/", '', $string);
+        // remove terminal hyperlinks
+        $string = preg_replace('/\\033]8;[^;]*;[^\\033]*\\033\\\\/', '', $string);
         $formatter->setDecorated($isDecorated);
 
         return $string;

--- a/src/Symfony/Component/Console/Tests/Helper/HelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Helper;
 
 class HelperTest extends TestCase
@@ -42,6 +43,16 @@ class HelperTest extends TestCase
         ];
     }
 
+    public function decoratedTextProvider()
+    {
+        return [
+            ['abc', 'abc'],
+            ['abc<fg=default;bg=default>', 'abc'],
+            ["a\033[1;36mbc", 'abc'],
+            ["a\033]8;;http://url\033\\b\033]8;;\033\\c", 'abc'],
+        ];
+    }
+
     /**
      * @dataProvider formatTimeProvider
      *
@@ -51,5 +62,13 @@ class HelperTest extends TestCase
     public function testFormatTime($secs, $expectedFormat)
     {
         $this->assertEquals($expectedFormat, Helper::formatTime($secs));
+    }
+
+    /**
+     * @dataProvider decoratedTextProvider
+     */
+    public function testRemoveDecoration(string $decoratedText, string $undecoratedText)
+    {
+        $this->assertEquals($undecoratedText, Helper::removeDecoration(new OutputFormatter(), $decoratedText));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -1392,4 +1392,29 @@ TABLE;
 
         $this->assertSame($expected, $this->getOutputContent($output));
     }
+
+    public function testWithHyperlinkAndMaxWidth()
+    {
+        $table = new Table($output = $this->getOutputStream(true));
+        $table
+            ->setRows([
+                ['<href=Lorem>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</>'],
+            ])
+        ;
+        $table->setColumnMaxWidth(0, 20);
+        $table->render();
+
+        $expected =
+            <<<TABLE
++----------------------+
+| \033]8;;Lorem\033\\Lorem ipsum dolor si\033]8;;\033\\ |
+| \033]8;;Lorem\033\\t amet, consectetur \033]8;;\033\\ |
+| \033]8;;Lorem\033\\adipiscing elit, sed\033]8;;\033\\ |
+| \033]8;;Lorem\033\\do eiusmod tempor\033]8;;\033\\    |
++----------------------+
+
+TABLE;
+
+        $this->assertSame($expected, $this->getOutputContent($output));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #47769 , fix #45521
| License       | MIT
| Doc PR        | none

`Helper::removeDecoration()` does correctly remove colors and such from the text, but terminal hyperlinks are not removed here. This causes `Helper::width()` and `Helper::length()` to report wrong values, as the number of visual characters it not the same as the number of characters in the text.

This PR
- removes hyperlinks in the `removeDecoration` method
- adds a test to ensure hyperlinks are correctly removed
- adds a `TableTest` to ensure that widths are correctly calculated for hyperlink texts (see #47769 for issue)

See https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda for information about hyperlinks in terminals