### PR TITLE
Fix Typos In Comments 5.4+

### DIFF
--- a/src/Symfony/Component/Cache/Marshaller/TagAwareMarshaller.php
+++ b/src/Symfony/Component/Cache/Marshaller/TagAwareMarshaller.php
@@ -51,7 +51,7 @@ class TagAwareMarshaller implements MarshallerInterface
                     $serialized[$id][9] = "\x5F";
                 }
             } else {
-                // other arbitratry values are serialized using the decorated marshaller below
+                // other arbitrary values are serialized using the decorated marshaller below
                 $notSerialized[$id] = $value;
             }
         }

--- a/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
@@ -47,7 +47,7 @@ class FormFieldRegistry
     }
 
     /**
-     * Removes a field based on the fully qualifed name and its children from the registry.
+     * Removes a field based on the fully qualified name and its children from the registry.
      */
     public function remove(string $name)
     {
@@ -64,7 +64,7 @@ class FormFieldRegistry
     }
 
     /**
-     * Returns the value of the field based on the fully qualifed name and its children.
+     * Returns the value of the field based on the fully qualified name and its children.
      *
      * @return FormField|FormField[]|FormField[][]
      *

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -590,7 +590,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
         $this->cacheConfig['stale_while_revalidate'] = 10;
 
-        // The prescence of Last-Modified makes this cacheable (because Response::isValidateable() then).
+        // The presence of Last-Modified makes this cacheable (because Response::isValidateable() then).
         $this->setNextResponse(200, ['Cache-Control' => 'public, s-maxage=5', 'Last-Modified' => 'some while ago'], 'Old response');
         $this->request('GET', '/'); // warm the cache
 

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -250,7 +250,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
     }
 
     /**
-     * Checks wether current platform supports table creation within transaction.
+     * Checks whether current platform supports table creation within transaction.
      */
     private function platformSupportsTableCreationInTransaction(): bool
     {

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -23,9 +23,9 @@ use Symfony\Component\Mime\RawMessage;
 /**
  * SendmailTransport for sending mail through a Sendmail/Postfix (etc..) binary.
  *
- * Transport can be instanciated through SendmailTransportFactory or NativeTransportFactory:
+ * Transport can be instantiated through SendmailTransportFactory or NativeTransportFactory:
  *
- * - SendmailTransportFactory to use most common sendmail path and recommanded options
+ * - SendmailTransportFactory to use most common sendmail path and recommended options
  * - NativeTransportFactory when configuration is set via php.ini
  *
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/SocketStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/SocketStream.php
@@ -145,7 +145,7 @@ final class SocketStream extends AbstractStream
         if ($this->streamContextOptions) {
             $options = array_merge($options, $this->streamContextOptions);
         }
-        // do it unconditionnally as it will be used by STARTTLS as well if supported
+        // do it unconditionally as it will be used by STARTTLS as well if supported
         $options['ssl']['crypto_method'] = $options['ssl']['crypto_method'] ?? \STREAM_CRYPTO_METHOD_TLS_CLIENT | \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT | \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
         $streamContext = stream_context_create($options);
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -274,7 +274,7 @@ class ConnectionTest extends TestCase
         $redis->expects($this->exactly(3))->method('xreadgroup')
             ->withConsecutive(
                 ['symfony', 'consumer', ['queue' => '0'], 1, null], // first call for pending messages
-                ['symfony', 'consumer', ['queue' => '0'], 1, null], // sencond call because of claimed message (redisid-123)
+                ['symfony', 'consumer', ['queue' => '0'], 1, null], // second call because of claimed message (redisid-123)
                 ['symfony', 'consumer', ['queue' => '>'], 1, null] // third call because of no result (other consumer claimed message redisid-123)
             )
             ->willReturnOnConsecutiveCalls([], [], []);
@@ -300,11 +300,11 @@ class ConnectionTest extends TestCase
         $redis->expects($this->exactly(2))->method('xreadgroup')
             ->withConsecutive(
                 ['symfony', 'consumer', ['queue' => '0'], 1, null], // first call for pending messages
-                ['symfony', 'consumer', ['queue' => '0'], 1, null] // sencond call because of claimed message (redisid-123)
+                ['symfony', 'consumer', ['queue' => '0'], 1, null] // second call because of claimed message (redisid-123)
             )
             ->willReturnOnConsecutiveCalls(
                 [], // first call returns no result
-                ['queue' => [['message' => '{"body":"1","headers":[]}']]] // second call returns clamed message (redisid-123)
+                ['queue' => [['message' => '{"body":"1","headers":[]}']]] // second call returns claimed message (redisid-123)
             );
 
         $redis->expects($this->once())->method('xpending')->willReturn([[

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -201,7 +201,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 // OR
                 // 2. its child is not passed by reference
                 //
-                // This may avoid uncessary value setting process for array elements.
+                // This may avoid unnecessary value setting process for array elements.
                 // For example:
                 // '[a][b][c]' => 'old-value'
                 // If you want to change its value to 'new-value',

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DockBlockFallback.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DockBlockFallback.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
 
 /**
- * PhpDocExtractor should fallback from property -> accessor -> mutator when looking up dockblocks.
+ * PhpDocExtractor should fallback from property -> accessor -> mutator when looking up docblocks.
  *
  * @author Martin Rademacher <mano@radebatz.net>
  */

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -377,7 +377,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
      * Validates a class node.
      *
      * A class node is a combination of an object with a {@link ClassMetadataInterface}
-     * instance. Each class node (conceptionally) has zero or more succeeding
+     * instance. Each class node (conceptually) has zero or more succeeding
      * property nodes:
      *
      *     (Article:class node)

--- a/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
+++ b/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
@@ -274,7 +274,7 @@ class TranslatorTest extends TestCase
             ['This is a text with a\nnew-line in it. Selector = 0.', '{0}This is a text with a\nnew-line in it. Selector = 0.|{1}This is a text with a\nnew-line in it. Selector = 1.|[1,Inf]This is a text with a\nnew-line in it. Selector > 1.', 0],
             // with double-quotes and id split accros lines
             ["This is a text with a\nnew-line in it. Selector = 1.", "{0}This is a text with a\nnew-line in it. Selector = 0.|{1}This is a text with a\nnew-line in it. Selector = 1.|[1,Inf]This is a text with a\nnew-line in it. Selector > 1.", 1],
-            // esacape pipe
+            // escape pipe
             ['This is a text with | in it. Selector = 0.', '{0}This is a text with || in it. Selector = 0.|{1}This is a text with || in it. Selector = 1.', 0],
             // Empty plural set (2 plural forms) from a .PO file
             ['', '|', 1],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| License       | MIT

Non complicated, uncontroversial typo fixes in comments only (no PHP code changes) across the codebase in the 5.4 branch while sat on the sofa watching TV. 