### PR TITLE
[Fabbot] Add `global_namespace_import` PHPCSFixer rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -31,6 +31,7 @@ return (new PhpCsFixer\Config())
         'protected_to_private' => false,
         'native_constant_invocation' => ['strict' => false],
         'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => false],
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
         'header_comment' => ['header' => $fileHeaderComment],
     ])
     ->setRiskyAllowed(true)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As suggested in https://github.com/symfony/symfony/pull/47709#discussion_r982428553