### PR TITLE
Shorten Placeholder for Search input

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -1018,7 +1018,7 @@ tr.status-warning td {
     background-position: 5px;
     box-shadow: inset 0 0 0 1px var(--form-input-border-color), 0 0 0 3px var(--page-background);
     padding: 5px 8px 5px 30px;
-    width: 200px;
+    width: 215px;
 }
 .theme-dark #header .search input {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' data-icon-name='icon-tabler-search' width='21' height='21' viewBox='0 0 24 24' stroke='%23a3a3a3' fill='none' stroke-linecap='round' stroke-linejoin='round' stroke-width='3'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'%3E%3C/path%3E%3Ccircle cx='10' cy='10' r='7'%3E%3C/circle%3E%3Cline x1='21' y1='21' x2='15' y2='15'%3E%3C/line%3E%3C/svg%3E");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| License       | MIT

Even on a stupidly large screen, the "Search on Symfony.com" input box has a placeholder that is truncated to `search on symfony.co` (missing final `m`) 

`Symfony.co` is not a valid or owned official domain. 

Screenshot is Safari, Google Chrome, Firefox. Firefox is the only one that renders the full placeholder. 

<img width="284" alt="Screenshot 2022-10-26 at 11 37 35" src="https://user-images.githubusercontent.com/400092/198005369-39bebfff-fc6d-4db8-80b7-a893d10e58c8.png">

Proposing to remove the word `on` so that the placeholder is just `search symfony.com`