### PR TITLE
[Notifier] GoogleChat CardsV1 is deprecated we must use cardsV2 instead

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Deprecate `GoogleChatOptions::card()` in favor of `cardV2()`
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatOptions.php
@@ -62,11 +62,25 @@ final class GoogleChatOptions implements MessageOptionsInterface
     }
 
     /**
+     * @deprecated since Symfony 6.3, use "cardV2()" instead
+     *
      * @return $this
      */
     public function card(array $card): static
     {
+        trigger_deprecation('symfony/google-chat-notifier', '6.3', '"%s()" is deprecated, use "cardV2()" instead.', __METHOD__);
+
         $this->options['cards'][] = $card;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function cardV2(array $card): static
+    {
+        $this->options['cardsV2'][] = $card;
 
         return $this;
     }

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatOptionsTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatOptions;
 
 final class GoogleChatOptionsTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testToArray()
     {
         $options = new GoogleChatOptions();
@@ -28,6 +31,47 @@ final class GoogleChatOptionsTest extends TestCase
             'text' => 'Pizza Bot',
             'cards' => [
                 ['header' => ['Pizza Bot Customer Support']],
+            ],
+        ];
+
+        $this->assertSame($expected, $options->toArray());
+    }
+
+    public function testToArrayWithCardV2()
+    {
+        $options = new GoogleChatOptions();
+
+        $cardV2 = [
+            'header' => [
+                'title' => 'Sasha',
+                'subtitle' => 'Software Engineer',
+                'imageUrl' => 'https://developers.google.com/chat/images/quickstart-app-avatar.png',
+                'imageType' => 'CIRCLE',
+                'imageAltText' => 'Avatar for Sasha',
+            ],
+            'sections' => [
+                [
+                    'header' => 'Contact Info',
+                    'collapsible' => true,
+                    'widgets' => [
+                        'decoratedText' => [
+                            'startIcon' => ['knownIcon' => 'EMAIL'],
+                            'text' => 'sasha@example.com',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $options
+            ->text('Hello Bot')
+            ->cardV2($cardV2)
+        ;
+
+        $expected = [
+            'text' => 'Hello Bot',
+            'cardsV2' => [
+                $cardV2,
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| License       | MIT

Based on google developers api documentation.
https://developers.google.com/chat/api/reference/rest/v1/cards-v1 
CardsV1 is deprecated we must use cardsV2 instead.
