### PR TITLE
[FrameworkBundle] secrets:generate-keys seal with DotenvVault

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsGenerateKeysCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsGenerateKeysCommand.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
+use Symfony\Bundle\FrameworkBundle\Secrets\DotenvVault;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -74,7 +75,7 @@ EOF
             return 1;
         }
 
-        if (!$input->getOption('rotate')) {
+        if (!$vault instanceof DotenvVault && !$input->getOption('rotate')) {
             if ($vault->generateKeys()) {
                 $io->success($vault->getLastMessage());
 
@@ -101,13 +102,15 @@ EOF
             $secrets[$name] = $value;
         }
 
-        if (!$vault->generateKeys(true)) {
+        if (!$vault instanceof DotenvVault && !$vault->generateKeys(true)) {
             $io->warning($vault->getLastMessage());
 
             return 1;
         }
 
-        $io->success($vault->getLastMessage());
+        if ($vault->getLastMessage()) {
+            $io->success($vault->getLastMessage());
+        }
 
         if ($secrets) {
             foreach ($secrets as $name => $value) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Closed because not a bug, just no real point in using the `--local` option.

The `SecretsGenerateKeysCommand` will finish early if `AbstractVault::generateKeys` returns `false`. However the vault used may be an instance of `DotenvVault` where the implementation of `generateKeys` will always return `false`. Hence the command can never be run to the point where `DotenvVault::seal` would be called.

This skips the `generateKeys` calls if the vault is an instance of `DotenvVault`.
