### PR TITLE
[Translation] translation:push command diff using intl-icu

### DIFF
--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -137,7 +137,7 @@ EOF
 
         // Reading local translations must be done after retrieving the domains from the provider
         // in order to manage only translations from configured domains
-        $localTranslations = $this->readLocalTranslations($locales, $domains, $this->transPaths);
+        $localTranslations = $this->readLocalTranslations($locales, $domains, $this->transPaths, true);
 
         if (!$domains) {
             $domains = $this->getDomainsFromTranslatorBag($localTranslations);

--- a/src/Symfony/Component/Translation/Command/TranslationTrait.php
+++ b/src/Symfony/Component/Translation/Command/TranslationTrait.php
@@ -20,7 +20,7 @@ use Symfony\Component\Translation\TranslatorBag;
  */
 trait TranslationTrait
 {
-    private function readLocalTranslations(array $locales, array $domains, array $transPaths): TranslatorBag
+    private function readLocalTranslations(array $locales, array $domains, array $transPaths, bool $mergeIntlIcu = false): TranslatorBag
     {
         $bag = new TranslatorBag();
 
@@ -32,7 +32,7 @@ trait TranslationTrait
 
             if ($domains) {
                 foreach ($domains as $domain) {
-                    $bag->addCatalogue($this->filterCatalogue($catalogue, $domain));
+                    $bag->addCatalogue($this->filterCatalogue($catalogue, $domain, $mergeIntlIcu));
                 }
             } else {
                 $bag->addCatalogue($catalogue);
@@ -42,14 +42,14 @@ trait TranslationTrait
         return $bag;
     }
 
-    private function filterCatalogue(MessageCatalogue $catalogue, string $domain): MessageCatalogue
+    private function filterCatalogue(MessageCatalogue $catalogue, string $domain, bool $mergeIntlIcu): MessageCatalogue
     {
         $filteredCatalogue = new MessageCatalogue($catalogue->getLocale());
 
         // extract intl-icu messages only
         $intlDomain = $domain.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
         if ($intlMessages = $catalogue->all($intlDomain)) {
-            $filteredCatalogue->add($intlMessages, $domain);
+            $filteredCatalogue->add($intlMessages, $mergeIntlIcu ? $domain : $intlDomain);
         }
 
         // extract all messages and subtract intl-icu messages

--- a/src/Symfony/Component/Translation/Command/TranslationTrait.php
+++ b/src/Symfony/Component/Translation/Command/TranslationTrait.php
@@ -49,7 +49,7 @@ trait TranslationTrait
         // extract intl-icu messages only
         $intlDomain = $domain.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
         if ($intlMessages = $catalogue->all($intlDomain)) {
-            $filteredCatalogue->add($intlMessages, $intlDomain);
+            $filteredCatalogue->add($intlMessages, $domain);
         }
 
         // extract all messages and subtract intl-icu messages


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47886
| License       | MIT

Provider translations do not come back with "+intl-icu" in `$provider->read($domains, $locales);`, so local translations should not include it for the diff.