### PR TITLE
update dependency

### DIFF
--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -22,6 +22,7 @@
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/doctrine-messenger": "^5.1|^6.0",
         "symfony/polyfill-php80": "^1.16",
+        "symfony/notifier": "^5.1|^6.0",
         "symfony/redis-messenger": "^5.1|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
potentially fixing the required class
Invalid Messenger routing configuration: class or interface `Symfony\Component\Notifier\Message\ChatMessage` not found.

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes/no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47900
| License       | MIT

