### PR TITLE
[Console] Fix computing column width containing multibyte chars

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -805,7 +805,7 @@ class Table
                             $textContent = Helper::removeDecoration($this->output->getFormatter(), $cell);
                             $textLength = Helper::width($textContent);
                             if ($textLength > 0) {
-                                $contentColumns = str_split($textContent, ceil($textLength / $cell->getColspan()));
+                                $contentColumns = mb_str_split($textContent, ceil($textLength / $cell->getColspan()));
                                 foreach ($contentColumns as $position => $content) {
                                     $row[$i + $position] = $content;
                                 }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -316,7 +316,7 @@ TABLE
                     ],
                     new TableSeparator(),
                     [
-                        new TableCell('Cupiditate dicta atque porro, tempora exercitationem modi animi nulla nemo vel nihil!', ['colspan' => 3]),
+                        new TableCell('Cupìdĭtâte díctá âtquè pôrrò, tèmpórà exercitátìónèm mòdí ânìmí núllà nèmò vèl níhìl!', ['colspan' => 3]),
                     ],
                 ],
                 'default',
@@ -333,7 +333,7 @@ TABLE
 | 9971-5-0210-0                 | A Tale of                                                   |
 |                               | Two Cities                                                  |
 +-------------------------------+-------------------------------+-----------------------------+
-| Cupiditate dicta atque porro, tempora exercitationem modi animi nulla nemo vel nihil!       |
+| Cupìdĭtâte díctá âtquè pôrrò, tèmpórà exercitátìónèm mòdí ânìmí núllà nèmò vèl níhìl!       |
 +-------------------------------+-------------------------------+-----------------------------+
 
 TABLE


### PR DESCRIPTION
Use mb_str_split instead of str_split because it works badly with multibyte chars on auto width adjustment.

| Q             | A
| ------------- | ---
| Branch?       | 5.4 and above
| Bug fix?      | yes

Console output with str_split:

![image](https://user-images.githubusercontent.com/3186515/210783727-7f67c371-67c0-4005-9914-e345fa9b5569.png)

Console output with mb_str_split:

![image](https://user-images.githubusercontent.com/3186515/210783808-bcd9e754-4831-43a1-86b3-6cbcdd93a3ec.png)

