### PR TITLE
[FrameworkBundle] add `kernel.locale_aware` tag to `LocaleSwitcher`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
@@ -168,10 +168,11 @@ return static function (ContainerConfigurator $container) {
         ->set('translation.locale_switcher', LocaleSwitcher::class)
             ->args([
                 param('kernel.default_locale'),
-                tagged_iterator('kernel.locale_aware'),
+                tagged_iterator('kernel.locale_aware', exclude: 'translation.locale_switcher'),
                 service('router.request_context')->ignoreOnInvalid(),
             ])
             ->tag('kernel.reset', ['method' => 'reset'])
+            ->tag('kernel.locale_aware')
         ->alias(LocaleAwareInterface::class, 'translation.locale_switcher')
         ->alias(LocaleSwitcher::class, 'translation.locale_switcher')
     ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48499
| License       | MIT
| Doc PR        | n/a

This adds `kernel.locale_aware` to the `LocalSwitcher` service so that when autowiring `LocaleAwareInterface` (which is an alias for `LocaleSwitcher`), it has the current locale.