### PR TITLE
[Console] Fix `OutputInterface` options int-mask for PHPStan

### DIFF
--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -33,17 +33,17 @@ interface OutputInterface
     /**
      * Writes a message to the output.
      *
-     * @param bool                             $newline Whether to add a newline
-     * @param self::VERBOSITY_*|self::OUTPUT_* $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
-     *                                                  0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
+     * @param bool $newline Whether to add a newline
+     * @param int  $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
+     *                      0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
      */
     public function write(string|iterable $messages, bool $newline = false, int $options = 0);
 
     /**
      * Writes a message to the output and adds a newline at the end.
      *
-     * @param self::VERBOSITY_*|self::OUTPUT_* $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
-     *                                                  0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
+     * @param int $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
+     *                     0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
      */
     public function writeln(string|iterable $messages, int $options = 0);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | N/A

When upgrading an application to 6.2, I encountered this issue with PHPStan:

```shell
 ------ -------------------------------------------------------------------------------------------------------
  Line   Pilot/Runner/Output/MultiplexingOutput.php
 ------ -------------------------------------------------------------------------------------------------------
  79     Default value of the parameter #3 $options (0) of method
         App\Pilot\Runner\Output\MultiplexingOutput::write() is incompatible with type 1|2|4|16|32|64|128|256.
 ------ -------------------------------------------------------------------------------------------------------
```

The `MultiplexingOutput` implements the `OutputInterface` and defined `0` as the default value for `$options`:

```php
    public function write(string|iterable $messages, bool $newline = false, int $options = 0): void
```

as defined by the interface:

https://github.com/symfony/symfony/blob/69f46f231b16be1bce1e2ecfa7f9a1fb192cda22/src/Symfony/Component/Console/Output/OutputInterface.php#L40

When trying to use `self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL` as default value:

```shell
 ------ -------------------------------------------------------------------------------------------------------
  Line   Pilot/Runner/Output/MultiplexingOutput.php
 ------ -------------------------------------------------------------------------------------------------------
  79     Default value of the parameter #3 $options (33) of method
         App\Pilot\Runner\Output\MultiplexingOutput::write() is incompatible with type 1|2|4|16|32|64|128|256.
 ------ -------------------------------------------------------------------------------------------------------
```

Or simply using `Output::write()` with specific options:

```shell
 ------ -------------------------------------------------------------------------------------------------------
  Line   Pilot/Runner/Output/MultiplexingOutput.php
 ------ -------------------------------------------------------------------------------------------------------
  81     Parameter #3 $options of method Symfony\Component\Console\Output\Output::write() expects
         1|2|4|16|32|64|128|256, 33 given.
 ------ -------------------------------------------------------------------------------------------------------
```

Using PHPStan's [`int-mask-of`](https://phpstan.org/writing-php-code/phpdoc-types#integer-masks) is the solution for this, and allows by nature the `0` value.
It was even used [at some point](https://github.com/symfony/symfony/pull/47016#discussion_r928320257), but reverted to use `self::VERBOSITY_*|self::OUTPUT_*`. However, it does not behave as expected for masks.

So, either we use `int-mask-of`, or we revert to `int`?
