### PR TITLE
[TwigBridge] Use exit code

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -107,7 +107,7 @@ EOF
             default => throw new InvalidArgumentException(sprintf('The format "%s" is not supported.', $input->getOption('format'))),
         };
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This pr replace the "0" returned in execute by the right const for exit code "SUCCESS"