### PR TITLE
[Validator] Validate time without seconds

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Deprecate `ValidatorBuilder::setDoctrineAnnotationReader()`
  * Deprecate `ValidatorBuilder::addDefaultDoctrineAnnotationReader()`
  * Add `number`, `finite-number` and `finite-float` types to `Type` constraint
+ * Add the `withSeconds` option to the `Time` constraint that allows to pass time without seconds
 
 6.3
 ---

--- a/src/Symfony/Component/Validator/Constraints/Time.php
+++ b/src/Symfony/Component/Validator/Constraints/Time.php
@@ -35,16 +35,19 @@ class Time extends Constraint
      */
     protected static $errorNames = self::ERROR_NAMES;
 
+    public $withSeconds = true;
     public $message = 'This value is not a valid time.';
 
     public function __construct(
         array $options = null,
         string $message = null,
         array $groups = null,
-        mixed $payload = null
+        mixed $payload = null,
+        bool $withSeconds = null,
     ) {
         parent::__construct($options, $groups, $payload);
 
+        $this->withSeconds = $withSeconds ?? $this->withSeconds;
         $this->message = $message ?? $this->message;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 class TimeValidator extends ConstraintValidator
 {
     public const PATTERN = '/^(\d{2}):(\d{2}):(\d{2})$/';
+    public const PATTERN_WITHOUT_SECONDS = '/^(\d{2}):(\d{2})$/';
 
     /**
      * Checks whether a time is valid.
@@ -52,7 +53,7 @@ class TimeValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        if (!preg_match(static::PATTERN, $value, $matches)) {
+        if (!preg_match($constraint->withSeconds ? static::PATTERN : static::PATTERN_WITHOUT_SECONDS, $value, $matches)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Time::INVALID_FORMAT_ERROR)
@@ -61,7 +62,7 @@ class TimeValidator extends ConstraintValidator
             return;
         }
 
-        if (!self::checkTime($matches[1], $matches[2], $matches[3])) {
+        if (!self::checkTime($matches[1], $matches[2], $constraint->withSeconds ? $matches[3] : 0)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Time::INVALID_TIME_ERROR)

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -30,6 +30,13 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    public function testDefaultWithSeconds()
+    {
+        $this->validator->validate('10:15:25', new Time());
+
+        $this->assertNoViolation();
+    }
+
     public function testEmptyStringIsValid()
     {
         $this->validator->validate('', new Time());
@@ -59,6 +66,49 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
             ['01:02:03'],
             ['00:00:00'],
             ['23:59:59'],
+        ];
+    }
+
+    /**
+     * @dataProvider getValidTimesWithoutSeconds
+     */
+    public function testValidTimesWithoutSeconds(string $time)
+    {
+        $this->validator->validate($time, new Time([
+            'withSeconds' => false,
+        ]));
+
+        $this->assertNoViolation();
+    }
+
+    public static function getValidTimesWithoutSeconds()
+    {
+        return [
+            ['01:02'],
+            ['00:00'],
+            ['23:59'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidTimesWithoutSeconds
+     */
+    public function testInvalidTimesWithoutSeconds(string $time)
+    {
+        $this->validator->validate($time, $constraint = new Time());
+
+        $this->buildViolation($constraint->message)
+            ->setParameter('{{ value }}', '"'.$time.'"')
+            ->setCode(Time::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
+    public static function getInvalidTimesWithoutSeconds()
+    {
+        return [
+            ['01:02'],
+            ['00:00'],
+            ['23:59'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


Adds ability to validate time with the `Time` constraint without having the last part of the regexp that's responsible for seconds.
I don't want to override the `Time` and create a new one with custom logic because I think that it maybe helpful for others.
Tell me if I need to touch the docs