### PR TITLE
[SecurityBundle] Deprecate the `enable_authenticator_manager` option

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -89,6 +89,11 @@ Security
  * Change the signature of `TokenStorageInterface::setToken()` to `setToken(?TokenInterface $token)`
  * Deprecate calling `TokenStorage::setToken()` or `UsageTrackingTokenStorage::setToken()` without arguments
 
+SecurityBundle
+--------------
+
+ * Deprecate the `security.enable_authenticator_manager` config option
+
 Serializer
 ----------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
@@ -8,8 +8,6 @@ services:
             - container.service_subscriber
 
 security:
-    enable_authenticator_manager: true
-
     providers:
         main:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `security.firewalls.logout.enable_csrf` to enable CSRF protection using the default CSRF token generator
  * Add RFC6750 Access Token support to allow token-based authentication
  * Add `security.firewalls.switch_user.target_route` option to configure redirect target route on switch user
+ * Deprecate the `security.enable_authenticator_manager` config option
 
 6.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -65,7 +65,7 @@ class MainConfiguration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('hide_user_not_found')->defaultTrue()->end()
                 ->booleanNode('erase_credentials')->defaultTrue()->end()
-                ->booleanNode('enable_authenticator_manager')->defaultTrue()->end()
+                ->booleanNode('enable_authenticator_manager')->setDeprecated('symfony/security-bundle', '6.2', 'The "%node%" option at "%path%" is deprecated.')->defaultTrue()->end()
                 ->arrayNode('access_decision_manager')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -139,7 +139,6 @@ class AddSessionDomainConstraintPassTest extends TestCase
 
         $config = [
             'security' => [
-                'enable_authenticator_manager' => true,
                 'providers' => ['some_provider' => ['id' => 'foo']],
                 'firewalls' => ['some_firewall' => ['security' => false]],
             ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
@@ -56,7 +56,6 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testEventIsPropagated(string $configuredEvent, string $registeredEvent)
     {
         $this->container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
         ]);
 
@@ -90,7 +89,6 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testRegisterCustomListener()
     {
         $this->container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
         ]);
 
@@ -111,7 +109,6 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testRegisterCustomSubscriber()
     {
         $this->container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
         ]);
 
@@ -131,7 +128,6 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testMultipleFirewalls()
     {
         $this->container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true], 'api' => ['pattern' => '/api', 'http_basic' => true]],
         ]);
 
@@ -161,7 +157,6 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testListenerAlreadySpecific()
     {
         $this->container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
         ]);
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_customized_config.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_customized_config.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'access_decision_manager' => [
         'allow_if_all_abstain' => true,
         'allow_if_equal_granted_denied' => false,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_default_strategy.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_default_strategy.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'access_decision_manager' => [
         'service' => 'app.access_decision_manager',
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service_and_strategy.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service_and_strategy.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'access_decision_manager' => [
         'service' => 'app.access_decision_manager',
         'strategy' => 'affirmative',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_strategy_service.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_strategy_service.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'access_decision_manager' => [
         'strategy_service' => 'app.custom_access_decision_strategy',
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_hasher.php
@@ -3,7 +3,6 @@
 $this->load('container1.php');
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'argon2i',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/authenticator_manager.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/authenticator_manager.php
@@ -3,7 +3,6 @@
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'firewalls' => [
         'main' => [
             'required_badges' => [CsrfTokenBadge::class, 'RememberMeBadge'],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_hasher.php
@@ -3,7 +3,6 @@
 $this->load('container1.php');
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'bcrypt',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User1' => 'plaintext',
         'JMS\FooBundle\Entity\User2' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_provider.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'providers' => [
         'default' => [
             'memory' => $memory = [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_undefined_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_undefined_provider.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_provider.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_undefined_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_undefined_provider.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/logout_delete_cookies.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/logout_delete_cookies.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'providers' => [
         'default' => ['id' => 'foo'],
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge.php
@@ -3,7 +3,6 @@
 $this->load('merge_import.php');
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'providers' => [
         'default' => ['id' => 'foo'],
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge_import.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge_import.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'firewalls' => [
         'main' => [
             'form_login' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_hasher.php
@@ -3,7 +3,6 @@
 $this->load('container1.php');
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'argon2i',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
@@ -1,7 +1,6 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'providers' => [
         'default' => ['id' => 'foo'],
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/sodium_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/sodium_hasher.php
@@ -3,7 +3,6 @@
 $this->load('container1.php');
 
 $container->loadFromExtension('security', [
-    'enable_authenticator_manager' => true,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'sodium',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_customized_config.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_customized_config.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <access-decision-manager allow-if-all-abstain="true" allow-if-equal-granted-denied="false" />
 
         <provider name="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_default_strategy.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_default_strategy.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <provider name="default">
             <memory>
                 <user identifier="foo" password="foo" roles="ROLE_USER" />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <access-decision-manager service="app.access_decision_manager" />
 
         <provider name="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service_and_strategy.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service_and_strategy.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <access-decision-manager service="app.access_decision_manager" strategy="affirmative" />
 
         <provider name="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_strategy_service.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_strategy_service.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <access-decision-manager strategy-service="app.custom_access_decision_strategy" />
 
         <provider name="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/argon2i_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/argon2i_hasher.xml
@@ -12,7 +12,7 @@
         <import resource="container1.xml"/>
     </imports>
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="argon2i" memory-cost="256" time-cost="1" />
     </sec:config>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/authenticator_manager.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/authenticator_manager.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <firewall name="main">
             <required-badge>Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge</required-badge>
             <required-badge>RememberMeBadge</required-badge>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_hasher.xml
@@ -12,7 +12,7 @@
         <import resource="container1.xml"/>
     </imports>
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="bcrypt" cost="15" />
     </sec:config>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <password_hasher class="JMS\FooBundle\Entity\User1" algorithm="plaintext" />
 
         <password_hasher class="JMS\FooBundle\Entity\User2" algorithm="sha1" encode-as-base64="false" iterations="5" />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_provider.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:providers>
             <sec:provider name="with-dash" id="foo" />
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_undefined_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_undefined_provider.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:providers>
             <sec:provider name="default" id="foo" />
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_provider.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:providers>
             <sec:provider name="default" id="foo" />
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_undefined_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_undefined_provider.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:providers>
             <sec:provider name="default" id="foo" />
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/logout_delete_cookies.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/logout_delete_cookies.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <provider name="default" id="foo" />
 
         <firewall name="main" provider="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge.xml
@@ -12,7 +12,7 @@
         <import resource="merge_import.xml"/>
     </imports>
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:provider name="default" id="foo" />
 
         <sec:firewall name="main" form-login="false">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge_import.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge_import.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <firewall name="main">
             <form-login login-path="/login" />
         </firewall>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/migrating_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/migrating_hasher.xml
@@ -12,7 +12,7 @@
         <import resource="container1.xml"/>
     </imports>
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="argon2i" memory-cost="256" time-cost="1">
             <sec:migrate-from>bcrypt</sec:migrate-from>
         </sec:password_hasher>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config enable-authenticator-manager="true">
+    <config>
         <provider name="default">
             <memory>
                 <user identifier="foo" password="foo" roles="ROLE_USER" />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/remember_me_options.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/remember_me_options.xml
@@ -8,7 +8,7 @@
     http://symfony.com/schema/dic/security
     https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:providers>
             <sec:provider name="default" id="foo"/>
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/sodium_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/sodium_hasher.xml
@@ -12,7 +12,7 @@
         <import resource="container1.xml"/>
     </imports>
 
-    <sec:config enable-authenticator-manager="true">
+    <sec:config>
         <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="sodium" time-cost="8" memory-cost="131072" />
     </sec:config>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_customized_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_customized_config.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     access_decision_manager:
         allow_if_all_abstain: true
         allow_if_equal_granted_denied: false

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_default_strategy.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_default_strategy.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     access_decision_manager:
         service: app.access_decision_manager
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service_and_strategy.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service_and_strategy.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     access_decision_manager:
         service: app.access_decision_manager
         strategy: affirmative

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_strategy_service.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_strategy_service.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     access_decision_manager:
         strategy_service: app.custom_access_decision_strategy
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_hasher.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: container1.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         JMS\FooBundle\Entity\User7:
             algorithm: argon2i

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/authenticator_manager.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/authenticator_manager.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     firewalls:
         main:
             required_badges:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_hasher.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: container1.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         JMS\FooBundle\Entity\User7:
             algorithm: bcrypt

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     password_hashers:
         JMS\FooBundle\Entity\User1: plaintext
         JMS\FooBundle\Entity\User2:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_provider.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_undefined_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_undefined_provider.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_provider.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_undefined_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_undefined_provider.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/logout_delete_cookies.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/logout_delete_cookies.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     providers:
         default:
             id: foo

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: merge_import.yml }
 
 security:
-    enable_authenticator_manager: true
     providers:
         default: { id: foo }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge_import.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge_import.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     firewalls:
         main:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/migrating_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/migrating_hasher.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: container1.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         JMS\FooBundle\Entity\User7:
             algorithm: argon2i

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
@@ -1,6 +1,4 @@
 security:
-    enable_authenticator_manager: true
-
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/remember_me_options.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/remember_me_options.yml
@@ -1,6 +1,4 @@
 security:
-    enable_authenticator_manager: true
-
     providers:
         default:
             id: foo

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/sodium_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/sodium_hasher.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: container1.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         JMS\FooBundle\Entity\User7:
             algorithm: sodium

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -50,7 +50,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -78,7 +77,6 @@ class SecurityExtensionTest extends TestCase
         $extension->addUserProviderFactory(new DummyProvider());
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'my_foo' => ['foo' => []],
             ],
@@ -99,7 +97,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -124,7 +121,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -147,7 +143,6 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -170,7 +165,6 @@ class SecurityExtensionTest extends TestCase
         $this->expectExceptionMessage('Not configuring explicitly the provider for the "http_basic" authenticator on "ambiguous" firewall is ambiguous as there is more than one registered provider.');
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -191,7 +185,6 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -216,7 +209,6 @@ class SecurityExtensionTest extends TestCase
         $rawExpression = "'foo' == 'bar' or 1 in [1, 3, 3]";
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -260,7 +252,6 @@ class SecurityExtensionTest extends TestCase
         $container->set($requestMatcherId, $requestMatcher);
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -295,7 +286,6 @@ class SecurityExtensionTest extends TestCase
         $container->set($requestMatcherId, $requestMatcher);
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -329,7 +319,6 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -350,7 +339,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -373,7 +361,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -400,8 +387,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
-
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'foo'],
@@ -427,7 +412,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -453,7 +437,6 @@ class SecurityExtensionTest extends TestCase
 
         $container->register('custom_remember_me', \stdClass::class);
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => [
                 'default' => [
                     'remember_me' => ['secret' => 'very', 'service' => 'custom_remember_me'],
@@ -474,7 +457,6 @@ class SecurityExtensionTest extends TestCase
 
         $container->register('custom_remember_me', \stdClass::class);
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => [
                 'default' => [
                     'remember_me' => ['secret' => 'very'],
@@ -494,7 +476,6 @@ class SecurityExtensionTest extends TestCase
 
         $container->register('custom_remember_me', \stdClass::class);
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => [
                 'default' => [
                     'remember_me' => ['secret' => 'very', 'token_provider' => 'token_provider_id'],
@@ -543,7 +524,6 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -568,7 +548,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -594,7 +573,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -625,7 +603,6 @@ class SecurityExtensionTest extends TestCase
 
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'first' => ['id' => 'users'],
             ],
@@ -655,7 +632,6 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
         $container->register(TestAuthenticator::class);
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'providers' => [
                 'first' => ['id' => 'users'],
             ],
@@ -689,7 +665,6 @@ class SecurityExtensionTest extends TestCase
 
         $firewallId = 'stateless_firewall';
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => [
                 $firewallId => [
                     'pattern' => '/.*',
@@ -710,7 +685,6 @@ class SecurityExtensionTest extends TestCase
 
         $firewallId = 'statefull_firewall';
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => [
                 $firewallId => [
                     'pattern' => '/.*',
@@ -734,7 +708,6 @@ class SecurityExtensionTest extends TestCase
         $container->register(TestUserChecker::class);
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => [
                 'main' => array_merge([
                     'pattern' => '/.*',
@@ -764,7 +737,6 @@ class SecurityExtensionTest extends TestCase
         $extension->addAuthenticatorFactory(new TestFirewallListenerFactory());
 
         $container->loadFromExtension('security', [
-            'enable_authenticator_manager' => true,
             'firewalls' => [
                 'main' => [
                     'custom_listener' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
@@ -8,8 +8,6 @@ services:
     class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\SecuredPageBundle\Security\Core\User\ArrayUserProvider
 
 security:
-  enable_authenticator_manager: true
-
   password_hashers:
     \Symfony\Component\Security\Core\User\UserInterface: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_anonymous.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_anonymous.yml
@@ -6,7 +6,6 @@ framework:
     serializer: ~
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_body_custom.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_body_custom.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_body_default.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_body_default.yml
@@ -6,7 +6,6 @@ framework:
     serializer: ~
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_header_custom.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_header_custom.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_header_default.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_header_default.yml
@@ -6,7 +6,6 @@ framework:
     serializer: ~
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_multiple_extractors.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_multiple_extractors.yml
@@ -6,7 +6,6 @@ framework:
     serializer: ~
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_no_extractors.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_no_extractors.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_no_handler.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_no_handler.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_query_custom.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_query_custom.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_query_default.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_query_default.yml
@@ -6,7 +6,6 @@ framework:
     serializer: ~
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/firewall_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/firewall_user_provider.yml
@@ -3,7 +3,6 @@ imports:
 - { resource: ./security.yml }
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         api:
             pattern: /

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/implicit_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/implicit_user_provider.yml
@@ -3,7 +3,6 @@ imports:
 - { resource: ./security.yml }
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         api:
             pattern: /

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/multiple_firewalls.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/multiple_firewalls.yml
@@ -3,7 +3,6 @@ imports:
 - { resource: ./security.yml }
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         firewall1:
             pattern: /firewall1

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/no_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/no_user_provider.yml
@@ -6,8 +6,6 @@ services:
         - true
 
 security:
-    enable_authenticator_manager: true
-
     firewalls:
         api:
             pattern: /

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/security.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/security.yml
@@ -1,6 +1,4 @@
 security:
-    enable_authenticator_manager: true
-
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
@@ -7,7 +7,6 @@ services:
         class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AutowiringBundle\AutowiredServices
         autowire: true
 security:
-    enable_authenticator_manager: true
     providers:
         dummy:
             memory: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
@@ -15,7 +15,6 @@ services:
             - { name: container.service_subscriber }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./base_config.yml }
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         default:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/routes_as_path.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/routes_as_path.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./config.yml }
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         default:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -17,7 +17,6 @@ services:
     logger: { class: Psr\Log\NullLogger }
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         secure:
             pattern: ^/secure/

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
@@ -6,7 +6,6 @@ framework:
     serializer: ~
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./config.yml }
 
 security:
-    enable_authenticator_manager: true
     providers:
         in_memory:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
@@ -12,7 +12,6 @@ services:
                     protocol_version: 3
                     referrals: false
 security:
-    enable_authenticator_manager: true
     providers:
         ldap:
             ldap:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/config.yml
@@ -2,8 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
-
     providers:
         in_memory:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
@@ -2,8 +2,6 @@ imports:
 - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
-
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
@@ -2,7 +2,6 @@ imports:
 - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
@@ -2,8 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
-
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/config.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         default:
             http_basic: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config_persistent.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config_persistent.yml
@@ -4,7 +4,6 @@ services:
         arguments: ['@kernel']
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         default:
             remember_me:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config_session.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config_session.yml
@@ -1,5 +1,4 @@
 security:
-    enable_authenticator_manager: true
     firewalls:
         default:
             remember_me:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/stateless_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/stateless_config.yml
@@ -9,7 +9,6 @@ framework:
         cookie_samesite: lax
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         default:
             stateless: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
@@ -25,8 +25,6 @@ services:
     Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
 
 security:
-    enable_authenticator_manager: true
-
     providers:
         main:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config_logout_csrf.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config_logout_csrf.yml
@@ -25,8 +25,6 @@ services:
     Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
 
 security:
-    enable_authenticator_manager: true
-
     providers:
         main:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/base_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/base_config.yml
@@ -6,7 +6,6 @@ parameters:
     env(APP_IPS): '127.0.0.1, ::1'
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/invalid_ip_access_control.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/invalid_ip_access_control.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/default.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_form_failure_handler.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_form_failure_handler.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/default.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/default.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes_with_forward.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes_with_forward.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./localized_routes.yml }
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         default:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/login_throttling.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/login_throttling.yml
@@ -7,7 +7,6 @@ framework:
     rate_limiter: ~
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         default:
             login_throttling:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/routes_as_path.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/routes_as_path.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./base_config.yml }
 
 security:
-    enable_authenticator_manager: true
     firewalls:
         default:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./base_config.yml }
 
 security:
-    enable_authenticator_manager: true
     providers:
         in_memory:
             memory:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Last step before we close the chapter in 7.0 🎉