### PR TITLE
[Security][SecurityBundle] made default access token extractors configurable in security.yaml

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -37,6 +37,28 @@ class AccessTokenFactoryTest extends TestCase
         $this->assertTrue($container->hasDefinition('security.authenticator.access_token.firewall1'));
     }
 
+    public function testTokenExtractor()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => 'in_memory_token_handler_service_id',
+            'success_handler' => 'success_handler_service_id',
+            'failure_handler' => 'failure_handler_service_id',
+            'token_extractors' => [
+                'query_string' => [
+                    'parameter' => 'c-auth-token',
+                ]
+            ],
+        ];
+
+        $factory = new AccessTokenFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.access_token.firewall1'));
+    }
+
     public function testDefaultServiceConfiguration()
     {
         $container = new ContainerBuilder();
@@ -50,6 +72,10 @@ class AccessTokenFactoryTest extends TestCase
         $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
 
         $this->assertTrue($container->hasDefinition('security.authenticator.access_token.firewall1'));
+        $this->assertEquals(
+            'security.access_token_extractor.header',
+            (string) $container->getDefinition('security.authenticator.access_token.firewall1')->getArgument(1)
+        );
     }
 
     public function testNoExtractorsDefined()
@@ -65,6 +91,117 @@ class AccessTokenFactoryTest extends TestCase
 
         $factory = new AccessTokenFactory();
         $this->processConfig($config, $factory);
+    }
+
+    public function extractorConfigs(): array
+    {
+        return [
+            'user_service_foo' => [
+                ['foo'], // param,
+                'foo',   // extractor(s)
+                null,    // error
+            ],
+
+            'predefined query_string' => [
+                ['query_string' => null],
+                'security.access_token_extractor.query_string',
+            ],
+
+            'predefined header' => [
+                ['header'],
+                'security.access_token_extractor.header',
+            ],
+
+            'predefined query_string, not exists param' => [
+                ['query_string' => ['tokenType' => 'this parameter does not exists in QueryStringExtractor']],
+                'security.access_token_extractor.query_string',
+            ],
+
+            'user defined query_string' => [
+                ['query_string' => ['parameter' => 'x-auth']],
+                'security.authenticator.access_token.query_string_extractor.firewall1.0',
+            ],
+
+            '5 different services' => [
+                [
+                    'query_string' => null,
+                    4 => 'request_body',
+                    'header' => ['headerParameter' => 'x-auth-token'],
+                    'header_x_bearer' => ['service' => 'header', 'tokenType' => 'X-Bearer'],
+                    'foo' => null,
+                    9 => ['service' => 'bar'],
+                ],
+                [
+                    'security.access_token_extractor.query_string',
+                    'security.access_token_extractor.request_body',
+                    'security.authenticator.access_token.header_extractor.firewall1.0',
+                    'security.authenticator.access_token.header_extractor.firewall1.1',
+                    'foo',
+                    'bar',
+                ],
+            ],
+
+            'error: not exists param' => [
+                ['header' => ['not_exists_param' => 'no matter']],
+                null,
+                'Unrecognized option "not_exists_param" under "access_token.token_extractors.header".',
+            ],
+
+            'error: undefined key' => [
+                ['header' => ['not_exists_param' => 'no matter']],
+                null,
+                'Unrecognized option "not_exists_param" under "access_token.token_extractors.header".',
+            ],
+
+            'error: extractor misconfigured' => [
+                ['abc' => 'abc'],
+                null,
+                'Please define extractor as "service_id" string or ["header|query_string|request_body" => ["abc" => "abc", ...].',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider extractorConfigs
+     */
+    public function testExtractorConfigs(array $extractorConfig, null|string|array $extractorIds, string $error = null): void
+    {
+        if ($error) {
+            $this->expectException(InvalidConfigurationException::class);
+            $this->expectExceptionMessage($error);
+        }
+
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => 'in_memory_token_handler_service_id',
+            'token_extractors' => $extractorConfig,
+        ];
+
+        $factory = new AccessTokenFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        if (!$error) {
+            $this->assertTrue($container->hasDefinition('security.authenticator.access_token.firewall1'));
+            $extractorDefinition = $container->getDefinition('security.authenticator.access_token.firewall1');
+
+            if (is_string($extractorIds)) {
+                $this->assertEquals(
+                    $extractorIds,
+                    (string) $extractorDefinition->getArgument(1)
+                );
+            } else { // all are in chain_extractor
+                $this->assertEquals(
+                    'security.authenticator.access_token.chain_extractor.firewall1',
+                    (string) $extractorDefinition->getArgument(1)
+                );
+                $chainExtractor = $container->getDefinition($extractorDefinition->getArgument(1));
+                $chainedExtractors = array_values($chainExtractor->getArgument(0));
+                // order must be guaranteed
+                $this->assertEquals($chainedExtractors, array_map('strval', $chainedExtractors));
+            }
+        }
     }
 
     public function testNoHandlerDefined()

--- a/src/Symfony/Component/Security/Http/AccessToken/FormEncodedBodyExtractor.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/FormEncodedBodyExtractor.php
@@ -27,9 +27,14 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class FormEncodedBodyExtractor implements AccessTokenExtractorInterface
 {
+    public const PARAMETER = 'access_token';
+
+    private readonly string $parameter;
+
     public function __construct(
-        private readonly string $parameter = 'access_token'
+        ?string $parameter =  null
     ) {
+        $this->parameter = $parameter ?? self::PARAMETER;
     }
 
     public function extractAccessToken(Request $request): ?string

--- a/src/Symfony/Component/Security/Http/AccessToken/HeaderAccessTokenExtractor.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/HeaderAccessTokenExtractor.php
@@ -22,12 +22,17 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class HeaderAccessTokenExtractor implements AccessTokenExtractorInterface
 {
-    private string $regex;
+    private readonly string $headerParameter;
+    private readonly string $tokenType;
+    private readonly string $regex;
 
     public function __construct(
-        private readonly string $headerParameter = 'Authorization',
-        private readonly string $tokenType = 'Bearer'
+        ?string $headerParameter = null,
+        ?string $tokenType = null
     ) {
+        $this->headerParameter = $headerParameter ?? 'Authorization';
+        $this->tokenType = $tokenType ?? 'Bearer';
+
         $this->regex = sprintf(
             '/^%s([a-zA-Z0-9\-_\+~\/\.]+)$/',
             '' === $this->tokenType ? '' : preg_quote($this->tokenType).'\s+'

--- a/src/Symfony/Component/Security/Http/AccessToken/QueryAccessTokenExtractor.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/QueryAccessTokenExtractor.php
@@ -30,9 +30,12 @@ final class QueryAccessTokenExtractor implements AccessTokenExtractorInterface
 {
     public const PARAMETER = 'access_token';
 
+    private readonly string $parameter;
+
     public function __construct(
-        private readonly string $parameter = self::PARAMETER,
+        ?string $parameter = null,
     ) {
+        $this->parameter = $parameter ?? self::PARAMETER;
     }
 
     public function extractAccessToken(Request $request): ?string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Imho access_token.token_extractors should be configurable in firewall settings.

Otherwise we have to register at least 2 services. 1 for token_handler one for token_extractors

Possible configurations are:
```.yaml
token_extractors:
    header:
        headerParameter: x-auth-token
        tokenType: ''

token_extractors:
    - 
        service: query_string
        parameter: x-auth-token

token_extractors:
    header:
        headerParameter: X-Authorization
    token:
        service: header
        headerParameter: X-Auth-Token
```

P.S. Should we rename `HeaderAccessTokenExtractor::headerParameter` to `parameter`?