### PR TITLE
[Notifier] Remove dependency `symfony/uid` on Notifier bridges

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneTransportTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -47,7 +46,7 @@ final class ContactEveryoneTransportTest extends TransportTestCase
 
     public function testSendSuccessfully()
     {
-        $messageId = Uuid::v4()->toRfc4122();
+        $messageId = bin2hex(random_bytes(7));
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(200);
         $response->method('getContent')->willReturn($messageId);

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/composer.json
@@ -20,9 +20,6 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
-    "require-dev": {
-        "symfony/uid": "^5.4|^6.0"
-    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\ContactEveryone\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -88,7 +87,7 @@ final class EsendexTransportTest extends TransportTestCase
 
     public function testSendWithSuccessfulResponseDispatchesMessageEvent()
     {
-        $messageId = Uuid::v4()->toRfc4122();
+        $messageId = bin2hex(random_bytes(7));
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->exactly(2))
             ->method('getStatusCode')

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
@@ -20,9 +20,6 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
-    "require-dev": {
-        "symfony/uid": "^5.4|^6.0"
-    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Esendex\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/composer.json
@@ -20,9 +20,6 @@
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },
-    "require-dev": {
-        "symfony/uid": "^5.4|^6.0"
-    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OrangeSms\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
@@ -17,7 +17,6 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -67,7 +66,7 @@ final class SmsFactorTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $messageId = Uuid::v4()->toRfc4122();
+        $messageId = bin2hex(random_bytes(7));;
         $query = [
             'to' => $message->getPhone(),
             'text' => $message->getSubject(),

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/composer.json
@@ -18,8 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2",
-        "symfony/uid": "^5.4|^6.0"
+        "symfony/notifier": "^6.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SmsFactor\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

We are using it already here:
https://github.com/symfony/symfony/blob/f3a9a0e2f22bd67074b596493a7e94779eb356e3/src/Symfony/Component/Notifier/Bridge/Isendpro/IsendproTransport.php#L59-L61