### PR TITLE
[Form][TwigBridge] Render an id on the form element so form_attr references resolve

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -28,6 +28,11 @@ DoctrineBridge
 Form
 ----
 
+ * [BC BREAK] Children that use the `form_attr` option now carry the id the themes render on the `<form>`
+   element instead of the id of the element wrapping the fields, so that the reference resolves. That id is
+   the `attr.id` of the root form when the application set one, the string given to `form_attr` when the
+   option is a string, wherever it sits in the form tree, and `form_<root id>` otherwise. Forms that do not
+   use `form_attr` are unaffected: the `form_id` view variable stays `null` when nothing references it
  * Deprecate the `regions` option of `TimezoneType`, it has had no effect since 5.0 and will be removed in 9.0
  * `TimezoneType` with the `intl` option enabled now offers the identifier PHP reports as canonical when ICU
    keys a zone and its legacy aliases under one display name, so `Asia/Kolkata` is offered where `Asia/Calcutta`
@@ -108,6 +113,14 @@ Tui
 ---
 
  * [BC BREAK] Add argument `$multiselect` as the third argument of `SelectListWidget::__construct()`, moving `$keybindings` to fourth position
+
+TwigBridge
+----------
+
+ * `form_start()` renders an `id` attribute on the `<form>` element when a child uses the `form_attr` option,
+   taken from the new `form_id` view variable. Forms that do not use it render as before. Set `attr.id` on
+   the root form to choose the id, or `attr: {id: false}` to render none. A custom theme overriding the
+   `form_start` block renders no id until that block is updated
 
 Validator
 ---------

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add the `logout_form()` function to build a form that logs the user out with a POST
  * Add the `normalize` filter to normalize values with the Serializer component
  * Add the `impersonation_form()` and `impersonation_exit_form()` functions to build a form that switches the user with a POST
+ * Render an `id` attribute on the `<form>` element when a child uses `form_attr`, so that the reference resolves
 
 8.1
 ---

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -393,6 +393,9 @@
 
 {%- block form_start -%}
     {%- do form.setMethodRendered() -%}
+    {%- if form_id is defined and form_id and attr.id is not defined -%}
+        {%- set attr = attr|merge({id: form_id}) -%}
+    {%- endif -%}
     {% set method = method|upper %}
     {%- if method in ['GET', 'POST'] -%}
         {% set form_method = method %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -2381,6 +2381,64 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         $this->assertSame('<form name="form" method="get" action="http://example.com/directory">', $html);
     }
 
+    public function testStartTagRendersNoIdWhenNothingReferencesIt()
+    {
+        $this->requireFormIdViewVariable();
+
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
+            'method' => 'get',
+            'action' => 'http://example.com/directory',
+        ])->add('username', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\TextType');
+
+        $html = $this->renderStart($form->createView());
+
+        $this->assertStringNotContainsString('id=', $html);
+    }
+
+    public function testStartTagIdIsWhatFormAttrChildrenReference()
+    {
+        $this->requireFormIdViewVariable();
+
+        $form = $this->factory->createNamedBuilder('registration', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType', null, [
+            'method' => 'get',
+            'form_attr' => true,
+        ])->add('username', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\TextType')->getForm();
+
+        $view = $form->createView();
+        $html = $this->renderStart($view);
+
+        $this->assertStringContainsString('id="form_registration"', $html);
+        $this->assertSame('form_registration', $view['username']->vars['attr']['form']);
+    }
+
+    public function testStartTagIdIsTheFormAttrStringIdentifier()
+    {
+        $this->requireFormIdViewVariable();
+
+        $form = $this->factory->createNamedBuilder('registration', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType', null, [
+            'method' => 'get',
+        ])->add('username', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\TextType', ['form_attr' => 'custom-identifier'])->getForm();
+
+        $view = $form->createView();
+        $html = $this->renderStart($view);
+
+        $this->assertStringContainsString('id="custom-identifier"', $html);
+        $this->assertSame('custom-identifier', $view['username']->vars['attr']['form']);
+    }
+
+    public function testStartTagKeepsAnExplicitIdFromAttr()
+    {
+        $form = $this->factory->create('Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType', null, [
+            'method' => 'get',
+            'attr' => ['id' => 'chosen-by-the-app'],
+        ]);
+
+        $html = $this->renderStart($form->createView());
+
+        $this->assertStringContainsString('id="chosen-by-the-app"', $html);
+        $this->assertStringNotContainsString('id="form_form"', $html);
+    }
+
     public function testStartTagForPutRequest()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
@@ -2843,5 +2901,17 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
     ]
     [count(./input)=2]'
         );
+    }
+
+    /**
+     * The "form_id" view variable ships with symfony/form 8.2; the themes degrade without it.
+     */
+    protected function requireFormIdViewVariable(): void
+    {
+        $vars = $this->factory->create('Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType')->createView()->vars;
+
+        if (!\array_key_exists('form_id', $vars)) {
+            $this->markTestSkipped('symfony/form 8.2 is required for the "form_id" view variable.');
+        }
     }
 }

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `inputmode="numeric"` to `IntegerType` when the `grouping` option is enabled
  * Add the `choice_help` option to `ChoiceType`
  * Add `$help` parameter to `ChoiceListFactoryInterface::createView()`
+ * Add the `form_id` view variable, holding the id to render on the `<form>` element of a root form when a child uses `form_attr`
 
 8.1
 ---

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractRendererEngine;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -63,14 +62,6 @@ abstract class BaseType extends AbstractType
             if (!$labelFormat) {
                 $labelFormat = $view->parent->vars['label_format'];
             }
-
-            $rootFormAttrOption = $form->getRoot()->getConfig()->getOption('form_attr');
-            if ($options['form_attr'] || $rootFormAttrOption) {
-                $options['attr']['form'] = \is_string($rootFormAttrOption) ? $rootFormAttrOption : $form->getRoot()->getName();
-                if (empty($options['attr']['form'])) {
-                    throw new LogicException('"form_attr" option must be a string identifier on root form when it has no id.');
-                }
-            }
         } else {
             $id = \is_string($options['form_attr']) ? $options['form_attr'] : $name;
             $fullName = $name;
@@ -94,6 +85,9 @@ abstract class BaseType extends AbstractType
         $view->vars = array_replace($view->vars, [
             'form' => $view,
             'id' => $id,
+            // filled by FormType::finishView(), which is the first point where the "form_attr"
+            // option of every descendant is known
+            'form_id' => null,
             'name' => $name,
             'full_name' => $fullName,
             'disabled' => $form->isDisabled(),

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -117,6 +117,10 @@ class FormType extends BaseType
         }
 
         $view->vars['multipart'] = $multipart;
+
+        if (!$view->parent) {
+            self::resolveFormId($view, $form);
+        }
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -202,5 +206,77 @@ class FormType extends BaseType
     public function getBlockPrefix(): string
     {
         return 'form';
+    }
+
+    /**
+     * Fills the "form_id" view variable of a root form and points the descendants that use the
+     * "form_attr" option at it.
+     *
+     * The option can sit on any descendant, so the id is only known once the whole view tree
+     * exists, which is what finishView() guarantees.
+     */
+    private static function resolveFormId(FormView $view, FormInterface $form): void
+    {
+        $rootFormAttr = $form->getConfig()->getOption('form_attr');
+        $identifier = null;
+        $referencing = [];
+
+        self::collectFormAttr($view, $form, (bool) $rootFormAttr, $identifier, $referencing);
+
+        // the id is only worth rendering on the <form> element once something points at it, so
+        // that forms that do not use "form_attr" keep the markup they had
+        if (!$referencing) {
+            return;
+        }
+
+        // a string "form_attr" on the root already went into vars["id"], and it wins over the one
+        // of a descendant
+        if (\is_string($rootFormAttr) && '' !== $rootFormAttr) {
+            $identifier = $view->vars['id'];
+        }
+
+        // an explicit id is the one the theme renders, and a string "form_attr" is an identifier
+        // the application chose for that very purpose, so only an id derived from the form name
+        // needs a prefix to tell it apart from the id of the element wrapping the fields
+        $explicitId = $view->vars['attr']['id'] ?? null;
+        $formId = \is_string($explicitId) && '' !== $explicitId ? $explicitId : $identifier;
+
+        if (null === $formId && '' !== $view->vars['id']) {
+            $formId = 'form_'.$view->vars['id'];
+        }
+
+        if (null === $formId) {
+            throw new LogicException('"form_attr" option must be a string identifier on root form when it has no id.');
+        }
+
+        $view->vars['form_id'] = $formId;
+
+        foreach ($referencing as $child) {
+            $child->vars['attr']['form'] = $formId;
+        }
+    }
+
+    /**
+     * @param list<FormView> $referencing
+     */
+    private static function collectFormAttr(FormView $view, FormInterface $form, bool $all, ?string &$identifier, array &$referencing): void
+    {
+        foreach ($form as $name => $child) {
+            if (!isset($view->children[$name])) {
+                continue;
+            }
+
+            $formAttr = $child->getConfig()->getOption('form_attr', false);
+
+            if ($all || $formAttr) {
+                $referencing[] = $view->children[$name];
+            }
+
+            if (null === $identifier && \is_string($formAttr) && '' !== $formAttr) {
+                $identifier = $formAttr;
+            }
+
+            self::collectFormAttr($view->children[$name], $child, $all, $identifier, $referencing);
+        }
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
@@ -51,8 +51,8 @@ class ButtonTypeTest extends BaseTypeTestCase
             ->getForm()
             ->createView();
         $this->assertArrayNotHasKey('form', $view->vars['attr']);
-        $this->assertSame($view->vars['id'], $view['child1']->vars['attr']['form']);
-        $this->assertSame($view->vars['id'], $view['child2']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child1']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child2']->vars['attr']['form']);
     }
 
     public function testFormAttrOnChild()
@@ -66,7 +66,7 @@ class ButtonTypeTest extends BaseTypeTestCase
             ->getForm()
             ->createView();
         $this->assertArrayNotHasKey('form', $view->vars['attr']);
-        $this->assertSame($view->vars['id'], $view['child1']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child1']->vars['attr']['form']);
         $this->assertArrayNotHasKey('form', $view['child2']->vars['attr']);
     }
 
@@ -97,7 +97,7 @@ class ButtonTypeTest extends BaseTypeTestCase
             ->createView();
         $this->assertArrayNotHasKey('form', $view->vars['attr']);
         $this->assertSame($stringId, $view->vars['id']);
-        $this->assertSame($view->vars['id'], $view['child1']->vars['attr']['form']);
-        $this->assertSame($view->vars['id'], $view['child2']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child1']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child2']->vars['attr']['form']);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -785,8 +785,93 @@ $ref2
             ->getForm()
             ->createView();
         $this->assertArrayNotHasKey('form', $view->vars['attr']);
-        $this->assertSame($view->vars['id'], $view['child1']->vars['attr']['form']);
-        $this->assertSame($view->vars['id'], $view['child2']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child1']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child2']->vars['attr']['form']);
+    }
+
+    public function testFormAttrAsStringIsUsedAsIs()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', self::TESTED_TYPE, null, [
+                'form_attr' => 'custom-identifier',
+            ])
+            ->add('child1', $this->getTestedType())
+            ->getForm()
+            ->createView();
+
+        $this->assertSame('custom-identifier', $view->vars['id']);
+        $this->assertSame('custom-identifier_child1', $view['child1']->vars['id']);
+        $this->assertSame('custom-identifier', $view->vars['form_id']);
+        $this->assertSame('custom-identifier', $view['child1']->vars['attr']['form']);
+    }
+
+    public function testFormAttrAsStringOnADescendantIsUsedAsIs()
+    {
+        $builder = $this->factory->createNamedBuilder('parent', self::TESTED_TYPE);
+        $builder->add(
+            $this->factory->createNamedBuilder('child1', self::TESTED_TYPE)
+                ->add('grandchild', $this->getTestedType(), ['form_attr' => 'custom-identifier'])
+        );
+        $view = $builder->getForm()->createView();
+
+        $this->assertSame('parent', $view->vars['id']);
+        $this->assertSame('custom-identifier', $view->vars['form_id']);
+        $this->assertSame('custom-identifier', $view['child1']['grandchild']->vars['attr']['form']);
+    }
+
+    public function testFormAttrAsStringOnTheRootWinsOverTheOneOfADescendant()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', self::TESTED_TYPE, null, [
+                'form_attr' => 'chosen-by-the-root',
+            ])
+            ->add('child1', $this->getTestedType(), ['form_attr' => 'chosen-by-the-child'])
+            ->getForm()
+            ->createView();
+
+        $this->assertSame('chosen-by-the-root', $view->vars['form_id']);
+        $this->assertSame('chosen-by-the-root', $view['child1']->vars['attr']['form']);
+    }
+
+    public function testFormIdMatchesTheReferenceWhenTheNameStartsWithAnUnderscore()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('_parent', self::TESTED_TYPE, null, [
+                'form_attr' => true,
+            ])
+            ->add('child1', $this->getTestedType())
+            ->getForm()
+            ->createView();
+
+        $this->assertSame($view->vars['form_id'], $view['child1']->vars['attr']['form']);
+    }
+
+    public function testFormIdMatchesTheReferenceWhenTheNameStartsWithADigit()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('2parent', self::TESTED_TYPE, null, [
+                'form_attr' => true,
+            ])
+            ->add('child1', $this->getTestedType())
+            ->getForm()
+            ->createView();
+
+        $this->assertSame($view->vars['form_id'], $view['child1']->vars['attr']['form']);
+    }
+
+    public function testFormIdIsTheExplicitIdFromAttr()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', self::TESTED_TYPE, null, [
+                'form_attr' => true,
+                'attr' => ['id' => 'chosen-by-the-app'],
+            ])
+            ->add('child1', $this->getTestedType())
+            ->getForm()
+            ->createView();
+
+        $this->assertSame('chosen-by-the-app', $view->vars['form_id']);
+        $this->assertSame('chosen-by-the-app', $view['child1']->vars['attr']['form']);
     }
 
     public function testFormAttrOnChild()
@@ -800,8 +885,45 @@ $ref2
             ->getForm()
             ->createView();
         $this->assertArrayNotHasKey('form', $view->vars['attr']);
-        $this->assertSame($view->vars['id'], $view['child1']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child1']->vars['attr']['form']);
         $this->assertArrayNotHasKey('form', $view['child2']->vars['attr']);
+    }
+
+    public function testFormIdIsNotSetWhenNothingReferencesIt()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', self::TESTED_TYPE)
+            ->add('child1', $this->getTestedType())
+            ->getForm()
+            ->createView();
+
+        $this->assertNull($view->vars['form_id']);
+    }
+
+    public function testFormIdIsNotSetWhenAChildPointsAtAnotherForm()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', self::TESTED_TYPE)
+            ->add('child1', $this->getTestedType(), [
+                'attr' => ['form' => 'another-form'],
+            ])
+            ->getForm()
+            ->createView();
+
+        $this->assertNull($view->vars['form_id']);
+    }
+
+    public function testFormIdIsSetWhenADescendantReferencesIt()
+    {
+        $builder = $this->factory->createNamedBuilder('parent', self::TESTED_TYPE);
+        $builder->add(
+            $this->factory->createNamedBuilder('child1', self::TESTED_TYPE)
+                ->add('grandchild', $this->getTestedType(), ['form_attr' => true])
+        );
+        $view = $builder->getForm()->createView();
+
+        $this->assertSame('form_parent', $view->vars['form_id']);
+        $this->assertSame('form_parent', $view['child1']['grandchild']->vars['attr']['form']);
     }
 
     public function testFormAttrAsBoolWithNoId()
@@ -831,8 +953,8 @@ $ref2
             ->createView();
         $this->assertArrayNotHasKey('form', $view->vars['attr']);
         $this->assertSame($stringId, $view->vars['id']);
-        $this->assertSame($view->vars['id'], $view['child1']->vars['attr']['form']);
-        $this->assertSame($view->vars['id'], $view['child2']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child1']->vars['attr']['form']);
+        $this->assertSame($view->vars['form_id'], $view['child2']->vars['attr']['form']);
     }
 
     public function testSortingViewChildrenBasedOnPriorityOption()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #42075
| License       | MIT

`BaseType` puts the root form's id in `vars['id']`, and the themes render it on the element wrapping the fields, never on the `<form>` tag. The `form_attr` option points children at that same id. HTML requires `form="X"` to reference a `<form id="X">`, so the reference has always pointed at a `<div>` and the option has never worked.

A new `form_id` view variable carries the id of the `<form>` element. It holds whatever that element will actually carry:

* the `attr.id` set on the root form, when the application chose one;
* the string given to `form_attr`, when that option is a string, on the root form or on any descendant, since that is the identifier the application already picked for this very purpose;
* otherwise `form_` followed by `vars['id']`, prefixed so that the id of the wrapping element does not move.

`FormType::finishView()` computes it. It runs on the root form after every child view exists, so it is the first point where the `form_attr` option of every descendant is known, and it is where the children that use the option are pointed at the value. The tag and the references are therefore written in one place and cannot drift apart.

The variable stays `null` when no descendant uses `form_attr`, and the theme then renders nothing. Forms that do not use the option, which is nearly all of them, render exactly as before.

`form_div_layout.html.twig` fills `attr.id` with the variable when it is set and the application has not chosen an id itself. Set `attr.id` on the root form to choose the id, or `attr: {id: false}` to render none, as for any attribute.

Before:

```html
<form name="my_form" method="post" action="/submit">
  <div id="my_form">
    <input id="my_form_first" name="my_form[first]" form="my_form" />
```

After:

```html
<form name="my_form" method="post" action="/submit" id="form_my_form">
  <div id="my_form">
    <input id="my_form_first" name="my_form[first]" form="form_my_form" />
```

A form with no `form_attr` anywhere is untouched:

```html
<form name="my_form" method="post" action="/submit">
```

All themes inherit `form_start` from `form_div_layout`, so all of them gain the id and none needed its own change. A custom theme that overrides `form_start` renders no id until it is updated.

The `form_attr` string form keeps its meaning: it still sets `vars['id']` for the root when it is set there, descendant ids and `label for=` are unaffected, and children keep referencing the string itself. What it gains is that the `<form>` element now renders that id, so the reference resolves without the application having to repeat the identifier in `attr.id`.

Documentation should cover: the `form_id` view variable, how it is derived and when it is set, that `form_attr` now resolves, and the two ways to control the id (`attr.id` for a custom one, `attr: {id: false}` for none).
