### PR TITLE
[DoctrineBridge] Deprecate calling `ContainerAwareEventManager::getListeners()` without event name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "composer-runtime-api": ">=2.1",
         "ext-xml": "*",
         "friendsofphp/proxy-manager-lts": "^1.0.2",
-        "doctrine/event-manager": "^1|^2",
+        "doctrine/event-manager": "^1.2|^2",
         "doctrine/persistence": "^2|^3",
         "twig/twig": "^2.13|^3.0.4",
         "psr/cache": "^2.0|^3.0",

--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -70,6 +70,8 @@ class ContainerAwareEventManager extends EventManager
     public function getListeners($event = null): array
     {
         if (null === $event) {
+            trigger_deprecation('symfony/doctrine-bridge', '6.2', 'Calling "%s()" without an event name is deprecated. Call "getAllListeners()" instead.', __METHOD__);
+
             return $this->getAllListeners();
         }
         if (!$this->initializedSubscribers) {

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -14,10 +14,13 @@ namespace Symfony\Bridge\Doctrine\Tests;
 use Doctrine\Common\EventSubscriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ContainerAwareEventManager;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
 
 class ContainerAwareEventManagerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private $container;
     private $evm;
 
@@ -171,11 +174,16 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->assertSame([$subscriber1, $listener1, $listener2], array_values($this->evm->getListeners('foo')));
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetListeners()
     {
         $this->container->set('lazy', $listener1 = new MyListener());
         $this->evm->addEventListener('foo', 'lazy');
         $this->evm->addEventListener('foo', $listener2 = new MyListener());
+
+        $this->expectDeprecation('Since symfony/doctrine-bridge 6.2: Calling "Symfony\Bridge\Doctrine\ContainerAwareEventManager::getListeners()" without an event name is deprecated. Call "getAllListeners()" instead.');
 
         $this->assertSame([$listener1, $listener2], array_values($this->evm->getListeners()['foo']));
     }

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "doctrine/event-manager": "^1|^2",
+        "doctrine/event-manager": "^1.2|^2",
         "doctrine/persistence": "^2|^3",
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/polyfill-ctype": "~1.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

With EventManager 1.2, calling `EventManager::getListeners()` without an event name has been deprecated. We should do the same for our `ContainerAwareEventManager`.