### PR TITLE
[Process] Introducing a new `PhpSubprocess` handler

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 6.4
 ---
 
+ * Add `PhpSubprocess` to handle PHP subprocesses that take over the
+   configuration from their parent
  * Add `RunProcessMessage` and `RunProcessMessageHandler`
  * Support using `Process::findExecutable()` independently of `open_basedir`
 

--- a/src/Symfony/Component/Process/PhpSubprocess.php
+++ b/src/Symfony/Component/Process/PhpSubprocess.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process;
+
+use Symfony\Component\Process\Exception\LogicException;
+use Symfony\Component\Process\Exception\RuntimeException;
+
+/**
+ * PhpSubprocess runs a PHP command as a subprocess while keeping the original php.ini settings.
+ *
+ * For this, it generates a temporary php.ini file taking over all the current settings and disables
+ * loading additional .ini files. Basically, your command gets prefixed using "php -n -c /tmp/temp.ini".
+ *
+ * Given your php.ini contains "memory_limit=-1" and you have a "MemoryTest.php" with the following content:
+ *
+ *     <?php var_dump(ini_get('memory_limit'));
+ *
+ * These are the differences between the regular Process and PhpSubprocess classes:
+ *
+ *     $p = new Process(['php', '-d', 'memory_limit=256M', 'MemoryTest.php']);
+ *     $p->run();
+ *     print $p->getOutput()."\n";
+ *
+ * This will output "string(2) "-1", because the process is started with the default php.ini settings.
+ *
+ *     $p = new PhpSubprocess(['MemoryTest.php'], null, null, 60, ['php', '-d', 'memory_limit=256M']);
+ *     $p->run();
+ *     print $p->getOutput()."\n";
+ *
+ * This will output "string(4) "256M"", because the process is started with the temporarily created php.ini settings.
+ *
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ * @author Partially copied and heavily inspired from composer/xdebug-handler by John Stevenson <john-stevenson@blueyonder.co.uk>
+ */
+class PhpSubprocess extends Process
+{
+    /**
+     * @param array       $command The command to run and its arguments listed as separate entries. They will automatically
+     *                             get prefixed with the PHP binary
+     * @param string|null $cwd     The working directory or null to use the working dir of the current PHP process
+     * @param array|null  $env     The environment variables or null to use the same environment as the current PHP process
+     * @param int         $timeout The timeout in seconds
+     * @param array|null  $php     Path to the PHP binary to use with any additional arguments
+     */
+    public function __construct(array $command, string $cwd = null, array $env = null, int $timeout = 60, array $php = null)
+    {
+        if (null === $php) {
+            $executableFinder = new PhpExecutableFinder();
+            $php = $executableFinder->find(false);
+            $php = false === $php ? null : array_merge([$php], $executableFinder->findArguments());
+        }
+
+        if (null === $php) {
+            throw new RuntimeException('Unable to find PHP binary.');
+        }
+
+        $tmpIni = $this->writeTmpIni($this->getAllIniFiles(), sys_get_temp_dir());
+
+        $php = array_merge($php, ['-n', '-c', $tmpIni]);
+        register_shutdown_function('unlink', $tmpIni);
+
+        $command = array_merge($php, $command);
+
+        parent::__construct($command, $cwd, $env, null, $timeout);
+    }
+
+    public static function fromShellCommandline(string $command, string $cwd = null, array $env = null, mixed $input = null, ?float $timeout = 60): static
+    {
+        throw new LogicException(sprintf('The "%s()" method cannot be called when using "%s".', __METHOD__, self::class));
+    }
+
+    public function start(callable $callback = null, array $env = [])
+    {
+        if (null === $this->getCommandLine()) {
+            throw new RuntimeException('Unable to find the PHP executable.');
+        }
+
+        parent::start($callback, $env);
+    }
+
+    private function writeTmpIni(array $iniFiles, string $tmpDir): string
+    {
+        if (false === $tmpfile = @tempnam($tmpDir, '')) {
+            throw new RuntimeException('Unable to create temporary ini file.');
+        }
+
+        // $iniFiles has at least one item and it may be empty
+        if ('' === $iniFiles[0]) {
+            array_shift($iniFiles);
+        }
+
+        $content = '';
+
+        foreach ($iniFiles as $file) {
+            // Check for inaccessible ini files
+            if (($data = @file_get_contents($file)) === false) {
+                throw new RuntimeException('Unable to read ini: '.$file);
+            }
+            // Check and remove directives after HOST and PATH sections
+            if (preg_match('/^\s*\[(?:PATH|HOST)\s*=/mi', $data, $matches)) {
+                $data = substr($data, 0, $matches[0][1]);
+            }
+
+            $content .= $data."\n";
+        }
+
+        // Merge loaded settings into our ini content, if it is valid
+        $config = parse_ini_string($content);
+        $loaded = ini_get_all(null, false);
+
+        if (false === $config || false === $loaded) {
+            throw new RuntimeException('Unable to parse ini data.');
+        }
+
+        $content .= $this->mergeLoadedConfig($loaded, $config);
+
+        // Work-around for https://bugs.php.net/bug.php?id=75932
+        $content .= "opcache.enable_cli=0\n";
+
+        if (false === @file_put_contents($tmpfile, $content)) {
+            throw new RuntimeException('Unable to write temporary ini file.');
+        }
+
+        return $tmpfile;
+    }
+
+    private function mergeLoadedConfig(array $loadedConfig, array $iniConfig): string
+    {
+        $content = '';
+
+        foreach ($loadedConfig as $name => $value) {
+            if (!\is_string($value)) {
+                continue;
+            }
+
+            if (!isset($iniConfig[$name]) || $iniConfig[$name] !== $value) {
+                // Double-quote escape each value
+                $content .= $name.'="'.addcslashes($value, '\\"')."\"\n";
+            }
+        }
+
+        return $content;
+    }
+
+    private function getAllIniFiles(): array
+    {
+        $paths = [(string) php_ini_loaded_file()];
+
+        if (false !== $scanned = php_ini_scanned_files()) {
+            $paths = array_merge($paths, array_map('trim', explode(',', $scanned)));
+        }
+
+        return $paths;
+    }
+}

--- a/src/Symfony/Component/Process/Tests/Fixtures/memory.php
+++ b/src/Symfony/Component/Process/Tests/Fixtures/memory.php
@@ -1,0 +1,3 @@
+<?php
+
+echo ini_get('memory_limit');

--- a/src/Symfony/Component/Process/Tests/OutputMemoryLimitProcess.php
+++ b/src/Symfony/Component/Process/Tests/OutputMemoryLimitProcess.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+use Symfony\Component\Process\PhpSubprocess;
+use Symfony\Component\Process\Process;
+
+require is_file(\dirname(__DIR__).'/vendor/autoload.php') ? \dirname(__DIR__).'/vendor/autoload.php' : \dirname(__DIR__, 5).'/vendor/autoload.php';
+
+['e' => $php, 'p' => $process] = getopt('e:p:') + ['e' => 'php', 'p' => 'Process'];
+
+if ('Process' === $process) {
+    $p = new Process([$php, __DIR__.'/Fixtures/memory.php']);
+} else {
+    $p = new PhpSubprocess([__DIR__.'/Fixtures/memory.php'], null, null, 60, [$php]);
+}
+
+$p->mustRun();
+echo $p->getOutput();

--- a/src/Symfony/Component/Process/Tests/PhpSubprocessTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpSubprocessTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+class PhpSubprocessTest extends TestCase
+{
+    private static $phpBin;
+
+    public static function setUpBeforeClass(): void
+    {
+        $phpBin = new PhpExecutableFinder();
+        self::$phpBin = getenv('SYMFONY_PROCESS_PHP_TEST_BINARY') ?: ('phpdbg' === \PHP_SAPI ? 'php' : $phpBin->find());
+    }
+
+    /**
+     * @dataProvider subprocessProvider
+     */
+    public function testSubprocess(string $processClass, string $memoryLimit, string $expectedMemoryLimit)
+    {
+        $process = new Process([self::$phpBin,
+            '-d',
+            'memory_limit='.$memoryLimit,
+            __DIR__.'/OutputMemoryLimitProcess.php',
+            '-e', self::$phpBin,
+            '-p', $processClass,
+        ]);
+
+        $process->mustRun();
+        $this->assertEquals($expectedMemoryLimit, trim($process->getOutput()));
+    }
+
+    public static function subprocessProvider(): \Generator
+    {
+        yield 'Process does ignore dynamic memory_limit' => [
+            'Process',
+            self::getRandomMemoryLimit(),
+            self::getCurrentMemoryLimit(),
+        ];
+
+        yield 'PhpSubprocess does not ignore dynamic memory_limit' => [
+            'PhpSubprocess',
+            self::getRandomMemoryLimit(),
+            self::getRandomMemoryLimit(),
+        ];
+    }
+
+    private static function getCurrentMemoryLimit(): string
+    {
+        return trim(\ini_get('memory_limit'));
+    }
+
+    private static function getRandomMemoryLimit(): string
+    {
+        $memoryLimit = 123; // Take something that's really unlikely to be configured on a user system.
+
+        while (($formatted = $memoryLimit.'M') === self::getCurrentMemoryLimit()) {
+            ++$memoryLimit;
+        }
+
+        return $formatted;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | will provide as soon as the API is clear

This PR provides a new `PhpSubprocess` handler which can be used to run PHP commands and taking over their parent PHP configuration. This is not super easy in PHP because the only way to do that requires a temporary `ini` file.
That's why I see perfect fit for it in the `symfony/process` component as it solves a common issue.

The code is heavily inspired/copied from `composer/xdebug-handler` where the requirement is similar - being able to have a child process/subprocess that takes over the config of the parent process. Hence, mentioning @Seldaek here.

Basically, this can be very useful in Symfony when you want to run `bin/console other-command` from within Symfony.
Let's imagine a general cronjob command that is supposed to delegate to other commands like this (simplified a lot):

```php
#[AsCommand(name: 'run-cronjobs')]
class RunCronJobsCommand extends Command
{
    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        $cron1 = new Process(['bin/console', 'cache:pool:prune']);
        $cron2 = new Process(['bin/console', 'something:else']);
        // etc.
    }
}
```

Now if you run the cronjob command itself with dynamic configuration like so: `php -d memory_limit=256M bin/console run-cronjobs`, the subprocesses (`cache:pool:prune` etc.) will not be limited to `256M` because they themselves will start a completely new PHP process which will take the default PHP settings again.
This affects everything, not just `memory_limit` but also runtime, extensions etc. You name it.

Oftentimes, however, that's not what you want. You'd like to have the children have the same restrictions as your parent process.

With this new handler, all you have to do is to use `PhpSubprocess` instead of `Process` and it will create a temporary `ini` file taking over all the settings of the parent process. Done 😊 

The current design is pretty straightforward without any extension points just yet (no way to fetch the `ini` files separately etc.). Also, it could maybe do with some more tests for the `ini` parsing but at this stage I would like to ask if this would even be a welcomed addition to Symfony or not 😊 