### PR TITLE
[CssSelector] Fix escape patterns

### DIFF
--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
@@ -49,22 +49,22 @@ class TokenizerPatterns
         $this->identifierPattern = '-?(?:'.$this->nmStartPattern.')(?:'.$this->nmCharPattern.')*';
         $this->hashPattern = '#((?:'.$this->nmCharPattern.')+)';
         $this->numberPattern = '[+-]?(?:[0-9]*\.[0-9]+|[0-9]+)';
-        $this->quotedStringPattern = '([^\n\r\f%s]|'.$this->stringEscapePattern.')*';
+        $this->quotedStringPattern = '([^\n\r\f\\\\%s]|'.$this->stringEscapePattern.')*';
     }
 
     public function getNewLineEscapePattern(): string
     {
-        return '~^'.$this->newLineEscapePattern.'~';
+        return '~'.$this->newLineEscapePattern.'~';
     }
 
     public function getSimpleEscapePattern(): string
     {
-        return '~^'.$this->simpleEscapePattern.'~';
+        return '~'.$this->simpleEscapePattern.'~';
     }
 
     public function getUnicodeEscapePattern(): string
     {
-        return '~^'.$this->unicodeEscapePattern.'~i';
+        return '~'.$this->unicodeEscapePattern.'~i';
     }
 
     public function getIdentifierPattern(): string

--- a/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
@@ -138,6 +138,16 @@ class ParserTest extends TestCase
             ['div:not(div.foo)', ['Negation[Element[div]:not(Class[Element[div].foo])]']],
             ['td ~ th', ['CombinedSelector[Element[td] ~ Element[th]]']],
             ['.foo[data-bar][data-baz=0]', ["Attribute[Attribute[Class[Element[*].foo][data-bar]][data-baz = '0']]"]],
+            ['div#foo\.bar', ['Hash[Element[div]#foo.bar]']],
+            ['div.w-1\/3', ['Class[Element[div].w-1/3]']],
+            ['#test\:colon', ['Hash[Element[*]#test:colon]']],
+            [".a\xc1b", ["Class[Element[*].a\xc1b]"]],
+            // unicode escape: \22 == "
+            ['*[aval="\'\22\'"]', ['Attribute[Element[*][aval = \'\'"\'\']]']],
+            ['*[aval="\'\22 2\'"]', ['Attribute[Element[*][aval = \'\'"2\'\']]']],
+            // unicode escape: \20 ==  (space)
+            ['*[aval="\'\20  \'"]', ['Attribute[Element[*][aval = \'\'  \'\']]']],
+            ["*[aval=\"'\\20\r\n '\"]", ['Attribute[Element[*][aval = \'\'  \'\']]']],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/46682 and https://github.com/symfony/symfony/issues/44516
| License       | MIT
| Doc PR        | -

I rechecked the original Python source code we "borrowed" (https://github.com/scrapy/cssselect/blob/master/cssselect/parser.py) and fixed some issues.