### PR TITLE
[HttpKernel] Fix message for unresovable arguments of invokable controllers

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/NotTaggedControllerValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/NotTaggedControllerValueResolver.php
@@ -69,8 +69,9 @@ final class NotTaggedControllerValueResolver implements ArgumentValueResolverInt
         }
 
         if (!$this->container->has($controller)) {
-            $i = strrpos($controller, ':');
-            $controller = substr($controller, 0, $i).strtolower(substr($controller, $i));
+            $controller = (false !== $i = strrpos($controller, ':'))
+                ? substr($controller, 0, $i).strtolower(substr($controller, $i))
+                : $controller.'::__invoke';
         }
 
         $what = sprintf('argument $%s of "%s()"', $argument->getName(), $controller);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/NotTaggedControllerValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/NotTaggedControllerValueResolverTest.php
@@ -98,6 +98,17 @@ class NotTaggedControllerValueResolverTest extends TestCase
         $resolver->resolve($request, $argument);
     }
 
+    public function testInvokableController()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not resolve argument $dummy of "App\Controller\Mine::__invoke()", maybe you forgot to register the controller as a service or missed tagging it with the "controller.service_arguments"?');
+        $resolver = new NotTaggedControllerValueResolver(new ServiceLocator([]));
+        $argument = new ArgumentMetadata('dummy', \stdClass::class, false, false, null);
+        $request = $this->requestWithAttributes(['_controller' => 'App\Controller\Mine']);
+        $this->assertTrue($resolver->supports($request, $argument));
+        $resolver->resolve($request, $argument);
+    }
+
     private function requestWithAttributes(array $attributes)
     {
         $request = Request::create('/');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Before:
```
Could not resolve argument $logger of "app\controller\foocontroller()", maybe you ...
```

After:
```
Could not resolve argument $logger of "App\Controller\FooController::__invoke()", maybe you ...
```