### PR TITLE
[Translation] Fix for resolving Constraint Validator FQCN defined as %foo.bar.class% parameters

### DIFF
--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
@@ -55,8 +55,10 @@ class TranslatorPass implements CompilerPassInterface
 
             foreach ($container->findTaggedServiceIds('validator.constraint_validator', true) as $id => $attributes) {
                 $serviceDefinition = $container->getDefinition($id);
+                // Resolve constraint validator FQCN even if defined as %foo.validator.class% parameter
+                $className = $container->getParameterBag()->resolveValue($serviceDefinition->getClass());
                 // Extraction of the constraint class name from the Constraint Validator FQCN
-                $constraintClassNames[] = str_replace('Validator', '', substr(strrchr($serviceDefinition->getClass(), '\\'), 1));
+                $constraintClassNames[] = str_replace('Validator', '', substr(strrchr($className, '\\'), 1));
             }
 
             $constraintVisitorDefinition->setArgument(0, $constraintClassNames);

--- a/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslatorPassTest.php
+++ b/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslatorPassTest.php
@@ -18,12 +18,10 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Translation\DependencyInjection\TranslatorPass;
 use Symfony\Component\Translation\Extractor\Visitor\ConstraintVisitor;
-use Symfony\Component\Validator\Constraints\Isbn;
 use Symfony\Component\Validator\Constraints\IsbnValidator;
 use Symfony\Component\Validator\Constraints\LengthValidator;
-use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotBlankValidator;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Constraints\TimeValidator;
 
 class TranslatorPassTest extends TestCase
 {
@@ -140,10 +138,13 @@ class TranslatorPassTest extends TestCase
             ->addTag('validator.constraint_validator');
         $container->register('validator.length', LengthValidator::class)
             ->addTag('validator.constraint_validator');
+        $container->register('validator.time', '%foo.time.validator.class%')
+            ->addTag('validator.constraint_validator');
+        $container->setParameter('foo.time.validator.class', TimeValidator::class);
 
         $pass = new TranslatorPass();
         $pass->process($container);
 
-        $this->assertSame(['NotBlank', 'Isbn', 'Length'], $constraintVisitor->getArgument(0));
+        $this->assertSame(['NotBlank', 'Isbn', 'Length', 'Time'], $constraintVisitor->getArgument(0));
     }
 }


### PR DESCRIPTION
For example `Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator` is defined as `%doctrine.orm.validator.unique.class%` and must be properly resolved.

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
