### PR TITLE
[TwigBridge][WebProfilerBundle] Fix spelling of e-mails

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
@@ -38,7 +38,7 @@ class NotificationEmail extends TemplatedEmail
         'action_url' => null,
         'markdown' => false,
         'raw' => false,
-        'footer_text' => 'Notification e-mail sent by Symfony',
+        'footer_text' => 'Notification email sent by Symfony',
     ];
     private bool $rendered = false;
 

--- a/src/Symfony/Bridge/Twig/Tests/Mime/NotificationEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/NotificationEmailTest.php
@@ -35,7 +35,7 @@ class NotificationEmailTest extends TestCase
             'markdown' => true,
             'raw' => false,
             'a' => 'b',
-            'footer_text' => 'Notification e-mail sent by Symfony',
+            'footer_text' => 'Notification email sent by Symfony',
         ], $email->getContext());
     }
 
@@ -58,7 +58,7 @@ class NotificationEmailTest extends TestCase
             'markdown' => false,
             'raw' => true,
             'a' => 'b',
-            'footer_text' => 'Notification e-mail sent by Symfony',
+            'footer_text' => 'Notification email sent by Symfony',
         ], $email->getContext());
 
         $this->assertSame('@email/example/notification/body.html.twig', $email->getHtmlTemplate());

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -30,7 +30,7 @@
     <span class="label {{ events.messages is empty ? 'disabled' }}">
         <span class="icon">{{ source('@WebProfiler/Icon/mailer.svg') }}</span>
 
-        <strong>E-mails</strong>
+        <strong>Emails</strong>
         {% if events.messages|length > 0 %}
             <span class="count">
                 <span>{{ events.messages|length }}</span>


### PR DESCRIPTION
Use correct spelling for e-mails 

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I previously made a PR where the spelling was 'e-mail', see https://github.com/symfony/symfony/pull/48380

Not sure what to do with https://github.com/symfony/symfony/blob/e9870a418619b296cafe67c4f8d1d0eb2dbd0ce5/src/Symfony/Component/Intl/Resources/data/transliterator/emoji/emoji-en.php#L3299

