### PR TITLE
[Notifier] Check Discord embed limitations

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Discord/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Check embed limitations
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordAuthorEmbedObject.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordAuthorEmbedObject.php
@@ -11,16 +11,24 @@
 
 namespace Symfony\Component\Notifier\Bridge\Discord\Embeds;
 
+use Symfony\Component\Notifier\Exception\LengthException;
+
 /**
  * @author Karoly Gossler <connor@connor.hu>
  */
 final class DiscordAuthorEmbedObject extends AbstractDiscordEmbedObject
 {
+    private const NAME_LIMIT = 256;
+
     /**
      * @return $this
      */
     public function name(string $name): static
     {
+        if (\strlen($name) > self::NAME_LIMIT) {
+            throw new LengthException(sprintf('Maximum length for the name is %d characters.', self::NAME_LIMIT));
+        }
+
         $this->options['name'] = $name;
 
         return $this;

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordEmbed.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordEmbed.php
@@ -11,16 +11,26 @@
 
 namespace Symfony\Component\Notifier\Bridge\Discord\Embeds;
 
+use Symfony\Component\Notifier\Exception\LengthException;
+
 /**
  * @author Karoly Gossler <connor@connor.hu>
  */
 final class DiscordEmbed extends AbstractDiscordEmbed
 {
+    private const TITLE_LIMIT = 256;
+    private const DESCRIPTION_LIMIT = 4096;
+    private const FIELDS_LIMIT = 25;
+
     /**
      * @return $this
      */
     public function title(string $title): static
     {
+        if (\strlen($title) > self::TITLE_LIMIT) {
+            throw new LengthException(sprintf('Maximum length for the title is %d characters.', self::TITLE_LIMIT));
+        }
+
         $this->options['title'] = $title;
 
         return $this;
@@ -31,6 +41,10 @@ final class DiscordEmbed extends AbstractDiscordEmbed
      */
     public function description(string $description): static
     {
+        if (\strlen($description) > self::DESCRIPTION_LIMIT) {
+            throw new LengthException(sprintf('Maximum length for the description is %d characters.', self::DESCRIPTION_LIMIT));
+        }
+
         $this->options['description'] = $description;
 
         return $this;
@@ -111,6 +125,10 @@ final class DiscordEmbed extends AbstractDiscordEmbed
      */
     public function addField(DiscordFieldEmbedObject $field): static
     {
+        if (self::FIELDS_LIMIT === \count($this->options['fields'] ?? [])) {
+            throw new LengthException(sprintf('Maximum number of fields should not exceed %d.', self::FIELDS_LIMIT));
+        }
+
         if (!isset($this->options['fields'])) {
             $this->options['fields'] = [];
         }

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordFieldEmbedObject.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordFieldEmbedObject.php
@@ -11,16 +11,25 @@
 
 namespace Symfony\Component\Notifier\Bridge\Discord\Embeds;
 
+use Symfony\Component\Notifier\Exception\LengthException;
+
 /**
  * @author Karoly Gossler <connor@connor.hu>
  */
 final class DiscordFieldEmbedObject extends AbstractDiscordEmbedObject
 {
+    private const NAME_LIMIT = 256;
+    private const VALUE_LIMIT = 1024;
+
     /**
      * @return $this
      */
     public function name(string $name): static
     {
+        if (\strlen($name) > self::NAME_LIMIT) {
+            throw new LengthException(sprintf('Maximum length for the name is %d characters.', self::NAME_LIMIT));
+        }
+
         $this->options['name'] = $name;
 
         return $this;
@@ -31,6 +40,10 @@ final class DiscordFieldEmbedObject extends AbstractDiscordEmbedObject
      */
     public function value(string $value): static
     {
+        if (\strlen($value) > self::VALUE_LIMIT) {
+            throw new LengthException(sprintf('Maximum length for the value is %d characters.', self::VALUE_LIMIT));
+        }
+
         $this->options['value'] = $value;
 
         return $this;

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordFooterEmbedObject.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordFooterEmbedObject.php
@@ -11,16 +11,24 @@
 
 namespace Symfony\Component\Notifier\Bridge\Discord\Embeds;
 
+use Symfony\Component\Notifier\Exception\LengthException;
+
 /**
  * @author Karoly Gossler <connor@connor.hu>
  */
 final class DiscordFooterEmbedObject extends AbstractDiscordEmbedObject
 {
+    private const TEXT_LIMIT = 2048;
+
     /**
      * @return $this
      */
     public function text(string $text): static
     {
+        if (\strlen($text) > self::TEXT_LIMIT) {
+            throw new LengthException(sprintf('Maximum length for the text is %d characters.', self::TEXT_LIMIT));
+        }
+
         $this->options['text'] = $text;
 
         return $this;

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordAuthorEmbedObjectTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordAuthorEmbedObjectTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Discord\Tests\Embeds;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Discord\Embeds\DiscordAuthorEmbedObject;
+use Symfony\Component\Notifier\Exception\LengthException;
+
+final class DiscordAuthorEmbedObjectTest extends TestCase
+{
+    public function testCanBeInstantiated()
+    {
+        $author = (new DiscordAuthorEmbedObject())
+            ->name('Doe')
+            ->url('http://ur.l')
+            ->iconUrl('http://icon-ur.l')
+            ->proxyIconUrl('http://proxy-icon-ur.l');
+
+        $this->assertSame([
+            'name' => 'Doe',
+            'url' => 'http://ur.l',
+            'icon_url' => 'http://icon-ur.l',
+            'proxy_icon_url' => 'http://proxy-icon-ur.l',
+        ], $author->toArray());
+    }
+
+    public function testThrowsWhenNameExceedsCharacterLimit()
+    {
+        $this->expectException(LengthException::class);
+        $this->expectExceptionMessage('Maximum length for the name is 256 characters.');
+
+        (new DiscordAuthorEmbedObject())->name(str_repeat('h', 257));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordEmbedTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordEmbedTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Discord\Tests\Embeds;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Discord\Embeds\DiscordEmbed;
+use Symfony\Component\Notifier\Bridge\Discord\Embeds\DiscordFieldEmbedObject;
+use Symfony\Component\Notifier\Exception\LengthException;
+
+final class DiscordEmbedTest extends TestCase
+{
+    public function testCanBeInstantiated()
+    {
+        $embed = (new DiscordEmbed())
+            ->title('foo')
+            ->description('bar')
+            ->addField((new DiscordFieldEmbedObject())
+                ->name('baz')
+                ->value('qux')
+            );
+
+        $this->assertSame([
+            'title' => 'foo',
+            'description' => 'bar',
+            'fields' => [
+                [
+                    'name' => 'baz',
+                    'value' => 'qux',
+                ],
+            ],
+        ], $embed->toArray());
+    }
+
+    public function testThrowsWhenTitleExceedsCharacterLimit()
+    {
+        $this->expectException(LengthException::class);
+        $this->expectExceptionMessage('Maximum length for the title is 256 characters.');
+
+        (new DiscordEmbed())->title(str_repeat('h', 257));
+    }
+
+    public function testThrowsWhenDescriptionExceedsCharacterLimit()
+    {
+        $this->expectException(LengthException::class);
+        $this->expectExceptionMessage('Maximum length for the description is 4096 characters.');
+
+        (new DiscordEmbed())->description(str_repeat('h', 4097));
+    }
+
+    public function testThrowsWhenFieldsLimitReached()
+    {
+        $embed = new DiscordEmbed();
+        for ($i = 0; $i < 25; ++$i) {
+            $embed->addField((new DiscordFieldEmbedObject())
+                ->name('baz')
+                ->value('qux')
+            );
+        }
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Maximum number of fields should not exceed 25.');
+
+        $embed->addField((new DiscordFieldEmbedObject())
+            ->name('fail')
+            ->value('fail')
+        );
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordFieldEmbedObjectTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordFieldEmbedObjectTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Discord\Tests\Embeds;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Discord\Embeds\DiscordFieldEmbedObject;
+use Symfony\Component\Notifier\Exception\LengthException;
+
+final class DiscordFieldEmbedObjectTest extends TestCase
+{
+    public function testCanBeInstantiated()
+    {
+        $field = (new DiscordFieldEmbedObject())
+            ->name('foo')
+            ->value('bar')
+            ->inline(true);
+
+        $this->assertSame([
+            'name' => 'foo',
+            'value' => 'bar',
+            'inline' => true,
+        ], $field->toArray());
+    }
+
+    public function testThrowsWhenNameExceedsCharacterLimit()
+    {
+        $this->expectException(LengthException::class);
+        $this->expectExceptionMessage('Maximum length for the name is 256 characters.');
+
+        (new DiscordFieldEmbedObject())->name(str_repeat('h', 257));
+    }
+
+    public function testThrowsWhenValueExceedsCharacterLimit()
+    {
+        $this->expectException(LengthException::class);
+        $this->expectExceptionMessage('Maximum length for the value is 1024 characters.');
+
+        (new DiscordFieldEmbedObject())->value(str_repeat('h', 1025));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordFooterEmbedObjectTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordFooterEmbedObjectTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Discord\Tests\Embeds;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Discord\Embeds\DiscordFooterEmbedObject;
+use Symfony\Component\Notifier\Exception\LengthException;
+
+final class DiscordFooterEmbedObjectTest extends TestCase
+{
+    public function testCanBeInstantiated()
+    {
+        $author = (new DiscordFooterEmbedObject())
+            ->text('foo')
+            ->iconUrl('http://icon-ur.l')
+            ->proxyIconUrl('http://proxy-icon-ur.l');
+
+        $this->assertSame([
+            'text' => 'foo',
+            'icon_url' => 'http://icon-ur.l',
+            'proxy_icon_url' => 'http://proxy-icon-ur.l',
+        ], $author->toArray());
+    }
+
+    public function testThrowsWhenTextExceedsCharacterLimit()
+    {
+        $this->expectException(LengthException::class);
+        $this->expectExceptionMessage('Maximum length for the text is 2048 characters.');
+
+        (new DiscordFooterEmbedObject())->text(str_repeat('h', 2049));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #47688 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add missing check on Discord Embeds (length and number).

See #47688 for description

Official embed limits: https://discord.com/developers/docs/resources/channel#embed-object-embed-limits

(unrelated phpunit failure)
