### PR TITLE
[Routing] Make sure enums don't confuse the PSR-4 loader

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/IrrelevantEnum.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Psr4Controllers/SubNamespace/IrrelevantEnum.php
@@ -11,6 +11,14 @@
 
 namespace Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\SubNamespace;
 
-interface IrrelevantInterface
+/**
+ * An irrelevant enum.
+ *
+ * This fixture is not referenced anywhere. Its presence makes sure, enums are silently ignored when loading routes
+ * from a directory.
+ */
+enum IrrelevantEnum
 {
+    case Foo;
+    case Bar;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/48170#issuecomment-1308747883
| License       | MIT
| Doc PR        | N/A