### PR TITLE
[HttpClient] Deprecation Contracts Dependency

### DIFF
--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -18,12 +18,12 @@
         "php-http/async-client-implementation": "*",
         "php-http/client-implementation": "*",
         "psr/http-client-implementation": "1.0",
-        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/http-client-implementation": "3.0"
     },
     "require": {
         "php": ">=8.1",
         "psr/log": "^1|^2|^3",
+        "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/http-client-contracts": "^3",
         "symfony/service-contracts": "^1.0|^2|^3"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 (branch follow-up)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | 

I believe ca3a2463a3a40a5fe348bcfc3c14a6a72efcc45d added `deprecation-contracts` to the incorrect field, which is causing the actual package not to install in some circumstances because it thinks HTTPClient provides the dependency.
