### PR TITLE
[PropertyInfo] ignore const expressions read by phpdocumentor

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\PropertyInfo\Util;
 
+use phpDocumentor\Reflection\PseudoTypes\ConstExpression;
 use phpDocumentor\Reflection\PseudoTypes\List_;
 use phpDocumentor\Reflection\Type as DocType;
 use phpDocumentor\Reflection\Types\Array_;
@@ -39,6 +40,11 @@ final class PhpDocTypeHelper
      */
     public function getTypes(DocType $varType): array
     {
+        if ($varType instanceof ConstExpression) {
+            // It's safer to fall back to other extractors here, as resolving const types correctly is not easy at the moment
+            return [];
+        }
+
         $types = [];
         $nullable = false;
 
@@ -63,6 +69,11 @@ final class PhpDocTypeHelper
         $varTypes = [];
         for ($typeIndex = 0; $varType->has($typeIndex); ++$typeIndex) {
             $type = $varType->get($typeIndex);
+
+            if ($type instanceof ConstExpression) {
+                // It's safer to fall back to other extractors here, as resolving const types correctly is not easy at the moment
+                return [];
+            }
 
             // If null is present, all types are nullable
             if ($type instanceof Null_) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

With the upcoming release, phpdocumentator will use the PhpStan docblock parser to extract type information. This change ensure that constant expressions are ignored when extracting types (as we did before when phpdocumentor failed to extract the type) as we do not evaluate them inside the PhpDocExtractor.
