### PR TITLE
[Routing] Fix TypeError when using UrlGenerator

### DIFF
--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -313,14 +313,15 @@ class Router implements RouterInterface, RequestMatcherInterface
 
         if (null === $this->options['cache_dir']) {
             $routes = $this->getRouteCollection();
-            $aliases = [];
             $compiled = is_a($this->options['generator_class'], CompiledUrlGenerator::class, true);
             if ($compiled) {
                 $generatorDumper = new CompiledUrlGeneratorDumper($routes);
                 $routes = $generatorDumper->getCompiledRoutes();
                 $aliases = $generatorDumper->getCompiledAliases();
+                $this->generator = new $this->options['generator_class'](array_merge($routes, $aliases), $this->context, $this->logger, $this->defaultLocale);
+            } else {
+                $this->generator = new $this->options['generator_class']($routes, $this->context, $this->logger, $this->defaultLocale);
             }
-            $this->generator = new $this->options['generator_class'](array_merge($routes, $aliases), $this->context, $this->logger, $this->defaultLocale);
         } else {
             $cache = $this->getConfigCacheFactory()->cache($this->options['cache_dir'].'/url_generating_routes.php',
                 function (ConfigCacheInterface $cache) {

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Routing\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\CompiledUrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
@@ -129,6 +130,29 @@ class RouterTest extends TestCase
             ->willReturn(new RouteCollection());
 
         $this->assertInstanceOf(UrlGenerator::class, $this->router->getGenerator());
+    }
+
+    /**
+     * @dataProvider provideGeneratorClass
+     */
+    public function testGeneratorIsCreatedWithGeneratorClass(string $generatorClass)
+    {
+        $this->router->setOption('cache_dir', null);
+        $this->router->setOption('generator_class', $generatorClass);
+
+        $this->loader->expects($this->once())
+            ->method('load')->with('routing.yml', null)
+            ->willReturn(new RouteCollection());
+
+        $this->assertInstanceOf($generatorClass, $this->router->getGenerator());
+    }
+
+    public function provideGeneratorClass(): array
+    {
+        return [
+            CompiledUrlGenerator::class => [CompiledUrlGenerator::class],
+            UrlGenerator::class => [UrlGenerator::class],
+        ];
     }
 
     public function testMatchRequestWithUrlMatcherInterface()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47844
| License       | MIT

This fixes bug #47844, based on [a suggestion](https://github.com/symfony/symfony/issues/47844#issuecomment-1276319455) from @stof.
