### PR TITLE
[HttpKernel] In DateTimeValueResolver, convert previously defined date attribute to the expected class

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
@@ -39,9 +39,10 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         $value = $request->attributes->get($argument->getName());
+        $class = \DateTimeInterface::class === $argument->getType() ? \DateTimeImmutable::class : $argument->getType();
 
         if ($value instanceof \DateTimeInterface) {
-            yield $value;
+            yield $value instanceof $class ? $value : $class::createFromInterface($value);
 
             return;
         }
@@ -52,7 +53,6 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface
             return;
         }
 
-        $class = \DateTimeInterface::class === $argument->getType() ? \DateTimeImmutable::class : $argument->getType();
         $format = null;
 
         if ($attributes = $argument->getAttributes(MapDateTime::class, ArgumentMetadata::IS_INSTANCEOF)) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class DateTimeValueResolverTest extends TestCase
 {
-    private $defaultTimezone;
+    private readonly string $defaultTimezone;
 
     protected function setUp(): void
     {
@@ -32,11 +32,18 @@ class DateTimeValueResolverTest extends TestCase
         date_default_timezone_set($this->defaultTimezone);
     }
 
-    public function getTimeZones()
+    public static function getTimeZones()
     {
         yield ['UTC'];
         yield ['Etc/GMT+9'];
         yield ['Etc/GMT-14'];
+    }
+
+    public static function getClasses()
+    {
+        yield [\DateTimeInterface::class];
+        yield [\DateTime::class];
+        yield [FooDateTime::class];
     }
 
     public function testSupports()
@@ -133,11 +140,16 @@ class DateTimeValueResolverTest extends TestCase
         $this->assertSame($timezone, $results[0]->getTimezone()->getName(), 'Default timezone');
     }
 
-    public function testPreviouslyConvertedAttribute()
+    /**
+     * @param class-string<\DateTimeInterface> $class
+     *
+     * @dataProvider getClasses
+     */
+    public function testPreviouslyConvertedAttribute(string $class)
     {
         $resolver = new DateTimeValueResolver();
 
-        $argument = new ArgumentMetadata('dummy', \DateTime::class, false, false, null, true);
+        $argument = new ArgumentMetadata('dummy', $class, false, false, null, true);
         $request = self::requestWithAttributes(['dummy' => $datetime = new \DateTime()]);
 
         /** @var \Generator $results */
@@ -145,7 +157,8 @@ class DateTimeValueResolverTest extends TestCase
         $results = iterator_to_array($results);
 
         $this->assertCount(1, $results);
-        $this->assertSame($datetime, $results[0]);
+        $this->assertEquals($datetime, $results[0], 'The value is the same, but the class can be modified.');
+        $this->assertInstanceOf($class, $results[0]);
     }
 
     public function testCustomClass()
@@ -209,7 +222,7 @@ class DateTimeValueResolverTest extends TestCase
         $this->assertEquals('2016-09-08 12:34:56', $results[0]->format('Y-m-d H:i:s'));
     }
 
-    public function provideInvalidDates()
+    public static function provideInvalidDates()
     {
         return [
             'invalid date' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/48098/files#r1013997729
| License       | MIT

Convert an instance of `DateTimeInterface` to the expected class if the value was predefined in the request attributes.

```php
# in a request listener
$request->attributes->set('date', new \DateTimeImmutable());
```

```php
class MyController
{
    public function index(\DateTime $date)
    {
        // Use the $date
    }
}
```

```
Uncaught TypeError: MyController::index(): Argument #1 ($date) must be of type DateTime, DateTimeImmutable given
```