### PR TITLE
Make sure `AuthenticationUtils::getLastUsername()` returns a string

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
@@ -56,7 +56,13 @@ class AuthenticationUtils
             return $request->attributes->get(Security::LAST_USERNAME, '');
         }
 
-        return $request->hasSession() ? $request->getSession()->get(Security::LAST_USERNAME, '') : '';
+        if (!$request->hasSession()) {
+            return '';
+        }
+
+        $lastUsername = $request->getSession()->get(Security::LAST_USERNAME, '');
+
+        return \is_string($lastUsername) ? $lastUsername : '';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  |no 
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When calling AuthenticationUtils::getLastUsername() there is a return type hint that this method return a string, but `$request->getSession()->get(SecurityRequestAttributes::LAST_USERNAME, '')` can also return null which throws a TypeError.

This PR makes sure that the method return an empty string in such cases.