### PR TITLE
[ExpressionLanguage] Fix GetAttrNode export with all versions of VarExporter

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -151,6 +151,14 @@ class GetAttrNode extends Node
     }
 
     /**
+     * Provides compatibility with symfony/var-exporter <= 6.2.2
+     */
+    public function __serialize(): array
+    {
+        return (array) $this;
+    }
+
+    /**
      * Provides BC with instances serialized before v6.2
      */
     public function __unserialize(array $data): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/48706
| License       | MIT
| Doc PR        | -

Adding `__serialize` fixes the bug and avoid us to add conflict rules.