### PR TITLE
[VarExporter] Fix signature of `Lazy*Trait::createLazy*()`

### DIFF
--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -41,8 +41,9 @@ trait LazyGhostTrait
      *        |array{"\0": \Closure(static, array<string, mixed>):array<string, mixed>}) $initializer
      * @param array<string, true>|null $skippedProperties An array indexed by the properties to skip, aka the ones
      *                                                    that the initializer doesn't set when its a closure
+     * @param static|null              $instance
      */
-    public static function createLazyGhost(\Closure|array $initializer, array $skippedProperties = null, self $instance = null): static
+    public static function createLazyGhost(\Closure|array $initializer, array $skippedProperties = null, object $instance = null): static
     {
         $onlyProperties = null === $skippedProperties && \is_array($initializer) ? $initializer : null;
 

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -25,8 +25,9 @@ trait LazyProxyTrait
      * Creates a lazy-loading virtual proxy.
      *
      * @param \Closure():object $initializer Returns the proxied object
+     * @param static|null $instance
      */
-    public static function createLazyProxy(\Closure $initializer, self $instance = null): static
+    public static function createLazyProxy(\Closure $initializer, object $instance = null): static
     {
         if (self::class !== $class = $instance ? $instance::class : static::class) {
             $skippedProperties = ["\0".self::class."\0lazyObjectState" => true];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/doctrine/DoctrineBundle/issues/1615
| License       | MIT
| Doc PR        | -

Using `self` makes the traits incompatible with inheritance as child classes cannot also use the trait when a parent class already does.