### PR TITLE
[HtmlSanitizer] Fix HtmlSanitizer default configuration behavior for allowed schemes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2738,10 +2738,14 @@ class FrameworkExtension extends Extension
 
             // Settings
             $def->addMethodCall('forceHttpsUrls', [$sanitizerConfig['force_https_urls']], true);
-            $def->addMethodCall('allowLinkSchemes', [$sanitizerConfig['allowed_link_schemes']], true);
+            if ($sanitizerConfig['allowed_link_schemes']) {
+                $def->addMethodCall('allowLinkSchemes', [$sanitizerConfig['allowed_link_schemes']], true);
+            }
             $def->addMethodCall('allowLinkHosts', [$sanitizerConfig['allowed_link_hosts']], true);
             $def->addMethodCall('allowRelativeLinks', [$sanitizerConfig['allow_relative_links']], true);
-            $def->addMethodCall('allowMediaSchemes', [$sanitizerConfig['allowed_media_schemes']], true);
+            if ($sanitizerConfig['allowed_media_schemes']) {
+                $def->addMethodCall('allowMediaSchemes', [$sanitizerConfig['allowed_media_schemes']], true);
+            }
             $def->addMethodCall('allowMediaHosts', [$sanitizerConfig['allowed_media_hosts']], true);
             $def->addMethodCall('allowRelativeMedias', [$sanitizerConfig['allow_relative_medias']], true);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -2140,7 +2140,9 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $calls = $container->getDefinition('html_sanitizer.config.custom_default')->getMethodCalls();
         $this->assertContains(['allowLinkHosts', [null], true], $calls);
+        $this->assertContains(['allowRelativeLinks', [false], true], $calls);
         $this->assertContains(['allowMediaHosts', [null], true], $calls);
+        $this->assertContains(['allowRelativeMedias', [false], true], $calls);
     }
 
     public function testHtmlSanitizerDefaultConfig()

--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
@@ -46,6 +46,33 @@ class UrlSanitizerTest extends TestCase
         ];
 
         yield [
+            'input' => 'http://trusted.com/link.php',
+            'allowedSchemes' => null,
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'output' => 'http://trusted.com/link.php',
+        ];
+
+        yield [
+            'input' => 'https://trusted.com/link.php',
+            'allowedSchemes' => null,
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'output' => 'https://trusted.com/link.php',
+        ];
+
+        yield [
+            'input' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+            'allowedSchemes' => null,
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'output' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+        ];
+
+        yield [
             'input' => 'https://trusted.com/link.php',
             'allowedSchemes' => ['https'],
             'allowedHosts' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/48556
| License       | MIT
| Doc PR        | -

This issue happened not in the component but in the default configuration behavior (array was passed instead of null).