### PR TITLE
[Translation] [Lokalize] Configure `replace_breaks` to prevent issues with multilines translations

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -151,6 +151,7 @@ final class LokaliseProvider implements ProviderInterface
                 'filter_langs' => array_values($locales),
                 'filter_filenames' => array_map([$this, 'getLokaliseFilenameFromDomain'], $domains),
                 'export_empty_as' => 'skip',
+                'replace_breaks' => false,
             ],
         ]);
 

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -562,6 +562,7 @@ class LokaliseProviderTest extends ProviderTestCase
                 'filter_langs' => [$locale],
                 'filter_filenames' => [$domain.'.xliff'],
                 'export_empty_as' => 'skip',
+                'replace_breaks' => false,
             ]);
 
             $this->assertSame('POST', $method);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Hi, as seen with @welcoMattic in private messages, I faced an issue when pulling translations from Lokalise.

Given the following translation, with newlines:
![image](https://user-images.githubusercontent.com/2103975/202193435-a2317097-6b44-4852-ab41-29b6685bc02d.png)

When I pull it, this is what the translation looks like in the Symfony's `.xliff`: 
![image](https://user-images.githubusercontent.com/2103975/202193506-0fe56a99-4d22-4e91-a1a2-2b23a3730b0a.png)
 
Which leads to a syntax issue for the ICU formatter:
![image](https://user-images.githubusercontent.com/2103975/202193580-a28fda8a-a60d-461d-a84b-86984b237446.png)

Using `replace_breaks: false` will fix this issue by preserving newlines:
<img width="753" alt="image" src="https://user-images.githubusercontent.com/2103975/202193741-c76d8d9a-34b5-48ba-8ed9-2eb94aade58f.png">

<img width="469" alt="image" src="https://user-images.githubusercontent.com/2103975/202194287-b8d4a1e1-5cf7-4684-9f7c-b3e7c971ffd5.png">
