### PR TITLE
[Workflow] Allow spaces in place names so the PUML dump doesn't break

### DIFF
--- a/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Workflow\Dumper;
 
-use InvalidArgumentException;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
@@ -57,7 +56,7 @@ class PlantUmlDumper implements DumperInterface
     public function __construct(string $transitionType = null)
     {
         if (!\in_array($transitionType, self::TRANSITION_TYPES, true)) {
-            throw new InvalidArgumentException("Transition type '$transitionType' does not exist.");
+            throw new \InvalidArgumentException("Transition type '$transitionType' does not exist.");
         }
         $this->transitionType = $transitionType;
     }
@@ -209,9 +208,7 @@ class PlantUmlDumper implements DumperInterface
 
         $description = $workflowMetadata->getMetadata('description', $place);
         if (null !== $description) {
-            $output .= ' as '.$place.
-                \PHP_EOL.
-                $place.' : '.$description;
+            $output .= \PHP_EOL.$placeEscaped.' : '.$description;
         }
 
         return $output;

--- a/src/Symfony/Component/Workflow/Tests/Dumper/PlantUmlDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/PlantUmlDumperTest.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\Workflow\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Dumper\PlantUmlDumper;
 use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 use Symfony\Component\Workflow\Tests\WorkflowBuilderTrait;
+use Symfony\Component\Workflow\Transition;
 
 class PlantUmlDumperTest extends TestCase
 {
@@ -61,6 +64,34 @@ class PlantUmlDumperTest extends TestCase
         yield [$this->createComplexStateMachineDefinition(), null, 'complex-state-machine-nomarking', 'SimpleDiagram'];
         $marking = new Marking(['c' => 1, 'e' => 1]);
         yield [$this->createComplexStateMachineDefinition(), $marking, 'complex-state-machine-marking', 'SimpleDiagram'];
+    }
+
+    public function testDumpWorkflowWithSpacesInTheStateNamesAndDescription()
+    {
+        $dumper = new PlantUmlDumper(PlantUmlDumper::WORKFLOW_TRANSITION);
+
+        // The graph looks like:
+        //
+        // +---------+  t 1   +----------+  |
+        // | place a | -----> | place b  |  |
+        // +---------+        +----------+  |
+        $places = ['place a', 'place b'];
+
+        $transitions = [];
+        $transition = new Transition('t 1', 'place a', 'place b');
+        $transitions[] = $transition;
+
+        $placesMetadata = [];
+        $placesMetadata['place a'] = [
+            'description' => 'My custom place description',
+        ];
+        $inMemoryMetadataStore = new InMemoryMetadataStore([], $placesMetadata);
+        $definition = new Definition($places, $transitions, null, $inMemoryMetadataStore);
+
+        $dump = $dumper->dump($definition, null, ['title' => 'SimpleDiagram']);
+        $dump = str_replace(\PHP_EOL, "\n", $dump.\PHP_EOL);
+        $file = $this->getFixturePath('simple-workflow-with-spaces', PlantUmlDumper::WORKFLOW_TRANSITION);
+        $this->assertStringEqualsFile($file, $dump);
     }
 
     private function getFixturePath($name, $transitionType)

--- a/src/Symfony/Component/Workflow/Tests/fixtures/puml/square/simple-workflow-nomarking.puml
+++ b/src/Symfony/Component/Workflow/Tests/fixtures/puml/square/simple-workflow-nomarking.puml
@@ -17,8 +17,8 @@ skinparam agent {
 }
 state "a" <<initial>>
 state "b"
-state "c" <<DeepSkyBlue>> as c
-c : My custom place description
+state "c" <<DeepSkyBlue>>
+"c" : My custom place description
 agent "t1"
 agent "t2"
 "a" -[#Purple]-> "t1": "<font color=Grey>My custom transition label 2</font>"

--- a/src/Symfony/Component/Workflow/Tests/fixtures/puml/square/simple-workflow-with-spaces.puml
+++ b/src/Symfony/Component/Workflow/Tests/fixtures/puml/square/simple-workflow-with-spaces.puml
@@ -9,20 +9,15 @@ skinparam state {
     BorderColor #3887C6
     BorderColor<<marked>> Black
     FontColor<<marked>> White
-    BackgroundColor<<DeepSkyBlue>> DeepSkyBlue
 }
 skinparam agent {
     BackgroundColor #ffffff
     BorderColor #3887C6
 }
-state "a" <<initial>>
-state "b" <<marked>>
-state "c" <<DeepSkyBlue>>
-"c" : My custom place description
-agent "t1"
-agent "t2"
-"a" -[#Purple]-> "t1": "<font color=Grey>My custom transition label 2</font>"
-"t1" -[#Purple]-> "b": "<font color=Grey>My custom transition label 2</font>"
-"b" -[#Pink]-> "t2"
-"t2" -[#Pink]-> "c"
+state "place a" <<initial>>
+"place a" : My custom place description
+state "place b"
+agent "t 1"
+"place a" --> "t 1"
+"t 1" --> "place b"
 @enduml


### PR DESCRIPTION
Remove state alias as not needed and use escaped name for a description

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Current `PlantUmlDumper` implementation doesn't allow states to have a description if state name contains spaces.

Sample definition:
```yaml
framework:
    workflows:
        test:
           ...
            places:
                - 'place a'
                - 'place b'
            transitions:
                't 1':
                    from: 'place a'
                    to:   'place b'
```

produces following puml:
```puml
state "place a" <<initial>> as place a
place a : My custom place description
state "place b"
agent "t 1"
"place a" --> "t 1"
"t 1" --> "place b"
```

which contains a syntax error in line `state "place a" <<initial>> as place a`

A solution is to remove the state alias and use escaped name as a key:
```puml
...
state "place a" <<initial>>
"place a" : My custom place description
```
And then the diagram looks like:

![simple-workflow-with-spaces-SimpleDiagram](https://user-images.githubusercontent.com/3974074/208901107-f356ef3b-4ba8-4018-87e7-e738836f75a5.png)

