### PR TITLE
[WebProfilerBundle] Fix profiler search link query params

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -128,7 +128,7 @@
                                     </div>
                                 {% endblock sidebar_shortcuts_links %}
 
-                                {{ render(controller('web_profiler.controller.profiler::searchBarAction', request.query.all)) }}
+                                {{ render(controller('web_profiler.controller.profiler::searchBarAction', query=request.query.all)) }}
                             </div>
 
                             {% if templates is defined %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

Reintroduce bug fix from #47417 after it was lost in 6.2 when #47148 was rebased and merged.