### PR TITLE
[TwigBundle] Alias BodyRendererInterface

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/mailer.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bridge\Twig\Mime\BodyRenderer;
 use Symfony\Component\Mailer\EventListener\MessageListener;
+use Symfony\Component\Mime\BodyRendererInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -22,5 +23,6 @@ return static function (ContainerConfigurator $container) {
 
         ->set('twig.mime_body_renderer', BodyRenderer::class)
             ->args([service('twig')])
+        ->alias(BodyRendererInterface::class, 'twig.mime_body_renderer')
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |  
| License       | MIT
| Doc PR        | 

In the [Sending Messages Async](https://symfony.com/doc/current/mailer.html#sending-messages-async) ( https://github.com/symfony/symfony-docs/commit/4fbbc16f7146d562089de5d322070aa831a3bf1b ) docs the BodyRenderer is mentioned and used in the example. But there's no alias yet, not sure if this was intentional @fabpot? But it would be nice if it works right away without the need to add the alias manually.