### PR TITLE
[HttpKernel] Allow using `#[WithLogLevel]` for setting custom log level for exceptions

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/WithLogLevel.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/WithLogLevel.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+use Psr\Log\LogLevel;
+
+/**
+ * @author Dejan Angelov <angelovdejan@protonmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class WithLogLevel
+{
+    /**
+     * @param LogLevel::* $level
+     */
+    public function __construct(public readonly string $level)
+    {
+        if (!\defined('Psr\Log\LogLevel::'.strtoupper($this->level))) {
+            throw new \InvalidArgumentException(sprintf('Invalid log level "%s".', $this->level));
+        }
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * `FileProfilerStorage` removes profiles automatically after two days
  * Add `#[HttpStatus]` for defining status codes for exceptions
  * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
+ * Add `#[WithLogLevel]` for defining log levels for exceptions
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Tests/Attribute/WithLogLevelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Attribute/WithLogLevelTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Symfony\Component\HttpKernel\Attribute\WithLogLevel;
+
+/**
+ * @author Dejan Angelov <angelovdejan@protonmail.com>
+ */
+class WithLogLevelTest extends TestCase
+{
+    public function testWithValidLogLevel()
+    {
+        $logLevel = LogLevel::NOTICE;
+
+        $attribute = new WithLogLevel($logLevel);
+
+        $this->assertSame($logLevel, $attribute->level);
+    }
+
+    public function testWithInvalidLogLevel()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid log level "invalid".');
+
+        new WithLogLevel('invalid');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | TODO

With these changes, we're extending the functionality for setting a custom log level for a given exception by introducing a new `WithLogLevel` attribute.

Example: 
```php
#[WithLogLevel(\Psr\Log\LogLevel::CRITICAL)]
class AccountBalanceIsNegative extends \Exception
{
}
```

This will have a lower priority compared to the log level set using the option in the configuration files.
(Meaning that if we have both an attribute declared on an exception class, and another level set for the same class in the configuration, the one from the configuration will be used.)
