### PR TITLE
[DoctrineBridge] Skip resolving entities when the corresponding request attribute is already an object

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -40,7 +40,13 @@ final class EntityValueResolver implements ValueResolverInterface
 
     public function resolve(Request $request, ArgumentMetadata $argument): array
     {
-        $options = $this->getMapEntityAttribute($argument);
+        if (\is_object($request->attributes->get($argument->getName()))) {
+            return [];
+        }
+
+        $options = $argument->getAttributes(MapEntity::class, ArgumentMetadata::IS_INSTANCEOF);
+        $options = ($options[0] ?? $this->defaults)->withDefaults($this->defaults, $argument->getType());
+
         if (!$options->class || $options->disabled) {
             return [];
         }
@@ -200,13 +206,5 @@ final class EntityValueResolver implements ValueResolverInterface
         } catch (NoResultException|ConversionException) {
             return null;
         }
-    }
-
-    private function getMapEntityAttribute(ArgumentMetadata $argument): MapEntity
-    {
-        /** @var MapEntity $options */
-        $options = $argument->getAttributes(MapEntity::class, ArgumentMetadata::IS_INSTANCEOF)[0] ?? $this->defaults;
-
-        return $options->withDefaults($this->defaults, $argument->getType());
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -373,6 +373,20 @@ class EntityValueResolverTest extends TestCase
         $resolver->resolve($request, $argument);
     }
 
+    public function testAlreadyResolved()
+    {
+        $manager = $this->getMockBuilder(ObjectManager::class)->getMock();
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('arg', new \stdClass());
+
+        $argument = $this->createArgument('stdClass', name: 'arg');
+
+        $this->assertSame([], $resolver->resolve($request, $argument));
+    }
+
     private function createArgument(string $class = null, MapEntity $entity = null, string $name = 'arg', bool $isNullable = false): ArgumentMetadata
     {
         return new ArgumentMetadata($name, $class ?? \stdClass::class, false, false, null, $isNullable, $entity ? [$entity] : []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48433
| License       | MIT
| Doc PR        | -