### PR TITLE
[PropertyAccess] Fix using the nullsafe operator on first level properties

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -108,7 +108,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             self::VALUE => $objectOrArray,
         ];
 
-        if (\is_object($objectOrArray) && false === strpbrk((string) $propertyPath, '.[')) {
+        if (\is_object($objectOrArray) && false === strpbrk((string) $propertyPath, '.[?')) {
             return $this->readProperty($zval, $propertyPath, $this->ignoreInvalidProperty)[self::VALUE];
         }
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -561,17 +561,17 @@ class PropertyAccessorTest extends TestCase
         ];
     }
 
-    public function getValidReadPropertyPaths()
+    public function getValidReadPropertyPaths(): iterable
     {
-        $testCases = $this->getValidWritePropertyPaths();
+        yield from $this->getValidWritePropertyPaths();
 
         // Optional paths can only be read and can't be written to.
-        $testCases[] = [(object) ['foo' => (object) ['firstName' => 'Bernhard']], 'foo.bar?', null];
-        $testCases[] = [(object) ['foo' => (object) ['firstName' => 'Bernhard']], 'foo.bar?.baz?', null];
-        $testCases[] = [['foo' => ['firstName' => 'Bernhard']], '[foo][bar?]', null];
-        $testCases[] = [['foo' => ['firstName' => 'Bernhard']], '[foo][bar?][baz?]', null];
-
-        return $testCases;
+        yield [(object) [], 'foo?', null];
+        yield [(object) ['foo' => (object) ['firstName' => 'Bernhard']], 'foo.bar?', null];
+        yield [(object) ['foo' => (object) ['firstName' => 'Bernhard']], 'foo.bar?.baz?', null];
+        yield [[], '[foo?]', null];
+        yield [['foo' => ['firstName' => 'Bernhard']], '[foo][bar?]', null];
+        yield [['foo' => ['firstName' => 'Bernhard']], '[foo][bar?][baz?]', null];
     }
 
     public function testTicket5755()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

There's a bug when using the nullsafe operator with first level properties, eg:

```php
var_dump((new PropertyAccessor())->getValue(new \stdClass(), 'foo?'));
```

throws an exception:

```
Uncaught Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException: Can't get a way to read the property "foo?" in class "stdClass".
```

I would expect `null` to be returned just like with lower level properties, eg:

```php
var_dump((new PropertyAccessor())->getValue((object) ['foo' => new \stdClass()], 'foo.bar?'));
```

When using the same logic with arrays, everything works as expected & `null` is returned, eg:

```php
var_dump((new PropertyAccessor())->getValue([], '[foo?]'));
```