### PR TITLE
[String] Add the stripEmojis() method

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\String;
 
+use Symfony\Component\Intl\Transliterator\EmojiTransliterator;
 use Symfony\Component\String\Exception\ExceptionInterface;
 use Symfony\Component\String\Exception\InvalidArgumentException;
 use Symfony\Component\String\Exception\RuntimeException;
@@ -41,6 +42,8 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
 
     protected $string = '';
     protected $ignoreCase = false;
+
+    private static ?EmojiTransliterator $emojiTransliterator = null;
 
     abstract public function __construct(string $string = '');
 
@@ -491,6 +494,22 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         }
 
         return false;
+    }
+
+    public function stripEmojis(): static
+    {
+        if (!self::$emojiTransliterator) {
+            if (!class_exists(EmojiTransliterator::class)) {
+                throw new \LogicException(sprintf('You cannot use the "%s()" method as the "symfony/intl" package is not installed. Try running "composer require symfony/intl".', __METHOD__));
+            }
+
+            self::$emojiTransliterator = EmojiTransliterator::create('emoji-strip');
+        }
+
+        $str = clone $this;
+        $str->string = self::$emojiTransliterator->transliterate($str->string);
+
+        return $str;
     }
 
     abstract public function title(bool $allWords = false): static;

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add the `stripEmojis()` method
+
 6.2
 ---
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1583,4 +1583,23 @@ abstract class AbstractAsciiTestCase extends TestCase
             [17, "\u{007f}\u{007f}f\u{001b}[0moo\u{0001}bar\u{007f}cccïf\u{008e}cy\u{0005}1", false], // f[0moobarcccïfcy1
         ];
     }
+
+    /**
+     * @dataProvider provideStripEmojis
+     */
+    public function testStripEmojis(string $expected, string $origin)
+    {
+        $this->assertSame($expected, (string) static::createFromString($origin)->stripEmojis());
+    }
+
+    public static function provideStripEmojis(): array
+    {
+        return [
+            ['', ''],
+            ['foo bar CcC', 'foo bar CcC'],
+            ['', '😅'],
+            ['', '😅😱🇦🇺'],
+            [' Lorem ipsum  dolor sit amet ', '😺 Lorem ipsum 🐈‍⬛ dolor sit amet 🦁'],
+        ];
+    }
 }

--- a/src/Symfony/Component/String/composer.json
+++ b/src/Symfony/Component/String/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "symfony/error-handler": "^5.4|^6.0",
-        "symfony/intl": "^6.2",
+        "symfony/intl": "^6.3",
         "symfony/http-client": "^5.4|^6.0",
         "symfony/translation-contracts": "^2.5|^3.0",
         "symfony/var-exporter": "^5.4|^6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/48850
| License       | MIT
| Doc PR        | -

Add the `stripEmojis()` shortcut method to easily strip emojis from any string by leveraging the special `strip` locale from the `EmojiTransliterator`.