### PR TITLE
[Security] Make request always available to `#[IsGranted]`

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -281,7 +281,7 @@ class IsGrantedAttributeListenerTest extends TestCase
         $listener->onKernelControllerArguments($event);
     }
 
-    public function testIsGrantedwithExpressionInAttribute()
+    public function testIsGrantedWithExpressionInAttribute()
     {
         $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $authChecker->expects($this->once())
@@ -301,8 +301,10 @@ class IsGrantedAttributeListenerTest extends TestCase
         $listener->onKernelControllerArguments($event);
     }
 
-    public function testIsGrantedwithExpressionInSubject()
+    public function testIsGrantedWithExpressionInSubject()
     {
+        $request = new Request();
+
         $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $authChecker->expects($this->once())
             ->method('isGranted')
@@ -314,6 +316,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->method('evaluate')
             ->with(new Expression('args["post"].getAuthor()'), [
                 'args' => ['post' => 'postVal'],
+                'request' => $request,
             ])
             ->willReturn('author');
 
@@ -321,7 +324,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             $this->createMock(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withExpressionInSubject'],
             ['postVal'],
-            new Request(),
+            $request,
             null
         );
 
@@ -329,8 +332,10 @@ class IsGrantedAttributeListenerTest extends TestCase
         $listener->onKernelControllerArguments($event);
     }
 
-    public function testIsGrantedwithNestedExpressionInSubject()
+    public function testIsGrantedWithNestedExpressionInSubject()
     {
+        $request = new Request();
+
         $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $authChecker->expects($this->once())
             ->method('isGranted')
@@ -342,6 +347,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->method('evaluate')
             ->with(new Expression('args["post"].getAuthor()'), [
                 'args' => ['post' => 'postVal', 'arg2Name' => 'arg2Val'],
+                'request' => $request,
             ])
             ->willReturn('author');
 
@@ -349,11 +355,53 @@ class IsGrantedAttributeListenerTest extends TestCase
             $this->createMock(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withNestedExpressionInSubject'],
             ['postVal', 'arg2Val'],
-            new Request(),
+            $request,
             null
         );
 
         $listener = new IsGrantedAttributeListener($authChecker, $expressionLanguage);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsGrantedWithRequestAsSubjectAndNoArgument()
+    {
+        $request = new Request();
+
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('SOME_VOTER', $request)
+            ->willReturn(true);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsGrantedAttributeMethodsController(), 'withRequestAsSubjectAndNoArgument'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsGrantedWithRequestAsSubjectAndArgument()
+    {
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('SOME_VOTER', 'foobar')
+            ->willReturn(true);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsGrantedAttributeMethodsController(), 'withRequestAsSubjectAndArgument'],
+            ['foobar'],
+            new Request(),
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
         $listener->onKernelControllerArguments($event);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
@@ -62,4 +62,14 @@ class IsGrantedAttributeMethodsController
     public function withNestedExpressionInSubject($post, $arg2Name)
     {
     }
+
+    #[IsGranted(attribute: 'SOME_VOTER', subject: 'request')]
+    public function withRequestAsSubjectAndNoArgument()
+    {
+    }
+
+    #[IsGranted(attribute: 'SOME_VOTER', subject: 'request')]
+    public function withRequestAsSubjectAndArgument($request)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/48071#issuecomment-1299936626
| License       | MIT
| Doc PR        | -

Currently, the request is only available to the `#[IsGranted]` attribute when it's a controller argument, eg:

```php
#[IsGranted(attribute: 'SOME_ATTRIBUTE', subject: 'request')]
public function index(Request $request)
{
}

#[IsGranted(
    attribute: 'SOME_ATTRIBUTE',
    subject: new Expression('args["request"].query.get("foo")'),
)]
public function index(Request $request)
{
}
```

However, since the `$request` variable might not always be needed in the controller itself, it seems kind of weird to have to add it as an argument just so the `#[IsGranted]` attribute could work. With this PR, the request will always be available to the attribute:

```php
#[IsGranted(attribute: 'SOME_ATTRIBUTE', subject: 'request')]
public function index()
{
}

#[IsGranted(
    attribute: 'SOME_ATTRIBUTE',
    subject: new Expression('request.query.get("foo")'),
)]
public function index()
{
}
```

Don't know if this qualifies as a tweak for 6.2 or feature for 6.3.