### PR TITLE
Fix exception when convert Request to string

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -502,7 +502,13 @@ class Request
         $cookies = [];
 
         foreach ($this->cookies as $k => $v) {
-            $cookies[] = $k.'='.$v;
+            if (is_array($v)) {
+                foreach ($v as $_k => $_v) {
+                    $cookies[] = "{$k}[{$_k}]={$_v}";
+                }
+            } else {
+                $cookies[] = $k.'='.$v;
+            }
         }
 
         if (!empty($cookies)) {


### PR DESCRIPTION
In some application like https://github.com/shopware/platform , they will store some data in cookie by an array struct. It will throw an Exception when we try to log the request. This PR fix it.

| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

<img width="1566" alt="image" src="https://user-images.githubusercontent.com/13899502/203995675-28eb7b8a-6a5e-44fa-a45b-664cb8186a24.png">
<img width="957" alt="image" src="https://user-images.githubusercontent.com/13899502/203995749-86d85663-6be6-4d87-a0f3-79e2f7dce2ca.png">
<img width="763" alt="image" src="https://user-images.githubusercontent.com/13899502/203995829-738efc54-708a-4a5a-9259-4c2ef59d9eba.png">
