### PR TITLE
[Clock] Autowire PSR interface

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\Types\ContextFactory;
 use PhpParser\Parser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Clock\ClockInterface as PsrClockInterface;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -277,6 +278,7 @@ class FrameworkExtension extends Extension
         if (!ContainerBuilder::willBeAvailable('symfony/clock', ClockInterface::class, ['symfony/framework-bundle'])) {
             $container->removeDefinition('clock');
             $container->removeAlias(ClockInterface::class);
+            $container->removeAlias(PsrClockInterface::class);
         }
 
         $container->registerAliasForArgument('parameter_bag', PsrContainerInterface::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Psr\Clock\ClockInterface as PsrClockInterface;
 use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\ConfigBuilderCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
@@ -230,6 +231,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('clock', NativeClock::class)
         ->alias(ClockInterface::class, 'clock')
+        ->alias(PsrClockInterface::class, 'clock')
 
         // register as abstract and excluded, aka not-autowirable types
         ->set(LoaderInterface::class)->abstract()->tag('container.excluded')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Sorry for doing two things in a single PR, but it felt too small to split.

* The first commit I'm sure about: autowire PSR's `ClockInterface`, just like we do for e.g. the `EventDispatcherInterface`
* ~The second commit is something I want to propose after trying to write some docs on using Clock as a framework user: It isn't trivial to change the class of a definition from an application... and using a fixed moment in time while testing is *the* advantage of a clock component. So what about automatically switching to it when test mode is enabled?~ @nicolas-grekas