### PR TITLE
[DomCrawler] remove duplicated catch block

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -1072,8 +1072,6 @@ HTML;
             $this->assertTrue(true, '->children() does not trigger a notice if the node has no children');
         } catch (\PHPUnit\Framework\Error\Notice $e) {
             $this->fail('->children() does not trigger a notice if the node has no children');
-        } catch (\PHPUnit\Framework\Error\Notice $e) {
-            $this->fail('->children() does not trigger a notice if the node has no children');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| License       | MIT

Exception '\PHPUnit\Framework\Error\Notice' is already caught - this PR deletes unused/unreachable code. 

Before:

```php
        try {
            $crawler = $this->createCrawler('<p></p>');
            $crawler->filter('p')->children();
            $this->assertTrue(true, '->children() does not trigger a notice if the node has no children');
        } catch (\PHPUnit\Framework\Error\Notice $e) {
            $this->fail('->children() does not trigger a notice if the node has no children');
        } catch (\PHPUnit\Framework\Error\Notice $e) {
            $this->fail('->children() does not trigger a notice if the node has no children');
        }
```

After

```php
        try {
            $crawler = $this->createCrawler('<p></p>');
            $crawler->filter('p')->children();
            $this->assertTrue(true, '->children() does not trigger a notice if the node has no children');
        } catch (\PHPUnit\Framework\Error\Notice $e) {
            $this->fail('->children() does not trigger a notice if the node has no children');
        }
```