### PR TITLE
[Notifier] Remove `ext-json` from `require` section

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.1",
-        "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.1",
-        "ext-json": "*",
         "symfony/mercure": "^0.5.2|^0.6",
         "symfony/notifier": "^6.2",
         "symfony/service-contracts": "^1.10|^2|^3"

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.1",
-        "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.1",
-        "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.1",
-        "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2"
     },

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.1",
-        "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/notifier": "^6.2",
         "symfony/polyfill-mbstring": "^1.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`ext-json` is always available in PHP 8

Not sure about the branch, this can also go into `6.0` from my POV, as we require PHP 8 even there 🤷 