### PR TITLE
[Form] Fix getter access on submit when setter callback is not used

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/DataMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/DataMapper.php
@@ -31,7 +31,7 @@ class DataMapper implements DataMapperInterface
     {
         $this->dataAccessor = $dataAccessor ?? new ChainAccessor([
             new CallbackAccessor(),
-            new PropertyPathAccessor(),
+            new PropertyPathAccessor(null, function () { return $this->dataAccessor; }),
         ]);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -23,7 +23,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Translation\TranslatableMessage;
 
@@ -33,9 +32,9 @@ class FormType extends BaseType
 
     public function __construct(PropertyAccessorInterface $propertyAccessor = null)
     {
-        $this->dataMapper = new DataMapper(new ChainAccessor([
+        $this->dataMapper = new DataMapper($chainAccessor = new ChainAccessor([
             new CallbackAccessor(),
-            new PropertyPathAccessor($propertyAccessor ?? PropertyAccess::createPropertyAccessor()),
+            new PropertyPathAccessor($propertyAccessor, static function () use (&$chainAccessor) { return $chainAccessor; }),
         ]));
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\DataAccessor\PropertyPathAccessor;
 use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\FormFactoryBuilder;
@@ -393,6 +394,22 @@ class DataMapperTest extends TestCase
         self::assertSame('Jane Doe', $person->myName());
     }
 
+    public function testSubmitWithGetterCallbackAndPropertyPathAccessor()
+    {
+        $person = new DummyPerson('John Doe');
+        $form = (new FormFactoryBuilder())->getFormFactory()->createBuilder(FormType::class, $person)
+            ->add('name', null, [
+                'getter' => static function (DummyPerson $person) {
+                    return $person->myName();
+                },
+            ])
+            ->getForm();
+
+        $form->submit(['name' => 'Jane Doe']);
+
+        self::assertSame('Jane Doe', $person->myName());
+    }
+
     public function testMapFormsToDataMapsDateTimeInstanceToArrayIfNotSetBefore()
     {
         $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
@@ -452,6 +469,11 @@ class DummyPerson
     }
 
     public function rename($name): void
+    {
+        $this->name = $name;
+    }
+
+    public function setName(string $name): void
     {
         $this->name = $name;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48167
| License       | MIT
| Doc PR        | -

This fix ensures that each data accessor remains unaware of the other while it calls the proper `getValue()` method depending on the accessor's priority (CallbackAccessor first, then PropertyPathAccessor) and whether the `getter` option is being used or not.

Test-case added.

ping @curry684 this is a 3rd alternative to keep it simple.