### PR TITLE
[SecurityBundle] Set request stateless when firewall is stateless

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate enabling bundle and not configuring it
+ * Add `_stateless` attribute to the request when firewall is stateless
 
 6.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -72,7 +72,14 @@ class FirewallMap implements FirewallMapInterface
             if (null === $requestMatcher || $requestMatcher->matches($request)) {
                 $request->attributes->set('_firewall_context', $contextId);
 
-                return $this->container->get($contextId);
+                /** @var FirewallContext $context */
+                $context = $this->container->get($contextId);
+
+                if ($context->getConfig()?->isStateless()) {
+                    $request->attributes->set('_stateless', true);
+                }
+
+                return $context;
             }
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -54,6 +54,7 @@ class FirewallMapTest extends TestCase
         $this->assertEquals([[], null, null], $firewallMap->getListeners($request));
         $this->assertNull($firewallMap->getFirewallConfig($request));
         $this->assertFalse($request->attributes->has(self::ATTRIBUTE_FIREWALL_CONTEXT));
+        $this->assertFalse($request->attributes->has('_stateless'));
     }
 
     public function testGetListeners()
@@ -62,8 +63,8 @@ class FirewallMapTest extends TestCase
 
         $firewallContext = $this->createMock(FirewallContext::class);
 
-        $firewallConfig = new FirewallConfig('main', 'user_checker');
-        $firewallContext->expects($this->once())->method('getConfig')->willReturn($firewallConfig);
+        $firewallConfig = new FirewallConfig('main', 'user_checker', null, true, true);
+        $firewallContext->expects($this->exactly(2))->method('getConfig')->willReturn($firewallConfig);
 
         $listener = function () {};
         $firewallContext->expects($this->once())->method('getListeners')->willReturn([$listener]);
@@ -88,5 +89,6 @@ class FirewallMapTest extends TestCase
         $this->assertEquals([[$listener], $exceptionListener, $logoutListener], $firewallMap->getListeners($request));
         $this->assertEquals($firewallConfig, $firewallMap->getFirewallConfig($request));
         $this->assertEquals('security.firewall.map.context.foo', $request->attributes->get(self::ATTRIBUTE_FIREWALL_CONTEXT));
+        $this->assertTrue($request->attributes->get('_stateless'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40372 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Automatically add `_stateless` attribute to the request when firewall is stateless


