### PR TITLE
[Security] add CAS 2.0 AccessToken handler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/CasTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/CasTokenHandlerFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken;
+
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\AccessToken\Cas\Cas2Handler;
+
+class CasTokenHandlerFactory implements TokenHandlerFactoryInterface
+{
+    public function create(ContainerBuilder $container, string $id, array|string $config): void
+    {
+        $container->setDefinition($id, new ChildDefinition('security.access_token_handler.cas'));
+
+        $container
+            ->register('security.access_token_handler.cas', Cas2Handler::class)
+            ->setArguments([
+                new Reference('request_stack'),
+                $config['validation_url'],
+                $config['prefix'],
+                $config['http_client'] ? new Reference($config['http_client']) : null,
+            ]);
+    }
+
+    public function getKey(): string
+    {
+        return 'cas';
+    }
+
+    public function addConfiguration(NodeBuilder $node): void
+    {
+        $node
+            ->arrayNode($this->getKey())
+                ->fixXmlConfig($this->getKey())
+                ->children()
+                    ->scalarNode('validation_url')
+                        ->info('CAS server validation URL')
+                        ->isRequired()
+                    ->end()
+                    ->scalarNode('prefix')
+                        ->info('CAS prefix')
+                        ->defaultValue('cas')
+                    ->end()
+                    ->scalarNode('http_client')
+                        ->info('HTTP Client service')
+                        ->defaultNull()
+                    ->end()
+                ->end()
+            ->end();
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterLdapLocat
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterTokenUsageTrackingPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\ReplaceDecoratedRememberMeHandlerPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\SortFirewallListenersPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\CasTokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\OidcTokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\OidcUserInfoTokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\ServiceTokenHandlerFactory;
@@ -78,6 +79,7 @@ class SecurityBundle extends Bundle
             new ServiceTokenHandlerFactory(),
             new OidcUserInfoTokenHandlerFactory(),
             new OidcTokenHandlerFactory(),
+            new CasTokenHandlerFactory(),
         ]));
 
         $extension->addUserProviderFactory(new InMemoryFactory());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_cas.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_cas.yml
@@ -1,0 +1,41 @@
+imports:
+  - { resource: ./../config/framework.yml }
+
+framework:
+  http_method_override: false
+  serializer: ~
+
+security:
+  password_hashers:
+    Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+  providers:
+    in_memory:
+      memory:
+        users:
+          dunglas: { password: foo, roles: [ROLE_USER] }
+
+  firewalls:
+    main:
+      pattern: ^/
+      access_token:
+        token_handler:
+          cas:
+            validation_url: 'https://www.example.com/cas/serviceValidate'
+            http_client: 'Symfony\Contracts\HttpClient\HttpClientInterface'
+        token_extractors:
+          - security.access_token_extractor.cas
+
+  access_control:
+    - { path: ^/foo, roles: ROLE_USER }
+
+services:
+  _defaults:
+    public: true
+
+  security.access_token_extractor.cas:
+    class: Symfony\Component\Security\Http\AccessToken\QueryAccessTokenExtractor
+    arguments:
+      - 'ticket'
+
+  Symfony\Contracts\HttpClient\HttpClientInterface: ~

--- a/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\AccessToken\Cas;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @see https://apereo.github.io/cas/6.6.x/protocol/CAS-Protocol-V2-Specification.html
+ *
+ * @author Nicolas Attard <contact@nicolasattard.fr>
+ */
+final class Cas2Handler implements AccessTokenHandlerInterface
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly string $validationUrl,
+        private readonly string $prefix = 'cas',
+        private ?HttpClientInterface $client = null,
+    ) {
+        if (null === $client) {
+            if (!class_exists(HttpClient::class)) {
+                throw new \LogicException(sprintf('You cannot use "%s" as the HttpClient component is not installed. Try running "composer require symfony/http-client".', __CLASS__));
+            }
+
+            $this->client = HttpClient::create();
+        }
+    }
+
+    /**
+     * @throws AuthenticationException
+     */
+    public function getUserBadgeFrom(string $accessToken): UserBadge
+    {
+        $response = $this->client->request('GET', $this->getValidationUrl($accessToken));
+
+        $xml = new \SimpleXMLElement($response->getContent(), 0, false, $this->prefix, true);
+
+        if (isset($xml->authenticationSuccess)) {
+            return new UserBadge((string) $xml->authenticationSuccess->user);
+        }
+
+        if (isset($xml->authenticationFailure)) {
+            throw new AuthenticationException('CAS Authentication Failure: '.trim((string) $xml->authenticationFailure));
+        }
+
+        throw new AuthenticationException('Invalid CAS response.');
+    }
+
+    private function getValidationUrl(string $accessToken): string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request) {
+            throw new \LogicException('Request should exist so it can be processed for error.');
+        }
+
+        $query = $request->query->all();
+
+        if (!isset($query['ticket'])) {
+            throw new AuthenticationException('No ticket found in request.');
+        }
+        unset($query['ticket']);
+        $queryString = empty($query) ? '' : '?'.http_build_query($query);
+
+        return sprintf('%s?ticket=%s&service=%s',
+            $this->validationUrl,
+            urlencode($accessToken),
+            urlencode($request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo().$queryString)
+        );
+    }
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
 
  * `UserValueResolver` no longer implements `ArgumentValueResolverInterface`
  * Deprecate calling the constructor of `DefaultLoginRateLimiter` with an empty secret
+ * Add CAS 2.0 access token handler
 
 6.3
 ---

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Cas/Cas2HandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Cas/Cas2HandlerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\AccessToken\Cas;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\AccessToken\Cas\Cas2Handler;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+
+final class Cas2HandlerTest extends TestCase
+{
+    public function testWithValidTicket()
+    {
+        $response = new MockResponse(<<<BODY
+            <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+                <cas:authenticationSuccess>
+                    <cas:user>lobster</cas:user>
+                    <cas:proxyGrantingTicket>PGTIOU-84678-8a9d</cas:proxyGrantingTicket>
+                </cas:authenticationSuccess>
+            </cas:serviceResponse>
+        BODY
+        );
+
+        $httpClient = new MockHttpClient([$response]);
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(['ticket' => 'PGTIOU-84678-8a9d']));
+
+        $cas2Handler = new Cas2Handler(requestStack: $requestStack, validationUrl: 'https://www.example.com/cas', client: $httpClient);
+        $userbadge = $cas2Handler->getUserBadgeFrom('PGTIOU-84678-8a9d');
+        $this->assertEquals(new UserBadge('lobster'), $userbadge);
+    }
+
+    public function testWithInvalidTicket()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('CAS Authentication Failure: Ticket ST-1856339 not recognized');
+
+        $response = new MockResponse(<<<BODY
+            <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+                <cas:authenticationFailure code="INVALID_TICKET">
+                    Ticket ST-1856339 not recognized
+                </cas:authenticationFailure>
+            </cas:serviceResponse>
+        BODY
+        );
+
+        $httpClient = new MockHttpClient([$response]);
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(['ticket' => 'ST-1856339']));
+
+        $cas2Handler = new Cas2Handler(requestStack: $requestStack, validationUrl: 'https://www.example.com/cas', client: $httpClient);
+        $cas2Handler->getUserBadgeFrom('should-not-work');
+    }
+
+    public function testWithInvalidCasResponse()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid CAS response.');
+
+        $response = new MockResponse(<<<BODY
+            <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+            </cas:serviceResponse>
+        BODY
+        );
+
+        $httpClient = new MockHttpClient([$response]);
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(['ticket' => 'ST-1856339']));
+
+        $cas2Handler = new Cas2Handler(requestStack: $requestStack, validationUrl: 'https://www.example.com/cas', client: $httpClient);
+        $cas2Handler->getUserBadgeFrom('should-not-work');
+    }
+
+    public function testWithoutTicket()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('No ticket found in request.');
+
+        $httpClient = new MockHttpClient();
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request());
+
+        $cas2Handler = new Cas2Handler(requestStack: $requestStack, validationUrl: 'https://www.example.com/cas', client: $httpClient);
+        $cas2Handler->getUserBadgeFrom('should-not-work');
+    }
+
+    public function testWithInvalidPrefix()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid CAS response.');
+
+        $response = new MockResponse(<<<BODY
+            <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+                <cas:authenticationSuccess>
+                    <cas:user>lobster</cas:user>
+                    <cas:proxyGrantingTicket>PGTIOU-84678-8a9d</cas:proxyGrantingTicket>
+                </cas:authenticationSuccess>
+            </cas:serviceResponse>
+        BODY
+        );
+
+        $httpClient = new MockHttpClient([$response]);
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(['ticket' => 'PGTIOU-84678-8a9d']));
+
+        $cas2Handler = new Cas2Handler(requestStack: $requestStack, validationUrl: 'https://www.example.com/cas', prefix: 'invalid-one', client: $httpClient);
+        $username = $cas2Handler->getUserBadgeFrom('PGTIOU-84678-8a9d');
+        $this->assertEquals('lobster', $username);
+    }
+}

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -28,6 +28,7 @@
         "symfony/cache": "^6.4|^7.0",
         "symfony/clock": "^6.4|^7.0",
         "symfony/expression-language": "^6.4|^7.0",
+        "symfony/http-client": "^6.4|^7.0",
         "symfony/http-client-contracts": "^3.0",
         "symfony/rate-limiter": "^6.4|^7.0",
         "symfony/routing": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  
| License       | MIT
| Doc PR        | in progress


Hello,

Thanks to the new access token, I've added the [CAS](https://apereo.github.io/cas/6.6.x/protocol/CAS-Protocol-V2-Specification.html) one.

In order to make it work : 

services.yaml

```yaml
    Symfony\Component\Security\Http\AccessToken\Handler\CasHandler:
        arguments:
            $validationUrl: '%env(CAS_SERVER_VALIDATION_URL)%'

    security.access_token_extractor.cas:
        class: Symfony\Component\Security\Http\AccessToken\QueryAccessTokenExtractor
        arguments:
            - 'ticket'
```

Thank you @welcoMattic for the conference at the SymfonyCon  and @jeremyFreeAgent for your support on my first PR on this project!
