### PR TITLE
[FrameworkBundle] restore call to addGlobalIgnoredName

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1631,11 +1631,14 @@ class FrameworkExtension extends Extension
 
         $loader->load('annotations.php');
 
+        // registerUniqueLoader exists since doctrine/annotations v1.6
         if (!method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
+            // registerLoader exists only in doctrine/annotations v1
             if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
                 $container->getDefinition('annotations.dummy_registry')
                     ->setMethodCalls([['registerLoader', ['class_exists']]]);
             } else {
+                // remove the dummy registry when doctrine/annotations v2 is used
                 $container->removeDefinition('annotations.dummy_registry');
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
@@ -26,7 +26,7 @@ return static function (ContainerConfigurator $container) {
         ->set('annotations.reader', AnnotationReader::class)
             ->call('addGlobalIgnoredName', [
                 'required',
-                service('annotations.dummy_registry')->ignoreOnInvalid(), // dummy arg to register class_exists as annotation loader only when required
+                service('annotations.dummy_registry')->nullOnInvalid(), // dummy arg to register class_exists as annotation loader only when required
             ])
 
         ->set('annotations.dummy_registry', AnnotationRegistry::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48792 and replace #48912
| License       | MIT
| Doc PR        | no

The service `annotations.dummy_registry` is unregistered with `doctrine/annotations` v2.

This had the unexpected effect to break the call to `addGlobalIgnoredName` with `doctrine/annotations` v2 : https://github.com/symfony/symfony/issues/48792#issuecomment-1374657943

By using `nullOnInvalid` instead of `ignoreOnInvalid`, the call to `addGlobalIgnoredName` is restored.

These changes can be tested with this reproducer: https://github.com/alexislefebvre/symfony_bug_app_48792

Downgrading and upgrading `doctrine/annotations` become possible:

```bash
composer require doctrine/annotations:^1.13.0 --with-all-dependencies
composer require doctrine/annotations:^2.0 --with-all-dependencies
```

Thanks to @derrabus: https://github.com/symfony/symfony/pull/48912#issuecomment-1374755771