### PR TITLE
[FrameworkBundle] Fix checkboxes check assertions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint as DomCrawlerConstraint;
-use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorAttributeValueSame;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorExists;
 
 /**
@@ -87,18 +86,12 @@ trait DomCrawlerAssertionsTrait
 
     public static function assertCheckboxChecked(string $fieldName, string $message = ''): void
     {
-        self::assertThat(self::getCrawler(), LogicalAnd::fromConstraints(
-            new CrawlerSelectorExists("input[name=\"$fieldName\"]"),
-            new CrawlerSelectorAttributeValueSame("input[name=\"$fieldName\"]", 'checked', 'checked')
-        ), $message);
+        self::assertThat(self::getCrawler(), new CrawlerSelectorExists("input[name=\"$fieldName\"]:checked"), $message);
     }
 
     public static function assertCheckboxNotChecked(string $fieldName, string $message = ''): void
     {
-        self::assertThat(self::getCrawler(), LogicalAnd::fromConstraints(
-            new CrawlerSelectorExists("input[name=\"$fieldName\"]"),
-            new LogicalNot(new CrawlerSelectorAttributeValueSame("input[name=\"$fieldName\"]", 'checked', 'checked'))
-        ), $message);
+        self::assertThat(self::getCrawler(), new LogicalNot(new CrawlerSelectorExists("input[name=\"$fieldName\"]:checked")), $message);
     }
 
     public static function assertFormValue(string $formSelector, string $fieldName, string $value, string $message = ''): void

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -238,16 +238,18 @@ class WebTestCaseTest extends TestCase
     public function testAssertCheckboxChecked()
     {
         $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxChecked('rememberMe');
+        $this->getCrawlerTester(new Crawler('<!DOCTYPE html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxChecked('rememberMe');
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('matches selector "input[name="rememberMe"]" and has a node matching selector "input[name="rememberMe"]" with attribute "checked" of value "checked".');
+        $this->expectExceptionMessage('matches selector "input[name="rememberMe"]:checked".');
         $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxChecked('rememberMe');
     }
 
     public function testAssertCheckboxNotChecked()
     {
         $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxNotChecked('rememberMe');
+        $this->getCrawlerTester(new Crawler('<!DOCTYPE html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxNotChecked('rememberMe');
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('matches selector "input[name="rememberMe"]" and does not have a node matching selector "input[name="rememberMe"]" with attribute "checked" of value "checked".');
+        $this->expectExceptionMessage('does not match selector "input[name="rememberMe"]:checked".');
         $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxNotChecked('rememberMe');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47830 
| License       | MIT
| Doc PR        | N/A

The CssSelector component knows better about the `checked` state!