### PR TITLE
Update supported versions of egulias/email-validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^2.13.1|^3.0",
         "doctrine/orm": "^2.12",
-        "egulias/email-validator": "^2.1.10|^3.1",
+        "egulias/email-validator": "^3.1|^4.0",
         "guzzlehttp/promises": "^1.4",
         "league/html-to-markdown": "^5.0",
         "masterminds/html5": "^2.7.2",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.12|^2",
-        "egulias/email-validator": "^2.1.10|^3",
+        "egulias/email-validator": "^3|^4.0",
         "league/html-to-markdown": "^5.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "symfony/asset": "^5.4|^6.0",

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "egulias/email-validator": "^2.1.10|^3",
+        "egulias/email-validator": "^3|^4.0",
         "psr/event-dispatcher": "^1",
         "psr/log": "^1|^2|^3",
         "symfony/event-dispatcher": "^5.4|^6.0",

--- a/src/Symfony/Component/Mime/composer.json
+++ b/src/Symfony/Component/Mime/composer.json
@@ -21,7 +21,7 @@
         "symfony/polyfill-mbstring": "^1.0"
     },
     "require-dev": {
-        "egulias/email-validator": "^2.1.10|^3.1",
+        "egulias/email-validator": "^3.1|^4.0",
         "league/html-to-markdown": "^5.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "symfony/dependency-injection": "^5.4|^6.0",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -40,7 +40,7 @@
         "symfony/property-info": "^5.4|^6.0",
         "symfony/translation": "^5.4|^6.0",
         "doctrine/annotations": "^1.13|^2",
-        "egulias/email-validator": "^2.1.10|^3"
+        "egulias/email-validator": "^3|^4.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.13",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Upgrade supported versions of [@egulias/email-validator](https://github.com/egulias/EmailValidator). Drop support for outdated version 2.1 and add support for newer version 4.0.

See https://github.com/egulias/EmailValidator#supported-versions for supported versions.