### PR TITLE
[Notifier] Add options to `SmsMessage`

### DIFF
--- a/src/Symfony/Component/Notifier/Message/SmsMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SmsMessage.php
@@ -24,8 +24,9 @@ class SmsMessage implements MessageInterface
     private string $subject;
     private string $phone;
     private string $from;
+    private ?MessageOptionsInterface $options;
 
-    public function __construct(string $phone, string $subject, string $from = '')
+    public function __construct(string $phone, string $subject, string $from = '', MessageOptionsInterface $options = null)
     {
         if ('' === $phone) {
             throw new InvalidArgumentException(sprintf('"%s" needs a phone number, it cannot be empty.', __CLASS__));
@@ -34,6 +35,7 @@ class SmsMessage implements MessageInterface
         $this->subject = $subject;
         $this->phone = $phone;
         $this->from = $from;
+        $this->options = $options;
     }
 
     public static function fromNotification(Notification $notification, SmsRecipientInterface $recipient): self
@@ -110,8 +112,18 @@ class SmsMessage implements MessageInterface
         return $this->from;
     }
 
+    /**
+     * @return $this
+     */
+    public function options(MessageOptionsInterface $options): static
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
     public function getOptions(): ?MessageOptionsInterface
     {
-        return null;
+        return $this->options;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

Add the ability to attach optional options to an SMS message, which can then be processed by the notifier bridge.

Some SMS APIs allow dynamic options that can be set on a per message basis, which cannot be satisfied by options in the DSN.