### PR TITLE
[VarExporter] Fix exporting classes with __unserialize() but not __serialize()

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -149,6 +149,7 @@ class Exporter
                 }
                 if (null !== $sleep) {
                     if (!isset($sleep[$n]) || ($i && $c !== $class)) {
+                        unset($arrayValue[$name]);
                         continue;
                     }
                     $sleep[$n] = false;
@@ -163,6 +164,9 @@ class Exporter
                         trigger_error(sprintf('serialize(): "%s" returned as member variable from __sleep() but does not exist', $n), \E_USER_NOTICE);
                     }
                 }
+            }
+            if (method_exists($class, '__unserialize')) {
+                $properties = $arrayValue;
             }
 
             prepare_value:

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/__unserialize-but-no-__serialize.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/__unserialize-but-no-__serialize.php
@@ -1,0 +1,15 @@
+<?php
+
+return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
+    $o = [
+        clone (\Symfony\Component\VarExporter\Internal\Registry::$prototypes['Symfony\\Component\\VarExporter\\Tests\\__UnserializeButNo__Serialize'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('Symfony\\Component\\VarExporter\\Tests\\__UnserializeButNo__Serialize')),
+    ],
+    null,
+    [],
+    $o[0],
+    [
+        [
+            'foo' => 'ccc',
+        ],
+    ]
+);

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -245,6 +245,8 @@ class VarExporterTest extends TestCase
 
         yield ['php74-serializable', new Php74Serializable()];
 
+        yield ['__unserialize-but-no-__serialize', new __UnserializeButNo__Serialize()];
+
         if (\PHP_VERSION_ID < 80100) {
             return;
         }
@@ -452,4 +454,19 @@ class Php74Serializable implements \Serializable
 #[\AllowDynamicProperties]
 class ArrayObject extends \ArrayObject
 {
+}
+
+class __UnserializeButNo__Serialize
+{
+    public $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'ccc';
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->foo = $data['foo'];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/48706 indirectly
| License       | MIT
| Doc PR        | -

This is an edge case not supported yet, highlighted by our own symfony/expression-language GetAttrNode class.