### PR TITLE
Fix html to markdown rendering issue

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -12,7 +12,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * bug #48020 [FrameworkBundle] add router cache directory option to XML schema (xabbuh)
  * feature #47976 Add padding to HIBP check (rullzer)
  * bug #47990 [HttpClient] Fix retrying requests when the content is used by the strategy (nicolas-grekas)
- * bug #48005 [ErrorHandler] s/</br>/<br> (PhilETaylor)
+ * bug #48005 [ErrorHandler] s/\</br\>/\<br\> (PhilETaylor)
  * bug #47907 [Console] Update Application.php (aleksandr-shevchenko)
  * bug #47992 [Mailer] Fix BC breaking event name change (chalasr)
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT


Simply fix the rendering of `<br>` tags in the markdown in https://github.com/symfony/symfony/blob/6.2/CHANGELOG-6.2.md  - my bad

# Before

<img width="389" alt="Screenshot 2022-11-03 at 07 16 20" src="https://user-images.githubusercontent.com/400092/199665354-9132cd55-546f-4db9-8c16-4aabe9862f13.png">

# After 
<img width="506" alt="Screenshot 2022-11-03 at 10 05 23" src="https://user-images.githubusercontent.com/400092/199693738-12ba65cb-8a2a-4af0-b2fd-f0a7032ef047.png">
