### PR TITLE
[Form] Call `getChoicesForValues()` once, to prevent several SQL queries

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -144,11 +144,10 @@ class ChoiceType extends AbstractType
                         }
                     }
                 } else {
-                    foreach ($data as $value) {
-                        if ($choiceList->getChoicesForValues([$value])) {
-                            $knownValues[] = $value;
-                            unset($unknownValues[$value]);
-                        }
+                    foreach ($choiceList->getChoicesForValues($data) as $index => $choice) {
+                        $value = $data[$index];
+                        $knownValues[] = $value;
+                        unset($unknownValues[$value]);
                     }
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

The feature "Keeping valid submitted choices when additional choices are submitted" adds some overload to list the valid choices.

With options set to `multiple=true`, `expanded=false` and using an `EntityType`, it performs several queries, one for each value.
