### PR TITLE
Fix phpredis cache trait

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -376,7 +376,7 @@ trait RedisTrait
         }
 
         foreach ($ids as $k => $id) {
-            yield $id => $results[$k];
+            yield $id => is_array($results) ? $results[$k] : $results;
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46384
| License       | MIT

When using `phpredis` client, the execution of `multi/exec` might return a boolean instead of an array, leading to an error when yielding the result.
