### PR TITLE
[FrameworkBundle] avoid issue with doctrine/annotations 2.0.0

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Controller;
 
+use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Container\ContainerInterface;
 use Psr\Link\LinkInterface;
@@ -53,6 +54,10 @@ use Twig\Environment;
  * Provides shortcuts for HTTP-related features in controllers.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * The following annotation is necessary for compatibility with doctrine/annotations:^2.
+ *
+ * @IgnoreAnnotation("required")
  */
 abstract class AbstractController implements ServiceSubscriberInterface
 {
@@ -411,7 +416,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
             return null;
         }
 
-        // @deprecated since 5.4, $user will always be a UserInterface instance
+        // @deprecated since Symfony 5.4, $user will always be a UserInterface instance
         if (!\is_object($user = $token->getUser())) {
             // e.g. anonymous authentication
             return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48792
| License       | MIT
| Doc PR        | no

Switching from `doctrine/annotations` 1 to 2 break some apps, here is a reproducer with an empty Controller: https://github.com/symfony/symfony/issues/48792#issuecomment-1370306674

I don't know how to add a test about this, but here is the fix suggested by the error message and greg0ire in https://github.com/doctrine/annotations/issues/474#issuecomment-1370773813