### PR TITLE
[PhpUnitBridge] Use verbose deprecation output for quiet types only when it reaches the threshold

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -200,7 +200,7 @@ class DeprecationErrorHandler
         // store failing status
         $isFailing = !$configuration->tolerates($this->deprecationGroups);
 
-        $this->displayDeprecations($groups, $configuration, $isFailing);
+        $this->displayDeprecations($groups, $configuration);
 
         $this->resetDeprecationGroups();
 
@@ -213,7 +213,7 @@ class DeprecationErrorHandler
             }
 
             $isFailingAtShutdown = !$configuration->tolerates($this->deprecationGroups);
-            $this->displayDeprecations($groups, $configuration, $isFailingAtShutdown);
+            $this->displayDeprecations($groups, $configuration);
 
             if ($configuration->isGeneratingBaseline()) {
                 $configuration->writeBaseline();
@@ -289,11 +289,10 @@ class DeprecationErrorHandler
     /**
      * @param string[]      $groups
      * @param Configuration $configuration
-     * @param bool          $isFailing
      *
      * @throws \InvalidArgumentException
      */
-    private function displayDeprecations($groups, $configuration, $isFailing)
+    private function displayDeprecations($groups, $configuration)
     {
         $cmp = function ($a, $b) {
             return $b->count() - $a->count();
@@ -320,7 +319,8 @@ class DeprecationErrorHandler
                     fwrite($handle, "\n".self::colorize($deprecationGroupMessage, 'legacy' !== $group && 'indirect' !== $group)."\n");
                 }
 
-                if ('legacy' !== $group && !$configuration->verboseOutput($group) && !$isFailing) {
+                // Skip the verbose output if the group is quiet and not failing according to its threshold:
+                if ('legacy' !== $group && !$configuration->verboseOutput($group) && $configuration->toleratesForGroup($group, $this->deprecationGroups)) {
                     continue;
                 }
                 $notices = $this->deprecationGroups[$group]->notices();

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -166,6 +166,32 @@ class Configuration
     }
 
     /**
+     * @param array<string,DeprecationGroup> $deprecationGroups
+     *
+     * @return bool true if the threshold is not reached for the deprecation type nor for the total
+     */
+    public function toleratesForGroup(string $groupName, array $deprecationGroups): bool
+    {
+        $grandTotal = 0;
+
+        foreach ($deprecationGroups as $type => $group) {
+            if ('legacy' !== $type) {
+                $grandTotal += $group->count();
+            }
+        }
+
+        if ($grandTotal > $this->thresholds['total']) {
+            return false;
+        }
+
+        if (\in_array($groupName, ['self', 'direct', 'indirect'], true) && $deprecationGroups[$groupName]->count() > $this->thresholds[$groupName]) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * @return bool
      */
     public function isBaselineDeprecation(Deprecation $deprecation)

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/partially_quiet2.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/partially_quiet2.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test DeprecationErrorHandler quiet on everything but self/direct deprecations
+--FILE--
+<?php
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'max[self]=0&max[direct]=0&quiet[]=unsilenced&quiet[]=indirect&quiet[]=other');
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+require __DIR__.'/fake_vendor/autoload.php';
+require __DIR__.'/fake_vendor/acme/lib/deprecation_riddled.php';
+require __DIR__.'/fake_vendor/acme/outdated-lib/outdated_file.php';
+
+?>
+--EXPECTF--
+Unsilenced deprecation notices (3)
+
+Remaining direct deprecation notices (2)
+
+  1x: root deprecation
+
+  1x: silenced bar deprecation
+    1x in FooTestCase::testNonLegacyBar
+
+Remaining indirect deprecation notices (1)
+
+Legacy deprecation notices (2)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | N/A

### Current

Given a configuration like:

```env
SYMFONY_DEPRECATIONS_HELPER="max[direct]=0&max[self]=0&max[total]=999999&quiet[]=indirect
```

If there is any deprecation reaching the configured threshold (for instance here, a `direct` or `self` deprec), 
the output contains the full verbose deprecations output, for each of the deprecation types,
despite excluding specifically the `other` and `indirect` ones by using `quiet`:

```shell
OK (2 tests, 18 assertions)

Remaining direct deprecation notices (6)

  4x: Since symfony/framework-bundle 5.4: Method "Symfony\Bundle\FrameworkBundle\Controller\AbstractController::get()" is deprecated, use method or constructor injection in your controller instead. 
  # […]
  # ✅ OK: Full verbose output for `direct` deprecations type

Remaining indirect deprecation notices (21)

  10x: Since symfony/http-kernel 5.3: "Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest()" is deprecated, use "isMainRequest()" instead. 
  # […]
  # ❌ KO: Full verbose output for `indirect` deprecations type

Other deprecation notices (12)

  10x: Since symfony/cache 5.4: Usage of a DBAL Connection 
  # […]
  # ❌ KO: Full verbose output for `other` deprecations type
```

➜ ❌ The verbose output is used as soon as there is any deprecation failure, regardless of the type and `quiet` config.

### Expected

Since the `other` and `indirect` deprecation types are configured as `quiet` and the threshold is not reached, I'd expect:
- the `direct` and `self` deprecation types output to be verbose (whatever the threshold is)
- the `other` and `indirect` deprecation types to be quiet (unless the threshold is reached)

```shell
OK (2 tests, 18 assertions)

Remaining direct deprecation notices (6)

  4x: Since symfony/framework-bundle 5.4: Method "Symfony\Bundle\FrameworkBundle\Controller\AbstractController::get()" is deprecated, use method or constructor injection in your controller instead. 
  # […]
  # ✅ OK: Full verbose output for `direct` deprecations type

Remaining indirect deprecation notices (21)

  # ✅ OK: No verbose output for `indirect` deprecations type, unless the threshold is reached

Other deprecation notices (12)

  # ✅ OK: NO verbose output for `other` deprecations type, unless the threshold is reached
```

### Solution

Add a `Configuration::toleratesGroup()` method to use on each deprecation type to avoid using the verbose output for the type, unless it's threshold is reached or the group is not quiet.