### PR TITLE
[Mailer] Fix: do not clear context of message after rendering

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
+++ b/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
@@ -67,8 +67,6 @@ final class BodyRenderer implements BodyRendererInterface
             $message->htmlTemplate(null);
         }
 
-        $message->context([]);
-
         // if text body is empty, compute one from the HTML body
         if (!$message->getTextBody() && null !== $html = $message->getHtmlBody()) {
             $text = $this->converter->convert(\is_resource($html) ? stream_get_contents($html) : $html, $message->getHtmlCharset());

--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -60,6 +60,8 @@ final class Mailer implements MailerInterface
         }
 
         try {
+            // Many users will have issues if they include unserializable items in their context of a TemplatedEmail
+            // Therefore to improve usability we will clear the context of this email which will have already been rendered
             if ($message instanceof TemplatedEmail) {
                 $message->context([]);
             }

--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Mailer;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Messenger\SendEmailMessage;
@@ -59,6 +60,9 @@ final class Mailer implements MailerInterface
         }
 
         try {
+            if ($message instanceof TemplatedEmail) {
+                $message->context([]);
+            }
             $this->bus->dispatch(new SendEmailMessage($message, $envelope), $stamps);
         } catch (HandlerFailedException $e) {
             foreach ($e->getNestedExceptions() as $nested) {

--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -112,14 +112,15 @@ class MailerTest extends TestCase
 
         $mailer->send($email);
 
+        $serializer = new PhpSerializer();
+
         self::assertCount(1, $bus->messages);
+        self::assertCount(1, $bus->envelopes);
+
         $templatedEmail = $bus->messages[0]->getMessage();
         self::assertInstanceOf(TemplatedEmail::class, $templatedEmail);
         self::assertSame($email, $templatedEmail);
-
-        $serializer = new PhpSerializer();
         self::assertArrayHasKey('body', $serializer->encode($bus->envelopes[0]));
-
         self::assertSame([], $templatedEmail->getContext());
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -93,7 +93,7 @@ class MailerTest extends TestCase
         self::assertSame([$stamp], $bus->stamps);
     }
 
-    public function testSendTemplatedEmailToBus()
+    public function testSendTemplatedEmailWithUnserializableContextToBus()
     {
         $bus = self::createDumyMailerBus();
         $stamp = $this->createMock(StampInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47993
| License       | MIT
| Doc PR        | n/a

When running tests in 6.1 I am checking the message context has been set correctly. The email that is collected in the logger is updated after rendering. This line doesn't seem necessary, but if it is, perhaps we should be looking here and to why the message, when cloned still has the context modified in the profiler.
https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Mailer/Mailer.php#L54

Thoughts?

//cc @fabpot as this change was a commit by him. Happy to discuss.

Thank you