### PR TITLE
[Messenger] Do not return fallback senders when other senders were already found

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -52,6 +52,23 @@ class SendersLocatorTest extends TestCase
         $this->assertSame([], iterator_to_array($locator->getSenders(new Envelope(new SecondMessage()))));
     }
 
+    public function testSendersMapWithFallback()
+    {
+        $firstSender = $this->createMock(SenderInterface::class);
+        $secondSender = $this->createMock(SenderInterface::class);
+        $sendersLocator = $this->createContainer([
+            'first' => $firstSender,
+            'second' => $secondSender,
+        ]);
+        $locator = new SendersLocator([
+            DummyMessage::class => ['first'],
+            '*' => ['second'],
+        ], $sendersLocator);
+
+        $this->assertSame(['first' => $firstSender], iterator_to_array($locator->getSenders(new Envelope(new DummyMessage('a')))), 'Unexpected senders for configured message');
+        $this->assertSame(['second' => $secondSender], iterator_to_array($locator->getSenders(new Envelope(new SecondMessage()))), 'Unexpected senders for unconfigured message');
+    }
+
     private function createContainer(array $senders): ContainerInterface
     {
         $container = $this->createMock(ContainerInterface::class);

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -51,6 +51,12 @@ class SendersLocator implements SendersLocatorInterface
 
         foreach (HandlersLocator::listTypes($envelope) as $type) {
             foreach ($this->sendersMap[$type] ?? [] as $senderAlias) {
+                if (str_ends_with($type, '*') && $seen) {
+                    // the '*' acts as a fallback, if other senders already matched
+                    // with previous types, skip the senders bound to the fallback
+                    continue;
+                }
+
                 if (!\in_array($senderAlias, $seen, true)) {
                     $seen[] = $senderAlias;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | n/a

See https://github.com/wouterj/sf-reproducer/tree/messenger-star-routing for a reproducer of the current situation.

Currently, if you use the special `*` in the Messenger's routing configuration, this sender is always returned for all messages (also for messages explicitly configured to use another sender). According to the [documentation](https://symfony.com/doc/current/messenger.html#routing-messages-to-a-transport), the star should act as a fallback instead:

> You may use `'*'` as the message class. This will act as a default routing rule for any message not matched under `routing`. This is useful to ensure no message is handled synchronously by default.