### PR TITLE
[DependencyInjection] Fix support for named arguments on non-autowired services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -43,6 +43,7 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
         foreach ($calls as $i => $call) {
             [$method, $arguments] = $call;
             $parameters = null;
+            $resolvedKeys = [];
             $resolvedArguments = [];
 
             foreach ($arguments as $key => $argument) {
@@ -51,6 +52,7 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
                 }
 
                 if (\is_int($key)) {
+                    $resolvedKeys[$key] = $key;
                     $resolvedArguments[$key] = $argument;
                     continue;
                 }
@@ -71,9 +73,11 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
                         if ($key === '$'.$p->name) {
                             if ($p->isVariadic() && \is_array($argument)) {
                                 foreach ($argument as $variadicArgument) {
+                                    $resolvedKeys[$j] = $j;
                                     $resolvedArguments[$j++] = $variadicArgument;
                                 }
                             } else {
+                                $resolvedKeys[$j] = $p->name;
                                 $resolvedArguments[$j] = $argument;
                             }
 
@@ -91,6 +95,7 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
                 $typeFound = false;
                 foreach ($parameters as $j => $p) {
                     if (!\array_key_exists($j, $resolvedArguments) && ProxyHelper::getTypeHint($r, $p, true) === $key) {
+                        $resolvedKeys[$j] = $p->name;
                         $resolvedArguments[$j] = $argument;
                         $typeFound = true;
                     }
@@ -103,6 +108,12 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
 
             if ($resolvedArguments !== $call[1]) {
                 ksort($resolvedArguments);
+
+                if (!$value->isAutowired() && !array_is_list($resolvedArguments)) {
+                    ksort($resolvedKeys);
+                    $resolvedArguments = array_combine($resolvedKeys, $resolvedArguments);
+                }
+
                 $calls[$i][1] = $resolvedArguments;
             }
         }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1102,7 +1102,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         } else {
             $r = new \ReflectionClass($parameterBag->resolveValue($definition->getClass()));
 
-            $service = null === $r->getConstructor() ? $r->newInstance() : $r->newInstanceArgs(array_values($arguments));
+            $service = null === $r->getConstructor() ? $r->newInstance() : $r->newInstanceArgs($arguments);
 
             if (!$definition->isDeprecated() && 0 < strpos($r->getDocComment(), "\n * @deprecated ")) {
                 trigger_deprecation('', '', 'The "%s" service relies on the deprecated "%s" class. It should either be deprecated or its implementation upgraded.', $id, $r->name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -165,7 +165,7 @@ class ResolveNamedArgumentsPassTest extends TestCase
         $pass = new ResolveNamedArgumentsPass();
         $pass->process($container);
 
-        $this->assertSame($expected, $definition->getArgument(3));
+        $this->assertSame($expected, $definition->getArgument('container'));
     }
 
     public function testResolvesMultipleArgumentsOfTheSameType()

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1773,6 +1773,24 @@ class ContainerBuilderTest extends TestCase
 
         $this->assertSame(['tag1', 'tag2', 'tag3'], $container->findTags());
     }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testNamedArgument()
+    {
+        $container = new ContainerBuilder();
+        $container->register(E::class)
+            ->setPublic(true)
+            ->setArguments(['$second' => 2]);
+
+        $container->compile();
+
+        $e = $container->get(E::class);
+
+        $this->assertSame('', $e->first);
+        $this->assertSame(2, $e->second);
+    }
 }
 
 class FooClass
@@ -1800,4 +1818,16 @@ class C implements X
 
 class D implements X
 {
+}
+
+class E
+{
+    public $first;
+    public $second;
+
+    public function __construct($first = '', $second = '')
+    {
+        $this->first = $first;
+        $this->second = $second;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48818
| License       | MIT
| Doc PR        | -

This fixes support for named arguments on non-autowired services as described in #48818.

Related to #43277 and #38091
