### PR TITLE
[Mailer] Set manipulated message from event to original message

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -61,6 +61,7 @@ abstract class AbstractTransport implements TransportInterface
             $event = new MessageEvent($message, $envelope, (string) $this);
             $this->dispatcher->dispatch($event);
             $envelope = $event->getEnvelope();
+            $message = $event->getMessage();
         }
 
         $message = new SentMessage($message, $envelope);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #48221 
| License       | MIT

Set manipulated message from event to original message.
