### PR TITLE
[Translation] Fix extraction when dealing with VariadicPlaceholder parameters

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/Visitor/AbstractVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/AbstractVisitor.php
@@ -42,32 +42,31 @@ abstract class AbstractVisitor
 
     protected function getStringArguments(Node\Expr\CallLike|Node\Attribute|Node\Expr\New_ $node, int|string $index, bool $indexIsRegex = false): array
     {
-        $args = $node instanceof Node\Expr\CallLike ? $node->getArgs() : $node->args;
-
         if (\is_string($index)) {
             return $this->getStringNamedArguments($node, $index, $indexIsRegex);
         }
+
+        $args = $node instanceof Node\Expr\CallLike ? $node->getRawArgs() : $node->args;
 
         if (\count($args) < $index) {
             return [];
         }
 
-        /** @var Node\Arg $arg */
-        $arg = $args[$index];
-        if (!$result = $this->getStringValue($arg->value)) {
-            return [];
+        if (($arg = $args[$index]) instanceof Node\Arg) {
+            if ($result = $this->getStringValue($arg->value)) {
+                return [$result];
+            }
         }
 
-        return [$result];
+        return [];
     }
 
     protected function hasNodeNamedArguments(Node\Expr\CallLike|Node\Attribute|Node\Expr\New_ $node): bool
     {
-        $args = $node instanceof Node\Expr\CallLike ? $node->getArgs() : $node->args;
+        $args = $node instanceof Node\Expr\CallLike ? $node->getRawArgs() : $node->args;
 
-        /** @var Node\Arg $arg */
         foreach ($args as $arg) {
-            if (null !== $arg->name) {
+            if ($arg instanceof Node\Arg && null !== $arg->name) {
                 return true;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #48422 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I don't have the time for now to check if the command has tests or not, but dealing with raw args with + filtering for `Node\Arg` instance make the `extract` command working again.

The issue is "caused by" https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php#L71, the extract command is not able to deal with VariadicPlaceholder node. Changing to `[$this, 'trans']` works, but this is not the wanted solution. 

**Before:**

```
symfony console translation:extract fr --force -vvv

Translation Messages Extractor and Dumper
=========================================

 // Generating "fr" translation files for "default directory"

 // Parsing templates...


In CallLike.php line 36:

  [AssertionError (1)]
  assert(!$this->isFirstClassCallable())


Exception trace:
  at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:36
 assert() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:36
 PhpParser\Node\Expr\CallLike->getArgs() at /Users/kocal/workspace/chronos/vendor/symfony/translation/Extractor/Visitor/AbstractVisitor.php:66
 Symfony\Component\Translation\Extractor\Visitor\AbstractVisitor->hasNodeNamedArguments() at /Users/kocal/workspace/chronos/vendor/symfony/translation/Extractor/Visitor/TransMethodVisitor.php:40
 Symfony\Component\Translation\Extractor\Visitor\TransMethodVisitor->enterNode() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:123
 PhpParser\NodeTraverser->traverseNode() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 PhpParser\NodeTraverser->traverseNode() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:146
 PhpParser\NodeTraverser->traverseNode() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 PhpParser\NodeTraverser->traverseNode() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:146
 PhpParser\NodeTraverser->traverseNode() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 PhpParser\NodeTraverser->traverseNode() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 PhpParser\NodeTraverser->traverseNode() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 PhpParser\NodeTraverser->traverseNode() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/kocal/workspace/chronos/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:91
 PhpParser\NodeTraverser->traverse() at /Users/kocal/workspace/chronos/vendor/symfony/translation/Extractor/PhpAstExtractor.php:56
 Symfony\Component\Translation\Extractor\PhpAstExtractor->extract() at /Users/kocal/workspace/chronos/vendor/symfony/translation/Extractor/ChainExtractor.php:48
 Symfony\Component\Translation\Extractor\ChainExtractor->extract() at /Users/kocal/workspace/chronos/vendor/symfony/framework-bundle/Command/TranslationUpdateCommand.php:395
 Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand->extractMessages() at /Users/kocal/workspace/chronos/vendor/symfony/framework-bundle/Command/TranslationUpdateCommand.php:200
 Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand->execute() at /Users/kocal/workspace/chronos/vendor/symfony/console/Command/Command.php:312
 Symfony\Component\Console\Command\Command->run() at /Users/kocal/workspace/chronos/vendor/symfony/console/Application.php:1038
 Symfony\Component\Console\Application->doRunCommand() at /Users/kocal/workspace/chronos/vendor/symfony/framework-bundle/Console/Application.php:88
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /Users/kocal/workspace/chronos/vendor/symfony/console/Application.php:312
 Symfony\Component\Console\Application->doRun() at /Users/kocal/workspace/chronos/vendor/symfony/framework-bundle/Console/Application.php:77
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /Users/kocal/workspace/chronos/vendor/symfony/console/Application.php:168
 Symfony\Component\Console\Application->run() at /Users/kocal/workspace/chronos/vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:54
 Symfony\Component\Runtime\Runner\Symfony\ConsoleApplicationRunner->run() at /Users/kocal/workspace/chronos/vendor/autoload_runtime.php:29
```

**After:**
```
symfony console translation:extract fr --force -vvv

Translation Messages Extractor and Dumper
=========================================

 // Generating "fr" translation files for "default directory"

 // Parsing templates...

 // Loading translation files...

 // Writing files...


 [OK] Translation files were successfully updated.

```