### PR TITLE
[SecurityBundle] Rename `firewalls.logout.csrf_token_generator` to `firewalls.logout.csrf_token_manager`

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -60,4 +60,5 @@ SecurityBundle
 Validator
 --------------
 
-* Implementing the `ConstraintViolationInterface` without implementing the `getConstraint()` method is deprecated
+ * Implementing the `ConstraintViolationInterface` without implementing the `getConstraint()` method is deprecated
+ * Deprecate the `security.firewalls.logout.csrf_token_generator` config option, use `security.firewalls.logout.csrf_token_manager` instead

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `StatelessAuthenticatorFactoryInterface` for authenticators targeting `stateless` firewalls only and that don't require a user provider
  * Modify "icon.svg" to improve accessibility for blind/low vision users
  * Make `Security::login()` return the authenticator response
+ * Deprecate the `security.firewalls.logout.csrf_token_generator` config option, use `security.firewalls.logout.csrf_token_manager` instead
 
 6.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -458,7 +458,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
             // add CSRF provider
             if ($firewall['logout']['enable_csrf']) {
-                $logoutListener->addArgument(new Reference($firewall['logout']['csrf_token_generator']));
+                $logoutListener->addArgument(new Reference($firewall['logout']['csrf_token_manager']));
             }
 
             // add session logout listener
@@ -482,7 +482,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                     $firewall['logout']['path'],
                     $firewall['logout']['csrf_token_id'],
                     $firewall['logout']['csrf_parameter'],
-                    isset($firewall['logout']['csrf_token_generator']) ? new Reference($firewall['logout']['csrf_token_generator']) : null,
+                    isset($firewall['logout']['csrf_token_manager']) ? new Reference($firewall['logout']['csrf_token_manager']) : null,
                     false === $firewall['stateless'] && isset($firewall['context']) ? $firewall['context'] : null,
                 ])
             ;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -71,7 +71,7 @@ class MainConfigurationTest extends TestCase
             'firewalls' => [
                 'stub' => [
                     'logout' => [
-                        'csrf_token_generator' => 'a_token_generator',
+                        'csrf_token_manager' => 'a_token_manager',
                         'csrf_token_id' => 'a_token_id',
                     ],
                 ],
@@ -82,8 +82,8 @@ class MainConfigurationTest extends TestCase
         $processor = new Processor();
         $configuration = new MainConfiguration([], []);
         $processedConfig = $processor->processConfiguration($configuration, [$config]);
-        $this->assertArrayHasKey('csrf_token_generator', $processedConfig['firewalls']['stub']['logout']);
-        $this->assertEquals('a_token_generator', $processedConfig['firewalls']['stub']['logout']['csrf_token_generator']);
+        $this->assertArrayHasKey('csrf_token_manager', $processedConfig['firewalls']['stub']['logout']);
+        $this->assertEquals('a_token_manager', $processedConfig['firewalls']['stub']['logout']['csrf_token_manager']);
         $this->assertArrayHasKey('csrf_token_id', $processedConfig['firewalls']['stub']['logout']);
         $this->assertEquals('a_token_id', $processedConfig['firewalls']['stub']['logout']['csrf_token_id']);
     }
@@ -92,13 +92,13 @@ class MainConfigurationTest extends TestCase
     {
         $config = [
             'firewalls' => [
-                'custom_token_generator' => [
+                'custom_token_manager' => [
                     'logout' => [
-                        'csrf_token_generator' => 'a_token_generator',
+                        'csrf_token_manager' => 'a_token_manager',
                         'csrf_token_id' => 'a_token_id',
                     ],
                 ],
-                'default_token_generator' => [
+                'default_token_manager' => [
                     'logout' => [
                         'enable_csrf' => true,
                         'csrf_token_id' => 'a_token_id',
@@ -121,18 +121,18 @@ class MainConfigurationTest extends TestCase
         $processedConfig = $processor->processConfiguration($configuration, [$config]);
 
         $assertions = [
-            'custom_token_generator' => [true, 'a_token_generator'],
-            'default_token_generator' => [true, 'security.csrf.token_manager'],
+            'custom_token_manager' => [true, 'a_token_manager'],
+            'default_token_manager' => [true, 'security.csrf.token_manager'],
             'disabled_csrf' => [false, null],
             'empty' => [false, null],
         ];
-        foreach ($assertions as $firewallName => [$enabled, $tokenGenerator]) {
+        foreach ($assertions as $firewallName => [$enabled, $tokenManager]) {
             $this->assertEquals($enabled, $processedConfig['firewalls'][$firewallName]['logout']['enable_csrf']);
-            if ($tokenGenerator) {
-                $this->assertEquals($tokenGenerator, $processedConfig['firewalls'][$firewallName]['logout']['csrf_token_generator']);
+            if ($tokenManager) {
+                $this->assertEquals($tokenManager, $processedConfig['firewalls'][$firewallName]['logout']['csrf_token_manager']);
                 $this->assertEquals('a_token_id', $processedConfig['firewalls'][$firewallName]['logout']['csrf_token_id']);
             } else {
-                $this->assertArrayNotHasKey('csrf_token_generator', $processedConfig['firewalls'][$firewallName]['logout']);
+                $this->assertArrayNotHasKey('csrf_token_manager', $processedConfig['firewalls'][$firewallName]['logout']);
             }
         }
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
@@ -43,7 +43,7 @@ security:
             logout:
                 path: /logout_path
                 target: /
-                csrf_token_generator: security.csrf.token_manager
+                csrf_token_manager: security.csrf.token_manager
 
     access_control:
         - { path: .*, roles: IS_AUTHENTICATED_FULLY }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/17482

A long time ago, #6554 replaced `CsrfProviderInterface` by `CsrfTokenGeneratorInterface`, and #9216 split the latter into `CsrfTokenManagerInterface` and `TokenGeneratorInterface`. #9587 later introduced `csrf_token_generator`, which was already wrong at the time.

Given that token generators exist, it feels weird to have to set <code>csrf_token_**generator**</code> to <code>security.csrf.token_**manager**</code> as mentioned in [the documentation](https://symfony.com/doc/current/reference/configuration/security.html#csrf-token-generator).

As this confusion recently led to #48339, I propose to rename `firewalls.logout.csrf_token_generator` to `firewalls.logout.csrf_token_manager`.