### PR TITLE
[WebProfilerBundle] Minor design tweaks and fixes in redesigned panels

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -498,7 +498,7 @@
             </div>
 
             <div class="tab {{ data.view_vars ?? [] is empty ? 'disabled' }}">
-                <h3 class="tab-title">View Variables</h3>
+                <h3 class="tab-title">View Vars</h3>
 
                 <div class="tab-content">
                     {{ _self.render_form_view_variables(data) }}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -68,7 +68,7 @@
             <h2><code>{{ transport }}</code> transport</h2>
             {{ _self.render_transport_details(collector, transport) }}
         {% endfor %}
-    {% else %}
+    {% elseif events.transports is not empty %}
         {{ _self.render_transport_details(collector, events.transports|first, true) }}
     {% endif %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -57,8 +57,6 @@
         .message-bus .badge.status-some-errors { line-height: 16px; border-bottom: 2px solid #B0413E; }
 
         .message-item tbody.sf-toggle-content.sf-toggle-visible { display: table-row-group; }
-        td.message-bus-dispatch-caller { background: #f1f2f3; }
-        .theme-dark td.message-bus-dispatch-caller { background: var(--base-1); }
     </style>
 {% endblock %}
 
@@ -71,6 +69,9 @@
         <div class="empty empty-panel">
             <p>No messages have been collected.</p>
         </div>
+    {% elseif 1 == collector.buses|length %}
+        <p class="text-muted">Ordered list of dispatched messages across all your buses</p>
+        {{ helper.render_bus_messages(collector.messages, true) }}
     {% else %}
         <div class="sf-tabs message-bus">
             <div class="tab">
@@ -112,9 +113,6 @@
                     data-toggle-initial="{{ loop.first ? 'display' }}"
                 >
                     <span class="dump-inline">{{ profiler_dump(dispatchCall.message.type) }}</span>
-                    {% if showBus %}
-                        <span class="label">{{ dispatchCall.bus }}</span>
-                    {% endif %}
                     {% if dispatchCall.exception is defined %}
                         <span class="label status-error">exception</span>
                     {% endif %}
@@ -127,21 +125,21 @@
         </thead>
         <tbody id="message-item-{{ discr }}-{{ loop.index0 }}-details" class="sf-toggle-content">
             <tr>
-                <td colspan="2" class="message-bus-dispatch-caller">
-                    <span class="metadata">In
-                        {% set caller = dispatchCall.caller %}
-                        {% if caller.line %}
-                            {% set link = caller.file|file_link(caller.line) %}
-                            {% if link %}
-                                <a href="{{ link }}" title="{{ caller.file }}">{{ caller.name }}</a>
-                            {% else %}
-                                <abbr title="{{ caller.file }}">{{ caller.name }}</abbr>
-                            {% endif %}
+                <th scope="row" class="font-normal">Caller</th>
+                <td class="message-bus-dispatch-caller">
+                    In
+                    {% set caller = dispatchCall.caller %}
+                    {% if caller.line %}
+                        {% set link = caller.file|file_link(caller.line) %}
+                        {% if link %}
+                            <a href="{{ link }}" title="{{ caller.file }}">{{ caller.name }}</a>
                         {% else %}
-                            {{ caller.name }}
+                            <abbr title="{{ caller.file }}">{{ caller.name }}</abbr>
                         {% endif %}
-                        line <a class="text-small sf-toggle" data-toggle-selector="#sf-trace-{{ discr }}-{{ loop.index0 }}">{{ caller.line }}</a>
-                    </span>
+                    {% else %}
+                        {{ caller.name }}
+                    {% endif %}
+                    line <a class="text-small sf-toggle" data-toggle-selector="#sf-trace-{{ discr }}-{{ loop.index0 }}">{{ caller.line }}</a>
 
                     <div class="hidden" id="sf-trace-{{ discr }}-{{ loop.index0 }}">
                         <div class="trace">
@@ -157,27 +155,27 @@
             </tr>
             {% if showBus %}
                 <tr>
-                    <td class="text-bold">Bus</td>
+                    <th scope="row" class="font-normal">Bus</th>
                     <td>{{ dispatchCall.bus }}</td>
                 </tr>
             {% endif %}
             <tr>
-                <td class="text-bold">Message</td>
+                <th scope="row" class="font-normal">Message</th>
                 <td>{{ profiler_dump(dispatchCall.message.value, maxDepth=2) }}</td>
             </tr>
             <tr>
-                <td class="text-bold">Envelope stamps <span class="text-muted">when dispatching</span></td>
+                <th scope="row" class="font-normal">Envelope stamps <span class="block text-muted">when dispatching</span></th>
                 <td>
                     {% for item in dispatchCall.stamps %}
                         {{ profiler_dump(item) }}
                     {% else %}
-                        <span class="text-muted">No items</span>
+                        <span class="text-muted font-normal">No items</span>
                     {% endfor %}
                 </td>
             </tr>
             {% if dispatchCall.stamps_after_dispatch is defined %}
                 <tr>
-                    <td class="text-bold">Envelope stamps <span class="text-muted">after dispatch</span></td>
+                    <th scope="row" class="font-normal">Envelope stamps <span class="block text-muted">after dispatch</span></th>
                     <td>
                         {% for item in dispatchCall.stamps_after_dispatch %}
                             {{ profiler_dump(item) }}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -107,14 +107,27 @@ button,hr,input{overflow:visible}progress,sub,sup{vertical-align:baseline}[type=
     --button-active-background: var(--gray-200);
     --badge-background: var(--gray-200);
     --badge-color: var(--gray-600);
+    --badge-shadow: none;
+    --selected-badge-background: var(--gray-200);
+    --selected-badge-color: var(--gray-600);
+    --selected-badge-shadow: inset 0 0 0 1px var(--gray-300);
     --badge-light-background: var(--gray-100);
     --badge-light-color: var(--gray-500);
     --badge-success-background: var(--green-100);
     --badge-success-color: var(--green-700);
+    --badge-success-shadow: none;
     --badge-warning-background: var(--yellow-200);
     --badge-warning-color: var(--yellow-700);
+    --badge-warning-shadow: none;
+    --selected-badge-warning-background: var(--yellow-200);
+    --selected-badge-warning-color: var(--yellow-700);
+    --selected-badge-warning-shadow: inset 0 0 0 1px var(--yellow-500);
     --badge-danger-background: var(--red-100);
     --badge-danger-color: var(--red-700);
+    --badge-danger-shadow: none;
+    --selected-badge-danger-background: var(--red-100);
+    --selected-badge-danger-color: var(--red-700);
+    --selected-badge-danger-shadow: inset 0 0 0 1px var(--red-200);
     --sidebar-shadow: inset 0 0 0 1px var(--menu-border-color), 0 0 0 3px var(--gray-50), 0 0 0 5px var(--page-background);
     --menu-border-color: var(--gray-300);
     --menu-color: var(--gray-700);
@@ -233,14 +246,29 @@ button,hr,input{overflow:visible}progress,sub,sup{vertical-align:baseline}[type=
     --button-box-shadow: 0 1px 0 0 var(--gray-500);
     --button-color: var(--gray-800);
     --button-active-background: var(--gray-400);
-    --badge-background: #555;
-    --badge-color: #ddd;
-    --badge-light-background: var(--gray-600);
-    --badge-light-color: var(--gray-200);
-    --badge-warning-background: var(--yellow-300);
-    --badge-warning-color: var(--yellow-700);
-    --badge-danger-background: var(--red-600);
-    --badge-danger-color: var(--red-100);
+    --badge-background: rgba(221, 221, 221, 0.2);
+    --badge-color: var(--gray-300);
+    --badge-shadow: none;
+    --selected-badge-background: #555;
+    --selected-badge-color: #ddd;
+    --selected-badge-shadow: none;
+    --badge-light-background: var(--gray-700);
+    --badge-light-color: var(--gray-300);
+    --badge-success-background: #1dc9a420;
+    --badge-success-color: #36e2bd;
+    --badge-success-shadow: inset 0 0 0 1px #36e2bd4d;
+    --badge-warning-background: #f97a1f33;
+    --badge-warning-color: #FCDE83;
+    --badge-warning-shadow: inset 0 0 0 1px #e6af0580;
+    --selected-badge-warning-background: var(--yellow-300);
+    --selected-badge-warning-color: var(--yellow-700);
+    --selected-badge-warning-shadow: inset 0 0 0 1px var(--yellow-600);
+    --badge-danger-background: #E1244B20;
+    --badge-danger-color: var(--red-300);
+    --badge-danger-shadow: inset 0 0 0 1px #e1244Bd0;
+    --selected-badge-danger-background: var(--red-600);
+    --selected-badge-danger-color: var(--red-100);
+    --selected-badge-danger-shadow: none;
     --sidebar-shadow: inset 0 0 0 1px var(--menu-border-color), 0 0 0 5px var(--page-background);
     --menu-border-color: var(--gray-500);
     --menu-color: var(--gray-300);
@@ -657,8 +685,9 @@ table tbody td.num-col {
 }
 
 .label {
-    background-color: var(--base-4);
+    background-color: var(--badge-background);
     border-radius: 4px;
+    box-shadow: var(--badge-shadow);
     color: #FAFAFA;
     display: inline-block;
     font-size: 12px;
@@ -670,9 +699,9 @@ table tbody td.num-col {
     min-width: 70px;
     text-align: center;
 }
-.label.status-success { background: var(--badge-success-background); color: var(--badge-success-color); }
-.label.status-warning { background: var(--badge-warning-background); color: var(--badge-warning-color); }
-.label.status-error   { background: var(--badge-danger-background); color: var(--badge-danger-color); }
+.label.status-success { background: var(--badge-success-background); box-shadow: var(--badge-success-shadow); color: var(--badge-success-color); }
+.label.status-warning { background: var(--badge-warning-background); box-shadow: var(--badge-warning-shadow); color: var(--badge-warning-color); }
+.label.status-error { background: var(--badge-danger-background); box-shadow: var(--badge-danger-shadow); color: var(--badge-danger-color); }
 
 {# Metrics
    ------------------------------------------------------------------------- #}
@@ -1381,10 +1410,10 @@ tr.status-warning td {
     border-radius: 6px;
     content: '';
     position: absolute;
-    top: calc(50% - 12px);
+    top: calc(50% - 14px);
     left: -8px;
     width: 4px;
-    height: 26px;
+    height: 28px;
 }
 #menu-profiler li.selected a .label,
 #menu-profiler:hover li.selected a:hover .label,
@@ -1403,9 +1432,10 @@ tr.status-warning td {
 }
 
 #menu-profiler li a .count {
-    background: var(--badge-background);
+    background: var(--selected-badge-background);
     border-radius: 4px;
-    color: var(--badge-color);
+    box-shadow: var(--selected-badge-shadow);
+    color: var(--selected-badge-color);
     display: inline-block;
     font-weight: bold;
     line-height: 1;
@@ -1423,15 +1453,14 @@ tr.status-warning td {
 }
 
 #menu-profiler .label-status-warning .count {
-    background: var(--badge-warning-background);
-    color: var(--badge-warning-color);
-}
-.theme-dark #menu-profiler .label-status-warning .count {
-    box-shadow: inset 0 0 0 1px var(--yellow-600);
+    background: var(--selected-badge-warning-background);
+    color: var(--selected-badge-warning-color);
+    box-shadow: var(--selected-badge-warning-shadow);
 }
 #menu-profiler .label-status-error .count {
-    background: var(--badge-danger-background);
-    color: var(--badge-danger-color);
+    background: var(--selected-badge-danger-background);
+    color: var(--selected-badge-danger-color);
+    box-shadow: var(--selected-badge-danger-shadow);
 }
 
 {# Timeline panel
@@ -1544,6 +1573,9 @@ tr.status-warning td {
     width: 0;
 }
 .tab-navigation li .badge {
+    background: var(--selected-badge-background);
+    box-shadow: var(--selected-badge-shadow);
+    color: var(--selected-badge-color);
     display: inline-block;
     font-size: 12px;
     font-weight: bold;
@@ -1568,11 +1600,16 @@ tr.status-warning td {
 .tab-content > *:first-child {
     margin-top: 0;
 }
-.tab-navigation li .badge.status-warning { background: var(--badge-warning-background); color: var(--badge-warning-color); }
-.theme-dark .tab-navigation li.active .badge.status-warning {
-    box-shadow: inset 0 0 0 1px var(--yellow-600);
+.tab-navigation li .badge.status-warning {
+    background: var(--selected-badge-warning-background);
+    box-shadow: var(--selected-badge-warning-shadow);
+    color: var(--selected-badge-warning-color);
 }
-.tab-navigation li .badge.status-error { background: var(--badge-danger-background); color: var(--badge-danger-color); }
+.tab-navigation li .badge.status-error {
+    background: var(--selected-badge-danger-background);
+    box-shadow: var(--selected-badge-danger-shadow);
+    color: var(--selected-badge-danger-color);
+}
 
 .sf-tabs .tab:not(:first-child) { display: none; }
 
@@ -1829,12 +1866,14 @@ table.logs .log-metadata .context + .context {
 }
 .log-type-badge {
     background: var(--badge-light-background);
+    box-shadow: none;
     color: var(--badge-light-color);
     display: inline-block;
     font-family: var(--font-family-system);
     margin-top: 5px;
 }
-.log-type-badge.badge-deprecation {
+.log-type-badge.badge-deprecation,
+.log-type-badge.badge-warning {
     background: var(--badge-warning-background);
     color: var(--badge-warning-color);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR does 3 things:

(1) It fixes some issues in some panels (e.g. `mailer`) when collector doesn't contain certain information

(2) It simplifies the `messenger` panel to not display certain information when not needed:

<img width="1030" alt="messenger-changes" src="https://user-images.githubusercontent.com/73419/194882843-9b607bfc-b175-4b9f-8a0b-a5d22e58f3cd.png">

The `1` callout refers to the list of available buses, which is no longer displayed when there's only 1 bus. The `2` callout refers to the bus name, which is no longer displayed in the table header because it's always displayed inside the table.

(3) It does misc. minor design tweaks. The main change is that badges in dark mode now look different than in light mode. This is similar to what GitHub and others do:

### Before

<img width="692" alt="labels-dark-before" src="https://user-images.githubusercontent.com/73419/194883308-3623e0d1-5159-4de2-a562-091b91183912.png">

### After

<img width="684" alt="labels-dark-after" src="https://user-images.githubusercontent.com/73419/194883333-bc4916d2-18b7-49ee-8f0a-061b2d8a5bd2.png">
