### PR TITLE
Add request route event to allow listening to specific route

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/RequestRouteEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/RequestRouteEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Allows to create a dedicated response for a specific request route.
+ *
+ * Call setResponse() to set the response that will be returned for the
+ * current request. The propagation of this event is stopped as soon as a
+ * response is set.
+ *
+ * @author Antoine Makdessi <amakdessi@me.com>
+ */
+class RequestRouteEvent extends RequestEvent
+{
+    public function getRouteName(): string
+    {
+        return $this->getRequest()->attributes->get('_route');
+    }
+}

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\RequestRouteEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
@@ -137,6 +138,14 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         // request
         $event = new RequestEvent($this, $request, $type);
         $this->dispatcher->dispatch($event, KernelEvents::REQUEST);
+
+        if ($event->hasResponse()) {
+            return $this->filterResponse($event->getResponse(), $request, $type);
+        }
+
+        // request route
+        $event = new RequestRouteEvent($this, $request, $type);
+        $this->dispatcher->dispatch($event, KernelEvents::REQUEST_ROUTE);
 
         if ($event->hasResponse()) {
             return $this->filterResponse($event->getResponse(), $request, $type);

--- a/src/Symfony/Component/HttpKernel/KernelEvents.php
+++ b/src/Symfony/Component/HttpKernel/KernelEvents.php
@@ -39,6 +39,16 @@ final class KernelEvents
     public const REQUEST = 'kernel.request';
 
     /**
+     * The REQUEST_ROUTE event occurs after the request route has been matched and found.
+     *
+     * This event allows you to create a dedicated response for a specific request route
+     * before any other code in the framework is executed.
+     *
+     * @Event("Symfony\Component\HttpKernel\Event\RequestRouteEvent")
+     */
+    public const REQUEST_ROUTE = 'kernel.request_route';
+
+    /**
      * The EXCEPTION event occurs when an uncaught exception appears.
      *
      * This event allows you to create a response for a thrown exception or


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes (changelog tbd) <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/45439
| License       | MIT
| Doc PR        | (doc tbw)

Hi, small PR attempt to gather some comments around the linked issue, that when browsing I also had the same need on some of my apps so give it a chance.

Please, first may you read the 2 benefits of the ticket.

I've implemented the easiest way to hook into the http kernel event flow, without adding dedicated event like the [workflow](https://symfony.com/doc/current/workflow.html#using-events) but for route, by mimic the ControllerArgumentsEvent dispatch dispatched below.

If accepted, I can continue working on code/test/doc etc for 6.3.
Otherwise please feel free to close the PR and perhaps the related issue :)
