### PR TITLE
[Contracts] Fix typo "internal" / "interval"

### DIFF
--- a/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
+++ b/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
@@ -140,7 +140,7 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider getInternal
+     * @dataProvider getInterval
      */
     public function testInterval($expected, $number, $interval)
     {
@@ -149,7 +149,7 @@ class TranslatorTest extends TestCase
         $this->assertEquals($expected, $translator->trans($interval.' foo|[1,Inf[ bar', ['%count%' => $number]));
     }
 
-    public function getInternal()
+    public function getInterval()
     {
         return [
             ['foo', 3, '{1,2, 3 ,4}'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A


Rename `getInternal` to `getInterval` in Translator tests.