### PR TITLE
Update the CI setup to use the new output file

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Find packages
         id: find-packages
-        run: echo "::set-output name=packages::$(php .github/get-modified-packages.php $(find src/Symfony -mindepth 2 -maxdepth 6 -type f -name composer.json -printf '%h\n' | jq -R -s -c 'split("\n")[:-1]') $(git diff --name-only origin/${{ github.base_ref }} HEAD | grep src/ | jq -R -s -c 'split("\n")[:-1]'))"
+        run: echo "packages=$(php .github/get-modified-packages.php $(find src/Symfony -mindepth 2 -maxdepth 6 -type f -name composer.json -printf '%h\n' | jq -R -s -c 'split("\n")[:-1]') $(git diff --name-only origin/${{ github.base_ref }} HEAD | grep src/ | jq -R -s -c 'split("\n")[:-1]'))" >> $GITHUB_OUTPUT
 
       - name: Verify meta files are correct
         run: |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/