### PR TITLE
[Translation] Deprecate PhpStringTokenParser

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.2
 ---
 
+ * Deprecate `PhpStringTokenParser`
  * Deprecate `PhpExtractor` in favor of `PhpAstExtractor`
  * Add `PhpAstExtractor` (requires [nikic/php-parser](https://github.com/nikic/php-parser) to be installed)
 

--- a/src/Symfony/Component/Translation/Extractor/PhpStringTokenParser.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpStringTokenParser.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Translation\Extractor;
 
+trigger_deprecation('symfony/translation', '6.2', '"%s" is deprecated.', PhpStringTokenParser::class);
+
 /*
  * The following is derived from code at http://github.com/nikic/PHP-Parser
  *
@@ -47,6 +49,9 @@ namespace Symfony\Component\Translation\Extractor;
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * @deprecated since Symfony 6.2
+ */
 class PhpStringTokenParser
 {
     protected static $replacements = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        | 

Following https://github.com/symfony/symfony/pull/46161/, we could deprecate PhpStringTokenParser, as it's only used by PhpExtractor (which is now deprecated).
