### PR TITLE
[SecurityBundle] Set `UserValueResolver`'s priority higher than `EntityValueResolver`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -100,7 +100,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('security.token_storage'),
             ])
-            ->tag('controller.argument_value_resolver', ['priority' => 40])
+            ->tag('controller.argument_value_resolver', ['priority' => 120])
 
         // Authentication related services
         ->set('security.authentication.trust_resolver', AuthenticationTrustResolver::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

`UserValueResolver`'s priority is currently `40` and `EntityValueResolver`'s priority is `110` (configured in doctrine-bundle).

Currently, to use the `CurrentUser` attribute and `MapEntity` (when `auto_mapping` is enabled), you need to do the following to have it work:

```php
public function postAction(
  #[CurrentUser]
  #[MapEntity(disabled: true)]
  User $user,
  Post $post
)
```

This removes this need for `#[MapEntity(disabled: true)]` but I'm not sure the larger impact of increasing the priority of `UserValueResolver`. Here is some context as to why the priorities are they way they are:
- https://github.com/doctrine/DoctrineBundle/pull/1554#discussion_r949478887
- https://github.com/symfony/symfony/pull/18510