### PR TITLE
[WebProfiler] Fix conditions for displaying the mailer panel in the absence of letters

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -68,7 +68,7 @@
             <h2><code>{{ transport }}</code> transport</h2>
             {{ _self.render_transport_details(collector, transport) }}
         {% endfor %}
-    {% else %}
+    {% elseif events.transports %}
         {{ _self.render_transport_details(collector, events.transports|first, true) }}
     {% endif %}
 
@@ -106,7 +106,7 @@
                 {% endfor %}
 
                 <script>Sfjs.initializeMailerTable();</script>
-            {% else %}
+            {% elseif num_emails %}
                 {% set event = (collector.events.events(transport)|first) %}
                 {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
             {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| License       | MIT 
 
Fixed a bug when opening the mailer panel, in the absence of letters.

Error message: `Impossible to access an attribute ("message") on a boolean variable (""). - on line 111  `
