### PR TITLE
[DependencyInjection] Fix typo in `RemoveBuildParametersPassTest`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveBuildParametersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveBuildParametersPassTest.php
@@ -28,6 +28,6 @@ class RemoveBuildParametersPassTest extends TestCase
 
         $this->assertSame('Foo', $builder->getParameter('foo'), '"foo" parameter must be defined.');
         $this->assertFalse($builder->hasParameter('.bar'), '".bar" parameter must be removed.');
-        $this->assertSame(['.bar' => 'Bar'], $pass->getRemovedParameters(), '".baz" parameter must be returned with its value.');
+        $this->assertSame(['.bar' => 'Bar'], $pass->getRemovedParameters(), '".bar" parameter must be returned with its value.');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
