### PR TITLE
[DependencyInjection] Accessing processed extension configs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -2183,6 +2183,7 @@ abstract class FrameworkExtensionTest extends TestCase
             'kernel.project_dir' => __DIR__,
             'kernel.debug' => false,
             'kernel.environment' => 'test',
+            'kernel.runtime_environment' => 'test',
             'kernel.name' => 'kernel',
             'kernel.container_class' => 'testContainer',
             'container.build_hash' => 'Abc1234',

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add build parameter `.extension.processed_configs` to get any extension configs (already processed) during compiler time
+
 6.2
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -114,6 +114,10 @@ class MergeExtensionConfigurationParameterBag extends EnvPlaceholderParameterBag
         }
         $this->processedEnvPlaceholders = [];
 
+        $processedConfigs = $this->has('.extension.processed_configs') ? $this->get('.extension.processed_configs') : [];
+        $processedConfigs[$extension->getAlias()] = $config;
+        $this->set('.extension.processed_configs', $processedConfigs);
+
         // serialize config and container to catch env vars nested in object graphs
         $config = serialize($config).serialize($container->getDefinitions()).serialize($container->getAliases()).serialize($container->getParameterBag()->all());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

This proposal adds a new container parameter `.extension.processed_configs` that holds all processed extension configs from all registered extensions in order to improve the DX during the DI compilation phase (load extension, compiler pass).

### Before

Currently, it's not possible to access processed configs, so this new parameter will avoid unsafely and hacking workarounds just to query a config value that belongs to another (already processed) extension and derives some DI definitions from it.

Some workarounds involve:
 * Collect extension configs during the "prepend extension" phase (even if other extensions can prepend more config after)
 * Duplicated configs with similar meanings in two or more extensions
 * Call/override the `processConfiguration()` method from another extension is forbidden as it's protected and final, meaning you'll have to process twice this config outside the extension owner.
 * Useless container parameters have to be defined to pass config information from "prepend" to "load" or/and from "load" to "compiler passes".

### After

With this proposal, you'll access these configs through the `.extension.processed_configs` parameter. It's an array of extensions configs, where the array key matches the extension alias:

```php
class AppExtension extends AbstractExtension
{
    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
    {
        $processedConfigs = $builder->getParameter('.extension.processed_configs');

        // $processedConfigs['framework']
    }
}
```

Note that in `load` or `loadExtension` you have access only to already loaded extensions depending on the extension/bundle definition order. If you need access to other extension configs that are not loaded yet then move your logic to a compiler pass or change the bundle/extension order in the `bundle.php` file of your project.

Also available in any compiler pass with the capability to resolve env placeholders:

```php
class AppCompilerPass implements CompilerPassInterface
{
    public function process(ContainerBuilder $container): void
    {
        $processedConfigs = $container->getParameter('.extension.processed_configs');
        $processedConfigs = $container->resolveEnvPlaceholders($processedConfigs, true);

        // $processedConfigs['framework']
    }
}
```

After merging https://github.com/symfony/symfony/pull/47680 this `.extension.processed_configs` parameter is considered a "build parameter" finally, so it will be used during compiler time only and will be removed at the end of the process.