### PR TITLE
[Console] #47809 remove exit() call in last SignalHandler

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -998,15 +998,8 @@ class Application implements ResetInterface
                 foreach ($this->signalsToDispatchEvent as $signal) {
                     $event = new ConsoleSignalEvent($command, $input, $output, $signal);
 
-                    $this->signalRegistry->register($signal, function ($signal, $hasNext) use ($event) {
+                    $this->signalRegistry->register($signal, function () use ($event) {
                         $this->dispatcher->dispatch($event, ConsoleEvents::SIGNAL);
-
-                        // No more handlers, we try to simulate PHP default behavior
-                        if (!$hasNext) {
-                            if (!\in_array($signal, [\SIGUSR1, \SIGUSR2], true)) {
-                                exit(0);
-                            }
-                        }
                     });
                 }
             }

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Remove `exit` call in `Application` signal handlers. Commands will no longer be automatically interrupted after receiving signal other than `SIGUSR1` or `SIGUSR2`
+
 6.2
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| BC? | yes 
| New feature?  | no
| Deprecations? | not sure
| Tickets       | Fix #47809
| License       | MIT

This PR possibly introduces some breaking changes.


Remove last SignalHandler `exit()` call in `Application:doRunCommand` introduced in df57119884f62c2c29e8a9232b56a287196dad32.

For more context see #47809 