### PR TITLE
[FrameworkBundle] Split loggers debug compiler pass

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\Log\Logger;
 
 class AddDebugLogProcessorPass implements CompilerPassInterface
 {
@@ -23,38 +22,22 @@ class AddDebugLogProcessorPass implements CompilerPassInterface
         if (!$container->hasDefinition('profiler')) {
             return;
         }
-
-        if ($container->hasDefinition('monolog.logger_prototype') && $container->hasDefinition('debug.log_processor')) {
-            $container->getDefinition('monolog.logger_prototype')
-                ->setConfigurator([__CLASS__, 'configureMonologLogger'])
-                ->addMethodCall('pushProcessor', [new Reference('debug.log_processor')])
-            ;
-
+        if (!$container->hasDefinition('monolog.logger_prototype')) {
+            return;
+        }
+        if (!$container->hasDefinition('debug.log_processor')) {
             return;
         }
 
-        if (!$container->hasDefinition('logger')) {
-            return;
-        }
-
-        $loggerDefinition = $container->getDefinition('logger');
-
-        if (Logger::class === $loggerDefinition->getClass()) {
-            $loggerDefinition->setConfigurator([__CLASS__, 'configureHttpKernelLogger']);
-        }
+        $definition = $container->getDefinition('monolog.logger_prototype');
+        $definition->setConfigurator([__CLASS__, 'configureLogger']);
+        $definition->addMethodCall('pushProcessor', [new Reference('debug.log_processor')]);
     }
 
-    public static function configureMonologLogger(mixed $logger)
+    public static function configureLogger(mixed $logger)
     {
-        if (\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && \is_object($logger) && method_exists($logger, 'removeDebugLogger')) {
+        if (\is_object($logger) && method_exists($logger, 'removeDebugLogger') && \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
             $logger->removeDebugLogger();
-        }
-    }
-
-    public static function configureHttpKernelLogger(Logger $logger)
-    {
-        if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && method_exists($logger, 'enableDebug')) {
-            $logger->enableDebug();
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/EnableLoggerDebugModePass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/EnableLoggerDebugModePass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Log\Logger;
+
+final class EnableLoggerDebugModePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('profiler') || !$container->hasDefinition('logger')) {
+            return;
+        }
+
+        $loggerDefinition = $container->getDefinition('logger');
+
+        if (Logger::class === $loggerDefinition->getClass()) {
+            $loggerDefinition->setConfigurator([__CLASS__, 'configureLogger']);
+        }
+    }
+
+    public static function configureLogger(Logger $logger): void
+    {
+        if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && method_exists($logger, 'enableDebug')) {
+            $logger->enableDebug();
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddExpressionLan
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AssetsContextPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DataCollectorTranslatorPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\EnableLoggerDebugModePass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggingTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSessionMarshallingHandlerPass;
@@ -165,6 +166,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RemoveUnusedSessionMarshallingHandlerPass());
 
         if ($container->getParameter('kernel.debug')) {
+            $container->addCompilerPass(new EnableLoggerDebugModePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -33);
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_BEFORE_REMOVING, -255);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48040
| License       | MIT
| Doc PR        | N/A

As the Monolog and HttpKernel’s loggers have nothing to do with each other I feel like giving each one its own compiler pass is best.