### PR TITLE
container:debug CLI output improvements for excluded services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -308,6 +308,9 @@ EOF
             if (!$showHidden && str_starts_with($serviceId, '.')) {
                 continue;
             }
+            if (!$showHidden && $builder->hasDefinition($serviceId) && $builder->getDefinition($serviceId)->hasTag('container.excluded')) {
+                continue;
+            }
             if (false !== stripos(str_replace('\\', '', $serviceId), $name)) {
                 $foundServiceIdsIgnoringBackslashes[] = $serviceId;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes (not sure)
| Deprecations? | no
| Tickets       | —
| License       | MIT
| Doc PR        | —
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Normally I test whether the exclusion rules from the service container of my bundles work correctly by just using the `debug:container` command and looking whether my excluded services occur in the last.
However, due to the latest changes in https://github.com/symfony/symfony/pull/46279 all services (excluded or not) are always in this list.

You need to open the definition to see if it was excluded:

![CleanShot 2022-12-12 at 11 01 08](https://user-images.githubusercontent.com/1032411/207017120-50d3c263-ce7a-4c92-bb7e-8a8f86c47983.png)

This PR proposes two things:

1. add a more prominent warning to the service definition details screen that the service is excluded

![CleanShot 2022-12-12 at 11 01 52](https://user-images.githubusercontent.com/1032411/207017261-44495233-f513-4c29-bb6d-469eb0418080.png)
(wording tbd)


2. mark the services as excluded in the list (right now by graying them out):

![CleanShot 2022-12-12 at 11 02 44](https://user-images.githubusercontent.com/1032411/207017481-993010da-3364-49dd-b7e0-4f3c07f14ad5.png)


If this looks like something you want to include, I will add the "graying out" part to the table view as well.
wdyt?