### PR TITLE
[Messenger] Fix time-limit check exception

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -179,7 +179,7 @@ EOF
         }
 
         if (null !== ($timeLimit = $input->getOption('time-limit'))) {
-            if (!is_numeric($timeLimit) || 0 >= $limit) {
+            if (!is_numeric($timeLimit) || 0 >= $timeLimit) {
                 throw new InvalidOptionException(sprintf('Option "time-limit" must be a positive integer, "%s" passed.', $timeLimit));
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #48196  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


Check on `time-limit` was invalid.

(Unrelated fabbot failure)