### PR TITLE
[HttpKernel] Fix `CacheAttributeListener` priority

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CacheAttributeListenerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CacheAttributeListenerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\Cache;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class CacheAttributeListenerTest extends AbstractWebTestCase
+{
+    public function testAnonimousUserWithEtag()
+    {
+        $client = self::createClient(['test_case' => 'CacheAttributeListener']);
+
+        $client->request('GET', '/', server: ['HTTP_IF_NONE_MATCH' => sprintf('"%s"', hash('sha256', '12345'))]);
+
+        self::assertTrue($client->getResponse()->isRedirect('http://localhost/login'));
+    }
+
+    public function testAnonimousUserWithoutEtag()
+    {
+        $client = self::createClient(['test_case' => 'CacheAttributeListener']);
+
+        $client->request('GET', '/');
+
+        self::assertTrue($client->getResponse()->isRedirect('http://localhost/login'));
+    }
+
+    public function testLoggedInUserWithEtag()
+    {
+        $client = self::createClient(['test_case' => 'CacheAttributeListener']);
+
+        $client->loginUser(new InMemoryUser('the-username', 'the-password', ['ROLE_USER']));
+        $client->request('GET', '/', server: ['HTTP_IF_NONE_MATCH' => sprintf('"%s"', hash('sha256', '12345'))]);
+
+        $response = $client->getResponse();
+
+        self::assertSame(304, $response->getStatusCode());
+        self::assertSame('', $response->getContent());
+    }
+
+    public function testLoggedInUserWithoutEtag()
+    {
+        $client = self::createClient(['test_case' => 'CacheAttributeListener']);
+
+        $client->loginUser(new InMemoryUser('the-username', 'the-password', ['ROLE_USER']));
+        $client->request('GET', '/');
+
+        $response = $client->getResponse();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('Hi there!', $response->getContent());
+    }
+}
+
+class TestEntityValueResolver implements ValueResolverInterface
+{
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        return Post::class === $argument->getType() ? [new Post()] : [];
+    }
+}
+
+class Post
+{
+    public function getId(): int
+    {
+        return 1;
+    }
+
+    public function getEtag(): string
+    {
+        return '12345';
+    }
+}
+
+class WithAttributesController
+{
+    #[IsGranted('ROLE_USER')]
+    #[Cache(etag: 'post.getEtag()')]
+    public function __invoke(Post $post): Response
+    {
+        return new Response('Hi there!');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CacheAttributeListener/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CacheAttributeListener/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+
+return [
+    new FrameworkBundle(),
+    new SecurityBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CacheAttributeListener/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CacheAttributeListener/config.yml
@@ -1,0 +1,24 @@
+imports:
+    - { resource: ../config/default.yml }
+
+services:
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\TestEntityValueResolver:
+        tags:
+            - { name: controller.argument_value_resolver, priority: 110 }
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\WithAttributesController:
+        public: true
+
+security:
+    providers:
+        main:
+            memory:
+                users:
+                    the-username: { password: the-password, roles: [ 'ROLE_USER' ] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            form_login:
+                login_path: /login
+            provider: main

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CacheAttributeListener/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CacheAttributeListener/routing.yml
@@ -1,0 +1,3 @@
+with_attributes_controller:
+    path: /
+    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithAttributesController

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/error-handler": "^6.1",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/http-foundation": "^6.2",
-        "symfony/http-kernel": "^6.2",
+        "symfony/http-kernel": "^6.2.1",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "^5.4|^6.0",
         "symfony/finder": "^5.4|^6.0",

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -77,7 +77,7 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
-        return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 10]];
+        return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 20]];
     }
 
     private function getIsGrantedSubject(string|Expression $subjectRef, Request $request, array $arguments): mixed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the `CacheAttributeListener` & the `IsGrantedAttributeListener` have the same priority:

```
Registered Listeners for "kernel.controller_arguments" Event
============================================================

 ------- --------------------------------------------------------------------------------------------------------- ---------- 
  Order   Callable                                                                                                  Priority  
 ------- --------------------------------------------------------------------------------------------------------- ---------- 
  #1      Symfony\Component\HttpKernel\EventListener\CacheAttributeListener::onKernelControllerArguments()          10        
  #2      Symfony\Component\Security\Http\EventListener\IsGrantedAttributeListener::onKernelControllerArguments()   10        
  #3      Symfony\Component\HttpKernel\EventListener\ErrorListener::onControllerArguments()                         0         
 ------- --------------------------------------------------------------------------------------------------------- ---------- 
```

Since the `CacheAttributeListener` is alphabetically first, it's first to get triggered. This can cause an unauthenticated user to receive a 304 Not modified instead of a 302 Redirect, resulting in the user seeing some stale content from when they were authenticated instead of getting redirected to the login page.

This PR changes the priority of the `CacheAttributeListener` to be lower than that of the `IsGrantedAttributeListener`.