### PR TITLE
[DependencyInjection] Use WeakReference to break circular references in the container

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -53,7 +53,7 @@ class ProxyDumper implements DumperInterface
         $instantiation = 'return';
 
         if ($definition->isShared()) {
-            $instantiation .= sprintf(' $this->%s[%s] =', $definition->isPublic() && !$definition->isPrivate() ? 'services' : 'privates', var_export($id, true));
+            $instantiation .= sprintf(' $container->%s[%s] =', $definition->isPublic() && !$definition->isPrivate() ? 'services' : 'privates', var_export($id, true));
         }
 
         $proxifiedClass = new \ReflectionClass($this->proxyGenerator->getProxifiedClass($definition));
@@ -61,8 +61,9 @@ class ProxyDumper implements DumperInterface
 
         return <<<EOF
         if (true === \$lazyLoad) {
-            $instantiation \$this->createProxy('$proxyClass', function () {
-                return \\$proxyClass::staticProxyConstructor(function (&\$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface \$proxy) {
+            $instantiation \$container->createProxy('$proxyClass', static function () use (\$containerRef) {
+                return \\$proxyClass::staticProxyConstructor(static function (&\$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface \$proxy) use (\$containerRef) {
+                    \$container = \$containerRef->get();
                     \$wrappedInstance = $factoryCode;
 
                     \$proxy->setProxyInitializer(null);

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service_structure.txt
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service_structure.txt
@@ -3,12 +3,15 @@
 use %a
 class LazyServiceProjectServiceContainer extends Container
 {%a
-    protected function getFooService($lazyLoad = true)
+    protected static function getFooService($container, $lazyLoad = true)
     {
+        $containerRef = $container->ref;
+
         if (true === $lazyLoad) {
-            return $this->services['foo'] = $this->createProxy('stdClass_%s', function () {
-                return %S\stdClass_%s(function (&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) {
-                    $wrappedInstance = $this->getFooService(false);
+            return $container->services['foo'] = $container->createProxy('stdClass_%s', static function () use ($containerRef) {
+                return %S\stdClass_%s(static function (&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) use ($containerRef) {
+                    $container = $containerRef->get();
+                    $wrappedInstance = self::getFooService($containerRef->get(), false);
 
                     $proxy->setProxyInitializer(null);
 

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-factory.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-factory.php
@@ -7,10 +7,14 @@ return new class
 
     public function getFooService($lazyLoad = true)
     {
+        $container = $this;
+        $containerRef = \WeakReference::create($this);
+
         if (true === $lazyLoad) {
-            return $this->privates['foo'] = $this->createProxy('SunnyInterface_1eff735', function () {
-                return \SunnyInterface_1eff735::staticProxyConstructor(function (&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) {
-                    $wrappedInstance = $this->getFooService(false);
+            return $container->privates['foo'] = $container->createProxy('SunnyInterface_1eff735', static function () use ($containerRef) {
+                return \SunnyInterface_1eff735::staticProxyConstructor(static function (&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) use ($containerRef) {
+                    $container = $containerRef->get();
+                    $wrappedInstance = $container->getFooService(false);
 
                     $proxy->setProxyInitializer(null);
 

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -72,10 +72,10 @@ class ProxyDumperTest extends TestCase
 
         $definition->setLazy(true);
 
-        $code = $this->dumper->getProxyFactoryCode($definition, 'foo', '$this->getFoo2Service(false)');
+        $code = $this->dumper->getProxyFactoryCode($definition, 'foo', '$container->getFoo2Service(false)');
 
         $this->assertStringMatchesFormat(
-            '%A$wrappedInstance = $this->getFoo2Service(false);%w$proxy->setProxyInitializer(null);%A',
+            '%A$wrappedInstance = $container->getFoo2Service(false);%w$proxy->setProxyInitializer(null);%A',
             $code
         );
     }
@@ -87,9 +87,9 @@ class ProxyDumperTest extends TestCase
     {
         $definition->setLazy(true);
 
-        $code = $this->dumper->getProxyFactoryCode($definition, 'foo', '$this->getFoo2Service(false)');
+        $code = $this->dumper->getProxyFactoryCode($definition, 'foo', '$container->getFoo2Service(false)');
 
-        $this->assertStringMatchesFormat('%A$this->'.$access.'[\'foo\'] = %A', $code);
+        $this->assertStringMatchesFormat('%A$container->'.$access.'[\'foo\'] = %A', $code);
     }
 
     public function getPrivatePublicDefinitions()
@@ -118,7 +118,7 @@ class ProxyDumperTest extends TestCase
         $definition->addTag('proxy', ['interface' => SunnyInterface::class]);
 
         $implem = "<?php\n\n".$this->dumper->getProxyCode($definition);
-        $factory = $this->dumper->getProxyFactoryCode($definition, 'foo', '$this->getFooService(false)');
+        $factory = $this->dumper->getProxyFactoryCode($definition, 'foo', '$container->getFooService(false)');
         $factory = <<<EOPHP
 <?php
 
@@ -129,6 +129,9 @@ return new class
 
     public function getFooService(\$lazyLoad = true)
     {
+        \$container = \$this;
+        \$containerRef = \\WeakReference::create(\$this);
+
 {$factory}        return new {$class}();
     }
 

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "friendsofphp/proxy-manager-lts": "^1.0.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "^6.3",
         "symfony/deprecation-contracts": "^2.1|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
@@ -40,19 +40,19 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
     {
         return [
             new ExpressionFunction('service', $this->serviceCompiler ?? function ($arg) {
-                return sprintf('$this->get(%s)', $arg);
+                return sprintf('$container->get(%s)', $arg);
             }, function (array $variables, $value) {
                 return $variables['container']->get($value);
             }),
 
             new ExpressionFunction('parameter', function ($arg) {
-                return sprintf('$this->getParameter(%s)', $arg);
+                return sprintf('$container->getParameter(%s)', $arg);
             }, function (array $variables, $value) {
                 return $variables['container']->getParameter($value);
             }),
 
             new ExpressionFunction('env', function ($arg) {
-                return sprintf('$this->getEnv(%s)', $arg);
+                return sprintf('$container->getEnv(%s)', $arg);
             }, function (array $variables, $value) {
                 if (!$this->getEnv) {
                     throw new LogicException('You need to pass a getEnv closure to the expression langage provider to use the "env" function.');

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1243,6 +1243,7 @@ class PhpDumperTest extends TestCase
 %A
     private function getDynamicParameter(string $name)
     {
+        $container = $this;
         $value = match ($name) {
             'unit_enum' => \Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum::BAR,
             'enum_array' => [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'closure' => 'getClosureService',
@@ -48,8 +50,8 @@ class ProjectServiceContainer extends Container
      *
      * @return \Closure
      */
-    protected function getClosureService()
+    protected static function getClosureService($container)
     {
-        return $this->services['closure'] = (new \stdClass())->__invoke(...);
+        return $container->services['closure'] = (new \stdClass())->__invoke(...);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_constructor_without_arguments.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_constructor_without_arguments.php
@@ -17,9 +17,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tests\Fixtures\Container\ConstructorWithoutArgumentsContainer
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         parent::__construct();
         $this->parameterBag = null;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_with_mandatory_constructor_arguments.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_with_mandatory_constructor_arguments.php
@@ -17,9 +17,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tests\Fixtures\Container\ConstructorWithMandatoryArgumentsContainer
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
 
         $this->aliases = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_with_optional_constructor_arguments.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_with_optional_constructor_arguments.php
@@ -17,9 +17,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tests\Fixtures\Container\ConstructorWithOptionalArgumentsContainer
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         parent::__construct();
         $this->parameterBag = null;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_without_constructor.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_without_constructor.php
@@ -17,9 +17,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tests\Fixtures\Container\NoConstructorContainer
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
 
         $this->aliases = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
@@ -17,9 +17,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Container extends \Symfony\Component\DependencyInjection\Dump\AbstractContainer
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
 
         $this->aliases = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
 
         $this->aliases = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -43,9 +45,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getTestService()
+    protected static function getTestService($container)
     {
-        return $this->services['test'] = new \stdClass(['only dot' => '.', 'concatenation as value' => '.\'\'.', 'concatenation from the start value' => '\'\'.', '.' => 'dot as a key', '.\'\'.' => 'concatenation as a key', '\'\'.' => 'concatenation from the start key', 'optimize concatenation' => 'string1-string2', 'optimize concatenation with empty string' => 'string1string2', 'optimize concatenation from the start' => 'start', 'optimize concatenation at the end' => 'end', 'new line' => 'string with '."\n".'new line']);
+        return $container->services['test'] = new \stdClass(['only dot' => '.', 'concatenation as value' => '.\'\'.', 'concatenation from the start value' => '\'\'.', '.' => 'dot as a key', '.\'\'.' => 'concatenation as a key', '\'\'.' => 'concatenation from the start key', 'optimize concatenation' => 'string1-string2', 'optimize concatenation with empty string' => 'string1string2', 'optimize concatenation from the start' => 'start', 'optimize concatenation at the end' => 'end', 'new line' => 'string with '."\n".'new line']);
     }
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
@@ -27,9 +27,13 @@ class getClosureService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
+        $containerRef = $container->ref;
+
         $container->services['closure'] = $instance = new \stdClass();
 
-        $instance->closures = [0 => #[\Closure(name: 'foo', class: 'FooClass')] function () use ($container): ?\stdClass {
+        $instance->closures = [0 => #[\Closure(name: 'foo', class: 'FooClass')] static function () use ($containerRef): ?\stdClass {
+            $container = $containerRef->get();
+
             return ($container->services['foo'] ?? null);
         }];
 
@@ -59,9 +63,11 @@ class ProjectServiceContainer extends Container
     protected $targetDir;
     protected $parameters = [];
     private $buildParameters;
+    protected readonly \WeakReference $ref;
 
     public function __construct(array $buildParameters = [], $containerDir = __DIR__)
     {
+        $this->ref = \WeakReference::create($this);
         $this->buildParameters = $buildParameters;
         $this->containerDir = $containerDir;
         $this->targetDir = \dirname($containerDir);
@@ -113,9 +119,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \FooClass
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
-        return $this->services['foo'] = new \FooClass(new \stdClass());
+        return $container->services['foo'] = new \FooClass(new \stdClass());
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -43,9 +45,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getTestService()
+    protected static function getTestService($container)
     {
-        return $this->services['test'] = new \stdClass(('file://'.\dirname(__DIR__, 1)), [('file://'.\dirname(__DIR__, 1)) => (\dirname(__DIR__, 2).'/')]);
+        return $container->services['test'] = new \stdClass(('file://'.\dirname(__DIR__, 1)), [('file://'.\dirname(__DIR__, 1)) => (\dirname(__DIR__, 2).'/')]);
     }
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'bar' => 'getBarService',
@@ -48,11 +50,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBarService()
+    protected static function getBarService($container)
     {
         $a = new \stdClass();
-        $a->add($this);
+        $a->add($container);
 
-        return $this->services['bar'] = new \stdClass($a);
+        return $container->services['bar'] = new \stdClass($a);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'foo' => 'getFooService',
@@ -41,8 +43,8 @@ class ProjectServiceContainer extends Container
      *
      * @return \Foo
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
-        return $this->services['foo'] = new \Foo();
+        return $container->services['foo'] = new \Foo();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'Bar\\Foo' => 'getFooService',
@@ -42,9 +44,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\Foo
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
-        return $this->services['Bar\\Foo'] = new \Bar\Foo();
+        return $container->services['Bar\\Foo'] = new \Bar\Foo();
     }
 
     /**
@@ -52,8 +54,8 @@ class ProjectServiceContainer extends Container
      *
      * @return \Foo\Foo
      */
-    protected function getFoo2Service()
+    protected static function getFoo2Service($container)
     {
-        return $this->services['Foo\\Foo'] = new \Foo\Foo();
+        return $container->services['Foo\\Foo'] = new \Foo\Foo();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -39,7 +39,7 @@ class getBAR2Service extends ProjectServiceContainer
     {
         $container->services['BAR'] = $instance = new \stdClass();
 
-        $instance->bar = ($container->services['bar'] ?? $container->getBarService());
+        $instance->bar = ($container->services['bar'] ?? self::getBarService($container));
 
         return $instance;
     }
@@ -281,7 +281,7 @@ class getFooService extends ProjectServiceContainer
         $instance->foo = 'bar';
         $instance->moo = $a;
         $instance->qux = ['bar' => 'foo is bar', 'foobar' => 'bar'];
-        $instance->setBar(($container->services['bar'] ?? $container->getBarService()));
+        $instance->setBar(($container->services['bar'] ?? self::getBarService($container)));
         $instance->initialize();
         sc_configure($instance);
 
@@ -319,11 +319,11 @@ class getFooBarService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $container->factories['foo_bar'] = function () use ($container) {
+        $container->factories['foo_bar'] = static function ($container) {
             return new \Bar\FooClass(($container->services['deprecated_service'] ?? $container->load('getDeprecatedServiceService')));
         };
 
-        return $container->factories['foo_bar']();
+        return $container->factories['foo_bar']($container);
     }
 }
 
@@ -361,10 +361,14 @@ class getLazyContextService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        return $container->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function () use ($container) {
+        $containerRef = $container->ref;
+
+        return $container->services['lazy_context'] = new \LazyContext(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
             yield 'k1' => ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'));
             yield 'k2' => $container;
-        }, 2), new RewindableGenerator(function () use ($container) {
+        }, 2), new RewindableGenerator(static function () {
             return new \EmptyIterator();
         }, 0));
     }
@@ -381,9 +385,13 @@ class getLazyContextIgnoreInvalidRefService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        return $container->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(function () use ($container) {
+        $containerRef = $container->ref;
+
+        return $container->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
             yield 0 => ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'));
-        }, 1), new RewindableGenerator(function () use ($container) {
+        }, 1), new RewindableGenerator(static function () {
             return new \EmptyIterator();
         }, 0));
     }
@@ -447,11 +455,11 @@ class getNonSharedFooService extends ProjectServiceContainer
     {
         include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
-        $container->factories['non_shared_foo'] = function () use ($container) {
+        $container->factories['non_shared_foo'] = static function ($container) {
             return new \Bar\FooClass();
         };
 
-        return $container->factories['non_shared_foo']();
+        return $container->factories['non_shared_foo']($container);
     }
 }
 
@@ -511,7 +519,11 @@ class getTaggedIteratorService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        return $container->services['tagged_iterator'] = new \Bar(new RewindableGenerator(function () use ($container) {
+        $containerRef = $container->ref;
+
+        return $container->services['tagged_iterator'] = new \Bar(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
             yield 0 => ($container->services['foo'] ?? $container->load('getFooService'));
             yield 1 => ($container->privates['tagged_iterator_foo'] ??= new \Bar());
         }, 2));
@@ -555,9 +567,11 @@ class ProjectServiceContainer extends Container
     protected $targetDir;
     protected $parameters = [];
     private $buildParameters;
+    protected readonly \WeakReference $ref;
 
     public function __construct(array $buildParameters = [], $containerDir = __DIR__)
     {
+        $this->ref = \WeakReference::create($this);
         $this->buildParameters = $buildParameters;
         $this->containerDir = $containerDir;
         $this->targetDir = \dirname($containerDir);
@@ -643,11 +657,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getBarService()
+    protected static function getBarService($container)
     {
-        $a = ($this->services['foo.baz'] ?? $this->load('getFoo_BazService'));
+        $a = ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'));
 
-        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
+        $container->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $container->getParameter('foo_bar'));
 
         $a->configure($instance);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -90,11 +92,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBARService()
+    protected static function getBARService($container)
     {
-        $this->services['BAR'] = $instance = new \stdClass();
+        $container->services['BAR'] = $instance = new \stdClass();
 
-        $instance->bar = ($this->services['bar'] ?? $this->getBar3Service());
+        $instance->bar = ($container->services['bar'] ?? self::getBar3Service($container));
 
         return $instance;
     }
@@ -104,9 +106,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBAR2Service()
+    protected static function getBAR2Service($container)
     {
-        return $this->services['BAR2'] = new \stdClass();
+        return $container->services['BAR2'] = new \stdClass();
     }
 
     /**
@@ -114,9 +116,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getAServiceService()
+    protected static function getAServiceService($container)
     {
-        return $this->services['a_service'] = ($this->privates['a_factory'] ??= new \Bar())->getBar();
+        return $container->services['a_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
@@ -124,9 +126,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getBServiceService()
+    protected static function getBServiceService($container)
     {
-        return $this->services['b_service'] = ($this->privates['a_factory'] ??= new \Bar())->getBar();
+        return $container->services['b_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
@@ -134,11 +136,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getBar3Service()
+    protected static function getBar3Service($container)
     {
-        $a = ($this->services['foo.baz'] ?? $this->getFoo_BazService());
+        $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
+        $container->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $container->getParameter('foo_bar'));
 
         $a->configure($instance);
 
@@ -150,9 +152,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBar22Service()
+    protected static function getBar22Service($container)
     {
-        return $this->services['bar2'] = new \stdClass();
+        return $container->services['bar2'] = new \stdClass();
     }
 
     /**
@@ -160,11 +162,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \Baz
      */
-    protected function getBazService()
+    protected static function getBazService($container)
     {
-        $this->services['baz'] = $instance = new \Baz();
+        $container->services['baz'] = $instance = new \Baz();
 
-        $instance->setFoo(($this->services['foo_with_inline'] ?? $this->getFooWithInlineService()));
+        $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
 
         return $instance;
     }
@@ -174,12 +176,12 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getConfiguredServiceService()
+    protected static function getConfiguredServiceService($container)
     {
-        $this->services['configured_service'] = $instance = new \stdClass();
+        $container->services['configured_service'] = $instance = new \stdClass();
 
         $a = new \ConfClass();
-        $a->setFoo(($this->services['baz'] ?? $this->getBazService()));
+        $a->setFoo(($container->services['baz'] ?? self::getBazService($container)));
 
         $a->configureStdClass($instance);
 
@@ -191,9 +193,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getConfiguredServiceSimpleService()
+    protected static function getConfiguredServiceSimpleService($container)
     {
-        $this->services['configured_service_simple'] = $instance = new \stdClass();
+        $container->services['configured_service_simple'] = $instance = new \stdClass();
 
         (new \ConfClass('bar'))->configureStdClass($instance);
 
@@ -205,9 +207,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getDecoratorServiceService()
+    protected static function getDecoratorServiceService($container)
     {
-        return $this->services['decorator_service'] = new \stdClass();
+        return $container->services['decorator_service'] = new \stdClass();
     }
 
     /**
@@ -215,9 +217,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getDecoratorServiceWithNameService()
+    protected static function getDecoratorServiceWithNameService($container)
     {
-        return $this->services['decorator_service_with_name'] = new \stdClass();
+        return $container->services['decorator_service_with_name'] = new \stdClass();
     }
 
     /**
@@ -227,11 +229,11 @@ class ProjectServiceContainer extends Container
      *
      * @deprecated Since vendor/package 1.1: The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected function getDeprecatedServiceService()
+    protected static function getDeprecatedServiceService($container)
     {
         trigger_deprecation('vendor/package', '1.1', 'The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.');
 
-        return $this->services['deprecated_service'] = new \stdClass();
+        return $container->services['deprecated_service'] = new \stdClass();
     }
 
     /**
@@ -239,9 +241,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getFactoryServiceService()
+    protected static function getFactoryServiceService($container)
     {
-        return $this->services['factory_service'] = ($this->services['foo.baz'] ?? $this->getFoo_BazService())->getInstance();
+        return $container->services['factory_service'] = ($container->services['foo.baz'] ?? self::getFoo_BazService($container))->getInstance();
     }
 
     /**
@@ -249,9 +251,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getFactoryServiceSimpleService()
+    protected static function getFactoryServiceSimpleService($container)
     {
-        return $this->services['factory_service_simple'] = $this->getFactorySimpleService()->getInstance();
+        return $container->services['factory_service_simple'] = self::getFactorySimpleService($container)->getInstance();
     }
 
     /**
@@ -259,16 +261,16 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
-        $a = ($this->services['foo.baz'] ?? $this->getFoo_BazService());
+        $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $this);
+        $container->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
 
         $instance->foo = 'bar';
         $instance->moo = $a;
         $instance->qux = ['bar' => 'foo is bar', 'foobar' => 'bar'];
-        $instance->setBar(($this->services['bar'] ?? $this->getBar3Service()));
+        $instance->setBar(($container->services['bar'] ?? self::getBar3Service($container)));
         $instance->initialize();
         sc_configure($instance);
 
@@ -280,9 +282,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \BazClass
      */
-    protected function getFoo_BazService()
+    protected static function getFoo_BazService($container)
     {
-        $this->services['foo.baz'] = $instance = \BazClass::getInstance();
+        $container->services['foo.baz'] = $instance = \BazClass::getInstance();
 
         \BazClass::configureStatic1($instance);
 
@@ -294,13 +296,13 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getFooBarService()
+    protected static function getFooBarService($container)
     {
-        $this->factories['foo_bar'] = function () {
-            return new \Bar\FooClass(($this->services['deprecated_service'] ?? $this->getDeprecatedServiceService()));
+        $container->factories['foo_bar'] = static function ($container) {
+            return new \Bar\FooClass(($container->services['deprecated_service'] ?? self::getDeprecatedServiceService($container)));
         };
 
-        return $this->factories['foo_bar']();
+        return $container->factories['foo_bar']($container);
     }
 
     /**
@@ -308,13 +310,13 @@ class ProjectServiceContainer extends Container
      *
      * @return \Foo
      */
-    protected function getFooWithInlineService()
+    protected static function getFooWithInlineService($container)
     {
-        $this->services['foo_with_inline'] = $instance = new \Foo();
+        $container->services['foo_with_inline'] = $instance = new \Foo();
 
         $a = new \Bar();
         $a->pub = 'pub';
-        $a->setBaz(($this->services['baz'] ?? $this->getBazService()));
+        $a->setBaz(($container->services['baz'] ?? self::getBazService($container)));
 
         $instance->setBar($a);
 
@@ -326,12 +328,16 @@ class ProjectServiceContainer extends Container
      *
      * @return \LazyContext
      */
-    protected function getLazyContextService()
+    protected static function getLazyContextService($container)
     {
-        return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function () {
-            yield 'k1' => ($this->services['foo.baz'] ?? $this->getFoo_BazService());
-            yield 'k2' => $this;
-        }, 2), new RewindableGenerator(function () {
+        $containerRef = $container->ref;
+
+        return $container->services['lazy_context'] = new \LazyContext(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 'k1' => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
+            yield 'k2' => $container;
+        }, 2), new RewindableGenerator(static function () {
             return new \EmptyIterator();
         }, 0));
     }
@@ -341,11 +347,15 @@ class ProjectServiceContainer extends Container
      *
      * @return \LazyContext
      */
-    protected function getLazyContextIgnoreInvalidRefService()
+    protected static function getLazyContextIgnoreInvalidRefService($container)
     {
-        return $this->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(function () {
-            yield 0 => ($this->services['foo.baz'] ?? $this->getFoo_BazService());
-        }, 1), new RewindableGenerator(function () {
+        $containerRef = $container->ref;
+
+        return $container->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 0 => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
+        }, 1), new RewindableGenerator(static function () {
             return new \EmptyIterator();
         }, 0));
     }
@@ -355,15 +365,15 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getMethodCall1Service()
+    protected static function getMethodCall1Service($container)
     {
         include_once '%path%foo.php';
 
-        $this->services['method_call1'] = $instance = new \Bar\FooClass();
+        $container->services['method_call1'] = $instance = new \Bar\FooClass();
 
-        $instance->setBar(($this->services['foo'] ?? $this->getFooService()));
+        $instance->setBar(($container->services['foo'] ?? self::getFooService($container)));
         $instance->setBar(NULL);
-        $instance->setBar((($this->services['foo'] ?? $this->getFooService())->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar((($container->services['foo'] ?? self::getFooService($container))->foo() . (($container->hasParameter("foo")) ? ($container->getParameter("foo")) : ("default"))));
 
         return $instance;
     }
@@ -373,12 +383,12 @@ class ProjectServiceContainer extends Container
      *
      * @return \FooBarBaz
      */
-    protected function getNewFactoryServiceService()
+    protected static function getNewFactoryServiceService($container)
     {
         $a = new \FactoryClass();
         $a->foo = 'bar';
 
-        $this->services['new_factory_service'] = $instance = $a->getInstance();
+        $container->services['new_factory_service'] = $instance = $a->getInstance();
 
         $instance->foo = 'bar';
 
@@ -390,9 +400,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getPreloadSidekickService()
+    protected static function getPreloadSidekickService($container)
     {
-        return $this->services['preload_sidekick'] = new \stdClass();
+        return $container->services['preload_sidekick'] = new \stdClass();
     }
 
     /**
@@ -400,9 +410,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getRuntimeErrorService()
+    protected static function getRuntimeErrorService($container)
     {
-        return $this->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
+        return $container->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
     }
 
     /**
@@ -410,9 +420,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getServiceFromStaticMethodService()
+    protected static function getServiceFromStaticMethodService($container)
     {
-        return $this->services['service_from_static_method'] = \Bar\FooClass::getInstance();
+        return $container->services['service_from_static_method'] = \Bar\FooClass::getInstance();
     }
 
     /**
@@ -420,11 +430,15 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getTaggedIteratorService()
+    protected static function getTaggedIteratorService($container)
     {
-        return $this->services['tagged_iterator'] = new \Bar(new RewindableGenerator(function () {
-            yield 0 => ($this->services['foo'] ?? $this->getFooService());
-            yield 1 => ($this->privates['tagged_iterator_foo'] ??= new \Bar());
+        $containerRef = $container->ref;
+
+        return $container->services['tagged_iterator'] = new \Bar(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 0 => ($container->services['foo'] ?? self::getFooService($container));
+            yield 1 => ($container->privates['tagged_iterator_foo'] ??= new \Bar());
         }, 2));
     }
 
@@ -435,7 +449,7 @@ class ProjectServiceContainer extends Container
      *
      * @deprecated Since vendor/package 1.1: The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected function getFactorySimpleService()
+    protected static function getFactorySimpleService($container)
     {
         trigger_deprecation('vendor/package', '1.1', 'The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -40,9 +40,11 @@ class ProjectServiceContainer extends Container
     protected $targetDir;
     protected $parameters = [];
     private $buildParameters;
+    protected readonly \WeakReference $ref;
 
     public function __construct(array $buildParameters = [], $containerDir = __DIR__)
     {
+        $this->ref = \WeakReference::create($this);
         $this->buildParameters = $buildParameters;
         $this->containerDir = $containerDir;
         $this->targetDir = \dirname($containerDir);
@@ -88,8 +90,8 @@ class ProjectServiceContainer extends Container
             'decorated' => 'decorator_service_with_name',
         ];
 
-        $this->privates['service_container'] = function () {
-            include_once $this->targetDir.''.'/Fixtures/includes/foo.php';
+        $this->privates['service_container'] = static function ($container) {
+            include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
         };
     }
 
@@ -113,11 +115,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBARService()
+    protected static function getBARService($container)
     {
-        $this->services['BAR'] = $instance = new \stdClass();
+        $container->services['BAR'] = $instance = new \stdClass();
 
-        $instance->bar = ($this->services['bar'] ?? $this->getBar3Service());
+        $instance->bar = ($container->services['bar'] ?? self::getBar3Service($container));
 
         return $instance;
     }
@@ -127,9 +129,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBAR2Service()
+    protected static function getBAR2Service($container)
     {
-        return $this->services['BAR2'] = new \stdClass();
+        return $container->services['BAR2'] = new \stdClass();
     }
 
     /**
@@ -137,9 +139,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getAServiceService()
+    protected static function getAServiceService($container)
     {
-        return $this->services['a_service'] = ($this->privates['a_factory'] ??= new \Bar())->getBar();
+        return $container->services['a_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
@@ -147,9 +149,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getBServiceService()
+    protected static function getBServiceService($container)
     {
-        return $this->services['b_service'] = ($this->privates['a_factory'] ??= new \Bar())->getBar();
+        return $container->services['b_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
@@ -157,11 +159,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getBar3Service()
+    protected static function getBar3Service($container)
     {
-        $a = ($this->services['foo.baz'] ?? $this->getFoo_BazService());
+        $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
+        $container->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $container->getParameter('foo_bar'));
 
         $a->configure($instance);
 
@@ -173,9 +175,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBar22Service()
+    protected static function getBar22Service($container)
     {
-        return $this->services['bar2'] = new \stdClass();
+        return $container->services['bar2'] = new \stdClass();
     }
 
     /**
@@ -183,11 +185,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \Baz
      */
-    protected function getBazService()
+    protected static function getBazService($container)
     {
-        $this->services['baz'] = $instance = new \Baz();
+        $container->services['baz'] = $instance = new \Baz();
 
-        $instance->setFoo(($this->services['foo_with_inline'] ?? $this->getFooWithInlineService()));
+        $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
 
         return $instance;
     }
@@ -197,12 +199,12 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getConfiguredServiceService()
+    protected static function getConfiguredServiceService($container)
     {
-        $this->services['configured_service'] = $instance = new \stdClass();
+        $container->services['configured_service'] = $instance = new \stdClass();
 
         $a = new \ConfClass();
-        $a->setFoo(($this->services['baz'] ?? $this->getBazService()));
+        $a->setFoo(($container->services['baz'] ?? self::getBazService($container)));
 
         $a->configureStdClass($instance);
 
@@ -214,9 +216,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getConfiguredServiceSimpleService()
+    protected static function getConfiguredServiceSimpleService($container)
     {
-        $this->services['configured_service_simple'] = $instance = new \stdClass();
+        $container->services['configured_service_simple'] = $instance = new \stdClass();
 
         (new \ConfClass('bar'))->configureStdClass($instance);
 
@@ -228,9 +230,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getDecoratorServiceService()
+    protected static function getDecoratorServiceService($container)
     {
-        return $this->services['decorator_service'] = new \stdClass();
+        return $container->services['decorator_service'] = new \stdClass();
     }
 
     /**
@@ -238,9 +240,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getDecoratorServiceWithNameService()
+    protected static function getDecoratorServiceWithNameService($container)
     {
-        return $this->services['decorator_service_with_name'] = new \stdClass();
+        return $container->services['decorator_service_with_name'] = new \stdClass();
     }
 
     /**
@@ -250,11 +252,11 @@ class ProjectServiceContainer extends Container
      *
      * @deprecated Since vendor/package 1.1: The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected function getDeprecatedServiceService()
+    protected static function getDeprecatedServiceService($container)
     {
         trigger_deprecation('vendor/package', '1.1', 'The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.');
 
-        return $this->services['deprecated_service'] = new \stdClass();
+        return $container->services['deprecated_service'] = new \stdClass();
     }
 
     /**
@@ -262,9 +264,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getFactoryServiceService()
+    protected static function getFactoryServiceService($container)
     {
-        return $this->services['factory_service'] = ($this->services['foo.baz'] ?? $this->getFoo_BazService())->getInstance();
+        return $container->services['factory_service'] = ($container->services['foo.baz'] ?? self::getFoo_BazService($container))->getInstance();
     }
 
     /**
@@ -272,9 +274,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getFactoryServiceSimpleService()
+    protected static function getFactoryServiceSimpleService($container)
     {
-        return $this->services['factory_service_simple'] = $this->getFactorySimpleService()->getInstance();
+        return $container->services['factory_service_simple'] = self::getFactorySimpleService($container)->getInstance();
     }
 
     /**
@@ -282,16 +284,16 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
-        $a = ($this->services['foo.baz'] ?? $this->getFoo_BazService());
+        $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $this);
+        $container->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
 
         $instance->foo = 'bar';
         $instance->moo = $a;
         $instance->qux = ['bar' => 'foo is bar', 'foobar' => 'bar'];
-        $instance->setBar(($this->services['bar'] ?? $this->getBar3Service()));
+        $instance->setBar(($container->services['bar'] ?? self::getBar3Service($container)));
         $instance->initialize();
         sc_configure($instance);
 
@@ -303,11 +305,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \BazClass
      */
-    protected function getFoo_BazService()
+    protected static function getFoo_BazService($container)
     {
-        include_once $this->targetDir.''.'/Fixtures/includes/classes.php';
+        include_once $container->targetDir.''.'/Fixtures/includes/classes.php';
 
-        $this->services['foo.baz'] = $instance = \BazClass::getInstance();
+        $container->services['foo.baz'] = $instance = \BazClass::getInstance();
 
         \BazClass::configureStatic1($instance);
 
@@ -319,13 +321,13 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getFooBarService()
+    protected static function getFooBarService($container)
     {
-        $this->factories['foo_bar'] = function () {
-            return new \Bar\FooClass(($this->services['deprecated_service'] ?? $this->getDeprecatedServiceService()));
+        $container->factories['foo_bar'] = static function ($container) {
+            return new \Bar\FooClass(($container->services['deprecated_service'] ?? self::getDeprecatedServiceService($container)));
         };
 
-        return $this->factories['foo_bar']();
+        return $container->factories['foo_bar']($container);
     }
 
     /**
@@ -333,13 +335,13 @@ class ProjectServiceContainer extends Container
      *
      * @return \Foo
      */
-    protected function getFooWithInlineService()
+    protected static function getFooWithInlineService($container)
     {
-        $this->services['foo_with_inline'] = $instance = new \Foo();
+        $container->services['foo_with_inline'] = $instance = new \Foo();
 
         $a = new \Bar();
         $a->pub = 'pub';
-        $a->setBaz(($this->services['baz'] ?? $this->getBazService()));
+        $a->setBaz(($container->services['baz'] ?? self::getBazService($container)));
 
         $instance->setBar($a);
 
@@ -351,14 +353,18 @@ class ProjectServiceContainer extends Container
      *
      * @return \LazyContext
      */
-    protected function getLazyContextService()
+    protected static function getLazyContextService($container)
     {
-        include_once $this->targetDir.''.'/Fixtures/includes/classes.php';
+        $containerRef = $container->ref;
 
-        return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function () {
-            yield 'k1' => ($this->services['foo.baz'] ?? $this->getFoo_BazService());
-            yield 'k2' => $this;
-        }, 2), new RewindableGenerator(function () {
+        include_once $container->targetDir.''.'/Fixtures/includes/classes.php';
+
+        return $container->services['lazy_context'] = new \LazyContext(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 'k1' => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
+            yield 'k2' => $container;
+        }, 2), new RewindableGenerator(static function () {
             return new \EmptyIterator();
         }, 0));
     }
@@ -368,13 +374,17 @@ class ProjectServiceContainer extends Container
      *
      * @return \LazyContext
      */
-    protected function getLazyContextIgnoreInvalidRefService()
+    protected static function getLazyContextIgnoreInvalidRefService($container)
     {
-        include_once $this->targetDir.''.'/Fixtures/includes/classes.php';
+        $containerRef = $container->ref;
 
-        return $this->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(function () {
-            yield 0 => ($this->services['foo.baz'] ?? $this->getFoo_BazService());
-        }, 1), new RewindableGenerator(function () {
+        include_once $container->targetDir.''.'/Fixtures/includes/classes.php';
+
+        return $container->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 0 => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
+        }, 1), new RewindableGenerator(static function () {
             return new \EmptyIterator();
         }, 0));
     }
@@ -384,15 +394,15 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getMethodCall1Service()
+    protected static function getMethodCall1Service($container)
     {
-        include_once $this->targetDir.''.'/Fixtures/includes/foo.php';
+        include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
-        $this->services['method_call1'] = $instance = new \Bar\FooClass();
+        $container->services['method_call1'] = $instance = new \Bar\FooClass();
 
-        $instance->setBar(($this->services['foo'] ?? $this->getFooService()));
+        $instance->setBar(($container->services['foo'] ?? self::getFooService($container)));
         $instance->setBar(NULL);
-        $instance->setBar((($this->services['foo'] ?? $this->getFooService())->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar((($container->services['foo'] ?? self::getFooService($container))->foo() . (($container->hasParameter("foo")) ? ($container->getParameter("foo")) : ("default"))));
 
         return $instance;
     }
@@ -402,12 +412,12 @@ class ProjectServiceContainer extends Container
      *
      * @return \FooBarBaz
      */
-    protected function getNewFactoryServiceService()
+    protected static function getNewFactoryServiceService($container)
     {
         $a = new \FactoryClass();
         $a->foo = 'bar';
 
-        $this->services['new_factory_service'] = $instance = $a->getInstance();
+        $container->services['new_factory_service'] = $instance = $a->getInstance();
 
         $instance->foo = 'bar';
 
@@ -419,15 +429,15 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getNonSharedFooService()
+    protected static function getNonSharedFooService($container)
     {
-        include_once $this->targetDir.''.'/Fixtures/includes/foo.php';
+        include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
-        $this->factories['non_shared_foo'] = function () {
+        $container->factories['non_shared_foo'] = static function ($container) {
             return new \Bar\FooClass();
         };
 
-        return $this->factories['non_shared_foo']();
+        return $container->factories['non_shared_foo']($container);
     }
 
     /**
@@ -435,9 +445,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getPreloadSidekickService()
+    protected static function getPreloadSidekickService($container)
     {
-        return $this->services['preload_sidekick'] = new \stdClass();
+        return $container->services['preload_sidekick'] = new \stdClass();
     }
 
     /**
@@ -445,9 +455,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getRuntimeErrorService()
+    protected static function getRuntimeErrorService($container)
     {
-        return $this->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
+        return $container->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
     }
 
     /**
@@ -455,9 +465,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getServiceFromStaticMethodService()
+    protected static function getServiceFromStaticMethodService($container)
     {
-        return $this->services['service_from_static_method'] = \Bar\FooClass::getInstance();
+        return $container->services['service_from_static_method'] = \Bar\FooClass::getInstance();
     }
 
     /**
@@ -465,11 +475,15 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar
      */
-    protected function getTaggedIteratorService()
+    protected static function getTaggedIteratorService($container)
     {
-        return $this->services['tagged_iterator'] = new \Bar(new RewindableGenerator(function () {
-            yield 0 => ($this->services['foo'] ?? $this->getFooService());
-            yield 1 => ($this->privates['tagged_iterator_foo'] ??= new \Bar());
+        $containerRef = $container->ref;
+
+        return $container->services['tagged_iterator'] = new \Bar(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 0 => ($container->services['foo'] ?? self::getFooService($container));
+            yield 1 => ($container->privates['tagged_iterator_foo'] ??= new \Bar());
         }, 2));
     }
 
@@ -478,9 +492,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getThrowingOneService()
+    protected static function getThrowingOneService($container)
     {
-        return $this->services['throwing_one'] = new \Bar\FooClass(throw new RuntimeException('No-no-no-no'));
+        return $container->services['throwing_one'] = new \Bar\FooClass(throw new RuntimeException('No-no-no-no'));
     }
 
     /**
@@ -490,7 +504,7 @@ class ProjectServiceContainer extends Container
      *
      * @deprecated Since vendor/package 1.1: The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected function getFactorySimpleService()
+    protected static function getFactorySimpleService($container)
     {
         trigger_deprecation('vendor/package', '1.1', 'The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -4,7 +4,7 @@ Array
 
 namespace Container%s;
 
-include_once $this->targetDir.''.'/Fixtures/includes/foo.php';
+include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
 class FooClassGhost2b16075 extends \Bar\FooClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 %A
@@ -35,9 +35,11 @@ class ProjectServiceContainer extends Container
     protected $targetDir;
     protected $parameters = [];
     private $buildParameters;
+    protected readonly \WeakReference $ref;
 
     public function __construct(array $buildParameters = [], $containerDir = __DIR__)
     {
+        $this->ref = \WeakReference::create($this);
         $this->buildParameters = $buildParameters;
         $this->containerDir = $containerDir;
         $this->targetDir = \dirname($containerDir);
@@ -50,7 +52,7 @@ class ProjectServiceContainer extends Container
 
         $this->aliases = [];
 
-        $this->privates['service_container'] = function () {
+        $this->privates['service_container'] = static function ($container) {
             include_once __DIR__.'/proxy-classes.php';
         };
     }
@@ -75,13 +77,15 @@ class ProjectServiceContainer extends Container
      *
      * @return object A %lazy_foo_class% instance
      */
-    protected function getLazyFooService($lazyLoad = true)
+    protected static function getLazyFooService($container, $lazyLoad = true)
     {
+        $containerRef = $container->ref;
+
         if (true === $lazyLoad) {
-            return $this->services['lazy_foo'] = $this->createProxy('FooClassGhost2b16075', fn () => \FooClassGhost2b16075::createLazyGhost($this->getLazyFooService(...)));
+            return $container->services['lazy_foo'] = $container->createProxy('FooClassGhost2b16075', static fn () => \FooClassGhost2b16075::createLazyGhost(static fn ($proxy) => self::getLazyFooService($containerRef->get(), $proxy)));
         }
 
-        include_once $this->targetDir.''.'/Fixtures/includes/foo_lazy.php';
+        include_once $container->targetDir.''.'/Fixtures/includes/foo_lazy.php';
 
         return ($lazyLoad->__construct(new \Bar\FooLazyClass()) && false ?: $lazyLoad);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'bar' => 'getBarService',
@@ -104,11 +106,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \BarCircular
      */
-    protected function getBarService()
+    protected static function getBarService($container)
     {
-        $this->services['bar'] = $instance = new \BarCircular();
+        $container->services['bar'] = $instance = new \BarCircular();
 
-        $instance->addFoobar(($this->services['foobar'] ?? $this->getFoobarService()));
+        $instance->addFoobar(($container->services['foobar'] ?? self::getFoobarService($container)));
 
         return $instance;
     }
@@ -118,11 +120,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \BarCircular
      */
-    protected function getBar3Service()
+    protected static function getBar3Service($container)
     {
-        $this->services['bar3'] = $instance = new \BarCircular();
+        $container->services['bar3'] = $instance = new \BarCircular();
 
-        $a = ($this->services['foobar3'] ??= new \FoobarCircular());
+        $a = ($container->services['foobar3'] ??= new \FoobarCircular());
 
         $instance->addFoobar($a, $a);
 
@@ -134,15 +136,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getBar5Service()
+    protected static function getBar5Service($container)
     {
-        $a = ($this->services['foo5'] ?? $this->getFoo5Service());
+        $a = ($container->services['foo5'] ?? self::getFoo5Service($container));
 
-        if (isset($this->services['bar5'])) {
-            return $this->services['bar5'];
+        if (isset($container->services['bar5'])) {
+            return $container->services['bar5'];
         }
 
-        $this->services['bar5'] = $instance = new \stdClass($a);
+        $container->services['bar5'] = $instance = new \stdClass($a);
 
         $instance->foo = $a;
 
@@ -154,11 +156,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getBaz6Service()
+    protected static function getBaz6Service($container)
     {
-        $this->services['baz6'] = $instance = new \stdClass();
+        $container->services['baz6'] = $instance = new \stdClass();
 
-        $instance->bar6 = ($this->privates['bar6'] ?? $this->getBar6Service());
+        $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
 
         return $instance;
     }
@@ -168,18 +170,18 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getConnectionService()
+    protected static function getConnectionService($container)
     {
-        $a = ($this->services['dispatcher'] ?? $this->getDispatcherService());
+        $a = ($container->services['dispatcher'] ?? self::getDispatcherService($container));
 
-        if (isset($this->services['connection'])) {
-            return $this->services['connection'];
+        if (isset($container->services['connection'])) {
+            return $container->services['connection'];
         }
         $b = new \stdClass();
 
-        $this->services['connection'] = $instance = new \stdClass($a, $b);
+        $container->services['connection'] = $instance = new \stdClass($a, $b);
 
-        $b->logger = ($this->services['logger'] ?? $this->getLoggerService());
+        $b->logger = ($container->services['logger'] ?? self::getLoggerService($container));
 
         return $instance;
     }
@@ -189,19 +191,19 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getConnection2Service()
+    protected static function getConnection2Service($container)
     {
-        $a = ($this->services['dispatcher2'] ?? $this->getDispatcher2Service());
+        $a = ($container->services['dispatcher2'] ?? self::getDispatcher2Service($container));
 
-        if (isset($this->services['connection2'])) {
-            return $this->services['connection2'];
+        if (isset($container->services['connection2'])) {
+            return $container->services['connection2'];
         }
         $b = new \stdClass();
 
-        $this->services['connection2'] = $instance = new \stdClass($a, $b);
+        $container->services['connection2'] = $instance = new \stdClass($a, $b);
 
         $c = new \stdClass($instance);
-        $c->handler2 = new \stdClass(($this->services['manager2'] ?? $this->getManager2Service()));
+        $c->handler2 = new \stdClass(($container->services['manager2'] ?? self::getManager2Service($container)));
 
         $b->logger2 = $c;
 
@@ -213,11 +215,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getConnection3Service()
+    protected static function getConnection3Service($container)
     {
-        $this->services['connection3'] = $instance = new \stdClass();
+        $container->services['connection3'] = $instance = new \stdClass();
 
-        $instance->listener = [0 => ($this->services['listener3'] ?? $this->getListener3Service())];
+        $instance->listener = [0 => ($container->services['listener3'] ?? self::getListener3Service($container))];
 
         return $instance;
     }
@@ -227,11 +229,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getConnection4Service()
+    protected static function getConnection4Service($container)
     {
-        $this->services['connection4'] = $instance = new \stdClass();
+        $container->services['connection4'] = $instance = new \stdClass();
 
-        $instance->listener = [0 => ($this->services['listener4'] ?? $this->getListener4Service())];
+        $instance->listener = [0 => ($container->services['listener4'] ?? self::getListener4Service($container))];
 
         return $instance;
     }
@@ -241,11 +243,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getDispatcherService($lazyLoad = true)
+    protected static function getDispatcherService($container, $lazyLoad = true)
     {
-        $this->services['dispatcher'] = $instance = new \stdClass();
+        $container->services['dispatcher'] = $instance = new \stdClass();
 
-        $instance->subscriber = ($this->services['subscriber'] ?? $this->getSubscriberService());
+        $instance->subscriber = ($container->services['subscriber'] ?? self::getSubscriberService($container));
 
         return $instance;
     }
@@ -255,11 +257,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getDispatcher2Service($lazyLoad = true)
+    protected static function getDispatcher2Service($container, $lazyLoad = true)
     {
-        $this->services['dispatcher2'] = $instance = new \stdClass();
+        $container->services['dispatcher2'] = $instance = new \stdClass();
 
-        $instance->subscriber2 = new \stdClass(($this->services['manager2'] ?? $this->getManager2Service()));
+        $instance->subscriber2 = new \stdClass(($container->services['manager2'] ?? self::getManager2Service($container)));
 
         return $instance;
     }
@@ -269,10 +271,14 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getDoctrine_EntityListenerResolverService()
+    protected static function getDoctrine_EntityListenerResolverService($container)
     {
-        return $this->services['doctrine.entity_listener_resolver'] = new \stdClass(new RewindableGenerator(function () {
-            yield 0 => ($this->services['doctrine.listener'] ?? $this->getDoctrine_ListenerService());
+        $containerRef = $container->ref;
+
+        return $container->services['doctrine.entity_listener_resolver'] = new \stdClass(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 0 => ($container->services['doctrine.listener'] ?? self::getDoctrine_ListenerService($container));
         }, 1));
     }
 
@@ -281,13 +287,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getDoctrine_EntityManagerService()
+    protected static function getDoctrine_EntityManagerService($container)
     {
         $a = new \stdClass();
-        $a->resolver = ($this->services['doctrine.entity_listener_resolver'] ?? $this->getDoctrine_EntityListenerResolverService());
+        $a->resolver = ($container->services['doctrine.entity_listener_resolver'] ?? self::getDoctrine_EntityListenerResolverService($container));
         $a->flag = 'ok';
 
-        return $this->services['doctrine.entity_manager'] = \FactoryChecker::create($a);
+        return $container->services['doctrine.entity_manager'] = \FactoryChecker::create($a);
     }
 
     /**
@@ -295,9 +301,9 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getDoctrine_ListenerService()
+    protected static function getDoctrine_ListenerService($container)
     {
-        return $this->services['doctrine.listener'] = new \stdClass(($this->services['doctrine.entity_manager'] ?? $this->getDoctrine_EntityManagerService()));
+        return $container->services['doctrine.listener'] = new \stdClass(($container->services['doctrine.entity_manager'] ?? self::getDoctrine_EntityManagerService($container)));
     }
 
     /**
@@ -305,15 +311,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \FooCircular
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
-        $a = ($this->services['bar'] ?? $this->getBarService());
+        $a = ($container->services['bar'] ?? self::getBarService($container));
 
-        if (isset($this->services['foo'])) {
-            return $this->services['foo'];
+        if (isset($container->services['foo'])) {
+            return $container->services['foo'];
         }
 
-        return $this->services['foo'] = new \FooCircular($a);
+        return $container->services['foo'] = new \FooCircular($a);
     }
 
     /**
@@ -321,13 +327,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \FooCircular
      */
-    protected function getFoo2Service()
+    protected static function getFoo2Service($container)
     {
         $a = new \BarCircular();
 
-        $this->services['foo2'] = $instance = new \FooCircular($a);
+        $container->services['foo2'] = $instance = new \FooCircular($a);
 
-        $a->addFoobar(($this->services['foobar2'] ?? $this->getFoobar2Service()));
+        $a->addFoobar(($container->services['foobar2'] ?? self::getFoobar2Service($container)));
 
         return $instance;
     }
@@ -337,17 +343,17 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getFoo4Service()
+    protected static function getFoo4Service($container)
     {
-        $this->factories['foo4'] = function () {
+        $container->factories['foo4'] = static function ($container) {
             $instance = new \stdClass();
 
-            $instance->foobar = ($this->services['foobar4'] ?? $this->getFoobar4Service());
+            $instance->foobar = ($container->services['foobar4'] ?? self::getFoobar4Service($container));
 
             return $instance;
         };
 
-        return $this->factories['foo4']();
+        return $container->factories['foo4']($container);
     }
 
     /**
@@ -355,11 +361,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getFoo5Service()
+    protected static function getFoo5Service($container)
     {
-        $this->services['foo5'] = $instance = new \stdClass();
+        $container->services['foo5'] = $instance = new \stdClass();
 
-        $instance->bar = ($this->services['bar5'] ?? $this->getBar5Service());
+        $instance->bar = ($container->services['bar5'] ?? self::getBar5Service($container));
 
         return $instance;
     }
@@ -369,11 +375,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getFoo6Service()
+    protected static function getFoo6Service($container)
     {
-        $this->services['foo6'] = $instance = new \stdClass();
+        $container->services['foo6'] = $instance = new \stdClass();
 
-        $instance->bar6 = ($this->privates['bar6'] ?? $this->getBar6Service());
+        $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
 
         return $instance;
     }
@@ -383,15 +389,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \FoobarCircular
      */
-    protected function getFoobarService()
+    protected static function getFoobarService($container)
     {
-        $a = ($this->services['foo'] ?? $this->getFooService());
+        $a = ($container->services['foo'] ?? self::getFooService($container));
 
-        if (isset($this->services['foobar'])) {
-            return $this->services['foobar'];
+        if (isset($container->services['foobar'])) {
+            return $container->services['foobar'];
         }
 
-        return $this->services['foobar'] = new \FoobarCircular($a);
+        return $container->services['foobar'] = new \FoobarCircular($a);
     }
 
     /**
@@ -399,15 +405,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \FoobarCircular
      */
-    protected function getFoobar2Service()
+    protected static function getFoobar2Service($container)
     {
-        $a = ($this->services['foo2'] ?? $this->getFoo2Service());
+        $a = ($container->services['foo2'] ?? self::getFoo2Service($container));
 
-        if (isset($this->services['foobar2'])) {
-            return $this->services['foobar2'];
+        if (isset($container->services['foobar2'])) {
+            return $container->services['foobar2'];
         }
 
-        return $this->services['foobar2'] = new \FoobarCircular($a);
+        return $container->services['foobar2'] = new \FoobarCircular($a);
     }
 
     /**
@@ -415,9 +421,9 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \FoobarCircular
      */
-    protected function getFoobar3Service()
+    protected static function getFoobar3Service($container)
     {
-        return $this->services['foobar3'] = new \FoobarCircular();
+        return $container->services['foobar3'] = new \FoobarCircular();
     }
 
     /**
@@ -425,11 +431,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getFoobar4Service()
+    protected static function getFoobar4Service($container)
     {
         $a = new \stdClass();
 
-        $this->services['foobar4'] = $instance = new \stdClass($a);
+        $container->services['foobar4'] = $instance = new \stdClass($a);
 
         $a->foobar = $instance;
 
@@ -441,11 +447,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getListener3Service()
+    protected static function getListener3Service($container)
     {
-        $this->services['listener3'] = $instance = new \stdClass();
+        $container->services['listener3'] = $instance = new \stdClass();
 
-        $instance->manager = ($this->services['manager3'] ?? $this->getManager3Service());
+        $instance->manager = ($container->services['manager3'] ?? self::getManager3Service($container));
 
         return $instance;
     }
@@ -455,15 +461,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getListener4Service()
+    protected static function getListener4Service($container)
     {
-        $a = ($this->privates['manager4'] ?? $this->getManager4Service());
+        $a = ($container->privates['manager4'] ?? self::getManager4Service($container));
 
-        if (isset($this->services['listener4'])) {
-            return $this->services['listener4'];
+        if (isset($container->services['listener4'])) {
+            return $container->services['listener4'];
         }
 
-        return $this->services['listener4'] = new \stdClass($a);
+        return $container->services['listener4'] = new \stdClass($a);
     }
 
     /**
@@ -471,17 +477,17 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getLoggerService()
+    protected static function getLoggerService($container)
     {
-        $a = ($this->services['connection'] ?? $this->getConnectionService());
+        $a = ($container->services['connection'] ?? self::getConnectionService($container));
 
-        if (isset($this->services['logger'])) {
-            return $this->services['logger'];
+        if (isset($container->services['logger'])) {
+            return $container->services['logger'];
         }
 
-        $this->services['logger'] = $instance = new \stdClass($a);
+        $container->services['logger'] = $instance = new \stdClass($a);
 
-        $instance->handler = new \stdClass(($this->services['manager'] ?? $this->getManagerService()));
+        $instance->handler = new \stdClass(($container->services['manager'] ?? self::getManagerService($container)));
 
         return $instance;
     }
@@ -491,9 +497,9 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getMailer_TransportService()
+    protected static function getMailer_TransportService($container)
     {
-        return $this->services['mailer.transport'] = ($this->services['mailer.transport_factory'] ?? $this->getMailer_TransportFactoryService())->create();
+        return $container->services['mailer.transport'] = ($container->services['mailer.transport_factory'] ?? self::getMailer_TransportFactoryService($container))->create();
     }
 
     /**
@@ -501,11 +507,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \FactoryCircular
      */
-    protected function getMailer_TransportFactoryService()
+    protected static function getMailer_TransportFactoryService($container)
     {
-        return $this->services['mailer.transport_factory'] = new \FactoryCircular(new RewindableGenerator(function () {
-            yield 0 => ($this->services['mailer.transport_factory.amazon'] ?? $this->getMailer_TransportFactory_AmazonService());
-            yield 1 => ($this->services['mailer_inline.transport_factory.amazon'] ?? $this->getMailerInline_TransportFactory_AmazonService());
+        $containerRef = $container->ref;
+
+        return $container->services['mailer.transport_factory'] = new \FactoryCircular(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 0 => ($container->services['mailer.transport_factory.amazon'] ?? self::getMailer_TransportFactory_AmazonService($container));
+            yield 1 => ($container->services['mailer_inline.transport_factory.amazon'] ?? self::getMailerInline_TransportFactory_AmazonService($container));
         }, 2));
     }
 
@@ -514,9 +524,9 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getMailer_TransportFactory_AmazonService()
+    protected static function getMailer_TransportFactory_AmazonService($container)
     {
-        return $this->services['mailer.transport_factory.amazon'] = new \stdClass(($this->services['monolog.logger_2'] ?? $this->getMonolog_Logger2Service()));
+        return $container->services['mailer.transport_factory.amazon'] = new \stdClass(($container->services['monolog.logger_2'] ?? self::getMonolog_Logger2Service($container)));
     }
 
     /**
@@ -524,9 +534,9 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \FactoryCircular
      */
-    protected function getMailerInline_TransportFactoryService()
+    protected static function getMailerInline_TransportFactoryService($container)
     {
-        return $this->services['mailer_inline.transport_factory'] = new \FactoryCircular(new RewindableGenerator(function () {
+        return $container->services['mailer_inline.transport_factory'] = new \FactoryCircular(new RewindableGenerator(static function () {
             return new \EmptyIterator();
         }, 0));
     }
@@ -536,9 +546,9 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getMailerInline_TransportFactory_AmazonService()
+    protected static function getMailerInline_TransportFactory_AmazonService($container)
     {
-        return $this->services['mailer_inline.transport_factory.amazon'] = new \stdClass(($this->services['monolog_inline.logger_2'] ?? $this->getMonologInline_Logger2Service()));
+        return $container->services['mailer_inline.transport_factory.amazon'] = new \stdClass(($container->services['monolog_inline.logger_2'] ?? self::getMonologInline_Logger2Service($container)));
     }
 
     /**
@@ -546,15 +556,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getManagerService()
+    protected static function getManagerService($container)
     {
-        $a = ($this->services['connection'] ?? $this->getConnectionService());
+        $a = ($container->services['connection'] ?? self::getConnectionService($container));
 
-        if (isset($this->services['manager'])) {
-            return $this->services['manager'];
+        if (isset($container->services['manager'])) {
+            return $container->services['manager'];
         }
 
-        return $this->services['manager'] = new \stdClass($a);
+        return $container->services['manager'] = new \stdClass($a);
     }
 
     /**
@@ -562,15 +572,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getManager2Service()
+    protected static function getManager2Service($container)
     {
-        $a = ($this->services['connection2'] ?? $this->getConnection2Service());
+        $a = ($container->services['connection2'] ?? self::getConnection2Service($container));
 
-        if (isset($this->services['manager2'])) {
-            return $this->services['manager2'];
+        if (isset($container->services['manager2'])) {
+            return $container->services['manager2'];
         }
 
-        return $this->services['manager2'] = new \stdClass($a);
+        return $container->services['manager2'] = new \stdClass($a);
     }
 
     /**
@@ -578,15 +588,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getManager3Service($lazyLoad = true)
+    protected static function getManager3Service($container, $lazyLoad = true)
     {
-        $a = ($this->services['connection3'] ?? $this->getConnection3Service());
+        $a = ($container->services['connection3'] ?? self::getConnection3Service($container));
 
-        if (isset($this->services['manager3'])) {
-            return $this->services['manager3'];
+        if (isset($container->services['manager3'])) {
+            return $container->services['manager3'];
         }
 
-        return $this->services['manager3'] = new \stdClass($a);
+        return $container->services['manager3'] = new \stdClass($a);
     }
 
     /**
@@ -594,11 +604,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getMonolog_LoggerService()
+    protected static function getMonolog_LoggerService($container)
     {
-        $this->services['monolog.logger'] = $instance = new \stdClass();
+        $container->services['monolog.logger'] = $instance = new \stdClass();
 
-        $instance->handler = ($this->services['mailer.transport'] ?? $this->getMailer_TransportService());
+        $instance->handler = ($container->services['mailer.transport'] ?? self::getMailer_TransportService($container));
 
         return $instance;
     }
@@ -608,11 +618,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getMonolog_Logger2Service()
+    protected static function getMonolog_Logger2Service($container)
     {
-        $this->services['monolog.logger_2'] = $instance = new \stdClass();
+        $container->services['monolog.logger_2'] = $instance = new \stdClass();
 
-        $instance->handler = ($this->services['mailer.transport'] ?? $this->getMailer_TransportService());
+        $instance->handler = ($container->services['mailer.transport'] ?? self::getMailer_TransportService($container));
 
         return $instance;
     }
@@ -622,11 +632,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getMonologInline_LoggerService()
+    protected static function getMonologInline_LoggerService($container)
     {
-        $this->services['monolog_inline.logger'] = $instance = new \stdClass();
+        $container->services['monolog_inline.logger'] = $instance = new \stdClass();
 
-        $instance->handler = ($this->privates['mailer_inline.mailer'] ?? $this->getMailerInline_MailerService());
+        $instance->handler = ($container->privates['mailer_inline.mailer'] ?? self::getMailerInline_MailerService($container));
 
         return $instance;
     }
@@ -636,11 +646,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getMonologInline_Logger2Service()
+    protected static function getMonologInline_Logger2Service($container)
     {
-        $this->services['monolog_inline.logger_2'] = $instance = new \stdClass();
+        $container->services['monolog_inline.logger_2'] = $instance = new \stdClass();
 
-        $instance->handler = ($this->privates['mailer_inline.mailer'] ?? $this->getMailerInline_MailerService());
+        $instance->handler = ($container->privates['mailer_inline.mailer'] ?? self::getMailerInline_MailerService($container));
 
         return $instance;
     }
@@ -650,20 +660,20 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getPAService()
+    protected static function getPAService($container)
     {
-        $a = ($this->services['pB'] ?? $this->getPBService());
+        $a = ($container->services['pB'] ?? self::getPBService($container));
 
-        if (isset($this->services['pA'])) {
-            return $this->services['pA'];
+        if (isset($container->services['pA'])) {
+            return $container->services['pA'];
         }
-        $b = ($this->services['pC'] ?? $this->getPCService());
+        $b = ($container->services['pC'] ?? self::getPCService($container));
 
-        if (isset($this->services['pA'])) {
-            return $this->services['pA'];
+        if (isset($container->services['pA'])) {
+            return $container->services['pA'];
         }
 
-        return $this->services['pA'] = new \stdClass($a, $b);
+        return $container->services['pA'] = new \stdClass($a, $b);
     }
 
     /**
@@ -671,11 +681,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getPBService()
+    protected static function getPBService($container)
     {
-        $this->services['pB'] = $instance = new \stdClass();
+        $container->services['pB'] = $instance = new \stdClass();
 
-        $instance->d = ($this->services['pD'] ?? $this->getPDService());
+        $instance->d = ($container->services['pD'] ?? self::getPDService($container));
 
         return $instance;
     }
@@ -685,11 +695,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getPCService($lazyLoad = true)
+    protected static function getPCService($container, $lazyLoad = true)
     {
-        $this->services['pC'] = $instance = new \stdClass();
+        $container->services['pC'] = $instance = new \stdClass();
 
-        $instance->d = ($this->services['pD'] ?? $this->getPDService());
+        $instance->d = ($container->services['pD'] ?? self::getPDService($container));
 
         return $instance;
     }
@@ -699,15 +709,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getPDService()
+    protected static function getPDService($container)
     {
-        $a = ($this->services['pA'] ?? $this->getPAService());
+        $a = ($container->services['pA'] ?? self::getPAService($container));
 
-        if (isset($this->services['pD'])) {
-            return $this->services['pD'];
+        if (isset($container->services['pD'])) {
+            return $container->services['pD'];
         }
 
-        return $this->services['pD'] = new \stdClass($a);
+        return $container->services['pD'] = new \stdClass($a);
     }
 
     /**
@@ -715,15 +725,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getRootService()
+    protected static function getRootService($container)
     {
         $a = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
 
         $b = new \stdClass();
 
-        $a->call(new \stdClass(new \stdClass($b, ($this->privates['level5'] ?? $this->getLevel5Service()))));
+        $a->call(new \stdClass(new \stdClass($b, ($container->privates['level5'] ?? self::getLevel5Service($container)))));
 
-        return $this->services['root'] = new \stdClass($a, $b);
+        return $container->services['root'] = new \stdClass($a, $b);
     }
 
     /**
@@ -731,15 +741,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getSubscriberService()
+    protected static function getSubscriberService($container)
     {
-        $a = ($this->services['manager'] ?? $this->getManagerService());
+        $a = ($container->services['manager'] ?? self::getManagerService($container));
 
-        if (isset($this->services['subscriber'])) {
-            return $this->services['subscriber'];
+        if (isset($container->services['subscriber'])) {
+            return $container->services['subscriber'];
         }
 
-        return $this->services['subscriber'] = new \stdClass($a);
+        return $container->services['subscriber'] = new \stdClass($a);
     }
 
     /**
@@ -747,15 +757,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getBar6Service()
+    protected static function getBar6Service($container)
     {
-        $a = ($this->services['foo6'] ?? $this->getFoo6Service());
+        $a = ($container->services['foo6'] ?? self::getFoo6Service($container));
 
-        if (isset($this->privates['bar6'])) {
-            return $this->privates['bar6'];
+        if (isset($container->privates['bar6'])) {
+            return $container->privates['bar6'];
         }
 
-        return $this->privates['bar6'] = new \stdClass($a);
+        return $container->privates['bar6'] = new \stdClass($a);
     }
 
     /**
@@ -763,11 +773,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getLevel5Service()
+    protected static function getLevel5Service($container)
     {
         $a = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
 
-        $this->privates['level5'] = $instance = new \stdClass($a);
+        $container->privates['level5'] = $instance = new \stdClass($a);
 
         $a->call($instance);
 
@@ -779,9 +789,9 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getMailerInline_MailerService()
+    protected static function getMailerInline_MailerService($container)
     {
-        return $this->privates['mailer_inline.mailer'] = new \stdClass(($this->services['mailer_inline.transport_factory'] ?? $this->getMailerInline_TransportFactoryService())->create());
+        return $container->privates['mailer_inline.mailer'] = new \stdClass(($container->services['mailer_inline.transport_factory'] ?? self::getMailerInline_TransportFactoryService($container))->create());
     }
 
     /**
@@ -789,14 +799,14 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      *
      * @return \stdClass
      */
-    protected function getManager4Service($lazyLoad = true)
+    protected static function getManager4Service($container, $lazyLoad = true)
     {
-        $a = ($this->services['connection4'] ?? $this->getConnection4Service());
+        $a = ($container->services['connection4'] ?? self::getConnection4Service($container));
 
-        if (isset($this->privates['manager4'])) {
-            return $this->privates['manager4'];
+        if (isset($container->privates['manager4'])) {
+            return $container->privates['manager4'];
         }
 
-        return $this->privates['manager4'] = new \stdClass($a);
+        return $container->privates['manager4'] = new \stdClass($a);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -43,11 +45,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \BarClass
      */
-    protected function getBarService()
+    protected static function getBarService($container)
     {
-        $this->services['bar'] = $instance = new \BarClass();
+        $container->services['bar'] = $instance = new \BarClass();
 
-        $instance->setBaz($this->parameters['array_1'], $this->parameters['array_2'], '%array_1%', $this->parameters['array_1']);
+        $instance->setBaz($container->parameters['array_1'], $container->parameters['array_2'], '%array_1%', $container->parameters['array_1']);
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Test_Base64Parameters extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -77,8 +79,9 @@ class Symfony_DI_PhpDumper_Test_Base64Parameters extends Container
 
     private function getDynamicParameter(string $name)
     {
+        $container = $this;
         $value = match ($name) {
-            'hello' => $this->getEnv('base64:foo'),
+            'hello' => $container->getEnv('base64:foo'),
             default => throw new ParameterNotFoundException($name),
         };
         $this->loadedDynamicParameters[$name] = true;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Test_CsvParameters extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -77,8 +79,9 @@ class Symfony_DI_PhpDumper_Test_CsvParameters extends Container
 
     private function getDynamicParameter(string $name)
     {
+        $container = $this;
         $value = match ($name) {
-            'hello' => $this->getEnv('csv:foo'),
+            'hello' => $container->getEnv('csv:foo'),
             default => throw new ParameterNotFoundException($name),
         };
         $this->loadedDynamicParameters[$name] = true;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'bar' => 'getBarService',
@@ -49,10 +51,12 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBarService($lazyLoad = true)
+    protected static function getBarService($container, $lazyLoad = true)
     {
+        $containerRef = $container->ref;
+
         if (true === $lazyLoad) {
-            return $this->services['bar'] = $this->createProxy('stdClassGhost5a8a5eb', fn () => \stdClassGhost5a8a5eb::createLazyGhost($this->getBarService(...)));
+            return $container->services['bar'] = $container->createProxy('stdClassGhost5a8a5eb', static fn () => \stdClassGhost5a8a5eb::createLazyGhost(static fn ($proxy) => self::getBarService($containerRef->get(), $proxy)));
         }
 
         return $lazyLoad;
@@ -63,10 +67,12 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBazService($lazyLoad = true)
+    protected static function getBazService($container, $lazyLoad = true)
     {
+        $containerRef = $container->ref;
+
         if (true === $lazyLoad) {
-            return $this->services['baz'] = $this->createProxy('stdClassProxy5a8a5eb', fn () => \stdClassProxy5a8a5eb::createLazyProxy(fn () => $this->getBazService(false)));
+            return $container->services['baz'] = $container->createProxy('stdClassProxy5a8a5eb', static fn () => \stdClassProxy5a8a5eb::createLazyProxy(static fn () => self::getBazService($containerRef->get(), false)));
         }
 
         return \foo_bar();
@@ -77,10 +83,12 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBuzService($lazyLoad = true)
+    protected static function getBuzService($container, $lazyLoad = true)
     {
+        $containerRef = $container->ref;
+
         if (true === $lazyLoad) {
-            return $this->services['buz'] = $this->createProxy('stdClassProxy5a8a5eb', fn () => \stdClassProxy5a8a5eb::createLazyProxy(fn () => $this->getBuzService(false)));
+            return $container->services['buz'] = $container->createProxy('stdClassProxy5a8a5eb', static fn () => \stdClassProxy5a8a5eb::createLazyProxy(static fn () => self::getBuzService($containerRef->get(), false)));
         }
 
         return \foo_bar();
@@ -91,10 +99,12 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getFooService($lazyLoad = true)
+    protected static function getFooService($container, $lazyLoad = true)
     {
+        $containerRef = $container->ref;
+
         if (true === $lazyLoad) {
-            return $this->services['foo'] = $this->createProxy('stdClassGhost5a8a5eb', fn () => \stdClassGhost5a8a5eb::createLazyGhost($this->getFooService(...)));
+            return $container->services['foo'] = $container->createProxy('stdClassGhost5a8a5eb', static fn () => \stdClassGhost5a8a5eb::createLazyGhost(static fn ($proxy) => self::getFooService($containerRef->get(), $proxy)));
         }
 
         return $lazyLoad;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Test_DefaultParameters extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -79,10 +81,11 @@ class Symfony_DI_PhpDumper_Test_DefaultParameters extends Container
 
     private function getDynamicParameter(string $name)
     {
+        $container = $this;
         $value = match ($name) {
-            'fallback_env' => $this->getEnv('foobar'),
-            'hello' => $this->getEnv('default:fallback_param:bar'),
-            'hello-bar' => $this->getEnv('default:fallback_env:key:baz:json:foo'),
+            'fallback_env' => $container->getEnv('foobar'),
+            'hello' => $container->getEnv('default:fallback_param:bar'),
+            'hello-bar' => $container->getEnv('default:fallback_env:key:baz:json:foo'),
             default => throw new ParameterNotFoundException($name),
         };
         $this->loadedDynamicParameters[$name] = true;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -52,9 +54,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBarService()
+    protected static function getBarService($container)
     {
-        return $this->services['bar'] = new \stdClass(($this->privates['bar_%env(BAR)%'] ??= new \stdClass()));
+        return $container->services['bar'] = new \stdClass(($container->privates['bar_%env(BAR)%'] ??= new \stdClass()));
     }
 
     /**
@@ -62,9 +64,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
-        return $this->services['foo'] = new \stdClass(($this->privates['bar_%env(BAR)%'] ??= new \stdClass()), ['baz_'.$this->getEnv('string:BAR') => new \stdClass()]);
+        return $container->services['foo'] = new \stdClass(($container->privates['bar_%env(BAR)%'] ??= new \stdClass()), ['baz_'.$container->getEnv('string:BAR') => new \stdClass()]);
     }
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Errored_Definition extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -90,11 +92,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \stdClass
      */
-    protected function getBARService()
+    protected static function getBARService($container)
     {
-        $this->services['BAR'] = $instance = new \stdClass();
+        $container->services['BAR'] = $instance = new \stdClass();
 
-        $instance->bar = ($this->services['bar'] ?? $this->getBar3Service());
+        $instance->bar = ($container->services['bar'] ?? self::getBar3Service($container));
 
         return $instance;
     }
@@ -104,9 +106,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \stdClass
      */
-    protected function getBAR2Service()
+    protected static function getBAR2Service($container)
     {
-        return $this->services['BAR2'] = new \stdClass();
+        return $container->services['BAR2'] = new \stdClass();
     }
 
     /**
@@ -114,9 +116,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar
      */
-    protected function getAServiceService()
+    protected static function getAServiceService($container)
     {
-        return $this->services['a_service'] = ($this->privates['a_factory'] ??= new \Bar())->getBar();
+        return $container->services['a_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
@@ -124,9 +126,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar
      */
-    protected function getBServiceService()
+    protected static function getBServiceService($container)
     {
-        return $this->services['b_service'] = ($this->privates['a_factory'] ??= new \Bar())->getBar();
+        return $container->services['b_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
@@ -134,11 +136,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getBar3Service()
+    protected static function getBar3Service($container)
     {
-        $a = ($this->services['foo.baz'] ?? $this->getFoo_BazService());
+        $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, 'foo_bar');
+        $container->services['bar'] = $instance = new \Bar\FooClass('foo', $a, 'foo_bar');
 
         $a->configure($instance);
 
@@ -150,9 +152,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \stdClass
      */
-    protected function getBar22Service()
+    protected static function getBar22Service($container)
     {
-        return $this->services['bar2'] = new \stdClass();
+        return $container->services['bar2'] = new \stdClass();
     }
 
     /**
@@ -160,11 +162,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Baz
      */
-    protected function getBazService()
+    protected static function getBazService($container)
     {
-        $this->services['baz'] = $instance = new \Baz();
+        $container->services['baz'] = $instance = new \Baz();
 
-        $instance->setFoo(($this->services['foo_with_inline'] ?? $this->getFooWithInlineService()));
+        $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
 
         return $instance;
     }
@@ -174,12 +176,12 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \stdClass
      */
-    protected function getConfiguredServiceService()
+    protected static function getConfiguredServiceService($container)
     {
-        $this->services['configured_service'] = $instance = new \stdClass();
+        $container->services['configured_service'] = $instance = new \stdClass();
 
         $a = new \ConfClass();
-        $a->setFoo(($this->services['baz'] ?? $this->getBazService()));
+        $a->setFoo(($container->services['baz'] ?? self::getBazService($container)));
 
         $a->configureStdClass($instance);
 
@@ -191,9 +193,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \stdClass
      */
-    protected function getConfiguredServiceSimpleService()
+    protected static function getConfiguredServiceSimpleService($container)
     {
-        $this->services['configured_service_simple'] = $instance = new \stdClass();
+        $container->services['configured_service_simple'] = $instance = new \stdClass();
 
         (new \ConfClass('bar'))->configureStdClass($instance);
 
@@ -205,9 +207,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \stdClass
      */
-    protected function getDecoratorServiceService()
+    protected static function getDecoratorServiceService($container)
     {
-        return $this->services['decorator_service'] = new \stdClass();
+        return $container->services['decorator_service'] = new \stdClass();
     }
 
     /**
@@ -215,9 +217,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \stdClass
      */
-    protected function getDecoratorServiceWithNameService()
+    protected static function getDecoratorServiceWithNameService($container)
     {
-        return $this->services['decorator_service_with_name'] = new \stdClass();
+        return $container->services['decorator_service_with_name'] = new \stdClass();
     }
 
     /**
@@ -227,11 +229,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @deprecated Since vendor/package 1.1: The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected function getDeprecatedServiceService()
+    protected static function getDeprecatedServiceService($container)
     {
         trigger_deprecation('vendor/package', '1.1', 'The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.');
 
-        return $this->services['deprecated_service'] = new \stdClass();
+        return $container->services['deprecated_service'] = new \stdClass();
     }
 
     /**
@@ -239,9 +241,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar
      */
-    protected function getFactoryServiceService()
+    protected static function getFactoryServiceService($container)
     {
-        return $this->services['factory_service'] = ($this->services['foo.baz'] ?? $this->getFoo_BazService())->getInstance();
+        return $container->services['factory_service'] = ($container->services['foo.baz'] ?? self::getFoo_BazService($container))->getInstance();
     }
 
     /**
@@ -249,9 +251,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar
      */
-    protected function getFactoryServiceSimpleService()
+    protected static function getFactoryServiceSimpleService($container)
     {
-        return $this->services['factory_service_simple'] = $this->getFactorySimpleService()->getInstance();
+        return $container->services['factory_service_simple'] = self::getFactorySimpleService($container)->getInstance();
     }
 
     /**
@@ -259,16 +261,16 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
-        $a = ($this->services['foo.baz'] ?? $this->getFoo_BazService());
+        $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $this);
+        $container->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
 
         $instance->foo = 'bar';
         $instance->moo = $a;
         $instance->qux = ['bar' => 'foo is bar', 'foobar' => 'bar'];
-        $instance->setBar(($this->services['bar'] ?? $this->getBar3Service()));
+        $instance->setBar(($container->services['bar'] ?? self::getBar3Service($container)));
         $instance->initialize();
         sc_configure($instance);
 
@@ -280,9 +282,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \BazClass
      */
-    protected function getFoo_BazService()
+    protected static function getFoo_BazService($container)
     {
-        $this->services['foo.baz'] = $instance = \BazClass::getInstance();
+        $container->services['foo.baz'] = $instance = \BazClass::getInstance();
 
         \BazClass::configureStatic1($instance);
 
@@ -294,13 +296,13 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getFooBarService()
+    protected static function getFooBarService($container)
     {
-        $this->factories['foo_bar'] = function () {
-            return new \Bar\FooClass(($this->services['deprecated_service'] ?? $this->getDeprecatedServiceService()));
+        $container->factories['foo_bar'] = static function ($container) {
+            return new \Bar\FooClass(($container->services['deprecated_service'] ?? self::getDeprecatedServiceService($container)));
         };
 
-        return $this->factories['foo_bar']();
+        return $container->factories['foo_bar']($container);
     }
 
     /**
@@ -308,13 +310,13 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Foo
      */
-    protected function getFooWithInlineService()
+    protected static function getFooWithInlineService($container)
     {
-        $this->services['foo_with_inline'] = $instance = new \Foo();
+        $container->services['foo_with_inline'] = $instance = new \Foo();
 
         $a = new \Bar();
         $a->pub = 'pub';
-        $a->setBaz(($this->services['baz'] ?? $this->getBazService()));
+        $a->setBaz(($container->services['baz'] ?? self::getBazService($container)));
 
         $instance->setBar($a);
 
@@ -326,12 +328,16 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \LazyContext
      */
-    protected function getLazyContextService()
+    protected static function getLazyContextService($container)
     {
-        return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function () {
-            yield 'k1' => ($this->services['foo.baz'] ?? $this->getFoo_BazService());
-            yield 'k2' => $this;
-        }, 2), new RewindableGenerator(function () {
+        $containerRef = $container->ref;
+
+        return $container->services['lazy_context'] = new \LazyContext(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 'k1' => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
+            yield 'k2' => $container;
+        }, 2), new RewindableGenerator(static function () {
             return new \EmptyIterator();
         }, 0));
     }
@@ -341,11 +347,15 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \LazyContext
      */
-    protected function getLazyContextIgnoreInvalidRefService()
+    protected static function getLazyContextIgnoreInvalidRefService($container)
     {
-        return $this->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(function () {
-            yield 0 => ($this->services['foo.baz'] ?? $this->getFoo_BazService());
-        }, 1), new RewindableGenerator(function () {
+        $containerRef = $container->ref;
+
+        return $container->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 0 => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
+        }, 1), new RewindableGenerator(static function () {
             return new \EmptyIterator();
         }, 0));
     }
@@ -355,15 +365,15 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getMethodCall1Service()
+    protected static function getMethodCall1Service($container)
     {
         include_once '%path%foo.php';
 
-        $this->services['method_call1'] = $instance = new \Bar\FooClass();
+        $container->services['method_call1'] = $instance = new \Bar\FooClass();
 
-        $instance->setBar(($this->services['foo'] ?? $this->getFooService()));
+        $instance->setBar(($container->services['foo'] ?? self::getFooService($container)));
         $instance->setBar(NULL);
-        $instance->setBar((($this->services['foo'] ?? $this->getFooService())->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar((($container->services['foo'] ?? self::getFooService($container))->foo() . (($container->hasParameter("foo")) ? ($container->getParameter("foo")) : ("default"))));
 
         return $instance;
     }
@@ -373,12 +383,12 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \FooBarBaz
      */
-    protected function getNewFactoryServiceService()
+    protected static function getNewFactoryServiceService($container)
     {
         $a = new \FactoryClass();
         $a->foo = 'bar';
 
-        $this->services['new_factory_service'] = $instance = $a->getInstance();
+        $container->services['new_factory_service'] = $instance = $a->getInstance();
 
         $instance->foo = 'bar';
 
@@ -390,9 +400,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \stdClass
      */
-    protected function getPreloadSidekickService()
+    protected static function getPreloadSidekickService($container)
     {
-        return $this->services['preload_sidekick'] = new \stdClass();
+        return $container->services['preload_sidekick'] = new \stdClass();
     }
 
     /**
@@ -400,9 +410,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \stdClass
      */
-    protected function getRuntimeErrorService()
+    protected static function getRuntimeErrorService($container)
     {
-        return $this->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
+        return $container->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
     }
 
     /**
@@ -410,9 +420,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar\FooClass
      */
-    protected function getServiceFromStaticMethodService()
+    protected static function getServiceFromStaticMethodService($container)
     {
-        return $this->services['service_from_static_method'] = \Bar\FooClass::getInstance();
+        return $container->services['service_from_static_method'] = \Bar\FooClass::getInstance();
     }
 
     /**
@@ -420,11 +430,15 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @return \Bar
      */
-    protected function getTaggedIteratorService()
+    protected static function getTaggedIteratorService($container)
     {
-        return $this->services['tagged_iterator'] = new \Bar(new RewindableGenerator(function () {
-            yield 0 => ($this->services['foo'] ?? $this->getFooService());
-            yield 1 => ($this->privates['tagged_iterator_foo'] ??= new \Bar());
+        $containerRef = $container->ref;
+
+        return $container->services['tagged_iterator'] = new \Bar(new RewindableGenerator(static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            yield 0 => ($container->services['foo'] ?? self::getFooService($container));
+            yield 1 => ($container->privates['tagged_iterator_foo'] ??= new \Bar());
         }, 2));
     }
 
@@ -435,7 +449,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      *
      * @deprecated Since vendor/package 1.1: The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected function getFactorySimpleService()
+    protected static function getFactorySimpleService($container)
     {
         trigger_deprecation('vendor/package', '1.1', 'The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_requires.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_requires.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\ParentNotExists' => 'getParentNotExistsService',
@@ -27,7 +29,7 @@ class ProjectServiceContainer extends Container
 
         $this->aliases = [];
 
-        $this->privates['service_container'] = function () {
+        $this->privates['service_container'] = static function ($container) {
             include_once \dirname(__DIR__, 1).'/includes/HotPath/I1.php';
             include_once \dirname(__DIR__, 1).'/includes/HotPath/P1.php';
             include_once \dirname(__DIR__, 1).'/includes/HotPath/T1.php';
@@ -57,9 +59,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists
      */
-    protected function getParentNotExistsService()
+    protected static function getParentNotExistsService($container)
     {
-        return $this->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\ParentNotExists'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists();
+        return $container->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\ParentNotExists'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists();
     }
 
     /**
@@ -67,9 +69,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C1
      */
-    protected function getC1Service()
+    protected static function getC1Service($container)
     {
-        return $this->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C1'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C1();
+        return $container->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C1'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C1();
     }
 
     /**
@@ -77,11 +79,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2
      */
-    protected function getC2Service()
+    protected static function getC2Service($container)
     {
         include_once \dirname(__DIR__, 1).'/includes/HotPath/C2.php';
         include_once \dirname(__DIR__, 1).'/includes/HotPath/C3.php';
 
-        return $this->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C2'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2(new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3());
+        return $container->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C2'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2(new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_self_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_self_ref.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Test_Inline_Self_Ref extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'App\\Foo' => 'getFooService',
@@ -41,14 +43,14 @@ class Symfony_DI_PhpDumper_Test_Inline_Self_Ref extends Container
      *
      * @return \App\Foo
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
         $a = new \App\Bar();
 
         $b = new \App\Baz($a);
         $b->bar = $a;
 
-        $this->services['App\\Foo'] = $instance = new \App\Foo($b);
+        $container->services['App\\Foo'] = $instance = new \App\Foo($b);
 
         $a->foo = $instance;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Test_JsonParameters extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -78,9 +80,10 @@ class Symfony_DI_PhpDumper_Test_JsonParameters extends Container
 
     private function getDynamicParameter(string $name)
     {
+        $container = $this;
         $value = match ($name) {
-            'hello' => $this->getEnv('json:foo'),
-            'hello-bar' => $this->getEnv('json:bar'),
+            'hello' => $container->getEnv('json:foo'),
+            'hello-bar' => $container->getEnv('json:bar'),
             default => throw new ParameterNotFoundException($name),
         };
         $this->loadedDynamicParameters[$name] = true;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_new_in_initializer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_new_in_initializer.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'foo' => 'getFooService',
@@ -41,8 +43,8 @@ class ProjectServiceContainer extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer
      */
-    protected function getFooService()
+    protected static function getFooService($container)
     {
-        return $this->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer(bar: 234);
+        return $container->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer(bar: 234);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'bar' => 'getBarService',
@@ -53,9 +55,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBarService()
+    protected static function getBarService($container)
     {
-        return $this->services['bar'] = new \stdClass((isset($this->factories['service_container']['foo']) ? $this->factories['service_container']['foo']() : $this->getFooService()));
+        return $container->services['bar'] = new \stdClass((isset($container->factories['service_container']['foo']) ? $container->factories['service_container']['foo']($container) : self::getFooService($container)));
     }
 
     /**
@@ -63,9 +65,11 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getFooService($lazyLoad = true)
+    protected static function getFooService($container, $lazyLoad = true)
     {
-        $this->factories['service_container']['foo'] ??= $this->getFooService(...);
+        $containerRef = $container->ref;
+
+        $container->factories['service_container']['foo'] ??= self::getFooService(...);
 
         // lazy factory for stdClass
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
@@ -19,10 +19,12 @@ class getNonSharedFooService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $container->factories['non_shared_foo'] ??= fn () => self::do($container);
+        $containerRef = $container->ref;
+
+        $container->factories['non_shared_foo'] ??= self::do(...);
 
         if (true === $lazyLoad) {
-            return $container->createProxy('FooLazyClassGhostF814e3a', fn () => \FooLazyClassGhostF814e3a::createLazyGhost(fn ($proxy) => self::do($container, $proxy)));
+            return $container->createProxy('FooLazyClassGhostF814e3a', static fn () => \FooLazyClassGhostF814e3a::createLazyGhost(static fn ($proxy) => self::do($containerRef->get(), $proxy)));
         }
 
         static $include = true;
@@ -79,9 +81,11 @@ class ProjectServiceContainer extends Container
     protected $targetDir;
     protected $parameters = [];
     private $buildParameters;
+    protected readonly \WeakReference $ref;
 
     public function __construct(array $buildParameters = [], $containerDir = __DIR__)
     {
+        $this->ref = \WeakReference::create($this);
         $this->buildParameters = $buildParameters;
         $this->containerDir = $containerDir;
         $this->targetDir = \dirname($containerDir);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'bar_service' => 'getBarServiceService',
@@ -49,9 +51,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getBarServiceService()
+    protected static function getBarServiceService($container)
     {
-        return $this->services['bar_service'] = new \stdClass(($this->privates['baz_service'] ??= new \stdClass()));
+        return $container->services['bar_service'] = new \stdClass(($container->privates['baz_service'] ??= new \stdClass()));
     }
 
     /**
@@ -59,8 +61,8 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getFooServiceService()
+    protected static function getFooServiceService($container)
     {
-        return $this->services['foo_service'] = new \stdClass(($this->privates['baz_service'] ??= new \stdClass()));
+        return $container->services['foo_service'] = new \stdClass(($container->privates['baz_service'] ??= new \stdClass()));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_in_expression.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_in_expression.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'public_foo' => 'getPublicFooService',
@@ -49,8 +51,8 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass
      */
-    protected function getPublicFooService()
+    protected static function getPublicFooService($container)
     {
-        return $this->services['public_foo'] = new \stdClass((new \stdClass())->bar);
+        return $container->services['public_foo'] = new \stdClass((new \stdClass())->bar);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Test_QueryStringParameters extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -77,8 +79,9 @@ class Symfony_DI_PhpDumper_Test_QueryStringParameters extends Container
 
     private function getDynamicParameter(string $name)
     {
+        $container = $this;
         $value = match ($name) {
-            'hello' => $this->getEnv('query_string:foo'),
+            'hello' => $container->getEnv('query_string:foo'),
             default => throw new ParameterNotFoundException($name),
         };
         $this->loadedDynamicParameters[$name] = true;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -15,11 +15,13 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
     protected \Closure $getService;
 
     public function __construct()
     {
-        $this->getService = $this->getService(...);
+        $containerRef = $this->ref = \WeakReference::create($this);
+        $this->getService = static function () use ($containerRef) { return $containerRef->get()->getService(...\func_get_args()); };
         $this->services = $this->privates = [];
         $this->methodMap = [
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber' => 'getTestServiceSubscriberService',
@@ -57,9 +59,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber
      */
-    protected function getTestServiceSubscriberService()
+    protected static function getTestServiceSubscriberService($container)
     {
-        return $this->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber();
+        return $container->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber();
     }
 
     /**
@@ -67,9 +69,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber
      */
-    protected function getFooServiceService()
+    protected static function getFooServiceService($container)
     {
-        return $this->services['foo_service'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber((new \Symfony\Component\DependencyInjection\Argument\ServiceLocator($this->getService, [
+        return $container->services['foo_service'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber((new \Symfony\Component\DependencyInjection\Argument\ServiceLocator($container->getService, [
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => ['privates', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition', 'getCustomDefinitionService', false],
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber' => ['services', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber', 'getTestServiceSubscriberService', false],
             'bar' => ['services', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber', 'getTestServiceSubscriberService', false],
@@ -81,7 +83,7 @@ class ProjectServiceContainer extends Container
             'bar' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition',
             'baz' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition',
             'late_alias' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestDefinition1',
-        ]))->withContext('foo_service', $this));
+        ]))->withContext('foo_service', $container));
     }
 
     /**
@@ -89,9 +91,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1
      */
-    protected function getLateAliasService()
+    protected static function getLateAliasService($container)
     {
-        return $this->services['late_alias'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1();
+        return $container->services['late_alias'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1();
     }
 
     /**
@@ -99,8 +101,8 @@ class ProjectServiceContainer extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition
      */
-    protected function getCustomDefinitionService()
+    protected static function getCustomDefinitionService($container)
     {
-        return $this->privates['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition();
+        return $container->privates['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tsantos.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tsantos.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class ProjectServiceContainer extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'tsantos_serializer' => 'getTsantosSerializerService',
@@ -48,7 +50,7 @@ class ProjectServiceContainer extends Container
      *
      * @return \TSantos\Serializer\EventEmitterSerializer
      */
-    protected function getTsantosSerializerService()
+    protected static function getTsantosSerializerService($container)
     {
         $a = new \TSantos\Serializer\NormalizerRegistry();
 
@@ -57,7 +59,7 @@ class ProjectServiceContainer extends Container
         $c = new \TSantos\Serializer\EventDispatcher\EventDispatcher();
         $c->addSubscriber(new \TSantos\SerializerBundle\EventListener\StopwatchListener(new \Symfony\Component\Stopwatch\Stopwatch(true)));
 
-        $this->services['tsantos_serializer'] = $instance = new \TSantos\Serializer\EventEmitterSerializer(new \TSantos\Serializer\Encoder\JsonEncoder(), $a, $c);
+        $container->services['tsantos_serializer'] = $instance = new \TSantos\Serializer\EventEmitterSerializer(new \TSantos\Serializer\Encoder\JsonEncoder(), $a, $c);
 
         $b->setSerializer($instance);
         $d = new \TSantos\Serializer\Normalizer\JsonNormalizer();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -45,9 +47,9 @@ class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
      *
      * @return \FooClass
      */
-    protected function getBarService()
+    protected static function getBarService($container)
     {
-        return $this->services['bar$'] = new \FooClass();
+        return $container->services['bar$'] = new \FooClass();
     }
 
     /**
@@ -55,9 +57,9 @@ class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
      *
      * @return \FooClass
      */
-    protected function getBar2Service()
+    protected static function getBar2Service($container)
     {
-        return $this->services['bar$!'] = new \FooClass();
+        return $container->services['bar$!'] = new \FooClass();
     }
 
     /**
@@ -65,9 +67,9 @@ class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
      *
      * @return \FooClass
      */
-    protected function getFooohnoService()
+    protected static function getFooohnoService($container)
     {
-        return $this->services['foo*/oh-no'] = new \FooClass();
+        return $container->services['foo*/oh-no'] = new \FooClass();
     }
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Test_UrlParameters extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = $this->privates = [];
@@ -77,8 +79,9 @@ class Symfony_DI_PhpDumper_Test_UrlParameters extends Container
 
     private function getDynamicParameter(string $name)
     {
+        $container = $this;
         $value = match ($name) {
-            'hello' => $this->getEnv('url:foo'),
+            'hello' => $container->getEnv('url:foo'),
             default => throw new ParameterNotFoundException($name),
         };
         $this->loadedDynamicParameters[$name] = true;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Service_Wither extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'wither' => 'getWitherService',
@@ -48,14 +50,14 @@ class Symfony_DI_PhpDumper_Service_Wither extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Compiler\Wither
      */
-    protected function getWitherService()
+    protected static function getWitherService($container)
     {
         $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\Wither();
 
         $a = new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo();
 
         $instance = $instance->withFoo1($a);
-        $this->services['wither'] = $instance = $instance->withFoo2($a);
+        $container->services['wither'] = $instance = $instance->withFoo2($a);
         $instance->setFoo($a);
 
         return $instance;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Service_Wither_Lazy extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'wither' => 'getWitherService',
@@ -53,10 +55,12 @@ class Symfony_DI_PhpDumper_Service_Wither_Lazy extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Compiler\Wither
      */
-    protected function getWitherService($lazyLoad = true)
+    protected static function getWitherService($container, $lazyLoad = true)
     {
+        $containerRef = $container->ref;
+
         if (true === $lazyLoad) {
-            return $this->services['wither'] = $this->createProxy('WitherProxy94fa281', fn () => \WitherProxy94fa281::createLazyProxy(fn () => $this->getWitherService(false)));
+            return $container->services['wither'] = $container->createProxy('WitherProxy94fa281', static fn () => \WitherProxy94fa281::createLazyProxy(static fn () => self::getWitherService($containerRef->get(), false)));
         }
 
         $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\Wither();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_staticreturntype.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_staticreturntype.php
@@ -15,9 +15,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class Symfony_DI_PhpDumper_Service_WitherStaticReturnType extends Container
 {
     protected $parameters = [];
+    protected readonly \WeakReference $ref;
 
     public function __construct()
     {
+        $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
             'wither' => 'getWitherService',
@@ -48,13 +50,13 @@ class Symfony_DI_PhpDumper_Service_WitherStaticReturnType extends Container
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\WitherStaticReturnType
      */
-    protected function getWitherService()
+    protected static function getWitherService($container)
     {
         $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\WitherStaticReturnType();
 
         $a = new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo();
 
-        $this->services['wither'] = $instance = $instance->withFoo($a);
+        $container->services['wither'] = $instance = $instance->withFoo($a);
         $instance->setFoo($a);
 
         return $instance;

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -37,7 +37,7 @@
         "ext-psr": "<1.1|>=2",
         "symfony/config": "<6.1",
         "symfony/finder": "<5.4",
-        "symfony/proxy-manager-bridge": "<6.2",
+        "symfony/proxy-manager-bridge": "<6.3",
         "symfony/yaml": "<5.4"
     },
     "provide": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While working on #48461, I realized that we could break many circular loops involving the container by using a `WeakReference` to access it. This happens when we generate closures.

Conceptually, we generate this at the moment:
```php
$internalClosure = function () { return $this->get('foo'); };
```

And we'd generate this with this PR:
```php
$containerRef = \WeakReference::create($this);
$internalClosure = static function () use ($containerRef) { return $containerRef->get()->get('foo'); };
```

This should reduce the pressure on the garbage collector.