### PR TITLE
[Console] The console app now can print the version even if the application name is not set

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -468,15 +468,17 @@ class Application implements ResetInterface
      */
     public function getLongVersion()
     {
-        if ('UNKNOWN' !== $this->getName()) {
-            if ('UNKNOWN' !== $this->getVersion()) {
-                return sprintf('%s <info>%s</info>', $this->getName(), $this->getVersion());
-            }
+        $name = 'Console Tool';
 
-            return $this->getName();
+        if ('UNKNOWN' !== $this->getName()) {
+            $name = $this->getName();
         }
 
-        return 'Console Tool';
+        if ('UNKNOWN' !== $this->getVersion()) {
+            $name .= sprintf(' <info>%s</info>', $this->getVersion());
+        }
+
+        return $name;
     }
 
     /**


### PR DESCRIPTION
The console application can now print the version even if the application name is not set.

$app = new Application();
$app->setVersion("1.0.585");

Before "console -V" print
Console Tool

Now "console -V" print
Console Tool 1.0.585
