### PR TITLE
Update ArgvInput to allow retrieving all tokens

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -54,7 +54,7 @@ class ArgvInput extends Input
 
         parent::__construct($definition);
     }
-    
+
     public function getTokens()
     {
         return $this->tokens;

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -54,6 +54,11 @@ class ArgvInput extends Input
 
         parent::__construct($definition);
     }
+    
+    public function getTokens()
+    {
+        return $this->tokens;
+    }
 
     protected function setTokens(array $tokens)
     {


### PR DESCRIPTION
There was no way to retrieve the tokens from an instance of this class (only by resorting to `$_SERVER['argv']`). The public `getParameterOption()` required you to know the exact arguments being passed so it does not suffice.

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
