### PR TITLE
[WebProfilerBundle] Improve css for explained doctrine queries in profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -2064,12 +2064,8 @@ tr.log-status-silenced > td:first-child:before {
     margin: .5em 0;
     padding: 1em;
 }
-.sql-explain {
-    overflow-x: auto;
-    max-width: 888px;
-}
-.width-full .sql-explain {
-    max-width: min-content;
+.sql-explain table th {
+    border-top: none;
 }
 .sql-explain table td, .sql-explain table tr {
     word-break: normal;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no - css change only
| License       | MIT


Before this change, the Doctrine Queries ->Explain query panel in Profiler looked and acted odd (Double top border, and doesn't resize to full width)

Improvements on https://github.com/symfony/symfony/pull/46750 from @zolikonta back in July. 

# Before

https://user-images.githubusercontent.com/400092/198737277-dcede803-5cff-449e-adda-44c72e0a5d81.mov

# After


https://user-images.githubusercontent.com/400092/198737297-6985ed3e-67c0-4e7d-b972-72711084e23c.mov

