### PR TITLE
[HttpKernel] Set a default file link format when none is provided to FileLinkFormatter

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -35,7 +35,7 @@ class FileLinkFormatter
      */
     public function __construct(string|array $fileLinkFormat = null, RequestStack $requestStack = null, string $baseDir = null, string|\Closure $urlFormat = null)
     {
-        $fileLinkFormat ??= $_SERVER['SYMFONY_IDE'] ?? '';
+        $fileLinkFormat ??= $_SERVER['SYMFONY_IDE'] ?? 'file://%f#L%l';
         if (!\is_array($fileLinkFormat) && $fileLinkFormat = (ErrorRendererInterface::IDE_LINK_FORMATS[$fileLinkFormat] ?? $fileLinkFormat) ?: \ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format') ?: false) {
             $i = strpos($f = $fileLinkFormat, '&', max(strrpos($f, '%f'), strrpos($f, '%l'))) ?: \strlen($f);
             $fileLinkFormat = [substr($f, 0, $i)] + preg_split('/&([^>]++)>/', substr($f, $i), -1, \PREG_SPLIT_DELIM_CAPTURE);

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
@@ -29,7 +29,7 @@ class FileLinkFormatterTest extends TestCase
     {
         $sut = unserialize(serialize(new FileLinkFormatter()));
 
-        $this->assertFalse($sut->format('/kernel/root/src/my/very/best/file.php', 3));
+        $this->assertSame('file:///kernel/root/src/my/very/best/file.php#L3', $sut->format('/kernel/root/src/my/very/best/file.php', 3));
     }
 
     public function testWhenFileLinkFormatAndNoRequest()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _N/A_
| License       | MIT
| Doc PR        | _N/A_

This change allow commands like `debug:route` to have clickable links.

![image](https://user-images.githubusercontent.com/2144837/204470917-0df8aeca-f71f-49b8-8f6b-57dbd2b7ed32.png)

Link pointed by controller's action: `file:///home/alexandredaubois/PhpstormProjects/dummy_project/src/Controller/SomeController.php#L13`