### PR TITLE
[Cache] Compatible with aliyun redis instance

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
@@ -292,13 +292,13 @@ EOLUA;
         foreach ($hosts as $host) {
             $info = $host->info('Memory');
 
-            if ($info instanceof ErrorInterface) {
+            if (false === $info || null === $info || $info instanceof ErrorInterface) {
                 continue;
             }
 
             $info = $info['Memory'] ?? $info;
 
-            return $this->redisEvictionPolicy = $info['maxmemory_policy'];
+            return $this->redisEvictionPolicy = $info['maxmemory_policy'] ?? '';
         }
 
         return $this->redisEvictionPolicy = '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix
| License       | MIT

Some cloud provider's redis instance is just compatible in common use command, but not some special command. Just like aliyun redis instance, doc: https://help.aliyun.com/document_detail/26342.html It based on redis protocol, but not really like the redis I know...

I found that `$host->info('Memory')` will return false/null sometime, so and more safe check will be better for those special redis server.
