### PR TITLE
[Notifier] [Telegram] Add support to answer callback queries

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+* Add support to answer callback queries
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
@@ -109,4 +109,19 @@ final class TelegramOptions implements MessageOptionsInterface
 
         return $this;
     }
+
+    /**
+     * @return $this
+     */
+    public function answerCallbackQuery(string $callbackQueryId, bool $showAlert = false, int $cacheTime = 0): static
+    {
+        $this->options['callback_query_id'] = $callbackQueryId;
+        $this->options['show_alert'] = $showAlert;
+
+        if ($cacheTime > 0) {
+            $this->options['cache_time'] = $cacheTime;
+        }
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramOptionsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
+
+final class TelegramOptionsTest extends TestCase
+{
+    /**
+     * @dataProvider validCacheTimeDataProvider
+     */
+    public function testAnswerCallbackQueryWithCacheTime(int $cacheTime)
+    {
+        $options = new TelegramOptions();
+
+        $returnedOptions = $options->answerCallbackQuery('123', true, $cacheTime);
+
+        $this->assertSame($options, $returnedOptions);
+        $this->assertEquals(
+            [
+                'callback_query_id' => '123',
+                'show_alert' => true,
+                'cache_time' => $cacheTime,
+            ],
+            $options->toArray(),
+        );
+    }
+
+    public function validCacheTimeDataProvider(): iterable
+    {
+        yield 'cache time equals 1' => [1];
+        yield 'cache time equals 2' => [2];
+        yield 'cache time equals 10' => [10];
+    }
+
+    /**
+     * @dataProvider invalidCacheTimeDataProvider
+     */
+    public function testAnswerCallbackQuery(int $cacheTime)
+    {
+        $options = new TelegramOptions();
+
+        $returnedOptions = $options->answerCallbackQuery('123', true, $cacheTime);
+
+        $this->assertSame($options, $returnedOptions);
+        $this->assertEquals(
+            [
+                'callback_query_id' => '123',
+                'show_alert' => true,
+            ],
+            $options->toArray(),
+        );
+    }
+
+    public function invalidCacheTimeDataProvider(): iterable
+    {
+        yield 'cache time equals 0' => [0];
+        yield 'cache time equals -1' => [-1];
+        yield 'cache time equals -10' => [-10];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -193,6 +193,37 @@ JSON;
         $transport->send(new ChatMessage('testMessage', $options));
     }
 
+    public function testSendWithOptionToAnswerCallbackQuery()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $content = <<<JSON
+            {
+                "ok": true,
+                "result": true
+            }
+JSON;
+
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn($content)
+        ;
+
+        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+            $this->assertStringEndsWith('/answerCallbackQuery', $url);
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+        $options = (new TelegramOptions())->answerCallbackQuery('123', true, 1);
+
+        $transport->send(new ChatMessage('testMessage', $options));
+    }
+
     public function testSendWithChannelOverride()
     {
         $channelOverride = 'channelOverride';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #47213 
| License       | MIT
| Doc PR        | -

### Example
```php
$options = new TelegramOptions();
$options->answerCallbackQuery('123456', $showAlert = true, $cacheTime = 1);

$chatMessage->options($options);
```
I've intentionally omitted url parameter as that would only work in case of game which does not fit into notifier use case.
Telegram Bot Api doc for answerCallbackQuery - https://core.telegram.org/bots/api#answercallbackquery