### PR TITLE
[VarExporter] Fix possible memory-leak when using lazy-objects

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -29,7 +29,6 @@ use Symfony\Component\DependencyInjection\Exception\EnvParameterException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
-use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\ExpressionLanguage;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface as ProxyDumper;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\LazyServiceDumper;
@@ -168,15 +167,7 @@ class PhpDumper extends Dumper
 
         if ($this->getProxyDumper() instanceof NullDumper) {
             (new AnalyzeServiceReferencesPass(true, false))->process($this->container);
-            try {
-                (new CheckCircularReferencesPass())->process($this->container);
-            } catch (ServiceCircularReferenceException $e) {
-                $path = $e->getPath();
-                end($path);
-                $path[key($path)] .= '". Try running "composer require symfony/proxy-manager-bridge';
-
-                throw new ServiceCircularReferenceException($e->getServiceId(), $path);
-            }
+            (new CheckCircularReferencesPass())->process($this->container);
         }
 
         $this->analyzeReferences();

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -765,7 +765,7 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->setProxyDumper(new NullDumper());
 
-        $message = 'Circular reference detected for service "foo", path: "foo -> bar -> foo". Try running "composer require symfony/proxy-manager-bridge".';
+        $message = 'Circular reference detected for service "foo", path: "foo -> bar -> foo".';
         $this->expectException(ServiceCircularReferenceException::class);
         $this->expectExceptionMessage($message);
 

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -31,8 +31,7 @@
         "symfony/yaml": "",
         "symfony/config": "",
         "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
-        "symfony/expression-language": "For using expressions in service container configuration",
-        "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
+        "symfony/expression-language": "For using expressions in service container configuration"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",

--- a/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\VarDumper\Cloner\Stub;
+use Symfony\Component\VarExporter\Internal\LazyObjectState;
 
 /**
  * @final
@@ -65,6 +66,22 @@ class SymfonyCaster
         }
 
         return $a;
+    }
+
+    public static function castLazyObjectState($state, array $a, Stub $stub, bool $isNested)
+    {
+        if (!$isNested) {
+            return $a;
+        }
+
+        $stub->cut += \count($a) - 1;
+
+        return ['status' => new ConstStub(match ($a['status']) {
+            LazyObjectState::STATUS_INITIALIZED_FULL => 'INITIALIZED_FULL',
+            LazyObjectState::STATUS_INITIALIZED_PARTIAL => 'INITIALIZED_PARTIAL',
+            LazyObjectState::STATUS_UNINITIALIZED_FULL => 'UNINITIALIZED_FULL',
+            LazyObjectState::STATUS_UNINITIALIZED_PARTIAL => 'UNINITIALIZED_PARTIAL',
+        }, $a['status'])];
     }
 
     public static function castUuid(Uuid $uuid, array $a, Stub $stub, bool $isNested)

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -89,6 +89,7 @@ abstract class AbstractCloner implements ClonerInterface
         'Symfony\Component\HttpFoundation\Request' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castRequest'],
         'Symfony\Component\Uid\Ulid' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castUlid'],
         'Symfony\Component\Uid\Uuid' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castUuid'],
+        'Symfony\Component\VarExporter\Internal\LazyObjectState' => ['Symfony\Component\VarDumper\Caster\SymfonyCaster', 'castLazyObjectState'],
         'Symfony\Component\VarDumper\Exception\ThrowingCasterException' => ['Symfony\Component\VarDumper\Caster\ExceptionCaster', 'castThrowingCasterException'],
         'Symfony\Component\VarDumper\Caster\TraceStub' => ['Symfony\Component\VarDumper\Caster\ExceptionCaster', 'castTraceStub'],
         'Symfony\Component\VarDumper\Caster\FrameStub' => ['Symfony\Component\VarDumper\Caster\ExceptionCaster', 'castFrameStub'],

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
@@ -21,11 +21,6 @@ namespace Symfony\Component\VarExporter\Internal;
 class LazyObjectRegistry
 {
     /**
-     * @var array<int, LazyObjectState>
-     */
-    public static $states = [];
-
-    /**
      * @var array<class-string, \ReflectionClass>
      */
     public static $classReflectors = [];
@@ -50,6 +45,11 @@ class LazyObjectRegistry
      */
     public static $parentMethods = [];
 
+    /**
+     * @var LazyObjectState
+     */
+    public static $noInitializerState;
+
     public static function getClassResetters($class)
     {
         $classProperties = [];
@@ -63,7 +63,7 @@ class LazyObjectRegistry
         foreach ($propertyScopes as $key => [$scope, $name, $readonlyScope]) {
             $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0*\0$name"] ?? $k = $name;
 
-            if ($k === $key && "\0$class\0lazyObjectId" !== $k) {
+            if ($k === $key && "\0$class\0lazyObjectState" !== $k) {
                 $classProperties[$readonlyScope ?? $scope][$name] = $key;
             }
         }

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -17,7 +17,7 @@ use Symfony\Component\VarExporter\Internal\LazyObjectState;
 
 trait LazyGhostTrait
 {
-    private int $lazyObjectId;
+    private LazyObjectState $lazyObjectState;
 
     /**
      * Creates a lazy-loading ghost instance.
@@ -47,15 +47,14 @@ trait LazyGhostTrait
         $onlyProperties = null === $skippedProperties && \is_array($initializer) ? $initializer : null;
 
         if (self::class !== $class = $instance ? $instance::class : static::class) {
-            $skippedProperties["\0".self::class."\0lazyObjectId"] = true;
+            $skippedProperties["\0".self::class."\0lazyObjectState"] = true;
         } elseif (\defined($class.'::LAZY_OBJECT_PROPERTY_SCOPES')) {
             Hydrator::$propertyScopes[$class] ??= $class::LAZY_OBJECT_PROPERTY_SCOPES;
         }
 
         $instance ??= (Registry::$classReflectors[$class] ??= new \ReflectionClass($class))->newInstanceWithoutConstructor();
         Registry::$defaultProperties[$class] ??= (array) $instance;
-        $instance->lazyObjectId = $id = spl_object_id($instance);
-        Registry::$states[$id] = new LazyObjectState($initializer, $skippedProperties ??= []);
+        $instance->lazyObjectState = new LazyObjectState($initializer, $skippedProperties ??= []);
 
         foreach (Registry::$classResetters[$class] ??= Registry::getClassResetters($class) as $reset) {
             $reset($instance, $skippedProperties, $onlyProperties);
@@ -71,7 +70,7 @@ trait LazyGhostTrait
      */
     public function isLazyObjectInitialized(bool $partial = false): bool
     {
-        if (!$state = Registry::$states[$this->lazyObjectId ?? ''] ?? null) {
+        if (!$state = $this->lazyObjectState ?? null) {
             return true;
         }
 
@@ -101,7 +100,7 @@ trait LazyGhostTrait
      */
     public function initializeLazyObject(): static
     {
-        if (!$state = Registry::$states[$this->lazyObjectId ?? ''] ?? null) {
+        if (!$state = $this->lazyObjectState ?? null) {
             return $this;
         }
 
@@ -151,7 +150,7 @@ trait LazyGhostTrait
      */
     public function resetLazyObject(): bool
     {
-        if (!$state = Registry::$states[$this->lazyObjectId ?? ''] ?? null) {
+        if (!$state = $this->lazyObjectState ?? null) {
             return false;
         }
 
@@ -169,7 +168,7 @@ trait LazyGhostTrait
 
         if ([$class, , $readonlyScope] = $propertyScopes[$name] ?? null) {
             $scope = Registry::getScope($propertyScopes, $class, $name);
-            $state = Registry::$states[$this->lazyObjectId ?? ''] ?? null;
+            $state = $this->lazyObjectState ?? null;
 
             if ($state && (null === $scope || isset($propertyScopes["\0$scope\0$name"]))
                 && LazyObjectState::STATUS_UNINITIALIZED_PARTIAL !== $state->initialize($this, $name, $readonlyScope ?? $scope)
@@ -215,7 +214,7 @@ trait LazyGhostTrait
 
         if ([$class, , $readonlyScope] = $propertyScopes[$name] ?? null) {
             $scope = Registry::getScope($propertyScopes, $class, $name, $readonlyScope);
-            $state = Registry::$states[$this->lazyObjectId ?? ''] ?? null;
+            $state = $this->lazyObjectState ?? null;
 
             if ($state && ($readonlyScope === $scope || isset($propertyScopes["\0$scope\0$name"]))) {
                 if (LazyObjectState::STATUS_UNINITIALIZED_FULL === $state->status) {
@@ -248,7 +247,7 @@ trait LazyGhostTrait
 
         if ([$class, , $readonlyScope] = $propertyScopes[$name] ?? null) {
             $scope = Registry::getScope($propertyScopes, $class, $name);
-            $state = Registry::$states[$this->lazyObjectId ?? ''] ?? null;
+            $state = $this->lazyObjectState ?? null;
 
             if ($state && (null === $scope || isset($propertyScopes["\0$scope\0$name"]))
                 && LazyObjectState::STATUS_UNINITIALIZED_PARTIAL !== $state->initialize($this, $name, $readonlyScope ?? $scope)
@@ -278,7 +277,7 @@ trait LazyGhostTrait
 
         if ([$class, , $readonlyScope] = $propertyScopes[$name] ?? null) {
             $scope = Registry::getScope($propertyScopes, $class, $name, $readonlyScope);
-            $state = Registry::$states[$this->lazyObjectId ?? ''] ?? null;
+            $state = $this->lazyObjectState ?? null;
 
             if ($state && ($readonlyScope === $scope || isset($propertyScopes["\0$scope\0$name"]))) {
                 if (LazyObjectState::STATUS_UNINITIALIZED_FULL === $state->status) {
@@ -306,8 +305,8 @@ trait LazyGhostTrait
 
     public function __clone(): void
     {
-        if ($state = Registry::$states[$this->lazyObjectId ?? ''] ?? null) {
-            Registry::$states[$this->lazyObjectId = spl_object_id($this)] = clone $state;
+        if ($state = $this->lazyObjectState ?? null) {
+            $this->lazyObjectState = clone $state;
         }
 
         if ((Registry::$parentMethods[self::class] ??= Registry::getParentMethods(self::class))['clone']) {
@@ -325,7 +324,7 @@ trait LazyGhostTrait
             $this->initializeLazyObject();
             $properties = (array) $this;
         }
-        unset($properties["\0$class\0lazyObjectId"]);
+        unset($properties["\0$class\0lazyObjectState"]);
 
         if (Registry::$parentMethods[$class]['serialize'] || !Registry::$parentMethods[$class]['sleep']) {
             return $properties;
@@ -349,26 +348,20 @@ trait LazyGhostTrait
 
     public function __destruct()
     {
-        $state = Registry::$states[$this->lazyObjectId ?? ''] ?? null;
+        $state = $this->lazyObjectState ?? null;
 
-        try {
-            if ($state && \in_array($state->status, [LazyObjectState::STATUS_UNINITIALIZED_FULL, LazyObjectState::STATUS_UNINITIALIZED_PARTIAL], true)) {
-                return;
-            }
+        if ($state && \in_array($state->status, [LazyObjectState::STATUS_UNINITIALIZED_FULL, LazyObjectState::STATUS_UNINITIALIZED_PARTIAL], true)) {
+            return;
+        }
 
-            if ((Registry::$parentMethods[self::class] ??= Registry::getParentMethods(self::class))['destruct']) {
-                parent::__destruct();
-            }
-        } finally {
-            if ($state) {
-                unset(Registry::$states[$this->lazyObjectId]);
-            }
+        if ((Registry::$parentMethods[self::class] ??= Registry::getParentMethods(self::class))['destruct']) {
+            parent::__destruct();
         }
     }
 
     private function setLazyObjectAsInitialized(bool $initialized): void
     {
-        $state = Registry::$states[$this->lazyObjectId ?? ''];
+        $state = $this->lazyObjectState ?? null;
 
         if ($state && !\is_array($state->initializer)) {
             $state->status = $initialized ? LazyObjectState::STATUS_INITIALIZED_FULL : LazyObjectState::STATUS_UNINITIALIZED_FULL;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48382
| License       | MIT
| Doc PR        | -

I would have loved to *not* store lazy-initializers in lazy objects, but this is not possible in PHP at the moment (see https://github.com/php/php-src/issues/10043 for details).

This PR moves storing state of lazy objects inside the objects themselves. This fixes the memory leak by allowing the garbage collector to free memory as needed. This has the drawback of adding noise when `var_dump($lazyObject)`, but at least we can make `dump($lazyObject)` aware of that, thus the change on VarDumper.