### PR TITLE
[WebProfilerBundle] Use same color as other icons for the close toolbar btn

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -125,6 +125,7 @@
 
 .sf-toolbarreset .hide-button {
     background: var(--sf-toolbar-gray-800);
+    color: var(--sf-toolbar-gray-300);
     display: block;
     position: absolute;
     top: 2px;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | N/A

Same color as `sf-toolbar-icon`, which has better contrast:

| Before | After |
| - | - |
|![SCR-20221205-dsi](https://user-images.githubusercontent.com/2211145/205595297-eaeae76e-1346-4968-98a8-08b16a43a9dc.png)|![SCR-20221205-dpf-2](https://user-images.githubusercontent.com/2211145/205594885-f9ec035f-043d-4028-80b7-b2b7f03e02f1.png)|