### PR TITLE
[Notifier] Add `symfony/event-dispatcher` to bridges' `require-dev` section

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\AllMySms\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
@@ -21,6 +21,9 @@
         "symfony/notifier": "^6.2",
         "async-aws/sns": "^1.0"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\AmazonSns\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Chatwork/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Chatwork/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Chatwork\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\ContactEveryone\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/composer.json
@@ -16,9 +16,12 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "symfony/http-client": "^4.3|^5.0|^6.0",
         "symfony/notifier": "^6.2"
+    },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Engagespot\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Esendex\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Expo\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
@@ -24,8 +24,10 @@
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2",
-        "symfony/event-dispatcher-contracts": "^2|^3",
         "symfony/mailer": "^5.4|^6.0"
+    },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FakeChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
@@ -23,10 +23,10 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2",
-        "symfony/event-dispatcher-contracts": "^2|^3"
+        "symfony/notifier": "^6.2"
     },
     "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/mailer": "^5.4|^6.0",
         "psr/log": "^1|^2|^3"
     },

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Firebase\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FortySixElks\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
@@ -21,6 +21,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FreeMobile\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
@@ -24,6 +24,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\GatewayApi\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Gitter\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\GoogleChat\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
@@ -24,6 +24,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Infobip\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
@@ -24,6 +24,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Iqsms\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/composer.json
@@ -1,32 +1,35 @@
 {
-  "name": "symfony/kaz-info-teh-notifier",
-  "type": "symfony-bridge",
-  "description": "Symfony KazInfoTeh Notifier Bridge",
-  "keywords": ["KazInfoTeh", "notifier", "symfony", "sms"],
-  "homepage": "https://symfony.com",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Egor Taranov",
-      "email": "dev@taranovegor.com",
-      "homepage": "https://taranovegor.com/contribution"
+    "name": "symfony/kaz-info-teh-notifier",
+    "type": "symfony-bridge",
+    "description": "Symfony KazInfoTeh Notifier Bridge",
+    "keywords": ["KazInfoTeh", "notifier", "symfony", "sms"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Egor Taranov",
+            "email": "dev@taranovegor.com",
+            "homepage": "https://taranovegor.com/contribution"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "ext-simplexml": "*",
+        "symfony/http-client": "^5.4|^6.0",
+        "symfony/notifier": "^6.2"
     },
-    {
-      "name": "Symfony Community",
-      "homepage": "https://symfony.com/contributors"
-    }
-  ],
-  "require": {
-    "php": ">=8.1",
-    "ext-simplexml": "*",
-    "symfony/http-client": "^5.4|^6.0",
-    "symfony/notifier": "^6.2"
-  },
-  "autoload": {
-    "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\KazInfoTeh\\": "" },
-    "exclude-from-classmap": [
-      "/Tests/"
-    ]
-  },
-  "minimum-stability": "dev"
+    "require-dev": {
+      "symfony/event-dispatcher": "^5.4|^6.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\KazInfoTeh\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
 }

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\LightSms\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
@@ -24,6 +24,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mailjet\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Mastodon/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mastodon/composer.json
@@ -21,6 +21,7 @@
         "symfony/notifier": "^6.2"
     },
     "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0",,
         "symfony/mime": "^6.2"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mattermost\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
@@ -21,6 +21,9 @@
         "symfony/notifier": "^6.2",
         "symfony/service-contracts": "^1.10|^2|^3"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mercure\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MessageBird\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
@@ -1,30 +1,33 @@
 {
-  "name": "symfony/message-media-notifier",
-  "type": "symfony-notifier-bridge",
-  "description": "Symfony MessageMedia Notifier Bridge",
-  "keywords": ["sms", "messagemedia", "notifier"],
-  "homepage": "https://symfony.com",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Adrian Nguyen",
-      "email": "vuphuong87@gmail.com"
+    "name": "symfony/message-media-notifier",
+    "type": "symfony-notifier-bridge",
+    "description": "Symfony MessageMedia Notifier Bridge",
+    "keywords": ["sms", "messagemedia", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Adrian Nguyen",
+            "email": "vuphuong87@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "symfony/http-client": "^5.4|^6.0",
+        "symfony/notifier": "^6.2"
     },
-    {
-      "name": "Symfony Community",
-      "homepage": "https://symfony.com/contributors"
-    }
-  ],
-  "require": {
-    "php": ">=8.1",
-    "symfony/http-client": "^5.4|^6.0",
-    "symfony/notifier": "^6.2"
-  },
-  "autoload": {
-    "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MessageMedia\\": "" },
-    "exclude-from-classmap": [
-      "/Tests/"
-    ]
-  },
-  "minimum-stability": "dev"
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MessageMedia\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
 }

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
@@ -24,6 +24,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MicrosoftTeams\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mobyt\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Octopush\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OrangeSms\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OvhCloud\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\RocketChat\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/composer.json
@@ -16,9 +16,12 @@
         }
     ],
     "require": {
-        "php": ">=8.0.2",
+        "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
+    },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sendberry\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sendinblue\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sinch\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sms77\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SmsBiuras\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SmsFactor\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsapi\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsc\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
@@ -24,6 +24,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SpotHit\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Telnyx\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
@@ -21,6 +21,9 @@
         "symfony/notifier": "^6.2",
         "symfony/polyfill-mbstring": "^1.0"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": {
             "Symfony\\Component\\Notifier\\Bridge\\TurboSms\\": ""

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Twilio\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/composer.json
@@ -21,6 +21,7 @@
         "symfony/notifier": "^6.2"
     },
     "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/mime": "^6.2"
     },
     "conflict": {

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/composer.json
@@ -16,9 +16,12 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "symfony/http-client": "^4.3|^5.0|^6.0",
         "symfony/notifier": "^6.2"
+    },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Vonage\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Yunpian\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Zendesk/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Zendesk/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Zendesk\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
+    "require-dev": {
+        "symfony/event-dispatcher": "^5.4|^6.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Zulip\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 (not sure)
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

`symfony/event-dispatcher` is used in all tests.

Also increase some php requirements to `>=8.1`

Not sure if this is the right branch