### PR TITLE
Release v6.0.18

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -7,6 +7,11 @@ in 6.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.0.0...v6.0.1
 
+* 6.0.18 (2022-12-29)
+
+ * bug #48823 [Cache] Fix possibly null value passed to preg_match() in RedisTrait (chalasr)
+ * bug #48816 [Cache] Fix for RedisAdapter without auth parameter (rikvdh)
+
 * 6.0.17 (2022-12-28)
 
  * bug #48787 [PhpUnitBridge] Use verbose deprecation output for quiet types only when it reaches the threshold (ogizanagi)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,12 +78,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.0.18-DEV';
+    public const VERSION = '6.0.18';
     public const VERSION_ID = 60018;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 18;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '01/2023';
     public const END_OF_LIFE = '01/2023';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.0.17...v6.0.18)

 * bug #48823 [Cache] Fix possibly null value passed to preg_match() in RedisTrait (@chalasr)
 * bug #48816 [Cache] Fix for RedisAdapter without auth parameter (@rikvdh)
