### PR TITLE
[Serializer] add a context to allow invalid values in BackedEnumNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `XmlEncoder::SAVE_OPTIONS` context option
+ * Add `BackedEnumNormalizer::ALLOW_INVALID_VALUES` context option
  * Deprecate `MissingConstructorArgumentsException` in favor of `MissingConstructorArgumentException`
 
 6.2

--- a/src/Symfony/Component/Serializer/Context/Normalizer/BackedEnumNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/BackedEnumNormalizerContextBuilder.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Context\Normalizer;
+
+use Symfony\Component\Serializer\Context\ContextBuilderInterface;
+use Symfony\Component\Serializer\Context\ContextBuilderTrait;
+use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
+
+/**
+ * A helper providing autocompletion for available BackedEnumNormalizer options.
+ *
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+final class BackedEnumNormalizerContextBuilder implements ContextBuilderInterface
+{
+    use ContextBuilderTrait;
+
+    /**
+     * Configures if invalid values are allowed in denormalization.
+     * They will be denormalized into `null` values.
+     */
+    public function withAllowInvalidValues(bool $allowInvalidValues): static
+    {
+        return $this->with(BackedEnumNormalizer::ALLOW_INVALID_VALUES, $allowInvalidValues);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/BackedEnumNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/BackedEnumNormalizerContextBuilderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Context\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\Normalizer\BackedEnumNormalizerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
+
+class BackedEnumNormalizerContextBuilderTest extends TestCase
+{
+    private BackedEnumNormalizerContextBuilder $contextBuilder;
+
+    protected function setUp(): void
+    {
+        $this->contextBuilder = new BackedEnumNormalizerContextBuilder();
+    }
+
+    public function testWithers()
+    {
+        $context = $this->contextBuilder->withAllowInvalidValues(true)->toArray();
+        self::assertSame([BackedEnumNormalizer::ALLOW_INVALID_VALUES => true], $context);
+
+        $context = $this->contextBuilder->withAllowInvalidValues(false)->toArray();
+        self::assertSame([BackedEnumNormalizer::ALLOW_INVALID_VALUES => false], $context);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -114,4 +114,19 @@ class BackedEnumNormalizerTest extends TestCase
     {
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
+
+    public function testItUsesTryFromIfContextIsPassed()
+    {
+        $this->assertNull($this->normalizer->denormalize(1, IntegerBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
+        $this->assertNull($this->normalizer->denormalize('', IntegerBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
+        $this->assertNull($this->normalizer->denormalize(null, IntegerBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
+
+        $this->assertSame(IntegerBackedEnumDummy::SUCCESS, $this->normalizer->denormalize(200, IntegerBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
+
+        $this->assertNull($this->normalizer->denormalize(1, StringBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
+        $this->assertNull($this->normalizer->denormalize('foo', StringBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
+        $this->assertNull($this->normalizer->denormalize(null, StringBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
+
+        $this->assertSame(StringBackedEnumDummy::GET, $this->normalizer->denormalize('GET', StringBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | todo if PR gets merged

sometimes it is needed to allow deserialization of an enum to end up in a `null` value, this PR allows this behavior by passing a context 