### PR TITLE
[DependencyInjection] Allow injecting the current env into php config closures

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Deprecate calling `ContainerAwareTrait::setContainer()` without arguments
  * Deprecate using numeric parameter names
  * Add support for tagged iterators/locators `exclude` option to the xml and yaml loaders/dumpers
+ * Allow injecting `string $env` into php config closures
 
 6.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -123,6 +123,12 @@ class PhpFileLoader extends FileLoader
                 case self::class:
                     $arguments[] = $this;
                     break;
+                case 'string':
+                    if (null !== $this->env && 'env' === $parameter->getName()) {
+                        $arguments[] = $this->env;
+                        break;
+                    }
+                    // no break
                 default:
                     try {
                         $configBuilder = $this->configBuilder($type);
@@ -163,7 +169,7 @@ class PhpFileLoader extends FileLoader
             return new $namespace();
         }
 
-        // If it does not start with Symfony\Config\ we dont know how to handle this
+        // If it does not start with Symfony\Config\ we don't know how to handle this
         if (!str_starts_with($namespace, 'Symfony\\Config\\')) {
             throw new InvalidArgumentException(sprintf('Could not find or generate class "%s".', $namespace));
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_param.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_param.expected.yml
@@ -1,0 +1,8 @@
+parameters:
+    acme.configs: [{ color: blue }]
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_param.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_param.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
+
+return function (AcmeConfig $config, string $env) {
+    if ('prod' === $env) {
+        $config->color('blue');
+    } else {
+        $config->color('red');
+    }
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -99,6 +99,7 @@ class PhpFileLoaderTest extends TestCase
         yield ['config_builder'];
         yield ['expression_factory'];
         yield ['closure'];
+        yield ['env_param'];
     }
 
     public function testAutoConfigureAndChildDefinition()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

The original idea of this PR was to allow injecting `string $env` into php config closures. Even though this can be done by injecting `ContainerConfigurator` & calling `env()` it seems kind of redundant when you don't need any features except the current env, eg when using the config builder classes:

```diff
- return function (AcmeConfig $config, ContainerConfigurator $c) {
+ return function (AcmeConfig $config, string $env) {
- if ('dev' === $c->env()) {
+ if ('dev' === $env) {
    // ...
  }
};
```
Injecting the `$env` variable looks a bit cleaner IMO.

However, while working on this PR I discovered #41182 . Even though there's already an `$env` variable presets in the scope of php files which can be used for the same thing, it's not really IDE friendly:

![image](https://user-images.githubusercontent.com/2445045/196558741-8931a3d9-f74f-423e-9494-2d931cbac995.png)

Since the original PR mentioned the that the `$env` variable was added for PHP <8 & Symfony 6.2 is >=8.1, it doesn't seem to be needed any more, so it can be deprecated.