### PR TITLE
[HttpKernel] AbstractSessionListener should not override the cache lifetime for private responses

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -101,6 +101,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
 
         $response = $event->getResponse();
         $autoCacheControl = !$response->headers->has(self::NO_AUTO_CACHE_CONTROL_HEADER);
+
         // Always remove the internal header if present
         $response->headers->remove(self::NO_AUTO_CACHE_CONTROL_HEADER);
 
@@ -201,9 +202,9 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
 
         if ($autoCacheControl) {
             $response
-                ->setExpires(new \DateTime())
                 ->setPrivate()
-                ->setMaxAge(0)
+                ->setMaxAge($response->getMaxAge() ?: 0)
+                ->setExpires((new \DateTime())->modify('+' . $response->getMaxAge() . ' seconds'))
                 ->headers->addCacheControlDirective('must-revalidate');
         }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47660 AbstractSessionListener should not override the cache lifetime
| License       | MIT

https://github.com/symfony/symfony/issues/47660 is opened as a bug
This PR fix that AbstractSessionListener override the max-age and the expires cache headers if cache control is private and these values are explicit defined
