### PR TITLE
[Console] Revert "bug #48089  Fix clear line with question in section (maxbeckers)

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -88,14 +88,6 @@ class ConsoleSectionOutput extends StreamOutput
     }
 
     /**
-     * @internal
-     */
-    public function incrementLines()
-    {
-        ++$this->lines;
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function doWrite(string $message, bool $newline)

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -22,7 +22,6 @@ use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
-use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\TrimmedBufferOutput;
 use Symfony\Component\Console\Question\ChoiceQuestion;
@@ -351,11 +350,6 @@ class SymfonyStyle extends OutputStyle
         if ($this->input->isInteractive()) {
             $this->newLine();
             $this->bufferedOutput->write("\n");
-            if ($this->output instanceof ConsoleSectionOutput) {
-                // add one line more to the ConsoleSectionOutput because of the `return` to submit the input
-                // this is relevant when a `ConsoleSectionOutput::clear` is called.
-                $this->output->incrementLines();
-            }
         }
 
         return $answer;

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -16,13 +16,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -182,39 +180,5 @@ class SymfonyStyleTest extends TestCase
         }
 
         $this->assertSame(0, memory_get_usage() - $start);
-    }
-
-    public function testAskAndClearExpectFullSectionCleared()
-    {
-        $answer = 'Answer';
-        $inputStream = fopen('php://memory', 'r+');
-        fwrite($inputStream, $answer.\PHP_EOL);
-        rewind($inputStream);
-        $input = $this->createMock(Input::class);
-        $sections = [];
-        $output = new ConsoleSectionOutput(fopen('php://memory', 'r+', false), $sections, StreamOutput::VERBOSITY_NORMAL, true, new OutputFormatter());
-        $input
-            ->method('isInteractive')
-            ->willReturn(true);
-        $input
-            ->method('getStream')
-            ->willReturn($inputStream);
-
-        $style = new SymfonyStyle($input, $output);
-
-        $style->write('foo');
-        $givenAnswer = $style->ask('Dummy question?');
-        $output->write('bar');
-        $output->clear();
-
-        rewind($output->getStream());
-        $this->assertEquals($answer, $givenAnswer);
-        $this->assertEquals(
-            'foo'.\PHP_EOL. // write foo
-            \PHP_EOL.\PHP_EOL.\PHP_EOL." \033[32mDummy question?\033[39m:".\PHP_EOL.' > '.\PHP_EOL.\PHP_EOL.\PHP_EOL. // question
-            'bar'.\PHP_EOL. // write bar
-            "\033[10A\033[0J", // clear 10 lines (9 output lines and one from the answer input return)
-            stream_get_contents($output->getStream())
-        );
     }
 }


### PR DESCRIPTION
This reverts commit caffee8d62e7f998fcf6116ca128b8343017f3d2, reversing changes made to f14901e3a4343bb628ff0f7e5f213752381a069e.

| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | -

The tests added in #48089 break on branch 6.2, and after checking the fix on both 6.1 and 6.2 based on the reproducer from https://github.com/symfony/symfony/issues/47411, I feel like the behavior is still not the expected one.
I propose to revert for now, hope we can fix this bug homogeneously in another PR.