### PR TITLE
[HttpClient] Fix buffering after calling AsyncContext::passthru()

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncContext.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncContext.php
@@ -181,9 +181,15 @@ final class AsyncContext
 
     /**
      * Replaces or removes the chunk filter iterator.
+     *
+     * @param ?callable(ChunkInterface, self): ?\Iterator $passthru
      */
     public function passthru(callable $passthru = null): void
     {
-        $this->passthru = $passthru;
+        $this->passthru = $passthru ?? static function ($chunk, $context) {
+            $context->passthru = null;
+
+            yield $chunk;
+        };
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
@@ -225,4 +225,22 @@ class RetryableHttpClientTest extends TestCase
         $this->assertNotNull($delay);
         $this->assertSame((int) ($retryAfter * 1000), $delay);
     }
+
+    public function testRetryOnErrorAssertContent()
+    {
+        $client = new RetryableHttpClient(
+            new MockHttpClient([
+               new MockResponse('', ['http_code' => 500]),
+               new MockResponse('Test out content', ['http_code' => 200]),
+            ]),
+            new GenericRetryStrategy([500], 0),
+            1
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('Test out content', $response->getContent());
+        self::assertSame('Test out content', $response->getContent(), 'Content should be buffered');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Hi, guys, I think there is an issue with the RetryableHttpClient, let me explain to you what I've seen.

1. Request is executed into AsyncResponse::__construct

2. The initializer Closure executes AsyncResponse::passthru, there the AsyncContext and a new stream are created

3. The next step is yielding from passthruStream and there the stream is checked - ```$r->stream->valid()```. Here the stream is not a valid iterator, because the last retry attempt has already been made and the generator is closed. 

4. This leads the response body stream to be unseekable because the ```$r->openBuffer()``` is not called. The content is left with a value ```null``` and when ```AsyncResponse->toStream()``` is called from ```Psr18Client::110``` the content with value null is bound to the ```content of StreamWrapper```.

5. After that this newly generated resource is passed to the ```Psr17Factory->createStreamFromResource()``` and the resulted (unseekable body) stream is passed to the ```$response->withBody($body)``` onto ```Psr18Client::121```

6. The result is that the Response body stream is not seekable and when I execute two times ```(string) $response->getBody()``` after the first attempt the body is an empty string.

Let me know what you think. 

Thank you.