### PR TITLE
[Serializer] fix: deserialization union type of enum

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -65,6 +65,9 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
             return $type::from($data);
         } catch (\ValueError $e) {
             throw new InvalidArgumentException('The data must belong to a backed enumeration of type '.$type);
+        } catch (\TypeError $e) {
+            $enumBackingType = (new \ReflectionEnum($type))->getBackingType()->getName();
+            throw NotNormalizableValueException::createForUnexpectedDataType('The data must be of the same type as the backed enumeration of type '.$type, $data, [$enumBackingType], $context['deserialization_path'] ?? null, true);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyObjectWithUnionEnumConstructor.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyObjectWithUnionEnumConstructor.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class DummyObjectWithUnionEnumConstructor
+{
+    public function __construct(public StringBackedEnumDummy|IntegerBackedEnumDummy $sub)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/47797

Fix deserialization of union type of BackedEnum
