### PR TITLE
[Serializer] fix context attribute with serializedName

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -331,8 +331,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             $params = [];
             foreach ($constructorParameters as $constructorParameter) {
                 $paramName = $constructorParameter->name;
+                $attributeContext = $this->getAttributeDenormalizationContext($class, $paramName, $context);
                 $key = $this->nameConverter ? $this->nameConverter->normalize($paramName, $class, $format, $context) : $paramName;
-                $attributeContext = $this->getAttributeDenormalizationContext($class, $key, $context);
 
                 $allowed = false === $allowedAttributes || \in_array($paramName, $allowedAttributes);
                 $ignored = !$this->isAllowedAttribute($class, $paramName, $format, $context);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectDummyWithContextAttribute.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectDummyWithContextAttribute.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
+
+use Symfony\Component\Serializer\Annotation\Context;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+
+final class ObjectDummyWithContextAttribute
+{
+    public function __construct(
+        #[Context([DateTimeNormalizer::FORMAT_KEY => 'm-d-Y'])]
+        #[SerializedName('property_with_serialized_name')]
+        public \DateTimeImmutable $propertyWithSerializedName,
+
+        #[Context([DateTimeNormalizer::FORMAT_KEY => 'm-d-Y'])]
+        public \DateTimeImmutable $propertyWithoutSerializedName,
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hello,

this PR fixes a bug where the `#[Context]` attribute is not read in denormalization process when it is used along with `#[SerializedName]` in a constructor.

In the test I provided, the two dates are not equals without the fix, although the same context is provided.
