### PR TITLE
[Serializer] The enclosure can be an empty string

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -89,6 +89,9 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         $headers = array_merge(array_values($headers), array_diff($this->extractHeaders($data), $headers));
         $endOfLine = $context[self::END_OF_LINE] ?? $this->defaultContext[self::END_OF_LINE];
 
+        $isEmptyEnclosure = $enclosure === '';
+        $enclosure = ($isEmptyEnclosure) ? $this->defaultContext[self::ENCLOSURE_KEY] : $enclosure;
+
         if (!($context[self::NO_HEADERS_KEY] ?? $this->defaultContext[self::NO_HEADERS_KEY])) {
             fputcsv($handle, $headers, $delimiter, $enclosure, $escapeChar);
             if ("\n" !== $endOfLine && 0 === fseek($handle, -1, \SEEK_CUR)) {
@@ -106,6 +109,13 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
         rewind($handle);
         $value = stream_get_contents($handle);
+
+        if ($isEmptyEnclosure) {
+            $value = str_replace($this->defaultContext[self::ENCLOSURE_KEY], '', $value);
+
+            fwrite($handle, $value, strlen($value));
+        }
+
         fclose($handle);
 
         if ($outputBom) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -699,4 +699,18 @@ CSV;
         $encoder = new CsvEncoder([CsvEncoder::END_OF_LINE => "\r\n"]);
         $this->assertSame("foo,bar\r\nhello,test\r\n", $encoder->encode($value, 'csv'));
     }
+
+    public function testDecodeStringWithTwoWords() {
+        $value = ['foo' => 'hello world'];
+
+        $encoder = new CsvEncoder();
+        $this->assertSame("foo\n\"hello world\"\n", $encoder->encode($value, 'csv'));
+    }
+
+    public function testDecodeWithEmptyEnclosure() {
+        $value = ['foo' => 'hello world'];
+
+        $encoder = new CsvEncoder();
+        $this->assertSame("foo\nhello world\n", $encoder->encode($value, 'csv', [CsvEncoder::ENCLOSURE_KEY => '']));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48440 
| License       | MIT

When trying to encode a CSV file with an empty enclosure the fputcsv method crashes.

In order not to crash we check the enclosure value before calling this method.
Then we replace the default enclosure by an empty string if the enclosure is empty.
