### PR TITLE
[Translation] Handle the translation of empty strings

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -116,6 +116,10 @@ final class TranslationExtension extends AbstractExtension
                 throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be a locale passed as a string when the message is a "%s", "%s" given.', __METHOD__, TranslatableInterface::class, get_debug_type($arguments)));
             }
 
+            if ($message instanceof TranslatableMessage && '' === $message->getMessage()) {
+                return '';
+            }
+
             return $message->trans($this->getTranslator(), $locale ?? (\is_string($arguments) ? $arguments : null));
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -124,6 +124,7 @@ class TranslationExtensionTest extends TestCase
             ['{{ foo|trans }}', '', ['foo' => null]],
 
             // trans object
+            ['{{ t("")|trans }}', ''],
             ['{{ t("Hello")|trans }}', 'Hello'],
             ['{{ t(name)|trans }}', 'Symfony', ['name' => 'Symfony']],
             ['{{ t(hello, { \'%name%\': \'Symfony\' })|trans }}', 'Hello Symfony', ['hello' => 'Hello %name%']],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In some apps, you might use an expression as the value of some `TranslatableMessage` object. The result of this expression can result in using an empty string as the value of the that object:

```php
new TranslatableMessage($someCondition ? $someObject->someMethod() : '')
```

The issue is that Symfony will report that empty string in the list of "missing translations" (like in the first row of this image):

![](https://user-images.githubusercontent.com/73419/209708276-2c321204-4e7b-40c6-9386-0779a7ac4bf7.png)

I think this is a bug and an empty string should just be output "as is" without reporting it as missing.

What do you think? Is this truly a bug? Would it be a new feature for 6.3? The current behavior is correct and we should close without merging? Thanks.
