### PR TITLE
[Mailer] Include all transports' debug messages in RoundRobin transport exception 

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mailer\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Transport\RoundRobinTransport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\RawMessage;
@@ -60,10 +61,21 @@ class RoundRobinTransportTest extends TestCase
         $t2 = $this->createMock(TransportInterface::class);
         $t2->expects($this->once())->method('send')->will($this->throwException(new TransportException()));
         $t = new RoundRobinTransport([$t1, $t2]);
-        $this->expectException(TransportException::class);
-        $this->expectExceptionMessage('All transports failed.');
-        $t->send(new RawMessage(''));
-        $this->assertTransports($t, 1, [$t1, $t2]);
+        $p = new \ReflectionProperty($t, 'cursor');
+        $p->setAccessible(true);
+        $p->setValue($t, 0);
+
+        try {
+            $t->send(new RawMessage(''));
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(TransportException::class, $e);
+            $this->assertStringContainsString('All transports failed.', $e->getMessage());
+            $this->assertTransports($t, 0, [$t1, $t2]);
+
+            return;
+        }
+
+        $this->fail('The expected exception was not thrown.');
     }
 
     public function testSendOneDead()
@@ -125,6 +137,34 @@ class RoundRobinTransportTest extends TestCase
         $this->assertTransports($t, 0, []);
         $t->send(new RawMessage(''));
         $this->assertTransports($t, 1, []);
+    }
+
+    public function testFailureDebugInformation()
+    {
+        $t1 = $this->createMock(TransportInterface::class);
+        $e1 = new TransportException();
+        $e1->appendDebug('Debug message 1');
+        $t1->expects($this->once())->method('send')->will($this->throwException($e1));
+        $t1->expects($this->once())->method('__toString')->willReturn('t1');
+
+        $t2 = $this->createMock(TransportInterface::class);
+        $e2 = new TransportException();
+        $e2->appendDebug('Debug message 2');
+        $t2->expects($this->once())->method('send')->will($this->throwException($e2));
+        $t2->expects($this->once())->method('__toString')->willReturn('t2');
+
+        $t = new RoundRobinTransport([$t1, $t2]);
+
+        try {
+            $t->send(new RawMessage(''));
+        } catch (TransportExceptionInterface $e) {
+            $this->assertStringContainsString('Transport "t1": Debug message 1', $e->getDebug());
+            $this->assertStringContainsString('Transport "t2": Debug message 2', $e->getDebug());
+
+            return;
+        }
+
+        $this->fail('Expected exception was not thrown!');
     }
 
     private function assertTransports(RoundRobinTransport $transport, int $cursor, array $deadTransports)

--- a/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
@@ -48,15 +48,19 @@ class RoundRobinTransport implements TransportInterface
 
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
+        $exception = null;
+
         while ($transport = $this->getNextTransport()) {
             try {
                 return $transport->send($message, $envelope);
             } catch (TransportExceptionInterface $e) {
+                $exception = $exception ?? new TransportException('All transports failed.');
+                $exception->appendDebug(sprintf("Transport \"%s\": %s\n", $transport, $e->getDebug()));
                 $this->deadTransports[$transport] = microtime(true);
             }
         }
 
-        throw new TransportException('All transports failed.');
+        throw $exception ?? new TransportException('No transports found.');
     }
 
     public function __toString(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?|      5.4
| Bug fix? |     yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

### Description
The RoundRobin Mail transport does not include inner transports' debug messages in case of failure, which makes it very difficult to reason about the failures.

This PR attempts to add that debug information to the thrown TransportException.

In the process of fixing this issue, I discovered that one of the existing tests is incorrect. The last assertion is never executed and the test passes regardless of the assertion state. The test was also fixed.

Note that although this issue exists in https://github.com/symfony/symfony/tree/5.0, I wasn't able to apply the same patch to it since the behavior of the transport (specifically the cursor property) was different. I can open a new PR to fix the same issue for that branch as well.
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
