### PR TITLE
[FrameworkBundle] fix: fix help message

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -69,7 +69,7 @@ When the option is not provided, <comment>yaml</comment> is used.
 
 For dumping a specific option, add its path as second argument (only available for the yaml format):
 
-  <info>php %command.full_name% framework profiler.matcher</info>
+  <info>php %command.full_name% framework http_client.default_options</info>
 
 EOF
             )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The `profiler.matcher` option does not exist anymore.