### PR TITLE
[SecurityBundle] Prevent RuntimeException on profiler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -177,7 +177,7 @@
                 </div>
             </div>
 
-            <div class="tab {{ collector.firewall.security_enabled is empty ? 'disabled' }}">
+            <div class="tab {{ (not collector.firewall or collector.firewall.security_enabled is empty) ? 'disabled' }}">
                 <h3 class="tab-title">Firewall</h3>
                 <div class="tab-content">
                     {% if collector.firewall %}


### PR DESCRIPTION
I've got RuntimeException "Impossible to access an attribute ("security_enabled") on a null variable." on the profiler page on a page without any configured firewall.

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Example: I have a page without any configured firewall. The profiler looks like this:
![Zrzut ekranu 2022-12-21 o 10 04 13](https://user-images.githubusercontent.com/57309/208866232-c93127aa-b6f7-48ef-9cd8-8df7a3b6d773.png)

When I click on "Security" tab. I've got:
![Zrzut ekranu 2022-12-21 o 10 06 10](https://user-images.githubusercontent.com/57309/208866346-c9a6c769-b6e7-4a87-9c3b-e4dcd6a9b843.png)


This commit fix this issue. Now it looks good:
![Zrzut ekranu 2022-12-21 o 10 07 04](https://user-images.githubusercontent.com/57309/208866567-28bddd7a-fc4c-4e6d-83db-9c9050319363.png)


