### PR TITLE
[FrameworkBundle] remove DateTime from core Bundles

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -114,15 +114,15 @@ EOT
 
     private static function isExpired(string $date): bool
     {
-        $date = \DateTime::createFromFormat('d/m/Y', '01/'.$date);
+        $date = \DateTimeImmutable::createFromFormat('d/m/Y', '01/'.$date);
 
-        return false !== $date && new \DateTime() > $date->modify('last day of this month 23:59:59');
+        return false !== $date && new \DateTimeImmutable() > $date->modify('last day of this month 23:59:59');
     }
 
     private static function daysBeforeExpiration(string $date): string
     {
-        $date = \DateTime::createFromFormat('d/m/Y', '01/'.$date);
+        $date = \DateTimeImmutable::createFromFormat('d/m/Y', '01/'.$date);
 
-        return (new \DateTime())->diff($date->modify('last day of this month 23:59:59'))->format('in %R%a days');
+        return (new \DateTimeImmutable())->diff($date->modify('last day of this month 23:59:59'))->format('in %R%a days');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #47580
| License       | MIT
| Doc PR        | symfony/symfony-docs

Remove DateTime from all core bundles. Find also some DateTime in the SecurityBundle, but expose to BC breaks so will be treated in another PR. 