### PR TITLE
[Console][RFC] Add named arguments (aka required options)

### DIFF
--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -61,6 +61,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
     {
         $definition = $this->definition;
         $givenArguments = $this->arguments;
+        $givenOptions = $this->options;
 
         $missingArguments = array_filter(array_keys($definition->getArguments()), function ($argument) use ($definition, $givenArguments) {
             return !\array_key_exists($argument, $givenArguments) && $definition->getArgument($argument)->isRequired();
@@ -68,6 +69,14 @@ abstract class Input implements InputInterface, StreamableInputInterface
 
         if (\count($missingArguments) > 0) {
             throw new RuntimeException(sprintf('Not enough arguments (missing: "%s").', implode(', ', $missingArguments)));
+        }
+
+        $missingOptions = array_filter(array_keys($definition->getOptions()), function ($option) use ($definition, $givenOptions) {
+            return !\array_key_exists($option, $givenOptions) && $definition->getOption($option)->isRequired();
+        });
+
+        if (\count($missingOptions) > 0) {
+            throw new RuntimeException(sprintf('Missing options (missing: "%s").', implode(', ', $missingOptions)));
         }
     }
 

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -50,6 +50,11 @@ class InputOption
      */
     public const VALUE_NEGATABLE = 16;
 
+    /**
+     * The option aka "named parameter" must be passed.
+     */
+    public const REQUIRED = 32;
+
     private string $name;
     private string|array|null $shortcut;
     private int $mode;
@@ -94,7 +99,7 @@ class InputOption
 
         if (null === $mode) {
             $mode = self::VALUE_NONE;
-        } elseif ($mode >= (self::VALUE_NEGATABLE << 1) || $mode < 1) {
+        } elseif ($mode >= (self::REQUIRED << 1) || $mode < 1) {
             throw new InvalidArgumentException(sprintf('Option mode "%s" is not valid.', $mode));
         }
 
@@ -131,6 +136,16 @@ class InputOption
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * Returns true if the argument is required.
+     *
+     * @return bool true if parameter mode is self::REQUIRED, false otherwise
+     */
+    public function isRequired(): bool
+    {
+        return self::REQUIRED === (self::REQUIRED & $this->mode);
     }
 
     /**
@@ -247,6 +262,7 @@ class InputOption
             && $option->isArray() === $this->isArray()
             && $option->isValueRequired() === $this->isValueRequired()
             && $option->isValueOptional() === $this->isValueOptional()
+            && $option->isRequired() === $this->isRequired()
         ;
     }
 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -139,7 +139,7 @@ class InputOption
     }
 
     /**
-     * Returns true if the argument is required.
+     * Returns true if the option is required.
      *
      * @return bool true if parameter mode is self::REQUIRED, false otherwise
      */

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -51,7 +51,7 @@ class InputOption
     public const VALUE_NEGATABLE = 16;
 
     /**
-     * The option aka "named parameter" must be passed.
+     * The option aka "named argument" must be passed.
      */
     public const REQUIRED = 32;
 

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -67,26 +67,37 @@ class InputOptionTest extends TestCase
         $this->assertFalse($option->acceptValue(), '__construct() gives a "InputOption::VALUE_NONE" mode by default');
         $this->assertFalse($option->isValueRequired(), '__construct() gives a "InputOption::VALUE_NONE" mode by default');
         $this->assertFalse($option->isValueOptional(), '__construct() gives a "InputOption::VALUE_NONE" mode by default');
+        $this->assertFalse($option->isRequired(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
 
         $option = new InputOption('foo', 'f', null);
         $this->assertFalse($option->acceptValue(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
         $this->assertFalse($option->isValueRequired(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
         $this->assertFalse($option->isValueOptional(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
+        $this->assertFalse($option->isRequired(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
 
         $option = new InputOption('foo', 'f', InputOption::VALUE_NONE);
         $this->assertFalse($option->acceptValue(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
         $this->assertFalse($option->isValueRequired(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
         $this->assertFalse($option->isValueOptional(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
+        $this->assertFalse($option->isRequired(), '__construct() can take "InputOption::VALUE_NONE" as its mode');
 
         $option = new InputOption('foo', 'f', InputOption::VALUE_REQUIRED);
         $this->assertTrue($option->acceptValue(), '__construct() can take "InputOption::VALUE_REQUIRED" as its mode');
         $this->assertTrue($option->isValueRequired(), '__construct() can take "InputOption::VALUE_REQUIRED" as its mode');
         $this->assertFalse($option->isValueOptional(), '__construct() can take "InputOption::VALUE_REQUIRED" as its mode');
+        $this->assertFalse($option->isRequired(), '__construct() can take "InputOption::VALUE_REQUIRED" as its mode');
 
         $option = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL);
         $this->assertTrue($option->acceptValue(), '__construct() can take "InputOption::VALUE_OPTIONAL" as its mode');
         $this->assertFalse($option->isValueRequired(), '__construct() can take "InputOption::VALUE_OPTIONAL" as its mode');
         $this->assertTrue($option->isValueOptional(), '__construct() can take "InputOption::VALUE_OPTIONAL" as its mode');
+        $this->assertFalse($option->isRequired(), '__construct() can take "InputOption::VALUE_OPTIONAL" as its mode');
+
+        $option = new InputOption('foo', 'f', InputOption::REQUIRED);
+        $this->assertFalse($option->acceptValue(), '__construct() can take "InputOption::REQUIRED" as its mode');
+        $this->assertFalse($option->isValueRequired(), '__construct() can take "InputOption::REQUIRED" as its mode');
+        $this->assertTrue($option->isValueOptional(), '__construct() can take "InputOption::REQUIRED" as its mode');
+        $this->assertTrue($option->isRequired(), '__construct() can take "InputOption::REQUIRED" as its mode');
     }
 
     public function testInvalidModes()
@@ -145,6 +156,9 @@ class InputOptionTest extends TestCase
 
         $option = new InputOption('foo', null, InputOption::VALUE_NONE);
         $this->assertFalse($option->getDefault(), '->getDefault() returns false if the option does not take a value');
+
+        $option = new InputOption('foo', null, InputOption::REQUIRED);
+        $this->assertFalse($option->getDefault(), '->getDefault() returns false if the option is required');
     }
 
     public function testSetDefault()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #14716 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

added  mode `InputOption::REQUIRED` to allow required "options" aka "named arguments"

edit:
- targeted 6.2 branch for now as there is no 6.3 yet
- definition how the mode should exactly behaves is to be discussed 
    - should a required option also require a value? in the sense of named arguments it would speak for having a required value but maybe i miss something.
    - in combination with negatable it would make sense again to not require a value, so you are forced to provide `--delete` or `--no-delete`.
    - should it be allowed to require array options?
    - from the logic point of view a required option should not have defaults, should it?
    
    - new tests have to be fixed/adapted
- quite many tests are failing which don't look like to have something to do with my change, is this right?

edit2:
renamed named parameters to named arguments