### PR TITLE
[TwigBridge] Provide a default non-empty label on empty options to validate HTML5

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -61,7 +61,7 @@
     {%- endif -%}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
         {%- if placeholder is not none -%}
-            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ placeholder != '' ? (translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain)) }}</option>
+            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ placeholder != '' ? (translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain)) : '--' }}</option>
         {%- endif -%}
         {%- if preferred_choices|length > 0 -%}
             {% set options = preferred_choices %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -156,7 +156,7 @@
     {%- endif -%}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple" data-customforms="disabled"{% endif %}>
         {% if placeholder is not none -%}
-            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain) }}</option>
+            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain) : '--' }}</option>
         {%- endif %}
         {%- if preferred_choices|length > 0 -%}
             {% set options = preferred_choices %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -626,6 +626,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
+    // Note: blank separator produces non standard HTML (option text should not be empty),
+    // but better not let Twig fix this automatically, user-side problem.
     public function testSingleChoiceWithPreferredAndBlankSeparator()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
@@ -683,7 +685,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     [@class="my&class form-control"]
     [not(@required)]
     [
-        ./option[@value=""][.=""]
+        ./option[@value=""][.="" or .="--"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -707,7 +709,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     [@class="my&class form-control"]
     [not(@required)]
     [
-        ./option[@value=""][.=""]
+        ./option[@value=""][.="" or .="--"]
         /following-sibling::option[@value="&a"][not(@selected)][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -766,6 +768,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
+    // Note: blank placeholder produces non standard HTML (option text should not be empty),
+    // but better not let Twig fix this automatically, user-side problem.
     public function testSingleChoiceRequiredWithPlaceholderViaView()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
@@ -781,7 +785,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     [@class="my&class form-control"]
     [@required="required"]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.=""]
+        ./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -1935,6 +1939,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
+    // Note: blank placeholder produces non standard HTML (option text should not be empty),
+    // but better not let Twig fix this automatically, user-side problem.
     public function testBirthDayWithPlaceholder()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType', '1950-01-01', [
@@ -1950,17 +1956,17 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         ./select
             [@id="name_month"]
             [@class="form-control"]
-            [./option[@value=""][not(@selected)][not(@disabled)][.=""]]
+            [./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]]
             [./option[@value="1"][@selected="selected"]]
         /following-sibling::select
             [@id="name_day"]
             [@class="form-control"]
-            [./option[@value=""][not(@selected)][not(@disabled)][.=""]]
+            [./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]]
             [./option[@value="1"][@selected="selected"]]
         /following-sibling::select
             [@id="name_year"]
             [@class="form-control"]
-            [./option[@value=""][not(@selected)][not(@disabled)][.=""]]
+            [./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]]
             [./option[@value="1950"][@selected="selected"]]
     ]
     [count(./select)=3]

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
@@ -610,6 +610,8 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
         );
     }
 
+    // Note: blank separator produces non standard HTML (option text should not be empty),
+    // but better not let Twig fix this automatically, user-side problem.
     public function testSingleChoiceWithPreferredAndBlankSeparator()
     {
         $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
@@ -667,7 +669,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     [@class="my&class form-select"]
     [not(@required)]
     [
-        ./option[@value=""][.=""]
+        ./option[@value=""][.="" or .="--"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -691,7 +693,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     [@class="my&class form-select"]
     [not(@required)]
     [
-        ./option[@value=""][.=""]
+        ./option[@value=""][.="" or .="--"]
         /following-sibling::option[@value="&a"][not(@selected)][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -750,6 +752,8 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
         );
     }
 
+    // Note: blank placeholder produces non standard HTML (option text should not be empty),
+    // but better not let Twig fix this automatically, user-side problem.
     public function testSingleChoiceRequiredWithPlaceholderViaView()
     {
         $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
@@ -765,7 +769,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     [@class="my&class form-select"]
     [@required="required"]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.=""]
+        ./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -1392,6 +1396,8 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
         );
     }
 
+    // Note: blank placeholder produces non standard HTML (option text should not be empty),
+    // but better not let Twig fix this automatically, user-side problem.
     public function testBirthDayWithPlaceholder()
     {
         $form = $this->factory->createNamed('name', BirthdayType::class, '1950-01-01', [
@@ -1410,17 +1416,17 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
                 ./select
                     [@id="name_month"]
                     [@class="form-select"]
-                    [./option[@value=""][not(@selected)][not(@disabled)][.=""]]
+                    [./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]]
                     [./option[@value="1"][@selected="selected"]]
                 /following-sibling::select
                     [@id="name_day"]
                     [@class="form-select"]
-                    [./option[@value=""][not(@selected)][not(@disabled)][.=""]]
+                    [./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]]
                     [./option[@value="1"][@selected="selected"]]
                 /following-sibling::select
                     [@id="name_year"]
                     [@class="form-select"]
-                    [./option[@value=""][not(@selected)][not(@disabled)][.=""]]
+                    [./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]]
                     [./option[@value="1950"][@selected="selected"]]
             ]
             [count(./select)=3]

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -783,6 +783,8 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         );
     }
 
+    // Note: blank separator produces non standard HTML (option text should not be empty),
+    // but better not let Twig fix this automatically, user-side problem.
     public function testSingleChoiceWithPreferredAndBlankSeparator()
     {
         $this->requiresFeatureSet(404);
@@ -841,7 +843,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [@name="name"]
     [not(@required)]
     [
-        ./option[@value=""][.=""]
+        ./option[@value=""][.="" or .="--"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -864,7 +866,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [@name="name"]
     [not(@required)]
     [
-        ./option[@value=""][.=""]
+        ./option[@value=""][.="" or .="--"]
         /following-sibling::option[@value="&a"][not(@selected)][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -924,6 +926,8 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         );
     }
 
+    // Note: blank placeholder produces non standard HTML (option text should not be empty),
+    // but better not let Twig fix this automatically, user-side problem.
     public function testSingleChoiceRequiredWithPlaceholderViaView()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
@@ -941,7 +945,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [@name="name"]
     [@required="required"]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.=""]
+        ./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -1687,6 +1691,8 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         );
     }
 
+    // Note: blank placeholder produces non standard HTML (option text should not be empty),
+    // but better not let Twig fix this automatically, user-side problem.
     public function testBirthDayWithPlaceholder()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType', '1950-01-01', [
@@ -1700,15 +1706,15 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [
         ./select
             [@id="name_month"]
-            [./option[@value=""][not(@selected)][not(@disabled)][.=""]]
+            [./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]]
             [./option[@value="1"][@selected="selected"]]
         /following-sibling::select
             [@id="name_day"]
-            [./option[@value=""][not(@selected)][not(@disabled)][.=""]]
+            [./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]]
             [./option[@value="1"][@selected="selected"]]
         /following-sibling::select
             [@id="name_year"]
-            [./option[@value=""][not(@selected)][not(@disabled)][.=""]]
+            [./option[@value=""][not(@selected)][not(@disabled)][.="" or .="--"]]
             [./option[@value="1950"][@selected="selected"]]
     ]
     [count(./select)=3]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

As described on https://rocketvalidator.com/html-validation/element-option-without-attribute-label-must-not-be-empty, so far this template generates empty options with no value, no content, and no label. This is not a break, but a simple "should".

Not sure how we should recommend handling this, users have the possibility to handle this themselves (https://symfony.com/doc/current/reference/forms/types/choice.html#placeholder), but if they don't we leave a non-stadanrd-compliant output.

The tailwind template is also affected from this, as it extends this one.

I proposed a double-dash default value:
- pretty affordant
- doesn't use translations as users might not use them
- doesn't suffer from language dependent doubtful meaning

I locally fix this by overriding the default templates, but I thought the default ones could get a fix.

(NB: this is just a new PR for #44464, as previous one was merged in haste and reverted, with tests up to date this time)