### PR TITLE
[Mime] Fix MessagePart serialization

### DIFF
--- a/src/Symfony/Component/Mime/Part/MessagePart.php
+++ b/src/Symfony/Component/Mime/Part/MessagePart.php
@@ -59,4 +59,17 @@ class MessagePart extends DataPart
     {
         return $this->message->toIterable();
     }
+
+    /**
+     * @return array
+     */
+    public function __sleep()
+    {
+        return ['message'];
+    }
+
+    public function __wakeup()
+    {
+        $this->__construct($this->message);
+    }
 }

--- a/src/Symfony/Component/Mime/Tests/Part/MessagePartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/MessagePartTest.php
@@ -39,4 +39,14 @@ class MessagePartTest extends TestCase
             new ParameterizedHeader('Content-Disposition', 'attachment', ['name' => 'Subject.eml', 'filename' => 'Subject.eml'])
         ), $p->getPreparedHeaders());
     }
+
+    public function testSerialize()
+    {
+        $email = (new Email())->from('fabien@symfony.com')->to('you@example.com')->text('content');
+        $email->getHeaders()->addIdHeader('Message-ID', $email->generateMessageId());
+
+        $p = new MessagePart($email);
+        $expected = clone $p;
+        $this->assertEquals($expected->toString(), unserialize(serialize($p))->toString());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48313 
| License       | MIT
| Doc PR        | n/a

Fixes serialization of Symfony\Component\Mime\Part\MessagePart and adds test coverage.