### PR TITLE
Allow Usage of ContentId in html

### DIFF
--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Support detection of related parts if `Content-Id` is used instead of the name
+
 6.2
 ---
 

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -492,14 +492,16 @@ class Email extends Message
         $otherParts = $relatedParts = [];
         foreach ($this->attachments as $part) {
             foreach ($names as $name) {
-                if ($name !== $part->getName()) {
+                if ($name !== $part->getName() && (!$part->hasContentId() || $name !== $part->getContentId())) {
                     continue;
                 }
                 if (isset($relatedParts[$name])) {
                     continue 2;
                 }
 
-                $html = str_replace('cid:'.$name, 'cid:'.$part->getContentId(), $html, $count);
+                if ($name !== $part->getContentId()) {
+                    $html = str_replace('cid:'.$name, 'cid:'.$part->getContentId(), $html, $count);
+                }
                 $relatedParts[$name] = $part;
                 $part->setName($part->getContentId())->asInline();
 

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -409,6 +409,24 @@ class EmailTest extends TestCase
         $this->assertStringContainsString('cid:'.$parts[1]->getContentId(), $generatedHtml->getBody());
     }
 
+    public function testGenerateBodyWithTextAndHtmlAndAttachedFileAndAttachedImageReferencedViaCidAndContentId()
+    {
+        [$text, $html, $filePart, $file, $imagePart, $image] = $this->generateSomeParts();
+        $e = (new Email())->from('me@example.com')->to('you@example.com');
+        $e->text('text content');
+        $e->addPart(new DataPart($file));
+        $img = new DataPart($image, 'test.gif');
+        $e->addPart($img);
+        $e->html($content = 'html content <img src="cid:'.$img->getContentId().'">');
+        $body = $e->getBody();
+        $this->assertInstanceOf(MixedPart::class, $body);
+        $this->assertCount(2, $related = $body->getParts());
+        $this->assertInstanceOf(RelatedPart::class, $related[0]);
+        $this->assertEquals($filePart, $related[1]);
+        $this->assertCount(2, $parts = $related[0]->getParts());
+        $this->assertInstanceOf(AlternativePart::class, $parts[0]);
+    }
+
     public function testGenerateBodyWithHtmlAndInlinedImageTwiceReferencedViaCid()
     {
         // inline image (twice) referenced in the HTML content


### PR DESCRIPTION
Detect usage of Content-Id in html and mark part as related, just as it would happen with a `cid:<name>` reference.

| Q             | A
| ------------- | ---
| Branch?       | 6.3 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | -
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Assumed you have a defined `Content-Id` for your attachment, as you modify and forward an id.
The HTML part will already contain the reference to that id in the `cid:` reference. Which means the name is no longer part of the html body. In this case it is currently not detected that the parts are related to each other. 
This will be improved with this PR.

I do not consider it a bug fix. The feature has a very special use case. If you consider otherwise, let me know and I will create a PR against the maintenance branch. (I already have one prepared: https://github.com/m42e/symfony/tree/allow-usage-of-content-id-in-html-5.4 Which means the feature/fix would reach more people. Please let me know what you think.)

