### PR TITLE
[DoctrineBridge] Fix detecting mapping with one line annotations

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -318,8 +318,8 @@ abstract class AbstractDoctrineExtension extends Extension
                 break;
             }
             if (
-                preg_match('/^ \* @.*'.$quotedMappingObjectName.'\b/m', $content) ||
-                preg_match('/^ \* @.*Embeddable\b/m', $content)
+                preg_match('/^(?: \*|\/\*\*) @.*'.$quotedMappingObjectName.'\b/m', $content) ||
+                preg_match('/^(?: \*|\/\*\*) @.*Embeddable\b/m', $content)
             ) {
                 $type = 'annotation';
                 break;

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -279,6 +279,7 @@ class DoctrineExtensionTest extends TestCase
     public function providerBundles()
     {
         yield ['AnnotationsBundle', 'annotation', '/Entity'];
+        yield ['AnnotationsOneLineBundle', 'annotation', '/Entity'];
         yield ['FullEmbeddableAnnotationsBundle', 'annotation', '/Entity'];
         if (\PHP_VERSION_ID >= 80000) {
             yield ['AttributesBundle', 'attribute', '/Entity'];

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Bundles/AnnotationsOneLineBundle/AnnotationsOneLineBundle.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Bundles/AnnotationsOneLineBundle/AnnotationsOneLineBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixtures\Bundles\AnnotationsOneLineBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class AnnotationsOneLineBundle extends Bundle
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Bundles/AnnotationsOneLineBundle/Entity/Person.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Bundles/AnnotationsOneLineBundle/Entity/Person.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixtures\Bundles\AnnotationsOneLineBundle\Entity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+/** @Entity */
+class Person
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /** @Column(type="string") */
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->name;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

When using one line comment (which is enabled by default when using [`doctrine/coding-standard` 11](https://github.com/doctrine/coding-standard/releases/tag/11.0.0)) to specify that a class is an `Entity`:

```php
/** @Entity */
class Person 
{
    // ...
}
```

it doesn't detect properly the annotation and returns `attribute` instead of `annotation`.