### PR TITLE
[SecurityBundle] Fix authenticator existence check in `Security::login()`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -116,7 +116,7 @@ class Security extends LegacySecurity
 
     private function getAuthenticator(?string $authenticatorName, string $firewallName): AuthenticatorInterface
     {
-        if (!\array_key_exists($firewallName, $this->authenticators)) {
+        if (!isset($this->authenticators[$firewallName])) {
             throw new LogicException(sprintf('No authenticators found for firewall "%s".', $firewallName));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48595 
| License       | MIT
| Doc PR        | -
