### PR TITLE
[DependencyInjection] Cut compilation time

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -51,6 +51,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass
             $analyzedContainer = $container;
         }
         try {
+            $notInlinableIds = [];
             $remainingInlinedIds = [];
             $this->connectedIds = $this->notInlinedIds = $container->getDefinitions();
             do {
@@ -60,7 +61,8 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass
                 }
                 $this->graph = $analyzedContainer->getCompiler()->getServiceReferenceGraph();
                 $notInlinedIds = $this->notInlinedIds;
-                $this->connectedIds = $this->notInlinedIds = $this->inlinedIds = [];
+                $notInlinableIds += $this->notInlinableIds;
+                $this->connectedIds = $this->notInlinedIds = $this->inlinedIds = $this->notInlinableIds = [];
 
                 foreach ($analyzedContainer->getDefinitions() as $id => $definition) {
                     if (!$this->graph->hasNode($id)) {
@@ -86,7 +88,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass
             } while ($this->inlinedIds && $this->analyzingPass);
 
             foreach ($remainingInlinedIds as $id) {
-                if (isset($this->notInlinableIds[$id])) {
+                if (isset($notInlinableIds[$id])) {
                     continue;
                 }
 
@@ -126,8 +128,10 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass
 
         $definition = $this->container->getDefinition($id);
 
-        if (!$this->isInlineableDefinition($id, $definition)) {
-            $this->notInlinableIds[$id] = true;
+        if (isset($this->notInlinableIds[$id]) || !$this->isInlineableDefinition($id, $definition)) {
+            if ($this->currentId !== $id) {
+                $this->notInlinableIds[$id] = true;
+            }
 
             return $value;
         }
@@ -188,7 +192,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass
             return true;
         }
 
-        if ($this->currentId == $id) {
+        if ($this->currentId === $id) {
             return false;
         }
         $this->connectedIds[$id] = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Two more victories for Blackfire.io :tada: 

First win for InlineServiceDefinitionsPass: -58%

![image](https://user-images.githubusercontent.com/243674/209802991-e985525a-4e03-4cb6-b43a-b3e7e530344a.png)

Second win for `ContainerBuilder::inVendors()`: an additional -6.5%

![image](https://user-images.githubusercontent.com/243674/209803312-90a8b343-68f3-4392-b834-2fd3404cab8a.png)

Confirmed -50% without Blackfire also: from 30s to 15s.