### PR TITLE
[Console] fix: throw exception on console command uncaught error

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -302,6 +302,8 @@ class Application implements ResetInterface
                     throw $e;
                 }
             }
+            
+            throw $e;
         }
 
         if ($command instanceof LazyCommand) {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -302,8 +302,8 @@ class Application implements ResetInterface
                     throw $e;
                 }
             }
-            
-            throw $e;
+
+            $command ?? throw $e;
         }
 
         if ($command instanceof LazyCommand) {

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -2106,7 +2106,7 @@ class CustomDefaultCommandApplication extends Application
 
 class ThrowUncaughtErrorApplication extends Application
 {
-    public function find(string $name)
+    public function find(string $name): Command
     {
         throw new \Exception('That doesn\'t work!');
     }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -2058,6 +2058,19 @@ class ApplicationTest extends TestCase
 
         return $application;
     }
+
+    public function testThrowUncaughtError()
+    {
+        $application = new ThrowUncaughtErrorApplication();
+        $application->add(new \FooCommand());
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['foo']);
+
+        $this->assertEquals(1, $tester->getStatusCode());
+        $this->assertStringContainsString('That doesn\'t work!', $tester->getDisplay(true));
+    }
 }
 
 class CustomApplication extends Application
@@ -2088,6 +2101,14 @@ class CustomDefaultCommandApplication extends Application
         $command = new \FooCommand();
         $this->add($command);
         $this->setDefaultCommand($command->getName());
+    }
+}
+
+class ThrowUncaughtErrorApplication extends Application
+{
+    public function find(string $name)
+    {
+        throw new \Exception('That doesn\'t work!');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Throw uncaught Error.

To avoid that message (and better DX):
```
In Application.php line 312:
                                        
  Warning: Undefined variable $command
```