### PR TITLE
[Security] Add generics to PasswordUpgraderInterface

### DIFF
--- a/src/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Security\Core\User;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @template TUser of PasswordAuthenticatedUserInterface
  */
 interface PasswordUpgraderInterface
 {
@@ -22,6 +24,8 @@ interface PasswordUpgraderInterface
      * This method should persist the new password in the user storage and update the $user object accordingly.
      * Because you don't want your users not being able to log in, this method should be opportunistic:
      * it's fine if it does nothing or if it fails without throwing any exception.
+     *
+     * @param TUser $user
      */
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes (but phpdoc only)
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Related to the discussion https://github.com/symfony/symfony/issues/48743

A PasswordUpgraderInterface might not support every existing user implementing `PasswordAuthenticatedUserInterface` because of specific needs like a `setId` method. I would even say that most of the time it's only supporting one class of user and the method `upgradePassword` might be implemented in the doctrine `UserRepository`.

This would allow to write
```
/**
 * @extends EntityRepository<User>
 * @implements PasswordUpgraderInterface<User>
 */
class UserRepository extends EntityRepository implements UserLoaderInterface, PasswordUpgraderInterface
{
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
     {
         // static analysis tool will know $user is supposed to be a User.
     }
}
```
and also having a static analysis error when using
```
$userRepository->($anotherUserClass, $password);
```