### PR TITLE
[HttpFoundation] Use relative timestamps with MemcachedSessionHandler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\MemcachedSessionHan
 
 /**
  * @requires extension memcached
+ *
  * @group time-sensitive
  */
 class MemcachedSessionHandlerTest extends TestCase
@@ -92,11 +93,28 @@ class MemcachedSessionHandlerTest extends TestCase
         $this->memcached
             ->expects($this->once())
             ->method('set')
-            ->with(self::PREFIX.'id', 'data', $this->equalTo(time() + self::TTL, 2))
+            ->with(self::PREFIX.'id', 'data', $this->equalTo(self::TTL, 2))
             ->willReturn(true)
         ;
 
         $this->assertTrue($this->storage->write('id', 'data'));
+    }
+
+    public function testWriteSessionWithLargeTTL()
+    {
+        $this->memcached
+            ->expects($this->once())
+            ->method('set')
+            ->with(self::PREFIX.'id', 'data', $this->equalTo(time() + self::TTL + 60 * 60 * 24 * 30, 2))
+            ->willReturn(true)
+        ;
+
+        $storage = new MemcachedSessionHandler(
+            $this->memcached,
+            ['prefix' => self::PREFIX, 'expiretime' => self::TTL + 60 * 60 * 24 * 30]
+        );
+
+        $this->assertTrue($storage->write('id', 'data'));
     }
 
     public function testDestroySession()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | 
| Deprecations? |
| Tickets       | Fix #48619
| License       | MIT
| Doc PR        | 

Use relative timestamps. If for some reason your client is not in sync with the server clock, you at least agree about the relative TTL. Or see #48619 for a case where the memcached monotonic clock is going faster than the server and causes users to add entries that are expired on entry.