### PR TITLE
[PropertyInfo] ensure docblock compatibility with PhpStan's docblock parser

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -84,7 +84,7 @@ class Dummy extends ParentDummy
     public $h;
 
     /**
-     * @var ?string|int
+     * @var string|int|null
      */
     public $i;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

In their next releases both packages phpdocumentor/reflection-docblock and phpdocumentor/type-resolver will start using the docblock parser from PhpStan.
