### PR TITLE
[Translation] Fix extraction when the domain is not defined

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/Visitor/AbstractVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/AbstractVisitor.php
@@ -48,7 +48,7 @@ abstract class AbstractVisitor
 
         $args = $node instanceof Node\Expr\CallLike ? $node->getRawArgs() : $node->args;
 
-        if (\count($args) < $index) {
+        if (\count($args) <= $index) {
             return [];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48633
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

The extraction process fails when we invoke the `trans` function with a message and a parameter but we do not define the domain explicitly.