### PR TITLE
[Console] Allow dynamic properties in ProgressBar

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Terminal;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Chris Jones <leeked@gmail.com>
  */
+#[\AllowDynamicProperties]
 final class ProgressBar
 {
     public const FORMAT_VERBOSE = 'verbose';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I rely on dynamic props in ProgressBar in https://github.com/ostrolucky/stdinho/blob/43c89658ae9d991f0daf7978d5d2877c2816cc68/src/ProgressBar.php#L32. However that will stop working starting PHP 8.2 unless this attribute is added. I see this attribute quite necessary here unless component is refactored, because of combination of static functions and final keyword usage.

Before this workaround, there was an issue https://github.com/symfony/symfony/issues/31193 that I closed because I've solved it by using dynamic properties.

I'm also open to move this to lower branch. The way I see it, this can go as low as Symfony 4.4, as it's perfectly safe patch.