### PR TITLE
[Clock] Provide `modify()` in MockClock

### DIFF
--- a/src/Symfony/Component/Clock/MockClock.php
+++ b/src/Symfony/Component/Clock/MockClock.php
@@ -47,6 +47,15 @@ final class MockClock implements ClockInterface
         $this->now = (new \DateTimeImmutable($now, $timezone))->setTimezone($timezone);
     }
 
+    public function modify(string $modifier): void
+    {
+        if (false === $modifiedNow = @$this->now->modify($modifier)) {
+            throw new \InvalidArgumentException(sprintf('Invalid modifier: "%s". Could not modify MockClock.', $modifier));
+        }
+
+        $this->now = $modifiedNow;
+    }
+
     public function withTimeZone(\DateTimeZone|string $timezone): static
     {
         $clone = clone $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


This is mostly for DX, especially when handling longer sleep periods and when having to change the time multiple times on a single MockClock-instance, e.g. when using a service from a booted kernel in functional tests.

This PR provides a way to modify the MockClock's current time by specifying either a relative string like "+2 days", which will forward the current clock-time by 2 days, or an absolute datetime like "2112-09-17 23:53:03". It uses [`DateTimeImmutable::modify()`](https://www.php.net/manual/en/datetimeimmutable.modify.php) and supports the same modifiers.

Example usage comparison between the already available sleep and modify:

```
$this->clock->sleep(172800); # 172800seconds = 48h

$this->clock->modify('48 hours');
```