### PR TITLE
[Security] Add remember me option for JSON logins

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -26,6 +26,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PasswordUpgradeBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
@@ -88,7 +89,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         }
 
         $userBadge = new UserBadge($credentials['username'], $this->userProvider->loadUserByIdentifier(...));
-        $passport = new Passport($userBadge, new PasswordCredentials($credentials['password']));
+        $passport = new Passport($userBadge, new PasswordCredentials($credentials['password']), [new RememberMeBadge()]);
 
         if ($this->userProvider instanceof PasswordUpgraderInterface) {
             $passport->addBadge(new PasswordUpgradeBadge($credentials['password'], $this->userProvider));

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/RememberMeBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/RememberMeBadge.php
@@ -28,6 +28,11 @@ class RememberMeBadge implements BadgeInterface
 {
     private bool $enabled = false;
 
+    public function __construct(
+        public readonly array $parameters = [],
+    ) {
+    }
+
     /**
      * Enables remember-me cookie creation.
      *

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `RememberMeBadge` to `JsonLoginAuthenticator` and enable reading parameter in JSON request body
+
 6.2
 ---
 

--- a/src/Symfony/Component/Security/Http/EventListener/CheckRememberMeConditionsListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CheckRememberMeConditionsListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\EventListener;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\ParameterBagUtils;
@@ -54,7 +55,7 @@ class CheckRememberMeConditionsListener implements EventSubscriberInterface
         /** @var RememberMeBadge $badge */
         $badge = $passport->getBadge(RememberMeBadge::class);
         if (!$this->options['always_remember_me']) {
-            $parameter = ParameterBagUtils::getRequestParameterValue($event->getRequest(), $this->options['remember_me_parameter']);
+            $parameter = $this->getParameter($event->getRequest(), $this->options['remember_me_parameter']);
             if (!('true' === $parameter || 'on' === $parameter || '1' === $parameter || 'yes' === $parameter || true === $parameter)) {
                 $this->logger?->debug('Remember me disabled; request does not contain remember me parameter ("{parameter}").', ['parameter' => $this->options['remember_me_parameter']]);
 
@@ -68,5 +69,24 @@ class CheckRememberMeConditionsListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [LoginSuccessEvent::class => ['onSuccessfulLogin', -32]];
+    }
+
+    private function getParameter(Request $request, string $parameterName): mixed
+    {
+        $parameter = ParameterBagUtils::getRequestParameterValue($request, $parameterName);
+        if (null !== $parameter) {
+            return $parameter;
+        }
+
+        if ('application/json' === $request->headers->get('Content-Type')) {
+            $data = json_decode($request->getContent());
+            if (!$data instanceof \stdClass) {
+                return null;
+            }
+
+            return $data->{$parameterName} ?? null;
+        }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CheckRememberMeConditionsListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CheckRememberMeConditionsListenerTest.php
@@ -59,7 +59,7 @@ class CheckRememberMeConditionsListenerTest extends TestCase
     public function testSuccessfulLoginWithoutRequestParameter()
     {
         $this->request = Request::create('/login');
-        $passport = $this->createPassport();
+        $passport = $this->createPassport([new RememberMeBadge()]);
 
         $this->listener->onSuccessfulLogin($this->createLoginSuccessfulEvent($passport));
 
@@ -110,7 +110,7 @@ class CheckRememberMeConditionsListenerTest extends TestCase
     {
         $this->createJsonRequest(['_remember_me' => $optInValue]);
 
-        $passport = $this->createPassport();
+        $passport = $this->createPassport([new RememberMeBadge(['_remember_me' => $optInValue])]);
 
         $this->listener->onSuccessfulLogin($this->createLoginSuccessfulEvent($passport));
 
@@ -133,7 +133,7 @@ class CheckRememberMeConditionsListenerTest extends TestCase
         $this->response = new Response();
     }
 
-    private function createJsonRequest(mixed $content = ['_remember_me' => true]): void
+    private function createJsonRequest(array $content = ['_remember_me' => true]): void
     {
         $this->request = Request::create('/login', 'POST', [], [], [], [], json_encode($content));
         $this->request->headers->add(['Content-Type' => 'application/json']);
@@ -147,6 +147,6 @@ class CheckRememberMeConditionsListenerTest extends TestCase
 
     private function createPassport(array $badges = null)
     {
-        return new SelfValidatingPassport(new UserBadge('test', fn ($username) => new InMemoryUser($username, null)), $badges ?? [new RememberMeBadge()]);
+        return new SelfValidatingPassport(new UserBadge('test', fn ($username) => new InMemoryUser($username, null)), $badges ?? [new RememberMeBadge(['_remember_me' => true])]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40918 
| License       | MIT
| Doc PR        | symfony/symfony-docs#17676

This resolves the above mentioned issue by adding a `RememberMeBadge` to `JsonLoginAuthenticator` and by extending `CheckRememberMeConditionsListener` to be able to read the remember me parameter from a JSON request body (if reading from ParameterBag was unsuccessful).

This means you can send a JSON request with a body like this and needn‘t use a fallback HTTP form login when building your API: 

```json
{
    "username": "dunglas",
    "password": "MyPassword",
    "_remember_me": true
}
````
