### PR TITLE
[HttpKernel]  Resolve DateTime value using the Clock

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -55,6 +55,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('controller.argument_value_resolver', ['priority' => 100])
 
         ->set('argument_resolver.datetime', DateTimeValueResolver::class)
+            ->args([
+                service('clock')->nullOnInvalid(),
+            ])
             ->tag('controller.argument_value_resolver', ['priority' => 100])
 
         ->set('argument_resolver.request_attribute', RequestAttributeValueResolver::class)

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Deprecate parameters `container.dumper.inline_factories` and `container.dumper.inline_class_loader`, use `.container.dumper.inline_factories` and `.container.dumper.inline_class_loader` instead
  * `FileProfilerStorage` removes profiles automatically after two days
  * Add `#[HttpStatus]` for defining status codes for exceptions
+ * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 
+use Psr\Clock\ClockInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\MapDateTime;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
@@ -26,6 +27,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final class DateTimeValueResolver implements ArgumentValueResolverInterface, ValueResolverInterface
 {
+    public function __construct(
+        private readonly ?ClockInterface $clock = null,
+    ) {
+    }
+
     /**
      * @deprecated since Symfony 6.2, use resolve() instead
      */
@@ -45,12 +51,18 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface, Val
         $value = $request->attributes->get($argument->getName());
         $class = \DateTimeInterface::class === $argument->getType() ? \DateTimeImmutable::class : $argument->getType();
 
-        if ($value instanceof \DateTimeInterface) {
-            return [$value instanceof $class ? $value : $class::createFromInterface($value)];
+        if (!$value) {
+            if ($argument->isNullable()) {
+                return [null];
+            }
+            if (!$this->clock) {
+                return [new $class()];
+            }
+            $value = $this->clock->now();
         }
 
-        if ($argument->isNullable() && !$value) {
-            return [null];
+        if ($value instanceof \DateTimeInterface) {
+            return [$value instanceof $class ? $value : $class::createFromInterface($value)];
         }
 
         $format = null;
@@ -71,7 +83,7 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface, Val
                 $value = '@'.$value;
             }
             try {
-                $date = new $class($value ?? 'now');
+                $date = new $class($value);
             } catch (\Exception) {
                 $date = false;
             }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -26,6 +26,7 @@
     },
     "require-dev": {
         "symfony/browser-kit": "^5.4|^6.0",
+        "symfony/clock": "^6.2",
         "symfony/config": "^6.1",
         "symfony/console": "^5.4|^6.0",
         "symfony/css-selector": "^5.4|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

In order to mock the current time in functional test cases by injecting a `Symfony\Component\Clock\MockClock` as `clock` service. This is necessary when a `DateTimeInterface` argument is not nullable and we expect the current date time by default.

Example when 2 routes are configured on the same controller with an optional parameter.
```php
class TvGridController
{
    #[Route('/', name: 'prime_now')]
    #[Route('/{date}', name: 'prime_date']
    public function prime(\DateTimeInterface $date)
    {
        return new Response('Grid for date: '.$date->format('Y-m-d'));
    }
}
```