### PR TITLE
fix: RegexValidator doesn't validate empty strings anymore

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -30,7 +30,7 @@ class RegexValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Regex::class);
         }
 
-        if (null === $value || '' === $value) {
+        if (null === $value) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

It is possible to pass an empty string as a $pattern to Regex() constraint, so it should be treated as a valid singular case, therefore Regex() should not consider empty strings via non-empty regexps as valid
