### PR TITLE
[Console] Fix a test when pcntl is not available (following #48329)

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1969,6 +1969,10 @@ class ApplicationTest extends TestCase
 
     public function testSignalableCommandInterfaceWithoutSignals()
     {
+        if (!\defined('SIGUSR1')) {
+            $this->markTestSkipped('SIGUSR1 not available');
+        }
+
         $command = new SignableCommand(false);
 
         $dispatcher = new EventDispatcher();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

The test is currently failing in AppVeyor (see https://ci.appveyor.com/project/fabpot/symfony/builds/45710392#L1577), the missing check seems present in tests above and below it.
Don't know what happened.