### PR TITLE
[DependencyInjection] Revert "bug #48027 Don't autoconfigure tag when it's already set with attributes"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -129,7 +129,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 foreach ($instanceofTags[$i] as $k => $v) {
                     if (null === $definition->getDecoratedService() || \in_array($k, $tagsToKeep, true)) {
                         foreach ($v as $v) {
-                            if ($definition->hasTag($k) && (!$v || \in_array($v, $definition->getTag($k)))) {
+                            if ($definition->hasTag($k) && \in_array($v, $definition->getTag($k))) {
                                 continue;
                             }
                             $definition->addTag($k, $v);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -883,7 +883,6 @@ class IntegrationTest extends TestCase
                 $definition->addTag('app.custom_tag', get_object_vars($attribute) + ['class' => $reflector->getName()]);
             }
         );
-        $container->registerForAutoconfiguration(TaggedService1::class)->addTag('app.custom_tag');
 
         $container->register('one', TaggedService1::class)
             ->setPublic(true)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | 
| Tickets       | Fix #48388
| License       | MIT
| Doc PR        | -

Reverting #48027, which is a regression.