### PR TITLE
[Security] Support loading UserBadge directly from accessToken

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
@@ -79,9 +79,9 @@ final class AccessTokenFactory extends AbstractFactory
 
         $container
             ->setDefinition($authenticatorId, new ChildDefinition('security.authenticator.access_token'))
-            ->replaceArgument(0, $userProvider)
-            ->replaceArgument(1, new Reference($config['token_handler']))
-            ->replaceArgument(2, new Reference($extractorId))
+            ->replaceArgument(0, new Reference($config['token_handler']))
+            ->replaceArgument(1, new Reference($extractorId))
+            ->replaceArgument(2, $userProvider)
             ->replaceArgument(3, $successHandler)
             ->replaceArgument(4, $failureHandler)
             ->replaceArgument(5, $config['realm'])

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -26,9 +26,9 @@ return static function (ContainerConfigurator $container) {
         ->set('security.authenticator.access_token', AccessTokenAuthenticator::class)
             ->abstract()
             ->args([
-                abstract_arg('user provider'),
                 abstract_arg('access token handler'),
                 abstract_arg('access token extractor'),
+                null,
                 null,
                 null,
                 null,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/AccessTokenHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/AccessTokenHandler.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundl
 
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 class AccessTokenHandler implements AccessTokenHandlerInterface
 {
@@ -20,10 +21,10 @@ class AccessTokenHandler implements AccessTokenHandlerInterface
     {
     }
 
-    public function getUserIdentifierFrom(string $accessToken): string
+    public function getUserBadgeFrom(string $accessToken): UserBadge
     {
         return match ($accessToken) {
-            'VALID_ACCESS_TOKEN' => 'dunglas',
+            'VALID_ACCESS_TOKEN' => new UserBadge('dunglas'),
             default => throw new BadCredentialsException('Invalid credentials.'),
         };
     }

--- a/src/Symfony/Component/Security/Http/AccessToken/AccessTokenHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/AccessTokenHandlerInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\AccessToken;
 
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 /**
  * The token handler retrieves the user identifier from the token.
@@ -24,5 +25,5 @@ interface AccessTokenHandlerInterface
     /**
      * @throws AuthenticationException
      */
-    public function getUserIdentifierFrom(#[\SensitiveParameter] string $accessToken): string;
+    public function getUserBadgeFrom(#[\SensitiveParameter] string $accessToken): UserBadge;
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/ChainedAccessTokenExtractorsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/ChainedAccessTokenExtractorsTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Security\Http\AccessToken\FormEncodedBodyExtractor;
 use Symfony\Component\Security\Http\AccessToken\HeaderAccessTokenExtractor;
 use Symfony\Component\Security\Http\AccessToken\QueryAccessTokenExtractor;
 use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Tests\Authenticator\InMemoryAccessTokenHandler;
 
@@ -40,7 +41,7 @@ class ChainedAccessTokenExtractorsTest extends TestCase
     /**
      * @dataProvider provideSupportData
      */
-    public function testSupport($request): void
+    public function testSupport($request)
     {
         $this->setUpAuthenticator();
 
@@ -53,9 +54,9 @@ class ChainedAccessTokenExtractorsTest extends TestCase
         yield [new Request([], [], [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer INVALID_ACCESS_TOKEN'])];
     }
 
-    public function testAuthenticate(): void
+    public function testAuthenticate()
     {
-        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', 'foo');
+        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', new UserBadge('foo'));
         $this->setUpAuthenticator();
 
         $request = new Request([], [], [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
@@ -66,7 +67,7 @@ class ChainedAccessTokenExtractorsTest extends TestCase
     /**
      * @dataProvider provideInvalidAuthenticateData
      */
-    public function testAuthenticateInvalid($request, $errorMessage, $exceptionType = BadRequestHttpException::class): void
+    public function testAuthenticateInvalid($request, $errorMessage, $exceptionType = BadRequestHttpException::class)
     {
         $this->expectException($exceptionType);
         $this->expectExceptionMessage($errorMessage);
@@ -100,13 +101,13 @@ class ChainedAccessTokenExtractorsTest extends TestCase
     private function setUpAuthenticator(): void
     {
         $this->authenticator = new AccessTokenAuthenticator(
-            $this->userProvider,
             $this->accessTokenHandler,
             new ChainAccessTokenExtractor([
                 new FormEncodedBodyExtractor(),
                 new QueryAccessTokenExtractor(),
                 new HeaderAccessTokenExtractor(),
-            ])
+            ]),
+            $this->userProvider
         );
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/FormEncodedBodyAccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/FormEncodedBodyAccessTokenAuthenticatorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\AccessToken\FormEncodedBodyExtractor;
 use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Tests\Authenticator\InMemoryAccessTokenHandler;
 
@@ -34,7 +35,7 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
         $this->accessTokenHandler = new InMemoryAccessTokenHandler();
     }
 
-    public function testSupport(): void
+    public function testSupport()
     {
         $this->setUpAuthenticator();
         $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
@@ -44,7 +45,7 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
         $this->assertNull($this->authenticator->supports($request));
     }
 
-    public function testSupportsWithCustomParameter(): void
+    public function testSupportsWithCustomParameter()
     {
         $this->setUpAuthenticator('protection-token');
         $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
@@ -54,9 +55,9 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
         $this->assertNull($this->authenticator->supports($request));
     }
 
-    public function testAuthenticate(): void
+    public function testAuthenticate()
     {
-        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', 'foo');
+        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', new UserBadge('foo'));
         $this->setUpAuthenticator();
         $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded'], 'access_token=VALID_ACCESS_TOKEN');
         $request->request->set('access_token', 'VALID_ACCESS_TOKEN');
@@ -66,9 +67,9 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
         $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
     }
 
-    public function testAuthenticateWithCustomParameter(): void
+    public function testAuthenticateWithCustomParameter()
     {
-        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', 'foo');
+        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', new UserBadge('foo'));
         $this->setUpAuthenticator('protection-token');
         $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
         $request->request->set('protection-token', 'VALID_ACCESS_TOKEN');
@@ -81,7 +82,7 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
     /**
      * @dataProvider provideInvalidAuthenticateData
      */
-    public function testAuthenticateInvalid($request, $errorMessage, $exceptionType = BadRequestHttpException::class): void
+    public function testAuthenticateInvalid($request, $errorMessage, $exceptionType = BadRequestHttpException::class)
     {
         $this->expectException($exceptionType);
         $this->expectExceptionMessage($errorMessage);
@@ -119,9 +120,9 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
     private function setUpAuthenticator(string $parameter = 'access_token'): void
     {
         $this->authenticator = new AccessTokenAuthenticator(
-            $this->userProvider,
             $this->accessTokenHandler,
-            new FormEncodedBodyExtractor($parameter)
+            new FormEncodedBodyExtractor($parameter),
+            $this->userProvider
         );
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/HeaderAccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/HeaderAccessTokenAuthenticatorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\AccessToken\HeaderAccessTokenExtractor;
 use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Tests\Authenticator\InMemoryAccessTokenHandler;
 
@@ -37,7 +38,7 @@ class HeaderAccessTokenAuthenticatorTest extends TestCase
     /**
      * @dataProvider provideSupportData
      */
-    public function testSupport($request): void
+    public function testSupport($request)
     {
         $this->setUpAuthenticator();
 
@@ -53,7 +54,7 @@ class HeaderAccessTokenAuthenticatorTest extends TestCase
     /**
      * @dataProvider provideSupportsWithCustomTokenTypeData
      */
-    public function testSupportsWithCustomTokenType($request, $result): void
+    public function testSupportsWithCustomTokenType($request, $result)
     {
         $this->setUpAuthenticator('Authorization', 'JWT');
 
@@ -71,7 +72,7 @@ class HeaderAccessTokenAuthenticatorTest extends TestCase
     /**
      * @dataProvider provideSupportsWithCustomHeaderParameter
      */
-    public function testSupportsWithCustomHeaderParameter($request, $result): void
+    public function testSupportsWithCustomHeaderParameter($request, $result)
     {
         $this->setUpAuthenticator('X-FOO');
 
@@ -86,9 +87,9 @@ class HeaderAccessTokenAuthenticatorTest extends TestCase
         yield [new Request([], [], [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer INVALID_ACCESS_TOKEN']), false];
     }
 
-    public function testAuthenticate(): void
+    public function testAuthenticate()
     {
-        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', 'foo');
+        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', new UserBadge('foo'));
         $this->setUpAuthenticator();
 
         $request = new Request([], [], [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
@@ -96,9 +97,9 @@ class HeaderAccessTokenAuthenticatorTest extends TestCase
         $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
     }
 
-    public function testAuthenticateWithCustomTokenType(): void
+    public function testAuthenticateWithCustomTokenType()
     {
-        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', 'foo');
+        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', new UserBadge('foo'));
         $this->setUpAuthenticator('Authorization', 'JWT');
 
         $request = new Request([], [], [], [], [], ['HTTP_AUTHORIZATION' => 'JWT VALID_ACCESS_TOKEN']);
@@ -109,7 +110,7 @@ class HeaderAccessTokenAuthenticatorTest extends TestCase
     /**
      * @dataProvider provideInvalidAuthenticateData
      */
-    public function testAuthenticateInvalid($request, $errorMessage, $exceptionType = BadRequestHttpException::class): void
+    public function testAuthenticateInvalid($request, $errorMessage, $exceptionType = BadRequestHttpException::class)
     {
         $this->expectException($exceptionType);
         $this->expectExceptionMessage($errorMessage);
@@ -143,9 +144,9 @@ class HeaderAccessTokenAuthenticatorTest extends TestCase
     private function setUpAuthenticator(string $headerParameter = 'Authorization', string $tokenType = 'Bearer'): void
     {
         $this->authenticator = new AccessTokenAuthenticator(
-            $this->userProvider,
             $this->accessTokenHandler,
-            new HeaderAccessTokenExtractor($headerParameter, $tokenType)
+            new HeaderAccessTokenExtractor($headerParameter, $tokenType),
+            $this->userProvider
         );
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/QueryAccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/QueryAccessTokenAuthenticatorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\AccessToken\QueryAccessTokenExtractor;
 use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Tests\Authenticator\InMemoryAccessTokenHandler;
 
@@ -34,7 +35,7 @@ class QueryAccessTokenAuthenticatorTest extends TestCase
         $this->accessTokenHandler = new InMemoryAccessTokenHandler();
     }
 
-    public function testSupport(): void
+    public function testSupport()
     {
         $this->setUpAuthenticator();
         $request = new Request();
@@ -43,7 +44,7 @@ class QueryAccessTokenAuthenticatorTest extends TestCase
         $this->assertNull($this->authenticator->supports($request));
     }
 
-    public function testSupportsWithCustomParameter(): void
+    public function testSupportsWithCustomParameter()
     {
         $this->setUpAuthenticator('protection-token');
         $request = new Request();
@@ -52,9 +53,9 @@ class QueryAccessTokenAuthenticatorTest extends TestCase
         $this->assertNull($this->authenticator->supports($request));
     }
 
-    public function testAuthenticate(): void
+    public function testAuthenticate()
     {
-        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', 'foo');
+        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', new UserBadge('foo'));
         $this->setUpAuthenticator();
         $request = new Request();
         $request->query->set('access_token', 'VALID_ACCESS_TOKEN');
@@ -63,9 +64,9 @@ class QueryAccessTokenAuthenticatorTest extends TestCase
         $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
     }
 
-    public function testAuthenticateWithCustomParameter(): void
+    public function testAuthenticateWithCustomParameter()
     {
-        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', 'foo');
+        $this->accessTokenHandler->add('VALID_ACCESS_TOKEN', new UserBadge('foo'));
         $this->setUpAuthenticator('protection-token');
         $request = new Request();
         $request->query->set('protection-token', 'VALID_ACCESS_TOKEN');
@@ -77,7 +78,7 @@ class QueryAccessTokenAuthenticatorTest extends TestCase
     /**
      * @dataProvider provideInvalidAuthenticateData
      */
-    public function testAuthenticateInvalid($request, $errorMessage, $exceptionType = BadRequestHttpException::class): void
+    public function testAuthenticateInvalid($request, $errorMessage, $exceptionType = BadRequestHttpException::class)
     {
         $this->expectException($exceptionType);
         $this->expectExceptionMessage($errorMessage);
@@ -111,9 +112,9 @@ class QueryAccessTokenAuthenticatorTest extends TestCase
     private function setUpAuthenticator(string $parameter = 'access_token'): void
     {
         $this->authenticator = new AccessTokenAuthenticator(
-            $this->userProvider,
             $this->accessTokenHandler,
-            new QueryAccessTokenExtractor($parameter)
+            new QueryAccessTokenExtractor($parameter),
+            $this->userProvider
         );
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/InMemoryAccessTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/InMemoryAccessTokenHandler.php
@@ -13,15 +13,16 @@ namespace Symfony\Component\Security\Http\Tests\Authenticator;
 
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 class InMemoryAccessTokenHandler implements AccessTokenHandlerInterface
 {
     /**
-     * @var array<string, string>
+     * @var array<string, UserBadge>
      */
     private $accessTokens = [];
 
-    public function getUserIdentifierFrom(string $accessToken): string
+    public function getUserBadgeFrom(string $accessToken): UserBadge
     {
         if (!\array_key_exists($accessToken, $this->accessTokens)) {
             throw new BadCredentialsException('Invalid access token or invalid user.');
@@ -37,7 +38,7 @@ class InMemoryAccessTokenHandler implements AccessTokenHandlerInterface
         return $this;
     }
 
-    public function add(string $accessToken, string $user): self
+    public function add(string $accessToken, UserBadge $user): self
     {
         $this->accessTokens[$accessToken] = $user;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        |  -

I attended @welcoMattic 's nice talk at SymfonyCon Paris last week, after which we and @wouterj discussed the way tokens need to be parsed to obtain a `userIdentifier`. With JWT tokens, there is usually no need to make a call to a database to instantiate a User object. Because the token is signed, we can guarantee the user details inside it are valid. See example code: https://github.com/welcoMattic/painless-authentication-with-access-token/blob/main/slides/slides.md#62-jwthandler

In Symfony's authentication system, retrieving the `userIdentifier` and the `User` is a two-step process. However with both the `userIdentifier` and the `User` object coming from the token, we either have to parse the token twice or store it in memory. 

I think this can be improved by allowing a single step to go from $token (string) -> parsed token (implementation specific) -> User object. 

The suggested change in this PR is probably not yet the way to go, but I'd like to hear from the Security contributers if they have any ideas. 
