### PR TITLE
Prevent browser bfcache by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -103,7 +103,7 @@ class WebTestCaseTest extends TestCase
 
     public function testAssertResponseHeaderSame()
     {
-        $this->getResponseTester(new Response())->assertResponseHeaderSame('Cache-Control', 'no-cache, private');
+        $this->getResponseTester(new Response())->assertResponseHeaderSame('Cache-Control', 'no-store, private');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public".');
         $this->getResponseTester(new Response())->assertResponseHeaderSame('Cache-Control', 'public');
@@ -113,8 +113,8 @@ class WebTestCaseTest extends TestCase
     {
         $this->getResponseTester(new Response())->assertResponseHeaderNotSame('Cache-Control', 'public');
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that the Response does not have header "Cache-Control" with value "no-cache, private".');
-        $this->getResponseTester(new Response())->assertResponseHeaderNotSame('Cache-Control', 'no-cache, private');
+        $this->expectExceptionMessage('Failed asserting that the Response does not have header "Cache-Control" with value "no-store, private".');
+        $this->getResponseTester(new Response())->assertResponseHeaderNotSame('Cache-Control', 'no-store, private');
     }
 
     public function testAssertResponseHasCookie()

--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -45,7 +45,7 @@ final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
             'buffer' => false,
             'headers' => [
                 'Accept' => 'text/event-stream',
-                'Cache-Control' => 'no-cache',
+                'Cache-Control' => 'no-store',
             ],
         ], true));
     }

--- a/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
@@ -68,7 +68,7 @@ TXT;
         })());
 
         $hasCorrectHeaders = function ($options) {
-            $this->assertSame(['Accept: text/event-stream', 'Cache-Control: no-cache'], $options['headers']);
+            $this->assertSame(['Accept: text/event-stream', 'Cache-Control: no-store'], $options['headers']);
 
             return true;
         };
@@ -124,7 +124,7 @@ TXT;
         })());
 
         $hasCorrectHeaders = function ($options) {
-            $this->assertSame(['Accept: text/event-stream', 'Cache-Control: no-cache'], $options['headers']);
+            $this->assertSame(['Accept: text/event-stream', 'Cache-Control: no-store'], $options['headers']);
 
             return true;
         };

--- a/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
@@ -89,7 +89,7 @@ class Psr18ClientTest extends TestCase
         $responseHeaders = [
             // space in header name not allowed in RFC 7230
             ' X-XSS-Protection' => '0',
-            'Cache-Control' => 'no-cache',
+            'Cache-Control' => 'no-store',
         ];
         $response = new MockResponse('body', ['response_headers' => $responseHeaders]);
         $this->assertArrayHasKey(' x-xss-protection', $response->getHeaders());

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1436,6 +1436,7 @@ class Request
      * @param bool $asResource If true, a resource will be returned
      *
      * @return string|resource
+     *
      * @psalm-return ($asResource is true ? resource : string)
      */
     public function getContent(bool $asResource = false)

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1510,7 +1510,7 @@ class Request
 
     public function isNoCache(): bool
     {
-        return $this->headers->hasCacheControlDirective('no-cache') || 'no-cache' == $this->headers->get('Pragma');
+        return $this->headers->hasCacheControlDirective('no-store') || 'no-store' == $this->headers->get('Pragma');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -307,8 +307,8 @@ class Response
         }
 
         // Check if we need to send extra expire info headers
-        if ('1.0' == $this->getProtocolVersion() && str_contains($headers->get('Cache-Control', ''), 'no-cache')) {
-            $headers->set('pragma', 'no-cache');
+        if ('1.0' == $this->getProtocolVersion() && str_contains($headers->get('Cache-Control', ''), 'no-store')) {
+            $headers->set('pragma', 'no-store');
             $headers->set('expires', -1);
         }
 

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -244,7 +244,7 @@ class ResponseHeaderBag extends HeaderBag
             }
 
             // conservative by default
-            return 'no-cache, private';
+            return 'no-store, private';
         }
 
         $header = $this->getCacheControlHeader();

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_raw_urlencode.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_raw_urlencode.expected
@@ -2,7 +2,7 @@
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: no-cache, private
+    [1] => Cache-Control: no-store, private
     [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
     [3] => Set-Cookie: ?*():@&+$/%#[]=?*():@&+$/%#[]; path=/
     [4] => Set-Cookie: ?*():@&+$/%#[]=?*():@&+$/%#[]; path=/

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_samesite_lax.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_samesite_lax.expected
@@ -2,7 +2,7 @@
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: no-cache, private
+    [1] => Cache-Control: no-store, private
     [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
     [3] => Set-Cookie: CookieSamesiteLaxTest=LaxValue; path=/; httponly; samesite=lax
 )

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_samesite_strict.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_samesite_strict.expected
@@ -2,7 +2,7 @@
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: no-cache, private
+    [1] => Cache-Control: no-store, private
     [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
     [3] => Set-Cookie: CookieSamesiteStrictTest=StrictValue; path=/; httponly; samesite=strict
 )

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_urlencode.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_urlencode.expected
@@ -2,7 +2,7 @@
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: no-cache, private
+    [1] => Cache-Control: no-store, private
     [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
     [3] => Set-Cookie: %3D%2C%3B%20%09%0D%0A%0B%0C=%3D%2C%3B%20%09%0D%0A%0B%0C; path=/
     [4] => Set-Cookie: ?*():@&+$/%#[]=%3F%2A%28%29%3A%40%26%2B%24%2F%25%23%5B%5D; path=/

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -62,17 +62,17 @@ class RedirectResponseTest extends TestCase
     public function testCacheHeaders()
     {
         $response = new RedirectResponse('foo.bar', 301);
-        $this->assertFalse($response->headers->hasCacheControlDirective('no-cache'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
 
         $response = new RedirectResponse('foo.bar', 301, ['cache-control' => 'max-age=86400']);
-        $this->assertFalse($response->headers->hasCacheControlDirective('no-cache'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
         $this->assertTrue($response->headers->hasCacheControlDirective('max-age'));
 
         $response = new RedirectResponse('foo.bar', 301, ['Cache-Control' => 'max-age=86400']);
-        $this->assertFalse($response->headers->hasCacheControlDirective('no-cache'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
         $this->assertTrue($response->headers->hasCacheControlDirective('max-age'));
 
         $response = new RedirectResponse('foo.bar', 302);
-        $this->assertTrue($response->headers->hasCacheControlDirective('no-cache'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('no-store'));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -43,17 +43,17 @@ class ResponseHeaderBagTest extends TestCase
     public function testCacheControlHeader()
     {
         $bag = new ResponseHeaderBag([]);
-        $this->assertEquals('no-cache, private', $bag->get('Cache-Control'));
-        $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
+        $this->assertEquals('no-store, private', $bag->get('Cache-Control'));
+        $this->assertTrue($bag->hasCacheControlDirective('no-store'));
 
         $bag = new ResponseHeaderBag(['Cache-Control' => 'public']);
         $this->assertEquals('public', $bag->get('Cache-Control'));
         $this->assertTrue($bag->hasCacheControlDirective('public'));
 
         $bag = new ResponseHeaderBag(['ETag' => 'abcde']);
-        $this->assertEquals('no-cache, private', $bag->get('Cache-Control'));
+        $this->assertEquals('no-store, private', $bag->get('Cache-Control'));
         $this->assertTrue($bag->hasCacheControlDirective('private'));
-        $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
+        $this->assertTrue($bag->hasCacheControlDirective('no-store'));
         $this->assertFalse($bag->hasCacheControlDirective('max-age'));
 
         $bag = new ResponseHeaderBag(['Expires' => 'Wed, 16 Feb 2011 14:17:43 GMT']);
@@ -139,8 +139,8 @@ class ResponseHeaderBagTest extends TestCase
     public function testReplace()
     {
         $bag = new ResponseHeaderBag([]);
-        $this->assertEquals('no-cache, private', $bag->get('Cache-Control'));
-        $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
+        $this->assertEquals('no-store, private', $bag->get('Cache-Control'));
+        $this->assertTrue($bag->hasCacheControlDirective('no-store'));
 
         $bag->replace(['Cache-Control' => 'public']);
         $this->assertEquals('public', $bag->get('Cache-Control'));
@@ -150,13 +150,13 @@ class ResponseHeaderBagTest extends TestCase
     public function testReplaceWithRemove()
     {
         $bag = new ResponseHeaderBag([]);
-        $this->assertEquals('no-cache, private', $bag->get('Cache-Control'));
-        $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
+        $this->assertEquals('no-store, private', $bag->get('Cache-Control'));
+        $this->assertTrue($bag->hasCacheControlDirective('no-store'));
 
         $bag->remove('Cache-Control');
         $bag->replace([]);
-        $this->assertEquals('no-cache, private', $bag->get('Cache-Control'));
-        $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
+        $this->assertEquals('no-store, private', $bag->get('Cache-Control'));
+        $this->assertTrue($bag->hasCacheControlDirective('no-store'));
     }
 
     public function testCookiesWithSameNames()

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -25,7 +25,7 @@ class ResponseTest extends ResponseTestCase
         $response = new Response();
         $response = explode("\r\n", $response);
         $this->assertEquals('HTTP/1.0 200 OK', $response[0]);
-        $this->assertEquals('Cache-Control: no-cache, private', $response[1]);
+        $this->assertEquals('Cache-Control: no-store, private', $response[1]);
     }
 
     public function testClone()
@@ -650,7 +650,7 @@ class ResponseTest extends ResponseTestCase
 
         $response = new Response('foo');
         $response->prepare($request);
-        $this->assertEquals('no-cache', $response->headers->get('pragma'));
+        $this->assertEquals('no-store', $response->headers->get('pragma'));
         $this->assertEquals('-1', $response->headers->get('expires'));
 
         $response = new Response('foo');

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
@@ -21,7 +21,7 @@ class ResponseHeaderSameTest extends TestCase
 {
     public function testConstraint()
     {
-        $constraint = new ResponseHeaderSame('Cache-Control', 'no-cache, private');
+        $constraint = new ResponseHeaderSame('Cache-Control', 'no-store, private');
         $this->assertTrue($constraint->evaluate(new Response(), '', true));
         $constraint = new ResponseHeaderSame('Cache-Control', 'public');
         $this->assertFalse($constraint->evaluate(new Response(), '', true));

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -61,7 +61,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *                            public or private via a Cache-Control directive. (default: Authorization and Cookie)
      *
      *   * allow_reload           Specifies whether the client can force a cache reload by including a
-     *                            Cache-Control "no-cache" directive in the request. Set it to ``true``
+     *                            Cache-Control "no-store" directive in the request. Set it to ``true``
      *                            for compliance with RFC 2616. (default: false)
      *
      *   * allow_revalidate       Specifies whether the client can force a cache revalidate by including
@@ -206,7 +206,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             $response = $this->pass($request, $catch);
         } elseif ($this->options['allow_reload'] && $request->isNoCache()) {
             /*
-                If allow_reload is configured and the client requests "Cache-Control: no-cache",
+                If allow_reload is configured and the client requests "Cache-Control: no-store",
                 reload the cache by fetching a fresh response and caching it (if possible).
             */
             $this->record($request, 'reload');
@@ -343,7 +343,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             return $this->validate($request, $entry, $catch);
         }
 
-        if ($entry->headers->hasCacheControlDirective('no-cache')) {
+        if ($entry->headers->hasCacheControlDirective('no-store')) {
             return $this->validate($request, $entry, $catch);
         }
 
@@ -469,7 +469,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
          * Cache-Control directives) that
          *
          *      A cache MUST NOT generate a stale response if it is prohibited by an
-         *      explicit in-protocol directive (e.g., by a "no-store" or "no-cache"
+         *      explicit in-protocol directive (e.g., by a "no-store" or "no-store"
          *      cache directive, a "must-revalidate" cache-response-directive, or an
          *      applicable "s-maxage" or "proxy-revalidate" cache-response-directive;
          *      see Section 5.2.2).
@@ -481,7 +481,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
          */
         if (null !== $entry
             && \in_array($response->getStatusCode(), [500, 502, 503, 504])
-            && !$entry->headers->hasCacheControlDirective('no-cache')
+            && !$entry->headers->hasCacheControlDirective('no-store')
             && !$entry->mustRevalidate()
         ) {
             if (null === $age = $entry->headers->getCacheControlDirective('stale-if-error')) {

--- a/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
@@ -27,7 +27,7 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
     /**
      * Cache-Control headers that are sent to the final response if they appear in ANY of the responses.
      */
-    private const OVERRIDE_DIRECTIVES = ['private', 'no-cache', 'no-store', 'no-transform', 'must-revalidate', 'proxy-revalidate'];
+    private const OVERRIDE_DIRECTIVES = ['private', 'no-store', 'no-store', 'no-transform', 'must-revalidate', 'proxy-revalidate'];
 
     /**
      * Cache-Control headers that are sent to the final response if they appear in ALL of the responses.
@@ -39,7 +39,7 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
     private int $age = 0;
     private \DateTimeInterface|null|false $lastModified = null;
     private array $flagDirectives = [
-        'no-cache' => null,
+        'no-store' => null,
         'no-store' => null,
         'no-transform' => null,
         'must-revalidate' => null,
@@ -113,9 +113,9 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
             $response->setLastModified(null);
 
             if ($this->flagDirectives['no-store']) {
-                $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');
+                $response->headers->set('Cache-Control', 'no-store, no-store, must-revalidate');
             } else {
-                $response->headers->set('Cache-Control', 'no-cache, must-revalidate');
+                $response->headers->set('Cache-Control', 'no-store, must-revalidate');
             }
 
             return;
@@ -126,7 +126,7 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
         $flags = array_filter($this->flagDirectives);
 
         if (isset($flags['must-revalidate'])) {
-            $flags['no-cache'] = true;
+            $flags['no-store'] = true;
         }
 
         $response->headers->set('Cache-Control', implode(', ', array_keys($flags)));
@@ -162,7 +162,7 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
     {
         // RFC2616: A response received with a status code of 200, 203, 300, 301 or 410
         // MAY be stored by a cache […] unless a cache-control directive prohibits caching.
-        if ($response->headers->hasCacheControlDirective('no-cache')
+        if ($response->headers->hasCacheControlDirective('no-store')
             || $response->headers->hasCacheControlDirective('no-store')
         ) {
             return true;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
@@ -84,7 +84,7 @@ class ResponseCacheStrategyTest extends TestCase
         $mainResponse->setSharedMaxAge(3600);
         $cacheStrategy->update($mainResponse);
 
-        $this->assertTrue($mainResponse->headers->hasCacheControlDirective('no-cache'));
+        $this->assertTrue($mainResponse->headers->hasCacheControlDirective('no-store'));
         $this->assertTrue($mainResponse->headers->hasCacheControlDirective('must-revalidate'));
         $this->assertFalse($mainResponse->isFresh());
     }
@@ -108,7 +108,7 @@ class ResponseCacheStrategyTest extends TestCase
         $this->assertFalse($mainResponse->isValidateable());
         $this->assertFalse($mainResponse->headers->has('Last-Modified'));
         $this->assertFalse($mainResponse->headers->has('ETag'));
-        $this->assertTrue($mainResponse->headers->hasCacheControlDirective('no-cache'));
+        $this->assertTrue($mainResponse->headers->hasCacheControlDirective('no-store'));
         $this->assertTrue($mainResponse->headers->hasCacheControlDirective('must-revalidate'));
     }
 
@@ -172,7 +172,7 @@ class ResponseCacheStrategyTest extends TestCase
         $cacheStrategy->add($embeddedResponse);
         $cacheStrategy->update($mainResponse);
 
-        $this->assertTrue($mainResponse->headers->hasCacheControlDirective('no-cache'));
+        $this->assertTrue($mainResponse->headers->hasCacheControlDirective('no-store'));
         $this->assertTrue($mainResponse->headers->hasCacheControlDirective('must-revalidate'));
         $this->assertFalse($mainResponse->isFresh());
     }
@@ -353,11 +353,11 @@ class ResponseCacheStrategyTest extends TestCase
             ],
         ];
 
-        yield 'inherits no-cache from surrogates' => [
-            ['no-cache' => true, 'public' => false],
+        yield 'inherits no-store from surrogates' => [
+            ['no-store' => true, 'public' => false],
             ['public' => true],
             [
-                ['no-cache' => true],
+                ['no-store' => true],
             ],
         ];
 
@@ -436,7 +436,7 @@ class ResponseCacheStrategyTest extends TestCase
         ];
 
         yield 'result is private when combining private responses' => [
-            ['no-cache' => false, 'must-revalidate' => false, 'private' => true],
+            ['no-store' => false, 'must-revalidate' => false, 'private' => true],
             ['s-maxage' => 60, 'private' => true],
             [
                 ['s-maxage' => 60, 'private' => true],

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
@@ -258,6 +258,7 @@ class ResponseCacheStrategyTest extends TestCase
 
     /**
      * @group time-sensitive
+     *
      * @dataProvider cacheControlMergingProvider
      */
     public function testCacheControlMerging(array $expects, array $master, array $surrogates)

--- a/src/Symfony/Component/Notifier/Bridge/Isendpro/IsendproTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Isendpro/IsendproTransport.php
@@ -80,7 +80,7 @@ final class IsendproTransport extends AbstractTransport
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/cgi-bin/sms', [
             'headers' => [
                 'Accept' => 'application/json',
-                'Cache-Control' => 'no-cache',
+                'Cache-Control' => 'no-store',
             ],
             'json' => $messageData,
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

----

Back / forward cache seems to be a fairly recent feature browsers seem to rollout.

More information can be found here: https://web.dev/bfcache.

Long story short, when a user for example login then logout from a given application, they could then hit the "Back" button from their browser and access the login page again with the credentials pre-filled as the page would be served from the `bfcache`. This could lead to security concerns, especially on shared devices where someone could inspect the page and retrieve some user credentials.

Currently, the sensible defaults for the HTTP cache headers seem to be `no-cache, private` in order to be conservative by default. A lot of applications currently rely on this to be the sensible default for their application too.

Replacing `no-cache` by `no-store` would prevent `bfcache` to kick in from any browser and could be considered as a more secure default.

> `no-cache` shows that returned responses can't be used for subsequent requests to the same URL before checking if server responses have changed. If a proper `ETag` (validation token) is present as a result, `no-cache` incurs a roundtrip in an effort to validate cached responses. Caches can however eliminate downloads if the resources haven't changed. In other words, web browsers might cache the assets but they have to check on every request if the assets have changed (304 response if nothing has changed).

> On the contrary, `no-store` is simpler. This is the case because it disallows browsers and all intermediate caches from storing any versions of returned responses, such as responses containing private/personal information or banking data. Every time users request this asset, requests are sent to the server. The assets are downloaded every time.

More information can be found here: https://www.keycdn.com/blog/http-cache-headers#no-cache-and-no-store

The purpose of this PR is to start the discussion rather than bringing a definite solution.