### PR TITLE
[TwigBridge] Amend `MoneyType` twig to include a space

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -6,7 +6,7 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-        <div class="input-group{{ group_class|default('') }}">
+        <div class="input-group {{ group_class|default('') }}">
             {%- if prepend -%}
                 <div class="input-group-prepend">
                     <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -6,7 +6,7 @@
     {%- set prepend = not (money_pattern starts with '{{') -%}
     {%- set append = not (money_pattern ends with '}}') -%}
     {%- if prepend or append -%}
-        <div class="input-group{{ group_class|default('') }}">
+        <div class="input-group {{ group_class|default('') }}">
             {%- if prepend -%}
                 <span class="input-group-text">{{ money_pattern|form_encode_currency }}</span>
             {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
@@ -11,7 +11,7 @@
     {% set prepend = not (money_pattern starts with '{{') %}
     {% set append = not (money_pattern ends with '}}') %}
     {% if prepend or append %}
-        <div class="input-group{{ group_class|default('') }}">
+        <div class="input-group {{ group_class|default('') }}">
             {% if prepend %}
                 <span class="input-group-addon">{{ money_pattern|form_encode_currency }}</span>
             {% endif %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
@@ -1165,7 +1165,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), ['id' => 'my&id', 'attr' => ['class' => 'my&class']],
             '/div
-    [@class="input-group"]
+    [@class="input-group "]
     [
         ./div
             [@class="input-group-prepend"]

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
@@ -1450,7 +1450,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), ['id' => 'my&id', 'attr' => ['class' => 'my&class']],
             '/div
-    [@class="input-group"]
+    [@class="input-group "]
     [
         ./span
             [@class="input-group-text"]

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -102,7 +102,7 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTest
         ;
 
         $this->assertSame(<<<'HTML'
-<div class="input-group"><div class="input-group-prepend">
+<div class="input-group "><div class="input-group-prepend">
                     <span class="input-group-text">&euro; </span>
                 </div><input type="text" id="name" name="name" required="required" class="form-control" /></div>
 HTML

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
@@ -104,7 +104,7 @@ class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTest
             ->createView();
 
         self::assertSame(<<<'HTML'
-<div class="input-group"><span class="input-group-text">&euro; </span><input type="text" id="name" name="name" required="required" class="form-control" /></div>
+<div class="input-group "><span class="input-group-text">&euro; </span><input type="text" id="name" name="name" required="required" class="form-control" /></div>
 HTML
             , trim($this->renderWidget($view)));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | 
| Deprecations? | 
| Tickets       | 
| License       | MIT
| Doc PR        | 

Fix for MoneyType not rendering classes in Bootstrap 4&5.
