### PR TITLE
[Asset] improve performance of `UrlPackage::chooseBaseUrl()`

### DIFF
--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -48,10 +48,10 @@ class UrlPackageTest extends TestCase
             ['file:///example/com/foo/', '', 'foo', 'file:///example/com/foo/foo?v1'],
 
             [['http://example.com'], '', '/foo', 'http://example.com/foo?v1'],
-            [['http://example.com', 'http://example.net'], '', '/foo', 'http://example.com/foo?v1'],
-            [['http://example.com', 'http://example.net'], '', '/fooa', 'http://example.net/fooa?v1'],
-            [['file:///example/com', 'file:///example/net'], '', '/foo', 'file:///example/com/foo?v1'],
-            [['ftp://example.com', 'ftp://example.net'], '', '/fooa', 'ftp://example.net/fooa?v1'],
+            [['http://example.com', 'http://example.net'], '', '/foo', 'http://example.net/foo?v1'],
+            [['http://example.com', 'http://example.net'], '', '/fooa', 'http://example.com/fooa?v1'],
+            [['file:///example/com', 'file:///example/net'], '', '/foo', 'file:///example/net/foo?v1'],
+            [['ftp://example.com', 'ftp://example.net'], '', '/fooa', 'ftp://example.com/fooa?v1'],
 
             ['http://example.com', 'version-%2$s/%1$s', '/foo', 'http://example.com/version-v1/foo'],
             ['http://example.com', 'version-%2$s/%1$s', 'foo', 'http://example.com/version-v1/foo'],
@@ -77,15 +77,16 @@ class UrlPackageTest extends TestCase
         return [
             [false, 'http://example.com', '', 'foo', 'http://example.com/foo?v1'],
             [false, ['http://example.com'], '', 'foo', 'http://example.com/foo?v1'],
-            [false, ['http://example.com', 'https://example.com'], '', 'foo', 'http://example.com/foo?v1'],
-            [false, ['http://example.com', 'https://example.com'], '', 'fooa', 'https://example.com/fooa?v1'],
+            [false, ['http://example.com', 'https://example.com'], '', 'foo', 'https://example.com/foo?v1'],
+            [false, ['http://example.com', 'https://example.com'], '', 'fooa', 'http://example.com/fooa?v1'],
             [false, ['http://example.com/bar'], '', 'foo', 'http://example.com/bar/foo?v1'],
             [false, ['http://example.com/bar/'], '', 'foo', 'http://example.com/bar/foo?v1'],
             [false, ['//example.com/bar/'], '', 'foo', '//example.com/bar/foo?v1'],
 
             [true, ['http://example.com'], '', 'foo', 'http://example.com/foo?v1'],
             [true, ['http://example.com', 'https://example.com'], '', 'foo', 'https://example.com/foo?v1'],
-            [true, ['', 'https://example.com'], '', 'foo', '/foo?v1'],
+            [true, ['', 'https://example.com'], '', 'foo', 'https://example.com/foo?v1'],
+            [true, ['', 'https://example.com'], '', 'bar', '/bar?v1'],
         ];
     }
 

--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -107,7 +107,7 @@ class UrlPackage extends Package
      */
     protected function chooseBaseUrl(string $path): int
     {
-        return (int) fmod(hexdec(substr(hash('sha256', $path), 0, 10)), \count($this->baseUrls));
+        return abs(crc32($path)) % \count($this->baseUrls);
     }
 
     private function getSslUrls(array $urls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

@frankdejonge discovered this performance improvement when implementing a similar feature in flysystem (https://github.com/thephpleague/flysystem/pull/1570). A simple benchmark by me indicated it was 3-4x faster.

Note: Sites using this feature that have assets heavily cached would now have a different distribution.
