### PR TITLE
Add padding to HIBP check

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Deprecate the "loose" e-mail validation mode, use "html5" instead
  * Add the `negate` option to the `Expression` constraint, to inverse the logic of the violation's creation
  * Add the `extensions` option to the `File` constraint as an alternative to `mimeTypes` which checks the mime type of the file, its extension, and the consistency between them
+ * Add padding for enhanced privacy to the `NotCompromisedPasswordValidator`
 
 6.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/NotCompromisedPasswordValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotCompromisedPasswordValidator.php
@@ -79,7 +79,7 @@ class NotCompromisedPasswordValidator extends ConstraintValidator
         $url = sprintf($this->endpoint, $hashPrefix);
 
         try {
-            $result = $this->httpClient->request('GET', $url)->getContent();
+            $result = $this->httpClient->request('GET', $url, ['headers' => ['Add-Padding' => 'true']])->getContent();
         } catch (ExceptionInterface $e) {
             if ($constraint->skipOnError) {
                 return;

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
@@ -40,6 +40,8 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
         '273CA8A2A78C9B2D724144F4FAF4D221C86:6', // ISO-8859-5 leaked password: мама
         '3686792BBC66A72D40D928ED15621124CFE:7',
         '36EEC709091B810AA240179A44317ED415C:2',
+        'EE6EB9C0DFA0F07098CEDB11ECC7AFF9D4E:0', // UTF-8 not leaked password: ]<0585"%sb^5aa$w6!b38",,72?dp3r4\45b28Hy
+        'FC9F37E51AACD6B692A62769267590D46B8:0', // ISO-8859-5 non leaked password: м<в0dp3r4\45b28Hy
     ];
 
     protected function createValidator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Ensures that we also add padding for the breached password validator.
See:
* https://www.troyhunt.com/enhancing-pwned-passwords-privacy-with-padding/
* https://haveibeenpwned.com/API/v3#PwnedPasswordsPadding
