### PR TITLE
[FrameworkBundle] Rename service `notifier.logger_notification_listener` to `notifier.notification_logger_listener`

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -38,6 +38,11 @@ FrameworkBundle
    </framework:config>
    ```
 
+FrameworkBundle
+---------------
+
+ * Deprecate the `notifier.logger_notification_listener` service, use the `notifier.notification_logger_listener` service instead
+
 HttpKernel
 ----------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `--format` option to the `debug:config` command
  * Add support to pass namespace wildcard in `framework.messenger.routing`
  * Deprecate `framework:exceptions` tag, unwrap it and replace `framework:exception` tags' `name` attribute by `class`
+ * Deprecate the `notifier.logger_notification_listener` service, use the `notifier.notification_logger_listener` service instead
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
@@ -126,7 +126,11 @@ return static function (ContainerConfigurator $container) {
             ->args([service('texter.transports')])
             ->tag('messenger.message_handler', ['handles' => PushMessage::class])
 
-        ->set('notifier.logger_notification_listener', NotificationLoggerListener::class)
+        ->set('notifier.notification_logger_listener', NotificationLoggerListener::class)
             ->tag('kernel.event_subscriber')
+
+        ->alias('notifier.logger_notification_listener', 'notifier.notification_logger_listener')
+            ->deprecate('symfony/framework-bundle', '6.3', 'The "%alias_id%" service is deprecated, use "notifier.notification_logger_listener" instead.')
+
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_debug.php
@@ -16,7 +16,7 @@ use Symfony\Component\Notifier\DataCollector\NotificationDataCollector;
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('notifier.data_collector', NotificationDataCollector::class)
-            ->args([service('notifier.logger_notification_listener')])
+            ->args([service('notifier.notification_logger_listener')])
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/notifier.html.twig', 'id' => 'notifier'])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Test/NotificationAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/NotificationAssertionsTrait.php
@@ -91,8 +91,8 @@ trait NotificationAssertionsTrait
     public static function getNotificationEvents(): NotificationEvents
     {
         $container = static::getContainer();
-        if ($container->has('notifier.logger_notification_listener')) {
-            return $container->get('notifier.logger_notification_listener')->getEvents();
+        if ($container->has('notifier.notification_logger_listener')) {
+            return $container->get('notifier.notification_logger_listener')->getEvents();
         }
 
         static::fail('A client must have Notifier enabled to make notifications assertions. Did you forget to require symfony/notifier?');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #48519
| License       | MIT
| Doc PR        | -
