### PR TITLE
Fix the DataTransformerInterface generic types to support the patcher

### DIFF
--- a/src/Symfony/Component/Form/DataTransformerInterface.php
+++ b/src/Symfony/Component/Form/DataTransformerInterface.php
@@ -58,7 +58,9 @@ interface DataTransformerInterface
      *
      * @param TValue|null $value The value in the original representation
      *
-     * @return TTransformedValue|null
+     * @return mixed
+     *
+     * @psalm-return TTransformedValue|null
      *
      * @throws TransformationFailedException when the transformation fails
      */
@@ -87,7 +89,9 @@ interface DataTransformerInterface
      *
      * @param TTransformedValue|null $value The value in the transformed representation
      *
-     * @return TValue|null
+     * @return mixed
+     *
+     * @psalm-return TValue|null
      *
      * @throws TransformationFailedException when the transformation fails
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

The type patcher adding return types handles template types only for methods that already have a return type. As `DataTransformerInterface` is not typed yet in Symfony 6.x, we need to keep the future native types in `@return` for the patcher tool. This puts the generic type (introduced in #47412) in `@psalm-return`, as done in #48012 (I detected this issue when regenerating the return type for that other PR)
