### PR TITLE
[SecurityBundle] Fix class name in UPGRADE-6.2.md

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -85,7 +85,7 @@ Security
 
  * Add maximum username length enforcement of 4096 characters in `UserBadge` to
    prevent [session storage flooding](https://symfony.com/blog/cve-2016-4423-large-username-storage-in-session)
- * Deprecate the `Symfony\Component\Security\Core\Security` class and service, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
+ * Deprecate the `Symfony\Component\Security\Core\Security` class and service, use `Symfony\Bundle\SecurityBundle\Security` instead
  * Passing empty username or password parameter when using `JsonLoginAuthenticator` is not supported anymore
  * Add `$lifetime` parameter to `LoginLinkHandlerInterface::createLoginLink()`
  * Change the signature of `TokenStorageInterface::setToken()` to `setToken(?TokenInterface $token)`


### PR DESCRIPTION
edit incorrect class name

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This just fixes a typo in the updated class's fully qualified name.
