### PR TITLE
[Validator] Dump Valid constraints on debug command

### DIFF
--- a/src/Symfony/Component/Validator/Command/DebugCommand.php
+++ b/src/Symfony/Component/Validator/Command/DebugCommand.php
@@ -22,8 +22,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Mapping\AutoMappingStrategy;
+use Symfony\Component\Validator\Mapping\CascadingStrategy;
 use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
+use Symfony\Component\Validator\Mapping\GenericMetadata;
+use Symfony\Component\Validator\Mapping\TraversalStrategy;
 
 /**
  * A console command to debug Validators information.
@@ -161,6 +165,31 @@ EOF
 
         $propertyMetadata = $classMetadata->getPropertyMetadata($constrainedProperty);
         foreach ($propertyMetadata as $metadata) {
+            $autoMapingStrategy = 'Not supported';
+            if ($metadata instanceof GenericMetadata) {
+                switch ($metadata->getAutoMappingStrategy()) {
+                    case AutoMappingStrategy::ENABLED: $autoMapingStrategy = 'Enabled'; break;
+                    case AutoMappingStrategy::DISABLED: $autoMapingStrategy = 'Disabled'; break;
+                    case AutoMappingStrategy::NONE: $autoMapingStrategy = 'None'; break;
+                }
+            }
+            $traversalStrategy = 'None';
+            if (TraversalStrategy::TRAVERSE === $metadata->getTraversalStrategy()) {
+                $traversalStrategy = 'Traverse';
+            }
+            if (TraversalStrategy::IMPLICIT === $metadata->getTraversalStrategy()) {
+                $traversalStrategy = 'Implicit';
+            }
+
+            $data[] = [
+                'class' => 'property options',
+                'groups' => [],
+                'options' => [
+                    'cascadeStrategy' => CascadingStrategy::CASCADE === $metadata->getCascadingStrategy() ? 'Cascade' : 'None',
+                    'autoMappingStrategy' => $autoMapingStrategy,
+                    'traversalStrategy' => $traversalStrategy,
+                ],
+            ];
             foreach ($metadata->getConstraints() as $constraint) {
                 $data[] = [
                     'class' => \get_class($constraint),

--- a/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
@@ -37,28 +37,43 @@ class DebugCommandTest extends TestCase
 Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 -----------------------------------------------------
 
-+----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
-| Property | Name                                               | Groups                 | Options                                                    |
-+----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
-| -        | Symfony\Component\Validator\Constraints\Expression | Default, DummyClassOne | [                                                          |
-|          |                                                    |                        |   "expression" => "1 + 1 = 2",                             |
-|          |                                                    |                        |   "message" => "This value is not valid.",                 |
-|          |                                                    |                        |   "payload" => null,                                       |
-|          |                                                    |                        |   "values" => []                                           |
-|          |                                                    |                        | ]                                                          |
-| code     | Symfony\Component\Validator\Constraints\NotBlank   | Default, DummyClassOne | [                                                          |
-|          |                                                    |                        |   "allowNull" => false,                                    |
-|          |                                                    |                        |   "message" => "This value should not be blank.",          |
-|          |                                                    |                        |   "normalizer" => null,                                    |
-|          |                                                    |                        |   "payload" => null                                        |
-|          |                                                    |                        | ]                                                          |
-| email    | Symfony\Component\Validator\Constraints\Email      | Default, DummyClassOne | [                                                          |
-|          |                                                    |                        |   "message" => "This value is not a valid email address.", |
-|          |                                                    |                        |   "mode" => null,                                          |
-|          |                                                    |                        |   "normalizer" => null,                                    |
-|          |                                                    |                        |   "payload" => null                                        |
-|          |                                                    |                        | ]                                                          |
-+----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
++---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| Property      | Name                                               | Groups                 | Options                                                    |
++---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| -             | Symfony\Component\Validator\Constraints\Expression | Default, DummyClassOne | [                                                          |
+|               |                                                    |                        |   "expression" => "1 + 1 = 2",                             |
+|               |                                                    |                        |   "message" => "This value is not valid.",                 |
+|               |                                                    |                        |   "payload" => null,                                       |
+|               |                                                    |                        |   "values" => []                                           |
+|               |                                                    |                        | ]                                                          |
+| code          | property options                                   |                        | [                                                          |
+|               |                                                    |                        |   "cascadeStrategy" => "None",                             |
+|               |                                                    |                        |   "autoMappingStrategy" => "None",                         |
+|               |                                                    |                        |   "traversalStrategy" => "None"                            |
+|               |                                                    |                        | ]                                                          |
+| code          | Symfony\Component\Validator\Constraints\NotBlank   | Default, DummyClassOne | [                                                          |
+|               |                                                    |                        |   "allowNull" => false,                                    |
+|               |                                                    |                        |   "message" => "This value should not be blank.",          |
+|               |                                                    |                        |   "normalizer" => null,                                    |
+|               |                                                    |                        |   "payload" => null                                        |
+|               |                                                    |                        | ]                                                          |
+| email         | property options                                   |                        | [                                                          |
+|               |                                                    |                        |   "cascadeStrategy" => "None",                             |
+|               |                                                    |                        |   "autoMappingStrategy" => "None",                         |
+|               |                                                    |                        |   "traversalStrategy" => "None"                            |
+|               |                                                    |                        | ]                                                          |
+| email         | Symfony\Component\Validator\Constraints\Email      | Default, DummyClassOne | [                                                          |
+|               |                                                    |                        |   "message" => "This value is not a valid email address.", |
+|               |                                                    |                        |   "mode" => null,                                          |
+|               |                                                    |                        |   "normalizer" => null,                                    |
+|               |                                                    |                        |   "payload" => null                                        |
+|               |                                                    |                        | ]                                                          |
+| dummyClassTwo | property options                                   |                        | [                                                          |
+|               |                                                    |                        |   "cascadeStrategy" => "Cascade",                          |
+|               |                                                    |                        |   "autoMappingStrategy" => "None",                         |
+|               |                                                    |                        |   "traversalStrategy" => "Implicit"                        |
+|               |                                                    |                        | ]                                                          |
++---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
 
 TXT
             , $tester->getDisplay(true)
@@ -77,54 +92,84 @@ TXT
 Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 -----------------------------------------------------
 
-+----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
-| Property | Name                                               | Groups                 | Options                                                    |
-+----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
-| -        | Symfony\Component\Validator\Constraints\Expression | Default, DummyClassOne | [                                                          |
-|          |                                                    |                        |   "expression" => "1 + 1 = 2",                             |
-|          |                                                    |                        |   "message" => "This value is not valid.",                 |
-|          |                                                    |                        |   "payload" => null,                                       |
-|          |                                                    |                        |   "values" => []                                           |
-|          |                                                    |                        | ]                                                          |
-| code     | Symfony\Component\Validator\Constraints\NotBlank   | Default, DummyClassOne | [                                                          |
-|          |                                                    |                        |   "allowNull" => false,                                    |
-|          |                                                    |                        |   "message" => "This value should not be blank.",          |
-|          |                                                    |                        |   "normalizer" => null,                                    |
-|          |                                                    |                        |   "payload" => null                                        |
-|          |                                                    |                        | ]                                                          |
-| email    | Symfony\Component\Validator\Constraints\Email      | Default, DummyClassOne | [                                                          |
-|          |                                                    |                        |   "message" => "This value is not a valid email address.", |
-|          |                                                    |                        |   "mode" => null,                                          |
-|          |                                                    |                        |   "normalizer" => null,                                    |
-|          |                                                    |                        |   "payload" => null                                        |
-|          |                                                    |                        | ]                                                          |
-+----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
++---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| Property      | Name                                               | Groups                 | Options                                                    |
++---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| -             | Symfony\Component\Validator\Constraints\Expression | Default, DummyClassOne | [                                                          |
+|               |                                                    |                        |   "expression" => "1 + 1 = 2",                             |
+|               |                                                    |                        |   "message" => "This value is not valid.",                 |
+|               |                                                    |                        |   "payload" => null,                                       |
+|               |                                                    |                        |   "values" => []                                           |
+|               |                                                    |                        | ]                                                          |
+| code          | property options                                   |                        | [                                                          |
+|               |                                                    |                        |   "cascadeStrategy" => "None",                             |
+|               |                                                    |                        |   "autoMappingStrategy" => "None",                         |
+|               |                                                    |                        |   "traversalStrategy" => "None"                            |
+|               |                                                    |                        | ]                                                          |
+| code          | Symfony\Component\Validator\Constraints\NotBlank   | Default, DummyClassOne | [                                                          |
+|               |                                                    |                        |   "allowNull" => false,                                    |
+|               |                                                    |                        |   "message" => "This value should not be blank.",          |
+|               |                                                    |                        |   "normalizer" => null,                                    |
+|               |                                                    |                        |   "payload" => null                                        |
+|               |                                                    |                        | ]                                                          |
+| email         | property options                                   |                        | [                                                          |
+|               |                                                    |                        |   "cascadeStrategy" => "None",                             |
+|               |                                                    |                        |   "autoMappingStrategy" => "None",                         |
+|               |                                                    |                        |   "traversalStrategy" => "None"                            |
+|               |                                                    |                        | ]                                                          |
+| email         | Symfony\Component\Validator\Constraints\Email      | Default, DummyClassOne | [                                                          |
+|               |                                                    |                        |   "message" => "This value is not a valid email address.", |
+|               |                                                    |                        |   "mode" => null,                                          |
+|               |                                                    |                        |   "normalizer" => null,                                    |
+|               |                                                    |                        |   "payload" => null                                        |
+|               |                                                    |                        | ]                                                          |
+| dummyClassTwo | property options                                   |                        | [                                                          |
+|               |                                                    |                        |   "cascadeStrategy" => "Cascade",                          |
+|               |                                                    |                        |   "autoMappingStrategy" => "None",                         |
+|               |                                                    |                        |   "traversalStrategy" => "Implicit"                        |
+|               |                                                    |                        | ]                                                          |
++---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
 
 Symfony\Component\Validator\Tests\Dummy\DummyClassTwo
 -----------------------------------------------------
 
-+----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
-| Property | Name                                               | Groups                 | Options                                                    |
-+----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
-| -        | Symfony\Component\Validator\Constraints\Expression | Default, DummyClassTwo | [                                                          |
-|          |                                                    |                        |   "expression" => "1 + 1 = 2",                             |
-|          |                                                    |                        |   "message" => "This value is not valid.",                 |
-|          |                                                    |                        |   "payload" => null,                                       |
-|          |                                                    |                        |   "values" => []                                           |
-|          |                                                    |                        | ]                                                          |
-| code     | Symfony\Component\Validator\Constraints\NotBlank   | Default, DummyClassTwo | [                                                          |
-|          |                                                    |                        |   "allowNull" => false,                                    |
-|          |                                                    |                        |   "message" => "This value should not be blank.",          |
-|          |                                                    |                        |   "normalizer" => null,                                    |
-|          |                                                    |                        |   "payload" => null                                        |
-|          |                                                    |                        | ]                                                          |
-| email    | Symfony\Component\Validator\Constraints\Email      | Default, DummyClassTwo | [                                                          |
-|          |                                                    |                        |   "message" => "This value is not a valid email address.", |
-|          |                                                    |                        |   "mode" => null,                                          |
-|          |                                                    |                        |   "normalizer" => null,                                    |
-|          |                                                    |                        |   "payload" => null                                        |
-|          |                                                    |                        | ]                                                          |
-+----------+----------------------------------------------------+------------------------+------------------------------------------------------------+
++---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| Property      | Name                                               | Groups                 | Options                                                    |
++---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
+| -             | Symfony\Component\Validator\Constraints\Expression | Default, DummyClassTwo | [                                                          |
+|               |                                                    |                        |   "expression" => "1 + 1 = 2",                             |
+|               |                                                    |                        |   "message" => "This value is not valid.",                 |
+|               |                                                    |                        |   "payload" => null,                                       |
+|               |                                                    |                        |   "values" => []                                           |
+|               |                                                    |                        | ]                                                          |
+| code          | property options                                   |                        | [                                                          |
+|               |                                                    |                        |   "cascadeStrategy" => "None",                             |
+|               |                                                    |                        |   "autoMappingStrategy" => "None",                         |
+|               |                                                    |                        |   "traversalStrategy" => "None"                            |
+|               |                                                    |                        | ]                                                          |
+| code          | Symfony\Component\Validator\Constraints\NotBlank   | Default, DummyClassTwo | [                                                          |
+|               |                                                    |                        |   "allowNull" => false,                                    |
+|               |                                                    |                        |   "message" => "This value should not be blank.",          |
+|               |                                                    |                        |   "normalizer" => null,                                    |
+|               |                                                    |                        |   "payload" => null                                        |
+|               |                                                    |                        | ]                                                          |
+| email         | property options                                   |                        | [                                                          |
+|               |                                                    |                        |   "cascadeStrategy" => "None",                             |
+|               |                                                    |                        |   "autoMappingStrategy" => "None",                         |
+|               |                                                    |                        |   "traversalStrategy" => "None"                            |
+|               |                                                    |                        | ]                                                          |
+| email         | Symfony\Component\Validator\Constraints\Email      | Default, DummyClassTwo | [                                                          |
+|               |                                                    |                        |   "message" => "This value is not a valid email address.", |
+|               |                                                    |                        |   "mode" => null,                                          |
+|               |                                                    |                        |   "normalizer" => null,                                    |
+|               |                                                    |                        |   "payload" => null                                        |
+|               |                                                    |                        | ]                                                          |
+| dummyClassOne | property options                                   |                        | [                                                          |
+|               |                                                    |                        |   "cascadeStrategy" => "None",                             |
+|               |                                                    |                        |   "autoMappingStrategy" => "Disabled",                     |
+|               |                                                    |                        |   "traversalStrategy" => "None"                            |
+|               |                                                    |                        | ]                                                          |
++---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
 
 TXT
             , $tester->getDisplay(true)

--- a/src/Symfony/Component/Validator/Tests/Dummy/DummyClassOne.php
+++ b/src/Symfony/Component/Validator/Tests/Dummy/DummyClassOne.php
@@ -31,4 +31,11 @@ class DummyClassOne
      * @Assert\Email
      */
     public $email;
+
+    /**
+     * @var DummyClassTwo|null
+     *
+     * @Assert\Valid()
+     */
+    public $dummyClassTwo;
 }

--- a/src/Symfony/Component/Validator/Tests/Dummy/DummyClassTwo.php
+++ b/src/Symfony/Component/Validator/Tests/Dummy/DummyClassTwo.php
@@ -31,4 +31,11 @@ class DummyClassTwo
      * @Assert\Email
      */
     public $email;
+
+    /**
+     * @var DummyClassOne|null
+     *
+     * @Assert\DisableAutoMapping()
+     */
+    public $dummyClassOne;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #46544
| License       | MIT

The command `debug:validator` doesn't dump the `Valid` constraints with the default group.

The `Valid` constraints with default group change the property `CascadingStrategy` and the `TraversalStrategy` on property metadata.

This patch adds the `Valid` constraint on debug output if the `CascadingStrategy` is the same as `CASCADE`.