### PR TITLE
[String] Fix AsciiSlugger with emojis

### DIFF
--- a/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
+++ b/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
@@ -49,6 +49,7 @@ class AsciiSluggerTest extends TestCase
 
     /**
      * @dataProvider provideSlugEmojiTests
+     *
      * @requires extension intl
      */
     public function testSlugEmoji(string $expected, string $string, ?string $locale, string|bool $emoji = true)
@@ -93,6 +94,16 @@ class AsciiSluggerTest extends TestCase
             'a 😺, 🐈‍⬛, and a 🦁 go to 🏞️... 😍 🎉 💛',
             'en',
             'github',
+        ];
+        yield [
+            'un-chat-qui-sourit-chat-noir-et-un-tete-de-lion-vont-au-parc-national',
+            'un 😺, 🐈‍⬛, et un 🦁 vont au 🏞️',
+            'fr_XX', // Fallback on parent locale
+        ];
+        yield [
+            'un-et-un-vont-au',
+            'un 😺, 🐈‍⬛, et un 🦁 vont au 🏞️',
+            'undefined_locale', // Behaves the same as if emoji support is disabled
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/48364
| License       | MIT
| Doc PR        | -

First fix: let's fall back to parent locales if the emoji map does not exist for the full locale? (like we do for symbols map)

Second fix: let's just ignore the emoji transliterator for totally unsupported locales, the behavior of the slugger will just strip the emojis like it already does.