### PR TITLE
[HttpFoundation] fix inner apache mod_fcgid HTTP protocol version

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add request matchers under the `Symfony\Component\HttpFoundation\RequestMatcher` namespace
  * Deprecate `RequestMatcher` in favor of `ChainRequestMatcher`
  * Deprecate `Symfony\Component\HttpFoundation\ExpressionRequestMatcher` in favor of `Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher`
+ * Fix server protocol version for apache mod_fastcgid HTTP\1.0
 
 6.1
 ---

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -306,6 +306,13 @@ class Response
             $this->setProtocolVersion('1.1');
         }
 
+        // Fix protocol (Apache mod_fcgid)
+        if ('HTTP/1.0' == $request->server->get('SERVER_PROTOCOL')
+            && $request->server->has('GATEWAY_INTERFACE') && 'CGI/1.1' == $request->server->get('GATEWAY_INTERFACE')
+            && $request->server->has('SERVER_SOFTWARE') && 0 === stripos($request->server->get('SERVER_SOFTWARE'), 'Apache')) {
+            $this->setProtocolVersion('1.1');
+        }
+
         // Check if we need to send extra expire info headers
         if ('1.0' == $this->getProtocolVersion() && str_contains($headers->get('Cache-Control', ''), 'no-cache')) {
             $headers->set('pragma', 'no-cache');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Apaches implementation of mod_fastcgi (`CGI/1.1`) always passing `SERVER_PROTOCOL HTTP/1.0` to the PHP socket.

In the current implementation, symfonys response is disabling any http caching method by passing `pragma no-cache` and `expires -1` headers for requests with an **inner** server protocol `HTTP/1.0`. This behavior prevents any server side http caching also if outer request sent by`HTTP/2` or `HTTP/1.1`.

This pull requests fix the wrong server protocol for Apaches `mod_fastcgid` by upgrading protocol version for apache `CGI/1.1` requests accordingly.