### PR TITLE
[DependencyInjection] Fix resolving parameters when dumping lazy proxies

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -2265,11 +2265,6 @@ EOF;
             return null;
         }
 
-        $bag = $this->container->getParameterBag();
-        $definition = (clone $definition)
-            ->setClass($bag->resolveValue($definition->getClass()))
-            ->setTags(($definition->hasTag('proxy') ? ['proxy' => $bag->resolveValue($definition->getTag('proxy'))] : []) + $definition->getTags());
-
         return $this->getProxyDumper()->isProxyCandidate($definition, $asGhostObject, $id) ? $definition : null;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
@@ -35,6 +35,8 @@ interface DumperInterface
 
     /**
      * Generates the code for the lazy proxy.
+     *
+     * @param string|null $id
      */
     public function getProxyCode(Definition $definition/* , string $id = null */): string;
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -281,9 +281,8 @@ class PhpDumperTest extends TestCase
         $container = new ContainerBuilder();
         $container->setParameter('container.dumper.inline_factories', true);
         $container->setParameter('container.dumper.inline_class_loader', true);
-        $container->setParameter('lazy_foo_class', \Bar\FooClass::class);
 
-        $container->register('lazy_foo', '%lazy_foo_class%')
+        $container->register('lazy_foo', \Bar\FooClass::class)
             ->addArgument(new Definition(\Bar\FooLazyClass::class))
             ->setPublic(true)
             ->setLazy(true);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -73,7 +73,7 @@ class ProjectServiceContainer extends Container
     /**
      * Gets the public 'lazy_foo' shared service.
      *
-     * @return object A %lazy_foo_class% instance
+     * @return \Bar\FooClass
      */
     protected function getLazyFooService($lazyLoad = true)
     {
@@ -145,7 +145,6 @@ class ProjectServiceContainer extends Container
         return [
             'container.dumper.inline_factories' => true,
             'container.dumper.inline_class_loader' => true,
-            'lazy_foo_class' => 'Bar\\FooClass',
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Resolving parameters in lazy services' "proxy" tags never worked and the code I added to 6.2 is broken. Let's drop it.