### PR TITLE
[DependencyInjection] Allow nullable args to php config functions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -130,12 +130,15 @@ class PhpFileLoader extends FileLoader
                     }
                     // no break
                 default:
+                    $configBuilder = null;
                     try {
                         $configBuilder = $this->configBuilder($type);
+                        $configBuilders[] = $configBuilder;
                     } catch (InvalidArgumentException|\LogicException $e) {
-                        throw new \InvalidArgumentException(sprintf('Could not resolve argument "%s" for "%s".', $type.' $'.$parameter->getName(), $path), 0, $e);
+                        if (!$reflectionType->allowsNull()) {
+                            throw new \InvalidArgumentException(sprintf('Could not resolve argument "%s" for "%s".', $type.' $'.$parameter->getName(), $path), 0, $e);
+                        }
                     }
-                    $configBuilders[] = $configBuilder;
                     $arguments[] = $configBuilder;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | 

I believe Symfony now encourages to configure multiple envs in one config file. But that's not possible yet with bundles that are only enabled in some envs, because their config classes are not generated.

For example with a WebProfilerConfig that you only want to configure in non-prod environments:

<details>
  <summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/1517978/205100899-a59a18ca-f8ba-4acc-88aa-8b6a3e3e6cf3.png)

</details>

