### PR TITLE
[FrameworkBundle][Messenger] Add support for namespace wildcard in Messenger routing

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `DomCrawlerAssertionsTrait::assertSelectorCount(int $count, string $selector)`
  * Allow to avoid `limit` definition in a RateLimiter configuration when using the `no_limit` policy
  * Add `--format` option to the `debug:config` command
+ * Add support to pass namespace wildcard in `framework.messenger.routing`
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2159,7 +2159,11 @@ class FrameworkExtension extends Extension
 
         $messageToSendersMapping = [];
         foreach ($config['routing'] as $message => $messageConfiguration) {
-            if ('*' !== $message && !class_exists($message) && !interface_exists($message, false)) {
+            if ('*' !== $message && !class_exists($message) && !interface_exists($message, false) && !preg_match('/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+\\\\)++\*$/', $message)) {
+                if (str_contains($message, '*')) {
+                    throw new LogicException(sprintf('Invalid Messenger routing configuration: invalid namespace "%s" wildcard.', $message));
+                }
+
                 throw new LogicException(sprintf('Invalid Messenger routing configuration: class or interface "%s" not found.', $message));
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
@@ -15,6 +15,7 @@ $container->loadFromExtension('framework', [
             SecondMessage::class => [
                 'senders' => ['amqp', 'audit'],
             ],
+            'Symfony\*' => 'amqp',
             '*' => 'amqp',
         ],
         'transports' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_wildcard.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_invalid_wildcard.php
@@ -1,0 +1,17 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'http_method_override' => false,
+    'serializer' => true,
+    'messenger' => [
+        'serializer' => [
+            'default_serializer' => 'messenger.transport.symfony_serializer',
+        ],
+        'routing' => [
+            'Symfony\*\DummyMessage' => ['audit'],
+        ],
+        'transports' => [
+            'audit' => 'null://',
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_wildcard.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_invalid_wildcard.xml
@@ -9,21 +9,9 @@
         <framework:serializer enabled="true" />
         <framework:messenger>
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />
-            <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage">
-                <framework:sender service="amqp" />
-                <framework:sender service="messenger.transport.audit" />
-            </framework:routing>
-            <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\SecondMessage">
-                <framework:sender service="amqp" />
+            <framework:routing message-class="Symfony\*\DummyMessage">
                 <framework:sender service="audit" />
             </framework:routing>
-            <framework:routing message-class="*">
-                <framework:sender service="amqp" />
-            </framework:routing>
-            <framework:routing message-class="Symfony\*">
-                <framework:sender service="amqp" />
-            </framework:routing>
-            <framework:transport name="amqp" dsn="amqp://localhost/%2f/messages" />
             <framework:transport name="audit" dsn="null://" />
         </framework:messenger>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
@@ -8,6 +8,8 @@ framework:
             'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage': [amqp, messenger.transport.audit]
             'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\SecondMessage':
                 senders: [amqp, audit]
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\*': [amqp]
+            'Symfony\*': [amqp]
             '*': amqp
         transports:
             amqp: 'amqp://localhost/%2f/messages'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_wildcard.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_invalid_wildcard.yml
@@ -1,0 +1,10 @@
+framework:
+    http_method_override: false
+    serializer: true
+    messenger:
+        serializer:
+            default_serializer: messenger.transport.symfony_serializer
+        routing:
+            'Symfony\*\DummyMessage': [audit]
+        transports:
+            audit: 'null://'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1061,6 +1061,13 @@ abstract class FrameworkExtensionTest extends TestCase
     public function testMessengerInvalidTransportRouting()
     {
         $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Invalid Messenger routing configuration: invalid namespace "Symfony\*\DummyMessage" wildcard.');
+        $this->createContainerFromFile('messenger_routing_invalid_wildcard');
+    }
+
+    public function testMessengerInvalidWildcardRouting()
+    {
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Invalid Messenger routing configuration: the "Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage" class is being routed to a sender called "invalid". This is not a valid transport or service id.');
         $this->createContainerFromFile('messenger_routing_invalid_transport');
     }

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.3
 ---
 
+ * Add support for namespace wildcards in the HandlersLocator to allow routing multiple messages within the same namespace
  * Deprecate `Symfony\Component\Messenger\Transport\InMemoryTransport` and
    `Symfony\Component\Messenger\Transport\InMemoryTransportFactory` in favor of
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport` and

--- a/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
@@ -68,7 +68,20 @@ class HandlersLocator implements HandlersLocatorInterface
         return [$class => $class]
             + class_parents($class)
             + class_implements($class)
+            + self::listWildcards($class)
             + ['*' => '*'];
+    }
+
+    private static function listWildcards(string $type): array
+    {
+        $type .= '\*';
+        $wildcards = [];
+        while ($i = strrpos($type, '\\', -3)) {
+            $type = substr_replace($type, '\*', $i);
+            $wildcards[$type] = $type;
+        }
+
+        return $wildcards;
     }
 
     private function shouldHandle(Envelope $envelope, HandlerDescriptor $handlerDescriptor): bool

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
@@ -56,6 +56,29 @@ class HandlersLocatorTest extends TestCase
             new Envelope(new DummyMessage('Body'), [new ReceivedStamp('transportName')])
         )));
     }
+
+    public function testItReturnsOnlyHandlersMatchingMessageNamespace()
+    {
+        $firstHandler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+        $secondHandler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+
+        $locator = new HandlersLocator([
+            str_replace('DummyMessage', '*', DummyMessage::class) => [
+                $first = new HandlerDescriptor($firstHandler, ['alias' => 'one']),
+            ],
+            str_replace('Fixtures\\DummyMessage', '*', DummyMessage::class) => [
+                $second = new HandlerDescriptor($secondHandler, ['alias' => 'two']),
+            ],
+        ]);
+
+        $first->getName();
+        $second->getName();
+
+        $this->assertEquals([
+            $first,
+            $second,
+        ], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('Body')))));
+    }
 }
 
 class HandlersLocatorTestCallable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/17532

This is a new feature for the Messenger component which is why there is no issue ticket attached.

Currently, HandlersLocator extracts message class along with all parent classes and all interfaces + a `'*'` wildcard to match any transport.
This is not fully efficient resulting in many routes for messages that share the same transport but by design don't share any inheritance or interface.

This is an opportunity to introduce simple wildcards which allow defining a transport for multiple messages grouped in one namespace.
For eg. given a bunch of messages acting as commands, queries, and events (in CQRS) 
* `App\Message\Command\CreatePost`
* `App\Message\Command\PublishPost`
* `App\Message\Event\PostCreated`
* `App\Message\Event\PostPublished`
* `App\Message\Query\FindPost`

The intention may be to send all Commands to `async` transport, Queries to `sync` transport but Events to a different transport for eg. `stream` - the configuration requires creating routing for at least 3 classes because none of them share inheritance or interfaces with one wildcard `'*'` for `async` or `sync` as these are the most numerous.

```yaml
framework:
    messenger:
        routing:
            App\Message\Command\CreatePost: async
            App\Message\Command\PublishPost: async
            App\Message\Query\FindPost: sync
            '*': stream
```

With this feature managing, multiple types of transport allow us to ultimately define 3 wildcarded namespaces instead and reduce the maintenance burden at the same time and prevent using standalone `'*'` which unconsciously may be the cause of problems. The configuration using namespace wildcards will look as follows:

```yaml
framework:
    messenger:
        routing:
            App\Message\Command\*: async
            App\Message\Event\*: stream
            App\Message\Query\*: sync
#            '*': stream
```

The aim of this PR is to provide a simple solution supporting wildcards in routing to prevent using `'*'`. In future scope, matching rules may be the subject of another PR addressing improvements in the future.