### PR TITLE
Validator: fix FileValidator when value is an UploadedFile

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -171,7 +171,7 @@ class FileValidator extends ConstraintValidator
         $mimeTypes = (array) $constraint->mimeTypes;
 
         if ($constraint->extensions) {
-            $fileExtension = pathinfo($path, \PATHINFO_EXTENSION);
+            $fileExtension = pathinfo($basename, \PATHINFO_EXTENSION);
 
             $found = false;
             $normalizedExtensions = [];

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -640,5 +640,22 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testUploadedFileExtensions()
+    {
+        $file = new UploadedFile(__DIR__.'/Fixtures/bar', 'bar.txt', 'text/plain', \UPLOAD_ERR_OK, true);
+
+        try {
+            $file->getMimeType();
+        } catch (\LogicException $e) {
+            $this->markTestSkipped('Guessing the mime type is not possible');
+        }
+
+        $constraint = new File(mimeTypesMessage: 'myMessage', extensions: ['txt']);
+
+        $this->validator->validate($file, $constraint);
+
+        $this->assertNoViolation();
+    }
+
     abstract protected function getFile($filename);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a| License       | MIT
| Doc PR        | n/a

The code I introduced in #47710 is currently broken if the file to validate is a `UploadedFile` instance, as we must check the original extension of the file submitted by the client, not the one (that doesn't exist) of the temporary file created on the server by PHP.

This patch fixes the issue.