### PR TITLE
[FrameworkBundle] fix removing commands if console not available

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -390,7 +390,7 @@ class FrameworkExtension extends Extension
         if ($this->readConfigEnabled('mailer', $container, $config['mailer'])) {
             $this->registerMailerConfiguration($config['mailer'], $container, $loader);
 
-            if (!class_exists(MailerTestCommand::class) || !$this->hasConsole()) {
+            if (!$this->hasConsole() || !class_exists(MailerTestCommand::class)) {
                 $container->removeDefinition('console.command.mailer_test');
             }
         }
@@ -1971,7 +1971,7 @@ class FrameworkExtension extends Extension
             throw new LogicException('Messenger support cannot be enabled as the Messenger component is not installed. Try running "composer require symfony/messenger".');
         }
 
-        if (!class_exists(StatsCommand::class)) {
+        if (!$this->hasConsole() || !class_exists(StatsCommand::class)) {
             $container->removeDefinition('console.command.messenger_stats');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #48415
| License       | MIT
| Doc PR        | n/a

#48416 didn't quite solve and we had the same issue with the new `messenger:stats` command.
