### PR TITLE
Make container property nullable in ContainerAwareTrait

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\DependencyInjection;
 trait ContainerAwareTrait
 {
     /**
-     * @var ContainerInterface
+     * @var ContainerInterface|null
      */
     protected $container;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT


I have the following method in my App.
```php
public function getContainer(): ContainerInterface {
    if (!$this->container) {
        throw new ContainerNotInitializedException('Application::$container is not initialized yet.');
    }
    return $this->container;
}
```

Psalm complains on this condition because per doctype the container can never be empty.
> Docblock-defined type Symfony\Component\DependencyInjection\ContainerInterface for $this->container is never falsy

Proposed solution: Make the container property nullable.