### PR TITLE
[DependencyInjection][ErrorHandler][FrameworkBundle][HttpKernel][TwigBridge] Fix "a" before "URL"

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
@@ -55,7 +55,7 @@ final class RoutingExtension extends AbstractExtension
      * saving the unneeded automatic escaping for performance reasons.
      *
      * The URL generation process percent encodes non-alphanumeric characters. So there is no risk
-     * that malicious/invalid characters are part of the URL. The only character within an URL that
+     * that malicious/invalid characters are part of the URL. The only character within a URL that
      * must be escaped in html is the ampersand ("&") which separates query params. So we cannot mark
      * the URL generation as always safe, but only when we are sure there won't be multiple query
      * params. This is the case when there are none or only one constant parameter given.

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -55,7 +55,7 @@ class DelegatingLoader extends BaseDelegatingLoader
             //   the fatal error from occurring a second time,
             //   otherwise the PHP process would be killed immediately;
             // - while rendering the exception page, the router can be required
-            //   (by e.g. the web profiler that needs to generate an URL);
+            //   (by e.g. the web profiler that needs to generate a URL);
             // - this handles the case and prevents the second fatal error
             //   by triggering an exception beforehand.
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -126,7 +126,7 @@ CHANGELOG
 
  * added `%env(trim:...)%` processor to trim a string value
  * added `%env(default:param_name:...)%` processor to fallback to a parameter or to null when using `%env(default::...)%`
- * added `%env(url:...)%` processor to convert an URL or DNS into an array of components
+ * added `%env(url:...)%` processor to convert a URL or DNS into an array of components
  * added `%env(query_string:...)%` processor to convert a query string into an array of key values
  * added support for deprecating aliases
  * made `ContainerParametersResource` final and not implement `Serializable` anymore

--- a/src/Symfony/Component/ErrorHandler/Resources/bin/patch-type-declarations
+++ b/src/Symfony/Component/ErrorHandler/Resources/bin/patch-type-declarations
@@ -24,7 +24,7 @@ if (\in_array('-h', $argv) || \in_array('--help', $argv)) {
         '',
         ' Available configuration via environment variables:',
         '  SYMFONY_PATCH_TYPE_DECLARATIONS',
-        '      An url-encoded string to change the behavior of the script. Available parameters:',
+        '      A url-encoded string to change the behavior of the script. Available parameters:',
         '      - "force": any value enables deprecation notices - can be any of:',
         '          - "phpdoc" to patch only docblock annotations',
         '          - "2" to add all possible return types',

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGeneratorInterface.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGeneratorInterface.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 /**
- * Interface implemented by rendering strategies able to generate an URL for a fragment.
+ * Interface implemented by rendering strategies able to generate a URL for a fragment.
  *
  * @author Kévin Dunglas <kevin@dunglas.fr>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      | 6.3 
| Bug fix?    |  no
| New feature?  |no 
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fix misspelling. Replace "an" by "a". 

> Although the U at the first of URL is a vowel, the abbreviation is pronounced “you-are-ell.” Because the letter Y is a consonant in this case, use a rather than an.

[Which-is-correct-a-URL-or-an-URL](https://www.techtarget.com/whatis/feature/Which-is-correct-a-URL-or-an-URL)
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
