### PR TITLE
[Process] Add new function getAnyOutput() to process component.

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2.0
+-----
+
+* added `Process::getAnyOutput()` to get any output regardless if it origins from stderr or stdout
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -227,7 +227,7 @@ class Process implements \IteratorAggregate
      * from the independent process during execution.
      *
      * The STDOUT and STDERR are also available after the process is finished
-     * via the getOutput() and getErrorOutput() methods.
+     * via the getOutput(), getErrorOutput() or getAnyOutput() methods.
      *
      * @param callable|null $callback A PHP callback to run whenever there is some
      *                                output available on STDOUT or STDERR

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -577,6 +577,17 @@ class Process implements \IteratorAggregate
     }
 
     /**
+     * Returns any output of the process (STDOUT and STDERR).
+     *
+     * @throws LogicException in case the output has been disabled
+     * @throws LogicException In case the process is not started
+     */
+    public function getAnyOutput(): string
+    {
+        return $this->getOutput() . $this->getErrorOutput();
+    }
+
+    /**
      * Returns the output incrementally.
      *
      * In comparison with the getOutput method which always return the whole

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -437,6 +437,19 @@ class ProcessTest extends TestCase
         $this->assertEquals(3, preg_match_all('/foo/', $p->getOutput(), $matches));
     }
 
+    public function testGetAnyOutput()
+    {
+        $p = $this->getProcessForCode('$n = 0; while ($n < 3) { echo \' foo \'; $n++; }');
+
+        $p->run();
+        $this->assertEquals(3, preg_match_all('/foo/', $p->getAnyOutput(), $matches));
+
+        $p = $this->getProcessForCode('$n = 0; while ($n < 3) { file_put_contents(\'php://stderr\', \'ERROR\'); $n++; }');
+
+        $p->run();
+        $this->assertEquals(3, preg_match_all('/ERROR/', $p->getAnyOutput(), $matches));
+    }
+
     public function testFlushOutput()
     {
         $p = $this->getProcessForCode('$n=0;while ($n<3) {echo \' foo \';$n++;}');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ?
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/17339

# Introducing getAnyOutput() to process component

While working with the process component on multiple projects, I stumbled upon this example:

```php
$process = Process::fromShellCommandline($command, $workdir, $parameters);

$process->run();
$logger->info('Yada, yada [...] command was executed. This is the output:' . $process->getOutput());
```
The problem with this kind of code is, that output streamed into stderr will not occur in the log message. We have to call getErrorOutput() to also get error output if the command fails. In my case, I don't really care if the command outputs information on stderr or stdout. I want to get any output from the executed process regardless if the executed command handles stderr or stdout properly or not. Many unix commands do not handle stderr or stdout properly due to historical reasons or lack of maintenance. 

You can get any output from a process by doing this:

```php
 $process->getOutput() . $process->getErrorOutput();
```

That's why I thought that there is a need for this component to have a method for this specific case, where we do not care about if the command streams output to stderr or stdout.  

With my new function, you can adapt my example like this:

```php
$process = Process::fromShellCommandline($command, $workdir, $parameters);

$process->run();
$logger->info('Yada, yada [...] command was executed. This is the output:' . $process->getAnyOutput());
```

and get any output of a process. 