### PR TITLE
[TwigBridge] Money type not rendering properly

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -6,7 +6,7 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-        <div class="input-group{{ group_class|default('') }}">
+        <div class="input-group {{ group_class|default('') }}">
             {%- if prepend -%}
                 <div class="input-group-prepend">
                     <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -24,7 +24,7 @@
     {%- endif -%}
 {%- endblock money_widget %}
 
-{% block date_widget -%}{{ ('http://' ~ app.request.host) | trans }}
+{% block date_widget -%}
     {%- if widget == 'single_text' -%}
         {{- block('form_widget_simple') -}}
     {%- else -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -62,15 +62,7 @@
         {%- if datetime is not defined or false == datetime -%}
             <div {{ block('widget_container_attributes') -}}>
         {%- endif -%}
-        {%- if label is not same as(false) -%}%- set inputClass = 'input-group' -%}
-10
-        {% if group_class | length > 0 %}
-11
-            {%- set inputClass = inputClass ~ ' ' ~ group_class -%}
-12
-        {% endif %}
-13
-        <div class="{{ inputClass }}">
+        {%- if label is not same as(false) -%}
             <div class="visually-hidden">
                 {{- form_label(form.hour) -}}
                 {%- if with_minutes -%}{{ form_label(form.minute) }}{%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -6,11 +6,7 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-        {%- set inputClass = 'input-group' -%}
-        {% if group_class | length > 0 %}
-            {%- set inputClass = inputClass ~ ' ' ~ group_class -%}
-        {% endif %}
-        <div class="{{ inputClass }}">
+        {<div class="input-group {{ group_class|default('') }}">
             {%- if prepend -%}
                 <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>
             {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -6,11 +6,11 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-        {%- set inputClass = ['input-group'] -%}
+        {%- set inputClass = 'input-group' -%}
         {% if group_class is defined %}
-            {% set inputClass = group_class|merge(inputClass) %}
+            {%- set inputClass = inputClass ~ ' ' ~ group_class -%}
         {% endif %}
-        <div class="{{ inputClass | join(' ')}}">
+        <div class="{{ inputClass }}">
             {%- if prepend -%}
                 <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>
             {%- endif -%}
@@ -24,7 +24,7 @@
     {%- endif -%}
 {%- endblock money_widget %}
 
-{% block date_widget -%}
+{% block date_widget -%}{{ ('http://' ~ app.request.host) | trans }}
     {%- if widget == 'single_text' -%}
         {{- block('form_widget_simple') -}}
     {%- else -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -6,7 +6,7 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-        <div class="input-group {{ group_class|default('') }}">
+            <div class="{{['input-group', group_class|default('')] | join(' ')}}">
             {%- if prepend -%}
                 <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>
             {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -6,7 +6,7 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-        <div class="input-group{{ group_class|default('') }}">
+        <div class="input-group {{ group_class|default('') }}">
             {%- if prepend -%}
                 <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>
             {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -6,7 +6,11 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-        <div class="{{['input-group', group_class] | join(' ')}}">
+        {%- set inputClass = ['input-group'] -%}
+        {% if group_class is defined %}
+            {% set inputClass = group_class|merge(inputClass) %}
+        {% endif %}
+        <div class="{{ inputClass | join(' ')}}">
             {%- if prepend -%}
                 <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>
             {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -7,7 +7,7 @@
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
         {%- set inputClass = 'input-group' -%}
-        {% if group_class is defined %}
+        {% if group_class | length > 0 %}
             {%- set inputClass = inputClass ~ ' ' ~ group_class -%}
         {% endif %}
         <div class="{{ inputClass }}">

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -6,7 +6,7 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-        {<div class="input-group {{ group_class|default('') }}">
+        <div class="input-group {{ group_class|default('') }}">
             {%- if prepend -%}
                 <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>
             {%- endif -%}
@@ -62,7 +62,15 @@
         {%- if datetime is not defined or false == datetime -%}
             <div {{ block('widget_container_attributes') -}}>
         {%- endif -%}
-        {%- if label is not same as(false) -%}
+        {%- if label is not same as(false) -%}%- set inputClass = 'input-group' -%}
+10
+        {% if group_class | length > 0 %}
+11
+            {%- set inputClass = inputClass ~ ' ' ~ group_class -%}
+12
+        {% endif %}
+13
+        <div class="{{ inputClass }}">
             <div class="visually-hidden">
                 {{- form_label(form.hour) -}}
                 {%- if with_minutes -%}{{ form_label(form.minute) }}{%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -6,7 +6,7 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-            <div class="{{['input-group', group_class|default('')] | join(' ')}}">
+        <div class="{{['input-group', group_class] | join(' ')}}">
             {%- if prepend -%}
                 <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>
             {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
@@ -11,7 +11,7 @@
     {% set prepend = not (money_pattern starts with '{{') %}
     {% set append = not (money_pattern ends with '}}') %}
     {% if prepend or append %}
-        <div class="input-group{{ group_class|default('') }}">
+        <div class="input-group {{ group_class|default('') }}">
             {% if prepend %}
                 <span class="input-group-addon">{{ money_pattern|form_encode_currency }}</span>
             {% endif %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -102,7 +102,7 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTest
         ;
 
         $this->assertSame(<<<'HTML'
-<div class="input-group"><div class="input-group-prepend">
+<div class="input-group "><div class="input-group-prepend">
                     <span class="input-group-text">&euro; </span>
                 </div><input type="text" id="name" name="name" required="required" class="form-control" /></div>
 HTML

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
@@ -104,7 +104,7 @@ class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTest
             ->createView();
 
         self::assertSame(<<<'HTML'
-<div class="input-group"><span class="input-group-text">&euro; </span><input type="text" id="name" name="name" required="required" class="form-control" /></div>
+<div class="input-group "><span class="input-group-text">&euro; </span><input type="text" id="name" name="name" required="required" class="form-control" /></div>
 HTML
             , trim($this->renderWidget($view)));
     }


### PR DESCRIPTION
Any classes passed to the money input are concatenated to the input-group class, so neither render. Add a space.

| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Money type not working when additional classes are past to the twig form. The additional classes are appended without a space, so the combined class might be "input-groupcol-md-3" and neither get rendered.