### PR TITLE
[Messenger] Do not throw 'no handlers' exception when skipping handlers due to duplicate handling

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -53,8 +53,10 @@ class HandleMessageMiddleware implements MiddlewareInterface
         ];
 
         $exceptions = [];
+        $alreadyHandled = false;
         foreach ($this->handlersLocator->getHandlers($envelope) as $handlerDescriptor) {
             if ($this->messageHasAlreadyBeenHandled($envelope, $handlerDescriptor)) {
+                $alreadyHandled = true;
                 continue;
             }
 
@@ -68,7 +70,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
             }
         }
 
-        if (null === $handler) {
+        if (null === $handler && !$alreadyHandled) {
             if (!$this->allowNoHandlers) {
                 throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', $context['class']));
             }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -123,6 +123,24 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $middleware->handle(new Envelope(new DummyMessage('Hey')), new StackMiddleware());
     }
 
+    public function testMessageAlreadyHandled()
+    {
+        $handler = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [$handler],
+        ]));
+
+        $envelope = new Envelope(new DummyMessage('Hey'));
+
+        $envelope = $middleware->handle($envelope, $this->getStackMock());
+        $handledStamp = $envelope->all(HandledStamp::class);
+
+        $envelope = $middleware->handle($envelope, $this->getStackMock());
+
+        $this->assertSame($envelope->all(HandledStamp::class), $handledStamp);
+    }
+
     public function testAllowNoHandlers()
     {
         $middleware = new HandleMessageMiddleware(new HandlersLocator([]), true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | n/a

I'm not sure if this change is expected or not, but I found this [while investigating another bug](https://github.com/wouterj/sf-reproducer/tree/messenger-star-routing in the Messenger component. When you handle the same message twice, you'll get an `NoHandlerForMessageException` because all handlers are skipped.

What would be the expected behavior? Maybe we have to throw a different exception when the same envelope is handled twice?