### PR TITLE
[Security][Serializer] Add missing args to trigger_deprecation

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -80,7 +80,7 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
             // @deprecated since Symfony 5.4
             if ($this->alwaysAuthenticate || !$authenticated = $token->isAuthenticated(false)) {
                 if (!($authenticated ?? true)) {
-                    trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s()" is deprecated, return null from "getUser()" instead.');
+                    trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s::isAuthenticated()" is deprecated, return null from "getUser()" instead.', get_debug_type($token));
                 }
                 $this->tokenStorage->setToken($token = $this->authenticationManager->authenticate($token));
             }

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -114,7 +114,7 @@ class AccessListener extends AbstractListener
 
         // @deprecated since Symfony 5.4
         if (method_exists($token, 'isAuthenticated') && !$token->isAuthenticated(false)) {
-            trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s()" is deprecated, return null from "getUser()" instead.');
+            trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s::isAuthenticated()" is deprecated, return null from "getUser()" instead.', get_debug_type($token));
 
             if ($this->authManager) {
                 $token = $this->authManager->authenticate($token);

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -89,7 +89,7 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
         }
 
         if (Serializer::class !== debug_backtrace()[1]['class'] ?? null) {
-            trigger_deprecation('symfony/serializer', '5.3', 'Calling "%s" is deprecated. Please call setDenormalizer() instead.');
+            trigger_deprecation('symfony/serializer', '5.3', 'Calling "%s()" is deprecated. Please call setDenormalizer() instead.', __METHOD__);
         }
 
         $this->setDenormalizer($serializer);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -89,7 +89,7 @@ class ArrayDenormalizerTest extends TestCase
 
         $denormalizer = new ArrayDenormalizer();
 
-        $this->expectDeprecation('Since symfony/serializer 5.3: Calling "%s" is deprecated. Please call setDenormalizer() instead.');
+        $this->expectDeprecation('Since symfony/serializer 5.3: Calling "Symfony\Component\Serializer\Normalizer\ArrayDenormalizer::setSerializer()" is deprecated. Please call setDenormalizer() instead.');
         $denormalizer->setSerializer($serializer);
 
         $result = $denormalizer->denormalize(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I found that an argument was missing to `trigger_deprecation` in AuthorizationChecker. Found other places with this problem.