### PR TITLE
Workaround BC breaks brought by RFC "improve_unserialize_error_handling" v1.4

### DIFF
--- a/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
+++ b/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
@@ -81,6 +81,14 @@ class DefaultMarshaller implements MarshallerInterface
             }
 
             throw new \DomainException(error_get_last() ? error_get_last()['message'] : 'Failed to unserialize values.');
+        } catch (\UnserializationFailedException $e) {
+            $p = $e->getPrevious();
+
+            if ($p instanceof \Error) {
+                throw new \ErrorException($p->getMessage(), $p->getCode(), \E_ERROR, $p->getFile(), $p->getLine());
+            }
+
+            throw $p instanceof \DomainException ? $p : $e;
         } catch (\Error $e) {
             throw new \ErrorException($e->getMessage(), $e->getCode(), \E_ERROR, $e->getFile(), $e->getLine());
         } finally {

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -156,7 +156,11 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
         });
 
         try {
-            $meta = unserialize($content);
+            try {
+                $meta = unserialize($content);
+            } catch (\UnserializationFailedException $e) {
+                throw $e instanceof \UnserializationFailedException && $e->getPrevious() === $signalingException ? $signalingException : $e;
+            }
         } catch (\Throwable $e) {
             if ($e !== $signalingException) {
                 throw $e;

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -93,6 +93,10 @@ class PhpSerializer implements SerializerInterface
         try {
             /** @var Envelope */
             $envelope = unserialize($contents);
+        } catch (\Throwable $e) {
+            $message = ($e instanceof \UnserializationFailedException ? $e->getPrevious() : $e)->getMessage();
+
+            throw new MessageDecodingFailedException($message, 0, $e);
         } finally {
             restore_error_handler();
             ini_set('unserialize_callback_func', $prevUnserializeHandler);

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -264,7 +264,11 @@ class ContextListener extends AbstractListener
         });
 
         try {
-            $token = unserialize($serializedToken);
+            try {
+                $token = unserialize($serializedToken);
+            } catch (\UnserializationFailedException $e) {
+                throw 0x37313BC !== $e->getPrevious()->getCode() ? $e : $e->getPrevious();
+            }
         } catch (\ErrorException $e) {
             if (0x37313BC !== $e->getCode()) {
                 throw $e;

--- a/src/Symfony/Component/VarExporter/Internal/Registry.php
+++ b/src/Symfony/Component/VarExporter/Internal/Registry.php
@@ -40,7 +40,11 @@ class Registry
 
         try {
             foreach ($serializables as $k => $v) {
-                $objects[$k] = unserialize($v);
+                try {
+                    $objects[$k] = unserialize($v);
+                } catch (\UnserializationFailedException $e) {
+                    throw $e->getPrevious() instanceof ClassNotFoundException ? $e->getPrevious() : $e;
+                }
             }
         } finally {
             ini_set('unserialize_callback_func', $unserializeCallback);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR highlights the changes that would be required if [PHP RFC: Improve unserialize() error handling](https://wiki.php.net/rfc/improve_unserialize_error_handling) were to be approved for PHP 8.3. It fixes failures listed [on this gist](https://gist.github.com/nicolas-grekas/3da652a51669baa40c99bd20e4a1b4dd).

See also https://externals.io/message/118813 and https://externals.io/message/118566

Note that the point being made here is NOT whether adapting is hard. It's that adapting should NOT be required to support a new minor version of PHP.