### PR TITLE
[Messenger] [Amqp] Revert BC break

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -195,11 +195,11 @@ class Connection
         self::validateOptions($amqpOptions);
 
         if (isset($parsedUrl['user'])) {
-            $amqpOptions['login'] = urldecode($parsedUrl['user']);
+            $amqpOptions['login'] = $parsedUrl['user'];
         }
 
         if (isset($parsedUrl['pass'])) {
-            $amqpOptions['password'] = urldecode($parsedUrl['pass']);
+            $amqpOptions['password'] = $parsedUrl['pass'];
         }
 
         if (!isset($amqpOptions['queues'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

After my latest `composer update` Symfony Messenger suddenly started to throw this error but only on some environments:

```
Could not connect to the AMQP server. Please verify the provided DSN.
```

The reason for that is that I have a `+` sign in the password for AMQP. I tracked the change back to the newly added `urldecode` call in [commit](https://github.com/symfony/symfony/commit/308edb55684f7afb3670414a6a69443551bf2e4d#diff-e73cdfa592b9e8cd24170c11468e4a3c26d69832c3e7d1322db693ba171df859) which changes the `+` character to a space. So it seems to be a BC break specifically in v5.4.13, v6.0.13 and v6.1.5.

ping @xabbuh as the author of that commit