### PR TITLE
[Routing] PSR-4 directory loader

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -25,7 +25,6 @@ use Psr\Log\LoggerAwareInterface;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
 use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Bundle\FullStack;
 use Symfony\Bundle\MercureBundle\MercureBundle;
@@ -194,8 +193,7 @@ use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
 use Symfony\Component\RateLimiter\LimiterInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
-use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
-use Symfony\Component\Routing\Loader\AnnotationFileLoader;
+use Symfony\Component\Routing\Loader\Psr4DirectoryLoader;
 use Symfony\Component\Security\Core\AuthenticationEvents;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -1157,29 +1155,9 @@ class FrameworkExtension extends Extension
                 ->replaceArgument(0, $config['default_uri']);
         }
 
-        $container->register('routing.loader.annotation', AnnotatedRouteControllerLoader::class)
-            ->setPublic(false)
-            ->addTag('routing.loader', ['priority' => -10])
-            ->setArguments([
-                new Reference('annotation_reader', ContainerInterface::NULL_ON_INVALID_REFERENCE),
-                '%kernel.environment%',
-            ]);
-
-        $container->register('routing.loader.annotation.directory', AnnotationDirectoryLoader::class)
-            ->setPublic(false)
-            ->addTag('routing.loader', ['priority' => -10])
-            ->setArguments([
-                new Reference('file_locator'),
-                new Reference('routing.loader.annotation'),
-            ]);
-
-        $container->register('routing.loader.annotation.file', AnnotationFileLoader::class)
-            ->setPublic(false)
-            ->addTag('routing.loader', ['priority' => -10])
-            ->setArguments([
-                new Reference('file_locator'),
-                new Reference('routing.loader.annotation'),
-            ]);
+        if (!class_exists(Psr4DirectoryLoader::class)) {
+            $container->removeDefinition('routing.loader.psr4');
+        }
     }
 
     private function registerSessionConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
@@ -15,6 +15,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
 use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
+use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
 use Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader;
 use Symfony\Bundle\FrameworkBundle\Routing\RedirectableCompiledUrlMatcher;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
@@ -23,10 +24,13 @@ use Symfony\Component\HttpKernel\EventListener\RouterListener;
 use Symfony\Component\Routing\Generator\CompiledUrlGenerator;
 use Symfony\Component\Routing\Generator\Dumper\CompiledUrlGeneratorDumper;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
+use Symfony\Component\Routing\Loader\AnnotationFileLoader;
 use Symfony\Component\Routing\Loader\ContainerLoader;
 use Symfony\Component\Routing\Loader\DirectoryLoader;
 use Symfony\Component\Routing\Loader\GlobFileLoader;
 use Symfony\Component\Routing\Loader\PhpFileLoader;
+use Symfony\Component\Routing\Loader\Psr4DirectoryLoader;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
 use Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper;
@@ -87,6 +91,33 @@ return static function (ContainerConfigurator $container) {
                 '%kernel.environment%',
             ])
             ->tag('routing.loader')
+
+        ->set('routing.loader.annotation', AnnotatedRouteControllerLoader::class)
+            ->args([
+                service('annotation_reader')->nullOnInvalid(),
+                '%kernel.environment%',
+            ])
+            ->tag('routing.loader', ['priority' => -10])
+
+        ->set('routing.loader.annotation.directory', AnnotationDirectoryLoader::class)
+            ->args([
+                service('file_locator'),
+                service('routing.loader.annotation'),
+            ])
+            ->tag('routing.loader', ['priority' => -10])
+
+        ->set('routing.loader.annotation.file', AnnotationFileLoader::class)
+            ->args([
+                service('file_locator'),
+                service('routing.loader.annotation'),
+            ])
+            ->tag('routing.loader', ['priority' => -10])
+
+        ->set('routing.loader.psr4', Psr4DirectoryLoader::class)
+            ->args([
+                service('file_locator'),
+            ])
+            ->tag('routing.loader', ['priority' => -10])
 
         ->set('routing.loader', DelegatingLoader::class)
             ->public()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractAttributeRoutingTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractAttributeRoutingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+abstract class AbstractAttributeRoutingTest extends AbstractWebTestCase
+{
+    /**
+     * @dataProvider getRoutes
+     */
+    public function testAnnotatedController(string $path, string $expectedValue)
+    {
+        $client = $this->createClient(['test_case' => $this->getTestCaseApp(), 'root_config' => 'config.yml']);
+        $client->request('GET', '/annotated'.$path);
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame($expectedValue, $client->getResponse()->getContent());
+
+        $router = self::getContainer()->get('router');
+
+        $this->assertSame('/annotated/create-transaction', $router->generate('symfony_framework_tests_functional_test_annotated_createtransaction'));
+    }
+
+    public function getRoutes(): array
+    {
+        return [
+            ['/null_request', 'Symfony\Component\HttpFoundation\Request'],
+            ['/null_argument', ''],
+            ['/null_argument_with_route_param', ''],
+            ['/null_argument_with_route_param/value', 'value'],
+            ['/argument_with_route_param_and_default', 'value'],
+            ['/argument_with_route_param_and_default/custom', 'custom'],
+        ];
+    }
+
+    abstract protected function getTestCaseApp(): string;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/AnnotatedController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/AnnotatedController.php
@@ -17,42 +17,32 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class AnnotatedController
 {
-    /**
-     * @Route("/null_request", name="null_request")
-     */
-    public function requestDefaultNullAction(Request $request = null)
+    #[Route('/null_request', name: 'null_request')]
+    public function requestDefaultNullAction(Request $request = null): Response
     {
         return new Response($request ? $request::class : null);
     }
 
-    /**
-     * @Route("/null_argument", name="null_argument")
-     */
-    public function argumentDefaultNullWithoutRouteParamAction($value = null)
+    #[Route('/null_argument', name: 'null_argument')]
+    public function argumentDefaultNullWithoutRouteParamAction($value = null): Response
     {
         return new Response($value);
     }
 
-    /**
-     * @Route("/null_argument_with_route_param/{value}", name="null_argument_with_route_param")
-     */
-    public function argumentDefaultNullWithRouteParamAction($value = null)
+    #[Route('/null_argument_with_route_param/{value}', name: 'null_argument_with_route_param')]
+    public function argumentDefaultNullWithRouteParamAction($value = null): Response
     {
         return new Response($value);
     }
 
-    /**
-     * @Route("/argument_with_route_param_and_default/{value}", defaults={"value": "value"}, name="argument_with_route_param_and_default")
-     */
-    public function argumentWithoutDefaultWithRouteParamAndDefaultAction($value)
+    #[Route('/argument_with_route_param_and_default/{value}', defaults: ['value' => 'value'], name: 'argument_with_route_param_and_default')]
+    public function argumentWithoutDefaultWithRouteParamAndDefaultAction($value): Response
     {
         return new Response($value);
     }
 
-    /**
-     * @Route("/create-transaction")
-     */
-    public function createTransaction()
+    #[Route('/create-transaction')]
+    public function createTransaction(): Response
     {
         return new Response();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Psr4RoutingTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Psr4RoutingTest.php
@@ -11,10 +11,13 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-class AnnotatedControllerTest extends AbstractAttributeRoutingTest
+/**
+ * @requires function Symfony\Component\Routing\Loader\Psr4DirectoryLoader::__construct
+ */
+final class Psr4RoutingTest extends AbstractAttributeRoutingTest
 {
     protected function getTestCaseApp(): string
     {
-        return 'AnnotatedController';
+        return 'Psr4Routing';
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Psr4Routing/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Psr4Routing/bundles.php
@@ -9,12 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
 
-class AnnotatedControllerTest extends AbstractAttributeRoutingTest
-{
-    protected function getTestCaseApp(): string
-    {
-        return 'AnnotatedController';
-    }
-}
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Psr4Routing/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Psr4Routing/config.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: ../config/default.yml }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Psr4Routing/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Psr4Routing/routing.yml
@@ -1,0 +1,4 @@
+test_bundle:
+    prefix:   /annotated
+    resource: "@TestBundle/Controller"
+    type:     attribute@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller

--- a/src/Symfony/Component/Routing/Loader/Psr4DirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/Psr4DirectoryLoader.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader;
+
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * A loader that discovers controller classes in a directory that follows PSR-4.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class Psr4DirectoryLoader extends FileLoader
+{
+    public function __construct(FileLocatorInterface $locator)
+    {
+        // PSR-4 directory loader has no env-aware logic, so we drop the $env constructor parameter.
+        parent::__construct($locator);
+    }
+
+    public function load(mixed $resource, string $type = null): ?RouteCollection
+    {
+        $path = $this->locator->locate($resource);
+        if (!is_dir($path)) {
+            return new RouteCollection();
+        }
+
+        return $this->loadFromDirectory($path, trim(substr($type, 10), ' \\'));
+    }
+
+    public function supports(mixed $resource, string $type = null): bool
+    {
+        return \is_string($resource) && null !== $type && str_starts_with($type, 'attribute@');
+    }
+
+    private function loadFromDirectory(string $directory, string $psr4Prefix): RouteCollection
+    {
+        $collection = new RouteCollection();
+
+        /** @var \SplFileInfo $file */
+        foreach (new \FilesystemIterator($directory) as $file) {
+            if ($file->isDir()) {
+                $collection->addCollection($this->loadFromDirectory($file->getPathname(), $psr4Prefix.'\\'.$file->getFilename()));
+
+                continue;
+            }
+            if ('php' !== $file->getExtension() || !class_exists($className = $psr4Prefix.'\\'.$file->getBasename('.php'))) {
+                continue;
+            }
+
+            $collection->addCollection($this->import($className, 'attribute'));
+        }
+
+        return $collection;
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/MyController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/MyController.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/my/route', name: 'my_route')]
+final class MyController
+{
+    public function __invoke(): Response
+    {
+        return new Response(status: Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/MyUnannotatedController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/MyUnannotatedController.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final class MyUnannotatedController
+{
+    public function myAction(): Response
+    {
+        return new Response(status: Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/EvenDeeperNamespace/MyOtherController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/EvenDeeperNamespace/MyOtherController.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\SubNamespace\EvenDeeperNamespace;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/my/other/route', name: 'my_other_controller_', methods: ['PUT'])]
+final class MyOtherController
+{
+    #[Route('/first', name: 'one')]
+    public function firstAction(): Response
+    {
+        return new Response(status: Response::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/second', name: 'two')]
+    public function secondAction(): Response
+    {
+        return new Response(status: Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/IrrelevantInterface.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/IrrelevantInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\SubNamespace;
+
+interface IrrelevantInterface
+{
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/MyControllerWithATrait.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/MyControllerWithATrait.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\SubNamespace;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/my/controller/with/a/trait', name: 'my_controller_')]
+final class MyControllerWithATrait implements IrrelevantInterface
+{
+    use SomeSharedImplementation;
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/SomeSharedImplementation.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/SomeSharedImplementation.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\SubNamespace;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+trait SomeSharedImplementation
+{
+    #[Route('/a/route/from/a/trait', name: 'with_a_trait')]
+    public function someAction(): Response
+    {
+        return new Response(status: Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/class-attributes.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/class-attributes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import resource="Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\MyController" prefix="/my-prefix"
+            type="attribute" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/class-attributes.yaml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/class-attributes.yaml
@@ -1,0 +1,4 @@
+my_controllers:
+    resource: Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\MyController
+    type: attribute
+    prefix: /my-prefix

--- a/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import resource="./Psr4Controllers" prefix="/my-prefix"
+            type="attribute@Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.yaml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.yaml
@@ -1,0 +1,4 @@
+my_controllers:
+    resource: ./Psr4Controllers
+    type: attribute@Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers
+    prefix: /my-prefix

--- a/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\DelegatingLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
+use Symfony\Component\Routing\Loader\Psr4DirectoryLoader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\MyController;
+use Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\SubNamespace\EvenDeeperNamespace\MyOtherController;
+use Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\SubNamespace\MyControllerWithATrait;
+
+class Psr4DirectoryLoaderTest extends TestCase
+{
+    public function testTopLevelController()
+    {
+        $route = $this->loadPsr4Controllers()->get('my_route');
+
+        $this->assertSame('/my/route', $route->getPath());
+        $this->assertSame(MyController::class.'::__invoke', $route->getDefault('_controller'));
+    }
+
+    public function testNestedController()
+    {
+        $collection = $this->loadPsr4Controllers();
+
+        $route = $collection->get('my_other_controller_one');
+        $this->assertSame('/my/other/route/first', $route->getPath());
+        $this->assertSame(['PUT'], $route->getMethods());
+        $this->assertSame(MyOtherController::class.'::firstAction', $route->getDefault('_controller'));
+
+        $route = $collection->get('my_other_controller_two');
+        $this->assertSame('/my/other/route/second', $route->getPath());
+        $this->assertSame(['PUT'], $route->getMethods());
+        $this->assertSame(MyOtherController::class.'::secondAction', $route->getDefault('_controller'));
+    }
+
+    public function testTraitController()
+    {
+        $route = $this->loadPsr4Controllers()->get('my_controller_with_a_trait');
+
+        $this->assertSame('/my/controller/with/a/trait/a/route/from/a/trait', $route->getPath());
+        $this->assertSame(MyControllerWithATrait::class.'::someAction', $route->getDefault('_controller'));
+    }
+
+    /**
+     * @dataProvider provideResourceTypesThatNeedTrimming
+     */
+    public function testPsr4NamespaceTrim(string $resourceType)
+    {
+        $route = $this->getLoader()
+            ->load('Psr4Controllers', $resourceType)
+            ->get('my_route');
+
+        $this->assertSame('/my/route', $route->getPath());
+        $this->assertSame(MyController::class.'::__invoke', $route->getDefault('_controller'));
+    }
+
+    public function provideResourceTypesThatNeedTrimming(): array
+    {
+        return [
+            ['attribute@ Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'],
+            ['attribute@\\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'],
+            ['attribute@Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\\'],
+            ['attribute@\\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\\'],
+            ['attribute@   \\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'],
+        ];
+    }
+
+    private function loadPsr4Controllers(): RouteCollection
+    {
+        return $this->getLoader()->load(
+            'Psr4Controllers',
+            'attribute@Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'
+        );
+    }
+
+    private function getLoader(): DelegatingLoader
+    {
+        $locator = new FileLocator(\dirname(__DIR__).'/Fixtures');
+
+        return new DelegatingLoader(
+            new LoaderResolver([
+                new Psr4DirectoryLoader($locator),
+                new class() extends AnnotationClassLoader {
+                    protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                    {
+                        $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+                    }
+                },
+            ])
+        );
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -13,11 +13,15 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
+use Symfony\Component\Routing\Loader\Psr4DirectoryLoader;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Tests\Fixtures\CustomXmlFileLoader;
+use Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\MyController;
 
 class XmlFileLoaderTest extends TestCase
 {
@@ -591,5 +595,41 @@ class XmlFileLoaderTest extends TestCase
         $expectedRoutes = require __DIR__.'/../Fixtures/alias/expected.php';
 
         $this->assertEquals($expectedRoutes('xml'), $routes);
+    }
+
+    public function testImportAttributesWithPsr4Prefix()
+    {
+        $locator = new FileLocator(\dirname(__DIR__).'/Fixtures');
+        new LoaderResolver([
+            $loader = new XmlFileLoader($locator),
+            new Psr4DirectoryLoader($locator),
+            new class() extends AnnotationClassLoader {
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                {
+                    $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+                }
+            },
+        ]);
+
+        $route = $loader->load('psr4-attributes.xml')->get('my_route');
+        $this->assertSame('/my-prefix/my/route', $route->getPath());
+        $this->assertSame(MyController::class.'::__invoke', $route->getDefault('_controller'));
+    }
+
+    public function testImportAttributesFromClass()
+    {
+        new LoaderResolver([
+            $loader = new XmlFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures')),
+            new class() extends AnnotationClassLoader {
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                {
+                    $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+                }
+            },
+        ]);
+
+        $route = $loader->load('class-attributes.xml')->get('my_route');
+        $this->assertSame('/my-prefix/my/route', $route->getPath());
+        $this->assertSame(MyController::class.'::__invoke', $route->getDefault('_controller'));
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -13,10 +13,14 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
+use Symfony\Component\Routing\Loader\Psr4DirectoryLoader;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\MyController;
 
 class YamlFileLoaderTest extends TestCase
 {
@@ -457,5 +461,41 @@ class YamlFileLoaderTest extends TestCase
         $expectedRoutes = require __DIR__.'/../Fixtures/alias/expected.php';
 
         $this->assertEquals($expectedRoutes('yaml'), $routes);
+    }
+
+    public function testImportAttributesWithPsr4Prefix()
+    {
+        $locator = new FileLocator(\dirname(__DIR__).'/Fixtures');
+        new LoaderResolver([
+            $loader = new YamlFileLoader($locator),
+            new Psr4DirectoryLoader($locator),
+            new class() extends AnnotationClassLoader {
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                {
+                    $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+                }
+            },
+        ]);
+
+        $route = $loader->load('psr4-attributes.yaml')->get('my_route');
+        $this->assertSame('/my-prefix/my/route', $route->getPath());
+        $this->assertSame(MyController::class.'::__invoke', $route->getDefault('_controller'));
+    }
+
+    public function testImportAttributesFromClass()
+    {
+        new LoaderResolver([
+            $loader = new YamlFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures')),
+            new class() extends AnnotationClassLoader {
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                {
+                    $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+                }
+            },
+        ]);
+
+        $route = $loader->load('class-attributes.yaml')->get('my_route');
+        $this->assertSame('/my-prefix/my/route', $route->getPath());
+        $this->assertSame(MyController::class.'::__invoke', $route->getDefault('_controller'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no (but we could…)
| Tickets       | Fix #47881
| License       | MIT
| Doc PR        | symfony/symfony-docs#17373

This PR adds a PSR-4 directory loader to the Routing component.

When we currently want to load routes from a directory with controllers, we configure it like this:

```YAML
controllers:
    resource: ../src/Controller/
    type: attribute
```

What happens now is that `AnnotationDirectoryLoader` searches that directory recursively for `*.php` files and uses PHP's tokenizer extension to discover all controller classes that are defined within that directory. This step feels unnecessarily expensive given that modern projects follow the PSR-4 standard to structure their code. And if we use the DI component's autodiscovery feature to register our controllers as services, our controller directory already has to follow PSR-4.

A client I'm working with adds the additional challange that they deliver their code to their customers in encrypted form (using SourceGuardian). This means that the PHP files contain encrypted bytecode instead of plain PHP and thus cannot be parsed. We currently overcome this limitation by extending `AnnotationDirectoryLoader` and overriding the protected `findClass()` method.

This PR proposes to extend the resource type `attribute` and allow to suffix it with a PSR-4 namespace root.

```YAML
controllers:
    resource: ../src/Controller/
    type: attribute@App\Controller
```

In order to use PSR-4 to discover controller classes, the directory path is not enough. We always need an additional piece of information which is the namespace root for the given directory. Without changing large parts of the Config component, I did not find a nice way to pass down that information to the PSR-4 route loader. Encoding that information into the `type` parameter seemed like the pragmatic approach, but I'm open to discussing alternatives.

This approach should play nicely with projects that already use attributes for routing and PSR-4 autodiscovery to register controllers as services. In fact, most project should be able to swap the `type: annotation` or `type: attribute` config with `type: attribute@Your\Namespace\Here` and the only difference they notice is that router compilation becomes a bit faster.