### PR TITLE
[HttpClient] Don't override header if is x-www-form-urlencoded

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -97,7 +97,7 @@ trait HttpClientTrait
         }
 
         if (isset($options['body'])) {
-            if (\is_array($options['body'])) {
+            if (\is_array($options['body']) && !isset($options['normalized_headers']['content-type'])) {
                 $options['normalized_headers']['content-type'] = ['Content-Type: application/x-www-form-urlencoded'];
             }
 

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -49,6 +49,25 @@ class HttpClientTraitTest extends TestCase
         yield ['http://example.com/?b=', 'http://example.com/', ['a' => null, 'b' => '']];
     }
 
+    public function testPrepareRequestWithBodyIsArray()
+    {
+        $defaults = [
+            'base_uri' => 'http://example.com?c=c',
+            'query' => ['a' => 1, 'b' => 'b'],
+            'body' => []
+        ];
+        [, $defaults] = self::prepareRequest(null, null, $defaults);
+
+        [,$options] = self::prepareRequest(null, 'http://example.com', [
+            'body' => [1, 2],
+            'headers' => [
+                'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8'
+            ]
+        ], $defaults);
+
+        $this->assertContains('Content-Type: application/x-www-form-urlencoded; charset=utf-8', $options['headers']);
+    }
+
     /**
      * @dataProvider provideResolveUrl
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47852
| License       | MIT

When body is array and the Content-Type is application/x-www-form-urlencoded we not override the header