### PR TITLE
[FrameworkBundle] Fix deprecation when accessing a "container.private" service from the test container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerRealRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerRealRefPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -35,6 +36,16 @@ class TestServiceContainerRealRefPass implements CompilerPassInterface
                 $argument->setValues([new Reference($target)]);
             } else {
                 unset($privateServices[$id]);
+            }
+        }
+
+        foreach ($container->getAliases() as $id => $target) {
+            while ($container->hasAlias($target = (string) $target)) {
+                $target = $container->getAlias($target);
+            }
+
+            if ($definitions[$target]->hasTag('container.private')) {
+                $privateServices[$id] = new ServiceClosureArgument(new Reference($target));
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TestServiceContainerRefPassesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TestServiceContainerRefPassesTest.php
@@ -43,6 +43,13 @@ class TestServiceContainerRefPassesTest extends TestCase
             ->setPublic(true)
             ->addTag('container.private', ['package' => 'foo/bar', 'version' => '1.42'])
         ;
+        $container->register('Test\soon_private_service_decorated')
+            ->setPublic(true)
+            ->addTag('container.private', ['package' => 'foo/bar', 'version' => '1.42'])
+        ;
+        $container->register('Test\soon_private_service_decorator')
+            ->setDecoratedService('Test\soon_private_service_decorated')
+            ->setArguments(['Test\soon_private_service_decorator.inner']);
 
         $container->register('Test\private_used_shared_service');
         $container->register('Test\private_unused_shared_service');
@@ -55,6 +62,8 @@ class TestServiceContainerRefPassesTest extends TestCase
             'Test\private_used_shared_service' => new ServiceClosureArgument(new Reference('Test\private_used_shared_service')),
             'Test\private_used_non_shared_service' => new ServiceClosureArgument(new Reference('Test\private_used_non_shared_service')),
             'Test\soon_private_service' => new ServiceClosureArgument(new Reference('.container.private.Test\soon_private_service')),
+            'Test\soon_private_service_decorator' => new ServiceClosureArgument(new Reference('.container.private.Test\soon_private_service_decorated')),
+            'Test\soon_private_service_decorated' => new ServiceClosureArgument(new Reference('.container.private.Test\soon_private_service_decorated')),
         ];
 
         $privateServices = $container->getDefinition('test.private_services_locator')->getArgument(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47408
| License       | MIT
| Doc PR        | -