### PR TITLE
[Validator] Fix bad handling of nulls when the 'fields' option of the Unique constraint is set

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -79,7 +79,7 @@ class UniqueValidator extends ConstraintValidator
             if (!\is_string($field)) {
                 throw new UnexpectedTypeException($field, 'string');
             }
-            if (isset($element[$field])) {
+            if (\array_key_exists($field, $element)) {
                 $output[$field] = $element[$field];
             }
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -280,6 +280,14 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
                 ['id' => 1, 'email' => 'bar@email.com'],
                 ['id' => 1, 'email' => 'foo@email.com'],
             ], ['id']],
+            'unique null' => [
+                [null, null],
+                [],
+            ],
+            'unique field null' => [
+                [['nullField' => null], ['nullField' => null]],
+                ['nullField'],
+            ],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

UniqueValidator results differ when using Unique constraint `fields` options and null values:

Example:
```php
$validator->validate([null,null], new Unique()); // Violation, OK

$validator->validate([['foo' => null], ['foo' => null]], new Unique(fields: ['foo']); // No violation, KO
```




