### PR TITLE
[Notifier] [FakeSms] Allow missing optional dependency

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsTransportFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\FakeSms;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -24,10 +25,10 @@ use Symfony\Component\Notifier\Transport\Dsn;
  */
 final class FakeSmsTransportFactory extends AbstractTransportFactory
 {
-    private MailerInterface $mailer;
-    private LoggerInterface $logger;
+    private ?MailerInterface $mailer;
+    private ?LoggerInterface $logger;
 
-    public function __construct(MailerInterface $mailer, LoggerInterface $logger)
+    public function __construct(MailerInterface $mailer = null, LoggerInterface $logger = null)
     {
         parent::__construct();
 
@@ -40,6 +41,10 @@ final class FakeSmsTransportFactory extends AbstractTransportFactory
         $scheme = $dsn->getScheme();
 
         if ('fakesms+email' === $scheme) {
+            if (null === $this->mailer) {
+                $this->throwMissingDependencyException($scheme, MailerInterface::class, 'symfony/mailer');
+            }
+
             $mailerTransport = $dsn->getHost();
             $to = $dsn->getRequiredOption('to');
             $from = $dsn->getRequiredOption('from');
@@ -48,6 +53,10 @@ final class FakeSmsTransportFactory extends AbstractTransportFactory
         }
 
         if ('fakesms+logger' === $scheme) {
+            if (null === $this->logger) {
+                $this->throwMissingDependencyException($scheme, LoggerInterface::class, 'psr/log');
+            }
+
             return new FakeSmsLoggerTransport($this->logger);
         }
 
@@ -57,5 +66,10 @@ final class FakeSmsTransportFactory extends AbstractTransportFactory
     protected function getSupportedSchemes(): array
     {
         return ['fakesms+email', 'fakesms+logger'];
+    }
+
+    private function throwMissingDependencyException(string $scheme, string $missingDependency, string $suggestedPackage): void
+    {
+        throw new LogicException(sprintf('Cannot create a transport for scheme "%s" without providing an implementation of "%s". Try running "composer require "%s"".', $scheme, $missingDependency, $suggestedPackage));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsTransportFactoryTest.php
@@ -14,10 +14,35 @@ namespace Symfony\Component\Notifier\Bridge\FakeSms\Tests;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsTransportFactory;
+use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\Dsn;
 
 final class FakeSmsTransportFactoryTest extends TransportFactoryTestCase
 {
+    /**
+     * @dataProvider missingRequiredDependencyProvider
+     */
+    public function testMissingRequiredDependency(?MailerInterface $mailer, ?LoggerInterface $logger, string $dsn, string $message)
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage($message);
+
+        $factory = new FakeSmsTransportFactory($mailer, $logger);
+        $factory->create(new Dsn($dsn));
+    }
+
+    /**
+     * @dataProvider missingOptionalDependencyProvider
+     */
+    public function testMissingOptionalDependency(?MailerInterface $mailer, ?LoggerInterface $logger, string $dsn)
+    {
+        $factory = new FakeSmsTransportFactory($mailer, $logger);
+        $transport = $factory->create(new Dsn($dsn));
+
+        $this->assertSame($dsn, (string) $transport);
+    }
+
     public function createFactory(): FakeSmsTransportFactory
     {
         return new FakeSmsTransportFactory($this->createMock(MailerInterface::class), $this->createMock(LoggerInterface::class));
@@ -62,5 +87,36 @@ final class FakeSmsTransportFactoryTest extends TransportFactoryTestCase
     public function unsupportedSchemeProvider(): iterable
     {
         yield ['somethingElse://default?to=recipient@email.net&from=sender@email.net'];
+    }
+
+    public function missingRequiredDependencyProvider(): iterable
+    {
+        $exceptionMessage = 'Cannot create a transport for scheme "%s" without providing an implementation of "%s".';
+        yield 'missing mailer' => [
+            null,
+            $this->createMock(LoggerInterface::class),
+            'fakesms+email://default?to=recipient@email.net&from=sender@email.net',
+            sprintf($exceptionMessage, 'fakesms+email', MailerInterface::class),
+        ];
+        yield 'missing logger' => [
+            $this->createMock(MailerInterface::class),
+            null,
+            'fakesms+logger://default',
+            sprintf($exceptionMessage, 'fakesms+logger', LoggerInterface::class),
+        ];
+    }
+
+    public function missingOptionalDependencyProvider(): iterable
+    {
+        yield 'missing logger' => [
+            $this->createMock(MailerInterface::class),
+            null,
+            'fakesms+email://default?to=recipient@email.net&from=sender@email.net',
+        ];
+        yield 'missing mailer' => [
+            null,
+            $this->createMock(LoggerInterface::class),
+            'fakesms+logger://default',
+        ];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
@@ -24,8 +24,11 @@
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2",
-        "symfony/event-dispatcher-contracts": "^2|^3",
-        "symfony/mailer": "^5.4|^6.0"
+        "symfony/event-dispatcher-contracts": "^2|^3"
+    },
+    "require-dev": {
+        "symfony/mailer": "^5.4|^6.0",
+        "psr/log": "^1|^2|^3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FakeSms\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #48441
| License       | MIT

Allow the `FakeSmsTransportFactory` to be used without providing an implementation of `MailerInterface` or `LoggerInterface` if one of them is actually not required during runtime.

Same could be applied to the `FakeChatTransportFactory` if the provided approach is ok.
