### PR TITLE
[Routing] TypeError in Router when using UrlGenerator

### DIFF
--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -313,14 +313,12 @@ class Router implements RouterInterface, RequestMatcherInterface
 
         if (null === $this->options['cache_dir']) {
             $routes = $this->getRouteCollection();
-            $aliases = [];
             $compiled = is_a($this->options['generator_class'], CompiledUrlGenerator::class, true);
             if ($compiled) {
                 $generatorDumper = new CompiledUrlGeneratorDumper($routes);
-                $routes = $generatorDumper->getCompiledRoutes();
-                $aliases = $generatorDumper->getCompiledAliases();
+                $routes = array_merge($generatorDumper->getCompiledRoutes(), $generatorDumper->getCompiledAliases());
             }
-            $this->generator = new $this->options['generator_class'](array_merge($routes, $aliases), $this->context, $this->logger, $this->defaultLocale);
+            $this->generator = new $this->options['generator_class']($routes, $this->context, $this->logger, $this->defaultLocale);
         } else {
             $cache = $this->getConfigCacheFactory()->cache($this->options['cache_dir'].'/url_generating_routes.php',
                 function (ConfigCacheInterface $cache) {

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Routing\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\CompiledUrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
@@ -128,7 +129,20 @@ class RouterTest extends TestCase
             ->method('load')->with('routing.yml', null)
             ->willReturn(new RouteCollection());
 
+        $this->assertInstanceOf(CompiledUrlGenerator::class, $this->router->getGenerator());
+    }
+
+    public function testGeneratorIsCreatedIfCacheIsNotConfiguredNotCompiled()
+    {
+        $this->router->setOption('cache_dir', null);
+        $this->router->setOption('generator_class', UrlGenerator::class);
+
+        $this->loader->expects($this->once())
+            ->method('load')->with('routing.yml', null)
+            ->willReturn(new RouteCollection());
+
         $this->assertInstanceOf(UrlGenerator::class, $this->router->getGenerator());
+        $this->assertNotInstanceOf(CompiledUrlGenerator::class, $this->router->getGenerator());
     }
 
     public function testMatchRequestWithUrlMatcherInterface()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47844
| License       | MIT
| Doc PR        | 


Fix the array_merge problem when using the `UrlGenerator ` and not the `CompiledUrlGenerator`. For more details about the bug see the issue #47844
