### PR TITLE
[MonologBridge] #48023 -  Suggestion to deprecation issue construction of Monolog Logger

### DIFF
--- a/src/Symfony/Bridge/Monolog/Monolog.php
+++ b/src/Symfony/Bridge/Monolog/Monolog.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Symfony\Bridge\Monolog;
+
+use DateTimeZone;
+use Psr\Log\LoggerInterface;
+use Monolog\Logger;
+use Stringable;
+
+class Monolog implements LoggerInterface
+{
+    protected Logger $monologLogger;
+    protected array $handlers = [];
+    protected array $processors = [];
+
+    public function __construct(
+        string $name,
+        array $handlers = [],
+        array $processors = [],
+        ?DateTimeZone $timezone = null
+    ) {
+        $this->monologLogger = new Logger($name, $handlers,  $processors,  $timezone);
+    }
+
+    public function pushProcessor(callable $callback): Logger
+    {
+        return $this->monologLogger->pushProcessor($callback);
+    }
+
+    public function emergency(Stringable|string $message, array $context = []): void
+    {
+        $this->monologLogger->emergency($message, $context);
+    }
+
+    public function alert(Stringable|string $message, array $context = []): void
+    {
+        $this->monologLogger->alert($message, $context);
+    }
+
+    public function critical(Stringable|string $message, array $context = []): void
+    {
+        $this->monologLogger->critical($message, $context);
+    }
+
+    public function error(Stringable|string $message, array $context = []): void
+    {
+        $this->monologLogger->error($message, $context);
+    }
+
+    public function warning(Stringable|string $message, array $context = []): void
+    {
+        $this->monologLogger->warning($message, $context);
+    }
+
+    public function notice(Stringable|string $message, array $context = []): void
+    {
+        $this->monologLogger->notice($message, $context);
+    }
+
+    public function info(Stringable|string $message, array $context = []): void
+    {
+        $this->monologLogger->info($message, $context);
+    }
+
+    public function debug(Stringable|string $message, array $context = []): void
+    {
+        $this->monologLogger->debug($message, $context);
+    }
+
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        $this->monologLogger->log($level, $message, $context);
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Monolog.php
+++ b/src/Symfony/Bridge/Monolog/Monolog.php
@@ -7,7 +7,7 @@ use Psr\Log\LoggerInterface;
 use Monolog\Logger;
 use Stringable;
 
-class Monolog implements LoggerInterface
+abstract class Monolog implements LoggerInterface
 {
     protected Logger $monologLogger;
     protected array $handlers = [];

--- a/src/Symfony/Bridge/Monolog/Monolog.php
+++ b/src/Symfony/Bridge/Monolog/Monolog.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+* This file is part of the Symfony package.
+*
+* (c) Fabien Potencier <fabien@symfony.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
 namespace Symfony\Bridge\Monolog;
 
 use DateTimeZone;
@@ -16,7 +25,7 @@ abstract class Monolog implements LoggerInterface
         string $name,
         array $handlers = [],
         array $processors = [],
-        ?DateTimeZone $timezone = null
+        DateTimeZone $timezone = null
     ) {
         $this->monologLogger = new Logger($name, $handlers,  $processors,  $timezone);
     }

--- a/src/Symfony/Bridge/Monolog/Monolog.php
+++ b/src/Symfony/Bridge/Monolog/Monolog.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Symfony\Bridge\Monolog;
 
 use DateTimeZone;

--- a/src/Symfony/Bridge/Monolog/Monolog.php
+++ b/src/Symfony/Bridge/Monolog/Monolog.php
@@ -1,14 +1,13 @@
 <?php
 
 /*
-* This file is part of the Symfony package.
-*
-* (c) Fabien Potencier <fabien@symfony.com>
-*
-* For the full copyright and license information, please view the LICENSE
-* file that was distributed with this source code.
-*/
-
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 namespace Symfony\Bridge\Monolog;
 
 use DateTimeZone;
@@ -27,7 +26,7 @@ abstract class Monolog implements LoggerInterface
         array $processors = [],
         DateTimeZone $timezone = null
     ) {
-        $this->monologLogger = new Logger($name, $handlers,  $processors,  $timezone);
+        $this->monologLogger = new Logger($name, $handlers, $processors, $timezone);
     }
 
     public function pushProcessor(callable $callback): Logger

--- a/src/Symfony/Bridge/Monolog/Monolog.php
+++ b/src/Symfony/Bridge/Monolog/Monolog.php
@@ -31,42 +31,42 @@ abstract class Monolog implements LoggerInterface
         $this->monologLogger->emergency($message, $context);
     }
 
-    public function alert(string|\Stringable $message, array $context = []): void
+    public function alert($message, array $context = []): void
     {
         $this->monologLogger->alert($message, $context);
     }
 
-    public function critical(string|\Stringable $message, array $context = []): void
+    public function critical($message, array $context = []): void
     {
         $this->monologLogger->critical($message, $context);
     }
 
-    public function error(string|\Stringable $message, array $context = []): void
+    public function error($message, array $context = []): void
     {
         $this->monologLogger->error($message, $context);
     }
 
-    public function warning(string|\Stringable $message, array $context = []): void
+    public function warning($message, array $context = []): void
     {
         $this->monologLogger->warning($message, $context);
     }
 
-    public function notice(string|\Stringable $message, array $context = []): void
+    public function notice($message, array $context = []): void
     {
         $this->monologLogger->notice($message, $context);
     }
 
-    public function info(string|\Stringable $message, array $context = []): void
+    public function info($message, array $context = []): void
     {
         $this->monologLogger->info($message, $context);
     }
 
-    public function debug(string|\Stringable $message, array $context = []): void
+    public function debug($message, array $context = []): void
     {
         $this->monologLogger->debug($message, $context);
     }
 
-    public function log($level, string|\Stringable $message, array $context = []): void
+    public function log($level, $message, array $context = []): void
     {
         $this->monologLogger->log($level, $message, $context);
     }

--- a/src/Symfony/Bridge/Monolog/Monolog.php
+++ b/src/Symfony/Bridge/Monolog/Monolog.php
@@ -3,8 +3,8 @@
 namespace Symfony\Bridge\Monolog;
 
 use DateTimeZone;
-use Psr\Log\LoggerInterface;
 use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 
 abstract class Monolog implements LoggerInterface
 {
@@ -26,7 +26,7 @@ abstract class Monolog implements LoggerInterface
         return $this->monologLogger->pushProcessor($callback);
     }
 
-    public function emergency(string|\Stringable $message, array $context = []): void
+    public function emergency($message, array $context = []): void
     {
         $this->monologLogger->emergency($message, $context);
     }

--- a/src/Symfony/Bridge/Monolog/Monolog.php
+++ b/src/Symfony/Bridge/Monolog/Monolog.php
@@ -5,7 +5,6 @@ namespace Symfony\Bridge\Monolog;
 use DateTimeZone;
 use Psr\Log\LoggerInterface;
 use Monolog\Logger;
-use Stringable;
 
 abstract class Monolog implements LoggerInterface
 {
@@ -27,47 +26,47 @@ abstract class Monolog implements LoggerInterface
         return $this->monologLogger->pushProcessor($callback);
     }
 
-    public function emergency(Stringable|string $message, array $context = []): void
+    public function emergency(string|\Stringable $message, array $context = []): void
     {
         $this->monologLogger->emergency($message, $context);
     }
 
-    public function alert(Stringable|string $message, array $context = []): void
+    public function alert(string|\Stringable $message, array $context = []): void
     {
         $this->monologLogger->alert($message, $context);
     }
 
-    public function critical(Stringable|string $message, array $context = []): void
+    public function critical(string|\Stringable $message, array $context = []): void
     {
         $this->monologLogger->critical($message, $context);
     }
 
-    public function error(Stringable|string $message, array $context = []): void
+    public function error(string|\Stringable $message, array $context = []): void
     {
         $this->monologLogger->error($message, $context);
     }
 
-    public function warning(Stringable|string $message, array $context = []): void
+    public function warning(string|\Stringable $message, array $context = []): void
     {
         $this->monologLogger->warning($message, $context);
     }
 
-    public function notice(Stringable|string $message, array $context = []): void
+    public function notice(string|\Stringable $message, array $context = []): void
     {
         $this->monologLogger->notice($message, $context);
     }
 
-    public function info(Stringable|string $message, array $context = []): void
+    public function info(string|\Stringable $message, array $context = []): void
     {
         $this->monologLogger->info($message, $context);
     }
 
-    public function debug(Stringable|string $message, array $context = []): void
+    public function debug(string|\Stringable $message, array $context = []): void
     {
         $this->monologLogger->debug($message, $context);
     }
 
-    public function log($level, Stringable|string $message, array $context = []): void
+    public function log($level, string|\Stringable $message, array $context = []): void
     {
         $this->monologLogger->log($level, $message, $context);
     }

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
@@ -13,11 +13,11 @@ namespace Symfony\Bridge\Monolog\Tests\Handler;
 
 use Monolog\Formatter\HtmlFormatter;
 use Monolog\Formatter\LineFormatter;
+use Monolog\Logger as Monolog;
 use Monolog\LogRecord;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\MailerHandler;
-use Symfony\Bridge\Monolog\Logger;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
@@ -43,7 +43,7 @@ class MailerHandlerTest extends TestCase
                 return 'Alert: WARNING message' === $email->getSubject() && null === $email->getHtmlBody();
             }))
         ;
-        $handler->handle($this->getRecord(Logger::WARNING, 'message'));
+        $handler->handle($this->getRecord(Monolog::WARNING, 'message'));
     }
 
     public function testHandleBatch()
@@ -70,11 +70,11 @@ class MailerHandlerTest extends TestCase
         $callback = function () {
             throw new \RuntimeException('Email creation callback should not have been called in this test');
         };
-        $handler = new MailerHandler($this->mailer, $callback, Logger::ALERT);
+        $handler = new MailerHandler($this->mailer, $callback, Monolog::ALERT);
 
         $records = [
-            $this->getRecord(Logger::DEBUG),
-            $this->getRecord(Logger::INFO),
+            $this->getRecord(Monolog::DEBUG),
+            $this->getRecord(Monolog::INFO),
         ];
         $handler->handleBatch($records);
     }
@@ -90,10 +90,10 @@ class MailerHandlerTest extends TestCase
                 return 'Alert: WARNING message' === $email->getSubject() && null === $email->getTextBody();
             }))
         ;
-        $handler->handle($this->getRecord(Logger::WARNING, 'message'));
+        $handler->handle($this->getRecord(Monolog::WARNING, 'message'));
     }
 
-    protected function getRecord($level = Logger::WARNING, $message = 'test', $context = []): array|LogRecord
+    protected function getRecord($level = Monolog::WARNING, $message = 'test', $context = []): array|LogRecord
     {
         return RecordFactory::create($level, $message, context: $context);
     }
@@ -101,11 +101,11 @@ class MailerHandlerTest extends TestCase
     protected function getMultipleRecords(): array
     {
         return [
-            $this->getRecord(Logger::DEBUG, 'debug message 1'),
-            $this->getRecord(Logger::DEBUG, 'debug message 2'),
-            $this->getRecord(Logger::INFO, 'information'),
-            $this->getRecord(Logger::WARNING, 'warning'),
-            $this->getRecord(Logger::ERROR, 'error'),
+            $this->getRecord(Monolog::DEBUG, 'debug message 1'),
+            $this->getRecord(Monolog::DEBUG, 'debug message 2'),
+            $this->getRecord(Monolog::INFO, 'information'),
+            $this->getRecord(Monolog::WARNING, 'warning'),
+            $this->getRecord(Monolog::ERROR, 'error'),
         ];
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Tests;
 
 use Monolog\Handler\TestHandler;
+use Monolog\Logger as Monolog;
 use Monolog\ResettableInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -79,7 +80,7 @@ class LoggerTest extends TestCase
         [$record] = $logger->getLogs();
 
         $this->assertEquals('test', $record['message']);
-        $this->assertEquals(\Monolog\Logger::INFO, $record['priority']);
+        $this->assertEquals(Monolog::INFO, $record['priority']);
     }
 
     public function testGetLogsWithDebugProcessor3()

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Monolog\Tests;
 use Monolog\Handler\TestHandler;
 use Monolog\ResettableInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Component\HttpFoundation\Request;
@@ -78,7 +79,7 @@ class LoggerTest extends TestCase
         [$record] = $logger->getLogs();
 
         $this->assertEquals('test', $record['message']);
-        $this->assertEquals(Logger::INFO, $record['priority']);
+        $this->assertEquals(\Monolog\Logger::INFO, $record['priority']);
     }
 
     public function testGetLogsWithDebugProcessor3()

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -15,7 +15,6 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger as Monolog;
 use Monolog\ResettableInterface;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #47096 #48023
| License       | MIT
<!--
Suggestion to solve notice related at issue #48023 
`1x: The "Monolog\Logger" class is considered final. It may change without
further notice as of its next major version. You should not extend it
from "Symfony\Bridge\Monolog\Logger".`

I'm abstracting Monolog using LoggerInterface, and using Monolog/Logger as dependency. 

Suggestions were welcome <3
