### PR TITLE
[Security] Allow custom user identifier for X509 authenticator

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/X509Factory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/X509Factory.php
@@ -36,6 +36,7 @@ class X509Factory implements AuthenticatorFactoryInterface
             ->replaceArgument(2, $firewallName)
             ->replaceArgument(3, $config['user'])
             ->replaceArgument(4, $config['credentials'])
+            ->replaceArgument(6, $config['user_identifier'])
         ;
 
         return $authenticatorId;
@@ -58,6 +59,7 @@ class X509Factory implements AuthenticatorFactoryInterface
                 ->scalarNode('provider')->end()
                 ->scalarNode('user')->defaultValue('SSL_CLIENT_S_DN_Email')->end()
                 ->scalarNode('credentials')->defaultValue('SSL_CLIENT_S_DN')->end()
+                ->scalarNode('user_identifier')->defaultValue('emailAddress')->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -149,6 +149,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('user key'),
                 abstract_arg('credentials key'),
                 service('logger')->nullOnInvalid(),
+                abstract_arg('credentials user identifier'),
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
 

--- a/src/Symfony/Component/Security/Http/Authenticator/X509Authenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/X509Authenticator.php
@@ -30,13 +30,15 @@ class X509Authenticator extends AbstractPreAuthenticatedAuthenticator
 {
     private string $userKey;
     private string $credentialsKey;
+    private string $credentialUserIdentifier;
 
-    public function __construct(UserProviderInterface $userProvider, TokenStorageInterface $tokenStorage, string $firewallName, string $userKey = 'SSL_CLIENT_S_DN_Email', string $credentialsKey = 'SSL_CLIENT_S_DN', LoggerInterface $logger = null)
+    public function __construct(UserProviderInterface $userProvider, TokenStorageInterface $tokenStorage, string $firewallName, string $userKey = 'SSL_CLIENT_S_DN_Email', string $credentialsKey = 'SSL_CLIENT_S_DN', LoggerInterface $logger = null, string $credentialUserIdentifier = 'emailAddress')
     {
         parent::__construct($userProvider, $tokenStorage, $firewallName, $logger);
 
         $this->userKey = $userKey;
         $this->credentialsKey = $credentialsKey;
+        $this->credentialUserIdentifier = $credentialUserIdentifier;
     }
 
     protected function extractUsername(Request $request): string
@@ -46,13 +48,13 @@ class X509Authenticator extends AbstractPreAuthenticatedAuthenticator
             $username = $request->server->get($this->userKey);
         } elseif (
             $request->server->has($this->credentialsKey)
-            && preg_match('#emailAddress=([^,/@]++@[^,/]++)#', $request->server->get($this->credentialsKey), $matches)
+            && preg_match('#'.preg_quote($this->credentialUserIdentifier, '#').'=([^,/]++)#', $request->server->get($this->credentialsKey), $matches)
         ) {
-            $username = $matches[1];
+            $username = trim($matches[1]);
         }
 
         if (null === $username) {
-            throw new BadCredentialsException(sprintf('SSL credentials not found: %s, %s', $this->userKey, $this->credentialsKey));
+            throw new BadCredentialsException(sprintf('SSL credentials not found: "%s", "%s".', $this->userKey, $this->credentialsKey));
         }
 
         return $username;

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/X509AuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/X509AuthenticatorTest.php
@@ -120,6 +120,35 @@ class X509AuthenticatorTest extends TestCase
         $this->assertEquals('cert@example.com', $passport->getUser()->getUserIdentifier());
     }
 
+    /**
+     * @dataProvider provideServerVarsUserIdentifier
+     */
+    public function testAuthenticationCustomCredentialsUserIdentifier($username, $credentials)
+    {
+        $authenticator = new X509Authenticator($this->userProvider, new TokenStorage(), 'main', 'SSL_CLIENT_S_DN_Email', 'SSL_CLIENT_S_DN', null, 'CN');
+
+        $request = $this->createRequest([
+            'SSL_CLIENT_S_DN' => $credentials,
+        ]);
+        $this->assertTrue($authenticator->supports($request));
+
+        $this->userProvider->createUser(new InMemoryUser($username, null));
+
+        $passport = $authenticator->authenticate($request);
+        $this->assertEquals($username, $passport->getUser()->getUserIdentifier());
+    }
+
+    public static function provideServerVarsUserIdentifier()
+    {
+        yield ['Sample certificate DN', 'CN=Sample certificate DN/emailAddress=cert@example.com'];
+        yield ['Sample certificate DN', 'CN=Sample certificate DN/emailAddress=cert+something@example.com'];
+        yield ['Sample certificate DN', 'CN=Sample certificate DN,emailAddress=cert@example.com'];
+        yield ['Sample certificate DN', 'CN=Sample certificate DN,emailAddress=cert+something@example.com'];
+        yield ['Sample certificate DN', 'emailAddress=cert+something@example.com,CN=Sample certificate DN'];
+        yield ['Firstname.Lastname', 'emailAddress=firstname.lastname@mycompany.co.uk,CN=Firstname.Lastname,OU=london,OU=company design and engineering,OU=Issuer London,OU=Roaming,OU=Interactive,OU=Users,OU=Standard,OU=Business,DC=england,DC=core,DC=company,DC=co,DC=uk'];
+        yield ['user1', 'C=FR, O=My Organization, CN=user1, emailAddress=user1@myorg.fr'];
+    }
+
     private function createRequest(array $server)
     {
         return new Request([], [], [], [], [], $server);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #47354
| License       | MIT
| Doc PR        | **to be created**

This PR allows defining a custom user identifier instead of the hardcoded `emailAddress`.
It also adds a new option for the firewall configuration:

```yaml
# config/packages/security.yaml
security:
    # ...

    firewalls:
        main:
            # ...
            x509:
                provider: your_user_provider
                user_identifier: CN # default to emailAddress
```

**💬 Discussion**: user identifier regex changed
Note that the regex is changed. The previous one was able to find an email address as expected, but now that the common name may not contain a `@` (or may contain more than one), it is required to update this part.
It does not impact the previously merged PR #33759, but I prefer highlight the fact that it can now catch invalid email addresses set in `emailAddress`.