### PR TITLE
[Mailer][Mime][TwigBridge] Allow EmailValidator 4

### DIFF
--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.12|^2",
-        "egulias/email-validator": "^2.1.10|^3",
+        "egulias/email-validator": "^2.1.10|^3|^4",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "symfony/asset": "^4.4|^5.0|^6.0",
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "egulias/email-validator": "^2.1.10|^3",
+        "egulias/email-validator": "^2.1.10|^3|^4",
         "psr/event-dispatcher": "^1",
         "psr/log": "^1|^2|^3",
         "symfony/deprecation-contracts": "^2.1|^3",

--- a/src/Symfony/Component/Mime/composer.json
+++ b/src/Symfony/Component/Mime/composer.json
@@ -23,7 +23,7 @@
         "symfony/polyfill-php80": "^1.16"
     },
     "require-dev": {
-        "egulias/email-validator": "^2.1.10|^3.1",
+        "egulias/email-validator": "^2.1.10|^3.1|^4",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "symfony/property-access": "^4.4|^5.1|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Follows #48904
| License       | MIT
| Doc PR        | N/A

This PR adjusts the versions constraints of EmailValidator in the composer.json files missed by #48904. cc @chalasr 