### PR TITLE
[Security] Remove extra call to check if Session exists

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -97,7 +97,7 @@ class ProfilerListener implements EventSubscriberInterface
             return;
         }
 
-        $session = $request->hasPreviousSession() && $request->hasSession() ? $request->getSession() : null;
+        $session = $request->hasPreviousSession() ? $request->getSession() : null;
 
         if ($session instanceof Session) {
             $usageIndexValue = $usageIndexReference = &$session->getUsageIndex();

--- a/src/Symfony/Component/Security/Http/EventListener/SessionStrategyListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/SessionStrategyListener.php
@@ -39,7 +39,7 @@ class SessionStrategyListener implements EventSubscriberInterface
         $request = $event->getRequest();
         $token = $event->getAuthenticatedToken();
 
-        if (!$request->hasSession() || !$request->hasPreviousSession()) {
+        if (!$request->hasPreviousSession()) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -87,7 +87,7 @@ class ContextListener extends AbstractListener
         }
 
         $request = $event->getRequest();
-        $session = $request->hasPreviousSession() && $request->hasSession() ? $request->getSession() : null;
+        $session = $request->hasPreviousSession() ? $request->getSession() : null;
 
         $request->attributes->set('_security_firewall_run', $this->sessionKey);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 (6.3 not exists yet)
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

While debugging Security Firewall I found that Symfony check the condition `$request->hasPreviousSession() && $request->hasSession()`. 
Then I deep to `\Symfony\Component\HttpFoundation\Request::hasPreviousSession` and saw that the method already checked `hasSession` condition:
```php
/**
     * Whether the request contains a Session which was started in one of the
     * previous requests.
     */
public function hasPreviousSession(): bool
    {
        // the check for $this->session avoids malicious users trying to fake a session cookie with proper name
        return $this->hasSession() && $this->cookies->has($this->getSession()->getName());
    }
```
===

Also already exists one place where only `hasPreviousSession` of condition checked `\Symfony\Component\Security\Http\EventListener\SessionStrategyListener::onSuccessfulLogin`
```php
public function onSuccessfulLogin(LoginSuccessEvent $event): void
    {
        $request = $event->getRequest();
        $token = $event->getAuthenticatedToken();

        if (!$request->hasPreviousSession()) {
            return;
        }

        $this->sessionAuthenticationStrategy->onAuthentication($request, $token);
    }
```
I think we can remove extra call to get some performance.