### PR TITLE
[Console] Add function for getting the current numeric shell verbosity

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -901,12 +901,6 @@ class Application implements ResetInterface
         } while ($e = $e->getPrevious());
     }
 
-    /**
-     * Get shell verbosity.
-     *
-     * @param InputInterface $input
-     * @return int
-     */
     public function getShellVerbosity(InputInterface $input): int
     {
         $optionValue = $input->getParameterOption('--verbose', false, true);
@@ -945,6 +939,7 @@ class Application implements ResetInterface
         $shellVerbosity = $this->getShellVerbosity($input);
 
         if ($shellVerbosity) {
+            // Transform to match the corresponding const OutputInterface::VERBOSITY_*, which is a power of two
             $output->setVerbosity(1 << $shellVerbosity + 5);
         }
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -943,7 +943,10 @@ class Application implements ResetInterface
         }
 
         $shellVerbosity = $this->getShellVerbosity($input);
-        $output->setVerbosity(1 << $shellVerbosity + 5);
+
+        if ($shellVerbosity) {
+            $output->setVerbosity(1 << $shellVerbosity + 5);
+        }
 
         if (-1 === $shellVerbosity) {
             $input->setInteractive(false);

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Remove `exit` call in `Application` signal handlers. Commands will no longer be automatically interrupted after receiving signal other than `SIGUSR1` or `SIGUSR2`
  * Add `ProgressBar::setPlaceholderFormatter` to set a placeholder attached to a instance, instead of being global.
+ * Add `Application::getShellVerbosity` for getting the current shell verbosity from `InputInterface` and environment variables.
 
 6.2
 ---

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1807,7 +1807,7 @@ class ApplicationTest extends TestCase
         $this->assertSame(
             0,
             $application->getShellVerbosity(new ArrayInput([])),
-            'Function returns 0 if not shell verbosity is specified'
+            'Function returns 0 if no shell verbosity is specified'
         );
         putenv('SHELL_VERBOSITY=3');
         $this->assertSame(

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1787,6 +1787,36 @@ class ApplicationTest extends TestCase
         $this->assertArrayNotHasKey('disabled', $application->all());
     }
 
+    public function testGetShellVerbosity()
+    {
+        $application = new Application();
+        $this->assertSame(-1, $application->getShellVerbosity(new ArrayInput(['--quiet'])));
+        $this->assertSame(-1, $application->getShellVerbosity(new ArrayInput(['-q'])));
+        $this->assertSame(1, $application->getShellVerbosity(new ArrayInput(['-v'])));
+        $this->assertSame(2, $application->getShellVerbosity(new ArrayInput(['-vv'])));
+        $this->assertSame(3, $application->getShellVerbosity(new ArrayInput(['-vvv'])));
+        $this->assertSame(1, $application->getShellVerbosity(new ArrayInput(['--verbose'])));
+        $this->assertSame(1, $application->getShellVerbosity(new ArrayInput(['--verbose' => 1])));
+        $this->assertSame(2, $application->getShellVerbosity(new ArrayInput(['--verbose' => 2])));
+        $this->assertSame(3, $application->getShellVerbosity(new ArrayInput(['--verbose' => 3])));
+        $this->assertSame(
+            1,
+            $application->getShellVerbosity(new ArrayInput(['--verbose' => 4])),
+            'Function returns 1 (verbose) if unknown --verbose level is passed'
+        );
+        $this->assertSame(
+            0,
+            $application->getShellVerbosity(new ArrayInput([])),
+            'Function returns 0 if not shell verbosity is specified'
+        );
+        putenv('SHELL_VERBOSITY=3');
+        $this->assertSame(
+            3,
+            $application->getShellVerbosity(new ArrayInput([])),
+            'Function returns SHELL_VERBOSITY env when no other verbosity is specified'
+        );
+    }
+
     public function testFindAlternativesDoesNotLoadSameNamespaceCommandsOnExactMatch()
     {
         $application = new Application();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

---

Add `Application::getShellVerbosity` for getting the current numeric shell verbosity.

This makes the code cleaner and allows us to do something like this to get the numeric verbosity level of an `InputInterface`:

```php
$input = new ArrayInput(
    [
        'command',
        '--foo' => 'bar',
        '-vvv'  => 1
    ]
);

$verbosity = $this->application->getShellVerbosity($input);
// int(256)
```
In my case I needed to get the verbosity of a dynamically built command call and found it too troublesome to get with the current tools.

---

Test pass and the functionality should remain the same as it is now.

The appropriate tests are here:

https://github.com/symfony/symfony/blob/21191d58fbff73033dde161e8c660ff96d91bdf6/src/Symfony/Component/Console/Tests/ApplicationTest.php#L1026-L1056

---

The PR is using the same internal verbosity levels from -1 to 3 as before. The following mapping is performed with a bit shift:

```
-1 => 16 (VERBOSITY_QUIET)
0 => 32 (VERBOSITY_NORMAL)
1 => 64 (VERBOSITY_VERBOSE)
2 => 128 (VERBOSITY_VERY_VERBOSE)
3 => 256 (VERBOSITY_DEBUG)
```

Perhaps a switch statement would be more readable but the bit shift makes for a neat one-liner.

---

`OutputInterface::setVerbosity` is not called when verbosity is 0 because it wasn't called in the previous implementation either:

https://github.com/symfony/symfony/blob/21191d58fbff73033dde161e8c660ff96d91bdf6/src/Symfony/Component/Console/Application.php#L919-L961

