### PR TITLE
[HttpKernel] Remove duplicate+unclear deprecation

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
@@ -42,8 +42,6 @@ final class TraceableValueResolver implements ArgumentValueResolverInterface, Va
             return true;
         }
 
-        @trigger_deprecation('symfony/http-kernel', '6.2', 'The "%s()" method is deprecated, use "resolve()" instead.', __METHOD__);
-
         $method = \get_class($this->inner).'::'.__FUNCTION__;
         $this->stopwatch->start($method, 'controller.argument_value_resolver');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Spotted during the workshop at SymfonyCon:

when a not-updated ArgumentValueResolver is decorated, this currently throws `The "Symfony\Component\HttpKernel\Controller\ArgumentResolver\TraceableValueResolver::supports()" method is deprecated, use "resolve()" instead.`, which is not actionable + is duplicate, since we also trigger `The "EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver\AdminContextResolver" class implements "Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface" that is deprecated since Symfony 6.2, implement ValueResolverInterface instead.`.