### PR TITLE
[HttpKernel] Allow dynamic header values within the WithHttpStatus attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -280,6 +280,10 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('argument_resolver.backed_enum_resolver');
         }
 
+        if (!class_exists(ExpressionLanguage::class)) {
+            $container->removeDefinition('exception_listener.expression_language');
+        }
+
         $loader->load('services.php');
         $loader->load('fragment_renderer.php');
         $loader->load('error_renderer.php');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\BackedEnumValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DateTimeValueResolver;
@@ -118,9 +119,17 @@ return static function (ContainerConfigurator $container) {
                 service('logger')->nullOnInvalid(),
                 param('kernel.debug'),
                 abstract_arg('an exceptions to log & status code mapping'),
+                service('exception_listener.expression_language')->nullOnInvalid(),
             ])
             ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'request'])
+
+        ->set('exception_listener.expression_language', ExpressionLanguage::class)
+            ->args([service('cache.exception_listener_expression_language')->nullOnInvalid()])
+
+        ->set('cache.exception_listener_expression_language')
+            ->parent('cache.system')
+            ->tag('cache.pool')
 
         ->set('controller.cache_attribute_listener', CacheAttributeListener::class)
             ->tag('kernel.event_subscriber')

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG
  * Add `#[WithHttpStatus]` for defining status codes for exceptions
  * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
  * Add `#[WithLogLevel]` for defining log levels for exceptions
- * Allow dynamic values for headers specified within `#[HttpStatus]`
+ * Allow dynamic values for headers specified within `#[WithHttpStatus]`
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `#[WithHttpStatus]` for defining status codes for exceptions
  * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
  * Add `#[WithLogLevel]` for defining log levels for exceptions
+ * Allow dynamic values for headers specified within `#[HttpStatus]`
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -357,7 +357,7 @@ class WarningWithLogLevelAttribute extends \Exception
 {
 }
 
-#[HttpStatus(
+#[WithHttpStatus(
     statusCode: 404,
     headers: [
         'name' => new Expression('"The name is " ~ this.name ~ "."'),

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -69,7 +69,8 @@
         "symfony/browser-kit": "",
         "symfony/config": "",
         "symfony/console": "",
-        "symfony/dependency-injection": ""
+        "symfony/dependency-injection": "",
+        "symfony/expression-language": "For setting dynamic header values within the WithHttpStatus attribute"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HttpKernel\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | TODO

This extends the functionality provided with the ~[`#[HttpStatus]`](https://github.com/symfony/symfony/pull/48352)~ [`#[WithHttpStatus]`](https://github.com/symfony/symfony/pull/48876) attribute to be allowing the header values to be set dynamically.

With the current implementation, the header values must be hard-coded:

```php
#[WithHttpStatus(
    statusCode: 422,
    headers: [
        'max-allowed-amount' => 500,
    ]
)]
class AmountTooBigException extends \Exception
{
    public function __construct(public readonly int $maxAllowedAmount)
    {
    }
}
```

With this, we can provide an `Symfony\Component\ExpressionLanguage\Expression` object as value for any of the headers, which will be evaluated when preparing the response. 
Note that the exception object can be accessed in the expression by using `this`, as in the example bellow. 

```php
#[WithHttpStatus(
    statusCode: 422,
    headers: [
        'max-allowed-amount' => new Expression('this.maxAllowedAmount'),
        'hard-coded-value' => 'still-possible',
    ]
)]
class AmountTooBigException extends \Exception
{
    public function __construct(public readonly int $maxAllowedAmount)
    {
    }
}
```

Note that this requires the `ExpressionLanguage` so it is added as a suggested package.
To be honest, I am not really sure if this is useful enough to add a new optional dependency, but I wanted to hear more opinions.