### PR TITLE
[Console] Add placeholder formatters per ProgressBar instance

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Remove `exit` call in `Application` signal handlers. Commands will no longer be automatically interrupted after receiving signal other than `SIGUSR1` or `SIGUSR2`
+ * Add `ProgressBar::setPlaceholderFormatter` to set a placeholder attached to a instance, instead of being global.
 
 6.2
 ---

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -861,6 +861,29 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         );
     }
 
+    public function testAddingInstancePlaceholderFormatter()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 3, 0);
+        $bar->setFormat(' %countdown% [%bar%]');
+        $bar->setPlaceholderFormatter('countdown', $function = function (ProgressBar $bar) {
+            return $bar->getMaxSteps() - $bar->getProgress();
+        });
+
+        $this->assertSame($function, $bar->getPlaceholderFormatter('countdown'));
+
+        $bar->start();
+        $bar->advance();
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            ' 3 [>---------------------------]'.
+            $this->generateOutput(' 2 [=========>------------------]').
+            $this->generateOutput(' 0 [============================]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
     public function testMultilineFormat()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 3, 0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #34929 #47898
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The `ProgressBar` class abuse of static properties to define formats and callables for placeholders. While it is possible to set the format pattern directly without using the statically defined formats, the placeholder formatters have to be defined globally which add limitations and produce unintended side effects.

Example on this command class: https://github.com/ostrolucky/stdinho/blob/76a54db4ff379fe428acc12cbe66d319a289eb3b/src/ProgressBar.php