### PR TITLE
[HttpClient] TraceableHttpClient: increase decorator's priority

### DIFF
--- a/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
+++ b/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
@@ -43,7 +43,7 @@ final class HttpClientPass implements CompilerPassInterface
             $container->register('.debug.'.$id, TraceableHttpClient::class)
                 ->setArguments([new Reference('.debug.'.$id.'.inner'), new Reference('debug.stopwatch', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)])
                 ->addTag('kernel.reset', ['method' => 'reset'])
-                ->setDecoratedService($id);
+                ->setDecoratedService($id, null, 5);
             $container->getDefinition('data_collector.http_client')
                 ->addMethodCall('registerClient', [$id, new Reference('.debug.'.$id)]);
         }

--- a/src/Symfony/Component/HttpClient/Tests/DependencyInjection/HttpClientPassTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DependencyInjection/HttpClientPassTest.php
@@ -38,7 +38,7 @@ class HttpClientPassTest extends TestCase
         $sut->process($container);
         $this->assertTrue($container->hasDefinition('.debug.foo'));
         $this->assertSame(TraceableHttpClient::class, $container->getDefinition('.debug.foo')->getClass());
-        $this->assertSame(['foo', null, 0], $container->getDefinition('.debug.foo')->getDecoratedService());
+        $this->assertSame(['foo', null, 5], $container->getDefinition('.debug.foo')->getDecoratedService());
     }
 
     public function testItRegistersDebugHttpClientToCollector()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->



Hello,

When I decorate my http client, all requests are not collected and visible in the profiler because of the decorator's priority of TraceableHttpClient (sub request for example). I think it should be increased. I fixed an arbitrary value of 100.

What do you think about that ?

Ty

