### PR TITLE
The Request instance converted parameters with boolean value 'false' to the empty string

### DIFF
--- a/src/Symfony/Component/BrowserKit/Request.php
+++ b/src/Symfony/Component/BrowserKit/Request.php
@@ -39,7 +39,7 @@ class Request
         $this->method = $method;
 
         array_walk_recursive($parameters, static function (&$value) {
-            $value = \is_bool($value) ? $value : (string) $value;
+            $value = $value !== false ?  (string) $value : '0';
         });
 
         $this->parameters = $parameters;

--- a/src/Symfony/Component/BrowserKit/Request.php
+++ b/src/Symfony/Component/BrowserKit/Request.php
@@ -39,7 +39,7 @@ class Request
         $this->method = $method;
 
         array_walk_recursive($parameters, static function (&$value) {
-            $value = $value !== false ?  (string) $value : '0';
+            $value = false === $value ? '0' : (string) $value;
         });
 
         $this->parameters = $parameters;

--- a/src/Symfony/Component/BrowserKit/Request.php
+++ b/src/Symfony/Component/BrowserKit/Request.php
@@ -39,7 +39,7 @@ class Request
         $this->method = $method;
 
         array_walk_recursive($parameters, static function (&$value) {
-            $value = (string) $value;
+            $value = is_bool($value) ? $value : (string) $value;
         });
 
         $this->parameters = $parameters;

--- a/src/Symfony/Component/BrowserKit/Request.php
+++ b/src/Symfony/Component/BrowserKit/Request.php
@@ -39,7 +39,7 @@ class Request
         $this->method = $method;
 
         array_walk_recursive($parameters, static function (&$value) {
-            $value = is_bool($value) ? $value : (string) $value;
+            $value = \is_bool($value) ? $value : (string) $value;
         });
 
         $this->parameters = $parameters;

--- a/src/Symfony/Component/BrowserKit/Tests/RequestTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/RequestTest.php
@@ -76,20 +76,18 @@ class RequestTest extends TestCase
     {
         $parameters = [
             'foo' => false,
-            'bar' => [
-                'baz' => true,
-            ],
+        ];
+
+        $expected = [
+            'foo' => '0',
         ];
 
         $notExpected = [
             'foo' => '',
-            'bar' => [
-                'baz' => '1',
-            ],
         ];
 
         $request = new Request('http://www.example.com/', 'get', $parameters);
-        $this->assertSame($parameters, $request->getParameters());
+        $this->assertSame($expected, $request->getParameters());
         $this->assertNotSame($notExpected, $request->getParameters());
     }
 }

--- a/src/Symfony/Component/BrowserKit/Tests/RequestTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/RequestTest.php
@@ -71,4 +71,25 @@ class RequestTest extends TestCase
         $request = new Request('http://www.example.com/', 'get', $parameters);
         $this->assertSame($expected, $request->getParameters());
     }
+
+    public function testFalseParameterAreNotConvertedToEmptyString()
+    {
+        $parameters = [
+            'foo' => false,
+            'bar' => [
+                'baz' => true,
+            ],
+        ];
+
+        $notExpected = [
+            'foo' => '',
+            'bar' => [
+                'baz' => '1',
+            ],
+        ];
+
+        $request = new Request('http://www.example.com/', 'get', $parameters);
+        $this->assertSame($parameters, $request->getParameters());
+        $this->assertNotSame($notExpected, $request->getParameters());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48309
| License       | MIT

Hello!

I have found not correct behaviour when we use the instance `Symfony\Component\BrowserKit\Request`.

When we try send a request with a parameter with the boolean `false`-value , the package transform the `false`-parameter to [an empty string](https://github.com/symfony/browser-kit/blob/6.1/Request.php#L42).
It is the standard PHP behaviour, but the package breaks a logic of the http-requests.
