### PR TITLE
[HttpFoundation] Create migration for session table when pdo handler is used

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\SchemaListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Doctrine\ORM\Tools\ToolEvents;
+
+abstract class AbstractSchemaSubscriber implements EventSubscriber
+{
+    abstract public function postGenerateSchema(GenerateSchemaEventArgs $event): void;
+
+    public function getSubscribedEvents(): array
+    {
+        if (!class_exists(ToolEvents::class)) {
+            return [];
+        }
+
+        return [
+            ToolEvents::postGenerateSchema,
+        ];
+    }
+
+    protected function getIsSameDatabaseChecker(Connection $connection): \Closure
+    {
+        return static function (\Closure $exec) use ($connection): bool {
+            $checkTable = 'schema_subscriber_check_'.bin2hex(random_bytes(7));
+            $connection->executeStatement(sprintf('CREATE TABLE %s (id INTEGER NOT NULL)', $checkTable));
+
+            try {
+                $exec(sprintf('DROP TABLE %s', $checkTable));
+            } catch (\Exception) {
+                // ignore
+            }
+
+            try {
+                $connection->executeStatement(sprintf('DROP TABLE %s', $checkTable));
+
+                return false;
+            } catch (TableNotFoundException) {
+                return true;
+            }
+        };
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaSubscriber.php
@@ -11,9 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\SchemaListener;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use Doctrine\ORM\Tools\ToolEvents;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 
 /**
@@ -22,7 +20,7 @@ use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-final class DoctrineDbalCacheAdapterSchemaSubscriber implements EventSubscriber
+final class DoctrineDbalCacheAdapterSchemaSubscriber extends AbstractSchemaSubscriber
 {
     private $dbalAdapters;
 
@@ -36,20 +34,10 @@ final class DoctrineDbalCacheAdapterSchemaSubscriber implements EventSubscriber
 
     public function postGenerateSchema(GenerateSchemaEventArgs $event): void
     {
-        $dbalConnection = $event->getEntityManager()->getConnection();
+        $connection = $event->getEntityManager()->getConnection();
+
         foreach ($this->dbalAdapters as $dbalAdapter) {
-            $dbalAdapter->configureSchema($event->getSchema(), $dbalConnection);
+            $dbalAdapter->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
         }
-    }
-
-    public function getSubscribedEvents(): array
-    {
-        if (!class_exists(ToolEvents::class)) {
-            return [];
-        }
-
-        return [
-            ToolEvents::postGenerateSchema,
-        ];
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\SchemaListener;
+
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+
+final class PdoSessionHandlerSchemaSubscriber extends AbstractSchemaSubscriber
+{
+    private iterable $pdoSessionHandlers;
+
+    /**
+     * @param iterable<mixed, PdoSessionHandler> $pdoSessionHandlers
+     */
+    public function __construct(iterable $pdoSessionHandlers)
+    {
+        $this->pdoSessionHandlers = $pdoSessionHandlers;
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
+    {
+        $connection = $event->getEntityManager()->getConnection();
+
+        foreach ($this->pdoSessionHandlers as $pdoSessionHandler) {
+            $pdoSessionHandler->configureSchema($event->getSchema(), $this->getIsSameDatabaseChecker($connection));
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -188,15 +188,18 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
 
     /**
      * Adds the Table to the Schema if "remember me" uses this Connection.
+     *
+     * @param \Closure $isSameDatabase
      */
-    public function configureSchema(Schema $schema, Connection $forConnection): void
+    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */): void
     {
-        // only update the schema for this connection
-        if ($forConnection !== $this->conn) {
+        if ($schema->hasTable('rememberme_token')) {
             return;
         }
 
-        if ($schema->hasTable('rememberme_token')) {
+        $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
+
+        if ($forConnection !== $this->conn && !$isSameDatabase($this->conn->executeStatement(...))) {
             return;
         }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaSubscriberTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaSubscriberTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\SchemaListener\PdoSessionHandlerSchemaSubscriber;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+
+class PdoSessionHandlerSchemaSubscriberTest extends TestCase
+{
+    public function testPostGenerateSchemaPdo()
+    {
+        $schema = new Schema();
+        $dbalConnection = $this->createMock(Connection::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $pdoSessionHandler = $this->createMock(PdoSessionHandler::class);
+        $pdoSessionHandler->expects($this->once())
+            ->method('configureSchema')
+            ->with($schema, fn() => true);
+
+        $subscriber = new PdoSessionHandlerSchemaSubscriber([$pdoSessionHandler]);
+        $subscriber->postGenerateSchema($event);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -56,6 +56,7 @@
         "symfony/cache": "<5.4",
         "symfony/dependency-injection": "<6.2",
         "symfony/form": "<5.4",
+        "symfony/http-foundation": "<6.3",
         "symfony/http-kernel": "<6.2",
         "symfony/messenger": "<5.4",
         "symfony/property-info": "<5.4",

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -98,14 +98,18 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
         }
     }
 
-    public function configureSchema(Schema $schema, Connection $forConnection): void
+    /**
+     * @param \Closure $isSameDatabase
+     */
+    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */): void
     {
-        // only update the schema for this connection
-        if ($forConnection !== $this->conn) {
+        if ($schema->hasTable($this->table)) {
             return;
         }
 
-        if ($schema->hasTable($this->table)) {
+        $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
+
+        if ($forConnection !== $this->conn && !$isSameDatabase($this->conn->executeStatement(...))) {
             return;
         }
 

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Create migration for session table when pdo handler is used
+
 6.2
 ---
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
@@ -22,15 +22,8 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  */
 class MigratingSessionHandler implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface
 {
-    /**
-     * @var \SessionHandlerInterface&\SessionUpdateTimestampHandlerInterface
-     */
-    private \SessionHandlerInterface $currentHandler;
-
-    /**
-     * @var \SessionHandlerInterface&\SessionUpdateTimestampHandlerInterface
-     */
-    private \SessionHandlerInterface $writeOnlyHandler;
+    private \SessionHandlerInterface&\SessionUpdateTimestampHandlerInterface $currentHandler;
+    private \SessionHandlerInterface&\SessionUpdateTimestampHandlerInterface $writeOnlyHandler;
 
     public function __construct(\SessionHandlerInterface $currentHandler, \SessionHandlerInterface $writeOnlyHandler)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+
 /**
  * Session handler using a PDO connection to read and write data.
  *
@@ -173,6 +176,52 @@ class PdoSessionHandler extends AbstractSessionHandler
         $this->connectionOptions = $options['db_connection_options'] ?? $this->connectionOptions;
         $this->lockMode = $options['lock_mode'] ?? $this->lockMode;
         $this->ttl = $options['ttl'] ?? null;
+    }
+
+    public function configureSchema(Schema $schema, \Closure $isSameDatabase): void
+    {
+        if ($schema->hasTable($this->table) || !$isSameDatabase($this->getConnection()->exec(...))) {
+            return;
+        }
+
+        $table = $schema->createTable($this->table);
+        switch ($this->driver) {
+            case 'mysql':
+                $table->addColumn($this->idCol, Types::BINARY)->setLength(128)->setNotnull(true);
+                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
+                $table->addColumn($this->timeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
+                $table->addOption('collate', 'utf8mb4_bin');
+                $table->addOption('engine', 'InnoDB');
+                break;
+            case 'sqlite':
+                $table->addColumn($this->idCol, Types::TEXT)->setNotnull(true);
+                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setNotnull(true);
+                $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
+                break;
+            case 'pgsql':
+                $table->addColumn($this->idCol, Types::STRING)->setLength(128)->setNotnull(true);
+                $table->addColumn($this->dataCol, Types::BINARY)->setNotnull(true);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setNotnull(true);
+                $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
+                break;
+            case 'oci':
+                $table->addColumn($this->idCol, Types::STRING)->setLength(128)->setNotnull(true);
+                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setNotnull(true);
+                $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
+                break;
+            case 'sqlsrv':
+                $table->addColumn($this->idCol, Types::TEXT)->setLength(128)->setNotnull(true);
+                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
+                $table->addColumn($this->timeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
+                break;
+            default:
+                throw new \DomainException(sprintf('Creating the session table is currently not implemented for PDO driver "%s".', $this->driver));
+        }
+        $table->setPrimaryKey([$this->idCol]);
     }
 
     /**
@@ -441,8 +490,8 @@ class PdoSessionHandler extends AbstractSessionHandler
                         return $dsn;
                     }
                 }
-            // If "unix_socket" is not in the query, we continue with the same process as pgsql
-            // no break
+                // If "unix_socket" is not in the query, we continue with the same process as pgsql
+                // no break
             case 'pgsql':
                 $dsn ??= 'pgsql:';
 

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -22,6 +22,7 @@
         "symfony/polyfill-php83": "^1.27"
     },
     "require-dev": {
+        "doctrine/dbal": "^2.13.1|^3.0",
         "predis/predis": "~1.0",
         "symfony/cache": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -411,7 +411,7 @@ class ConnectionTest extends TestCase
         $schema = new Schema();
 
         $connection = new Connection(['table_name' => 'queue_table'], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection);
+        $connection->configureSchema($schema, $driverConnection, fn() => true);
         $this->assertTrue($schema->hasTable('queue_table'));
     }
 
@@ -422,7 +422,7 @@ class ConnectionTest extends TestCase
         $schema = new Schema();
 
         $connection = new Connection([], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection2);
+        $connection->configureSchema($schema, $driverConnection2, fn() => true);
         $this->assertFalse($schema->hasTable('messenger_messages'));
     }
 
@@ -433,7 +433,7 @@ class ConnectionTest extends TestCase
         $schema->createTable('messenger_messages');
 
         $connection = new Connection([], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection);
+        $connection->configureSchema($schema, $driverConnection, fn() => true);
         $table = $schema->getTable('messenger_messages');
         $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -324,14 +324,13 @@ class Connection implements ResetInterface
     /**
      * @internal
      */
-    public function configureSchema(Schema $schema, DBALConnection $forConnection): void
+    public function configureSchema(Schema $schema, DBALConnection $forConnection, \Closure $isSameDatabase): void
     {
-        // only update the schema for this connection
-        if ($forConnection !== $this->driverConnection) {
+        if ($schema->hasTable($this->configuration['table_name'])) {
             return;
         }
 
-        if ($schema->hasTable($this->configuration['table_name'])) {
+        if ($forConnection !== $this->driverConnection && !$isSameDatabase($this->executeStatement(...))) {
             return;
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
@@ -79,10 +79,14 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
 
     /**
      * Adds the Table to the Schema if this transport uses this connection.
+     *
+     * @param \Closure $isSameDatabase
      */
-    public function configureSchema(Schema $schema, DbalConnection $forConnection): void
+    public function configureSchema(Schema $schema, DbalConnection $forConnection/* , \Closure $isSameDatabase */): void
     {
-        $this->connection->configureSchema($schema, $forConnection);
+        $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
+
+        $this->connection->configureSchema($schema, $forConnection, $isSameDatabase);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The purpose of this PR is to automatically generate the session table with the make migration command in addition to https://symfony.com/doc/current/session/database.html#preparing-the-database-to-store-sessions

Even though  `WellKnownSchemaFilterPass`  is deprecated, atm the session table is blacklisted by the `WellKnownSchemaFilterPass`, that's why I need to set the SchemaAssetFilter to null. 

todo: 

- [ ] doctrineBundle => https://github.com/doctrine/DoctrineBundle/pull/1569
- [x] Add mention to changelog
- [ ] update documentation
