### PR TITLE
[DependencyInjection] Add support for tagged iterators/locators exclude option to xml and yaml

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Change the signature of `ContainerAwareInterface::setContainer()` to `setContainer(?ContainerInterface)`
  * Deprecate calling `ContainerAwareTrait::setContainer()` without arguments
  * Deprecate using numeric parameter names
+ * Add support for tagged iterators/locators `exclude` option to the xml and yaml loaders/dumpers
 
 6.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -287,6 +287,15 @@ class XmlDumper extends Dumper
                         $element->setAttribute('default-priority-method', $tag->getDefaultPriorityMethod());
                     }
                 }
+                if ($excludes = $tag->getExclude()) {
+                    if (1 === \count($excludes)) {
+                        $element->setAttribute('exclude', $excludes[0]);
+                    } else {
+                        foreach ($excludes as $exclude) {
+                            $element->appendChild($this->document->createElement('exclude', $exclude));
+                        }
+                    }
+                }
             } elseif ($value instanceof IteratorArgument) {
                 $element->setAttribute('type', 'iterator');
                 $this->convertParameters($value->getValues(), $type, $element, 'key');

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -266,6 +266,12 @@ class YamlDumper extends Dumper
                         $content['default_priority_method'] = $tag->getDefaultPriorityMethod();
                     }
                 }
+                if ($excludes = $tag->getExclude()) {
+                    if (!\is_array($content)) {
+                        $content = ['tag' => $content];
+                    }
+                    $content['exclude'] = 1 === \count($excludes) ? $excludes[0] : $excludes;
+                }
 
                 return new TaggedValue($value instanceof TaggedIteratorArgument ? 'tagged_iterator' : 'tagged_locator', $content);
             }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -538,7 +538,15 @@ class XmlFileLoader extends FileLoader
                         throw new InvalidArgumentException(sprintf('Tag "<%s>" with type="%s" has no or empty "tag" attribute in "%s".', $name, $type, $file));
                     }
 
-                    $arguments[$key] = new TaggedIteratorArgument($arg->getAttribute('tag'), $arg->getAttribute('index-by') ?: null, $arg->getAttribute('default-index-method') ?: null, $forLocator, $arg->getAttribute('default-priority-method') ?: null);
+                    $excludes = array_column($this->getChildren($arg, 'exclude'), 'nodeValue');
+                    if ($arg->hasAttribute('exclude')) {
+                        if (\count($excludes) > 0) {
+                            throw new InvalidArgumentException('You cannot use both the attribute "exclude" and <exclude> tags at the same time.');
+                        }
+                        $excludes = [$arg->getAttribute('exclude')];
+                    }
+
+                    $arguments[$key] = new TaggedIteratorArgument($arg->getAttribute('tag'), $arg->getAttribute('index-by') ?: null, $arg->getAttribute('default-index-method') ?: null, $forLocator, $arg->getAttribute('default-priority-method') ?: null, $excludes);
 
                     if ($forLocator) {
                         $arguments[$key] = new ServiceLocatorArgument($arguments[$key]);

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -832,11 +832,11 @@ class YamlFileLoader extends FileLoader
                 $forLocator = 'tagged_locator' === $value->getTag();
 
                 if (\is_array($argument) && isset($argument['tag']) && $argument['tag']) {
-                    if ($diff = array_diff(array_keys($argument), ['tag', 'index_by', 'default_index_method', 'default_priority_method'])) {
-                        throw new InvalidArgumentException(sprintf('"!%s" tag contains unsupported key "%s"; supported ones are "tag", "index_by", "default_index_method", and "default_priority_method".', $value->getTag(), implode('", "', $diff)));
+                    if ($diff = array_diff(array_keys($argument), $supportedKeys = ['tag', 'index_by', 'default_index_method', 'default_priority_method', 'exclude'])) {
+                        throw new InvalidArgumentException(sprintf('"!%s" tag contains unsupported key "%s"; supported ones are "%s".', $value->getTag(), implode('", "', $diff), implode('", "', $supportedKeys)));
                     }
 
-                    $argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null, $forLocator, $argument['default_priority_method'] ?? null);
+                    $argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null, $forLocator, $argument['default_priority_method'] ?? null, (array) ($argument['exclude'] ?? null));
                 } elseif (\is_string($argument) && $argument) {
                     $argument = new TaggedIteratorArgument($argument, null, null, $forLocator);
                 } else {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -284,6 +284,7 @@
     <xsd:choice minOccurs="0">
       <xsd:element name="argument" type="argument" maxOccurs="unbounded" />
       <xsd:element name="service" type="service" />
+      <xsd:element name="exclude" type="xsd:string" maxOccurs="unbounded" />
     </xsd:choice>
     <xsd:attribute name="type" type="argument_type" />
     <xsd:attribute name="id" type="xsd:string" />
@@ -294,6 +295,7 @@
     <xsd:attribute name="index-by" type="xsd:string" />
     <xsd:attribute name="default-index-method" type="xsd:string" />
     <xsd:attribute name="default-priority-method" type="xsd:string" />
+    <xsd:attribute name="exclude" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="call">

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -203,15 +203,39 @@ class XmlDumperTest extends TestCase
     public function testTaggedArguments()
     {
         $taggedIterator = new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar', false, 'getPriority');
+        $taggedIterator2 = new TaggedIteratorArgument('foo_tag', null, null, false, null, ['baz']);
+        $taggedIterator3 = new TaggedIteratorArgument('foo_tag', null, null, false, null, ['baz', 'qux']);
+
         $container = new ContainerBuilder();
+
         $container->register('foo', 'Foo')->addTag('foo_tag');
+        $container->register('baz', 'Baz')->addTag('foo_tag');
+        $container->register('qux', 'Qux')->addTag('foo_tag');
+
         $container->register('foo_tagged_iterator', 'Bar')
             ->setPublic(true)
             ->addArgument($taggedIterator)
         ;
+        $container->register('foo2_tagged_iterator', 'Bar')
+            ->setPublic(true)
+            ->addArgument($taggedIterator2)
+        ;
+        $container->register('foo3_tagged_iterator', 'Bar')
+            ->setPublic(true)
+            ->addArgument($taggedIterator3)
+        ;
+
         $container->register('foo_tagged_locator', 'Bar')
             ->setPublic(true)
             ->addArgument(new ServiceLocatorArgument($taggedIterator))
+        ;
+        $container->register('foo2_tagged_locator', 'Bar')
+            ->setPublic(true)
+            ->addArgument(new ServiceLocatorArgument($taggedIterator2))
+        ;
+        $container->register('foo3_tagged_locator', 'Bar')
+            ->setPublic(true)
+            ->addArgument(new ServiceLocatorArgument($taggedIterator3))
         ;
 
         $dumper = new XmlDumper($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -112,10 +112,22 @@ class YamlDumperTest extends TestCase
     public function testTaggedArguments()
     {
         $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar', false, 'getPriority');
+        $taggedIterator2 = new TaggedIteratorArgument('foo', null, null, false, null, ['baz']);
+        $taggedIterator3 = new TaggedIteratorArgument('foo', null, null, false, null, ['baz', 'qux']);
+
         $container = new ContainerBuilder();
+
         $container->register('foo_service', 'Foo')->addTag('foo');
+        $container->register('baz_service', 'Baz')->addTag('foo');
+        $container->register('qux_service', 'Qux')->addTag('foo');
+
         $container->register('foo_service_tagged_iterator', 'Bar')->addArgument($taggedIterator);
+        $container->register('foo2_service_tagged_iterator', 'Bar')->addArgument($taggedIterator2);
+        $container->register('foo3_service_tagged_iterator', 'Bar')->addArgument($taggedIterator3);
+
         $container->register('foo_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument($taggedIterator));
+        $container->register('foo2_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument($taggedIterator2));
+        $container->register('foo3_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument($taggedIterator3));
         $container->register('bar_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('foo')));
 
         $dumper = new YamlDumper($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
@@ -5,11 +5,35 @@
     <service id="foo" class="Foo">
       <tag name="foo_tag"/>
     </service>
+    <service id="baz" class="Baz">
+      <tag name="foo_tag"/>
+    </service>
+    <service id="qux" class="Qux">
+      <tag name="foo_tag"/>
+    </service>
     <service id="foo_tagged_iterator" class="Bar" public="true">
       <argument type="tagged_iterator" tag="foo_tag" index-by="barfoo" default-index-method="foobar" default-priority-method="getPriority"/>
     </service>
+    <service id="foo2_tagged_iterator" class="Bar" public="true">
+      <argument type="tagged_iterator" tag="foo_tag" exclude="baz"/>
+    </service>
+    <service id="foo3_tagged_iterator" class="Bar" public="true">
+      <argument type="tagged_iterator" tag="foo_tag">
+        <exclude>baz</exclude>
+        <exclude>qux</exclude>
+      </argument>
+    </service>
     <service id="foo_tagged_locator" class="Bar" public="true">
       <argument type="tagged_locator" tag="foo_tag" index-by="barfoo" default-index-method="foobar" default-priority-method="getPriority"/>
+    </service>
+    <service id="foo2_tagged_locator" class="Bar" public="true">
+      <argument type="tagged_locator" tag="foo_tag" exclude="baz"/>
+    </service>
+    <service id="foo3_tagged_locator" class="Bar" public="true">
+      <argument type="tagged_locator" tag="foo_tag">
+        <exclude>baz</exclude>
+        <exclude>qux</exclude>
+      </argument>
     </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
@@ -8,12 +8,32 @@ services:
         class: Foo
         tags:
             - foo
+    baz_service:
+        class: Baz
+        tags:
+            - foo
+    qux_service:
+        class: Qux
+        tags:
+            - foo
     foo_service_tagged_iterator:
         class: Bar
         arguments: [!tagged_iterator { tag: foo, index_by: barfoo, default_index_method: foobar, default_priority_method: getPriority }]
+    foo2_service_tagged_iterator:
+        class: Bar
+        arguments: [!tagged_iterator { tag: foo, exclude: baz }]
+    foo3_service_tagged_iterator:
+        class: Bar
+        arguments: [!tagged_iterator { tag: foo, exclude: [baz, qux] }]
     foo_service_tagged_locator:
         class: Bar
         arguments: [!tagged_locator { tag: foo, index_by: barfoo, default_index_method: foobar, default_priority_method: getPriority }]
+    foo2_service_tagged_locator:
+        class: Bar
+        arguments: [!tagged_locator { tag: foo, exclude: baz }]
+    foo3_service_tagged_locator:
+        class: Bar
+        arguments: [!tagged_locator { tag: foo, exclude: [baz, qux] }]
     bar_service_tagged_locator:
         class: Bar
         arguments: [!tagged_locator foo]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -404,9 +404,17 @@ class XmlFileLoaderTest extends TestCase
 
         $taggedIterator = new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar', false, 'getPriority');
         $this->assertEquals($taggedIterator, $container->getDefinition('foo_tagged_iterator')->getArgument(0));
+        $taggedIterator2 = new TaggedIteratorArgument('foo_tag', null, null, false, null, ['baz']);
+        $this->assertEquals($taggedIterator2, $container->getDefinition('foo2_tagged_iterator')->getArgument(0));
+        $taggedIterator3 = new TaggedIteratorArgument('foo_tag', null, null, false, null, ['baz', 'qux']);
+        $this->assertEquals($taggedIterator3, $container->getDefinition('foo3_tagged_iterator')->getArgument(0));
 
         $taggedIterator = new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar', true, 'getPriority');
         $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_tagged_locator')->getArgument(0));
+        $taggedIterator2 = new TaggedIteratorArgument('foo_tag', 'foo_tag', 'getDefaultFooTagName', true, 'getDefaultFooTagPriority', ['baz']);
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator2), $container->getDefinition('foo2_tagged_locator')->getArgument(0));
+        $taggedIterator3 = new TaggedIteratorArgument('foo_tag', 'foo_tag', 'getDefaultFooTagName', true, 'getDefaultFooTagPriority', ['baz', 'qux']);
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator3), $container->getDefinition('foo3_tagged_locator')->getArgument(0));
     }
 
     public function testParseServiceClosure()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -392,9 +392,17 @@ class YamlFileLoaderTest extends TestCase
 
         $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar', false, 'getPriority');
         $this->assertEquals($taggedIterator, $container->getDefinition('foo_service_tagged_iterator')->getArgument(0));
+        $taggedIterator2 = new TaggedIteratorArgument('foo', null, null, false, null, ['baz']);
+        $this->assertEquals($taggedIterator2, $container->getDefinition('foo2_service_tagged_iterator')->getArgument(0));
+        $taggedIterator3 = new TaggedIteratorArgument('foo', null, null, false, null, ['baz', 'qux']);
+        $this->assertEquals($taggedIterator3, $container->getDefinition('foo3_service_tagged_iterator')->getArgument(0));
 
         $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar', true, 'getPriority');
         $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_service_tagged_locator')->getArgument(0));
+        $taggedIterator2 = new TaggedIteratorArgument('foo', 'foo', 'getDefaultFooName', true, 'getDefaultFooPriority', ['baz']);
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator2), $container->getDefinition('foo2_service_tagged_locator')->getArgument(0));
+        $taggedIterator3 = new TaggedIteratorArgument('foo', 'foo', 'getDefaultFooName', true, 'getDefaultFooPriority', ['baz', 'qux']);
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator3), $container->getDefinition('foo3_service_tagged_locator')->getArgument(0));
 
         $taggedIterator = new TaggedIteratorArgument('foo', null, null, true);
         $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('bar_service_tagged_locator')->getArgument(0));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Followup to #44774 .

The previous PR added support for the `exclude` option to php attributes & php config files, but not xml or yaml, making it impossible to use this feature with those config types.
Also, since the support for this feature was never added to the yaml & xml dumpers, the generated `App_KernelDevDebugContainer.xml` is actually incorrect (possibly should be considered a bug), eg the following php configuration:

```php
    $services->set(TestExclude::class)
        ->public()
        ->args([
            tagged_iterator('app.test', exclude: TestExclude::class),
        ]);
```

produces this xml file:

```xml
    <service id="App\Service\TestExclude" class="App\Service\TestExclude" public="true">
      <tag name="app.test"/>
      <argument type="tagged_iterator" tag="app.test"/>
    </service>
```

With this PR, the dumpers are now aware of the `exclude` option:

```diff
    <service id="App\Service\TestExclude" class="App\Service\TestExclude" public="true">
      <tag name="app.test"/>
-     <argument type="tagged_iterator" tag="app.test"/>
+     <argument type="tagged_iterator" tag="app.test" exclude="App\Service\TestExclude"/>
    </service>
```