### PR TITLE
[Security] Fix outdated docblock

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
@@ -27,9 +27,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 interface AuthenticationSuccessHandlerInterface
 {
     /**
-     * This is called when an interactive authentication attempt succeeds. This
-     * is called by authentication listeners inheriting from
-     * AbstractAuthenticationListener.
+     * Usually called by AuthenticatorInterface::onAuthenticationSuccess() implementations.
      */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`AbstractAuthenticationListener` has been removed in 6.0.