### PR TITLE
prevent the installation of unstable phpdocumentor/type-resolver releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -158,7 +158,7 @@
         "egulias/email-validator": "~3.0.0",
         "masterminds/html5": "<2.6",
         "phpdocumentor/reflection-docblock": "<3.2.2",
-        "phpdocumentor/type-resolver": "<1.4.0",
+        "phpdocumentor/type-resolver": "<1.4.0|>=1.7.0",
         "ocramius/proxy-manager": "<2.1",
         "phpunit/phpunit": "<5.4.3"
     },

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -44,7 +44,7 @@
     "conflict": {
         "doctrine/annotations": "<1.12",
         "phpdocumentor/reflection-docblock": "<3.2.2",
-        "phpdocumentor/type-resolver": "<1.4.0",
+        "phpdocumentor/type-resolver": "<1.4.0|>=1.7.0",
         "symfony/dependency-injection": "<4.4",
         "symfony/property-access": "<5.4",
         "symfony/property-info": "<5.3.13",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I suggest to not make use of the development version of the upcoming minor release of phpdocumentor/type-resolver as it is quite unstable at the moment and causes our pipeline to fail constantly.
