### PR TITLE
[DoctrineBridge] Allow doctrine/event-manager 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "composer-runtime-api": ">=2.1",
         "ext-xml": "*",
         "friendsofphp/proxy-manager-lts": "^1.0.2",
-        "doctrine/event-manager": "~1.0",
+        "doctrine/event-manager": "^1|^2",
         "doctrine/persistence": "^2|^3",
         "twig/twig": "^2.13|^3.0.4",
         "psr/cache": "^2.0|^3.0",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.0.2",
-        "doctrine/event-manager": "~1.0",
+        "doctrine/event-manager": "^1|^2",
         "doctrine/persistence": "^2|^3",
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/polyfill-ctype": "~1.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

We can allow installing EventManager 2 on the 6.0 branch because we have all the necessary return types here. On 5.4 and below, this would require a breaking change.