### PR TITLE
[HttpClient] Move Http clients data collecting at a late level

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -38,6 +38,10 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
      */
     public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
+    }
+
+    public function lateCollect()
+    {
         $this->reset();
 
         foreach ($this->clients as $name => $client) {
@@ -50,12 +54,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
 
             $this->data['request_count'] += \count($traces);
             $this->data['error_count'] += $errorCount;
-        }
-    }
 
-    public function lateCollect()
-    {
-        foreach ($this->clients as $client) {
             $client->reset();
         }
     }

--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -15,8 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Component\HttpClient\TraceableHttpClient;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 class HttpClientDataCollectorTest extends TestCase
@@ -50,7 +48,7 @@ class HttpClientDataCollectorTest extends TestCase
         $sut->registerClient('http_client2', $httpClient2);
         $sut->registerClient('http_client3', $httpClient3);
         $this->assertEquals(0, $sut->getRequestCount());
-        $sut->collect(new Request(), new Response());
+        $sut->lateCollect();
         $this->assertEquals(3, $sut->getRequestCount());
     }
 
@@ -79,7 +77,7 @@ class HttpClientDataCollectorTest extends TestCase
         $sut->registerClient('http_client2', $httpClient2);
         $sut->registerClient('http_client3', $httpClient3);
         $this->assertEquals(0, $sut->getErrorCount());
-        $sut->collect(new Request(), new Response());
+        $sut->lateCollect();
         $this->assertEquals(1, $sut->getErrorCount());
     }
 
@@ -108,7 +106,7 @@ class HttpClientDataCollectorTest extends TestCase
         $sut->registerClient('http_client2', $httpClient2);
         $sut->registerClient('http_client3', $httpClient3);
         $this->assertEquals([], $sut->getClients());
-        $sut->collect(new Request(), new Response());
+        $sut->lateCollect();
         $collectedData = $sut->getClients();
         $this->assertEquals(0, $collectedData['http_client1']['error_count']);
         $this->assertEquals(1, $collectedData['http_client2']['error_count']);
@@ -140,7 +138,7 @@ class HttpClientDataCollectorTest extends TestCase
         $sut->registerClient('http_client2', $httpClient2);
         $sut->registerClient('http_client3', $httpClient3);
         $this->assertEquals([], $sut->getClients());
-        $sut->collect(new Request(), new Response());
+        $sut->lateCollect();
         $collectedData = $sut->getClients();
         $this->assertCount(2, $collectedData['http_client1']['traces']);
         $this->assertCount(1, $collectedData['http_client2']['traces']);
@@ -157,7 +155,7 @@ class HttpClientDataCollectorTest extends TestCase
         ]);
         $sut = new HttpClientDataCollector();
         $sut->registerClient('http_client1', $httpClient1);
-        $sut->collect(new Request(), new Response());
+        $sut->lateCollect();
         $collectedData = $sut->getClients();
         $this->assertCount(1, $collectedData['http_client1']['traces']);
         $sut->reset();


### PR DESCRIPTION
This allows to collect http clients data when sending them in a StreamedResponse callback method

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48894 
| License       | MIT
| Doc PR        | 
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
When a controller action is returning a StreamedResponse doing some HttpClient requests, http clients data are collected to early, so the Web profiler HttpClient panel is wrongly empty.
To fix this we moved data collecting to the HttpClientDataCollector::lateCollect() method which is called on ther kernel.terminate event.