### PR TITLE
[FrameworkBundle] Fail properly on unregistrable command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
+use function max;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -68,13 +69,16 @@ class Application extends BaseApplication
     {
         $this->registerCommands();
 
+        $statusCode = Command::SUCCESS;
         if ($this->registrationErrors) {
+            $statusCode = Command::FAILURE;
+
             $this->renderRegistrationErrors($input, $output);
         }
 
         $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));
 
-        return parent::doRun($input, $output);
+        return max($statusCode, parent::doRun($input, $output));
     }
 
     protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output): int
@@ -83,7 +87,9 @@ class Application extends BaseApplication
         $renderRegistrationErrors = true;
 
         if (!$command instanceof ListCommand) {
+            $statusCode = Command::SUCCESS;
             if ($this->registrationErrors) {
+                $statusCode = Command::FAILURE;
                 $this->renderRegistrationErrors($input, $output);
                 $this->registrationErrors = [];
                 $renderRegistrationErrors = false;
@@ -120,7 +126,7 @@ class Application extends BaseApplication
         }
 
         try {
-            $returnCode = parent::doRunCommand($command, $input, $output);
+            $returnCode = max($statusCode ?? 0, parent::doRunCommand($command, $input, $output));
         } finally {
             $requestStack?->pop();
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -124,7 +124,7 @@ class ApplicationTest extends TestCase
         $this->assertSame($newCommand, $application->get('example'));
     }
 
-    public function testRunOnlyWarnsOnUnregistrableCommand()
+    public function testUnregistrableCommandsAreConsideredFailure()
     {
         $container = new ContainerBuilder();
         $container->register('event_dispatcher', EventDispatcher::class);
@@ -148,7 +148,7 @@ class ApplicationTest extends TestCase
         $tester->run(['command' => 'fine']);
         $output = $tester->getDisplay();
 
-        $tester->assertCommandIsSuccessful();
+        $this->assertSame(1, $tester->getStatusCode());
         $this->assertStringContainsString('Some commands could not be registered:', $output);
         $this->assertStringContainsString('throwing', $output);
         $this->assertStringContainsString('fine', $output);
@@ -181,7 +181,7 @@ class ApplicationTest extends TestCase
         $this->assertStringContainsString('Command "fine" is not defined.', $output);
     }
 
-    public function testRunOnlyWarnsOnUnregistrableCommandAtTheEnd()
+    public function testRunFailsOnUnregistrableCommandAtTheEnd()
     {
         $container = new ContainerBuilder();
         $container->register('event_dispatcher', EventDispatcher::class);
@@ -205,7 +205,7 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'list']);
 
-        $tester->assertCommandIsSuccessful();
+        $this->assertSame(1, $tester->getStatusCode());
         $display = explode('List commands', $tester->getDisplay());
 
         $this->assertStringContainsString(trim('[WARNING] Some commands could not be registered:'), trim($display[1]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When commands are not possible to be registered, the console should return non-zero status code and not fail silently

Real-case scenario: SncRedisBundle v4.4 broke the rest of my commands because its commands could not be registered https://github.com/snc/SncRedisBundle/issues/683.  
I run `bin/console` in CI to see if something is broken.  
But even though in CI there were tonz of warnings, it returned Success at the end and the broken application slipped into the production and broke it.
```
 [WARNING] Some commands could not be registered:


In ReplicationOption.php line 52:

  Values evaluating to FALSE are not accepted for `replication`


In ReplicationOption.php line 52:

  Values evaluating to FALSE are not accepted for `replication`


In ReplicationOption.php line 52:

  Values evaluating to FALSE are not accepted for `replication`
```
