### PR TITLE
[Security] AuthenticationUtils: fix returning coalesced value of LastUsername

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
@@ -53,10 +53,10 @@ class AuthenticationUtils
         $request = $this->getRequest();
 
         if ($request->attributes->has(Security::LAST_USERNAME)) {
-            return $request->attributes->get(Security::LAST_USERNAME, '');
+            return $request->attributes->get(Security::LAST_USERNAME, '') ?? '';
         }
 
-        return $request->hasSession() ? $request->getSession()->get(Security::LAST_USERNAME, '') : '';
+        return ($request->hasSession() ? $request->getSession()->get(Security::LAST_USERNAME, '') : '') ?? '';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

In some sophisticated use cases, there might be conditions within which the Session object HAS LastUsername in the attribute bag but the value is null. I believe "AuthenticationUtils" is responsible to properly coalesce the retrieved value and turn it to a blank string if it's null. This PR responds to this issue.
