### PR TITLE
[Cache] Reserve numeric keys when doing memory leak prevention

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -331,6 +331,19 @@ abstract class AdapterTestCase extends CachePoolTest
 
         $this->assertSame(123, $cache->getItem("a\0b")->get());
     }
+
+    public function testNumericKeysWorkAfterMemoryLeakPrevention()
+    {
+        $cache = $this->createCachePool(0, __FUNCTION__);
+
+        for ($i = 0; $i < 1001; ++$i) {
+            $cacheItem = $cache->getItem((string) $i);
+            $cacheItem->set('value-'.$i);
+            $cache->save($cacheItem);
+        }
+
+        $this->assertEquals('value-50', $cache->getItem((string) 50)->get());
+    }
 }
 
 class NotUnserializable

--- a/src/Symfony/Component/Cache/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractTrait.php
@@ -290,7 +290,7 @@ trait AbstractTrait
         $this->ids[$key] = $key;
 
         if (\count($this->ids) > 1000) {
-            array_splice($this->ids, 0, 500); // stop memory leak if there are many keys
+            $this->ids = \array_slice($this->ids, 500, null, true); // stop memory leak if there are many keys
         }
 
         if (null === $this->maxIdLength) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

`getItem()` started to return invalid entries after 1000 calls because `array_slice()` doesn't preserve numeric keys

```php
<?php

require_once 'vendor/autoload.php';

use Symfony\Component\Cache\Adapter\FilesystemAdapter;

// works:
$cache = new FilesystemAdapter('foo-namespace');
$keys = range(0, 999);
foreach ($keys as $key) {
    $cacheItem = $cache->getItem((string) $key);
    $cacheItem->set('value: ' . $key);
    $cache->save($cacheItem);
}
echo $cache->getItem('25')->get() . PHP_EOL; // "value: 25"

// doesn't work:
$cache = new FilesystemAdapter('xyz-namespace');
$keys = range(0, 1000);
foreach ($keys as $key) {
    $cacheItem = $cache->getItem((string) $key);
    $cacheItem->set('value: ' . $key);
    $cache->save($cacheItem);
}
echo $cache->getItem('25')->get() . PHP_EOL; // "value: 525"
```

after:

```php
// works:
$cache = new FilesystemAdapter('xyz-namespace');
$keys = range(0, 1000);
foreach ($keys as $key) {
    $cacheItem = $cache->getItem((string) $key);
    $cacheItem->set('value: ' . $key);
    $cache->save($cacheItem);
}
echo $cache->getItem('25')->get() . PHP_EOL; // "value: 25"
```