### PR TITLE
[HttpFoundation] IPv4-mapped IPv6 addresses incorrectly rejected

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -125,16 +125,16 @@ class IpUtils
         }
 
         // Check to see if we were given a IP4 $requestIp or $ip by mistake
-        if (str_contains($requestIp, '.') || str_contains($ip, '.')) {
-            return self::$checkedIps[$cacheKey] = false;
-        }
-
         if (!filter_var($requestIp, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
             return self::$checkedIps[$cacheKey] = false;
         }
 
         if (str_contains($ip, '/')) {
             [$address, $netmask] = explode('/', $ip, 2);
+
+            if (!filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
+                return self::$checkedIps[$cacheKey] = false;
+            }
 
             if ('0' === $netmask) {
                 return (bool) unpack('n*', @inet_pton($address));
@@ -144,6 +144,10 @@ class IpUtils
                 return self::$checkedIps[$cacheKey] = false;
             }
         } else {
+            if (!filter_var($ip, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
+                return self::$checkedIps[$cacheKey] = false;
+            }
+
             $address = $ip;
             $netmask = 128;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -77,6 +77,7 @@ class IpUtilsTest extends TestCase
             [false, '0.0.0.0/8', '::1'],
             [false,  '::1', '127.0.0.1'],
             [false,  '::1', '0.0.0.0/8'],
+            [true, '::ffff:10.126.42.2', '::ffff:10.0.0.0/0'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #48420 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I've based it on 4.4 because that's where #48050 was merged into, but I guess I'm 1 day too late with a fix for that version