### PR TITLE
[Serializer] Prevent `GetSetMethodNormalizer` from creating invalid magic method call

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -126,17 +126,17 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         $ucfirsted = ucfirst($attribute);
 
         $getter = 'get'.$ucfirsted;
-        if (\is_callable([$object, $getter])) {
+        if (method_exists($object, $getter) && \is_callable([$object, $getter])) {
             return $object->$getter();
         }
 
         $isser = 'is'.$ucfirsted;
-        if (\is_callable([$object, $isser])) {
+        if (method_exists($object, $isser) && \is_callable([$object, $isser])) {
             return $object->$isser();
         }
 
         $haser = 'has'.$ucfirsted;
-        if (\is_callable([$object, $haser])) {
+        if (method_exists($object, $haser) && \is_callable([$object, $haser])) {
             return $object->$haser();
         }
 
@@ -152,7 +152,14 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         $key = \get_class($object).':'.$setter;
 
         if (!isset(self::$setterAccessibleCache[$key])) {
-            self::$setterAccessibleCache[$key] = \is_callable([$object, $setter]) && !(new \ReflectionMethod($object, $setter))->isStatic();
+            try {
+                // We have to use is_callable() here since method_exists()
+                // does not "see" protected/private methods
+                self::$setterAccessibleCache[$key] = \is_callable([$object, $setter]) && !(new \ReflectionMethod($object, $setter))->isStatic();
+            } catch (\ReflectionException $e) {
+                // Method does not exist in the class, probably a magic method
+                self::$setterAccessibleCache[$key] = false;
+            }
         }
 
         if (self::$setterAccessibleCache[$key]) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -453,6 +453,22 @@ class GetSetMethodNormalizerTest extends TestCase
         );
     }
 
+    public function testCallMagicMethodDenormalize()
+    {
+        $obj = $this->normalizer->denormalize(['active' => true], ObjectWithMagicMethod::class);
+        $this->assertTrue($obj->isActive());
+    }
+
+    public function testCallMagicMethodNormalize()
+    {
+        $obj = new ObjectWithMagicMethod();
+
+        $this->assertSame(
+            ['active' => true],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
     protected function getObjectCollectionWithExpectedArray(): array
     {
         return [[
@@ -720,5 +736,20 @@ class ObjectWithHasGetterDummy
     public function hasFoo()
     {
         return $this->foo;
+    }
+}
+
+class ObjectWithMagicMethod
+{
+    private $active = true;
+
+    public function isActive()
+    {
+        return $this->active;
+    }
+
+    public function __call($key, $value)
+    {
+        throw new \RuntimeException('__call should not be called. Called with: '.$key);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When serializing an object that has an `isser` for a property, but not a `getter`, and the object happens to have a `__call` magic method, the `GetSetMethodNormalizer` will attempt to call the magic method with the attribute. This may cause unexpected behavior, or, a fatal. It depends on the `__call` implementation. 

This undefined behavior is caused by the use of `is_callable` on `getAttributeValue`, which will return true since there is a `__call` implementation. The correct behavior can be achieved by using `method_exists` instead. A test case has been added that illustrates the issue. 