### PR TITLE
[Console] Fix clear line with question in section

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -88,6 +88,14 @@ class ConsoleSectionOutput extends StreamOutput
     }
 
     /**
+     * @internal
+     */
+    public function incrementLines()
+    {
+        ++$this->lines;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function doWrite(string $message, bool $newline)

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\TrimmedBufferOutput;
 use Symfony\Component\Console\Question\ChoiceQuestion;
@@ -350,6 +351,11 @@ class SymfonyStyle extends OutputStyle
         if ($this->input->isInteractive()) {
             $this->newLine();
             $this->bufferedOutput->write("\n");
+            if ($this->output instanceof ConsoleSectionOutput) {
+                // add one line more to the ConsoleSectionOutput because of the `return` to submit the input
+                // this is relevant when a `ConsoleSectionOutput::clear` is called.
+                $this->output->incrementLines();
+            }
         }
 
         return $answer;

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -16,11 +16,13 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -180,5 +182,39 @@ class SymfonyStyleTest extends TestCase
         }
 
         $this->assertSame(0, memory_get_usage() - $start);
+    }
+
+    public function testAskAndClearExpectFullSectionCleared()
+    {
+        $answer = 'Answer';
+        $inputStream = fopen('php://memory', 'r+');
+        fwrite($inputStream, $answer.\PHP_EOL);
+        rewind($inputStream);
+        $input = $this->createMock(Input::class);
+        $sections = [];
+        $output = new ConsoleSectionOutput(fopen('php://memory', 'r+', false), $sections, StreamOutput::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $input
+            ->method('isInteractive')
+            ->willReturn(true);
+        $input
+            ->method('getStream')
+            ->willReturn($inputStream);
+
+        $style = new SymfonyStyle($input, $output);
+
+        $style->write('foo');
+        $givenAnswer = $style->ask('Dummy question?');
+        $output->write('bar');
+        $output->clear();
+
+        rewind($output->getStream());
+        $this->assertEquals($answer, $givenAnswer);
+        $this->assertEquals(
+            'foo'.\PHP_EOL. // write foo
+            \PHP_EOL.\PHP_EOL.\PHP_EOL." \033[32mDummy question?\033[39m:".\PHP_EOL.' > '.\PHP_EOL.\PHP_EOL.\PHP_EOL. // question
+            'bar'.\PHP_EOL. // write bar
+            "\033[10A\033[0J", // clear 10 lines (9 output lines and one from the answer input return)
+            stream_get_contents($output->getStream())
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47411
| License       | MIT
| Doc PR        | -

In the issue #47411 is the current behavior described (with videos).

The problem is in a section using a question and a clear. Then one line is not cleared because of the `return` so submit the input.

NOTICE: This bug might be as well in the versions 4.4+, but in the versions < 6.1 it would be more complicated to fix, because the `SymfonyStyle` does not have the property `$output` in this versions.