### PR TITLE
[Security] Fix invalid deprecation messages in Security constants

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\ParameterBagUtils;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
 /**
@@ -37,6 +38,10 @@ use Symfony\Contracts\Service\ServiceProviderInterface;
  */
 class Security extends LegacySecurity
 {
+    public const ACCESS_DENIED_ERROR = SecurityRequestAttributes::ACCESS_DENIED_ERROR;
+    public const AUTHENTICATION_ERROR = SecurityRequestAttributes::AUTHENTICATION_ERROR;
+    public const LAST_USERNAME = SecurityRequestAttributes::LAST_USERNAME;
+
     public function __construct(private readonly ContainerInterface $container, private readonly array $authenticators = [])
     {
         parent::__construct($container, false);

--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -26,22 +26,16 @@ class Security implements AuthorizationCheckerInterface
 {
     /**
      * @deprecated since Symfony 6.2, use \Symfony\Bundle\SecurityBundle\Security::ACCESS_DENIED_ERROR instead
-     *
-     * In 7.0, move this constant to the NewSecurityHelper class and make it reference SecurityRequestAttributes::ACCESS_DENIED_ERROR.
      */
     public const ACCESS_DENIED_ERROR = '_security.403_error';
 
     /**
      * @deprecated since Symfony 6.2, use \Symfony\Bundle\SecurityBundle\Security::AUTHENTICATION_ERROR instead
-     *
-     * In 7.0, move this constant to the NewSecurityHelper class and make it reference SecurityRequestAttributes::AUTHENTICATION_ERROR.
      */
     public const AUTHENTICATION_ERROR = '_security.last_error';
 
     /**
      * @deprecated since Symfony 6.2, use \Symfony\Bundle\SecurityBundle\Security::LAST_USERNAME instead
-     *
-     * In 7.0, move this constant to the NewSecurityHelper class and make it reference SecurityRequestAttributes::LAST_USERNAME.
      */
     public const LAST_USERNAME = '_security.last_username';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR changes invalid deprecation message, suggesting to use `\Symfony\Bundle\SecurityBundle\Security::ACCESS_DENIED_ERROR` instead of `\Symfony\Component\Security\Core\Security::ACCESS_DENIED_ERROR`, while `\Symfony\Component\Security\Http\SecurityRequestAttributes::ACCESS_DENIED_ERROR` should be used.

For reference: #47760
