### PR TITLE
[TwigBridge] Fix casing of getCurrentRoute/getCurrentRouteParameters methods

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -159,7 +159,7 @@ class AppVariable
         return $result;
     }
 
-    public function getCurrent_Route(): ?string
+    public function getCurrent_route(): ?string
     {
         if (!isset($this->requestStack)) {
             throw new \RuntimeException('The "app.current_route" variable is not available.');
@@ -171,7 +171,7 @@ class AppVariable
     /**
      * @return array<string, mixed>
      */
-    public function getCurrent_Route_Parameters(): array
+    public function getCurrent_route_parameters(): array
     {
         if (!isset($this->requestStack)) {
             throw new \RuntimeException('The "app.current_route_parameters" variable is not available.');

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -232,13 +232,13 @@ class AppVariableTest extends TestCase
     {
         $this->setRequestStack(new Request(attributes: ['_route' => 'some_route']));
 
-        $this->assertSame('some_route', $this->appVariable->getCurrent_Route());
+        $this->assertSame('some_route', $this->appVariable->getCurrent_route());
     }
 
     public function testGetCurrentRouteWithRequestStackNotSet()
     {
         $this->expectException(\RuntimeException::class);
-        $this->appVariable->getCurrent_Route();
+        $this->appVariable->getCurrent_route();
     }
 
     public function testGetCurrentRouteParameters()
@@ -246,20 +246,20 @@ class AppVariableTest extends TestCase
         $routeParams = ['some_param' => true];
         $this->setRequestStack(new Request(attributes: ['_route_params' => $routeParams]));
 
-        $this->assertSame($routeParams, $this->appVariable->getCurrent_Route_Parameters());
+        $this->assertSame($routeParams, $this->appVariable->getCurrent_route_parameters());
     }
 
     public function testGetCurrentRouteParametersWithoutAttribute()
     {
         $this->setRequestStack(new Request());
 
-        $this->assertSame([], $this->appVariable->getCurrent_Route_Parameters());
+        $this->assertSame([], $this->appVariable->getCurrent_route_parameters());
     }
 
     public function testGetCurrentRouteParametersWithRequestStackNotSet()
     {
         $this->expectException(\RuntimeException::class);
-        $this->appVariable->getCurrent_Route_Parameters();
+        $this->appVariable->getCurrent_route_parameters();
     }
 
     protected function setRequestStack($request)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | -

Following of #47535, those two methods were named like this in order to get `app.current_route` and `app.current_route_parameters`, however PHPStorm autocomplete for `app.current_Route` and `app.current_Route_Parameters`.

I'm not sure if this is a PHPStorm-only issue or not.

**Before:**
![image](https://user-images.githubusercontent.com/2103975/205177835-fe5c64d7-2581-44be-8f3f-39f7cd4dcf9e.png)


**After:**
<img width="604" alt="image" src="https://user-images.githubusercontent.com/2103975/205177787-b3e55d95-4a0f-40ea-8b65-a0b3ddc447f0.png">
