### PR TITLE
[Messenger] [Sqs] Add `AddFifoStamp` middleware

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add `AddFifoStampMiddleware` to help adding `AmazonSqsFifoStamp`
+
 6.1
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/MessageDeduplicationAwareInterface.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/MessageDeduplicationAwareInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs;
+
+/**
+ * @see https://docs.aws.amazon.com/en_gb/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
+ */
+interface MessageDeduplicationAwareInterface
+{
+    /**
+     * The max length of MessageDeduplicationId is 128 characters.
+     * Valid values: alphanumeric characters and punctuation (!"#$%&'()*+,-./:;<=>?@[]^_`{|}~).
+     */
+    public function getMessageDeduplicationId(): ?string;
+}

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/MessageGroupAwareInterface.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/MessageGroupAwareInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs;
+
+/**
+ * @see https://docs.aws.amazon.com/en_gb/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html
+ */
+interface MessageGroupAwareInterface
+{
+    /**
+     * The max length of MessageGroupId is 128 characters.
+     * Valid values: alphanumeric characters and punctuation (!"#$%&'()*+,-./:;<=>?@[]^_`{|}~).
+     */
+    public function getMessageGroupId(): ?string;
+}

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Middleware/AddFifoStampMiddleware.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Middleware/AddFifoStampMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware;
+
+use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageDeduplicationAwareInterface;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFifoStamp;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+final class AddFifoStampMiddleware implements MiddlewareInterface
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $message = $envelope->getMessage();
+        $messageGroupId = null;
+        $messageDeduplicationId = null;
+
+        if ($message instanceof MessageGroupAwareInterface) {
+            $messageGroupId = $message->getMessageGroupId();
+        }
+        if ($message instanceof MessageDeduplicationAwareInterface) {
+            $messageDeduplicationId = $message->getMessageDeduplicationId();
+        }
+
+        if (null !== $messageGroupId || null !== $messageDeduplicationId) {
+            $envelope = $envelope->with(new AmazonSqsFifoStamp($messageGroupId, $messageDeduplicationId));
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Middleware/AddFifoStampTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Middleware/AddFifoStampTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Middleware;
+
+use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageDeduplicationAwareInterface;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware\AddFifoStampMiddleware;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFifoStamp;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class AddFifoStampTest extends MiddlewareTestCase
+{
+    public function testAddStampWithGroupIdOnly()
+    {
+        $middleware = new AddFifoStampMiddleware();
+        $envelope = new Envelope(new WithMessageGroupIdMessage('groupId'));
+        $finalEnvelope = $middleware->handle($envelope, $this->getStackMock());
+        $stamp = $finalEnvelope->last(AmazonSqsFifoStamp::class);
+        $this->assertInstanceOf(AmazonSqsFifoStamp::class, $stamp);
+        $this->assertSame('groupId', $stamp->getMessageGroupId());
+        $this->assertNull($stamp->getMessageDeduplicationId());
+    }
+
+    public function testHandleWithDeduplicationIdOnly()
+    {
+        $middleware = new AddFifoStampMiddleware();
+        $envelope = new Envelope(new WithMessageDeduplicationIdMessage('deduplicationId'));
+        $finalEnvelope = $middleware->handle($envelope, $this->getStackMock());
+        $stamp = $finalEnvelope->last(AmazonSqsFifoStamp::class);
+        $this->assertInstanceOf(AmazonSqsFifoStamp::class, $stamp);
+        $this->assertSame('deduplicationId', $stamp->getMessageDeduplicationId());
+        $this->assertNull($stamp->getMessageGroupId());
+    }
+
+    public function testHandleWithGroupIdAndDeduplicationId()
+    {
+        $middleware = new AddFifoStampMiddleware();
+        $envelope = new Envelope(new WithMessageDeduplicationIdAndMessageGroupIdMessage('my_group', 'my_random_id'));
+        $finalEnvelope = $middleware->handle($envelope, $this->getStackMock());
+        $stamp = $finalEnvelope->last(AmazonSqsFifoStamp::class);
+        $this->assertInstanceOf(AmazonSqsFifoStamp::class, $stamp);
+        $this->assertSame('my_random_id', $stamp->getMessageDeduplicationId());
+        $this->assertSame('my_group', $stamp->getMessageGroupId());
+    }
+
+    public function testHandleWithoutId()
+    {
+        $middleware = new AddFifoStampMiddleware();
+        $envelope = new Envelope(new WithoutIdMessage());
+        $finalEnvelope = $middleware->handle($envelope, $this->getStackMock());
+        $stamp = $finalEnvelope->last(AmazonSqsFifoStamp::class);
+        $this->assertNull($stamp);
+    }
+}
+
+class WithMessageDeduplicationIdAndMessageGroupIdMessage implements MessageDeduplicationAwareInterface, MessageGroupAwareInterface
+{
+    public function __construct(
+        private string $messageGroupId,
+        private string $messageDeduplicationId,
+    ) {
+    }
+
+    public function getMessageDeduplicationId(): ?string
+    {
+        return $this->messageDeduplicationId;
+    }
+
+    public function getMessageGroupId(): ?string
+    {
+        return $this->messageGroupId;
+    }
+}
+
+class WithMessageDeduplicationIdMessage implements MessageDeduplicationAwareInterface
+{
+    public function __construct(
+        private string $messageDeduplicationId,
+    ) {
+    }
+
+    public function getMessageDeduplicationId(): ?string
+    {
+        return $this->messageDeduplicationId;
+    }
+}
+
+class WithMessageGroupIdMessage implements MessageGroupAwareInterface
+{
+    public function __construct(
+        private string $messageGroupId,
+    ) {
+    }
+
+    public function getMessageGroupId(): ?string
+    {
+        return $this->messageGroupId;
+    }
+}
+class WithoutIdMessage
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      |  no
| New feature?  | yes 
| Deprecations? |no
| License       | MIT
| Doc PR        | on my way 



Currently it is not very easy to use fifo stamp as you need to go down to the envelope when you often handle only message in your app.

We also think that the message should be responsible to choose its own groupId.

So we come with this very simple middleware and 2 interfaces. We use it in our own system since 3 months.

It allows to keep messenger concept outside our messages while continuing to benefit from it.


## Example

To group message by user for example

### Current

```php
class SmsNotification {
    public function __construct(private string $userId) {}
}
//....
    $bus->dispatch(new SmsNotification($userId), [
        new AmazonSqsFifoStamp($userId)
    ]);
```

### After

```php
class SmsNotification implements WithMessageGroupId {
    public function __construct(private string $userId) {}
    
    public function messageGroupId() 
    {
        return $this->userId;
    }
}
//....
    $bus->dispatch(new SmsNotification($userId));
```

## Usage

It can be enabled with this kind of config

```yaml
# config/packages/messenger.yaml
framework:
  messenger:
    buses:
      event_bus:
        default_middleware:
          allow_no_handlers: true
        middleware:
          - 'Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware\AddFifoStampMiddleware'
```