### PR TITLE
[DependencyInjection] Allow array for the value of Autowire attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
@@ -23,7 +23,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 class Autowire
 {
-    public readonly string|Expression|Reference $value;
+    public readonly string|array|Expression|Reference $value;
 
     /**
      * Use only ONE of the following.
@@ -33,7 +33,7 @@ class Autowire
      * @param string|null $expression Expression (ie 'service("some.service").someMethod()')
      */
     public function __construct(
-        string $value = null,
+        string|array $value = null,
         string $service = null,
         string $expression = null,
     ) {
@@ -41,7 +41,7 @@ class Autowire
             throw new LogicException('#[Autowire] attribute must declare exactly one of $service, $expression, or $value.');
         }
 
-        if (null !== $value && str_starts_with($value, '@')) {
+        if (\is_string($value) && str_starts_with($value, '@')) {
             match (true) {
                 str_starts_with($value, '@@') => $value = substr($value, 1),
                 str_starts_with($value, '@=') => $expression = substr($value, 2),

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\DependencyInjection\Tests\Attribute;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 class AutowireTest extends TestCase
 {
@@ -34,5 +36,25 @@ class AutowireTest extends TestCase
     public function testCanUseZeroForValue()
     {
         $this->assertSame('0', (new Autowire(value: '0'))->value);
+    }
+
+    public function testCanUseArrayForValue()
+    {
+        $this->assertSame(['FOO' => 'BAR'], (new Autowire(value: ['FOO' => 'BAR']))->value);
+    }
+
+    public function testCanUseValueWithAtSign()
+    {
+        $this->assertInstanceOf(Reference::class, (new Autowire(value: '@service'))->value);
+    }
+
+    public function testCanUseValueWithDoubleAtSign()
+    {
+        $this->assertSame('@service', (new Autowire(value: '@@service'))->value);
+    }
+
+    public function testCanUseValueWithAtAndEqualSign()
+    {
+        $this->assertInstanceOf(Expression::class, (new Autowire(value: '@=service'))->value);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Since Symfony 6.1 it's possible to use #[Autowire] for the service autowiring logic. Array as autowire parameters is not supported yet. In YAML or the attribute Autoconfigure it worked.

```php
#[Autoconfigure(bind: [
    '$parameters' => [
        'PARAMETER_DAY_START' => '%env(string:PARAMETER_DAY_START)%',
        'PARAMETER_DAY_END' => '%env(string:PARAMETER_DAY_END)%',
        'FILTER_LIMIT' => '%env(int:FILTER_LIMIT)%',
        'FILTER_OFFSET' => '%env(int:FILTER_OFFSET)%',
    ],
])]
class WidgetService
{
    public function __construct(private readonly array $parameters)
    {
    }
}
```

After this PR there is support for an array (including some extra tests):

```php
class WidgetService
{
    public function __construct(#[Autowire([
        'PARAMETER_DAY_START' => '%env(string:PARAMETER_DAY_START)%',
        'PARAMETER_DAY_END' => '%env(string:PARAMETER_DAY_END)%',
        'FILTER_LIMIT' => '%env(int:FILTER_LIMIT)%',
        'FILTER_OFFSET' => '%env(int:FILTER_OFFSET)%',
    ])] private readonly array $parameters)
    {
    }
}
```