### PR TITLE
[Console] Fix missing command not matching namespace error message

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -298,6 +298,8 @@ class Application implements ResetInterface
 
                         return isset($event) ? $event->getExitCode() : 1;
                     }
+
+                    throw $e;
                 } catch (NamespaceNotFoundException) {
                     throw $e;
                 }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 use Symfony\Component\Console\CommandLoader\FactoryCommandLoader;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -1464,6 +1465,25 @@ class ApplicationTest extends TestCase
         } catch (\Error $e) {
             $this->assertSame('dymerr', $e->getMessage());
         }
+    }
+
+    public function testRunWithFindError()
+    {
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Find exception');
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        // Throws an exception when find fails
+        $commandLoader = $this->createMock(CommandLoaderInterface::class);
+        $commandLoader->method('getNames')->willThrowException(new \Error('Find exception'));
+        $application->setCommandLoader($commandLoader);
+
+        // The exception should not be ignored
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'foo']);
     }
 
     public function testRunAllowsErrorListenersToSilenceTheException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix for https://github.com/symfony/symfony/pull/47750
| License       | MIT
| Doc PR        | -

Following https://github.com/symfony/symfony/pull/47750, running a command with an exception not related to the console (for instance fatal error) could end up in a situation where the error handling code doesn't stop the execution flow and result in:

```
In Application.php line 307:

  [ErrorException]
  Warning: Undefined variable $command
```

This fixes this behavior by throwing the original exception when no other error handling cases could handle the problem.