### PR TITLE
[Notifier] [FakeChat] Allow missing optional dependency

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
@@ -23,9 +23,12 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2",
-        "symfony/event-dispatcher-contracts": "^2|^3",
-        "symfony/mailer": "^5.4|^6.0"
+        "symfony/notifier": "^6.2"
+    },
+    "require-dev": {
+        "symfony/mailer": "^5.4|^6.0",
+        "symfony/event-dispatcher": "^5.4|^6.0",
+        "psr/log": "^1|^2|^3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FakeChat\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      |no
| New feature?  | kind of
| Deprecations? | no
| Tickets       | see https://github.com/symfony/symfony/issues/48441
| License       | MIT

Nearly the same as in this PR: https://github.com/symfony/symfony/pull/48546

This allows the `FakeChatTransportFactory` to be used without providing an implementation of `MailerInterface` or `LoggerInterface` if one of them is actually not required during runtime.

I did not share any of the implementation now between both components. I could think of pulling out the Exception as well as Parts of the test to something like a `FakeTransportFactoryTestCase` for example. What do you think?