### PR TITLE
[Translation] Fix undefined variable messages in ConstraintVisitor

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/Visitor/ConstraintVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/ConstraintVisitor.php
@@ -72,6 +72,7 @@ final class ConstraintVisitor extends AbstractVisitor implements NodeVisitor
                 return null;
             }
 
+            $messages = [];
             $options = $arg->value;
 
             /** @var Node\Expr\ArrayItem $item */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #48767. <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fix `Warning: Undefined variable $messages`

(Found no unit test on this class)