### PR TITLE
[PhpUnitBridge] Fix language deprecations incorrectly marked as direct

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -139,7 +139,7 @@ class DeprecationErrorHandler
             $msg = $trace[1]['args'][0];
         }
 
-        $deprecation = new Deprecation($msg, $trace, $file);
+        $deprecation = new Deprecation($msg, $trace, $file, \E_DEPRECATED === $type);
         if ($deprecation->isMuted()) {
             return null;
         }

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -37,6 +37,7 @@ class Deprecation
 
     private $trace = [];
     private $message;
+    private $languageDeprecation;
     private $originClass;
     private $originMethod;
     private $triggeringFile;
@@ -56,11 +57,13 @@ class Deprecation
     /**
      * @param string $message
      * @param string $file
+     * @param bool   $languageDeprecation
      */
-    public function __construct($message, array $trace, $file)
+    public function __construct($message, array $trace, $file, $languageDeprecation = false)
     {
         $this->trace = $trace;
         $this->message = $message;
+        $this->languageDeprecation = $languageDeprecation;
 
         $i = \count($trace);
         while (1 < $i && $this->lineShouldBeSkipped($trace[--$i])) {
@@ -227,7 +230,12 @@ class Deprecation
      */
     public function getType()
     {
-        if (self::PATH_TYPE_SELF === $pathType = $this->getPathType($this->triggeringFile)) {
+        $pathType = $this->getPathType($this->triggeringFile);
+        if ($this->languageDeprecation && self::PATH_TYPE_VENDOR === $pathType) {
+            // the triggering file must be used for language deprecations
+            return self::TYPE_INDIRECT;
+        }
+        if (self::PATH_TYPE_SELF === $pathType) {
             return self::TYPE_SELF;
         }
         if (self::PATH_TYPE_UNDETERMINED === $pathType) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor/acme/lib/PhpDeprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor/acme/lib/PhpDeprecation.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace acme\lib;
+
+class PhpDeprecation implements \Serializable
+{
+    public function serialize(): string
+    {
+        return serialize([]);
+    }
+
+    public function unserialize($data): void
+    {
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/php_deprecation_from_vendor_class.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/php_deprecation_from_vendor_class.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test that a PHP deprecation from a vendor class autoload is considered indirect.
+--SKIPIF--
+<?php if (\PHP_VERSION_ID < 80100) echo 'skip'; ?>
+--FILE--
+<?php
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'max[total]=0');
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+eval(<<<'EOPHP'
+namespace PHPUnit\Util;
+
+class Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+EOPHP
+);
+require __DIR__.'/fake_vendor/autoload.php';
+
+\Symfony\Component\ErrorHandler\DebugClassLoader::enable();
+new \acme\lib\PhpDeprecation();
+
+?>
+--EXPECTF--
+Remaining indirect deprecation notices (1)
+
+  1x: acme\lib\PhpDeprecation implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
+    1x in DebugClassLoader::loadClass from Symfony\Component\ErrorHandler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When using a vendor class that has a language deprecation (e.g. missing `__serialize` methods), these deprecations were incorrectly considered "direct".