### PR TITLE
[FrameworkBundle] Deprecated the `registerRateLimiter()` method

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -34,6 +34,7 @@ FrameworkBundle
    `Symfony\Component\Serializer\Normalizer\PropertyNormalizer` autowiring aliases, type-hint against
    `Symfony\Component\Serializer\Normalizer\NormalizerInterface` or implement `NormalizerAwareInterface` instead
  * Deprecate `AbstractController::renderForm()`, use `render()` instead
+ * Deprecate `FrameworkExtension::registerRateLimiter()`, to be made private in 7.0
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -21,6 +21,8 @@ CHANGELOG
  * Deprecate `framework.form.legacy_error_messages` config node
  * Add a `framework.router.cache_dir` configuration option to configure the default `Router` `cache_dir` option
  * Add option `framework.messenger.buses.*.default_middleware.allow_no_senders` to enable throwing when a message doesn't have a sender
+ * Deprecate `AbstractController::renderForm()`, use `render()` instead
+ * Deprecate `FrameworkExtension::registerRateLimiter()`, to be made private in 7.0
 
 6.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR deprecated the `public static` method `FrameworkExtension::registerRateLimiter` method

This method is used by the `LoginThrottlingFactory` class (from securityBundle`.
It adds a tight coupling between the 2 bundles, and also exposes a public static (non-internal) method in the `FrameworkExtension`.

Being `static` also prevent non-static call in the frameworkExtension method, and prevent such feature: #45569