### PR TITLE
[WebProfilerBundle] Fix the dump view panel

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
+++ b/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
@@ -68,7 +68,7 @@
             {{ dump.data|raw }}
         </div>
     {% else %}
-        <div class="empty">
+        <div class="empty empty-panel">
             <p>No content was dumped.</p>
         </div>
     {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | view fix
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix my OCD ^^,
| License       | MIT
| Doc PR        | .

Hi, checking the new profiler, I've came accros this and it bothered me
So this PR fix the view of the dump panel to be similar to others

<img width="1235" alt="dump" src="https://user-images.githubusercontent.com/1358361/205566564-7779f026-212c-4b80-a29b-3bfe4c6ca1c4.png">
<img width="1235" alt="mail" src="https://user-images.githubusercontent.com/1358361/205566573-074ee8f6-4f6b-4dfd-b2c9-5d66dcee47e0.png">
<img width="1232" alt="validator" src="https://user-images.githubusercontent.com/1358361/205566578-5704d0c7-282b-439a-9f21-67e7aa8267d7.png">
