### PR TITLE
[Mailer] [Amazon] add message id headers to original message

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -119,6 +119,8 @@ class SesApiAsyncAwsTransportTest extends TestCase
         $message = $transport->send($mail);
 
         $this->assertSame('foobar', $message->getMessageId());
+        $this->assertSame('foobar', $message->getOriginalMessage()->getHeaders()->get('X-Message-ID')->getBody());
+        $this->assertSame('foobar', $message->getOriginalMessage()->getHeaders()->get('X-SES-Message-ID')->getBody());
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -112,6 +112,8 @@ class SesHttpAsyncAwsTransportTest extends TestCase
         $message = $transport->send($mail);
 
         $this->assertSame('foobar', $message->getMessageId());
+        $this->assertSame('foobar', $message->getOriginalMessage()->getHeaders()->get('X-Message-ID')->getBody());
+        $this->assertSame('foobar', $message->getOriginalMessage()->getHeaders()->get('X-SES-Message-ID')->getBody());
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -65,6 +65,11 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
 
             throw $exception;
         }
+
+        if ($message->getOriginalMessage() instanceof Message) {
+            $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-ID', $result->getMessageId());
+            $message->getOriginalMessage()->getHeaders()->addHeader('X-SES-Message-ID', $result->getMessageId());
+        }
     }
 
     protected function getRequest(SentMessage $message): SendEmailRequest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45871
| License       | MIT
| Doc PR        | n/a

This is the simplest workaround to solve #45871. I believe this will enable Laravel to replace their own `SesTransport` with `symfony/amazon-mailer`. @driesvints, can you confirm?

Ref: https://github.com/laravel/framework/pull/41615
