### PR TITLE
[DoctrineBridge] Implement `EventManager::getAllListeners()`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -72,15 +72,23 @@ class ContainerAwareEventManager extends EventManager
      */
     public function getListeners($event = null)
     {
+        if (null === $event) {
+            return $this->getAllListeners();
+        }
         if (!$this->initializedSubscribers) {
             $this->initializeSubscribers();
         }
-        if (null !== $event) {
-            if (!isset($this->initialized[$event])) {
-                $this->initializeListeners($event);
-            }
+        if (!isset($this->initialized[$event])) {
+            $this->initializeListeners($event);
+        }
 
-            return $this->listeners[$event];
+        return $this->listeners[$event];
+    }
+
+    public function getAllListeners(): array
+    {
+        if (!$this->initializedSubscribers) {
+            $this->initializeSubscribers();
         }
 
         foreach ($this->listeners as $event => $listeners) {

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -165,6 +165,15 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->assertSame([$listener1, $listener2], array_values($this->evm->getListeners()['foo']));
     }
 
+    public function testGetAllListeners()
+    {
+        $this->container->set('lazy', $listener1 = new MyListener());
+        $this->evm->addEventListener('foo', 'lazy');
+        $this->evm->addEventListener('foo', $listener2 = new MyListener());
+
+        $this->assertSame([$listener1, $listener2], array_values($this->evm->getAllListeners()['foo']));
+    }
+
     public function testRemoveEventListener()
     {
         $this->container->set('lazy', $listener1 = new MyListener());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`doctrine/event-manager` 1.2 introduces a new method `getAllListeners()`. Since our `ContainerAwareEventManager` overrides the behavior of all public methods, we need to override that one too.