### PR TITLE
[Mailer] fix: use message object from event

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -61,6 +61,7 @@ abstract class AbstractTransport implements TransportInterface
             $event = new MessageEvent($message, $envelope, (string) $this);
             $this->dispatcher->dispatch($event);
             $envelope = $event->getEnvelope();
+            $message = $event->getMessage();
         }
 
         $message = new SentMessage($message, $envelope);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  |no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Based on the documentation https://symfony.com/doc/current/mailer.html#messageevent 
> MessageEvent allows to change the Message and the Envelope before the email is sent

However right now you can do only the following:
- modify the Envelope object or replace it with a new one
- modify the Message object (e.g. change subject, update recipients)

But you can **not** replace the Message object, even if there is a method `setMessage` on the event.
The reason is that the AbstractTransport does get the updated/replaced Envelope object from the event, but not the Message object:

```php
        if (null !== $this->dispatcher) {
            $event = new MessageEvent($message, $envelope, (string) $this);
            $this->dispatcher->dispatch($event);
            $envelope = $event->getEnvelope();
            // here we should also get the message
        }
```

So why would we need to replace the Message object in the first place?
One example would be the signing of messages (see example here https://symfony.com/doc/current/mailer.html#dkim-signer) in a listener. The signer does not modify the existing Message object, but returns a new instance. If we then use `$event->setMessage($signedEmail)` it simply doesn't work, because it's going to be ignored in the transport.

See also this comment here, where someone encountered the same issue: https://github.com/symfony/symfony/issues/39354#issuecomment-894379296