### PR TITLE
[HttpKernel] Fix deprecation for DateTimeValueResolver with null on non-nullable argument

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
@@ -60,8 +60,6 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface
             $format = $attribute->format;
         }
 
-        $date = false;
-
         if (null !== $format) {
             $date = $class::createFromFormat($format, $value);
 
@@ -73,7 +71,7 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface
                 $value = '@'.$value;
             }
             try {
-                $date = new $class($value);
+                $date = new $class($value ?? 'now');
             } catch (\Exception) {
                 $date = false;
             }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
@@ -113,6 +113,26 @@ class DateTimeValueResolverTest extends TestCase
         $this->assertNull($results[0]);
     }
 
+    /**
+     * @dataProvider getTimeZones
+     */
+    public function testNow(string $timezone)
+    {
+        date_default_timezone_set($timezone);
+        $resolver = new DateTimeValueResolver();
+
+        $argument = new ArgumentMetadata('dummy', \DateTime::class, false, false, null, false);
+        $request = self::requestWithAttributes(['dummy' => null]);
+
+        /** @var \Generator $results */
+        $results = $resolver->resolve($request, $argument);
+        $results = iterator_to_array($results);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('0', $results[0]->diff(new \DateTimeImmutable())->format('%s'));
+        $this->assertSame($timezone, $results[0]->getTimezone()->getName(), 'Default timezone');
+    }
+
     public function testPreviouslyConvertedAttribute()
     {
         $resolver = new DateTimeValueResolver();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/48098/files#r1013918566
| License       | MIT
| Doc PR        | n/a

Remove deprecation message when the value is `null` and the controller argument is not nullable.

```
Deprecated: DateTimeImmutable::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated
```

This class have been modified in 6.2. The new test case needs to be updated.