### PR TITLE
[DependencyInjection] Sealed classes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Sealed.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Sealed.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class Sealed
+{
+    public function __construct(public readonly array $permits = []) {}
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/Sealed.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Sealed.php
@@ -14,5 +14,7 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class Sealed
 {
-    public function __construct(public readonly array $permits = []) {}
+    public function __construct(public readonly array $permits = [])
+    {
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireSealedPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireSealedPass.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Attribute\Sealed;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\SealedClassException;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class AutowireSealedPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $sealedDefinitionList = array_filter($container->getDefinitions(), static function (Definition $definition) use ($container): bool {
+            $reflectionClass = $container->getReflectionClass($definition->getClass(), false);
+
+            return $reflectionClass instanceof \ReflectionClass && [] !== $reflectionClass->getAttributes(Sealed::class, \ReflectionAttribute::IS_INSTANCEOF);
+        });
+
+        foreach ($container->getDefinitions() as $definition) {
+            $this->processClass($definition, $sealedDefinitionList);
+        }
+    }
+
+    private function processClass(Definition $definition, array $sealedDefinitionList): void
+    {
+        $constructorArgs = $definition->getArguments();
+        $definitionClassName = $definition->getClass();
+
+        if ([] === $constructorArgs) {
+            return;
+        }
+
+        $permittedClassesPerSealedClass = array_map(static function (Definition $definition) use ($sealedDefinitionList): array {
+            $reflectionClass = new \ReflectionClass($sealedDefinitionList[$definition->getClass()]->getClass());
+
+            return array_merge(...array_map(static fn (\ReflectionAttribute $attribute): array => $attribute->newInstance()->permits, $reflectionClass->getAttributes(Sealed::class, \ReflectionAttribute::IS_INSTANCEOF)));
+        }, $sealedDefinitionList);
+
+        foreach ($permittedClassesPerSealedClass as $sealedDefinition) {
+            $definitionConstructorArguments = array_map(static fn (Reference $reference): string => $reference, $constructorArgs);
+
+            if (\in_array($definitionClassName, $sealedDefinition, true)) {
+                continue;
+            }
+
+            if (0 === \count(array_intersect($definitionConstructorArguments, $sealedDefinition))) {
+                $argumentPosition = array_search($definitionClassName, $definitionConstructorArguments, true);
+
+                $reflectionClass = new \ReflectionClass($definitionClassName);
+                $arguments = $reflectionClass->getConstructor()->getParameters();
+
+                throw new SealedClassException(sprintf('Cannot autowire service "%s", argument "$%s" of method "%s::__construct()" references class "%s" but this class is sealed.', $definitionClassName, $arguments[$argumentPosition]->getName(), $definitionClassName, $definition->getArgument($argumentPosition)));
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Exception/SealedClassException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/SealedClassException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+final class SealedClassException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1257,7 +1257,7 @@ class AutowirePassTest extends TestCase
         }
     }
 
-    public function testSealedAttribute()
+    public function testSealedAttributeCannotBeUsedWithInvalidPermittedList()
     {
         $container = new ContainerBuilder();
 
@@ -1275,5 +1275,20 @@ class AutowirePassTest extends TestCase
         } catch (SealedClassException $e) {
             $this->assertSame('Cannot autowire service "Symfony\Component\DependencyInjection\Tests\Compiler\AsNonPermittedBar", argument "$asSealedBar" of method "Symfony\Component\DependencyInjection\Tests\Compiler\AsNonPermittedBar::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\AsSealedBar" but this class is sealed.', (string) $e->getMessage());
         }
+    }
+
+    public function testSealedAttributeCanBeUsedWithValidPermittedList()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(AsSealedFoo::class);
+        $container->register(AsPermittedBar::class)->setArgument(0, new Reference(AsSealedFoo::class));
+        $container->register(AsPermittedBaz::class)->setArgument(0, new Reference(AsSealedFoo::class));
+
+        (new ResolveClassPass())->process($container);
+        (new AutowireSealedPass())->process($container);
+
+        $this->assertSame(AsSealedFoo::class, (string) $container->getDefinition(AsPermittedBar::class)->getArgument(0));
+        $this->assertSame(AsSealedFoo::class, (string) $container->getDefinition(AsPermittedBaz::class)->getArgument(0));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -5,6 +5,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\MapDecorated;
+use Symfony\Component\DependencyInjection\Attribute\Sealed;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -84,4 +85,19 @@ class AsDecoratorBaz implements AsDecoratorInterface
     public function __construct(#[MapDecorated] AsDecoratorInterface $inner = null)
     {
     }
+}
+
+#[Sealed(permits: [AsPermittedFoo::class])]
+final class AsSealedBar
+{
+}
+
+final class AsPermittedFoo
+{
+    public function __construct(private readonly AsSealedBar $asSealedBar) {}
+}
+
+final class AsNonPermittedBar
+{
+    public function __construct(private readonly AsSealedBar $asSealedBar) {}
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -101,3 +101,21 @@ final class AsNonPermittedBar
 {
     public function __construct(private readonly AsSealedBar $asSealedBar) {}
 }
+
+#[Sealed(permits: [
+    AsPermittedBar::class,
+    AsPermittedBaz::class,
+])]
+final class AsSealedFoo
+{
+}
+
+final class AsPermittedBar
+{
+    public function __construct(private readonly AsSealedFoo $asSealedFoo) {}
+}
+
+final class AsPermittedBaz
+{
+    public function __construct(private readonly AsSealedFoo $asSealedFoo) {}
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR introduces a new attribute in the DIC component for "sealed classes", the idea comes from the [RFC](https://wiki.php.net/rfc/sealed_classes) submitted on PHP more than a year ago, here's the idea behind this attribute:

> Sometimes, you want to restrict the classes that can be injected into a service that use an interface or just the concrete implementation.

Here's a small implementation: 

```php
<?php

namespace App\Tools;

# ...

#[Sealed(permits: [Bar::class])]
final class Foo
{
    # ...
}

<?php

namespace App\Tools;

final class Bar
{
    public function __construct(private readonly Foo $foo) {}
}

<?php

namespace App\Tools;

final class NonPermitted
{
    public function __construct(private readonly Foo $foo) {}
}
```

Once injected, the container will trigger a `SealedClassException` to inform that `NonPermitted` is not allowed to receive the `Bar` class as a constructor argument.

For now, this PR does not handle setter injections (or properties) but as its for now, just a proposal, it can be easily introduced during the development process if needed.

Thanks for the feedback and have a great day 🙂 

PS: Tests could and will be improved during the discussion phase.