### PR TITLE
[FrameworkBundle] Remove check of undefined service in mailer assertions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
@@ -123,10 +123,6 @@ trait MailerAssertionsTrait
             return $container->get('mailer.message_logger_listener')->getEvents();
         }
 
-        if ($container->has('mailer.logger_message_listener')) {
-            return $container->get('mailer.logger_message_listener')->getEvents();
-        }
-
         static::fail('A client must have Mailer enabled to make email assertions. Did you forget to require symfony/mailer?');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -

The `mailer.logger_message_listener` service has been deprecated in `5.2` and completely removed in `6.0`. Therefore, these lines can be safely removed.
