### PR TITLE
Catch throwable class to catch type error

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -111,7 +111,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
             $logoutUrl = null;
             try {
                 $logoutUrl = $this->logoutUrlGenerator?->getLogoutPath();
-            } catch (\Exception) {
+            } catch (\Throwable) {
                 // fail silently when the logout URL cannot be generated
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.1 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I've faced with error when my API respond with an exception. It fails with internal error while creating logout link, but I don't use any templates and convert my response to JSON by custom listener.
I think it happens because `current request` is empty for some reasons. I suggest just ignore this case for a while or someone may deep into the problem.
<details>
<img width="968" alt="image" src="https://user-images.githubusercontent.com/6815714/197907483-14f47a2e-a997-4d0e-987d-3c7983390e72.png">

```text
Error:
Call to a member function getBaseUrl() on null
  at /app/vendor/symfony/security-http/Logout/LogoutUrlGenerator.php:97
  at Symfony\Component\Security\Http\Logout\LogoutUrlGenerator-&gt;generateLogoutUrl(null, 1)
     (/app/vendor/symfony/security-http/Logout/LogoutUrlGenerator.php:60)
  at Symfony\Component\Security\Http\Logout\LogoutUrlGenerator-&gt;getLogoutPath()
     (/app/vendor/symfony/security-bundle/DataCollector/SecurityDataCollector.php:113)
  at Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector-&gt;collect(object(Request), object(JsonResponse), null)
     (/app/vendor/symfony/http-kernel/Profiler/Profiler.php:156)
  at Symfony\Component\HttpKernel\Profiler\Profiler-&gt;collect(object(Request), object(JsonResponse), null)
     (/app/vendor/symfony/http-kernel/EventListener/ProfilerListener.php:108)
  at Symfony\Component\HttpKernel\EventListener\ProfilerListener-&gt;onKernelResponse(object(ResponseEvent), 'kernel.response', object(TraceableEventDispatcher))
     (/app/vendor/symfony/event-dispatcher/Debug/WrappedListener.php:115)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener-&gt;__invoke(object(ResponseEvent), 'kernel.response', object(TraceableEventDispatcher))
     (/app/vendor/symfony/event-dispatcher/EventDispatcher.php:230)
  at Symfony\Component\EventDispatcher\EventDispatcher-&gt;callListeners(array(object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener)), 'kernel.response', object(ResponseEvent))
     (/app/vendor/symfony/event-dispatcher/EventDispatcher.php:59)
  at Symfony\Component\EventDispatcher\EventDispatcher-&gt;dispatch(object(ResponseEvent), 'kernel.response')
     (/app/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:153)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher-&gt;dispatch(object(ResponseEvent), 'kernel.response')
     (/app/vendor/symfony/http-kernel/HttpKernel.php:186)
  at Symfony\Component\HttpKernel\HttpKernel-&gt;filterResponse(object(JsonResponse), object(Request), 1)
     (/app/vendor/symfony/http-kernel/HttpKernel.php:239)
  at Symfony\Component\HttpKernel\HttpKernel-&gt;handleThrowable(object(ClassNotFoundError), object(Request), 1)
     (/app/vendor/symfony/http-kernel/HttpKernel.php:109)
  at Symfony\Component\HttpKernel\HttpKernel-&gt;terminateWithException(object(ClassNotFoundError), object(Request))
     (/app/vendor/symfony/http-kernel/EventListener/DebugHandlersListener.php:125)
  at Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::Symfony\Component\HttpKernel\EventListener\{closure}(object(ClassNotFoundError))
     (/app/vendor/symfony/error-handler/ErrorHandler.php:540)
  at Symfony\Component\ErrorHandler\ErrorHandler-&gt;handleException(object(ClassNotFoundError))               
```
</details>

`$ cat composer.json| grep symfony/`

```text
    "symfony/amqp-messenger": "^6.1.0",
    "symfony/asset": "^6.1.0",
    "symfony/console" : "^6.1.0",
    "symfony/doctrine-messenger" : "^6.1.0",
    "symfony/dotenv" : "^6.1.0",
    "symfony/expression-language" : "^6.1.0",
    "symfony/filesystem" : "^6.1.0",
    "symfony/flex" : "^2.2.0",
    "symfony/framework-bundle" : "^6.0.3",
    "symfony/mailer" : "^6.1.0",
    "symfony/messenger" : "^6.1.0",
    "symfony/mime" : "^6.1.0",
    "symfony/monolog-bundle" : "^3.8",
    "symfony/property-access" : "^6.1.0",
    "symfony/property-info" : "^6.1.0",
    "symfony/runtime" : "^6.1.0",
    "symfony/security-bundle" : "^6.1.0",
    "symfony/security-core" : "^6.1.0",
    "symfony/serializer" : "^6.1.0",
    "symfony/translation" : "^6.1.0",
    "symfony/twig-bundle" : "^6.1.0",
    "symfony/uid" : "^6.1.0",
    "symfony/validator" : "^6.1.0",
    "symfony/yaml": "^6.1.0"
    "symfony/browser-kit": "^6.1.0",
    "symfony/css-selector": "^6.1.0",
    "symfony/debug-bundle": "^6.1.0",
    "symfony/maker-bundle": "^1.21",
    "symfony/phpunit-bridge": "^6.1",
    "symfony/stopwatch": "^6.1.0",
    "symfony/var-dumper": "^6.1.0",
    "symfony/web-profiler-bundle": "^6.1.1"
```

I'm open to help but wanted to fix the issue asap.