### PR TITLE
[WebProfilerBundle] Fix dump header not being displayed

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Twig/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Twig/WebProfilerExtensionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Twig\Environment;
+use Twig\Extension\CoreExtension;
+use Twig\Extension\EscaperExtension;
+
+class WebProfilerExtensionTest extends TestCase
+{
+    /**
+     * @dataProvider provideMessages
+     */
+    public function testDumpHeaderIsDisplayed(string $message, array $context, bool $dump1HasHeader, bool $dump2HasHeader)
+    {
+        class_exists(CoreExtension::class); // Load twig_convert_encoding()
+        class_exists(EscaperExtension::class); // Load twig_escape_filter()
+
+        $twigEnvironment = $this->mockTwigEnvironment();
+        $varCloner = new VarCloner();
+
+        $webProfilerExtension = new WebProfilerExtension();
+
+        $needle = 'window.Sfdump';
+
+        $dump1 = $webProfilerExtension->dumpLog($twigEnvironment, $message, $varCloner->cloneVar($context));
+        self::assertSame($dump1HasHeader, str_contains($dump1, $needle));
+
+        $dump2 = $webProfilerExtension->dumpData($twigEnvironment, $varCloner->cloneVar([]));
+        self::assertSame($dump2HasHeader, str_contains($dump2, $needle));
+    }
+
+    public function provideMessages(): iterable
+    {
+        yield ['Some message', ['foo' => 'foo', 'bar' => 'bar'], false, true];
+        yield ['Some message {@see some text}', ['foo' => 'foo', 'bar' => 'bar'], false, true];
+        yield ['Some message {foo}', ['foo' => 'foo', 'bar' => 'bar'], true, false];
+        yield ['Some message {foo}', ['bar' => 'bar'], false, true];
+    }
+
+    private function mockTwigEnvironment()
+    {
+        $twigEnvironment = $this->createMock(Environment::class);
+
+        $twigEnvironment->expects($this->any())->method('getCharset')->willReturn('UTF-8');
+
+        return $twigEnvironment;
+    }
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
@@ -90,13 +90,19 @@ class WebProfilerExtension extends ProfilerExtension
         $message = twig_escape_filter($env, $message);
         $message = preg_replace('/&quot;(.*?)&quot;/', '&quot;<b>$1</b>&quot;', $message);
 
-        if (null === $context || !str_contains($message, '{')) {
+        $replacements = [];
+        foreach ($context ?? [] as $k => $v) {
+            $k = '{'.twig_escape_filter($env, $k).'}';
+            if (str_contains($message, $k)) {
+                $replacements[$k] = $v;
+            }
+        }
+
+        if (!$replacements) {
             return '<span class="dump-inline">'.$message.'</span>';
         }
 
-        $replacements = [];
-        foreach ($context as $k => $v) {
-            $k = '{'.twig_escape_filter($env, $k).'}';
+        foreach ($replacements as $k => $v) {
             $replacements['&quot;<b>'.$k.'</b>&quot;'] = $replacements['&quot;'.$k.'&quot;'] = $replacements[$k] = $this->dumpData($env, $v);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48039
| License       | MIT
| Doc PR        | -

The bug occurs because of the following log message:
```
The "Symfony\Bridge\Doctrine\Logger\DbalLogger" class implements "Doctrine\DBAL\Logging\SQLLogger" that is deprecated Use {@see \Doctrine\DBAL\Logging\Middleware} or implement {@see \Doctrine\DBAL\Driver\Middleware} instead.
```

Since this is the **first** message and it contains the `{` character the dump header gets rendered (line 93):

https://github.com/symfony/symfony/blob/f9eaefa677b8b6bf35eecb11487b3f730d3e1c91/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php#L88-L104

However, since there is no actual placeholder to replace, the header is never displayed, but is marked as displayed and never rendered again:

https://github.com/symfony/symfony/blob/f9eaefa677b8b6bf35eecb11487b3f730d3e1c91/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php#L149-L152
https://github.com/symfony/symfony/blob/f9eaefa677b8b6bf35eecb11487b3f730d3e1c91/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php#L944-L952

With this PR, the `WebProfilerExtension::dumpLog()` method will check the message for exact placeholders.