### PR TITLE
[VarDumper] Add support for options in `dump()`/`dd()`

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `FORCE_COLOR` environment variable
+ * Add support of options when using `dd()` and `dump()`
 
 7.1
 ---

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Cloner;
 
 use Symfony\Component\VarDumper\Caster\Caster;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\BacktraceContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
 
 /**
@@ -270,12 +271,17 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate, \Stringable
         $cursor->hashType = -1;
         $cursor->attr = $this->context[SourceContextProvider::class] ?? [];
         $label = $this->context['label'] ?? '';
+        $options = $this->context['options'] ?? [];
 
         if ($cursor->attr || '' !== $label) {
             $dumper->dumpScalar($cursor, 'label', $label);
         }
         $cursor->hashType = 0;
         $this->dumpItem($dumper, $cursor, $refs, $this->data[$this->position][$this->key]);
+
+        if (false !== ($options['_trace'] ?? false) && $cursor->attr = $this->context[BacktraceContextProvider::class] ?? []) {
+            $this->dumpDebugBacktrace($dumper, $cursor);
+        }
     }
 
     /**
@@ -425,5 +431,15 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate, \Stringable
         $stub->value = $stub->cut + ($stub->position ? \count($this->data[$stub->position]) : 0);
 
         return $stub;
+    }
+
+    private function dumpDebugBacktrace(DumperInterface $dumper, Cursor $cursor): void
+    {
+        $backtrace = $cursor->attr['backtrace'];
+
+        $dumper->dumpScalar($cursor, 'default', '');
+        $dumper->dumpScalar($cursor, 'default', '**DEBUG BACKTRACE**');
+
+        $backtrace->dump($dumper);
     }
 }

--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/BacktraceContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/BacktraceContextProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Dumper\ContextProvider;
+
+use Symfony\Component\VarDumper\Caster\TraceStub;
+use Symfony\Component\VarDumper\Cloner\ClonerInterface;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+
+/**
+ * Provides the debug stacktrace of the VarDumper call.
+ *
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+final class BacktraceContextProvider implements ContextProviderInterface
+{
+    private const BACKTRACE_CONTEXT_PROVIDER_DEPTH = 4;
+
+    public function __construct(
+        private readonly bool|int $limit,
+        private ?ClonerInterface $cloner,
+    ) {
+        $this->cloner ??= new VarCloner();
+    }
+
+    public function getContext(): ?array
+    {
+        if (false === $this->limit) {
+            return [];
+        }
+
+        $context = [];
+        $traces = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
+
+        for ($i = self::BACKTRACE_CONTEXT_PROVIDER_DEPTH; $i < \count($traces); ++$i) {
+            $context[] = $traces[$i];
+
+            if ($this->limit === \count($context)) {
+                break;
+            }
+        }
+
+        $stub = new TraceStub($context);
+
+        return ['backtrace' => $this->cloner->cloneVar($stub->value)];
+    }
+}

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -19,18 +19,33 @@ if (!function_exists('dump')) {
      */
     function dump(mixed ...$vars): mixed
     {
-        if (!$vars) {
-            VarDumper::dump(new ScalarStub('🐛'));
+        $options = array_filter(
+            $vars,
+            static fn (mixed $key): bool => \in_array($key, VarDumper::AVAILABLE_OPTIONS, true),
+            \ARRAY_FILTER_USE_KEY
+        );
 
-            return null;
-        }
+        $trace = $options['_trace'] ?? null;
+        unset($options['_trace']);
 
         if (array_key_exists(0, $vars) && 1 === count($vars)) {
-            VarDumper::dump($vars[0]);
+            VarDumper::dump($vars[0], null, $options);
             $k = 0;
         } else {
+            $vars = array_filter($vars, static fn (int|string $key) => !str_starts_with($key, '_'), \ARRAY_FILTER_USE_KEY);
+
+            if (!$vars) {
+                VarDumper::dump(new ScalarStub('🐛'), null, $options);
+
+                return null;
+            }
+
             foreach ($vars as $k => $v) {
-                VarDumper::dump($v, is_int($k) ? 1 + $k : $k);
+                if (array_key_last($vars) === $k) {
+                    $options['_trace'] = $trace;
+                }
+
+                VarDumper::dump($v, is_int($k) ? 1 + $k : $k, $options);
             }
         }
 
@@ -55,11 +70,21 @@ if (!function_exists('dd')) {
             exit(1);
         }
 
+        $options = array_filter(
+            $vars,
+            static fn (mixed $key): bool => \in_array($key, VarDumper::AVAILABLE_OPTIONS, true),
+            \ARRAY_FILTER_USE_KEY
+        );
+
         if (array_key_exists(0, $vars) && 1 === count($vars)) {
-            VarDumper::dump($vars[0]);
+            VarDumper::dump($vars[0], null, $options);
         } else {
             foreach ($vars as $k => $v) {
-                VarDumper::dump($v, is_int($k) ? 1 + $k : $k);
+                if (str_starts_with($k, '_')) {
+                    continue;
+                }
+
+                VarDumper::dump($v, is_int($k) ? 1 + $k : $k, $options);
             }
         }
 

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ContextProvider/BacktraceContextProviderTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ContextProvider/BacktraceContextProviderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Dumper\ContextProvider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\BacktraceContextProvider;
+
+class BacktraceContextProviderTest extends TestCase
+{
+    public function testFalseBacktraceLimit()
+    {
+        $provider = new BacktraceContextProvider(false, new VarCloner());
+        $this->assertArrayNotHasKey('backtrace', $provider->getContext());
+    }
+
+    public function testPositiveBacktraceLimit()
+    {
+        $provider = new BacktraceContextProvider(2, new VarCloner());
+        $this->assertCount(2, $provider->getContext()['backtrace']);
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
@@ -85,6 +85,20 @@ class FunctionsTest extends TestCase
         $this->assertSame([$var1, 'second' => $var2, 'third' => $var3], $return);
     }
 
+    public function testDumpReturnsAllNamedArgsExceptSpecialOptionOnes()
+    {
+        $this->setupVarDumper();
+
+        $var1 = 'a';
+        $var2 = 'b';
+
+        ob_start();
+        $return = dump($var1, named: $var2, _trace: true, _flags: 0);
+        ob_end_clean();
+
+        $this->assertSame([$var1, 'named' => $var2], $return);
+    }
+
     protected function setupVarDumper()
     {
         $cloner = new VarCloner();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #48474 
| License       | MIT

Following up #48432, this PR brings an options builder to configure VarDumper's behavior thanks to a special `_options` named argument. Here is a snippet of it in action and a screenshot of the result. Feedbacks on UI are really welcomed, especially about the debug backtrace!

```php
<?php

use Symfony\Component\VarDumper\Dumper\CliDumper;

require 'vendor/autoload.php';

dump(
    var: ['Hi', 'Greetings' => 'Good morning, Symfony!'],
    _trace: true,
    _flags: CliDumper::DUMP_LIGHT_ARRAY | CliDumper::DUMP_STRING_LENGTH,
);
```

![image](https://github.com/user-attachments/assets/5633db23-e9a1-419a-88c5-b84f7e871f7d)

