### PR TITLE
[Messenger][Amqp] Pass the routing key to the serializer when decoding

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Round delays up to two significant digits and add the `delay[granularity]` option to control that rounding
  * Implement the `KeepaliveReceiverInterface` to enable asynchronously notifying AMQP that the job is still being processed, in order to avoid timeouts
+ * Pass the routing key to the serializer as `extra[routing_key]` when decoding
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
@@ -219,6 +219,28 @@ class AmqpReceiverTest extends TestCase
         $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
     }
 
+    public function testItPassesTheRoutingKeyToTheSerializer()
+    {
+        $amqpEnvelope = $this->createAMQPEnvelope();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with([
+                'body' => '{"message": "Hi"}',
+                'headers' => ['type' => DummyMessage::class],
+                'extra' => ['routing_key' => 'dummy_routing_key'],
+            ])
+            ->willReturn(new Envelope(new DummyMessage('Hi')));
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+        iterator_to_array($receiver->get());
+    }
+
     private function createAMQPEnvelope(?string $messageId = null, string $body = '{"message": "Hi"}'): \AMQPEnvelope
     {
         $envelope = $this->createStub(\AMQPEnvelope::class);
@@ -227,6 +249,7 @@ class AmqpReceiverTest extends TestCase
             'type' => DummyMessage::class,
         ]);
         $envelope->method('getMessageId')->willReturn($messageId);
+        $envelope->method('getRoutingKey')->willReturn('dummy_routing_key');
 
         return $envelope;
     }

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
@@ -43,8 +43,9 @@ class AmqpTransportTest extends TestCase
         $amqpEnvelope = $this->createMock(\AMQPEnvelope::class);
         $amqpEnvelope->method('getBody')->willReturn('body');
         $amqpEnvelope->method('getHeaders')->willReturn(['my' => 'header']);
+        $amqpEnvelope->method('getRoutingKey')->willReturn('routing-key');
 
-        $serializer->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));
+        $serializer->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header'], 'extra' => ['routingKey' => 'routing-key']])->willReturn(new Envelope($decodedMessage));
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
@@ -43,8 +43,9 @@ class AmqpTransportTest extends TestCase
         $amqpEnvelope = $this->createStub(\AMQPEnvelope::class);
         $amqpEnvelope->method('getBody')->willReturn('body');
         $amqpEnvelope->method('getHeaders')->willReturn(['my' => 'header']);
+        $amqpEnvelope->method('getRoutingKey')->willReturn('routing_key');
 
-        $serializer->expects($this->once())->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));
+        $serializer->expects($this->once())->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header'], 'extra' => ['routing_key' => 'routing_key']])->willReturn(new Envelope($decodedMessage));
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->expects($this->once())->method('get')->with('queueName')->willReturn($amqpEnvelope);
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -66,6 +66,9 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
             $envelope = $this->serializer->decode([
                 'body' => false === $body ? '' : $body, // workaround https://github.com/pdezwart/php-amqp/issues/351
                 'headers' => $amqpEnvelope->getHeaders(),
+                'extra' => [
+                    'routingKey' => $amqpEnvelope->getRoutingKey(),
+                ],
             ]);
         } catch (MessageDecodingFailedException $exception) {
             // invalid message of some type

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -115,6 +115,7 @@ class AmqpReceiver implements QueueReceiverInterface, KeepaliveReceiverInterface
         $data = [
             'body' => false === $body ? '' : $body,
             'headers' => $amqpEnvelope->getHeaders(),
+            'extra' => ['routing_key' => $amqpEnvelope->getRoutingKey()],
         ];
 
         try {

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add a `--concurrency` option to the `messenger:consume` command to process messages in parallel
  * Add a `--redispatch` option to the `messenger:failed:retry` command to send messages back to their transport instead of handling them in the command
  * Allow prioritizing receivers so that `messenger:consume --all` consumes receivers in a predefined order
+ * Add an optional `extra` key to the encoded envelope passed to `SerializerInterface::decode()`, holding metadata added by the receiving transport
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Transport/Serialization/MessageTypeAwareSerializerInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/MessageTypeAwareSerializerInterface.php
@@ -32,7 +32,12 @@ interface MessageTypeAwareSerializerInterface
      * therefore return the actual class for every well-formed envelope they can
      * produce, reserving null for malformed or unrecognized input.
      *
-     * @param array{body: string, headers?: array<string, string>} $encodedEnvelope
+     * The `extra` key, when present, holds metadata added by the transport that received
+     * the message rather than data produced by encode(). Implementations SHOULD NOT
+     * determine the message type from it: a signature covers the encoded envelope, so a
+     * type derived from transport metadata is not covered by one.
+     *
+     * @param array{body: string, headers?: array<string, string>, extra?: array<string, mixed>} $encodedEnvelope
      *
      * @return class-string|null
      */

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
@@ -28,6 +28,10 @@ interface SerializerInterface
      * The most common keys are:
      * - `body` (string) - the message body
      * - `headers` (string<string>) - a key/value pair of headers
+     * - `extra` (array<string, mixed>) - metadata added by the transport that received
+     *   the message, e.g. the AMQP routing key. Unlike `body` and `headers`, it is not
+     *   produced by encode() and does not survive a round trip, so implementations MUST
+     *   treat it as optional and MUST NOT require it to decode.
      *
      * On failure, implementations SHOULD return an Envelope wrapping a
      * MessageDecodingFailedException instead of throwing, so that the worker
@@ -35,7 +39,7 @@ interface SerializerInterface
      * MessageDecodingFailedException is still supported for BC with custom
      * serializers; transports will wrap the exception as a fallback.
      *
-     * @param array{body: string, headers?: array<string, string>} $encodedEnvelope
+     * @param array{body: string, headers?: array<string, string>, extra?: array<string, mixed>} $encodedEnvelope
      *
      * @throws MessageDecodingFailedException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #43039
| License       | MIT

The AMQP routing key often carries information needed to decode a message, most commonly which class the body should be denormalized into. It is not reachable at decode time today: `AmqpReceiver` passes only `body` and `headers` to the serializer, and reading it from `AmqpReceivedStamp` afterwards is too late, because `Serializer::decode()` already requires `headers['type']` and `PhpSerializer` already requires a serialized envelope.

This adds a third, optional key to the array the receiver passes to `SerializerInterface::decode()`:

```php
[
    'body' => '…',
    'headers' => ['type' => …],
    'extra' => ['routing_key' => 'orders.created'],
]
```

A custom serializer can then pick the message class from the routing key. Nothing in the component reads `extra`, so decoding is unchanged for everyone else.

### `extra` is transport metadata, not part of the encoded envelope

`body` and `headers` are what `encode()` produced. `extra` is what the transport observed on delivery, so it does not survive a round trip and is never present when encoding. Both are documented on `SerializerInterface::decode()`, which now states that implementations must treat `extra` as optional and must not require it to decode.

The same array reaches `MessageTypeAwareSerializerInterface::getMessageType()`, which `SigningSerializer` uses to decide whether a message required a signature. That method is documented with a `SHOULD NOT` against deriving the message type from `extra`: a signature covers the encoded envelope, so a type taken from transport metadata is not covered by one.

### Why not a header

Injecting the routing key into `headers` would need no interface change, but no receiver in the tree fabricates a header today: `headers` is exactly what the sender put on the wire. An injected one would either overwrite a header the publisher legitimately set, or be indistinguishable from one they forged, and `getMessageType()` could not tell the two apart. Under `extra` the receiver is the only writer.

### Notes for reviewers

The key is `routing_key` rather than `routingKey`, to match `body` and `headers` and the bridge's own `default_publish_routing_key` and `%routing_key%` naming.

Only the AMQP receiver populates `extra`. Other transports are free to add their own keys later, and the exchange name is the obvious next candidate for this one.

### Documentation

`extra` is a new optional key on a public contract, so `SerializerInterface` and `MessageTypeAwareSerializerInterface` both need it described in the Messenger docs, together with the rule that it is receive-side only and must not be used for type determination.