### PR TITLE
[Console] Support a set of control keys and key combinations in `QuestionHelper`

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -57,6 +57,11 @@ class SymfonyStyle extends OutputStyle
         parent::__construct($output);
     }
 
+    public function getOutput(): OutputInterface
+    {
+        return $this->output;
+    }
+
     /**
      * Formats a message as a block of text.
      */

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -96,6 +96,14 @@ class SymfonyStyleTest extends TestCase
         $this->assertStringEqualsFile($outputFilepath, $this->tester->getDisplay(true));
     }
 
+    public function testGetOutput()
+    {
+        $output = $this->createMock(OutputInterface::class);
+        $io = new SymfonyStyle($this->createMock(InputInterface::class), $output);
+
+        $this->assertSame($output, $io->getOutput());
+    }
+
     public function testGetErrorStyle()
     {
         $input = $this->createMock(InputInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #36657
| License       | MIT
| Doc PR        | -

Add support for using arrow keys in the QuestionHelper.

There was already a try #36700 to fix the issue.

The approach here does not depend on `readline` at all (removed in #17669)

This key combinations are added:
| Key combination | Comment
| --- | ---
| `←` | Backward one character
| `CTRL` + `B` | Backward one character
| `→` | Forward one character
| `CTRL` + `F` | Forward one character
| `CTRL` + `←` | Backward one word
| `ALT` + `B` | Backward one word
| `CTRL` + `SHIFT` + `←` | Backward one word
| `CTRL` + `→` | Forward one word
| `ALT` + `F` | Forward one word
| `CTRL` + `SHIFT` + `→` | Forward  one word
| `CTRL` + `H` | Delete previous character
| `Backspace` | Delete previous character
| `Delete` | Delete next character
| `CTRL` + `A` | Beginning of input
| `Home` | Beginning of input
| `CTRL` + `E` | End of input
| `End` | End of input

Feel free to test it out and leave comments about the experience.

**UPDATE** For better testing i now created a repo https://github.com/maxbeckers/symfony-cli-input-handling 