### PR TITLE
[DependencyInjection] Add `env` and `param` parameters for Autowire attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
@@ -28,17 +28,21 @@ class Autowire
     /**
      * Use only ONE of the following.
      *
-     * @param string|null $value      Parameter value (ie "%kernel.project_dir%/some/path")
-     * @param string|null $service    Service ID (ie "some.service")
-     * @param string|null $expression Expression (ie 'service("some.service").someMethod()')
+     * @param string|array|null $value      Parameter value (ie "%kernel.project_dir%/some/path")
+     * @param string|null       $service    Service ID (ie "some.service")
+     * @param string|null       $expression Expression (ie 'service("some.service").someMethod()')
+     * @param string|null       $env        Environment variable name (ie 'SOME_ENV_VARIABLE')
+     * @param string|null       $param      Parameter name (ie 'some.parameter.name')
      */
     public function __construct(
         string|array $value = null,
         string $service = null,
         string $expression = null,
+        string $env = null,
+        string $param = null,
     ) {
-        if (!($service xor $expression xor null !== $value)) {
-            throw new LogicException('#[Autowire] attribute must declare exactly one of $service, $expression, or $value.');
+        if (!(null !== $value xor null !== $service xor null !== $expression xor null !== $env xor null !== $param)) {
+            throw new LogicException('#[Autowire] attribute must declare exactly one of $service, $expression, $env, $param or $value.');
         }
 
         if (\is_string($value) && str_starts_with($value, '@')) {
@@ -52,6 +56,8 @@ class Autowire
         $this->value = match (true) {
             null !== $service => new Reference($service),
             null !== $expression => class_exists(Expression::class) ? new Expression($expression) : throw new LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed. Try running "composer require symfony/expression-language".'),
+            null !== $env => "%env($env)%",
+            null !== $param => "%$param%",
             null !== $value => $value,
         };
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
@@ -19,11 +19,14 @@ use Symfony\Component\ExpressionLanguage\Expression;
 
 class AutowireTest extends TestCase
 {
-    public function testCanOnlySetOneParameter()
+    /**
+     * @dataProvider provideMultipleParameters
+     */
+    public function testCanOnlySetOneParameter(array $parameters)
     {
         $this->expectException(LogicException::class);
 
-        new Autowire(service: 'id', expression: 'expr');
+        new Autowire(...$parameters);
     }
 
     public function testMustSetOneParameter()
@@ -56,5 +59,27 @@ class AutowireTest extends TestCase
     public function testCanUseValueWithAtAndEqualSign()
     {
         $this->assertInstanceOf(Expression::class, (new Autowire(value: '@=service'))->value);
+    }
+
+    public function testCanUseEnv()
+    {
+        $this->assertSame('%env(SOME_ENV_VAR)%', (new Autowire(env: 'SOME_ENV_VAR'))->value);
+    }
+
+    public function testCanUseParam()
+    {
+        $this->assertSame('%some.param%', (new Autowire(param: 'some.param'))->value);
+    }
+
+    /**
+     * @see testCanOnlySetOneParameter
+     */
+    private function provideMultipleParameters(): iterable
+    {
+        yield [['service' => 'id', 'expression' => 'expr']];
+
+        yield [['env' => 'ENV', 'param' => 'param']];
+
+        yield [['value' => 'some-value', 'expression' => 'expr']];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

These parameters will help not to miss `%` when auto-wiring the env variable or parameter.
