### PR TITLE
[DependencyInjection] add `AsAliasOf` attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsAliasOf.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsAliasOf.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to alias an interface with an implementation.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsAliasOf
+{
+    public function __construct(
+        public readonly string $id,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireAsAliasOfPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireAsAliasOfPass.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAliasOf;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Reads #[AsAliasOf] attributes on definitions that are autowired
+ * and don't have the "container.ignore_attributes" tag.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AutowireAsAliasOfPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            if ($this->accept($definition) && $reflectionClass = $container->getReflectionClass($definition->getClass(), false)) {
+                $this->processClass($container, $reflectionClass);
+            }
+        }
+    }
+
+    private function accept(Definition $definition): bool
+    {
+        return !$definition->hasTag('container.ignore_attributes') && $definition->isAutowired();
+    }
+
+    private function processClass(ContainerBuilder $container, \ReflectionClass $class): void
+    {
+        if (!$attribute = ($class->getAttributes(AsAliasOf::class)[0] ?? null)?->newInstance()) {
+            return;
+        }
+
+        $container->setAlias($class->name, $attribute->id);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -44,6 +44,7 @@ class PassConfig
                 new ResolveClassPass(),
                 new RegisterAutoconfigureAttributesPass(),
                 new AutowireAsDecoratorPass(),
+                new AutowireAsAliasOfPass(),
                 new AttributeAutoconfigurationPass(),
                 new ResolveInstanceofConditionalsPass(),
                 new RegisterEnvVarProcessorsPass(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #47323, #41207, #41188
| License       | MIT
| Doc PR        | todo

This attribute is meant to be added to an interface to mark the implementation you wish it to be an alias for.

```php
#[AsAliasOf(B::class)]
interface I {}

class A implements I;
class B implements I;
```

Now autowiring `I` gives you `B`.

Looking for feedback before finishing up.

---

TODO:
- [ ] finish implementation
- [ ] tests
- [ ] changelog