### PR TITLE
[Intl] Get emoji-test.txt from unicode.org

### DIFF
--- a/src/Symfony/Component/Intl/Resources/emoji/Makefile
+++ b/src/Symfony/Component/Intl/Resources/emoji/Makefile
@@ -5,6 +5,7 @@ update: ## Update sources
 	@composer update
 	@curl https://api.github.com/emojis > vendor/github-emojis.json
 	@curl https://raw.githubusercontent.com/iamcal/emoji-data/master/emoji.json > vendor/slack-emojis.json
+	@curl https://unicode.org/Public/emoji/latest/emoji-test.txt > vendor/emoji-test.txt
 
 build: ## Build rules
 	@./build.php

--- a/src/Symfony/Component/Intl/Resources/emoji/README.md
+++ b/src/Symfony/Component/Intl/Resources/emoji/README.md
@@ -6,11 +6,17 @@ This folder contains the tool to build all transliterator rules.
 
 * composer
 * PHP
+* curl
+* make
 
 ## Update the rules
 
 To update the rules, you need to update the version of `unicode-org/cldr` in the
-`composer.json` file, then run `make update`.
+`composer.json` file, then run:
+
+```bash
+make update
+```
 
 Finally, run the following command:
 

--- a/src/Symfony/Component/Intl/Resources/emoji/build.php
+++ b/src/Symfony/Component/Intl/Resources/emoji/build.php
@@ -28,7 +28,7 @@ final class Builder
 
     public static function getEmojisCodePoints(): array
     {
-        $lines = file(__DIR__.'/vendor/unicode-org/cldr/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/emoji/emoji-test.txt');
+        $lines = file(__DIR__.'/vendor/emoji-test.txt');
 
         $emojisCodePoints = [];
         foreach ($lines as $line) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

No need to download the full CLDR repo to get this file.