### PR TITLE
[Security] Make login redirection logic available to programmatic login

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `_stateless` attribute to the request when firewall is stateless
  * Add `StatelessAuthenticatorFactoryInterface` for authenticators targeting `stateless` firewalls only and that don't require a user provider
  * Modify "icon.svg" to improve accessibility for blind/low vision users
+ * Make `Security::login()` return the authenticator response
 
 6.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -56,8 +56,10 @@ class Security extends LegacySecurity
      * @param UserInterface $user              The user to authenticate
      * @param string|null   $authenticatorName The authenticator name (e.g. "form_login") or service id (e.g. SomeApiKeyAuthenticator::class) - required only if multiple authenticators are configured
      * @param string|null   $firewallName      The firewall name - required only if multiple firewalls are configured
+     *
+     * @return Response|null The authenticator success response if any
      */
-    public function login(UserInterface $user, string $authenticatorName = null, string $firewallName = null): void
+    public function login(UserInterface $user, string $authenticatorName = null, string $firewallName = null): ?Response
     {
         $request = $this->container->get('request_stack')->getCurrentRequest();
         $firewallName ??= $this->getFirewallConfig($request)?->getName();
@@ -69,7 +71,8 @@ class Security extends LegacySecurity
         $authenticator = $this->getAuthenticator($authenticatorName, $firewallName);
 
         $this->container->get('security.user_checker')->checkPreAuth($user);
-        $this->container->get('security.user_authenticator')->authenticateUser($user, $authenticator, $request);
+
+        return $this->container->get('security.user_authenticator')->authenticateUser($user, $authenticator, $request);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        |  [17556](https://github.com/symfony/symfony-docs/pull/17556)


The `Security::login()` method [introduced in 6.2](https://github.com/symfony/symfony/pull/41274/files) returns `void`, whereas `UserAuthenticator::authenticateUser()` called under the hood returns a response which can be used to redirect the user.

This PR makes `login()` return the response from `authenticateUser()`, allowing the regular login redirection logic to be used if needed.


**Usage**

````php

use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Bundle\SecurityBundle\Security;
use Symfony\Component\HttpFoundation\Response;

class RegistrationController extends AbstractController
{    
    public function verifyUserEmail(Security $security): Response
    {

        ...

        $redirectResponse = $security->login($user);
    
        return $redirectResponse;
    }
}
````
