### PR TITLE
[VarDumper] Fix bug introduced by adding null coalescing incorrectly

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -946,7 +946,7 @@ EOHTML
         if (-1 === $this->lastDepth) {
             $this->line = sprintf($this->dumpPrefix, $this->dumpId, $this->indentPad).$this->line;
         }
-        if ($this->headerIsDumped !== ($this->outputStream ?? $this->lineDumper)) {
+        if ($this->headerIsDumped !== (null !== ($this->outputStream ?? $this->lineDumper))) {
             $this->line = $this->getDumpHeader().$this->line;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| License       | MIT

This PR fixes a bug introduced by (@javiereguiluz) in https://github.com/symfony/symfony/pull/42165 (EDIT: No, I think it predates that now... https://github.com/symfony/symfony/pull/19623 @nicolas-grekas who replaced a `bool`  with this code, which #42165 just refactored) ...

The code that was replaced was

```php
if ($this->headerIsDumped !== (null !== $this->outputStream ? $this->outputStream : $this->lineDumper)) {
```

That was replaced in #42165 with code 

```php
if ($this->headerIsDumped !== ($this->outputStream ?? $this->lineDumper)) {
```

The correct code is proposed in this PR and is 

```php
if ($this->headerIsDumped !== (null !== ($this->outputStream ?? $this->lineDumper))) {
```

# What is the bug/Why ?

So.... To replicate create a demo app with Symfony 5.4

```
composer create-project symfony/symfony-demo mySymfony54 1.8.0
cd mySymfony54
symfony serve
# Visit http://127.0.0.1:8000/en/blog/ to confirm its working
# Edit BlogController.php and throw an \Exception('test') in the index function
# Visit http://127.0.0.1:8000/en/blog/ to confirm you see the exception 
# Click the toolbar at the bottom to get to the Symfony Profiler
# Click LOGS in the left menu 
# Check console.log 
```

see console.log: 

<img width="305" alt="Screenshot 2022-10-29 at 00 14 52" src="https://user-images.githubusercontent.com/400092/198749293-47ae5000-d210-4577-85c7-664045766225.png">

Click to open the error message and see overlapping text and no pretty-ness.

<img width="1247" alt="Screenshot 2022-10-29 at 00 15 10" src="https://user-images.githubusercontent.com/400092/198749346-917904f7-c4d1-4195-8e0c-0fbdc33fc99e.png">

Once this PR is applied you then can repeat and you will see no console.log error message and you will see a pretty output like:

<img width="1096" alt="Screenshot 2022-10-29 at 00 16 24" src="https://user-images.githubusercontent.com/400092/198749391-04d722ad-2638-43bb-9cf9-aef3e1dece9a.png">
