### PR TITLE
fix new lines in @required comments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -262,8 +262,7 @@ class SetterInjection extends SetterInjectionParent
         // should be called only when explicitly specified
     }
 
-    /**
-     * @required*/
+    /** @required */
     public function setChildMethodWithoutDocBlock(A $a)
     {
     }
@@ -306,7 +305,7 @@ class Wither
 
 class SetterInjectionParent
 {
-    /** @required*/
+    /** @required */
     public function setDependencies(Foo $foo, A $a)
     {
         // should be called


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Comments were inconsistent, and maybe it may lead to unexpected errors if the parser doesn't recognize them.