### PR TITLE
[DependencyInjection] Deprecate integer keys in "service_locator" config

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -5,6 +5,7 @@ DependencyInjection
 -------------------
 
  * Deprecate `PhpDumper` options `inline_factories_parameter` and `inline_class_loader_parameter`, use `inline_factories` and `inline_class_loader` instead
+ * Deprecate undefined and numeric keys with `service_locator` config, use string aliases instead
 
 HttpKernel
 ----------

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate `PhpDumper` options `inline_factories_parameter` and `inline_class_loader_parameter`
  * Add `RemoveBuildParametersPass`, which removes parameters starting with a dot during compilation
  * Add support for nesting autowiring-related attributes into `#[Autowire(...)]`
+ * Deprecate undefined and numeric keys with `service_locator` config
 
 6.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -123,7 +123,13 @@ function inline_service(string $class = null): InlineServiceConfigurator
  */
 function service_locator(array $values): ServiceLocatorArgument
 {
-    return new ServiceLocatorArgument(AbstractConfigurator::processValue($values, true));
+    $values = AbstractConfigurator::processValue($values, true);
+
+    if (isset($values[0])) {
+        trigger_deprecation('symfony/dependency-injection', '6.3', 'Using integers as keys in a "service_locator()" argument is deprecated. The keys will default to the IDs of the original services in 7.0.');
+    }
+
+    return new ServiceLocatorArgument($values);
 }
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -526,6 +526,11 @@ class XmlFileLoader extends FileLoader
                     break;
                 case 'service_locator':
                     $arg = $this->getArgumentsAsPhp($arg, $name, $file);
+
+                    if (isset($arg[0])) {
+                        trigger_deprecation('symfony/dependency-injection', '6.3', 'Skipping "key" argument or using integers as values in a "service_locator" tag is deprecated. The keys will default to the IDs of the original services in 7.0.');
+                    }
+
                     $arguments[$key] = new ServiceLocatorArgument($arg);
                     break;
                 case 'tagged':

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -814,6 +814,10 @@ class YamlFileLoader extends FileLoader
 
                 $argument = $this->resolveServices($argument, $file, $isParameter);
 
+                if (isset($argument[0])) {
+                    trigger_deprecation('symfony/dependency-injection', '6.3', 'Using integers as keys in a "!service_locator" tag is deprecated. The keys will default to the IDs of the original services in 7.0.');
+                }
+
                 return new ServiceLocatorArgument($argument);
             }
             if (\in_array($value->getTag(), ['tagged', 'tagged_iterator', 'tagged_locator'], true)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_service_locator_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_service_locator_argument.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $configurator) {
+    $services = $configurator->services()->defaults()->public();
+
+    $services->set('foo_service', \stdClass::class);
+
+    $services->set('bar_service', \stdClass::class);
+
+    $services->set('locator_dependent_service_indexed', \ArrayObject::class)
+        ->args([service_locator([
+            'foo' => service('foo_service'),
+            'bar' => service('bar_service'),
+        ])]);
+
+    $services->set('locator_dependent_service_not_indexed', \ArrayObject::class)
+        ->args([service_locator([
+            service('foo_service'),
+            service('bar_service'),
+        ])]);
+
+    $services->set('locator_dependent_service_mixed', \ArrayObject::class)
+        ->args([service_locator([
+            'foo' => service('foo_service'),
+            service('bar_service'),
+        ])]);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_service_locator_argument.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_service_locator_argument.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="foo_service" class="stdClass"/>
+
+    <service id="bar_service" class="stdClass"/>
+
+    <service id="locator_dependent_service_indexed" class="ArrayObject">
+      <argument type="service_locator">
+        <argument key="foo" type="service" id="foo_service"/>
+        <argument key="bar" type="service" id="bar_service"/>
+      </argument>
+    </service>
+
+    <service id="locator_dependent_service_not_indexed" class="ArrayObject">
+      <argument type="service_locator">
+        <argument type="service" id="foo_service"/>
+        <argument type="service" id="bar_service"/>
+      </argument>
+    </service>
+
+    <service id="locator_dependent_service_mixed" class="ArrayObject">
+      <argument type="service_locator">
+        <argument key="foo" type="service" id="foo_service"/>
+        <argument type="service" id="bar_service"/>
+      </argument>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_service_locator_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_service_locator_argument.yml
@@ -1,0 +1,28 @@
+
+services:
+    foo_service:
+        class: stdClass
+
+    bar_service:
+        class: stdClass
+
+    locator_dependent_service_indexed:
+        class: ArrayObject
+        arguments:
+            - !service_locator
+                'foo': '@foo_service'
+                'bar': '@bar_service'
+
+    locator_dependent_service_not_indexed:
+        class: ArrayObject
+        arguments:
+            - !service_locator
+                - '@foo_service'
+                - '@bar_service'
+
+    locator_dependent_service_mixed:
+        class: ArrayObject
+        arguments:
+            - !service_locator
+                'foo': '@foo_service'
+                '0': '@bar_service'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
 use Symfony\Component\Config\Exception\LoaderLoadException;
 use Symfony\Component\Config\FileLocator;
@@ -45,6 +46,8 @@ use Symfony\Component\ExpressionLanguage\Expression;
 
 class YamlFileLoaderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     protected static $fixturesPath;
 
     public static function setUpBeforeClass(): void
@@ -406,6 +409,27 @@ class YamlFileLoaderTest extends TestCase
 
         $taggedIterator = new TaggedIteratorArgument('foo', null, null, true);
         $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('bar_service_tagged_locator')->getArgument(0));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testServiceWithServiceLocatorArgument()
+    {
+        $this->expectDeprecation('Since symfony/dependency-injection 6.3: Using integers as keys in a "!service_locator" tag is deprecated. The keys will default to the IDs of the original services in 7.0.');
+
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_service_locator_argument.yml');
+
+        $values = ['foo' => new Reference('foo_service'), 'bar' => new Reference('bar_service')];
+        $this->assertEquals([new ServiceLocatorArgument($values)], $container->getDefinition('locator_dependent_service_indexed')->getArguments());
+
+        $values = [new Reference('foo_service'), new Reference('bar_service')];
+        $this->assertEquals([new ServiceLocatorArgument($values)], $container->getDefinition('locator_dependent_service_not_indexed')->getArguments());
+
+        $values = ['foo' => new Reference('foo_service'), 0 => new Reference('bar_service')];
+        $this->assertEquals([new ServiceLocatorArgument($values)], $container->getDefinition('locator_dependent_service_mixed')->getArguments());
     }
 
     public function testParseServiceClosure()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Deprecation befor #48653
| License       | MIT
| Doc PR        | symfony/symfony-docs#17576

It deprecates undefined/wrong behaviour of https://symfony.com/doc/current/service_container/service_subscribers_locators.html#defining-a-service-locator

