### PR TITLE
[Validator] Allow to use translation_domain false for validators and to use custom translation domain by constraints

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add the `filenameMaxLength` option to the `File` constraint
  * Add the `exclude` option to the `Cascade` constraint
  * Add the `value_length` parameter to `Length` constraint
+ * Allow to disable the translation domain for `ConstraintViolationInterface` messages
 
 6.2
 ---

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -142,7 +142,7 @@ class ExecutionContext implements ExecutionContextInterface
     public function addViolation(string $message, array $parameters = []): void
     {
         $this->violations->add(new ConstraintViolation(
-            $this->translator->trans($message, $parameters, $this->translationDomain),
+            false === $this->translationDomain ? strtr($message, $parameters) : $this->translator->trans($message, $parameters, $this->translationDomain),
             $message,
             $parameters,
             $this->root,

--- a/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ConstraintViolationBuilderTest extends TestCase
 {
@@ -81,6 +82,18 @@ class ConstraintViolationBuilderTest extends TestCase
             ->addViolation();
 
         $this->assertViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data', 'foo', null, null, new Valid(), $cause));
+    }
+
+    public function testTranslationDomainFalse()
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())->method('trans');
+
+        $builder = new ConstraintViolationBuilder($this->violations, new Valid(), $this->messageTemplate, [], $this->root, 'data', 'foo', $translator);
+        $builder->addViolation();
+
+        $builder->disableTranslation();
+        $builder->addViolation();
     }
 
     private function assertViolationEquals(ConstraintViolation $expectedViolation)

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
@@ -20,6 +20,8 @@ namespace Symfony\Component\Validator\Violation;
  * execution context.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @method $this disableTranslation()
  */
 interface ConstraintViolationBuilderInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

Currently it's possible to write
```
$this->context->addViolation($constraint->message);
$this->context->addViolation($constraint->message, ['customParameter' => $value]);
```
but it's not allowed to pass a custom translation_domain (or to disable the translation by passing `false`).

Adding a third parameter would allow this. (And changing the `?string` type to `string|false|null`).

Wdyt about this feature ? How can we make it fully BC ?