### PR TITLE
[Serializer] Add encoder option for saving options

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `XmlEncoder::SAVE_OPTIONS` context option
+
 6.2
 ---
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -44,9 +44,15 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     public const FORMAT_OUTPUT = 'xml_format_output';
 
     /**
-     * A bit field of LIBXML_* constants.
+     * A bit field of LIBXML_* constants for loading XML documents.
      */
     public const LOAD_OPTIONS = 'load_options';
+
+    /**
+     * A bit field of LIBXML_* constants for saving XML documents.
+     */
+    public const SAVE_OPTIONS = 'save_options';
+
     public const REMOVE_EMPTY_TAGS = 'remove_empty_tags';
     public const ROOT_NODE_NAME = 'xml_root_node_name';
     public const STANDALONE = 'xml_standalone';
@@ -58,6 +64,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::DECODER_IGNORED_NODE_TYPES => [\XML_PI_NODE, \XML_COMMENT_NODE],
         self::ENCODER_IGNORED_NODE_TYPES => [],
         self::LOAD_OPTIONS => \LIBXML_NONET | \LIBXML_NOBLANKS,
+        self::SAVE_OPTIONS => 0,
         self::REMOVE_EMPTY_TAGS => false,
         self::ROOT_NODE_NAME => 'response',
         self::TYPE_CAST_ATTRIBUTES => true,
@@ -88,7 +95,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             $this->appendNode($dom, $data, $format, $context, $xmlRootNodeName);
         }
 
-        return $dom->saveXML($ignorePiNode ? $dom->documentElement : null);
+        return $dom->saveXML($ignorePiNode ? $dom->documentElement : null, $context[self::SAVE_OPTIONS] ?? $this->defaultContext[self::SAVE_OPTIONS]);
     }
 
     public function decode(string $data, string $format, array $context = []): mixed

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -189,12 +189,13 @@ class XmlEncoderTest extends TestCase
 
     public function testContext()
     {
-        $array = ['person' => ['name' => 'George Abitbol']];
+        $array = ['person' => ['name' => 'George Abitbol', 'age' => null]];
         $expected = <<<'XML'
 <?xml version="1.0"?>
 <response>
   <person>
     <name>George Abitbol</name>
+    <age></age>
   </person>
 </response>
 
@@ -202,6 +203,7 @@ XML;
 
         $context = [
             'xml_format_output' => true,
+            'save_options' => \LIBXML_NOEMPTYTAG,
         ];
 
         $this->assertSame($expected, $this->encoder->encode($array, 'xml', $context));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | symfony/symfony-docs#17418

This changes add a new `SAVE_OPTIONS` to `XmlEncoder`. This new option is the counterpart to the `LOAD_OPTIONS`.