### PR TITLE
[VarDumper] Ignore \Error in __debugInfo()

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -47,7 +47,7 @@ class Caster
         if ($hasDebugInfo) {
             try {
                 $debugInfo = $obj->__debugInfo();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 // ignore failing __debugInfo()
                 $hasDebugInfo = false;
             }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
@@ -175,4 +175,14 @@ EOTXT
             , $c
         );
     }
+
+    public function testTypeErrorInDebugInfo()
+    {
+        $this->assertDumpMatchesFormat('class@anonymous {}', new class() {
+            public function __debugInfo(): array
+            {
+                return ['class' => \get_class(null)];
+            }
+        });
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`__debugInfo()` can throw `\TypeError` (the test case is from a real vendor doing that :sweat_smile:)