### PR TITLE
[Security] Make onAuthenticationSuccess Response optional

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
@@ -29,5 +29,5 @@ interface AuthenticationSuccessHandlerInterface
     /**
      * Usually called by AuthenticatorInterface::onAuthenticationSuccess() implementations.
      */
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response;
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): ?Response;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0, 6.1, and 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT



Most authenticators currently use onAuthenticationSuccess with an optional Response. That's mainly due to usecases whereby we want to redirect specific users etc.
