### PR TITLE
Release v5.4.14

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -7,6 +7,21 @@ in 5.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.4.0...v5.4.1
 
+* 5.4.14 (2022-10-12)
+
+ * bug #47621 [Serializer] Allow getting discriminated type by class name (TamasSzigeti)
+ * bug #47833 [TwigBridge] Remove empty spaces between choices when using checkbox-inline or checkbox-switch (simondaigre)
+ * bug #47808 [HttpClient] Fix seeking in not-yet-initialized requests (nicolas-grekas)
+ * bug #47798 [DoctrineBridge] Fix auto mapping for bundles that contain only embeddables (jorissae)
+ * bug #47702 [Messenger] Fix default serializer not handling DateTime objects properly (barton-webwings)
+ * bug #47779 [Console] Fix `Helper::removeDecoration` hyperlink bug (greew)
+ * bug #47753 [Mime] sync message serializer code for forward-compatibility (xabbuh)
+ * bug #47763 [PropertyInfo] a readonly property must not be reported as being writable (xabbuh)
+ * bug #47731 [WebProfiler] Fix overflow issue in Forms panel (zolikonta)
+ * bug #46956 [FrameworkBundle] Allow to specify `null` for exception mapping configuration values (andrew-demb)
+ * bug #47746 [HttpFoundation] Fix BinaryFileResponse content type detection logic (X-Coder264)
+ * bug #47626 [Notifier] [Expo] Throw exception on error-response from expo api (sdrewergutland)
+
 * 5.4.13 (2022-09-30)
 
  * bug #47317 [Security] Fix login url matching when app is not run with url rewriting or from a sub folder (sgehrig)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,12 +78,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static $freshCache = [];
 
-    public const VERSION = '5.4.14-DEV';
+    public const VERSION = '5.4.14';
     public const VERSION_ID = 50414;
     public const MAJOR_VERSION = 5;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 14;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2024';
     public const END_OF_LIFE = '11/2025';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.4.13...v5.4.14)

 * bug #47621 [Serializer] Allow getting discriminated type by class name (@TamasSzigeti)
 * bug #47833 [TwigBridge] Remove empty spaces between choices when using checkbox-inline or checkbox-switch (@simondaigre)
 * bug #47808 [HttpClient] Fix seeking in not-yet-initialized requests (@nicolas-grekas)
 * bug #47798 [DoctrineBridge] Fix auto mapping for bundles that contain only embeddables (@jorissae)
 * bug #47702 [Messenger] Fix default serializer not handling DateTime objects properly (@barton-webwings)
 * bug #47779 [Console] Fix `Helper::removeDecoration` hyperlink bug (@greew)
 * bug #47753 [Mime] sync message serializer code for forward-compatibility (@xabbuh)
 * bug #47763 [PropertyInfo] a readonly property must not be reported as being writable (@xabbuh)
 * bug #47731 [WebProfiler] Fix overflow issue in Forms panel (@zolikonta)
 * bug #46956 [FrameworkBundle] Allow to specify `null` for exception mapping configuration values (@andrew-demb)
 * bug #47746 [HttpFoundation] Fix BinaryFileResponse content type detection logic (@X-Coder264)
 * bug #47626 [Notifier] [Expo] Throw exception on error-response from expo api (@sdrewergutland)
