### PR TITLE
[WebProfilerBundle] separate controller class and method link

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -415,7 +415,18 @@
     {% if controller.class is defined -%}
         {%- if method|default(false) %}<span class="sf-toolbar-status sf-toolbar-redirection-method">{{ method }}</span>{% endif -%}
         {%- set link = controller.file|file_link(controller.line) %}
-        {%- if link %}<a href="{{ link }}" title="{{ controller.class }}">{% else %}<span title="{{ controller.class }}">{% endif %}
+
+        {%- if controller.classFile is defined and controller.method %}
+            {%- set classLink = controller.classFile|file_link(controller.classLine) %}
+            <a href="{{ classLink }}" title="{{ controller.class }}">
+                {{- controller.class|abbr_class|striptags -}}
+            </a>
+            ::
+            <a href="{{ link }}" title="{{ controller.methodClass }}::{{ controller.method }}">
+                {{ controller.method }}
+            </a>
+        {%- else -%}
+            {%- if link %}<a href="{{ link }}" title="{{ controller.class }}">{% else %}<span title="{{ controller.class }}">{% endif %}
 
             {%- if route|default(false) -%}
                 @{{ route }}
@@ -424,7 +435,8 @@
                 {{- controller.method ? ' :: ' ~ controller.method -}}
             {%- endif -%}
 
-        {%- if link %}</a>{% else %}</span>{% endif %}
+            {%- if link %}</a>{% else %}</span>{% endif %}
+        {% endif -%}
     {%- else -%}
         <span>{{ route|default(controller) }}</span>
     {%- endif %}

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -471,14 +471,23 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
 
         if (\is_array($controller)) {
             try {
+                $rc = new \ReflectionClass($controller[0]);
                 $r = new \ReflectionMethod($controller[0], $controller[1]);
 
-                return [
+                $data = [
                     'class' => \is_object($controller[0]) ? get_debug_type($controller[0]) : $controller[0],
                     'method' => $controller[1],
                     'file' => $r->getFileName(),
                     'line' => $r->getStartLine(),
                 ];
+
+                if ($r->class !== $rc->name || $r->getFileName() !== $rc->getFileName()) {
+                    $data['methodClass'] = $r->class;
+                    $data['classFile'] = $rc->getFileName();
+                    $data['classLine'] = $rc->getStartLine();
+                }
+
+                return $data;
             } catch (\ReflectionException) {
                 if (\is_callable($controller)) {
                     // using __call or  __callStatic

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/AbstractRequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/AbstractRequestDataCollectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\DataCollector;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
+
+abstract class AbstractRequestDataCollectorTest extends TestCase
+{
+    public function inheritedControllerMethod($name, $callable, $expected)
+    {
+        $c = new RequestDataCollector();
+        $request = $this->createRequest();
+        $response = $this->createResponse();
+        $this->injectController($c, $callable, $request);
+        $c->collect($request, $response);
+        $c->lateCollect();
+
+        $this->assertSame($expected, $c->getController()->getValue(true), sprintf('Testing: %s', $name));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/SubRequestDataCollectorTrait.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/SubRequestDataCollectorTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\DataCollector;
+
+use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
+
+trait SubRequestDataCollectorTrait
+{
+    public function traitControllerMethod($name, $callable, $expected)
+    {
+        $c = new RequestDataCollector();
+        $request = $this->createRequest();
+        $response = $this->createResponse();
+        $this->injectController($c, $callable, $request);
+        $c->collect($request, $response);
+        $c->lateCollect();
+
+        $this->assertSame($expected, $c->getController()->getValue(true), sprintf('Testing: %s', $name));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When the executed method from a controller is defined in a parent class the link opens the parent class in the IDE. I often have the case that i want to open the subclass because it contains the configuration or want to override the method there. This splits the link in the profiler so the class name opens the sub class and the method name opens the parent class.

Any feedback is very appreciated.

<details><summary>Screenshot</summary>

![sfprofiler](https://user-images.githubusercontent.com/321891/205458734-54de88b5-43ce-4ff0-bdc1-8d20b9588ab8.png)

</details>
