### PR TITLE
[HttpFoundation] Fix tests getting enum from bag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
@@ -111,7 +111,7 @@ class InputBagTest extends TestCase
     {
         $bag = new InputBag(['valid-value' => 1]);
 
-        $this->assertSame(Foo::Bar, $bag->getEnum('valid-value', Foo::class));
+        $this->assertSame(InputEnum::Bar, $bag->getEnum('valid-value', InputEnum::class));
     }
 
     public function testGetEnumThrowsExceptionWithInvalidValue()
@@ -119,8 +119,13 @@ class InputBagTest extends TestCase
         $bag = new InputBag(['invalid-value' => 2]);
 
         $this->expectException(BadRequestException::class);
-        $this->expectExceptionMessage('Parameter "invalid-value" cannot be converted to enum: 2 is not a valid backing value for enum "Symfony\Component\HttpFoundation\Tests\Foo".');
+        $this->expectExceptionMessage(sprintf('Parameter "invalid-value" cannot be converted to enum: 2 is not a valid backing value for enum %s.', version_compare(\PHP_VERSION, '8.2', '<') ? '"'.InputEnum::class.'"' : InputEnum::class));
 
-        $this->assertNull($bag->getEnum('invalid-value', Foo::class));
+        $this->assertNull($bag->getEnum('invalid-value', InputEnum::class));
     }
+}
+
+enum InputEnum: int
+{
+    case Bar = 1;
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -231,10 +231,10 @@ class ParameterBagTest extends TestCase
     {
         $bag = new ParameterBag(['valid-value' => 1]);
 
-        $this->assertSame(Foo::Bar, $bag->getEnum('valid-value', Foo::class));
+        $this->assertSame(ParameterEnum::Bar, $bag->getEnum('valid-value', ParameterEnum::class));
 
-        $this->assertNull($bag->getEnum('invalid-key', Foo::class));
-        $this->assertSame(Foo::Bar, $bag->getEnum('invalid-key', Foo::class, Foo::Bar));
+        $this->assertNull($bag->getEnum('invalid-key', ParameterEnum::class));
+        $this->assertSame(ParameterEnum::Bar, $bag->getEnum('invalid-key', ParameterEnum::class, ParameterEnum::Bar));
     }
 
     public function testGetEnumThrowsExceptionWithNotBackingValue()
@@ -242,9 +242,9 @@ class ParameterBagTest extends TestCase
         $bag = new ParameterBag(['invalid-value' => 2]);
 
         $this->expectException(\UnexpectedValueException::class);
-        $this->expectExceptionMessage('Parameter "invalid-value" cannot be converted to enum: 2 is not a valid backing value for enum "Symfony\Component\HttpFoundation\Tests\Foo".');
+        $this->expectExceptionMessage(sprintf('Parameter "invalid-value" cannot be converted to enum: 2 is not a valid backing value for enum %s.', version_compare(\PHP_VERSION, '8.2', '<') ? '"'.ParameterEnum::class.'"' : ParameterEnum::class));
 
-        $this->assertNull($bag->getEnum('invalid-value', Foo::class));
+        $this->assertNull($bag->getEnum('invalid-value', ParameterEnum::class));
     }
 
     public function testGetEnumThrowsExceptionWithInvalidValueType()
@@ -252,13 +252,13 @@ class ParameterBagTest extends TestCase
         $bag = new ParameterBag(['invalid-value' => ['foo']]);
 
         $this->expectException(\UnexpectedValueException::class);
-        $this->expectExceptionMessage('Parameter "invalid-value" cannot be converted to enum: Symfony\Component\HttpFoundation\Tests\Foo::from(): Argument #1 ($value) must be of type int, array given.');
+        $this->expectExceptionMessage('Parameter "invalid-value" cannot be converted to enum: Symfony\Component\HttpFoundation\Tests\ParameterEnum::from(): Argument #1 ($value) must be of type int, array given.');
 
-        $this->assertNull($bag->getEnum('invalid-value', Foo::class));
+        $this->assertNull($bag->getEnum('invalid-value', ParameterEnum::class));
     }
 }
 
-enum Foo: int
+enum ParameterEnum: int
 {
     case Bar = 1;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR fixes two issues related to #48820’s tests:

- it was impossible to run `InputBagTest` alone because it depended on the `Foo` enum defined in `ParameterBagTest`
- the error message on invalid backing value changed with PHP 8.2 (https://github.com/php/php-src/pull/9350). Not sure how to handle this one. 