### PR TITLE
[Clock] Remove superfluous timezone in constructor.

### DIFF
--- a/src/Symfony/Component/Clock/MockClock.php
+++ b/src/Symfony/Component/Clock/MockClock.php
@@ -44,7 +44,7 @@ final class MockClock implements ClockInterface
         $now = substr_replace(sprintf('@%07.0F', $now), '.', -6, 0);
         $timezone = $this->now->getTimezone();
 
-        $this->now = (new \DateTimeImmutable($now, $timezone))->setTimezone($timezone);
+        $this->now = (new \DateTimeImmutable($now))->setTimezone($timezone);
     }
 
     public function modify(string $modifier): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -

Minor "bugfix". The `$timezone` argument in the constructor is ignored when providing a timestamp and can be removed.

See also: https://www.php.net/manual/en/datetimeimmutable.construct

> The `$timezone` parameter and the current timezone are ignored
> when the `$datetime` parameter either is a UNIX timestamp
> (e.g. @946684800) or specifies a timezone
> (e.g. 2010-01-28T15:00:00+02:00, or 2010-07-05T06:00:00Z).