### PR TITLE
[BrowserKit] Reinitialize server parameters on restart

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -154,14 +154,6 @@ abstract class AbstractBrowser
         return $this->server[$key] ?? $default;
     }
 
-    /**
-     * Gets server parameters.
-     */
-    public function getServerParameters(): array
-    {
-        return $this->server;
-    }
-
     public function xmlHttpRequest(string $method, string $uri, array $parameters = [], array $files = [], array $server = [], string $content = null, bool $changeHistory = true): Crawler
     {
         $this->setServerParameter('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -154,6 +154,14 @@ abstract class AbstractBrowser
         return $this->server[$key] ?? $default;
     }
 
+    /**
+     * Gets server parameters.
+     */
+    public function getServerParameters(): array
+    {
+        return $this->server;
+    }
+
     public function xmlHttpRequest(string $method, string $uri, array $parameters = [], array $files = [], array $server = [], string $content = null, bool $changeHistory = true): Crawler
     {
         $this->setServerParameter('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');
@@ -606,6 +614,7 @@ abstract class AbstractBrowser
      */
     public function restart()
     {
+        $this->setServerParameters([]);
         $this->cookieJar->clear();
         $this->history->clear();
     }

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `AbstractBrowser::useHtml5Parser()`
+ * Reset `$server` parameters in `Symfony\Component\BrowserKit\AbstractBrowser::restart()`
 
 6.1
 ---

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -1,11 +1,15 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+* Reset `$server` parameters in `Symfony\Component\BrowserKit\AbstractBrowser::restart()`
+
 6.3
 ---
 
  * Add `AbstractBrowser::useHtml5Parser()`
- * Reset `$server` parameters in `Symfony\Component\BrowserKit\AbstractBrowser::restart()`
 
 6.1
 ---

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -721,10 +721,11 @@ class AbstractBrowserTest extends TestCase
 
     public function testRestart()
     {
-        $client = $this->getBrowser();
+        $client = $this->getBrowser(['HTTP_FOO' => 'bar']);
         $client->request('GET', 'http://www.example.com/foo/foobar');
         $client->restart();
 
+        $this->assertSame(['HTTP_USER_AGENT' => 'Symfony BrowserKit'], $client->getServerParameters(), '->restart() clears the server parameters');
         $this->assertTrue($client->getHistory()->isEmpty(), '->restart() clears the history');
         $this->assertSame([], $client->getCookieJar()->all(), '->restart() clears the cookies');
     }

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -725,7 +725,9 @@ class AbstractBrowserTest extends TestCase
         $client->request('GET', 'http://www.example.com/foo/foobar');
         $client->restart();
 
-        $this->assertSame(['HTTP_USER_AGENT' => 'Symfony BrowserKit'], $client->getServerParameters(), '->restart() clears the server parameters');
+        $getServerParameters = \Closure::bind(fn () => $this->server, $client, $client);
+
+        $this->assertSame(['HTTP_USER_AGENT' => 'Symfony BrowserKit'], $getServerParameters(), '->restart() clears the server parameters');
         $this->assertTrue($client->getHistory()->isEmpty(), '->restart() clears the history');
         $this->assertSame([], $client->getCookieJar()->all(), '->restart() clears the cookies');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no  
| Tickets       | Fix #48442
| License       | MIT
| Doc PR        | [!17642](https://github.com/symfony/symfony-docs/pull/17642)


In order to refresh the state of the application, the `Symfony\Component\BrowserKit\AbstractBrowser::restart()` method must reset the `$server` parameter.
