### PR TITLE
[DomCrawler][FrameworkBundle] Add `assertSelectorCount`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `DomCrawlerAssertionsTrait::assertSelectorCount(int $count, string $selector)`
+
 6.2
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
@@ -35,6 +35,11 @@ trait DomCrawlerAssertionsTrait
         self::assertThat(self::getCrawler(), new LogicalNot(new DomCrawlerConstraint\CrawlerSelectorExists($selector)), $message);
     }
 
+    public static function assertSelectorCount(int $expectedCount, string $selector, string $message = ''): void
+    {
+        self::assertThat(self::getCrawler(), new DomCrawlerConstraint\CrawlerSelectorCount($expectedCount, $selector), $message);
+    }
+
     public static function assertSelectorTextContains(string $selector, string $text, string $message = ''): void
     {
         self::assertThat(self::getCrawler(), LogicalAnd::fromConstraints(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -190,6 +190,16 @@ class WebTestCaseTest extends TestCase
         $this->getCrawlerTester(new Crawler('<html><body><h1>'))->assertSelectorNotExists('body > h1');
     }
 
+    public function testAssertSelectorCount()
+    {
+        $this->getCrawlerTester(new Crawler('<html><body><p>Hello</p></body></html>'))->assertSelectorCount(1, 'p');
+        $this->getCrawlerTester(new Crawler('<html><body><p>Hello</p><p>Foo</p></body></html>'))->assertSelectorCount(2, 'p');
+        $this->getCrawlerTester(new Crawler('<html><body><h1>This is not a paragraph.</h1></body></html>'))->assertSelectorCount(0, 'p');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that the Crawler selector "p" was expected to be found 0 time(s) but was found 1 time(s).');
+        $this->getCrawlerTester(new Crawler('<html><body><p>Hello</p></body></html>'))->assertSelectorCount(0, 'p');
+    }
+
     public function testAssertSelectorTextNotContains()
     {
         $this->getCrawlerTester(new Crawler('<html><body><h1>Foo'))->assertSelectorTextNotContains('body > h1', 'Bar');

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -39,7 +39,7 @@
         "symfony/browser-kit": "^5.4|^6.0",
         "symfony/console": "^5.4.9|^6.0.9",
         "symfony/css-selector": "^5.4|^6.0",
-        "symfony/dom-crawler": "^5.4|^6.0",
+        "symfony/dom-crawler": "^6.3",
         "symfony/dotenv": "^5.4|^6.0",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/form": "^5.4|^6.0",

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `CrawlerSelectorCount` test constraint
+
 6.0
 ---
 

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorCount.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorCount.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\DomCrawler\Crawler;
+
+final class CrawlerSelectorCount extends Constraint
+{
+    public function __construct(
+        private readonly int $count,
+        private readonly string $selector,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return sprintf('selector "%s" count is "%d"', $this->selector, $this->count);
+    }
+
+    /**
+     * @param Crawler $crawler
+     */
+    protected function matches($crawler): bool
+    {
+        return $this->count === \count($crawler->filter($this->selector));
+    }
+
+    /**
+     * @param Crawler $crawler
+     */
+    protected function failureDescription($crawler): string
+    {
+        return sprintf('the Crawler selector "%s" was expected to be found %d time(s) but was found %d time(s)', $this->selector, $this->count, \count($crawler->filter($this->selector)));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | todo?

I was using the following test in my application:
```php
// ...
class UserControllerTest extends WebTestCase
{
    public function testShow(): void
    {
        // ....

        $crawler = $client->request(Request::METHOD_GET, '/user/show/'.$user->getId());

        self::assertResponseStatusCodeSame(Response::HTTP_OK);
        self::assertRouteSame('app_user_show');
        self::assertPageTitleSame('User information');
        // Only the following assertion requires the crawler
        self::assertCount(3, $crawler->filter('p'), 'There should be 3 p selectors on this page');
        self::assertSelectorTextContains('p', 'john@example.com');
    }
}
```

After this PR: 
```diff
-$crawler = $client->request(Request::METHOD_GET, '/user/show/'.$user->getId());
+$client->request(Request::METHOD_GET, '/user/show/'.$user->getId());

 self::assertResponseStatusCodeSame(Response::HTTP_OK);
 self::assertRouteSame('app_user_show');
 self::assertPageTitleSame('User information');
-self::assertCount(3, $crawler->filter('p'), 'There should be 3 p selectors on this page');
+self::assertSelectorCount(3, 'p', 'There should be 3 p selectors on this page');
 self::assertSelectorTextContains('p', 'john@example.com');
```

What do you think about this?