### PR TITLE
[HttpClient] Add `withOptions()` to `HttplugClient` and `Psr18Client`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Make `HttplugClient` implement `Psr\Http\Message\RequestFactoryInterface`, `StreamFactoryInterface` and `UriFactoryInterface`
  * Deprecate implementing `Http\Message\RequestFactory`, `StreamFactory` and `UriFactory` on `HttplugClient`
+ * Add `withOptions()` to `HttplugClient` and `Psr18Client`
 
 6.1
 ---

--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -99,6 +99,14 @@ final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestF
         $this->waitLoop = new HttplugWaitLoop($this->client, $this->promisePool, $this->responseFactory, $this->streamFactory);
     }
 
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->client = $clone->client->withOptions($options);
+
+        return $clone;
+    }
+
     public function sendRequest(RequestInterface $request): Psr7ResponseInterface
     {
         try {

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -79,6 +79,14 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
         $this->streamFactory = $streamFactory;
     }
 
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->client = $clone->client->withOptions($options);
+
+        return $clone;
+    }
+
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Add a simple way to configure `HttplugClient` and `Psr18Client`.
This is going to be useful for SDKs that want to configure eg. the default timeout.
