### PR TITLE
Run tests with UTC to avoid daylight saving time messing with assertions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           coverage: "none"
           extensions: "memcached,redis-5.3.4,xsl,ldap"
-          ini-values: date.timezone=Europe/Paris,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1
+          ini-values: date.timezone=UTC,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1
           php-version: "${{ matrix.php }}"
 
       - name: Load fixtures

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,7 +48,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
-          ini-values: date.timezone=Europe/Paris,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1
+          ini-values: date.timezone=UTC,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1
           php-version: "${{ matrix.php }}"
           extensions: "${{ env.extensions }}"
           tools: flex


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Pipelines are failing today (like https://github.com/symfony/symfony/actions/runs/3350921526/jobs/5552038137#step:7:710) because it’s the eve of setting clocks back by one hour in the Europe/Paris timezone, so one day from now is 25 instead of 24 hours.

This PR just changes the timezone to UTC where there is no daylight saving time.