### PR TITLE
[Mime] When serializing File parts convert to string to allow proper unserialization

### DIFF
--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -218,7 +218,7 @@ class TextPart extends AbstractPart
     public function __sleep(): array
     {
         // convert resources to strings for serialization
-        if (null !== $this->seekable) {
+        if (null !== $this->seekable || $this->body instanceof File) {
             $this->body = $this->getBody();
             $this->seekable = null;
         }

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -483,6 +483,7 @@ class EmailTest extends TestCase
         $name = __DIR__.'/Fixtures/mimetypes/test';
         $file = fopen($name, 'r');
         $e->addPart(new DataPart($file, 'test'));
+        $e->attachFromPath($name, 'same_test');
         $expected = clone $e;
         $n = unserialize(serialize($e));
         $this->assertEquals($expected->getHeaders(), $n->getHeaders());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47991
| License       | MIT

I took a stab at #47991. I found an existing serialization test and added the missing case, for regression purposes.

The bug was a `\BadMethodCallException` thrown in `\Symfony\Component\Mime\Part\DataPart::__wakeup` when it would encounter a `File` instance instead of a `string`.

My fix comes with the implication that, when serializing a `TextPart` with a `File`, it will read and serialize the content of the file, discarding the `File` instance in the process. The assumption being that the machine producing a serialized message might not be the machine consuming that message.