### PR TITLE
[FrameworkBundle] don't register the MailerTestCommand symfony/console is not installed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -389,7 +389,7 @@ class FrameworkExtension extends Extension
         if ($this->readConfigEnabled('mailer', $container, $config['mailer'])) {
             $this->registerMailerConfiguration($config['mailer'], $container, $loader);
 
-            if (!class_exists(MailerTestCommand::class)) {
+            if (!class_exists(MailerTestCommand::class) || !$this->hasConsole()) {
                 $container->removeDefinition('console.command.mailer_test');
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48415
| License       | MIT
| Doc PR        | 