### PR TITLE
[FrameworkBundle] Fix "service_<APP_ENV>.php"-files not being imported

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -58,6 +58,7 @@ trait MicroKernelTrait
             $container->import($configDir.'/{services}_'.$this->environment.'.yaml');
         } else {
             $container->import($configDir.'/{services}.php');
+            $container->import($configDir.'/{services}_'.$this->environment.'.php');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

**Bugfix**

`config/service_<APP_ENV>.php`-files are not being imported resulting in `You have requested a non-existent service (...)`-Exceptions.

**Why is this a bug?**
See https://symfony.com/doc/current/configuration.html#configuration-environments -> 4.

**Screenshot:**
> ![2022-10-18 18_50_27-Configuring Symfony (Symfony Docs)](https://user-images.githubusercontent.com/47354551/196494948-90485037-3632-4f22-b26f-3de4891cf31e.png)
