### PR TITLE
[RateLimiter] Move lock component to dev dependency

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -91,6 +91,7 @@ use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\StoreFactory;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesTransportFactory;
@@ -2679,8 +2680,11 @@ class FrameworkExtension extends Extension
         $limiter = $container->setDefinition($limiterId = 'limiter.'.$name, new ChildDefinition('limiter'));
 
         if (null !== $limiterConfig['lock_factory']) {
+            if (!interface_exists(LockInterface::class)) {
+                throw new LogicException(sprintf('Rate limiter "%s" requires the Lock component to be installed. Try running "composer require symfony/lock".', $name));
+            }
             if (!self::$lockConfigEnabled) {
-                throw new LogicException(sprintf('Rate limiter "%s" requires the Lock component to be installed and configured.', $name));
+                throw new LogicException(sprintf('Rate limiter "%s" requires the Lock component to be configured.', $name));
             }
 
             $limiter->replaceArgument(2, new Reference($limiterConfig['lock_factory']));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -103,7 +103,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTest
 
             $this->fail('No LogicException thrown');
         } catch (LogicException $e) {
-            $this->assertEquals('Rate limiter "with_lock" requires the Lock component to be installed and configured.', $e->getMessage());
+            $this->assertEquals('Rate limiter "with_lock" requires the Lock component to be configured.', $e->getMessage());
         }
 
         $container = $this->createContainerFromClosure(function (ContainerBuilder $container) {

--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+* Move `symfony/lock` to dev dependency in `composer.json`
+
 5.4
 ---
 

--- a/src/Symfony/Component/RateLimiter/composer.json
+++ b/src/Symfony/Component/RateLimiter/composer.json
@@ -17,11 +17,14 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/lock": "^5.4|^6.0",
         "symfony/options-resolver": "^5.4|^6.0"
     },
     "require-dev": {
-        "psr/cache": "^1.0|^2.0|^3.0"
+        "psr/cache": "^1.0|^2.0|^3.0",
+        "symfony/lock": "^5.4|^6.0"
+    },
+    "suggest": {
+        "symfony/lock": "For preventing race conditions in rate limiters"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\RateLimiter\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47277
| License       | MIT
| Doc PR        | -

Since using locks is an optional feature of the rate limiter component, there's no need for the lock component to be a hard dependency.