### PR TITLE
[VarExporter] List required properties in lazy traits

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
@@ -29,9 +29,6 @@ class Redis5Proxy extends \Redis implements ResetInterface, LazyObjectInterface
         resetLazyObject as reset;
     }
 
-    private int $lazyObjectId;
-    private \Redis $lazyObjectReal;
-
     private const LAZY_OBJECT_PROPERTY_SCOPES = [
         'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
         "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],

--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -29,9 +29,6 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
         resetLazyObject as reset;
     }
 
-    private int $lazyObjectId;
-    private \Redis $lazyObjectReal;
-
     private const LAZY_OBJECT_PROPERTY_SCOPES = [
         'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
         "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],

--- a/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
@@ -29,9 +29,6 @@ class RedisCluster5Proxy extends \RedisCluster implements ResetInterface, LazyOb
         resetLazyObject as reset;
     }
 
-    private int $lazyObjectId;
-    private \RedisCluster $lazyObjectReal;
-
     private const LAZY_OBJECT_PROPERTY_SCOPES = [
         'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
         "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],

--- a/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
@@ -29,9 +29,6 @@ class RedisCluster6Proxy extends \RedisCluster implements ResetInterface, LazyOb
         resetLazyObject as reset;
     }
 
-    private int $lazyObjectId;
-    private \RedisCluster $lazyObjectReal;
-
     private const LAZY_OBJECT_PROPERTY_SCOPES = [
         'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
         "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy_ghost.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy_ghost.php
@@ -75,8 +75,6 @@ class stdClass_5a8a5eb extends \stdClass implements \Symfony\Component\VarExport
 {
     use \Symfony\Component\VarExporter\LazyGhostTrait;
 
-    private int $lazyObjectId;
-
     private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
@@ -45,8 +45,6 @@ class FooLazyClass_f814e3a extends \Bar\FooLazyClass implements \Symfony\Compone
 {
     use \Symfony\Component\VarExporter\LazyGhostTrait;
 
-    private int $lazyObjectId;
-
     private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_ghost.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_ghost.php
@@ -79,8 +79,6 @@ class stdClass_5a8a5eb extends \stdClass implements \Symfony\Component\VarExport
 {
     use \Symfony\Component\VarExporter\LazyGhostTrait;
 
-    private int $lazyObjectId;
-
     private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
@@ -75,9 +75,6 @@ class Wither_94fa281 extends \Symfony\Component\DependencyInjection\Tests\Compil
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 
-    private int $lazyObjectId;
-    private parent $lazyObjectReal;
-
     private const LAZY_OBJECT_PROPERTY_SCOPES = [
         'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
         "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -15,11 +15,10 @@ use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
 
-/**
- * @property int $lazyObjectId This property must be declared as private in classes using this trait
- */
 trait LazyGhostTrait
 {
+    private int $lazyObjectId;
+
     /**
      * Creates a lazy-loading ghost instance.
      *
@@ -30,6 +29,9 @@ trait LazyGhostTrait
      * properties and closures should accept 4 arguments: the instance to
      * initialize, the property to initialize, its write-scope, and its default
      * value. Each closure should return the value of the corresponding property.
+     *
+     * Properties should be indexed by their array-cast name, see
+     * https://php.net/manual/language.types.array#language.types.array.casting
      *
      * @param \Closure(static):void|array<string, \Closure(static, string, ?string, mixed):mixed> $initializer
      * @param array<string, true> $skippedProperties An array indexed by the properties to skip, aka the ones

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -16,13 +16,11 @@ use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
 
-/**
- * @property int    $lazyObjectId   This property must be declared as private in classes using this trait
- * @property parent $lazyObjectReal This property must be declared as private in classes using this trait;
- *                                  its type should match the type of the proxied object
- */
 trait LazyProxyTrait
 {
+    private int $lazyObjectId;
+    private object $lazyObjectReal;
+
     /**
      * Creates a lazy-loading virtual proxy.
      *

--- a/src/Symfony/Component/VarExporter/README.md
+++ b/src/Symfony/Component/VarExporter/README.md
@@ -92,8 +92,6 @@ when accessing a property.
 class FooLazyGhost extends Foo
 {
     use LazyGhostTrait;
-
-    private int $lazyObjectId;
 }
 
 $foo = FooLazyGhost::createLazyGhost(initializer: function (Foo $instance): void {

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ChildMagicClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ChildMagicClass.php
@@ -18,6 +18,5 @@ class ChildMagicClass extends MagicClass implements LazyObjectInterface
 {
     use LazyGhostTrait;
 
-    private int $lazyObjectId;
     private int $data = 123;
 }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ChildStdClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ChildStdClass.php
@@ -17,6 +17,4 @@ use Symfony\Component\VarExporter\LazyObjectInterface;
 class ChildStdClass extends \stdClass implements LazyObjectInterface
 {
     use LazyGhostTrait;
-
-    private int $lazyObjectId;
 }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/LazyClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/LazyClass.php
@@ -19,7 +19,6 @@ class LazyClass
         createLazyGhost as private;
     }
 
-    private int $lazyObjectId;
     public int $public;
 
     public function __construct(\Closure $initializer)

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/TestClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/TestClass.php
@@ -17,7 +17,6 @@ class TestClass extends NoMagicClass
 {
     use LazyGhostTrait;
 
-    private int $lazyObjectId;
     public int $public = 1;
     protected int $protected = 2;
     protected readonly int $protectedReadonly;

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -248,7 +248,7 @@ class LazyGhostTraitTest extends TestCase
         $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(123, $instance->public);
         $this->assertFalse($instance->isLazyObjectInitialized());
-        $this->assertSame(["\0".TestClass::class."\0lazyObjectId", 'public'], array_keys((array) $instance));
+        $this->assertSame(['public', "\0".TestClass::class."\0lazyObjectId"], array_keys((array) $instance));
         $this->assertSame(1, $counter);
 
         $instance->initializeLazyObject();

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -249,9 +249,6 @@ class LazyProxyTraitTest extends TestCase
                 createLazyProxy as private;
             }
 
-            private int $lazyObjectId;
-            private parent $lazyObjectReal;
-
             public function __construct()
             {
                 self::createLazyProxy(fn () => new TestClass((object) ['foo' => 123]), $this);

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -66,9 +66,6 @@ class ProxyHelperTest extends TestCase
         {
             use \Symfony\Component\VarExporter\LazyProxyTrait;
 
-            private int $lazyObjectId;
-            private parent $lazyObjectReal;
-
             private const LAZY_OBJECT_PROPERTY_SCOPES = [
                 'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
                 "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
@@ -118,9 +115,6 @@ class ProxyHelperTest extends TestCase
          implements \Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface1, \Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2, \Symfony\Component\VarExporter\LazyObjectInterface
         {
             use \Symfony\Component\VarExporter\LazyProxyTrait;
-
-            private int $lazyObjectId;
-            private \Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface1&\Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2 $lazyObjectReal;
 
             private const LAZY_OBJECT_PROPERTY_SCOPES = [
                 'lazyObjectReal' => [self::class, 'lazyObjectReal', null],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

At first I decided to not list those properties to work around limitations of readonly classes.
By listing properties as proposed here, we make the lazy traits incompatible with readonly classes.
But 1. declaring those properties in consumers is a WTF, and 2. the issues with readonly classes are likely going to be removed in PHP 8.3 after https://wiki.php.net/rfc/readonly_amendments

