### PR TITLE
[VarExporter] Fix calling `parent::__wakeup()` when unserializing with LazyProxyTrait

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -337,7 +337,7 @@ trait LazyProxyTrait
             PublicHydrator::hydrate($this, $data);
 
             if (Registry::$parentMethods[$class]['wakeup']) {
-                parent:__wakeup();
+                parent::__wakeup();
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | N.A
| License       | MIT
| Doc PR        | N.A

`parent:` was getting parsed as a goto label, and `__wakeup()` as a function call.

this would result in a runtime error once this code branch is reached.

ref: https://twitter.com/azjezz/status/1600870101606989824

Note: i didn't run into this at runtime, so i have no idea how to reach this code branch to test it.