### PR TITLE
[HttpFoundation] Fix session tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
@@ -54,10 +54,12 @@ ob_start();
 class TestSessionHandler extends AbstractSessionHandler
 {
     private $data;
+    private $sessionId;
 
-    public function __construct($data = '')
+    public function __construct($data = '', $sessionId = null)
     {
         $this->data = $data;
+        $this->sessionId = $sessionId;
     }
 
     public function open($path, $name): bool
@@ -131,7 +133,13 @@ class TestSessionHandler extends AbstractSessionHandler
 
     protected function doRead($sessionId): string
     {
-        echo __FUNCTION__.': ', $this->data, "\n";
+        if (isset($this->sessionId) && $sessionId !== $this->sessionId) {
+            echo __FUNCTION__ . ": invalid sessionId\n";
+
+            return '';
+        }
+        echo __FUNCTION__ . ': ', $this->data, "\n";
+        $this->sessionId = $sessionId;
 
         return $this->data;
     }
@@ -139,6 +147,7 @@ class TestSessionHandler extends AbstractSessionHandler
     protected function doWrite($sessionId, $data): bool
     {
         echo __FUNCTION__.': ', $data, "\n";
+        $this->sessionId = $sessionId;
 
         return true;
     }
@@ -146,6 +155,7 @@ class TestSessionHandler extends AbstractSessionHandler
     protected function doDestroy($sessionId): bool
     {
         echo __FUNCTION__, "\n";
+        $this->sessionId = '';
 
         return true;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/regenerate.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/regenerate.expected
@@ -9,9 +9,8 @@ close
 open
 validateId
 read
-doRead: abc|i:123;
+doRead: invalid sessionId
 read
-doRead: abc|i:123;
 
 write
 doWrite: abc|i:123;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/with_samesite_and_migration.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/with_samesite_and_migration.expected
@@ -8,7 +8,7 @@ close
 open
 validateId
 read
-doRead: 
+doRead: invalid sessionId
 read
 
 write


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Spotted after https://github.com/php/php-src/pull/9638

The `validateId()` method of session handlers should return true only when the session-id maps to actual data in the storage.
This behavior was not correctly mocked in our function tests.