### PR TITLE
[Validator] Allow opt-out of EmailValidator deprecation when using Validation::createValidatorBuilder()

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintValidatorFactory.php
+++ b/src/Symfony/Component/Validator/ConstraintValidatorFactory.php
@@ -26,20 +26,17 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
 {
     protected $validators = [];
 
-    public function __construct()
+    public function __construct(array $validators = [])
     {
+        $this->validators = $validators;
     }
 
     public function getInstance(Constraint $constraint): ConstraintValidatorInterface
     {
-        $className = $constraint->validatedBy();
-
-        if (!isset($this->validators[$className])) {
-            $this->validators[$className] = 'validator.expression' === $className
-                ? new ExpressionValidator()
-                : new $className();
+        if ('validator.expression' === $name = $class = $constraint->validatedBy()) {
+            $class = ExpressionValidator::class;
         }
 
-        return $this->validators[$className];
+        return $this->validators[$name] ??= new $class();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/ConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintValidatorFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\Tests\Fixtures\DummyConstraint;
+use Symfony\Component\Validator\Tests\Fixtures\DummyConstraintValidator;
+
+class ConstraintValidatorFactoryTest extends TestCase
+{
+    public function testGetInstance()
+    {
+        $factory = new ConstraintValidatorFactory();
+        $this->assertInstanceOf(DummyConstraintValidator::class, $factory->getInstance(new DummyConstraint()));
+    }
+
+    public function testPredefinedGetInstance()
+    {
+        $validator = new DummyConstraintValidator();
+        $factory = new ConstraintValidatorFactory([DummyConstraintValidator::class => $validator]);
+        $this->assertSame($validator, $factory->getInstance(new DummyConstraint()));
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
@@ -15,9 +15,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Blank as BlankConstraint;
-use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
 use Symfony\Component\Validator\Exception\ValidatorException;
+use Symfony\Component\Validator\Tests\Fixtures\DummyConstraint;
+use Symfony\Component\Validator\Tests\Fixtures\DummyConstraintValidator;
 
 class ContainerConstraintValidatorFactoryTest extends TestCase
 {
@@ -57,20 +58,5 @@ class ContainerConstraintValidatorFactoryTest extends TestCase
 
         $factory = new ContainerConstraintValidatorFactory(new Container());
         $factory->getInstance($constraint);
-    }
-}
-
-class DummyConstraint extends Constraint
-{
-    public function validatedBy(): string
-    {
-        return DummyConstraintValidator::class;
-    }
-}
-
-class DummyConstraintValidator extends ConstraintValidator
-{
-    public function validate($value, Constraint $constraint)
-    {
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/DummyConstraint.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/DummyConstraint.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+
+class DummyConstraint extends Constraint
+{
+    public function validatedBy(): string
+    {
+        return DummyConstraintValidator::class;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/DummyConstraintValidator.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/DummyConstraintValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class DummyConstraintValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #48541
| License       | MIT
| Doc PR        | -

As described in the linked issue, there is currently no way to opt out from a deprecation triggered by a validator when using the component standalone.

The example at hand presently is "The "loose" mode is deprecated. The default mode will be changed to "html5" in 7.0" as triggered by EmailValidator. There could be others in the future.

This PR provides a way around:
```php
$builder = Validation::createValidatorBuilder()
	->setConstraintValidatorFactory(new ConstraintValidatorFactory([EmailValidator::class => new EmailValidator(Email::VALIDATION_MODE_HTML5)]));
```

That's a bit verbose, but that does the job in a future-proof way.