### PR TITLE
[HttpKernel] Fix empty request stack when terminating with exception

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -112,7 +112,17 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
             throw $exception;
         }
 
-        $response = $this->handleThrowable($exception, $request, self::MASTER_REQUEST);
+        if ($pop = $request !== $this->requestStack->getMasterRequest()) {
+            $this->requestStack->push($request);
+        }
+
+        try {
+            $response = $this->handleThrowable($exception, $request, self::MASTER_REQUEST);
+        } finally {
+            if ($pop) {
+                $this->requestStack->pop();
+            }
+        }
 
         $response->sendHeaders();
         $response->sendContent();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\ControllerDoesNotReturnResponseException;
@@ -338,6 +339,22 @@ class HttpKernelTest extends TestCase
         $this->assertEquals($kernel, $capturedKernel);
         $this->assertEquals($request, $capturedRequest);
         $this->assertEquals($response, $capturedResponse);
+    }
+
+    public function testTerminateWithException()
+    {
+        $dispatcher = new EventDispatcher();
+        $requestStack = new RequestStack();
+        $kernel = $this->getHttpKernel($dispatcher, null, $requestStack);
+
+        $dispatcher->addListener(KernelEvents::EXCEPTION, function (ExceptionEvent $event) use (&$capturedRequest, $requestStack) {
+            $capturedRequest = $requestStack->getCurrentRequest();
+            $event->setResponse(new Response());
+        });
+
+        $kernel->terminateWithException(new \Exception('boo'), $request = Request::create('/'));
+        $this->assertSame($request, $capturedRequest);
+        $this->assertNull($requestStack->getCurrentRequest());
     }
 
     public function testVerifyRequestStackPushPopDuringHandle()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4, 5.4, 6.0, 6.1, 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47577
| License       | MIT
| Doc PR        | 

After https://github.com/symfony/symfony/pull/47358 the RequestStack is empty when request terminates with exception, which prevents SecurityDataCollector to generate logout URL and generates fatal error.