### PR TITLE
Fix and update GitHub Actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,7 +48,7 @@ jobs:
         ports:
           - 16379:6379
       redis-cluster:
-        image: grokzen/redis-cluster:5.0.4
+        image: bitnami/redis-cluster:7.0
         ports:
           - 7000:7000
           - 7001:7001
@@ -58,7 +58,7 @@ jobs:
           - 7005:7005
           - 7006:7006
         env:
-          STANDALONE: 1
+          ALLOW_EMPTY_PASSWORD: 1
       redis-sentinel:
         image: bitnami/redis-sentinel:6.0
         ports:

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: Ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch branch from where the PR started
         run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
@@ -50,7 +50,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+        uses: actions/upload-artifact@v3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`grokzen/redis-cluster` v3, v4 and v5 are not supported anymore, updating to latest `7.0.7`