### PR TITLE
[HttpKernel] Allow using `#[HttpStatus]` for setting status code and headers for HTTP exceptions

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/HttpStatus.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/HttpStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+/**
+ * @author Dejan Angelov <angelovdejan@protonmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class HttpStatus
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function __construct(
+        public readonly int $statusCode,
+        public readonly array $headers = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate parameters `container.dumper.inline_factories` and `container.dumper.inline_class_loader`, use `.container.dumper.inline_factories` and `.container.dumper.inline_class_loader` instead
  * `FileProfilerStorage` removes profiles automatically after two days
+ * Add `#[HttpStatus]` for defining status codes for exceptions
 
 6.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

Currently, among the other ways, to specify a status code and list of headers to be used for the response for a given exception, we can implement the `HttpExceptionInterface` interface. 

With this PR now, the framework will provide a new PHP attribute that can be declared on exception classes in order to set a custom HTTP status code and a list of headers to be used when preparing a response for the client.

For example, if the user wants to return 404 for `SomethingNotFoundException` exceptions, they will be able to declare the `\Symfony\Component\HttpKernel\Attribute\HttpStatus` on the exception class, and provide the status code and optionally a list of headers as arguments.

```php
// ...
use Symfony\Component\HttpKernel\Attribute\HttpStatus;

#[HttpStatus(404, headers: [
    'resource' => 'something'
])]
class SomethingNotFoundException extends ResourceNotFound
{
    // ...
}
```

The users can also can create additional status-specific attributes themself by extending the `\Symfony\Component\HttpKernel\Attribute\HttpStatus` class.

```php
// ...
use Symfony\Component\HttpKernel\Attribute\HttpStatus;

#[\Attribute(\Attribute::TARGET_CLASS)]
class NotFound extends HttpStatus
{
    public function __construct(array $headers = [])
    {
        parent::__construct(
            Response::HTTP_NOT_FOUND,
            $headers
        );
    }
}

#[NotFound(headers: [
    'name' => 'value',
])]
class WithCustomUserProvidedAttribute extends \Exception
{
}
```

Note that this has the lowest priority when using it alongside some of the other possible ways for setting the status code.
The list of priorities is:

1. Setting the status code in the configuration
2. Implementing the `HttpExceptionInterface` interface
3. Declaring an attribute

(Meaning that, for example, if there's an exception with a `NotFound` attribute declared on an exception, but it is defined in the configuration that the status code for this exception should be 400, 400 will be used as a final status code. The priority of the first two ways is not changed.)