### PR TITLE
[Security][SecurityBundle] User authorization checker

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add `Security::userIsGranted()` to test user authorization without relying on the session. For example, users not currently logged in, or while processing a message from a message queue
+
 7.2
 ---
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -31,6 +31,8 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
+use Symfony\Component\Security\Core\Authorization\UserAuthorizationChecker;
+use Symfony\Component\Security\Core\Authorization\UserAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\ExpressionVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\RoleHierarchyVoter;
@@ -67,6 +69,12 @@ return static function (ContainerConfigurator $container) {
             ])
         ->alias(AuthorizationCheckerInterface::class, 'security.authorization_checker')
 
+        ->set('security.user_authorization_checker', UserAuthorizationChecker::class)
+            ->args([
+                service('security.access.decision_manager'),
+            ])
+        ->alias(UserAuthorizationCheckerInterface::class, 'security.user_authorization_checker')
+
         ->set('security.token_storage', UsageTrackingTokenStorage::class)
             ->args([
                 service('security.untracked_token_storage'),
@@ -85,6 +93,7 @@ return static function (ContainerConfigurator $container) {
                 service_locator([
                     'security.token_storage' => service('security.token_storage'),
                     'security.authorization_checker' => service('security.authorization_checker'),
+                    'security.user_authorization_checker' => service('security.user_authorization_checker'),
                     'security.authenticator.managers_locator' => service('security.authenticator.managers_locator')->ignoreOnInvalid(),
                     'request_stack' => service('request_stack'),
                     'security.firewall.map' => service('security.firewall.map'),

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -13,20 +13,27 @@ namespace Symfony\Bundle\SecurityBundle;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\UserAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\FirewallMapInterface;
 use Symfony\Component\Security\Http\ParameterBagUtils;
 use Symfony\Contracts\Service\ServiceProviderInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
 /**
  * Helper class for commonly-needed security tasks.
@@ -37,7 +44,7 @@ use Symfony\Contracts\Service\ServiceProviderInterface;
  *
  * @final
  */
-class Security implements AuthorizationCheckerInterface
+class Security implements AuthorizationCheckerInterface, ServiceSubscriberInterface, UserAuthorizationCheckerInterface
 {
     public function __construct(
         private readonly ContainerInterface $container,
@@ -148,6 +155,17 @@ class Security implements AuthorizationCheckerInterface
         return $logoutEvent->getResponse();
     }
 
+    /**
+     * Checks if the attribute is granted against the user and optionally supplied subject.
+     *
+     * This should be used over isGranted() when checking permissions against a user that is not currently logged in or while in a CLI context.
+     */
+    public function userIsGranted(UserInterface $user, mixed $attribute, mixed $subject = null): bool
+    {
+        return $this->container->get('security.user_authorization_checker')
+            ->userIsGranted($user, $attribute, $subject);
+    }
+
     private function getAuthenticator(?string $authenticatorName, string $firewallName): AuthenticatorInterface
     {
         if (!isset($this->authenticators[$firewallName])) {
@@ -181,5 +199,20 @@ class Security implements AuthorizationCheckerInterface
         }
 
         return $firewallAuthenticatorLocator->get($authenticatorId);
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            'security.token_storage' => TokenStorageInterface::class,
+            'security.authorization_checker' => AuthorizationCheckerInterface::class,
+            'security.user_authorization_checker' => UserAuthorizationCheckerInterface::class,
+            'security.authenticator.managers_locator' => '?'.ServiceProviderInterface::class,
+            'request_stack' => RequestStack::class,
+            'security.firewall.map' => FirewallMapInterface::class,
+            'security.user_checker' => UserCheckerInterface::class,
+            'security.firewall.event_dispatcher_locator' => ServiceLocator::class,
+            'security.csrf.token_manager' => '?'.CsrfTokenManagerInterface::class,
+        ];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",
         "symfony/password-hasher": "^6.4|^7.0",
-        "symfony/security-core": "^7.2",
+        "symfony/security-core": "^7.3",
         "symfony/security-csrf": "^6.4|^7.0",
         "symfony/security-http": "^7.2",
         "symfony/service-contracts": "^2.5|^3"

--- a/src/Symfony/Component/Security/Core/Authentication/Token/OfflineTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/OfflineTokenInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * Interface used for marking tokens that do not represent the currently logged-in user.
+ *
+ * @author Nate Wiebe <nate@northern.co>
+ */
+interface OfflineTokenInterface extends TokenInterface
+{
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UserAuthorizationCheckerToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UserAuthorizationCheckerToken.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * UserAuthorizationCheckerToken implements a token used for checking authorization.
+ *
+ * @author Nate Wiebe <nate@northern.co>
+ *
+ * @internal
+ */
+final class UserAuthorizationCheckerToken extends AbstractToken implements OfflineTokenInterface
+{
+    public function __construct(UserInterface $user)
+    {
+        parent::__construct($user->getRoles());
+
+        $this->setUser($user);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationChecker.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+use Symfony\Component\Security\Core\Authentication\Token\UserAuthorizationCheckerToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author Nate Wiebe <nate@northern.co>
+ */
+final class UserAuthorizationChecker implements UserAuthorizationCheckerInterface
+{
+    public function __construct(
+        private readonly AccessDecisionManagerInterface $accessDecisionManager,
+    ) {
+    }
+
+    public function userIsGranted(UserInterface $user, mixed $attribute, mixed $subject = null): bool
+    {
+        return $this->accessDecisionManager->decide(new UserAuthorizationCheckerToken($user), [$attribute], $subject);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationCheckerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Interface is used to check user authorization without a session.
+ *
+ * @author Nate Wiebe <nate@northern.co>
+ */
+interface UserAuthorizationCheckerInterface
+{
+    /**
+     * Checks if the attribute is granted against the user and optionally supplied subject.
+     *
+     * @param mixed $attribute A single attribute to vote on (can be of any type, string and instance of Expression are supported by the core)
+     */
+    public function userIsGranted(UserInterface $user, mixed $attribute, mixed $subject = null): bool;
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Security\Core\Authorization\Voter;
 
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
+use Symfony\Component\Security\Core\Authentication\Token\OfflineTokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 
 /**
  * AuthenticatedVoter votes if an attribute like IS_AUTHENTICATED_FULLY,
@@ -52,6 +54,10 @@ class AuthenticatedVoter implements CacheableVoterInterface
                     && self::IS_IMPERSONATOR !== $attribute
                     && self::IS_REMEMBERED !== $attribute)) {
                 continue;
+            }
+
+            if ($token instanceof OfflineTokenInterface) {
+                throw new InvalidArgumentException('Cannot decide on authentication attributes when an offline token is used.');
             }
 
             $result = VoterInterface::ACCESS_DENIED;

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add `UserAuthorizationChecker::userIsGranted()` to test user authorization without relying on the session.
+   For example, users not currently logged in, or while processing a message from a message queue.
+ * Add `OfflineTokenInterface` to mark tokens that do not represent the currently logged-in user
+
 7.2
 ---
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UserAuthorizationCheckerTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UserAuthorizationCheckerTokenTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UserAuthorizationCheckerToken;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+class UserAuthorizationCheckerTokenTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $token = new UserAuthorizationCheckerToken($user = new InMemoryUser('foo', 'bar', ['ROLE_FOO']));
+        $this->assertSame(['ROLE_FOO'], $token->getRoleNames());
+        $this->assertSame($user, $token->getUser());
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/UserAuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/UserAuthorizationCheckerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authorization;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UserAuthorizationCheckerToken;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\UserAuthorizationChecker;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+class UserAuthorizationCheckerTest extends TestCase
+{
+    private AccessDecisionManagerInterface&MockObject $accessDecisionManager;
+    private UserAuthorizationChecker $authorizationChecker;
+
+    protected function setUp(): void
+    {
+        $this->accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+
+        $this->authorizationChecker = new UserAuthorizationChecker($this->accessDecisionManager);
+    }
+
+    /**
+     * @dataProvider isGrantedProvider
+     */
+    public function testIsGranted(bool $decide, array $roles)
+    {
+        $user = new InMemoryUser('username', 'password', $roles);
+
+        $this->accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($this->callback(fn (UserAuthorizationCheckerToken $token): bool => $user === $token->getUser()), $this->identicalTo(['ROLE_FOO']))
+            ->willReturn($decide);
+
+        $this->assertSame($decide, $this->authorizationChecker->userIsGranted($user, 'ROLE_FOO'));
+    }
+
+    public static function isGrantedProvider(): array
+    {
+        return [
+            [false, ['ROLE_USER']],
+            [true, ['ROLE_USER', 'ROLE_FOO']],
+        ];
+    }
+
+    public function testIsGrantedWithObjectAttribute()
+    {
+        $attribute = new \stdClass();
+
+        $token = new UserAuthorizationCheckerToken(new InMemoryUser('username', 'password', ['ROLE_USER']));
+
+        $this->accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($this->isInstanceOf($token::class), $this->identicalTo([$attribute]))
+            ->willReturn(true);
+        $this->assertTrue($this->authorizationChecker->userIsGranted($token->getUser(), $attribute));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #43372
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18033

`isGranted()` assumes that it's checking against the currently logged in user. This provides the same functionality to check against a user during times when there isn't a session (cronjobs/commands, message queue, etc.) or for a different user than the one logged in.

Having this functionality allows for removing the dependency on sessions entirely for services reducing the number of issues that come up during a project because some underlying function was session dependent.