### PR TITLE
[Routing] Add tests for loading PSR-4 classes from PHP files

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Fixtures/class-attributes.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/class-attributes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+use Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\MyController;
+
+return function (RoutingConfigurator $routes): void {
+    $routes
+        ->import(
+            resource: MyController::class,
+            type: 'attribute',
+        )
+        ->prefix('/my-prefix');
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/psr4-attributes.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes): void {
+    $routes
+        ->import(
+            resource: [
+                'path' => './Psr4Controllers',
+                'namespace' => 'Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers',
+            ],
+            type: 'attribute',
+        )
+        ->prefix('/my-prefix');
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/psr4-controllers-redirection.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/psr4-controllers-redirection.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes): void {
+    $routes->import('psr4-controllers-redirection/psr4-attributes.php');
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/psr4-controllers-redirection/psr4-attributes.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/psr4-controllers-redirection/psr4-attributes.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes): void {
+    $routes
+        ->import(
+            resource: [
+                'path' => '../Psr4Controllers',
+                'namespace' => 'Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers',
+            ],
+            type: 'attribute',
+        )
+        ->prefix('/my-prefix');
+};

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -13,10 +13,14 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
 use Symfony\Component\Routing\Loader\PhpFileLoader;
+use Symfony\Component\Routing\Loader\Psr4DirectoryLoader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\MyController;
 
 class PhpFileLoaderTest extends TestCase
 {
@@ -296,5 +300,52 @@ class PhpFileLoaderTest extends TestCase
         $expectedRoutes = require __DIR__.'/../Fixtures/alias/expected.php';
 
         $this->assertEquals($expectedRoutes('php'), $routes);
+    }
+
+    /**
+     * @dataProvider providePsr4ConfigFiles
+     */
+    public function testImportAttributesWithPsr4Prefix(string $configFile)
+    {
+        $locator = new FileLocator(\dirname(__DIR__).'/Fixtures');
+        new LoaderResolver([
+            $loader = new PhpFileLoader($locator),
+            new Psr4DirectoryLoader($locator),
+            new class() extends AnnotationClassLoader {
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                {
+                    $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+                }
+            },
+        ]);
+
+        $route = $loader->load($configFile)->get('my_route');
+        $this->assertSame('/my-prefix/my/route', $route->getPath());
+        $this->assertSame(MyController::class.'::__invoke', $route->getDefault('_controller'));
+    }
+
+    public function providePsr4ConfigFiles(): array
+    {
+        return [
+            ['psr4-attributes.php'],
+            ['psr4-controllers-redirection.php'],
+        ];
+    }
+
+    public function testImportAttributesFromClass()
+    {
+        new LoaderResolver([
+            $loader = new PhpFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures')),
+            new class() extends AnnotationClassLoader {
+                protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, object $annot)
+                {
+                    $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+                }
+            },
+        ]);
+
+        $route = $loader->load('class-attributes.php')->get('my_route');
+        $this->assertSame('/my-prefix/my/route', $route->getPath());
+        $this->assertSame(MyController::class.'::__invoke', $route->getDefault('_controller'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follow-up to #47916, #47943

This PR adds more tests, demonstrating how to trigger the new PSR-4 loader from a PHP config file.