### PR TITLE
(5.4) add compatibility layer for doctrine/annotations v1 and v2

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
 use Composer\InstalledVersions;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\Reader;
 use Http\Client\HttpClient;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
@@ -2678,12 +2677,18 @@ class FrameworkExtension extends Extension
 
         foreach ($headers as $h) {
             switch ($h) {
-                case 'forwarded': $trustedHeaders |= Request::HEADER_FORWARDED; break;
-                case 'x-forwarded-for': $trustedHeaders |= Request::HEADER_X_FORWARDED_FOR; break;
-                case 'x-forwarded-host': $trustedHeaders |= Request::HEADER_X_FORWARDED_HOST; break;
-                case 'x-forwarded-proto': $trustedHeaders |= Request::HEADER_X_FORWARDED_PROTO; break;
-                case 'x-forwarded-port': $trustedHeaders |= Request::HEADER_X_FORWARDED_PORT; break;
-                case 'x-forwarded-prefix': $trustedHeaders |= Request::HEADER_X_FORWARDED_PREFIX; break;
+                case 'forwarded': $trustedHeaders |= Request::HEADER_FORWARDED;
+                break;
+                case 'x-forwarded-for': $trustedHeaders |= Request::HEADER_X_FORWARDED_FOR;
+                break;
+                case 'x-forwarded-host': $trustedHeaders |= Request::HEADER_X_FORWARDED_HOST;
+                break;
+                case 'x-forwarded-proto': $trustedHeaders |= Request::HEADER_X_FORWARDED_PROTO;
+                break;
+                case 'x-forwarded-port': $trustedHeaders |= Request::HEADER_X_FORWARDED_PORT;
+                break;
+                case 'x-forwarded-prefix': $trustedHeaders |= Request::HEADER_X_FORWARDED_PREFIX;
+                break;
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1631,15 +1631,6 @@ class FrameworkExtension extends Extension
 
         $loader->load('annotations.php');
 
-        if (!method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
-            if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
-                $container->getDefinition('annotations.dummy_registry')
-                    ->setMethodCalls([['registerLoader', ['class_exists']]]);
-            } else {
-                $container->removeDefinition('annotations.dummy_registry');
-            }
-        }
-
         if ('none' === $config['cache']) {
             $container->removeDefinition('annotations.cached_reader');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
@@ -22,19 +22,13 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
 return static function (ContainerConfigurator $container) {
-    // compatibility layer to support doctrine/annotations ^1.0 and ^2.0
-    // registerLoader only exists in doctrine/annotations ^1.0
-    if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
-        // registerUniqueLoader only exists in doctrine/annotations ^1.6
-        if (method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
-            $container->services()
-                ->set('annotations.dummy_registry', AnnotationRegistry::class)
-                ->call('registerUniqueLoader', ['class_exists']);
-        } else {
-            $container->services()
-                ->set('annotations.dummy_registry', AnnotationRegistry::class)
-                ->call('registerLoader', ['class_exists']);
-        }
+    // compatibility layer to support doctrine/annotations ^1.13 and ^2.0
+    // registerUniqueLoader only exists in doctrine/annotations ^1.13
+    // (it was added in 1.6 but a conflict forbid versions lower than 1.13.1)
+    if (method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
+        $container->services()
+            ->set('annotations.dummy_registry', AnnotationRegistry::class)
+            ->call('registerUniqueLoader', ['class_exists']);
 
         $container->services()
             ->set('annotations.reader', AnnotationReader::class)
@@ -44,7 +38,7 @@ return static function (ContainerConfigurator $container) {
             ])
         ;
     }
-    // for doctrine/annotations v2
+    // with doctrine/annotations v2, there's no need for annotations.dummy_registry
     else {
         $container->services()
             ->set('annotations.reader', AnnotationReader::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48792
| License       | MIT
| Doc PR        | no

The previous code always registered `annotations.dummy_registry` and unregistered it with `doctrine/annotations` v1.

This has the unexpected effect to break the call to `addGlobalIgnoredName` with `doctrine/annotations` v2 : https://github.com/symfony/symfony/issues/48792#issuecomment-1374657943

I propose a novel approach with a workaround that:
- register `annotations.dummy_registry` only with `doctrine/annotations` v1, which avoid registering and unregistering a dummy service
- get rid of `registerLoader`, because a conflict block the installation of `doctrine/annotations` without `registerUniqueLoader`: https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bundle/FrameworkBundle/composer.json#L72 and `registerUniqueLoader` is available in 1.13.1 and later releases: https://github.com/doctrine/annotations/blob/1.13.x/lib/Doctrine/Common/Annotations/AnnotationRegistry.php#L124, so a test on `registerUniqueLoader` is enough to identify `doctrine/annotations` v1

These changes can be tested with this reproducer: https://github.com/alexislefebvre/symfony_bug_app_48792

Downgrading and upgrading become possible:

```bash
composer require doctrine/annotations:~1.13.0 --with-all-dependencies
composer require doctrine/annotations:^1.13.0 --with-all-dependencies
composer require doctrine/annotations:^2.0 --with-all-dependencies
```

It looks like services declaration was meant to be as simple as possible, and logic went into `FrameworkExtension`, I think it made things more complicated in this case, with the service `annotations.dummy_registry` being declared and unregistered just after. So I took a simpler approach.