### PR TITLE
[ExpressionLanguage] Fix BC of cached SerializedParsedExpression containing GetAttrNode

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -149,4 +149,15 @@ class GetAttrNode extends Node
                 return [$this->nodes['node'], '[', $this->nodes['attribute'], ']'];
         }
     }
+
+    /**
+     * Provides BC with instances serialized before v6.2
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->nodes = $data['nodes'];
+        $this->attributes = $data['attributes'];
+        $this->attributes['is_null_coalesce'] ??= false;
+        $this->attributes['is_short_circuited'] ??= $data["\x00Symfony\Component\ExpressionLanguage\Node\GetAttrNode\x00isShortCircuited"] ?? false;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/48543
| License       | MIT
| Doc PR        | -

Ref https://github.com/symfony/symfony/pull/47058

`GetAttrNode` can be serialized and cached through `SerializedParsedExpression`.

@fsevestre Can you try this small patch plz?