### PR TITLE
[Console] Fix console `ProgressBar::override()` after manual `ProgressBar::cleanup()`

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -474,10 +474,13 @@ final class ProgressBar
                     }
                     $this->output->clear($lineCount);
                 } else {
-                    for ($i = 0; $i < $this->formatLineCount; ++$i) {
-                        $this->cursor->moveToColumn(1);
-                        $this->cursor->clearLine();
-                        $this->cursor->moveUp();
+                    if ('' !== $this->previousMessage) {
+                        // only clear upper lines when last call was not a clear
+                        for ($i = 0; $i < $this->formatLineCount; ++$i) {
+                            $this->cursor->moveToColumn(1);
+                            $this->cursor->clearLine();
+                            $this->cursor->moveUp();
+                        }
                     }
 
                     $this->cursor->moveToColumn(1);

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -812,8 +812,10 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $this->assertEquals(
             ">---------------------------\nfoobar".
             $this->generateOutput("=========>------------------\nfoobar").
-            "\x1B[1G\x1B[2K\x1B[1A\x1B[1G\x1B[2K".
-            $this->generateOutput("============================\nfoobar"),
+            "\x1B[1G\x1B[2K\x1B[1A".
+            $this->generateOutput('').
+            $this->generateOutput('============================').
+            "\nfoobar",
             stream_get_contents($output->getStream())
         );
     }
@@ -1121,6 +1123,31 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
             $this->generateOutput("1/3\nABC\nFoo").
             $this->generateOutput("2/3\nA\nFoo").
             $this->generateOutput("3/3\nA\nFoo"),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testMultiLineFormatIsFullyCorrectlyWithManuallyCleanup()
+    {
+        ProgressBar::setFormatDefinition('normal_nomax', "[%bar%]\n%message%");
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->setMessage('Processing "foobar"...');
+        $bar->start();
+        $bar->clear();
+        $output->writeln('Foo!');
+        $bar->display();
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            "[>---------------------------]\n".
+            'Processing "foobar"...'.
+            "\x1B[1G\x1B[2K\x1B[1A".
+            $this->generateOutput('').
+            'Foo!'.\PHP_EOL.
+            $this->generateOutput('[--->------------------------]').
+            "\nProcessing \"foobar\"...".
+            $this->generateOutput("[----->----------------------]\nProcessing \"foobar\"..."),
             stream_get_contents($output->getStream())
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47987
| License       | MIT
| Doc PR        | 

In the issue #47987 is described, that there is a problem with overriding lines with `ProgressBar::override()` on a multiline console output with manual call of `ProgressBar::cleanup()`.

Testcode:
```
ProgressBar::setFormatDefinition('normal_nomax', "[%bar%]\n%message%");
$progressBar = new ProgressBar($output);
$progressBar->setMessage('Processing "foobar"...');
$progressBar->start();
$progressBar->clear();
$output->writeln('Foo!');
$progressBar->display();
$progressBar->finish();
```

Output before the fix:
```
Progress bar having only one line:
Foo!
[----->----------------------]
=-=-=-=
Progress bar having two lines:
[----->----------------------]
Processing "foobar"...
```

Expected output / output after the fix:
```
Progress bar having only one line:
Foo!
[----->----------------------]
=-=-=-=
Progress bar having two lines:
Foo!
[----->----------------------]
Processing "foobar"...
```
