### PR TITLE
Fix the notification email theme for asynchronously dispatched emails

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
@@ -210,7 +210,7 @@ class NotificationEmail extends TemplatedEmail
      */
     public function __serialize(): array
     {
-        return [$this->context, parent::__serialize()];
+        return [$this->context, $this->theme, parent::__serialize()];
     }
 
     /**
@@ -218,7 +218,12 @@ class NotificationEmail extends TemplatedEmail
      */
     public function __unserialize(array $data): void
     {
-        [$this->context, $parentData] = $data;
+        if (3 === \count($data)) {
+            [$this->context, $this->theme, $parentData] = $data;
+        } else {
+            // Backwards compatibility for deserializing data structures that were serialized without the theme
+            [$this->context, $parentData] = $data;
+        }
 
         parent::__unserialize($parentData);
     }

--- a/src/Symfony/Bridge/Twig/Tests/Mime/NotificationEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/NotificationEmailTest.php
@@ -46,6 +46,7 @@ class NotificationEmailTest extends TestCase
             ->importance(NotificationEmail::IMPORTANCE_HIGH)
             ->action('Bar', 'http://example.com/')
             ->context(['a' => 'b'])
+            ->theme('example')
         ));
         $this->assertEquals([
             'importance' => NotificationEmail::IMPORTANCE_HIGH,
@@ -57,6 +58,8 @@ class NotificationEmailTest extends TestCase
             'raw' => true,
             'a' => 'b',
         ], $email->getContext());
+
+        $this->assertSame('@email/example/notification/body.html.twig', $email->getHtmlTemplate());
     }
 
     public function testTheme()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When the `\Symfony\Component\Mailer\Messenger\SendEmailMessage` is dispatched asynchronously, the email message is serialised and unserialised. The theme that was set on the `NotificationEmail` was not included in the serialisation, causing the value to return back to the default after deserialisation.