### PR TITLE
[VarDumper] Don't use async mode to connect to dump server

### DIFF
--- a/src/Symfony/Component/VarDumper/Server/Connection.php
+++ b/src/Symfony/Component/VarDumper/Server/Connection.php
@@ -91,7 +91,7 @@ class Connection
     {
         set_error_handler([self::class, 'nullErrorHandler']);
         try {
-            return stream_socket_client($this->host, $errno, $errstr, 3, \STREAM_CLIENT_CONNECT | \STREAM_CLIENT_ASYNC_CONNECT);
+            return stream_socket_client($this->host, $errno, $errstr, 3, \STREAM_CLIENT_CONNECT);
         } finally {
             restore_error_handler();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Let's see on appveyor if it hangs.
