### PR TITLE
Compatibility with doctrine/annotations 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
         "async-aws/sqs": "^1.0",
         "async-aws/sns": "^1.0",
         "cache/integration-tests": "dev-master",
-        "doctrine/annotations": "^1.13.1",
+        "doctrine/annotations": "^1.13.1 || ^2",
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/collections": "^1.0|^2.0",
         "doctrine/data-fixtures": "^1.1",

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\Setup;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
@@ -33,7 +34,9 @@ class DoctrineExtractorTest extends TestCase
 {
     private function createExtractor()
     {
-        $config = Setup::createAnnotationMetadataConfiguration([__DIR__.\DIRECTORY_SEPARATOR.'Fixtures'], true);
+        $config = class_exists(ORMSetup::class)
+            ? ORMSetup::createAnnotationMetadataConfiguration([__DIR__.\DIRECTORY_SEPARATOR.'Fixtures'], true)
+            : Setup::createAnnotationMetadataConfiguration([__DIR__.\DIRECTORY_SEPARATOR.'Fixtures'], true);
         $entityManager = EntityManager::create(['driver' => 'pdo_sqlite'], $config);
 
         if (!DBALType::hasType('foo')) {

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -43,7 +43,7 @@
         "symfony/validator": "^5.2|^6.0",
         "symfony/translation": "^4.4|^5.0|^6.0",
         "symfony/var-dumper": "^4.4|^5.0|^6.0",
-        "doctrine/annotations": "^1.10.4",
+        "doctrine/annotations": "^1.10.4|^2",
         "doctrine/collections": "^1.0|^2.0",
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^2.13.1|^3.0",

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -138,7 +138,7 @@ class SymfonyTestsListenerTrait
             if (!class_exists(AnnotationRegistry::class, false) && class_exists(AnnotationRegistry::class)) {
                 if (method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
                     AnnotationRegistry::registerUniqueLoader('class_exists');
-                } else {
+                } elseif (method_exists(AnnotationRegistry::class, 'registerLoader')) {
                     AnnotationRegistry::registerLoader('class_exists');
                 }
             }

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -30,7 +30,7 @@ setlocale(\LC_ALL, 'C');
 if (!class_exists(AnnotationRegistry::class, false) && class_exists(AnnotationRegistry::class)) {
     if (method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
         AnnotationRegistry::registerUniqueLoader('class_exists');
-    } else {
+    } elseif (method_exists(AnnotationRegistry::class, 'registerLoader')) {
         AnnotationRegistry::registerLoader('class_exists');
     }
 }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -22,7 +22,7 @@
         "twig/twig": "^2.13|^3.0.4"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.12",
+        "doctrine/annotations": "^1.12|^2",
         "egulias/email-validator": "^2.1.10|^3",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "symfony/asset": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1632,8 +1632,12 @@ class FrameworkExtension extends Extension
         $loader->load('annotations.php');
 
         if (!method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
-            $container->getDefinition('annotations.dummy_registry')
-                ->setMethodCalls([['registerLoader', ['class_exists']]]);
+            if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
+                $container->getDefinition('annotations.dummy_registry')
+                    ->setMethodCalls([['registerLoader', ['class_exists']]]);
+            } else {
+                $container->removeDefinition('annotations.dummy_registry');
+            }
         }
 
         if ('none' === $config['cache']) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
@@ -26,7 +26,7 @@ return static function (ContainerConfigurator $container) {
         ->set('annotations.reader', AnnotationReader::class)
             ->call('addGlobalIgnoredName', [
                 'required',
-                service('annotations.dummy_registry'), // dummy arg to register class_exists as annotation loader only when required
+                service('annotations.dummy_registry')->ignoreOnInvalid(), // dummy arg to register class_exists as annotation loader only when required
             ])
 
         ->set('annotations.dummy_registry', AnnotationRegistry::class)

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -34,7 +34,7 @@
         "symfony/routing": "^5.3|^6.0"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.13.1",
+        "doctrine/annotations": "^1.13.1|^2",
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/persistence": "^1.3|^2|^3",
         "symfony/asset": "^5.3|^6.0",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -32,7 +32,7 @@
         "symfony/security-http": "^5.4|^6.0"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.10.4",
+        "doctrine/annotations": "^1.10.4|^2",
         "symfony/asset": "^4.4|^5.0|^6.0",
         "symfony/browser-kit": "^4.4|^5.0|^6.0",
         "symfony/console": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -37,7 +37,7 @@
         "symfony/yaml": "^4.4|^5.0|^6.0",
         "symfony/framework-bundle": "^5.0|^6.0",
         "symfony/web-link": "^4.4|^5.0|^6.0",
-        "doctrine/annotations": "^1.10.4",
+        "doctrine/annotations": "^1.10.4|^2",
         "doctrine/cache": "^1.0|^2.0"
     },
     "conflict": {

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -34,7 +34,7 @@
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "phpstan/phpdoc-parser": "^1.0",
-        "doctrine/annotations": "^1.10.4"
+        "doctrine/annotations": "^1.10.4|^2"
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.2.2",

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderWithAnnotationsTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderWithAnnotationsTest.php
@@ -26,7 +26,9 @@ class AnnotationClassLoaderWithAnnotationsTest extends AnnotationClassLoaderTest
             {
             }
         };
-        AnnotationRegistry::registerLoader('class_exists');
+        if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
+            AnnotationRegistry::registerLoader('class_exists');
+        }
     }
 
     public function testDefaultRouteName()

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -26,7 +26,7 @@
         "symfony/yaml": "^4.4|^5.0|^6.0",
         "symfony/expression-language": "^4.4|^5.0|^6.0",
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-        "doctrine/annotations": "^1.12",
+        "doctrine/annotations": "^1.12|^2",
         "psr/log": "^1|^2|^3"
     },
     "conflict": {

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -22,7 +22,7 @@
         "symfony/polyfill-php80": "^1.16"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.12",
+        "doctrine/annotations": "^1.12|^2",
         "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
         "symfony/cache": "^4.4|^5.0|^6.0",
         "symfony/config": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -41,7 +41,7 @@
         "symfony/property-access": "^4.4|^5.0|^6.0",
         "symfony/property-info": "^5.3|^6.0",
         "symfony/translation": "^4.4|^5.0|^6.0",
-        "doctrine/annotations": "^1.13",
+        "doctrine/annotations": "^1.13|^2",
         "doctrine/cache": "^1.11|^2.0",
         "egulias/email-validator": "^2.1.10|^3"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48717
| License       | MIT
| Doc PR        | N/A

Doctrine Annotations 2 has been released, including the removal of deprecated classes and methods that were still called. Unfortunately, we have never declared a conflict with Annotations 2.