### PR TITLE
[HttpKernel] fix wrong deprecation message

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -660,7 +660,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         if (isset($buildParameters['.container.dumper.inline_factories'])) {
             $inlineFactories = $buildParameters['.container.dumper.inline_factories'];
         } elseif ($container->hasParameter('container.dumper.inline_factories')) {
-            trigger_deprecation('symfony/http-kernel', '6.3', 'Parameter "%s" is deprecated, use ".%$1s" instead.', 'container.dumper.inline_factories');
+            trigger_deprecation('symfony/http-kernel', '6.3', 'Parameter "%s" is deprecated, use ".%1$s" instead.', 'container.dumper.inline_factories');
             $inlineFactories = $container->getParameter('container.dumper.inline_factories');
         }
 
@@ -668,7 +668,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         if (isset($buildParameters['.container.dumper.inline_class_loader'])) {
             $inlineClassLoader = $buildParameters['.container.dumper.inline_class_loader'];
         } elseif ($container->hasParameter('container.dumper.inline_class_loader')) {
-            trigger_deprecation('symfony/http-kernel', '6.3', 'Parameter "%s" is deprecated, use ".%$1s" instead.', 'container.dumper.inline_class_loader');
+            trigger_deprecation('symfony/http-kernel', '6.3', 'Parameter "%s" is deprecated, use ".%1$s" instead.', 'container.dumper.inline_class_loader');
             $inlineClassLoader = $container->getParameter('container.dumper.inline_class_loader');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

Introduced in https://github.com/symfony/symfony/pull/47680 

Not sure about how to catch the deprecation. 