### PR TITLE
[HttpFoundation] Check IPv6 is valid before comparing it

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -124,6 +124,15 @@ class IpUtils
             throw new \RuntimeException('Unable to check Ipv6. Check that PHP was not compiled with option "disable-ipv6".');
         }
 
+        // Check to see if we were given a IP4 $requestIp or $ip by mistake
+        if (str_contains($requestIp, '.') || str_contains($ip, '.')) {
+            return self::$checkedIps[$cacheKey] = false;
+        }
+
+        if (!filter_var($requestIp, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
+            return self::$checkedIps[$cacheKey] = false;
+        }
+
         if (str_contains($ip, '/')) {
             [$address, $netmask] = explode('/', $ip, 2);
 

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -73,6 +73,10 @@ class IpUtilsTest extends TestCase
             [false, '2a01:198:603:0:396e:4789:8e99:890f', 'unknown'],
             [false, '', '::1'],
             [false, null, '::1'],
+            [false, '127.0.0.1', '::1'],
+            [false, '0.0.0.0/8', '::1'],
+            [false,  '::1', '127.0.0.1'],
+            [false,  '::1', '0.0.0.0/8'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #48049
| License       | MIT


Ensure that the `checkIp6` only validates IPv6 addresses and ipv6 subnets. 

PR Assumes that IPv6 and ipv6 subnets can never have a period in them (which as far as I know, is correct). 