### PR TITLE
Enhancement: Allow DateTimeInterface as value in date(time) constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -31,6 +31,10 @@ class DateTimeValidator extends DateValidator
             return;
         }
 
+        if ($value instanceof \DateTimeInterface) {
+            $value = $value->format($constraint->format);
+        }
+
         if (!\is_scalar($value) && !$value instanceof \Stringable) {
             throw new UnexpectedValueException($value, 'string');
         }

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -27,12 +27,8 @@ class DateTimeValidator extends DateValidator
             throw new UnexpectedTypeException($constraint, DateTime::class);
         }
 
-        if (null === $value || '' === $value) {
+        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
             return;
-        }
-
-        if ($value instanceof \DateTimeInterface) {
-            $value = $value->format($constraint->format);
         }
 
         if (!\is_scalar($value) && !$value instanceof \Stringable) {

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -43,6 +43,10 @@ class DateValidator extends ConstraintValidator
             return;
         }
 
+        if ($value instanceof \DateTimeInterface) {
+            $value = $value->format('Y-m-d');
+        }
+
         if (!\is_scalar($value) && !$value instanceof \Stringable) {
             throw new UnexpectedValueException($value, 'string');
         }

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -39,12 +39,8 @@ class DateValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Date::class);
         }
 
-        if (null === $value || '' === $value) {
+        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
             return;
-        }
-
-        if ($value instanceof \DateTimeInterface) {
-            $value = $value->format('Y-m-d');
         }
 
         if (!\is_scalar($value) && !$value instanceof \Stringable) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | can be seen as bug fix :D
| New feature?  | can also be seen as feature...
| Deprecations? | no
| License       | MIT

Allow DateTimeInterface as value type. Otherwise we cannot use DateTimeValidation for entity properties like this (enforces string as property type):
```php
    #[Assert\DateTime]
    #[ORM\Column(type: 'datetime', nullable: true)]
    private ?\DateTimeInterface $date;
```