### PR TITLE
[Messenger] [Amqp] Added missing rpc_timeout option

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -32,6 +32,9 @@ class Connection
         'x-message-ttl',
     ];
 
+    /**
+     * @see https://github.com/php-amqp/php-amqp/blob/master/amqp_connection_resource.h
+     */
     private const AVAILABLE_OPTIONS = [
         'host',
         'port',
@@ -53,6 +56,7 @@ class Connection
         'write_timeout',
         'confirm_timeout',
         'connect_timeout',
+        'rpc_timeout',
         'cacert',
         'cert',
         'key',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

Without this option, it's not possible to set a timeout on the connection. It
means, if the network between RabbitMQ and the application goes down, the code
in `Connection::get()` will hand forever. And at some point it will cause more
troubles. For example:

* many connection/channel opened (because the consumer is not killed) ;
* or, when the connexion gets back, RabbitMQ have killed the consumer anyway =>
  Another Exception.

With this patch, and with the following configuration, exception are clear on
what occurs.

```
framework:
    messenger:
        transports:
            rabbitmq:
                dsn: ....
                options:
                    read_timeout: 5
                    write_timeout: 5
                    connect_timeout: 5
                    confirm_timeout: 5
                    rpc_timeout: 5
                    [...]
```

Example of exception:

```
In AmqpReceiver.php line 56:

  [Symfony\Component\Messenger\Exception\TransportException]
  Library error: request timed out

Exception trace:
  at /app/vendor/symfony/amqp-messenger/Transport/AmqpReceiver.php:56
 Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver->getEnvelope() at /app/vendor/symfony/amqp-messenger/Transport/AmqpReceiver.php:47
 Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver->getFromQueues() at /app/vendor/symfony/amqp-messenger/Transport/AmqpReceiver.php:41
 Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver->get() at /app/vendor/symfony/symfony/src/Symfony/Component/Messenger/Worker.php:106
 Symfony\Component\Messenger\Worker->run() at /app/vendor/symfony/symfony/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php:229
 Symfony\Component\Messenger\Command\ConsumeMessagesCommand->execute() at /app/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:312
 Symfony\Component\Console\Command\Command->run() at /app/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:1038
 Symfony\Component\Console\Application->doRunCommand() at /app/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:88
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /app/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:312
 Symfony\Component\Console\Application->doRun() at /app/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:77
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /app/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:168
 Symfony\Component\Console\Application->run() at /app/bin/console:29

In Connection.php line 432:

  [AMQPException]
  Library error: request timed out

Exception trace:
  at /app/vendor/symfony/amqp-messenger/Transport/Connection.php:432
 AMQPQueue->get() at /app/vendor/symfony/amqp-messenger/Transport/Connection.php:432
 Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection->get() at /app/vendor/symfony/amqp-messenger/Transport/AmqpReceiver.php:54
 Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver->getEnvelope() at /app/vendor/symfony/amqp-messenger/Transport/AmqpReceiver.php:47
 Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver->getFromQueues() at /app/vendor/symfony/amqp-messenger/Transport/AmqpReceiver.php:41
 Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver->get() at /app/vendor/symfony/symfony/src/Symfony/Component/Messenger/Worker.php:106
 Symfony\Component\Messenger\Worker->run() at /app/vendor/symfony/symfony/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php:229
 Symfony\Component\Messenger\Command\ConsumeMessagesCommand->execute() at /app/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:312
 Symfony\Component\Console\Command\Command->run() at /app/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:1038
 Symfony\Component\Console\Application->doRunCommand() at /app/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:88
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /app/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:312
 Symfony\Component\Console\Application->doRun() at /app/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:77
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /app/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:168
 Symfony\Component\Console\Application->run() at /app/bin/console:29

messenger:consume [-l|--limit LIMIT] [-f|--failure-limit FAILURE-LIMIT] [-m|--memory-limit MEMORY-LIMIT] [-t|--time-limit TIME-LIMIT] [--sleep SLEEP] [-b|--bus BUS] [--queues QUEUES] [--no-reset] [--] [<receivers>...]

```

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
