### PR TITLE
[TwigBridge] Remove empty spaces between choices when using checkbox-inline or checkbox-switch

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -213,10 +213,10 @@
     {%- set parent_label_class = parent_label_class|default(label_attr.class|default('')) -%}
     {%- set row_class = 'form-check' -%}
     {%- if 'checkbox-inline' in parent_label_class %}
-        {% set row_class = row_class ~ ' form-check-inline' %}
+        {%- set row_class = row_class ~ ' form-check-inline' -%}
     {% endif -%}
     {%- if 'checkbox-switch' in parent_label_class %}
-        {% set row_class = row_class ~ ' form-switch' %}
+        {%- set row_class = row_class ~ ' form-switch' -%}
     {% endif -%}
     <div class="{{ row_class }}">
         {{- form_label(form, null, { widget: parent() }) -}}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR fixes empty spaces between choices when using checkbox-inline or checkbox-switch.