### PR TITLE
[VarExporter] Use `array<property-name,Closure>` for partial initialization of lazy ghost objects

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
@@ -70,18 +70,18 @@ class LazyObjectRegistry
 
         $resetters = [];
         foreach ($classProperties as $scope => $properties) {
-            $resetters[] = \Closure::bind(static function ($instance, $skippedProperties = []) use ($properties) {
+            $resetters[] = \Closure::bind(static function ($instance, $skippedProperties, $onlyProperties = null) use ($properties) {
                 foreach ($properties as $name => $key) {
-                    if (!\array_key_exists($key, $skippedProperties)) {
+                    if (!\array_key_exists($key, $skippedProperties) && (null === $onlyProperties || \array_key_exists($key, $onlyProperties))) {
                         unset($instance->$name);
                     }
                 }
             }, null, $scope);
         }
 
-        $resetters[] = static function ($instance, $skippedProperties = []) {
+        $resetters[] = static function ($instance, $skippedProperties, $onlyProperties = null) {
             foreach ((array) $instance as $name => $value) {
-                if ("\0" !== ($name[0] ?? '') && !\array_key_exists($name, $skippedProperties)) {
+                if ("\0" !== ($name[0] ?? '') && !\array_key_exists($name, $skippedProperties) && (null === $onlyProperties || \array_key_exists($name, $onlyProperties))) {
                     unset($instance->$name);
                 }
             }

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
@@ -22,9 +22,10 @@ use Symfony\Component\VarExporter\Hydrator as PublicHydrator;
  */
 class LazyObjectState
 {
-    public const STATUS_INITIALIZED_PARTIAL = 1;
-    public const STATUS_UNINITIALIZED_FULL = 2;
+    public const STATUS_UNINITIALIZED_FULL = 1;
+    public const STATUS_UNINITIALIZED_PARTIAL = 2;
     public const STATUS_INITIALIZED_FULL = 3;
+    public const STATUS_INITIALIZED_PARTIAL = 4;
 
     /**
      * @var array<string, true>
@@ -36,37 +37,34 @@ class LazyObjectState
      */
     public int $status = 0;
 
-    public function __construct(public \Closure $initializer, $skippedProperties = [])
+    public function __construct(public readonly \Closure|array $initializer, $skippedProperties = [])
     {
         $this->skippedProperties = $skippedProperties;
+        $this->status = \is_array($initializer) ? self::STATUS_UNINITIALIZED_PARTIAL : self::STATUS_UNINITIALIZED_FULL;
     }
 
     public function initialize($instance, $propertyName, $propertyScope)
     {
-        if (!$this->status) {
-            $this->status = 4 <= (new \ReflectionFunction($this->initializer))->getNumberOfParameters() ? self::STATUS_INITIALIZED_PARTIAL : self::STATUS_UNINITIALIZED_FULL;
-
-            if (null === $propertyName) {
-                return $this->status;
-            }
-        }
-
         if (self::STATUS_INITIALIZED_FULL === $this->status) {
             return self::STATUS_INITIALIZED_FULL;
         }
 
-        if (self::STATUS_INITIALIZED_PARTIAL === $this->status) {
+        if (\is_array($this->initializer)) {
             $class = $instance::class;
             $propertyScope ??= $class;
             $propertyScopes = Hydrator::$propertyScopes[$class];
             $propertyScopes[$k = "\0$propertyScope\0$propertyName"] ?? $propertyScopes[$k = "\0*\0$propertyName"] ?? $k = $propertyName;
 
-            $value = ($this->initializer)(...[$instance, $propertyName, $propertyScope, LazyObjectRegistry::$defaultProperties[$class][$k] ?? null]);
+            if (!$initializer = $this->initializer[$k] ?? null) {
+                return self::STATUS_UNINITIALIZED_PARTIAL;
+            }
+
+            $value = $initializer(...[$instance, $propertyName, $propertyScope, LazyObjectRegistry::$defaultProperties[$class][$k] ?? null]);
 
             $accessor = LazyObjectRegistry::$classAccessors[$propertyScope] ??= LazyObjectRegistry::getClassAccessors($propertyScope);
             $accessor['set']($instance, $propertyName, $value);
 
-            return self::STATUS_INITIALIZED_PARTIAL;
+            return $this->status = self::STATUS_INITIALIZED_PARTIAL;
         }
 
         $this->status = self::STATUS_INITIALIZED_FULL;
@@ -93,6 +91,7 @@ class LazyObjectState
         $propertyScopes = Hydrator::$propertyScopes[$class] ??= Hydrator::getPropertyScopes($class);
         $skippedProperties = $this->skippedProperties;
         $properties = (array) $instance;
+        $onlyProperties = \is_array($this->initializer) ? $this->initializer : null;
 
         foreach ($propertyScopes as $key => [$scope, $name, $readonlyScope]) {
             $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0*\0$name"] ?? $k = $name;
@@ -103,7 +102,9 @@ class LazyObjectState
         }
 
         foreach (LazyObjectRegistry::$classResetters[$class] as $reset) {
-            $reset($instance, $skippedProperties);
+            $reset($instance, $skippedProperties, $onlyProperties);
         }
+
+        $this->status = self::STATUS_INITIALIZED_FULL === $this->status ? self::STATUS_UNINITIALIZED_FULL : self::STATUS_UNINITIALIZED_PARTIAL;
     }
 }

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -17,8 +17,8 @@ use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
 
 /**
- * @property int    $lazyObjectId   This property must be declared in classes using this trait
- * @property parent $lazyObjectReal This property must be declared in classes using this trait;
+ * @property int    $lazyObjectId   This property must be declared as private in classes using this trait
+ * @property parent $lazyObjectReal This property must be declared as private in classes using this trait;
  *                                  its type should match the type of the proxied object
  */
 trait LazyProxyTrait


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

Lazy ghost objects can be either fully-initialized or partially-initialized: either the lazy-properties are all initialized at once, or they're initialized one-by-one.

In the one-by-one way, the initializer is still one closure for all properties that accepts the property to initialize as argument.

While preparing my talk for SymfonyCon, I realized that it would be better to pass an array of closures instead, keyed by the properties to lazy-initialize.