### PR TITLE
[Console] Support completion for bash functions

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.bash
+++ b/src/Symfony/Component/Console/Resources/completion.bash
@@ -11,13 +11,14 @@ _sf_{{ COMMAND_NAME }}() {
     local sf_cmd="${COMP_WORDS[0]}"
 
     # for an alias, get the real script behind it
-    if [[ $(type -t $sf_cmd) == "alias" ]]; then
+    sf_cmd_type=$(type -t $sf_cmd)
+    if [[ $sf_cmd_type == "alias" ]]; then
         sf_cmd=$(alias $sf_cmd | sed -E "s/alias $sf_cmd='(.*)'/\1/")
-    else
+    elif [[ $sf_cmd_type == "file" ]]; then
         sf_cmd=$(type -p $sf_cmd)
     fi
 
-    if [ ! -x "$sf_cmd" ]; then
+    if [[ $sf_cmd_type != "function" && ! -x $sf_cmd ]]; then
         return 1
     fi
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 6.2
| Bug fix?      | no
| New feature  | yes
| Deprecations | no
| License       | MIT

I often use bash functions as wrappers for executable files that live in vendor/bin. So that they can be executed from any location within a project. Symfony Console has recently added support for Bash completions but right now that only applies to executable files and aliases. This PR adds support for Bash functions.

