### PR TITLE
[FrameworkBundle] Fix too eager deprecations for PhpAstExtractor

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1306,9 +1306,8 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('translation.locale_switcher');
         }
 
-        if (ContainerBuilder::willBeAvailable('nikic/php-parser', Parser::class, ['symfony/translation'])
-            && ContainerBuilder::willBeAvailable('symfony/translation', PhpAstExtractor::class, ['symfony/framework-bundle'])
-        ) {
+        // don't use ContainerBuilder::willBeAvailable() as these are not needed in production
+        if (interface_exists(Parser::class) && class_exists(PhpAstExtractor::class)) {
             $container->removeDefinition('translation.extractor.php');
         } else {
             $container->removeDefinition('translation.extractor.php_ast');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
@@ -153,6 +153,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('translation.dumper', ['alias' => 'res'])
 
         ->set('translation.extractor.php', PhpExtractor::class)
+            ->deprecate('symfony/framework-bundle', '6.2', 'The "%service_id%" service is deprecated, use "translation.extractor.php_ast" instead.')
             ->tag('translation.extractor', ['alias' => 'php'])
 
         ->set('translation.extractor.php_ast', PhpAstExtractor::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php
@@ -41,9 +41,9 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
         ->set('.workflow.registry', Registry::class)
         ->alias(Registry::class, '.workflow.registry')
-            ->deprecate('symfony/workflow', '6.2', 'The "%alias_id%" alias is deprecated since Symfony 6.2 and will be removed in Symfony 7.0. Inject the workflow directly.')
+            ->deprecate('symfony/workflow', '6.2', 'The "%alias_id%" alias is deprecated, inject the workflow directly.')
         ->alias('workflow.registry', '.workflow.registry')
-            ->deprecate('symfony/workflow', '6.2', 'The "%alias_id%" service is deprecated since Symfony 6.2 and will be removed in Symfony 7.0. Inject the workflow directly.')
+            ->deprecate('symfony/workflow', '6.2', 'The "%alias_id%" alias is deprecated, inject the workflow directly.')
         ->set('workflow.security.expression_language', ExpressionLanguage::class)
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | n/a

Improve some deprecation handling for `PhpAstExtractor`, as found in the Symfony Demo application by @javiereguiluz:

* Extractors are not a production feature, so we should not be using `ContainerBuilder::willBeAvailable()`
* Mark the `translation.extractor.php` service as deprecated, which prevents the `AutowirePass` from always [including the class](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php#L452) and therefor triggering the deprecation

Also, I've improved 2 workflow deprecation messages. These were using an old deprecation standard that we removed since using `trigger_deprecation()`.