### PR TITLE
[HttpClient] Fix seeking in not-yet-initialized requests

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
+++ b/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 class StreamWrapper
 {
-    /** @var resource|string|null */
+    /** @var resource|null */
     public $context;
 
     /** @var HttpClientInterface */
@@ -31,7 +31,7 @@ class StreamWrapper
     /** @var ResponseInterface */
     private $response;
 
-    /** @var resource|null */
+    /** @var resource|string|null */
     private $content;
 
     /** @var resource|null */
@@ -81,6 +81,7 @@ class StreamWrapper
     {
         $this->handle = &$handle;
         $this->content = &$content;
+        $this->offset = null;
     }
 
     public function stream_open(string $path, string $mode, int $options): bool
@@ -125,7 +126,7 @@ class StreamWrapper
                 }
             }
 
-            if (0 !== fseek($this->content, $this->offset)) {
+            if (0 !== fseek($this->content, $this->offset ?? 0)) {
                 return false;
             }
 
@@ -154,6 +155,11 @@ class StreamWrapper
             try {
                 $this->eof = true;
                 $this->eof = !$chunk->isTimeout();
+
+                if (!$this->eof && !$this->blocking) {
+                    return '';
+                }
+
                 $this->eof = $chunk->isLast();
 
                 if ($chunk->isFirst()) {
@@ -196,7 +202,7 @@ class StreamWrapper
 
     public function stream_tell(): int
     {
-        return $this->offset;
+        return $this->offset ?? 0;
     }
 
     public function stream_eof(): bool
@@ -206,6 +212,11 @@ class StreamWrapper
 
     public function stream_seek(int $offset, int $whence = \SEEK_SET): bool
     {
+        if (null === $this->content && null === $this->offset) {
+            $this->response->getStatusCode();
+            $this->offset = 0;
+        }
+
         if (!\is_resource($this->content) || 0 !== fseek($this->content, 0, \SEEK_END)) {
             return false;
         }
@@ -213,7 +224,7 @@ class StreamWrapper
         $size = ftell($this->content);
 
         if (\SEEK_CUR === $whence) {
-            $offset += $this->offset;
+            $offset += $this->offset ?? 0;
         }
 
         if (\SEEK_END === $whence || $size < $offset) {

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -118,6 +118,18 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertTrue(feof($stream));
     }
 
+    public function testSeekAsyncStream()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/timeout-body');
+        $stream = $response->toStream(false);
+
+        $this->assertSame(0, fseek($stream, 0, \SEEK_CUR));
+        $this->assertSame('<1>', fread($stream, 8192));
+        $this->assertFalse(feof($stream));
+        $this->assertSame('<2>', stream_get_contents($stream));
+    }
+
     public function testTimeoutIsNotAFatalError()
     {
         $client = $this->getHttpClient(__FUNCTION__);

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -311,6 +311,7 @@ class MockHttpClientTest extends HttpClientTestCase
                 return $client;
 
             case 'testNonBlockingStream':
+            case 'testSeekAsyncStream':
                 $responses[] = new MockResponse((function () { yield '<1>'; yield ''; yield '<2>'; })(), ['response_headers' => $headers]);
                 break;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Reported on Slack by @drupol 