### PR TITLE
[HttpKernel] AbstractSessionListener should not override the cache lifetime for private responses

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -200,10 +200,11 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
         }
 
         if ($autoCacheControl) {
+            $maxAge = $response->headers->hasCacheControlDirective('public') ? 0 : (int) $response->getMaxAge();
             $response
-                ->setExpires(new \DateTime())
+                ->setExpires(new \DateTimeImmutable('+'.$maxAge.' seconds'))
                 ->setPrivate()
-                ->setMaxAge(0)
+                ->setMaxAge($maxAge)
                 ->headers->addCacheControlDirective('must-revalidate');
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -39,6 +39,7 @@ class SessionListenerTest extends TestCase
 {
     /**
      * @dataProvider provideSessionOptions
+     *
      * @runInSeparateProcess
      */
     public function testSessionCookieOptions(array $phpSessionOptions, array $sessionOptions, array $expectedSessionOptions)
@@ -529,6 +530,64 @@ class SessionListenerTest extends TestCase
         $this->assertFalse($response->headers->hasCacheControlDirective('private'));
         $this->assertFalse($response->headers->hasCacheControlDirective('must-revalidate'));
         $this->assertSame('60', $response->headers->getCacheControlDirective('s-maxage'));
+    }
+
+    public function testResponseHeadersMaxAgeAndExpiresNotBeOverridenIfSessionStarted()
+    {
+        $session = $this->createMock(Session::class);
+        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+
+        $container = new Container();
+        $container->set('initialized_session', $session);
+
+        $listener = new SessionListener($container);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+
+        $request = new Request();
+        $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $response = new Response();
+        $response->setPrivate();
+        $expiresHeader = gmdate('D, d M Y H:i:s', time() + 600).' GMT';
+        $response->setMaxAge(600);
+        $listener->onKernelResponse(new ResponseEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST, $response));
+
+        $this->assertTrue($response->headers->has('expires'));
+        $this->assertSame($expiresHeader, $response->headers->get('expires'));
+        $this->assertFalse($response->headers->has('max-age'));
+        $this->assertSame('600', $response->headers->getCacheControlDirective('max-age'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('public'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('private'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
+        $this->assertFalse($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
+    }
+
+    public function testResponseHeadersMaxAgeAndExpiresDefaultValuesIfSessionStarted()
+    {
+        $session = $this->createMock(Session::class);
+        $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
+
+        $container = new Container();
+        $container->set('initialized_session', $session);
+
+        $listener = new SessionListener($container);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+
+        $request = new Request();
+        $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $response = new Response();
+        $expiresHeader = gmdate('D, d M Y H:i:s', time()).' GMT';
+        $listener->onKernelResponse(new ResponseEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST, $response));
+
+        $this->assertTrue($response->headers->has('expires'));
+        $this->assertSame($expiresHeader, $response->headers->get('expires'));
+        $this->assertFalse($response->headers->has('max-age'));
+        $this->assertSame('0', $response->headers->getCacheControlDirective('max-age'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('public'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('private'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
+        $this->assertFalse($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
     }
 
     public function testSurrogateMainRequestIsPublic()


### PR DESCRIPTION
Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47660 AbstractSessionListener should not override the cache lifetime
| License       | MIT

https://github.com/symfony/symfony/issues/47660 is opened as a bug
This PR fix that AbstractSessionListener override the max-age and the expires cache headers if cache control is private and these values are explicit defined