### PR TITLE
[Validator] Add `getConstraint()` method to `ConstraintViolationInterface`

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -23,3 +23,9 @@ SecurityBundle
 --------------
 
  * Deprecate enabling bundle and not configuring it
+
+
+Validator
+--------------
+
+* Implementing the `ConstraintViolationInterface` without implementing the `getConstraint()` method is deprecated

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.3
 ---
 
+ * Add method `getConstraint()` to `ConstraintViolationInterface`
  * Add `Uuid::TIME_BASED_VERSIONS` to match that a UUID being validated embeds a timestamp
  * Add the `pattern` parameter in violations of the `Regex` constraint
 

--- a/src/Symfony/Component/Validator/ConstraintViolationInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationInterface.php
@@ -31,8 +31,9 @@ namespace Symfony\Component\Validator;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @method mixed  getCause()   Returns the cause of the violation. Not implementing it is deprecated since Symfony 6.2.
- * @method string __toString() Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
+ * @method Constraint|null getConstraint() Returns the constraint whose validation caused the violation. Not implementing it is deprecated since Symfony 6.3.
+ * @method mixed           getCause()      Returns the cause of the violation. Not implementing it is deprecated since Symfony 6.2.
+ * @method string          __toString()    Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
  */
 interface ConstraintViolationInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #48626
| License       | MIT
| Doc PR        | 
