### PR TITLE
[HttpFoundation] Add native handlers for Memcache and Redis

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHand
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\IdentityMarshaller;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\MarshallingSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeMemcachedSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeRedisSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\SessionHandlerFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\StrictSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
@@ -72,6 +74,18 @@ return static function (ContainerConfigurator $container) {
         ->set('session.handler.native_file', StrictSessionHandler::class)
             ->args([
                 inline_service(NativeFileSessionHandler::class)
+                    ->args([param('session.save_path')]),
+            ])
+
+        ->set('session.handler.native_memcached', StrictSessionHandler::class)
+            ->args([
+                inline_service(NativeMemcachedSessionHandler::class)
+                    ->args([param('session.save_path')]),
+            ])
+
+        ->set('session.handler.native_redis', StrictSessionHandler::class)
+            ->args([
+                inline_service(NativeRedisSessionHandler::class)
                     ->args([param('session.save_path')]),
             ])
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -80,13 +80,13 @@ return static function (ContainerConfigurator $container) {
         ->set('session.handler.native_memcached', StrictSessionHandler::class)
             ->args([
                 inline_service(NativeMemcachedSessionHandler::class)
-                    ->args([param('session.save_path')]),
+                    ->args([param('session.save_path'), param('session.storage.options')]),
             ])
 
         ->set('session.handler.native_redis', StrictSessionHandler::class)
             ->args([
                 inline_service(NativeRedisSessionHandler::class)
-                    ->args([param('session.save_path')]),
+                    ->args([param('session.save_path'), param('session.storage.options')]),
             ])
 
         ->set('session.abstract_handler', AbstractSessionHandler::class)

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `NativeMemcachedSessionHandler` and `NativeRedisSessionHandler` to `Symfony\Component\HttpFoundation\Session\Storage\Handler` for native (locking) sessions in Memcache and Redis.
+ 
 6.2
 ---
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcachedSessionHandler.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
+
+/**
+ * Native session handler using php-memcached, PHP's Memcache extension (ext-memcached).
+ *
+ * @author Maurits van der Schee <maurits@vdschee.nl>
+ */
+class NativeMemcachedSessionHandler extends \SessionHandler
+{
+    /**
+     * @param string $savePath tells php-memcached where to store the sessions
+     *
+     * @see https://github.com/php-memcached-dev/php-memcached for further details.
+     */
+    public function __construct(string $savePath = null, string $sessionName = null)
+    {
+        // 
+        // Sessions support (from: https://www.php.net/manual/en/memcached.sessions.php)
+        //
+        // Memcached provides a custom session handler that can be used to store user sessions in memcache. 
+        // A completely separate memcached instance is used for that internally, so you can use a different 
+        // server pool if necessary. The session keys are stored under the prefix memc.sess.key., so be aware 
+        // of this if you use the same server pool for sessions and generic caching.
+        //
+        // - session.save_handler string
+        //   Set to memcached to enable sessions support.
+        //
+        // - session.save_path string
+        //   Defines a comma separated of hostname:port entries to use for session server 
+        //   pool, for example "sess1:11211, sess2:11211".
+        //
+
+        if (null === $savePath) {
+            $savePath = ini_get('session.save_path');
+        }
+
+        ini_set('session.save_path', $savePath);
+        ini_set('session.save_handler', 'memcached');
+
+        //
+        // Runtime Configuration (from: https://www.php.net/manual/en/memcached.configuration.php)
+        // 
+        // Here's a short explanation of the configuration directives.
+        // 
+        // - memcached.sess_locking bool
+        //   Use session locking. Valid values: On, Off, the default is On.
+        // 
+        // - memcached.sess_lock_wait int
+        //   Session spin lock retry wait time in microseconds. Be careful when setting this value. 
+        //   Valid values are integers, where 0 is interpreted as the default value. Negative values 
+        //   result in a reduces locking to a try lock. The default is 150000.
+        //
+        // - memcached.sess_prefix string
+        //   Memcached session key prefix. Valid values are strings less than 219 bytes long. 
+        //   The default value is "memc.sess.key."
+        // 
+        // - memcached.sess_lock_expire int
+        //   The time, in seconds, before a lock should release itself. Setting to 0 results in the 
+        //   default behaviour, which is to use PHP's max_execution_time. Default is 0.
+        // 
+        // - memcached.sess_lock_retries int
+        //   The number of times to retry locking the session lock, not including the first attempt. 
+        //   Default is 5.
+        // 
+        // - memcached.sess_lock_wait_max int
+        //   The maximum time, in milliseconds, to wait between session lock attempts. The default is 150.
+        // 
+        // - memcached.sess_lock_wait_min int
+        //   The minimum time, in milliseconds, to wait between session lock attempts. This value is 
+        //   double on each lock retry until memcached.sess_lock_wait_max is reached, after which any 
+        //   further retries will take sess_lock_wait_max seconds. The default is 150.
+        //
+
+        if (null === $sessionName) {
+            $sessionName = ini_get('session.name');
+        }
+
+        $prefix = "memc.sess.key.$sessionName.";
+        $lock_expire = ini_get("max_execution_time") ?: 30; // 30s
+        $lock_wait_time = ini_get('memcached.sess_lock_wait_min') ?: 150; // 150ms
+        $lock_retries = (int) ($lock_expire / ($lock_wait_time / 1000)); // 200x
+
+        ini_set('memcached.sess_locking', 1);
+        ini_set('memcached.sess_prefix', $prefix);
+        ini_set('memcached.sess_lock_expire', $lock_expire);
+        ini_set('memcached.sess_lock_wait', $lock_wait_time * 1000);
+        ini_set('memcached.sess_lock_wait_min', $lock_wait_time);
+        ini_set('memcached.sess_lock_wait_max', $lock_wait_time);
+        ini_set('memcached.sess_lock_retries', $lock_retries);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcachedSessionHandler.php
@@ -23,7 +23,7 @@ class NativeMemcachedSessionHandler extends \SessionHandler
      *
      * @see https://github.com/php-memcached-dev/php-memcached for further details.
      */
-    public function __construct(string $savePath = null, string $sessionName = null)
+    public function __construct(string $savePath = null, array $sessionOptions = null)
     {
         // 
         // Sessions support (from: https://www.php.net/manual/en/memcached.sessions.php)
@@ -41,9 +41,7 @@ class NativeMemcachedSessionHandler extends \SessionHandler
         //   pool, for example "sess1:11211, sess2:11211".
         //
 
-        if (null === $savePath) {
-            $savePath = ini_get('session.save_path');
-        }
+        $savePath ??= ini_get('session.save_path');
 
         ini_set('session.save_path', $savePath);
         ini_set('session.save_handler', 'memcached');
@@ -56,11 +54,6 @@ class NativeMemcachedSessionHandler extends \SessionHandler
         // - memcached.sess_locking bool
         //   Use session locking. Valid values: On, Off, the default is On.
         // 
-        // - memcached.sess_lock_wait int
-        //   Session spin lock retry wait time in microseconds. Be careful when setting this value. 
-        //   Valid values are integers, where 0 is interpreted as the default value. Negative values 
-        //   result in a reduces locking to a try lock. The default is 150000.
-        //
         // - memcached.sess_prefix string
         //   Memcached session key prefix. Valid values are strings less than 219 bytes long. 
         //   The default value is "memc.sess.key."
@@ -73,18 +66,13 @@ class NativeMemcachedSessionHandler extends \SessionHandler
         //   The number of times to retry locking the session lock, not including the first attempt. 
         //   Default is 5.
         // 
-        // - memcached.sess_lock_wait_max int
-        //   The maximum time, in milliseconds, to wait between session lock attempts. The default is 150.
-        // 
         // - memcached.sess_lock_wait_min int
         //   The minimum time, in milliseconds, to wait between session lock attempts. This value is 
         //   double on each lock retry until memcached.sess_lock_wait_max is reached, after which any 
         //   further retries will take sess_lock_wait_max seconds. The default is 150.
         //
 
-        if (null === $sessionName) {
-            $sessionName = ini_get('session.name');
-        }
+        $sessionName = $sessionOptions['name'] ?? ini_get('session.name');
 
         $prefix = "memc.sess.key.$sessionName.";
         $lock_expire = ini_get("max_execution_time") ?: 30; // 30s
@@ -94,9 +82,7 @@ class NativeMemcachedSessionHandler extends \SessionHandler
         ini_set('memcached.sess_locking', 1);
         ini_set('memcached.sess_prefix', $prefix);
         ini_set('memcached.sess_lock_expire', $lock_expire);
-        ini_set('memcached.sess_lock_wait', $lock_wait_time * 1000);
         ini_set('memcached.sess_lock_wait_min', $lock_wait_time);
-        ini_set('memcached.sess_lock_wait_max', $lock_wait_time);
         ini_set('memcached.sess_lock_retries', $lock_retries);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcachedSessionHandler.php
@@ -25,58 +25,58 @@ class NativeMemcachedSessionHandler extends \SessionHandler
      */
     public function __construct(string $savePath = null, array $sessionOptions = null)
     {
-        // 
+        //
         // Sessions support (from: https://www.php.net/manual/en/memcached.sessions.php)
         //
-        // Memcached provides a custom session handler that can be used to store user sessions in memcache. 
-        // A completely separate memcached instance is used for that internally, so you can use a different 
-        // server pool if necessary. The session keys are stored under the prefix memc.sess.key., so be aware 
+        // Memcached provides a custom session handler that can be used to store user sessions in memcache.
+        // A completely separate memcached instance is used for that internally, so you can use a different
+        // server pool if necessary. The session keys are stored under the prefix memc.sess.key., so be aware
         // of this if you use the same server pool for sessions and generic caching.
         //
         // - session.save_handler string
         //   Set to memcached to enable sessions support.
         //
         // - session.save_path string
-        //   Defines a comma separated of hostname:port entries to use for session server 
+        //   Defines a comma separated of hostname:port entries to use for session server
         //   pool, for example "sess1:11211, sess2:11211".
         //
 
-        $savePath ??= ini_get('session.save_path');
+        $savePath ??= \ini_get('session.save_path');
 
         ini_set('session.save_path', $savePath);
         ini_set('session.save_handler', 'memcached');
 
         //
         // Runtime Configuration (from: https://www.php.net/manual/en/memcached.configuration.php)
-        // 
+        //
         // Here's a short explanation of the configuration directives.
-        // 
+        //
         // - memcached.sess_locking bool
         //   Use session locking. Valid values: On, Off, the default is On.
-        // 
+        //
         // - memcached.sess_prefix string
-        //   Memcached session key prefix. Valid values are strings less than 219 bytes long. 
+        //   Memcached session key prefix. Valid values are strings less than 219 bytes long.
         //   The default value is "memc.sess.key."
-        // 
+        //
         // - memcached.sess_lock_expire int
-        //   The time, in seconds, before a lock should release itself. Setting to 0 results in the 
+        //   The time, in seconds, before a lock should release itself. Setting to 0 results in the
         //   default behaviour, which is to use PHP's max_execution_time. Default is 0.
-        // 
+        //
         // - memcached.sess_lock_retries int
-        //   The number of times to retry locking the session lock, not including the first attempt. 
+        //   The number of times to retry locking the session lock, not including the first attempt.
         //   Default is 5.
-        // 
+        //
         // - memcached.sess_lock_wait_min int
-        //   The minimum time, in milliseconds, to wait between session lock attempts. This value is 
-        //   double on each lock retry until memcached.sess_lock_wait_max is reached, after which any 
+        //   The minimum time, in milliseconds, to wait between session lock attempts. This value is
+        //   double on each lock retry until memcached.sess_lock_wait_max is reached, after which any
         //   further retries will take sess_lock_wait_max seconds. The default is 150.
         //
 
-        $sessionName = $sessionOptions['name'] ?? ini_get('session.name');
+        $sessionName = $sessionOptions['name'] ?? \ini_get('session.name');
 
         $prefix = "memc.sess.key.$sessionName.";
-        $lock_expire = ini_get("max_execution_time") ?: 30; // 30s
-        $lock_wait_time = ini_get('memcached.sess_lock_wait_min') ?: 150; // 150ms
+        $lock_expire = \ini_get('max_execution_time') ?: 30; // 30s
+        $lock_wait_time = \ini_get('memcached.sess_lock_wait_min') ?: 150; // 150ms
         $lock_retries = (int) ($lock_expire / ($lock_wait_time / 1000)); // 200x
 
         ini_set('memcached.sess_locking', 1);

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeRedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeRedisSessionHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
+
+/**
+ * Native session handler using PhpRedis, PHP's Redis extension (ext-redis).
+ *
+ * @author Maurits van der Schee <maurits@vdschee.nl>
+ */
+class NativeRedisSessionHandler extends \SessionHandler
+{
+    /**
+     * @param string $savePath tells PhpRedis where to store the sessions
+     *
+     * @see https://github.com/phpredis/phpredis#php-session-handler for further details.
+     */
+    public function __construct(string $savePath = null, string $sessionName = null)
+    {
+        // 
+        // PHP Session handler (from: https://github.com/phpredis/phpredis#php-session-handler)
+        //
+        // phpredis can be used to store PHP sessions. To do this, configure session.save_handler and session.save_path
+        // in your php.ini to tell phpredis where to store the sessions:
+        //
+        // session.save_handler = redis
+        // session.save_path = "tcp://host1:6379?weight=1, tcp://host2:6379?weight=2&timeout=2.5, tcp://host3:6379?weight=2&read_timeout=2.5"
+        //
+        // session.save_path can have a simple host:port format too, but you need to provide the tcp:// scheme if 
+        // you want to use the parameters. The following parameters are available:
+        //
+        // - weight (integer): the weight of a host is used in comparison with the others in order to 
+        //   customize the session distribution on several hosts. If host A has twice the weight of host B,
+        //   it will get twice the amount of sessions. In the example, host1 stores 20% of all the 
+        //   sessions (1/(1+2+2)) while host2 and host3 each store 40% (2/(1+2+2)). The target host is 
+        //   determined once and for all at the start of the session, and doesn't change. The default weight is 1.
+        // - timeout (float): the connection timeout to a redis host, expressed in seconds. 
+        //   If the host is unreachable in that amount of time, the session storage will be unavailable for the client. 
+        //   The default timeout is very high (86400 seconds).
+        // - persistent (integer, should be 1 or 0): defines if a persistent connection should be used.
+        // - prefix (string, defaults to "PHPREDIS_SESSION:"): used as a prefix to the Redis key in which the session is stored. 
+        //   The key is composed of the prefix followed by the session ID.
+        // - auth (string, or an array with one or two elements): used to authenticate with the server prior to sending commands.
+        // - database (integer): selects a different database.
+        //
+        // Sessions have a lifetime expressed in seconds and stored in the INI variable "session.gc_maxlifetime". 
+        // You can change it with ini_set(). The session handler requires a version of Redis supporting EX and NX 
+        // options of SET command (at least 2.6.12). phpredis can also connect to a unix domain socket: 
+        // session.save_path = "unix:///var/run/redis/redis.sock?persistent=1&weight=1&database=0"
+        //
+
+        if (null === $savePath) {
+            $savePath = ini_get('session.save_path');
+        }
+        if (null === $sessionName) {
+            $sessionName = ini_get('session.name');
+        }
+
+        $query = parse_url($savePath, PHP_URL_QUERY);
+        parse_str($query, $arguments);
+        if (!isset($arguments['prefix'])) {
+            $arguments['prefix'] = "PHPREDIS_SESSION:$sessionName:";
+        }
+        $query = http_build_query($arguments);
+
+        ini_set('session.save_path', $savePath);
+        ini_set('session.save_handler', 'redis');
+
+        //
+        // Session locking (from: https://github.com/phpredis/phpredis#session-locking)
+        // 
+        // Support: Locking feature is currently only supported for Redis setup with single master instance
+        // (e.g. classic master/slave Sentinel environment). 
+        // So locking may not work properly in RedisArray or RedisCluster environments.
+        // 
+        // Following INI variables can be used to configure session locking:
+        //
+        //; Should the locking be enabled? Defaults to: 0.
+        //redis.session.locking_enabled = 1
+        //; How long should the lock live (in seconds)? Defaults to: value of max_execution_time (defaults to 30).
+        //redis.session.lock_expire = 60
+        //; How long to wait between attempts to acquire lock, in microseconds (µs)?. Defaults to: 20000
+        //redis.session.lock_wait_time = 100000
+        //; Maximum number of times to retry (-1 means infinite). Defaults to: 100
+        //redis.session.lock_retries = 300
+        //
+
+        $lock_expire = (ini_get("redis.session.lock_expire") ?: ini_get("max_execution_time")) ?: 30; // 30s
+        $lock_wait_time = (ini_get("redis.session.lock_wait_time") ?: 20000); // 20ms
+        $lock_retries = (int) ($lock_expire / ($lock_wait_time / 1000000)); // 1500x
+
+        ini_set('redis.session.locking_enabled', 1);
+        ini_set('redis.session.lock_expire', $lock_expire);
+        ini_set('redis.session.lock_wait_time', $lock_wait_time);
+        ini_set('redis.session.lock_retries', $lock_retries);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeRedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeRedisSessionHandler.php
@@ -25,7 +25,7 @@ class NativeRedisSessionHandler extends \SessionHandler
      */
     public function __construct(string $savePath = null, array $sessionOptions = null)
     {
-        // 
+        //
         // PHP Session handler (from: https://github.com/phpredis/phpredis#php-session-handler)
         //
         // phpredis can be used to store PHP sessions. To do this, configure session.save_handler and session.save_path
@@ -34,31 +34,31 @@ class NativeRedisSessionHandler extends \SessionHandler
         // session.save_handler = redis
         // session.save_path = "tcp://host1:6379?weight=1, tcp://host2:6379?weight=2&timeout=2.5, tcp://host3:6379?weight=2&read_timeout=2.5"
         //
-        // session.save_path can have a simple host:port format too, but you need to provide the tcp:// scheme if 
+        // session.save_path can have a simple host:port format too, but you need to provide the tcp:// scheme if
         // you want to use the parameters. The following parameters are available:
         //
-        // - weight (integer): the weight of a host is used in comparison with the others in order to 
+        // - weight (integer): the weight of a host is used in comparison with the others in order to
         //   customize the session distribution on several hosts. If host A has twice the weight of host B,
-        //   it will get twice the amount of sessions. In the example, host1 stores 20% of all the 
-        //   sessions (1/(1+2+2)) while host2 and host3 each store 40% (2/(1+2+2)). The target host is 
+        //   it will get twice the amount of sessions. In the example, host1 stores 20% of all the
+        //   sessions (1/(1+2+2)) while host2 and host3 each store 40% (2/(1+2+2)). The target host is
         //   determined once and for all at the start of the session, and doesn't change. The default weight is 1.
-        // - timeout (float): the connection timeout to a redis host, expressed in seconds. 
-        //   If the host is unreachable in that amount of time, the session storage will be unavailable for the client. 
+        // - timeout (float): the connection timeout to a redis host, expressed in seconds.
+        //   If the host is unreachable in that amount of time, the session storage will be unavailable for the client.
         //   The default timeout is very high (86400 seconds).
         // - persistent (integer, should be 1 or 0): defines if a persistent connection should be used.
-        // - prefix (string, defaults to "PHPREDIS_SESSION:"): used as a prefix to the Redis key in which the session is stored. 
+        // - prefix (string, defaults to "PHPREDIS_SESSION:"): used as a prefix to the Redis key in which the session is stored.
         //   The key is composed of the prefix followed by the session ID.
         // - auth (string, or an array with one or two elements): used to authenticate with the server prior to sending commands.
         // - database (integer): selects a different database.
         //
-        // Sessions have a lifetime expressed in seconds and stored in the INI variable "session.gc_maxlifetime". 
-        // You can change it with ini_set(). The session handler requires a version of Redis supporting EX and NX 
-        // options of SET command (at least 2.6.12). phpredis can also connect to a unix domain socket: 
+        // Sessions have a lifetime expressed in seconds and stored in the INI variable "session.gc_maxlifetime".
+        // You can change it with ini_set(). The session handler requires a version of Redis supporting EX and NX
+        // options of SET command (at least 2.6.12). phpredis can also connect to a unix domain socket:
         // session.save_path = "unix:///var/run/redis/redis.sock?persistent=1&weight=1&database=0"
         //
 
-        $savePath ??= ini_get('session.save_path');
-        $sessionName = $sessionOptions['name'] ?? ini_get('session.name');
+        $savePath ??= \ini_get('session.save_path');
+        $sessionName = $sessionOptions['name'] ?? \ini_get('session.name');
 
         $savePathParts = explode('?', $savePath, 2);
         parse_str($savePathParts[1] ?? '', $arguments);
@@ -72,25 +72,25 @@ class NativeRedisSessionHandler extends \SessionHandler
 
         //
         // Session locking (from: https://github.com/phpredis/phpredis#session-locking)
-        // 
+        //
         // Support: Locking feature is currently only supported for Redis setup with single master instance
-        // (e.g. classic master/slave Sentinel environment). 
+        // (e.g. classic master/slave Sentinel environment).
         // So locking may not work properly in RedisArray or RedisCluster environments.
-        // 
+        //
         // Following INI variables can be used to configure session locking:
         //
-        //; Should the locking be enabled? Defaults to: 0.
-        //redis.session.locking_enabled = 1
-        //; How long should the lock live (in seconds)? Defaults to: value of max_execution_time (defaults to 30).
-        //redis.session.lock_expire = 60
-        //; How long to wait between attempts to acquire lock, in microseconds (µs)?. Defaults to: 20000
-        //redis.session.lock_wait_time = 100000
-        //; Maximum number of times to retry (-1 means infinite). Defaults to: 100
-        //redis.session.lock_retries = 300
+        // ; Should the locking be enabled? Defaults to: 0.
+        // redis.session.locking_enabled = 1
+        // ; How long should the lock live (in seconds)? Defaults to: value of max_execution_time (defaults to 30).
+        // redis.session.lock_expire = 60
+        // ; How long to wait between attempts to acquire lock, in microseconds (µs)?. Defaults to: 20000
+        // redis.session.lock_wait_time = 100000
+        // ; Maximum number of times to retry (-1 means infinite). Defaults to: 100
+        // redis.session.lock_retries = 300
         //
 
-        $lock_expire = (ini_get("redis.session.lock_expire") ?: ini_get("max_execution_time")) ?: 30; // 30s
-        $lock_wait_time = (ini_get("redis.session.lock_wait_time") ?: 20000); // 20ms
+        $lock_expire = (\ini_get('redis.session.lock_expire') ?: \ini_get('max_execution_time')) ?: 30; // 30s
+        $lock_wait_time = (\ini_get('redis.session.lock_wait_time') ?: 20000); // 20ms
         $lock_retries = (int) ($lock_expire / ($lock_wait_time / 1000000)); // 1500x
 
         ini_set('redis.session.locking_enabled', 1);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeMemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeMemcachedSessionHandlerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
  * @author Maurits van der Schee <maurits@vdschee.nl>
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
  */
 class NativeMemcachedSessionHandlerTest extends TestCase
@@ -35,9 +36,9 @@ class NativeMemcachedSessionHandlerTest extends TestCase
 
         new NativeSessionStorage($sessionOptions, new NativeMemcachedSessionHandler($savePath, $sessionOptions));
 
-        $this->assertEquals($expectedSessionName, ini_get('session.name'));
-        $this->assertEquals($expectedSavePath, ini_get('session.save_path'));
-        $this->assertTrue((bool) ini_get('memcached.sess_locking'));
+        $this->assertEquals($expectedSessionName, \ini_get('session.name'));
+        $this->assertEquals($expectedSavePath, \ini_get('session.save_path'));
+        $this->assertTrue((bool) \ini_get('memcached.sess_locking'));
     }
 
     public function savePathDataProvider()
@@ -56,8 +57,8 @@ class NativeMemcachedSessionHandlerTest extends TestCase
 
         new NativeSessionStorage([], new NativeMemcachedSessionHandler());
 
-        $this->assertEquals('localhost:11211', ini_get('session.save_path'));
-        $this->assertEquals('TESTING', ini_get('session.name'));
-        $this->assertTrue((bool) ini_get('memcached.sess_locking'));
+        $this->assertEquals('localhost:11211', \ini_get('session.save_path'));
+        $this->assertEquals('TESTING', \ini_get('session.name'));
+        $this->assertTrue((bool) \ini_get('memcached.sess_locking'));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeMemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeMemcachedSessionHandlerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeMemcachedSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+
+/**
+ * Test class for NativeMemcachedSessionHandler.
+ *
+ * @author Maurits van der Schee <maurits@vdschee.nl>
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class NativeMemcachedSessionHandlerTest extends TestCase
+{
+    /**
+     * @dataProvider savePathDataProvider
+     */
+    public function testConstruct(string $savePath, array $sessionOptions, string $expectedSavePath, string $expectedSessionName)
+    {
+        ini_set('session.save_path', '/var/lib/php/sessions');
+        ini_set('session.name', 'PHPSESSID');
+
+        new NativeSessionStorage($sessionOptions, new NativeMemcachedSessionHandler($savePath, $sessionOptions));
+
+        $this->assertEquals($expectedSessionName, ini_get('session.name'));
+        $this->assertEquals($expectedSavePath, ini_get('session.save_path'));
+        $this->assertTrue((bool) ini_get('memcached.sess_locking'));
+    }
+
+    public function savePathDataProvider()
+    {
+        return [
+            ['localhost:11211', ['name' => 'TESTING'], 'localhost:11211', 'TESTING'],
+            ['', ['name' => 'TESTING'], '', 'TESTING'],
+            ['', [], '', 'PHPSESSID'],
+        ];
+    }
+
+    public function testConstructDefault()
+    {
+        ini_set('session.save_path', 'localhost:11211');
+        ini_set('session.name', 'TESTING');
+
+        new NativeSessionStorage([], new NativeMemcachedSessionHandler());
+
+        $this->assertEquals('localhost:11211', ini_get('session.save_path'));
+        $this->assertEquals('TESTING', ini_get('session.name'));
+        $this->assertTrue((bool) ini_get('memcached.sess_locking'));
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeRedisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeRedisSessionHandlerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
  * @author Maurits van der Schee <maurits@vdschee.nl>
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
  */
 class NativeRedisSessionHandlerTest extends TestCase
@@ -35,9 +36,9 @@ class NativeRedisSessionHandlerTest extends TestCase
 
         new NativeSessionStorage($sessionOptions, new NativeRedisSessionHandler($savePath, $sessionOptions));
 
-        $this->assertEquals($expectedSessionName, ini_get('session.name'));
-        $this->assertEquals($expectedSavePath, ini_get('session.save_path'));
-        $this->assertTrue((bool) ini_get('redis.session.locking_enabled'));
+        $this->assertEquals($expectedSessionName, \ini_get('session.name'));
+        $this->assertEquals($expectedSavePath, \ini_get('session.save_path'));
+        $this->assertTrue((bool) \ini_get('redis.session.locking_enabled'));
     }
 
     public function savePathDataProvider()
@@ -57,8 +58,8 @@ class NativeRedisSessionHandlerTest extends TestCase
 
         new NativeSessionStorage([], new NativeRedisSessionHandler());
 
-        $this->assertEquals('tcp://localhost:6379?prefix=PHPREDIS_SESSION.TESTING.', ini_get('session.save_path'));
-        $this->assertEquals('TESTING', ini_get('session.name'));
-        $this->assertTrue((bool) ini_get('redis.session.locking_enabled'));
+        $this->assertEquals('tcp://localhost:6379?prefix=PHPREDIS_SESSION.TESTING.', \ini_get('session.save_path'));
+        $this->assertEquals('TESTING', \ini_get('session.name'));
+        $this->assertTrue((bool) \ini_get('redis.session.locking_enabled'));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeRedisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeRedisSessionHandlerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeRedisSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+
+/**
+ * Test class for NativeRedisSessionHandler.
+ *
+ * @author Maurits van der Schee <maurits@vdschee.nl>
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class NativeRedisSessionHandlerTest extends TestCase
+{
+    /**
+     * @dataProvider savePathDataProvider
+     */
+    public function testConstruct(string $savePath, array $sessionOptions, string $expectedSavePath, string $expectedSessionName)
+    {
+        ini_set('session.save_path', '/var/lib/php/sessions');
+        ini_set('session.name', 'PHPSESSID');
+
+        new NativeSessionStorage($sessionOptions, new NativeRedisSessionHandler($savePath, $sessionOptions));
+
+        $this->assertEquals($expectedSessionName, ini_get('session.name'));
+        $this->assertEquals($expectedSavePath, ini_get('session.save_path'));
+        $this->assertTrue((bool) ini_get('redis.session.locking_enabled'));
+    }
+
+    public function savePathDataProvider()
+    {
+        return [
+            ['tcp://localhost:6379', [], 'tcp://localhost:6379?prefix=PHPREDIS_SESSION.PHPSESSID.', 'PHPSESSID'],
+            ['tcp://localhost:6379', ['name' => 'TESTING'], 'tcp://localhost:6379?prefix=PHPREDIS_SESSION.TESTING.', 'TESTING'],
+            ['tcp://localhost:6379?prefix=CUSTOM.', ['name' => 'TESTING'], 'tcp://localhost:6379?prefix=CUSTOM.', 'TESTING'],
+            ['tcp://localhost:6379?prefix=CUSTOM.&prefix=CUSTOM2.', ['name' => 'TESTING'], 'tcp://localhost:6379?prefix=CUSTOM2.', 'TESTING'],
+        ];
+    }
+
+    public function testConstructDefault()
+    {
+        ini_set('session.save_path', 'tcp://localhost:6379');
+        ini_set('session.name', 'TESTING');
+
+        new NativeSessionStorage([], new NativeRedisSessionHandler());
+
+        $this->assertEquals('tcp://localhost:6379?prefix=PHPREDIS_SESSION.TESTING.', ini_get('session.save_path'));
+        $this->assertEquals('TESTING', ini_get('session.name'));
+        $this->assertTrue((bool) ini_get('redis.session.locking_enabled'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #4976 
| License       | MIT
| Doc PR        | symfony/symfony-docs#17550

As discussed in ticket #4976 Symfony does not provide Session locking. See also this test suite:

https://github.com/mevdschee/symfony-session-tests

While the documentation does mention race conditions it does not provide a solution. It also fails to mention that the phpredis extension also does not lock by default and that you need to set `redis.session.locking_enabled = 1`.

To provide a simple and performant solution for session locking I implemented the "native" session handlers for Memcache and Redis.

Some concurrency tests are here: https://github.com/mintyphp/session-handlers