### PR TITLE
Add basic union type support to property-info php doc extractor

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -7,6 +7,15 @@ in 6.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.2.0...v6.2.1
 
+* 6.2.0-RC2 (2022-11-28)
+
+ * bug #48366 [Mailer] Fix body renderer check (fabpot)
+ * bug #48347 [Clock] Autowire PSR interface (wouterj)
+ * bug #48341 [SecurityBundle] Fix `logout.csrf_token_generator` default value (MatTheCat)
+ * bug #48333 [Yaml] parse unquoted digits in tag values as integers (xabbuh)
+ * bug #48330 [FrameworkBundle] do not wire the MercureTransportFactory if the MercureBundle is not enabled (xabbuh)
+ * bug #48320 [Clock] Implement PSR-20 (nicolas-grekas)
+
 * 6.2.0-RC1 (2022-11-25)
 
  * bug #48312 [VarExporter] Improve partial-initialization API for ghost objects (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -75,12 +75,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.2.0-RC2';
+    public const VERSION = '6.2.0-DEV';
     public const VERSION_ID = 60200;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 2;
     public const RELEASE_VERSION = 0;
-    public const EXTRA_VERSION = 'RC2';
+    public const EXTRA_VERSION = 'DEV';
 
     public const END_OF_MAINTENANCE = '07/2023';
     public const END_OF_LIFE = '07/2023';

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -75,12 +75,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.2.0-DEV';
+    public const VERSION = '6.2.0-RC2';
     public const VERSION_ID = 60200;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 2;
     public const RELEASE_VERSION = 0;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = 'RC2';
 
     public const END_OF_MAINTENANCE = '07/2023';
     public const END_OF_LIFE = '07/2023';

--- a/src/Symfony/Component/Mailer/EventListener/MessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageListener.php
@@ -11,11 +11,9 @@
 
 namespace Symfony\Component\Mailer\EventListener;
 
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
-use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Exception\RuntimeException;
 use Symfony\Component\Mime\BodyRendererInterface;
 use Symfony\Component\Mime\Header\Headers;
@@ -121,10 +119,6 @@ class MessageListener implements EventSubscriberInterface
     private function renderMessage(Message $message): void
     {
         if (!$this->renderer) {
-            if ($message instanceof TemplatedEmail && ($message->getTextTemplate() || $message->getHtmlTemplate())) {
-                throw new LogicException(sprintf('You must configure a "%s" when a "%s" instance has a text or HTML template set.', BodyRendererInterface::class, get_debug_type($message)));
-            }
-
             return;
         }
 

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -14,12 +14,15 @@ namespace Symfony\Component\Mailer\Transport;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Event\FailedMessageEvent;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Event\SentMessageEvent;
+use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\BodyRendererInterface;
 use Symfony\Component\Mime\RawMessage;
 
 /**
@@ -72,6 +75,10 @@ abstract class AbstractTransport implements TransportInterface
             $this->dispatcher->dispatch($event);
             $envelope = $event->getEnvelope();
             $message = $event->getMessage();
+
+            if ($message instanceof TemplatedEmail && ($message->getTextTemplate() || $message->getHtmlTemplate())) {
+                throw new LogicException(sprintf('You must configure a "%s" when a "%s" instance has a text or HTML template set.', BodyRendererInterface::class, get_debug_type($message)));
+            }
 
             $sentMessage = new SentMessage($message, $envelope);
 

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -27,7 +27,8 @@
     "require-dev": {
         "symfony/console": "^5.4|^6.0",
         "symfony/http-client-contracts": "^1.1|^2|^3",
-        "symfony/messenger": "^6.2"
+        "symfony/messenger": "^6.2",
+        "symfony/twig-bridge": "^6.2"
     },
     "conflict": {
         "symfony/http-kernel": "<5.4",

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -49,7 +49,7 @@ class VarDumper
     public static function setHandler(callable $callable = null): ?callable
     {
         if (1 > \func_num_args()) {
-            trigger_deprecation('symfony/va-dumper', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+            trigger_deprecation('symfony/var-dumper', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
         }
         $prevHandler = self::$handler;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #45903
| License       | MIT
| Doc PR        | 

This PR adds basic union type support to PropertyInfo / PhpDocExtractor. Unit tests are copied from PhpStanExtractor, which already handles union types. Not all test cases can be fulfilled by the PhpDocExtractor, though. These tests are disabled.
