### PR TITLE
[VarExporter] Improve partial-initialization API for ghost objects

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyObjectInterface.php
+++ b/src/Symfony/Component/VarExporter/LazyObjectInterface.php
@@ -15,8 +15,10 @@ interface LazyObjectInterface
 {
     /**
      * Returns whether the object is initialized.
+     *
+     * @param $partial Whether partially initialized objects should be considered as initialized
      */
-    public function isLazyObjectInitialized(): bool;
+    public function isLazyObjectInitialized(bool $partial = false): bool;
 
     /**
      * Forces initialization of a lazy object and returns it.

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -47,8 +47,10 @@ trait LazyProxyTrait
 
     /**
      * Returns whether the object is initialized.
+     *
+     * @param $partial Whether partially initialized objects should be considered as initialized
      */
-    public function isLazyObjectInitialized(): bool
+    public function isLazyObjectInitialized(bool $partial = false): bool
     {
         if (0 >= ($this->lazyObjectId ?? 0)) {
             return true;

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -248,6 +248,7 @@ class LazyGhostTraitTest extends TestCase
         $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(123, $instance->public);
         $this->assertFalse($instance->isLazyObjectInitialized());
+        $this->assertTrue($instance->isLazyObjectInitialized(true));
         $this->assertSame(['public', "\0".TestClass::class."\0lazyObjectId"], array_keys((array) $instance));
         $this->assertSame(1, $counter);
 
@@ -329,5 +330,90 @@ class LazyGhostTraitTest extends TestCase
         $r = new \ReflectionProperty($obj, 'private');
 
         $this->assertSame(-3, $r->getValue($obj));
+    }
+
+    public function testFullPartialInitialization()
+    {
+        $counter = 0;
+        $initializer = static function (ChildTestClass $instance, string $property, ?string $scope, mixed $default) use (&$counter) {
+            return 234;
+        };
+        $instance = ChildTestClass::createLazyGhost([
+            'public' => $initializer,
+            'publicReadonly' => $initializer,
+            "\0*\0protected" => $initializer,
+            "\0" => function ($obj, $defaults) use (&$instance, &$counter) {
+                $counter += 1000;
+                $this->assertSame($instance, $obj);
+
+                return [
+                    'public' => 345,
+                    'publicReadonly' => 456,
+                    "\0*\0protected" => 567,
+                ] + $defaults;
+            },
+        ]);
+
+        $this->assertSame($instance, $instance->initializeLazyObject());
+        $this->assertSame(345, $instance->public);
+        $this->assertSame(456, $instance->publicReadonly);
+        $this->assertSame(6, ((array) $instance)["\0".ChildTestClass::class."\0private"]);
+        $this->assertSame(3, ((array) $instance)["\0".TestClass::class."\0private"]);
+        $this->assertSame(1000, $counter);
+    }
+
+    public function testPartialInitializationFallback()
+    {
+        $counter = 0;
+        $instance = ChildTestClass::createLazyGhost([
+            "\0" => function ($obj) use (&$instance, &$counter) {
+                $counter += 1000;
+                $this->assertSame($instance, $obj);
+
+                return [
+                    'public' => 345,
+                    'publicReadonly' => 456,
+                    "\0*\0protected" => 567,
+                ];
+            },
+        ], []);
+
+        $this->assertSame(345, $instance->public);
+        $this->assertSame(456, $instance->publicReadonly);
+        $this->assertSame(567, ((array) $instance)["\0*\0protected"]);
+        $this->assertSame(1000, $counter);
+    }
+
+    public function testFullInitializationAfterPartialInitialization()
+    {
+        $counter = 0;
+        $initializer = static function (ChildTestClass $instance, string $property, ?string $scope, mixed $default) use (&$counter) {
+            ++$counter;
+
+            return 234;
+        };
+        $instance = ChildTestClass::createLazyGhost([
+            'public' => $initializer,
+            'publicReadonly' => $initializer,
+            "\0*\0protected" => $initializer,
+            "\0" => function ($obj, $defaults) use (&$instance, &$counter) {
+                $counter += 1000;
+                $this->assertSame($instance, $obj);
+
+                return [
+                    'public' => 345,
+                    'publicReadonly' => 456,
+                    "\0*\0protected" => 567,
+                ] + $defaults;
+            },
+        ]);
+
+        $this->assertSame(234, $instance->public);
+        $this->assertSame($instance, $instance->initializeLazyObject());
+        $this->assertSame(234, $instance->public);
+        $this->assertSame(456, $instance->publicReadonly);
+        $this->assertSame(6, ((array) $instance)["\0".ChildTestClass::class."\0private"]);
+        $this->assertSame(3, ((array) $instance)["\0".TestClass::class."\0private"]);
+        $this->assertSame(1001, $counter);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Discussed with @alcaeus at SymfonyCon, this improves support for partial-initialization of lazy ghost objects.

- `isLazyObjectInitialized(bool $partial = false): bool` allows checking if an object is partially-initialized.
- a partial initializer set to the special `"\0"` key can be used to initialize all/many properties at once.

Targeting 6.2 because this would be a BC break in 6.3, also because this improves a new unreleased feature.