### PR TITLE
[HttpFoundation] Compare cookie with null value as empty string in ResponseCookieValueSame

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Test/Constraint/ResponseCookieValueSame.php
+++ b/src/Symfony/Component/HttpFoundation/Test/Constraint/ResponseCookieValueSame.php
@@ -59,7 +59,7 @@ final class ResponseCookieValueSame extends Constraint
             return false;
         }
 
-        return $this->value === $cookie->getValue();
+        return $this->value === (string) $cookie->getValue();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseCookieValueSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseCookieValueSameTest.php
@@ -41,4 +41,12 @@ class ResponseCookieValueSameTest extends TestCase
 
         $this->fail();
     }
+
+    public function testCookieWithNullValueIsComparedAsEmptyString()
+    {
+        $response = new Response();
+        $response->headers->setCookie(Cookie::create('foo', null, 0, '/path'));
+
+        $this->assertTrue((new ResponseCookieValueSame('foo', '', '/path'))->evaluate($response, '', true));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/48105
| License       | MIT
| Doc PR        | -

We already consider `null` as `''` when we "compute" the cookie:
https://github.com/symfony/symfony/blob/4d4c411a609ef62dcbdfd6f309deab76a7431135/src/Symfony/Component/HttpFoundation/Cookie.php#L253

So in the related issue, `self::assertResponseCookieValueSame('SOME_COOKIE_NAME', '');` could be used. WDYT @werwolf666?