### PR TITLE
[Clock] Fix `usleep` deprecation warning

### DIFF
--- a/src/Symfony/Component/Clock/MonotonicClock.php
+++ b/src/Symfony/Component/Clock/MonotonicClock.php
@@ -67,7 +67,7 @@ final class MonotonicClock implements ClockInterface
         }
 
         if (0 < $us = $seconds - $s) {
-            usleep($us * 1E6);
+            usleep((int) ($us * 1E6));
         }
     }
 

--- a/src/Symfony/Component/Clock/NativeClock.php
+++ b/src/Symfony/Component/Clock/NativeClock.php
@@ -41,7 +41,7 @@ final class NativeClock implements ClockInterface
         }
 
         if (0 < $us = $seconds - $s) {
-            usleep($us * 1E6);
+            usleep((int) ($us * 1E6));
         }
     }
 

--- a/src/Symfony/Component/Clock/Tests/MonotonicClockTest.php
+++ b/src/Symfony/Component/Clock/Tests/MonotonicClockTest.php
@@ -56,7 +56,7 @@ class MonotonicClockTest extends TestCase
         usleep(10);
         $after = microtime(true);
 
-        $this->assertGreaterThanOrEqual($before + 1.5, $now);
+        $this->assertGreaterThanOrEqual($before + 1.499999, $now);
         $this->assertLessThan($after, $now);
         $this->assertLessThan(1.9, $now - $before);
         $this->assertSame($tz, $clock->now()->getTimezone()->getName());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48537 
| License       | MIT
| Doc PR        | /

Hi,
As explained in the issue, i just makes the cast explicit from float to int and avoid deprecation warning