### PR TITLE
[DependencyInjection] Shared private services becomes public after a public service is accessed

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ReverseContainer.php
+++ b/src/Symfony/Component/DependencyInjection/ReverseContainer.php
@@ -63,10 +63,6 @@ final class ReverseContainer
      */
     public function getService(string $id): object
     {
-        if ($this->serviceContainer->has($id)) {
-            return $this->serviceContainer->get($id);
-        }
-
         if ($this->reversibleLocator->has($id)) {
             return $this->reversibleLocator->get($id);
         }
@@ -75,7 +71,6 @@ final class ReverseContainer
             throw new ServiceNotFoundException($id, null, null, [], sprintf('The "%s" service is private and cannot be accessed by reference. You should either make it public, or tag it as "%s".', $id, $this->tagName));
         }
 
-        // will throw a ServiceNotFoundException
-        $this->serviceContainer->get($id);
+        return $this->serviceContainer->get($id);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1105,10 +1105,19 @@ class ContainerBuilderTest extends TestCase
         $container->addDefinitions([
             'bar' => $fooDefinition,
             'bar_user' => $fooUserDefinition->setPublic(true),
+            'bar_user2' => $fooUserDefinition->setPublic(true),
         ]);
 
         $container->compile();
+        $this->assertNull($container->get('bar', $container::NULL_ON_INVALID_REFERENCE));
         $this->assertInstanceOf(\BarClass::class, $container->get('bar_user')->bar);
+
+        // Ensure that accessing a public service with a shared private service
+        // does not make the private service available.
+        $this->assertNull($container->get('bar', $container::NULL_ON_INVALID_REFERENCE));
+
+        // Ensure the private service is still shared.
+        $this->assertSame($container->get('bar_user')->bar, $container->get('bar_user2')->bar);
     }
 
     public function testThrowsExceptionWhenSetServiceOnACompiledContainer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | N/a <!-- required for new features -->
<!--

If a private service is an argument to at least two other services and one of those services is public. If the public service is accessed via container::get() then the private service becomes available via container::get() afterwards.