### PR TITLE
[FrameworkBundle] Allow setting private services with the test container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add support to pass namespace wildcard in `framework.messenger.routing`
  * Deprecate `framework:exceptions` tag, unwrap it and replace `framework:exception` tags' `name` attribute by `class`
  * Deprecate the `notifier.logger_notification_listener` service, use the `notifier.notification_logger_listener` service instead
+ * Allow setting private services with the test container
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -30,10 +29,9 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
 
         $privateServices = [];
         $definitions = $container->getDefinitions();
-        $hasErrors = method_exists(Definition::class, 'hasErrors') ? 'hasErrors' : 'getErrors';
 
         foreach ($definitions as $id => $definition) {
-            if ($id && '.' !== $id[0] && (!$definition->isPublic() || $definition->isPrivate() || $definition->hasTag('container.private')) && !$definition->$hasErrors() && !$definition->isAbstract()) {
+            if ($id && '.' !== $id[0] && (!$definition->isPublic() || $definition->isPrivate() || $definition->hasTag('container.private')) && !$definition->hasErrors() && !$definition->isAbstract()) {
                 $privateServices[$id] = new Reference($id, ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE);
             }
         }
@@ -45,7 +43,7 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
                 while (isset($aliases[$target = (string) $alias])) {
                     $alias = $aliases[$target];
                 }
-                if (isset($definitions[$target]) && !$definitions[$target]->$hasErrors() && !$definitions[$target]->isAbstract()) {
+                if (isset($definitions[$target]) && !$definitions[$target]->hasErrors() && !$definitions[$target]->isAbstract()) {
                     $privateServices[$id] = new Reference($target, ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE);
                 }
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/KernelTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/KernelTestCaseTest.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServic
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PublicService;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\UnusedPrivateService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 class KernelTestCaseTest extends AbstractWebTestCase
 {
@@ -40,5 +41,21 @@ class KernelTestCaseTest extends AbstractWebTestCase
         $this->assertTrue($container->has(PrivateService::class));
         $this->assertTrue($container->has('private_service'));
         $this->assertFalse($container->has(UnusedPrivateService::class));
+    }
+
+    public function testThatPrivateServicesCanBeSetIfTestConfigIsEnabled()
+    {
+        static::bootKernel(['test_case' => 'TestServiceContainer']);
+
+        $container = static::getContainer();
+
+        $service = new \stdClass();
+
+        $container->set('private_service', $service);
+        $this->assertSame($service, $container->get('private_service'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "private_service" service is already initialized, you cannot replace it.');
+        $container->set('private_service', new \stdClass());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR allows mocking a service for a test case. A typical example could be for HttpClient:

```php
static::getContainer()->set('example.client', new MockHttpClient(...));

// do stuff that will use `example.client` and will get mock responses instead of using the network
```