### PR TITLE
[Mailer] add reject to `MessageEvent` to stop sending mail

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 6.3
 ---
 
- * Add `reject()` in `MessageEvent` to reject sending mail
+ * Add `MessageEvent::reject()` to allow rejecting an email before sending it
 
 6.2
 ---

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `reject()` in `MessageEvent` to reject sending mail
+
 6.2
 ---
 

--- a/src/Symfony/Component/Mailer/Event/MessageEvent.php
+++ b/src/Symfony/Component/Mailer/Event/MessageEvent.php
@@ -79,6 +79,7 @@ final class MessageEvent extends Event
     public function reject(): void
     {
         $this->rejected = true;
+        $this->stopPropagation();
     }
 
     public function addStamp(StampInterface $stamp): void

--- a/src/Symfony/Component/Mailer/Event/MessageEvent.php
+++ b/src/Symfony/Component/Mailer/Event/MessageEvent.php
@@ -28,6 +28,7 @@ final class MessageEvent extends Event
     private Envelope $envelope;
     private string $transport;
     private bool $queued;
+    private bool $rejected = false;
 
     /** @var StampInterface[] */
     private array $stamps = [];
@@ -70,10 +71,20 @@ final class MessageEvent extends Event
         return $this->queued;
     }
 
+    public function isRejected(): bool
+    {
+        return $this->rejected;
+    }
+
+    public function reject(): void
+    {
+        $this->rejected = true;
+    }
+
     public function addStamp(StampInterface $stamp): void
     {
         if (!$this->queued) {
-            throw new LogicException(sprintf('Cannot call "%s()" on a message that is not meant to be queued', __METHOD__));
+            throw new LogicException(sprintf('Cannot call "%s()" on a message that is not meant to be queued.', __METHOD__));
         }
 
         $this->stamps[] = $stamp;

--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -56,6 +56,10 @@ final class Mailer implements MailerInterface
             $event = new MessageEvent($clonedMessage, $clonedEnvelope, (string) $this->transport, true);
             $this->dispatcher->dispatch($event);
             $stamps = $event->getStamps();
+
+            if ($event->isRejected()) {
+                return;
+            }
         }
 
         try {

--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -87,7 +87,8 @@ class MailerTest extends TestCase
     public function testRejectMessage()
     {
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(MessageEvent::class, fn (MessageEvent $event) => $event->reject());
+        $dispatcher->addListener(MessageEvent::class, fn (MessageEvent $event) => $event->reject(), 255);
+        $dispatcher->addListener(MessageEvent::class, fn () => throw new \RuntimeException('Should never be called.'));
 
         $transport = new class($dispatcher, $this) extends AbstractTransport {
             public function __construct(EventDispatcherInterface $dispatcher, private TestCase $test)

--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -13,14 +13,19 @@ namespace Symfony\Component\Mailer\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Mailer\Envelope as MailerEnvelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mailer\Transport\NullTransport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\StampInterface;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\RawMessage;
 
@@ -77,5 +82,34 @@ class MailerTest extends TestCase
         self::assertSame($email, $bus->messages[0]->getMessage());
         self::assertCount(1, $bus->stamps);
         self::assertSame([$stamp], $bus->stamps);
+    }
+
+    public function testRejectMessage()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(MessageEvent::class, fn (MessageEvent $event) => $event->reject());
+
+        $transport = new class($dispatcher, $this) extends AbstractTransport {
+            public function __construct(EventDispatcherInterface $dispatcher, private TestCase $test)
+            {
+                parent::__construct($dispatcher);
+            }
+
+            protected function doSend(SentMessage $message): void
+            {
+                $this->test->fail('This should never be called as message is rejected.');
+            }
+
+            public function __toString(): string
+            {
+                return 'fake://';
+            }
+        };
+        $mailer = new Mailer($transport);
+
+        $message = new RawMessage('');
+        $envelope = new MailerEnvelope(new Address('fabien@example.com'), [new Address('helene@example.com')]);
+        $mailer->send($message, $envelope);
+        $this->assertTrue(true);
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
@@ -86,7 +86,8 @@ class AbstractTransportTest extends TestCase
     public function testRejectMessage()
     {
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(MessageEvent::class, fn (MessageEvent $event) => $event->reject());
+        $dispatcher->addListener(MessageEvent::class, fn (MessageEvent $event) => $event->reject(), 255);
+        $dispatcher->addListener(MessageEvent::class, fn () => throw new \RuntimeException('Should never be called.'));
 
         $transport = new class($dispatcher, $this) extends AbstractTransport {
             public function __construct(EventDispatcherInterface $dispatcher, private TestCase $test)

--- a/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
@@ -15,9 +15,13 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Mime\BodyRenderer;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\EventListener\MessageListener;
 use Symfony\Component\Mailer\Exception\LogicException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mailer\Transport\NullTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\RawMessage;
@@ -77,5 +81,32 @@ class AbstractTransportTest extends TestCase
 
         $sentMessage = $transport->send((new TemplatedEmail())->to('me@example.com')->from('me@example.com')->htmlTemplate('tpl'));
         $this->assertMatchesRegularExpression('/Some message/', $sentMessage->getMessage()->toString());
+    }
+
+    public function testRejectMessage()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(MessageEvent::class, fn (MessageEvent $event) => $event->reject());
+
+        $transport = new class($dispatcher, $this) extends AbstractTransport {
+            public function __construct(EventDispatcherInterface $dispatcher, private TestCase $test)
+            {
+                parent::__construct($dispatcher);
+            }
+
+            protected function doSend(SentMessage $message): void
+            {
+                $this->test->fail('This should never be called as message is rejected.');
+            }
+
+            public function __toString(): string
+            {
+                return 'fake://';
+            }
+        };
+
+        $message = new RawMessage('');
+        $envelope = new Envelope(new Address('fabien@example.com'), [new Address('helene@example.com')]);
+        $this->assertNull($transport->send($message, $envelope));
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -73,6 +73,10 @@ abstract class AbstractTransport implements TransportInterface
 
             $event = new MessageEvent($message, $envelope, (string) $this);
             $this->dispatcher->dispatch($event);
+            if ($event->isRejected()) {
+                return null;
+            }
+
             $envelope = $event->getEnvelope();
             $message = $event->getMessage();
 
@@ -81,10 +85,6 @@ abstract class AbstractTransport implements TransportInterface
             }
 
             $sentMessage = new SentMessage($message, $envelope);
-
-            if ($event->isRejected()) {
-                return $sentMessage;
-            }
 
             try {
                 $this->doSend($sentMessage);

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -82,6 +82,10 @@ abstract class AbstractTransport implements TransportInterface
 
             $sentMessage = new SentMessage($message, $envelope);
 
+            if ($event->isRejected()) {
+                return $sentMessage;
+            }
+
             try {
                 $this->doSend($sentMessage);
             } catch (\Throwable $error) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add `reject()` in `MessageEvent` to reject sending mail
