### PR TITLE
Release v5.4.18

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -7,6 +7,11 @@ in 5.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.4.0...v5.4.1
 
+* 5.4.18 (2022-12-29)
+
+ * bug #48823 [Cache] Fix possibly null value passed to preg_match() in RedisTrait (chalasr)
+ * bug #48816 [Cache] Fix for RedisAdapter without auth parameter (rikvdh)
+
 * 5.4.17 (2022-12-28)
 
  * bug #48787 [PhpUnitBridge] Use verbose deprecation output for quiet types only when it reaches the threshold (ogizanagi)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,12 +78,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static $freshCache = [];
 
-    public const VERSION = '5.4.18-DEV';
+    public const VERSION = '5.4.18';
     public const VERSION_ID = 50418;
     public const MAJOR_VERSION = 5;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 18;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2024';
     public const END_OF_LIFE = '11/2025';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.4.17...v5.4.18)

 * bug #48823 [Cache] Fix possibly null value passed to preg_match() in RedisTrait (@chalasr)
 * bug #48816 [Cache] Fix for RedisAdapter without auth parameter (@rikvdh)
