### PR TITLE
[Security] Throw LogicException instead of Error when trying to generate logout-…

### DIFF
--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -107,6 +107,10 @@ class LogoutUrlGenerator
 
             $request = $this->requestStack->getCurrentRequest();
 
+            if (!$request) {
+                throw new \LogicException('Unable to generate the logout URL without a Request.');
+            }
+
             $url = UrlGeneratorInterface::ABSOLUTE_URL === $referenceType ? $request->getUriForPath($logoutPath) : $request->getBaseUrl().$logoutPath;
 
             if (!empty($parameters)) {


### PR DESCRIPTION
…URL without request

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Currently the LogoutUrlGenerator will raise an Error if called without a current request present because it does not check if there is a request present before using it.
The error that is raised is: `Call to a member function getBaseUrl() on null` on line 110 (line 114 with this patch applied)

In my use-case, this get's called by `Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector::collect()` using the following code:

```php
$logoutUrl = null;
try {
    if (null !== $this->logoutUrlGenerator && !$token instanceof AnonymousToken) {
        $logoutUrl = $this->logoutUrlGenerator->getLogoutPath();
    }
} catch (\Exception $e) {
    // fail silently when the logout URL cannot be generated
}
```

The above code inside the `SecurityDataCollector` tries to "fail silently" if no logout-URL cannot be generated. But this silent-fail fails itself because the thrown "exception" is not an `\Exception`, but an `\Error` instead (`\Error` is not an descendant of `\Exception`, so it does not get catched here).

In order to resolve this situation, the proposed patch makes the LogoutUrlGenerator explicitly test if a request is actually present and then throw a `\LogicException` instead of an `\Error` if that check fails.