### PR TITLE
Fix search scope when performing fallback mapping driver detection

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -279,8 +279,8 @@ abstract class AbstractDoctrineExtension extends Extension
             }
             $container->fileExists($resource, false);
 
-            if ($container->fileExists($dir.'/'.$this->getMappingObjectDefaultName(), false)) {
-                return $this->detectMappingType($dir, $container);
+            if ($container->fileExists($discoveryPath = $dir.'/'.$this->getMappingObjectDefaultName(), false)) {
+                return $this->detectMappingType($discoveryPath, $container);
             }
 
             return null;

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Bundles/AttributesBundle/AnnotatedEntity/Person.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Bundles/AttributesBundle/AnnotatedEntity/Person.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixtures\Bundles\AttributesBundle\AnnotatedEntity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+/**
+ * @Entity
+ */
+class Person
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /** @Column(type="string") */
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->name;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

When using `auto_mapping` inside `orm` configuration to enable automatic entity registration for all bundles that are used within your application, the fallback mechanism for determining which mapping driver should be used for extracting entity information has a wrong starting point.

Instead of beginning its search from the `Entity` folder, the entire bundle root gets traversed recursively, which can lead to wrong mapping driver being selected or just plainly having a performance hit during development just because the potential list of files that need to be examined can get huge.

We actually stumbled upon this bug because we noticed a big jump in memory usage during development (`850+ MB vs ~100 MB`) ever since we switched to using attributes for describing our entities. Turns out, the `DoctrineBridge` was scanning all files inside our `Resources` folder (and we had **a lot** of files in there).
