### PR TITLE
[RateLimiter] Add `int` to `Reservation::wait()`

### DIFF
--- a/src/Symfony/Component/RateLimiter/Reservation.php
+++ b/src/Symfony/Component/RateLimiter/Reservation.php
@@ -45,6 +45,6 @@ final class Reservation
 
     public function wait(): void
     {
-        usleep($this->getWaitDuration() * 1e6);
+        usleep((int) ($this->getWaitDuration() * 1e6));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48500
| License       | MIT

The `usleep` function accepts int as parameter type (https://www.php.net/manual/en/function.usleep.php), while the passed type is float in `Reservation::wait` (due to `Reservation::getWaitDuration` returning a float value for the 1e6 multiplication)
To prevent deprecation notices we can typecast the float value to int before passing it to `usleep`
