### PR TITLE
[DependencyInjection] Target Attribute must fail if the target does not exist

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Target.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Target.php
@@ -28,13 +28,15 @@ final class Target
         $this->name = lcfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name))));
     }
 
-    public static function parseName(\ReflectionParameter $parameter): string
+    public static function parseName(\ReflectionParameter $parameter, self &$attribute = null): string
     {
+        $attribute = null;
         if (!$target = $parameter->getAttributes(self::class)[0] ?? null) {
             return $parameter->name;
         }
 
-        $name = $target->newInstance()->name;
+        $attribute = $target->newInstance();
+        $name = $attribute->name;
 
         if (!preg_match('/^[a-zA-Z_\x7f-\xff]/', $name)) {
             if (($function = $parameter->getDeclaringFunction()) instanceof \ReflectionMethod) {

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `RemoveBuildParametersPass`, which removes parameters starting with a dot during compilation
  * Add support for nesting autowiring-related attributes into `#[Autowire(...)]`
  * Deprecate undefined and numeric keys with `service_locator` config
+ * Fail if Target attribute does not exist during compilation
 
 6.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1142,6 +1142,21 @@ class AutowirePassTest extends TestCase
         $this->assertSame(BarInterface::class.' $imageStorage', (string) $container->getDefinition('with_target')->getArgument(0));
     }
 
+    public function testArgumentWithTypoTarget()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(BarInterface::class, BarInterface::class);
+        $container->register(BarInterface::class.' $iamgeStorage', BarInterface::class);
+        $container->register('with_target', WithTarget::class)
+            ->setAutowired(true);
+
+        $this->expectException(AutowiringFailedException::class);
+        $this->expectExceptionMessage('Cannot autowire service "with_target": "#[Target(\'imageStorage\')" on argument "$bar" of method "Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget::__construct()"');
+
+        (new AutowirePass())->process($container);
+    }
+
     public function testDecorationWithServiceAndAliasedInterface()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -463,7 +463,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             'autowired.nullable' => new ServiceClosureArgument(new Reference('service.id', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
             'autowired.parameter' => new ServiceClosureArgument('foobar'),
             'map.decorated' => new ServiceClosureArgument(new Reference('.service_locator.oZHAdom.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
-            'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'someTarget')),
+            'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'someTarget', [new Target('someTarget')])),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #48555 
| License       | MIT
| Doc PR        | -

This change checks if an attribute is a Target to not auto bind with a new default object if the target name does not exists.
The existent behavior should be in charge of suggest possible options for a typo on the Target name.

I can't mark `allow edit by maintainers` I think because I'm open the PR from a organization repo.

