### PR TITLE
[FrameworkBundle] remove double required annotation + attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -58,9 +58,6 @@ abstract class AbstractController implements ServiceSubscriberInterface
      */
     protected $container;
 
-    /**
-     * @required
-     */
     #[Required]
     public function setContainer(ContainerInterface $container): ?ContainerInterface
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48792 (checked with [this reproducer](https://github.com/symfony/symfony/issues/48792#issuecomment-1370306674))
| License       | MIT
| Doc PR        | no

Annotation and attribute were kept: https://github.com/symfony/symfony/pull/45680#issuecomment-1062297998

To my understanding, it's not necessary since #48810

Alternative to #48868