### PR TITLE
[Form] Make `ButtonType` handle `form_attr` option

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractRendererEngine;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -70,8 +71,16 @@ abstract class BaseType extends AbstractType
             if (!$labelFormat) {
                 $labelFormat = $view->parent->vars['label_format'];
             }
+
+            $rootFormAttrOption = $form->getRoot()->getConfig()->getOption('form_attr');
+            if ($options['form_attr'] || $rootFormAttrOption) {
+                $options['attr']['form'] = \is_string($rootFormAttrOption) ? $rootFormAttrOption : $form->getRoot()->getName();
+                if (empty($options['attr']['form'])) {
+                    throw new LogicException('"form_attr" option must be a string identifier on root form when it has no id.');
+                }
+            }
         } else {
-            $id = $name;
+            $id = \is_string($options['form_attr']) ? $options['form_attr'] : $name;
             $fullName = $name;
             $uniqueBlockPrefix = '_'.$blockName;
 
@@ -137,6 +146,7 @@ abstract class BaseType extends AbstractType
             'translation_domain' => null,
             'auto_initialize' => true,
             'priority' => 0,
+            'form_attr' => false,
         ]);
 
         $resolver->setAllowedTypes('block_prefix', ['null', 'string']);
@@ -144,6 +154,7 @@ abstract class BaseType extends AbstractType
         $resolver->setAllowedTypes('row_attr', 'array');
         $resolver->setAllowedTypes('label_html', 'bool');
         $resolver->setAllowedTypes('priority', 'int');
+        $resolver->setAllowedTypes('form_attr', ['bool', 'string']);
 
         $resolver->setInfo('priority', 'The form rendering priority (higher priorities will be rendered first)');
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -97,16 +97,6 @@ class FormType extends BaseType
             }
 
             $helpTranslationParameters = array_merge($view->parent->vars['help_translation_parameters'], $helpTranslationParameters);
-
-            $rootFormAttrOption = $form->getRoot()->getConfig()->getOption('form_attr');
-            if ($options['form_attr'] || $rootFormAttrOption) {
-                $view->vars['attr']['form'] = \is_string($rootFormAttrOption) ? $rootFormAttrOption : $form->getRoot()->getName();
-                if (empty($view->vars['attr']['form'])) {
-                    throw new LogicException('"form_attr" option must be a string identifier on root form when it has no id.');
-                }
-            }
-        } elseif (\is_string($options['form_attr'])) {
-            $view->vars['id'] = $options['form_attr'];
         }
 
         $formConfig = $form->getConfig();
@@ -221,7 +211,6 @@ class FormType extends BaseType
             'is_empty_callback' => null,
             'getter' => null,
             'setter' => null,
-            'form_attr' => false,
         ]);
 
         $resolver->setAllowedTypes('label_attr', 'array');
@@ -233,7 +222,6 @@ class FormType extends BaseType
         $resolver->setAllowedTypes('is_empty_callback', ['null', 'callable']);
         $resolver->setAllowedTypes('getter', ['null', 'callable']);
         $resolver->setAllowedTypes('setter', ['null', 'callable']);
-        $resolver->setAllowedTypes('form_attr', ['bool', 'string']);
 
         $resolver->setInfo('getter', 'A callable that accepts two arguments (the view data and the current form field) and must return a value.');
         $resolver->setInfo('setter', 'A callable that accepts three arguments (a reference to the view data, the submitted value and the current form field).');

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -234,6 +234,7 @@ TXT
                 'translation_domain',
                 'auto_initialize',
                 'priority',
+                'form_attr',
             ],
         ];
 
@@ -253,6 +254,7 @@ TXT
                 'translation_domain',
                 'auto_initialize',
                 'priority',
+                'form_attr',
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | Not sure
| New feature?  | Not sure
| Deprecations? | no
| Tickets       | Fix #48794
| License       | MIT
| Doc PR        | N/A

Seems #40430 just forgot about `ButtonType` so I’m basically moving the implementation to `BaseType` and duplicating the tests in `ButtonTypeTest`.