### PR TITLE
[Console]  Fix signal handlers called after event listeners and skip exit

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1012,10 +1012,6 @@ class Application implements ResetInterface
                         });
                     }
                 }
-
-                foreach ($commandSignals as $signal) {
-                    $this->signalRegistry->register($signal, [$command, 'handleSignal']);
-                }
             }
 
             if (null !== $this->dispatcher) {
@@ -1033,6 +1029,10 @@ class Application implements ResetInterface
                         }
                     });
                 }
+            }
+
+            foreach ($commandSignals as $signal) {
+                $this->signalRegistry->register($signal, [$command, 'handleSignal']);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48205
| License       | MIT
| Doc PR        | -

Restore registration of signal handlers after the event dispatcher. 
https://github.com/symfony/symfony/pull/45333/files#diff-8f1fd83284712ab08cb5d391da70ea0e78719ef08db852596997a4085848a026L1009