### PR TITLE
[CssSelector] Do not remove escape sequences backslash

### DIFF
--- a/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
@@ -148,6 +148,10 @@ class ParserTest extends TestCase
             // unicode escape: \20 ==  (space)
             ['*[aval="\'\20  \'"]', ['Attribute[Element[*][aval = \'\'  \'\']]']],
             ["*[aval=\"'\\20\r\n '\"]", ['Attribute[Element[*][aval = \'\'  \'\']]']],
+            // unicode escape: \5c == \
+            ['*[aval="\\5cz"]', ['Attribute[Element[*][aval = \'\\z\']]']],
+            ['*[aval="\\5c\\z"]', ['Attribute[Element[*][aval = \'\\z\']]']],
+            ['*[aval="\\\\5cz"]', ['Attribute[Element[*][aval = \'\\5cz\']]']],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Spotted in #48832

Escaping hex sequences before “simple” ones meant a backslash produced by an hex sequence would have been removed if it was followed by any character.

Note that the workaround of doubling such backslashes still works.

(There is no https://github.com/symfony/symfony/labels/Deprecation here.)