### PR TITLE
Fix Typos In Comments 6.0+

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -119,7 +119,7 @@ class KernelBrowser extends HttpKernelBrowser
         }
 
         $token = new TestBrowserToken($user->getRoles(), $user, $firewallContext);
-        // required for compatibilty with Symfony 5.4
+        // required for compatibility with Symfony 5.4
         if (method_exists($token, 'isAuthenticated')) {
             $token->setAuthenticated(true, false);
         }

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -162,7 +162,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 // OR
                 // 2. its child is not passed by reference
                 //
-                // This may avoid uncessary value setting process for array elements.
+                // This may avoid unnecessary value setting process for array elements.
                 // For example:
                 // '[a][b][c]' => 'old-value'
                 // If you want to change its value to 'new-value',


### PR DESCRIPTION
Simple comment typo fixes present in 6.0 branch, that can be merged and up merged.