### PR TITLE
[Serializer] Fix legacy nullable type in docblock

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -740,7 +740,7 @@ class ObjectNormalizerTest extends TestCase
         $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
 
         $this->assertSame('bar', $serializer->denormalize(['foo' => 'bar'], \get_class(new class() {
-            /** @var self::*|null */
+            /** @var self::*|?string */
             public $foo;
         }))->foo);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | Not really
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | n/a

Fixes failing Serializer test:

Unsilenced deprecation notices (1)

  1x: Legacy nullable type detected, please update your code as
         you are using nullable types in a docblock. support will be removed in v2.0.0
    1x in ObjectNormalizerTest::testDoesntHaveIssuesWithUnionConstTypes from Symfony\Component\Serializer\Tests\Normalizer
