### PR TITLE
[Mime] Rename SMimeEncryptorTest to SMimeEncrypterTest

### DIFF
--- a/src/Symfony/Component/Mime/Tests/Crypto/SMimeEncrypterTest.php
+++ b/src/Symfony/Component/Mime/Tests/Crypto/SMimeEncrypterTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Mime\Message;
 /**
  * @requires extension openssl
  */
-class SMimeEncryptorTest extends SMimeTestCase
+class SMimeEncrypterTest extends SMimeTestCase
 {
     public function testEncryptMessage()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

`SMimeEncryptorTest` name doesn't match classname `SMimeEncrypter`.
(Jetbrains CTRL+T shortcut doesn't work)

Found while analysing issue #47914
