### PR TITLE
[Config][Routing] Nicer config syntax for PSR-4 route loading

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Psr4Routing/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Psr4Routing/routing.yml
@@ -1,4 +1,6 @@
 test_bundle:
     prefix:   /annotated
-    resource: "@TestBundle/Controller"
-    type:     attribute@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller
+    resource:
+        path: "@TestBundle/Controller"
+        namespace: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller
+    type:     attribute

--- a/src/Symfony/Component/Config/Exception/LoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/LoaderLoadException.php
@@ -19,14 +19,22 @@ namespace Symfony\Component\Config\Exception;
 class LoaderLoadException extends \Exception
 {
     /**
-     * @param string          $resource       The resource that could not be imported
+     * @param mixed           $resource       The resource that could not be imported
      * @param string|null     $sourceResource The original resource importing the new resource
      * @param int             $code           The error code
      * @param \Throwable|null $previous       A previous exception
      * @param string|null     $type           The type of resource
      */
-    public function __construct(string $resource, string $sourceResource = null, int $code = 0, \Throwable $previous = null, string $type = null)
+    public function __construct(mixed $resource, string $sourceResource = null, int $code = 0, \Throwable $previous = null, string $type = null)
     {
+        if (!\is_string($resource)) {
+            try {
+                $resource = json_encode($resource, \JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                $resource = sprintf('resource of type "%s"', get_debug_type($resource));
+            }
+        }
+
         $message = '';
         if ($previous) {
             // Include the previous exception, to help the user see what might be the underlying cause

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -136,7 +136,11 @@ abstract class FileLoader extends Loader
         try {
             $loader = $this->resolve($resource, $type);
 
-            if ($loader instanceof self && null !== $this->currentDir) {
+            if (!$loader instanceof self) {
+                return $loader->load($resource, $type);
+            }
+
+            if (null !== $this->currentDir) {
                 $resource = $loader->getLocator()->locate($resource, $this->currentDir, false);
             }
 

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -66,11 +66,15 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
 
     public function supports(mixed $resource, string $type = null): bool
     {
+        if (!\is_string($resource)) {
+            return false;
+        }
+
         if (\in_array($type, ['annotation', 'attribute'], true)) {
             return true;
         }
 
-        if ($type || !\is_string($resource)) {
+        if ($type) {
             return false;
         }
 

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -151,8 +151,17 @@ class XmlFileLoader extends FileLoader
      */
     protected function parseImport(RouteCollection $collection, \DOMElement $node, string $path, string $file)
     {
-        if ('' === $resource = $node->getAttribute('resource')) {
-            throw new \InvalidArgumentException(sprintf('The <import> element in file "%s" must have a "resource" attribute.', $path));
+        /** @var \DOMElement $resourceElement */
+        if (!($resource = $node->getAttribute('resource') ?: null) && $resourceElement = $node->getElementsByTagName('resource')[0] ?? null) {
+            $resource = [];
+            /** @var \DOMAttr $attribute */
+            foreach ($resourceElement->attributes as $attribute) {
+                $resource[$attribute->name] = $attribute->value;
+            }
+        }
+
+        if (!$resource) {
+            throw new \InvalidArgumentException(sprintf('The <import> element in file "%s" must have a "resource" attribute or element.', $path));
         }
 
         $type = $node->getAttribute('type');
@@ -275,6 +284,8 @@ class XmlFileLoader extends FileLoader
                     break;
                 case 'condition':
                     $condition = trim($n->textContent);
+                    break;
+                case 'resource':
                     break;
                 default:
                     throw new \InvalidArgumentException(sprintf('Unknown tag "%s" used in file "%s". Expected "default", "requirement", "option" or "condition".', $n->localName, $path));

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -76,8 +76,9 @@
       <xsd:element name="prefix" type="localized-path" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="exclude" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="host" type="localized-path" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="resource" type="resource" minOccurs="0" maxOccurs="1" />
     </xsd:sequence>
-    <xsd:attribute name="resource" type="xsd:string" use="required" />
+    <xsd:attribute name="resource" type="xsd:string" />
     <xsd:attribute name="type" type="xsd:string" />
     <xsd:attribute name="exclude" type="xsd:string" />
     <xsd:attribute name="prefix" type="xsd:string" />
@@ -91,6 +92,12 @@
     <xsd:attribute name="trailing-slash-on-root" type="xsd:boolean" />
     <xsd:attribute name="utf8" type="xsd:boolean" />
     <xsd:attribute name="stateless" type="xsd:boolean" />
+  </xsd:complexType>
+
+  <xsd:complexType name="resource">
+    <xsd:attribute name="path" type="xsd:string" />
+    <xsd:attribute name="namespace" type="xsd:string" />
+    <xsd:anyAttribute />
   </xsd:complexType>
 
   <xsd:complexType name="default" mixed="true">

--- a/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.xml
@@ -4,6 +4,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <import resource="./Psr4Controllers" prefix="/my-prefix"
-            type="attribute@Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers" />
+    <import prefix="/my-prefix" type="attribute">
+        <resource path="./Psr4Controllers" namespace="Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers" />
+    </import>
 </routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.yaml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.yaml
@@ -1,4 +1,6 @@
 my_controllers:
-    resource: ./Psr4Controllers
-    type: attribute@Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers
+    resource:
+        path: ./Psr4Controllers
+        namespace: Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers
+    type: attribute
     prefix: /my-prefix

--- a/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
@@ -57,34 +57,35 @@ class Psr4DirectoryLoaderTest extends TestCase
     }
 
     /**
-     * @dataProvider provideResourceTypesThatNeedTrimming
+     * @dataProvider provideNamespacesThatNeedTrimming
      */
-    public function testPsr4NamespaceTrim(string $resourceType)
+    public function testPsr4NamespaceTrim(string $namespace)
     {
         $route = $this->getLoader()
-            ->load('Psr4Controllers', $resourceType)
+            ->load(
+                ['path' => 'Psr4Controllers', 'namespace' => $namespace],
+                'attribute',
+            )
             ->get('my_route');
 
         $this->assertSame('/my/route', $route->getPath());
         $this->assertSame(MyController::class.'::__invoke', $route->getDefault('_controller'));
     }
 
-    public function provideResourceTypesThatNeedTrimming(): array
+    public function provideNamespacesThatNeedTrimming(): array
     {
         return [
-            ['attribute@ Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'],
-            ['attribute@\\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'],
-            ['attribute@Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\\'],
-            ['attribute@\\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\\'],
-            ['attribute@   \\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'],
+            ['\\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'],
+            ['Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\\'],
+            ['\\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\\'],
         ];
     }
 
     private function loadPsr4Controllers(): RouteCollection
     {
         return $this->getLoader()->load(
-            'Psr4Controllers',
-            'attribute@Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'
+            ['path' => 'Psr4Controllers', 'namespace' => 'Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'],
+            'attribute'
         );
     }
 

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1"
     },
     "require-dev": {
-        "symfony/config": "^5.4|^6.0",
+        "symfony/config": "^6.2",
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/yaml": "^5.4|^6.0",
         "symfony/expression-language": "^5.4|^6.0",
@@ -29,7 +29,7 @@
     },
     "conflict": {
         "doctrine/annotations": "<1.12",
-        "symfony/config": "<5.4",
+        "symfony/config": "<6.2",
         "symfony/dependency-injection": "<5.4",
         "symfony/yaml": "<5.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Follow-up to #47916
| License       | MIT
| Doc PR        | symfony/symfony-docs#17373 (WIP)

This PR implements an alternative syntax for the PSR-4 route loader introduced in #47916.

```YAML
controllers:
    resource:
        path: ./Controllers
        namespace: App\Controllers
    type: attribute
```

```XML
<routes>
    <import type="attribute">
        <resource path="./Controllers" namespace="App\Psr4Controllers" />
    </import>
</routes>
```