### PR TITLE
[Security] Remove special case for `#[IsGranted()]` subject

### DIFF
--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -92,9 +92,6 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
         }
 
         if (!\array_key_exists($subjectRef, $arguments)) {
-            if ('request' === $subjectRef) {
-                return $request;
-            }
             throw new RuntimeException(sprintf('Could not find the subject "%s" for the #[IsGranted] attribute. Try adding a "$%s" argument to your controller method.', $subjectRef, $subjectRef));
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Component\Security\Http\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\EventListener\IsGrantedAttributeListener;
 use Symfony\Component\Security\Http\Tests\Fixtures\IsGrantedAttributeController;
@@ -363,7 +363,7 @@ class IsGrantedAttributeListenerTest extends TestCase
         $listener->onKernelControllerArguments($event);
     }
 
-    public function testIsGrantedWithRequestAsSubjectAndNoArgument()
+    public function testIsGrantedWithRequestAsSubject()
     {
         $request = new Request();
 
@@ -375,33 +375,13 @@ class IsGrantedAttributeListenerTest extends TestCase
 
         $event = new ControllerArgumentsEvent(
             $this->createMock(HttpKernelInterface::class),
-            [new IsGrantedAttributeMethodsController(), 'withRequestAsSubjectAndNoArgument'],
+            [new IsGrantedAttributeMethodsController(), 'withRequestAsSubject'],
             [],
             $request,
             null
         );
 
-        $listener = new IsGrantedAttributeListener($authChecker);
-        $listener->onKernelControllerArguments($event);
-    }
-
-    public function testIsGrantedWithRequestAsSubjectAndArgument()
-    {
-        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authChecker->expects($this->once())
-            ->method('isGranted')
-            ->with('SOME_VOTER', 'foobar')
-            ->willReturn(true);
-
-        $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
-            [new IsGrantedAttributeMethodsController(), 'withRequestAsSubjectAndArgument'],
-            ['foobar'],
-            new Request(),
-            null
-        );
-
-        $listener = new IsGrantedAttributeListener($authChecker);
+        $listener = new IsGrantedAttributeListener($authChecker, new ExpressionLanguage());
         $listener->onKernelControllerArguments($event);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
@@ -63,13 +63,8 @@ class IsGrantedAttributeMethodsController
     {
     }
 
-    #[IsGranted(attribute: 'SOME_VOTER', subject: 'request')]
-    public function withRequestAsSubjectAndNoArgument()
-    {
-    }
-
-    #[IsGranted(attribute: 'SOME_VOTER', subject: 'request')]
-    public function withRequestAsSubjectAndArgument($request)
+    #[IsGranted(attribute: 'SOME_VOTER', subject: new Expression('request'))]
+    public function withRequestAsSubject()
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/48080#discussion_r1012064906
| License       | MIT
| Doc PR        | -

Addresses a comment by @stof 

Instead of having `request` as a special case, an expression can be used instead:

```diff
-#[IsGranted(attribute: 'SOME_ATTRIBUTE', subject: 'request')]
+#[IsGranted(attribute: 'SOME_ATTRIBUTE', subject: new Expression('request'))]
public function index()
{
}
```