### PR TITLE
[Serializer] Fix SerializerInterface for PHPStan

### DIFF
--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -33,6 +33,8 @@ interface SerializerInterface
      * @param array<string, mixed> $context
      *
      * @psalm-return (TType is class-string<TObject> ? TObject : mixed)
+     *
+     * @phpstan-return ($type is class-string<TObject> ? TObject : mixed)
      */
     public function deserialize(mixed $data, string $type, string $format, array $context = []): mixed;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

PHPStan normalizes the class-string<TObject> away in the TType template. In order to fix this we use the $type param directly for phpstan specifically.

These annotations were introduces in symfony 6.2

See also: https://github.com/phpstan/phpstan/issues/8637
