### PR TITLE
Fixed undefined variable error

### DIFF
--- a/src/Symfony/Component/Console/Completion/Output/ZshCompletionOutput.php
+++ b/src/Symfony/Component/Console/Completion/Output/ZshCompletionOutput.php
@@ -21,6 +21,7 @@ class ZshCompletionOutput implements CompletionOutputInterface
 {
     public function write(CompletionSuggestions $suggestions, OutputInterface $output): void
     {
+        $values = [];
         foreach ($suggestions->getValueSuggestions() as $value) {
             $values[] = $value->getValue().($value->getDescription() ? "\t".$value->getDescription() : '');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48426
| License       | MIT
| Doc PR        | n/a

Fixes an undefined variable warning during ZSH autocomplete if no suggestions have been provided.
