### PR TITLE
[Notifier] [SMSBiuras] `true`/`false` mismatch for `test_mode` option

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
@@ -85,7 +85,7 @@ final class SmsBiurasTransport extends AbstractTransport
                 'apikey' => $this->apiKey,
                 'message' => $message->getSubject(),
                 'from' => $this->from,
-                'test' => $this->testMode ? 0 : 1,
+                'test' => $this->testMode ? 1 : 0,
                 'to' => $message->getPhone(),
             ],
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/Tests/SmsBiurasTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/Tests/SmsBiurasTransportTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\SmsBiuras\Tests;
 
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\SmsBiuras\SmsBiurasTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
@@ -18,6 +19,7 @@ use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class SmsBiurasTransportTest extends TransportTestCase
 {
@@ -43,5 +45,81 @@ final class SmsBiurasTransportTest extends TransportTestCase
     {
         yield [new ChatMessage('Hello!')];
         yield [$this->createMock(MessageInterface::class)];
+    }
+
+    /**
+     * @dataProvider provideTestMode()
+     */
+    public function testTestMode(array $expected, array $provided)
+    {
+        $message = new SmsMessage($provided['phone'], $provided['message']);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->atLeast(1))
+            ->method('getStatusCode')
+            ->willReturn(200);
+        $response->expects($this->atLeast(1))
+            ->method('getContent')
+            ->willReturn('OK: 519545');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expected): ResponseInterface {
+            $this->assertSame('GET', $method);
+            $this->assertSame(sprintf(
+                'https://savitarna.smsbiuras.lt/api?uid=uid&apikey=api_key&message=%s&from=from&test=%s&to=%s',
+                rawurlencode($expected['message']),
+                $expected['transport']['test_mode'],
+                rawurlencode($expected['phone']),
+            ), $url);
+            $this->assertSame($expected['transport']['test_mode'], $options['query']['test']);
+
+            $this->assertSame(200, $response->getStatusCode());
+            $this->assertSame('OK: 519545', $response->getContent());
+
+            return $response;
+        });
+
+        $transport = new SmsBiurasTransport('uid', 'api_key', 'from', $provided['transport']['test_mode'], $client);
+
+        $sentMessage = $transport->send($message);
+
+        $this->assertSame('519545', $sentMessage->getMessageId());
+    }
+
+    public static function provideTestMode(): array
+    {
+        return [
+            [
+                [
+                    'phone' => '+37012345678',
+                    'message' => 'Hello world!',
+                    'transport' => [
+                        'test_mode' => 0,
+                    ],
+                ],
+                [
+                    'phone' => '+37012345678',
+                    'message' => 'Hello world!',
+                    'transport' => [
+                        'test_mode' => 0,
+                    ],
+                ],
+            ],
+            [
+                [
+                    'phone' => '+37012345678',
+                    'message' => 'Hello world!',
+                    'transport' => [
+                        'test_mode' => 1,
+                    ],
+                ],
+                [
+                    'phone' => '+37012345678',
+                    'message' => 'Hello world!',
+                    'transport' => [
+                        'test_mode' => 1,
+                    ],
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Moved from LightSMS service into SMSBiuras and found an issue.
SMSBIURAS_DSN=smsbiuras://UID:API_KEY@default?from=FROM&test_mode=0

Documentation is good but in the code bug. If test_mode = 0 - does not send SMS. If test_mode = 1 - sends SMS.
Boolean true | false mismatch.

SMSBiuras API documentation https://docs.smsbiuras.lt/