### PR TITLE
[Security] Json login exception

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -137,6 +137,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('authentication failure handler'),
                 abstract_arg('options'),
                 service('property_accessor')->nullOnInvalid(),
+                service('logger')->nullOnInvalid(),
             ])
             ->call('setTranslator', [service('translator')->ignoreOnInvalid()])
 

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -67,11 +67,11 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             !str_contains($request->getRequestFormat() ?? '', 'json')
             && !str_contains((method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType()) ?? '', 'json')
         ) {
-            $this->errorBadFormatException($request);
+            $this->errorBadFormatMessage($request);
             return false;
         }
 
-        if (isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+        if ($this->isNotLoginPath($request)) {
             return false;
         }
 
@@ -171,11 +171,22 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
 
         return $credentials;
     }
+
+    private function isNotLoginPath(Request $request):bool {
+        if(isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Check is the user wants to login.
      * It will detected by check the body content. If the array see a key called password and the type is wrong the Exception will be display.
      */
-    private function errorBadFormatException(Request $request) {
+    private function errorBadFormatMessage($request):void {
+        if($this->isNotLoginPath($request)) {
+            return;
+        }
         if(method_exists(Request::class, 'getContentTypeFormat')) {
             $contentType = $request->getContentTypeFormat();
         } else {

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -68,7 +68,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             && !str_contains((method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType()) ?? '', 'json')
         ) {
             $this->errorBadFormatMessage($request);
-            
+
             return false;
         }
 
@@ -173,7 +173,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         return $credentials;
     }
 
-    private function isNotLoginPath(Request $request):bool 
+    private function isNotLoginPath(Request $request): bool 
     {
         if (isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
             return true;
@@ -186,18 +186,18 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
      * Check is the user wants to login.
      * It will detected by check the body content. If the array see a key called password and the type is wrong the Exception will be display.
      */
-    private function errorBadFormatMessage($request):void 
+    private function errorBadFormatMessage($request): void 
     {
         if ($this->isNotLoginPath($request)) {
             return;
         }
-        if(method_exists(Request::class, 'getContentTypeFormat')) {
+        if (method_exists(Request::class, 'getContentTypeFormat')) {
             $contentType = $request->getContentTypeFormat();
         } else {
             $contentType = $request->getContentType();
         }
         $data = json_decode($request->getContent(), true);
-        if(\is_array($data) && \array_key_exists($this->options['password_path'], $data)) {
+        if (\is_array($data) && \array_key_exists($this->options['password_path'], $data)) {
             throw new BadRequestHttpException(sprintf('Content type was detected as "%s". Request format was detected as "%s". Please use "json" as request format or content type. ', $contentType, $request->getRequestFormat()));
         }        
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -199,6 +199,6 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         $data = json_decode($request->getContent(), true);
         if (\is_array($data) && \array_key_exists($this->options['password_path'], $data)) {
             throw new BadRequestHttpException(sprintf('Content type was detected as "%s". Request format was detected as "%s". Please use "json" as request format or content type. ', $contentType, $request->getRequestFormat()));
-        }        
+        }
     }
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -173,7 +173,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         return $credentials;
     }
 
-    private function isNotLoginPath(Request $request): bool 
+    private function isNotLoginPath(Request $request): bool
     {
         if (isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
             return true;
@@ -186,7 +186,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
      * Check is the user wants to login.
      * It will detected by check the body content. If the array see a key called password and the type is wrong the Exception will be display.
      */
-    private function errorBadFormatMessage($request): void 
+    private function errorBadFormatMessage($request): void
     {
         if ($this->isNotLoginPath($request)) {
             return;

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Authenticator;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -50,8 +51,9 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
     private ?AuthenticationSuccessHandlerInterface $successHandler;
     private ?AuthenticationFailureHandlerInterface $failureHandler;
     private ?TranslatorInterface $translator = null;
+    private ?LoggerInterface $logger = null;
 
-    public function __construct(HttpUtils $httpUtils, UserProviderInterface $userProvider, AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler = null, array $options = [], PropertyAccessorInterface $propertyAccessor = null)
+    public function __construct(HttpUtils $httpUtils, UserProviderInterface $userProvider, AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler = null, array $options = [], PropertyAccessorInterface $propertyAccessor = null, LoggerInterface $logger = null)
     {
         $this->options = array_merge(['username_path' => 'username', 'password_path' => 'password'], $options);
         $this->httpUtils = $httpUtils;
@@ -59,6 +61,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         $this->failureHandler = $failureHandler;
         $this->userProvider = $userProvider;
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
+        $this->logger = $logger;
     }
 
     public function supports(Request $request): ?bool
@@ -185,6 +188,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
     /**
      * Check is the user wants to login.
      * It will detected by check the body content. If the array see a key called password and the type is wrong the Exception will be display.
+     * Also body is empty is.
      */
     private function errorBadFormatMessage($request): void
     {
@@ -198,7 +202,12 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         }
         $data = json_decode($request->getContent(), true);
         if (\is_array($data) && \array_key_exists($this->options['password_path'], $data)) {
-            throw new BadRequestHttpException(sprintf('Content type was detected as "%s". Request format was detected as "%s". Please use "json" as request format or content type. ', $contentType, $request->getRequestFormat()));
+            $this->logger?->debug(sprintf('Skipping JSON authenticator as the request body is not JSON (got: "%s").', $contentType), ['authenticator' => static::class]);
+
+            return;
+        }
+        if (null === $data) {
+            $this->logger?->debug('Skipping json login authenticator. No content in body. May you forget to add content or you installed a custom authenticator on same path?', ['authenticator' => static::class]);
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -67,6 +67,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             !str_contains($request->getRequestFormat() ?? '', 'json')
             && !str_contains((method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType()) ?? '', 'json')
         ) {
+            $this->errorBadFormatException($request);
             return false;
         }
 
@@ -169,5 +170,20 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         }
 
         return $credentials;
+    }
+    /**
+     * Check is the user wants to login.
+     * It will detected by check the body content. If the array see a key called password and the type is wrong the Exception will be display.
+     */
+    private function errorBadFormatException(Request $request) {
+        if(method_exists(Request::class, 'getContentTypeFormat')) {
+            $contentType = $request->getContentTypeFormat();
+        } else {
+            $contentType = $request->getContentType();
+        }
+        $data = json_decode($request->getContent(), true);
+        if(is_array($data) && array_key_exists($this->options['password_path'], $data)) {
+            throw new BadRequestHttpException(sprintf('Content type was detected as "%s". Request format was detected as "%s". Please use "json" as request format or content type. ', $contentType, $request->getRequestFormat()));
+        }        
     }
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -68,6 +68,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             && !str_contains((method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType()) ?? '', 'json')
         ) {
             $this->errorBadFormatMessage($request);
+            
             return false;
         }
 
@@ -172,10 +173,12 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         return $credentials;
     }
 
-    private function isNotLoginPath(Request $request):bool {
-        if(isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+    private function isNotLoginPath(Request $request):bool 
+    {
+        if (isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
             return true;
         }
+
         return false;
     }
 
@@ -183,8 +186,9 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
      * Check is the user wants to login.
      * It will detected by check the body content. If the array see a key called password and the type is wrong the Exception will be display.
      */
-    private function errorBadFormatMessage($request):void {
-        if($this->isNotLoginPath($request)) {
+    private function errorBadFormatMessage($request):void 
+    {
+        if ($this->isNotLoginPath($request)) {
             return;
         }
         if(method_exists(Request::class, 'getContentTypeFormat')) {
@@ -193,7 +197,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             $contentType = $request->getContentType();
         }
         $data = json_decode($request->getContent(), true);
-        if(is_array($data) && array_key_exists($this->options['password_path'], $data)) {
+        if(\is_array($data) && \array_key_exists($this->options['password_path'], $data)) {
             throw new BadRequestHttpException(sprintf('Content type was detected as "%s". Request format was detected as "%s". Please use "json" as request format or content type. ', $contentType, $request->getRequestFormat()));
         }        
     }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `$lifetime` parameter to `LoginLinkHandlerInterface::createLoginLink()`
  * Add RFC6750 Access Token support to allow token-based authentication
  * Allow using expressions as `#[IsGranted()]` attribute and subject
+ * Add error exception method if user wants to JsonLogin with wrong content type `JsonLoginAuthenticator::errorBadFormatException()`
 
 6.0
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes (but I am not sure that it is on the right place :( ) 
| Tickets       | No Ticket
| License       | MIT
| Doc PR        | ?

Hello everyone,

to find my error in my last project, it took me a few hours, but it was such a simple and stupid mistake of mine. The mean thing was that I didn't get an error message. Had I had an error message, it would have been a matter of minutes. 

@weaverryan gave me a hint via symfonycast to watch Symfony\Component\Security\Http\Authenticator\JsonLoginAuthenticator and there it was so easy to figure out that I was just trying with application/text and not json. :D

Ryan suggested making a request for a class update, and so I implemented a new method that checks if the user has any content that looks like they are trying to log in, the error message is displayed if they use the wrong request method. 

For me it is a first pull request. I hope I didn't do too much wrong :-)