### PR TITLE
[SecurityBundle] Improve support for authenticators that don't need a user provider

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate enabling bundle and not configuring it
  * Add `_stateless` attribute to the request when firewall is stateless
+ * Add `StatelessAuthenticatorFactoryInterface` for authenticators targeting `stateless` firewalls only and that don't require a user provider
 
 6.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @internal
  */
-final class AccessTokenFactory extends AbstractFactory
+final class AccessTokenFactory extends AbstractFactory implements StatelessAuthenticatorFactoryInterface
 {
     private const PRIORITY = -40;
 
@@ -67,7 +67,7 @@ final class AccessTokenFactory extends AbstractFactory
         return 'access_token';
     }
 
-    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): string
+    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, ?string $userProviderId): string
     {
         $successHandler = isset($config['success_handler']) ? new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config)) : null;
         $failureHandler = isset($config['failure_handler']) ? new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config)) : null;
@@ -78,7 +78,7 @@ final class AccessTokenFactory extends AbstractFactory
             ->setDefinition($authenticatorId, new ChildDefinition('security.authenticator.access_token'))
             ->replaceArgument(0, new Reference($config['token_handler']))
             ->replaceArgument(1, new Reference($extractorId))
-            ->replaceArgument(2, new Reference($userProviderId))
+            ->replaceArgument(2, $userProviderId ? new Reference($userProviderId) : null)
             ->replaceArgument(3, $successHandler)
             ->replaceArgument(4, $failureHandler)
             ->replaceArgument(5, $config['realm'])

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/StatelessAuthenticatorFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/StatelessAuthenticatorFactoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Stateless authenticators are authenticators that can work without a user provider.
+ *
+ * This situation can only occur in stateless firewalls, as statefull firewalls
+ * need the user provider to refresh the user in each subsequent request. A
+ * stateless authenticator can be used on both stateless and statefull authenticators.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+interface StatelessAuthenticatorFactoryInterface extends AuthenticatorFactoryInterface
+{
+    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, ?string $userProviderId): string|array;
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
@@ -315,4 +315,16 @@ class AccessTokenTest extends AbstractWebTestCase
     {
         yield ['/foo?protection_token=INVALID_ACCESS_TOKEN'];
     }
+
+    public function testSelfContainedTokens()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_self_contained_token.yml']);
+        $client->catchExceptions(false);
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer SELF_CONTAINED_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['message' => 'Welcome @dunglas!'], json_decode($response->getContent(), true));
+    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/AccessTokenHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/AccessTokenHandler.php
@@ -12,19 +12,17 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler;
 
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 class AccessTokenHandler implements AccessTokenHandlerInterface
 {
-    public function __construct()
-    {
-    }
-
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
         return match ($accessToken) {
             'VALID_ACCESS_TOKEN' => new UserBadge('dunglas'),
+            'SELF_CONTAINED_ACCESS_TOKEN' => new UserBadge('dunglas', fn () => new InMemoryUser('dunglas', null, ['ROLE_USER'])),
             default => throw new BadCredentialsException('Invalid credentials.'),
         };
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_self_contained_token.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_self_contained_token.yml
@@ -1,0 +1,26 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+framework:
+    http_method_override: false
+    serializer: ~
+
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    firewalls:
+        main:
+            pattern: ^/
+            stateless: true
+            access_token:
+                token_handler: access_token.access_token_handler
+                token_extractors: 'header'
+                realm: 'My API'
+
+    access_control:
+        - { path: ^/foo, roles: ROLE_USER }
+
+services:
+    access_token.access_token_handler:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\AccessTokenHandler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Ref #48285, #48272
| License       | MIT
| Doc PR        | -

This builds on top of the self-contained token feature added in 6.2 (#48285). While that PR allows access token handlers to load the user from the access token without user provider, it was still required to configure a user provider in the code.

With this PR, the bundle allows a user provider to not be configured when:

1. The firewall is `stateless`, otherwise we still need the user provider to refresh the user
2. The authenticator factory implements `StatelessAuthenticatorFactoryInterface` (i.e. declares compatibility with no user provider)

This can help with simplifying the code in https://github.com/symfony/symfony/pull/48272#discussion_r1043638818 , as we no longer have to define a special user badge and provider.

cc @Jeroeny 