### PR TITLE
[PhpUnitBridge] Fix `enum_exists` mock tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/EnumExistsMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/EnumExistsMockTest.php
@@ -23,6 +23,9 @@ class EnumExistsMockTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
+        // Require the fixture file to allow PHP to be fully aware of the enum existence
+        require __DIR__.'/Fixtures/ExistingEnumReal.php';
+
         ClassExistsMock::register(__CLASS__);
     }
 
@@ -32,6 +35,11 @@ class EnumExistsMockTest extends TestCase
             ExistingEnum::class => false,
             'NonExistingEnum' => true,
         ]);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        ClassExistsMock::withMockedEnums([]);
     }
 
     public function testClassExists()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

This fixes some tests broken by https://github.com/symfony/symfony/pull/48516.
It seems that PHP needs the file to be required to be fully aware of the enum. Otherwise, even `\class_exists` and `\enum_exists` are returning false on `ExistingEnumReal::class`.