### PR TITLE
[WebProfilerBundle] Remove redundant code from logger template

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -253,10 +253,6 @@
         {% if has_trace %}
             {% set trace_id = 'trace-' ~ category ~ '-' ~ log_index %}
             <span><button type="button" class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ trace_id }}" data-toggle-alt-content="Hide trace">Show trace</button></span>
-
-            <div id="{{ trace_id }}" class="context sf-toggle-content sf-toggle-hidden">
-                {{ profiler_dump(log.context.exception.trace, maxDepth=1) }}
-            </div>
         {% endif %}
 
         {% if has_context %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Introduced in #42195, the log trace gets unnecessarily rendered twice:

![image](https://user-images.githubusercontent.com/2445045/198841019-4fce7dce-f32f-42f2-9f55-829fafa0d558.png)
