### PR TITLE
[Notifier] Add support for editing Telegram messages

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
@@ -99,4 +99,14 @@ final class TelegramOptions implements MessageOptionsInterface
 
         return $this;
     }
+
+    /**
+     * @return $this
+     */
+    public function edit(int $messageId): static
+    {
+        $this->options['message_id'] = $messageId;
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -49,7 +49,7 @@ final class TelegramTransportTest extends TransportTestCase
     public function testSendWithErrorResponseThrowsTransportException()
     {
         $this->expectException(TransportException::class);
-        $this->expectExceptionMessageMatches('/testDescription.+testErrorCode/');
+        $this->expectExceptionMessageMatches('/post.+testDescription.+400/');
 
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->exactly(2))
@@ -57,7 +57,7 @@ final class TelegramTransportTest extends TransportTestCase
             ->willReturn(400);
         $response->expects($this->once())
             ->method('getContent')
-            ->willReturn(json_encode(['description' => 'testDescription', 'error_code' => 'testErrorCode']));
+            ->willReturn(json_encode(['description' => 'testDescription', 'error_code' => 400]));
 
         $client = new MockHttpClient(static function () use ($response): ResponseInterface {
             return $response;
@@ -66,6 +66,28 @@ final class TelegramTransportTest extends TransportTestCase
         $transport = $this->createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('testMessage'));
+    }
+
+    public function testSendWithErrorResponseThrowsTransportExceptionForEdit()
+    {
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessageMatches('/edit.+testDescription.+404/');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(400);
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn(json_encode(['description' => 'testDescription', 'error_code' => 404]));
+
+        $client = new MockHttpClient(static function () use ($response): ResponseInterface {
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+
+        $transport->send(new ChatMessage('testMessage', (new TelegramOptions())->edit(123)));
     }
 
     public function testSendWithOptions()
@@ -110,6 +132,7 @@ JSON;
         ];
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
+            $this->assertStringEndsWith('/sendMessage', $url);
             $this->assertSame($expectedBody, json_decode($options['body'], true));
 
             return $response;
@@ -121,6 +144,53 @@ JSON;
 
         $this->assertEquals(1, $sentMessage->getMessageId());
         $this->assertEquals('telegram://api.telegram.org?channel=testChannel', $sentMessage->getTransport());
+    }
+
+    public function testSendWithOptionForEditMessage()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $content = <<<JSON
+            {
+                "ok": true,
+                "result": {
+                    "message_id": 1,
+                    "from": {
+                        "id": 12345678,
+                        "first_name": "YourBot",
+                        "username": "YourBot"
+                    },
+                    "chat": {
+                        "id": 1234567890,
+                        "first_name": "John",
+                        "last_name": "Doe",
+                        "username": "JohnDoe",
+                        "type": "private"
+                    },
+                    "date": 1459958199,
+                    "text": "Hello from Bot!"
+                }
+            }
+JSON;
+
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn($content)
+        ;
+
+        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+            $this->assertStringEndsWith('/editMessageText', $url);
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+        $options = (new TelegramOptions())->edit(123);
+
+        $transport->send(new ChatMessage('testMessage', $options));
     }
 
     public function testSendWithChannelOverride()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Telegram supports updating messages which is quite a use case while working with buttons to create an interactive inline interface.

See https://core.telegram.org/bots/api#editmessagetext