### PR TITLE
[HttpKernel] Use TZ from clock service in DateTimeValueResolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
@@ -73,7 +73,7 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface, Val
         }
 
         if (null !== $format) {
-            $date = $class::createFromFormat($format, $value);
+            $date = $class::createFromFormat($format, $value, $this->clock?->now()->getTimeZone());
 
             if (($class::getLastErrors() ?: ['warning_count' => 0])['warning_count']) {
                 $date = false;
@@ -83,7 +83,7 @@ final class DateTimeValueResolver implements ArgumentValueResolverInterface, Val
                 $value = '@'.$value;
             }
             try {
-                $date = new $class($value);
+                $date = new $class($value, $this->clock?->now()->getTimeZone());
             } catch (\Exception) {
                 $date = false;
             }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/DateTimeValueResolverTest.php
@@ -84,8 +84,8 @@ class DateTimeValueResolverTest extends TestCase
      */
     public function testFullDate(string $timezone, bool $withClock)
     {
-        date_default_timezone_set($timezone);
-        $resolver = new DateTimeValueResolver($withClock ? new MockClock() : null);
+        date_default_timezone_set($withClock ? 'UTC' : $timezone);
+        $resolver = new DateTimeValueResolver($withClock ? new MockClock('now', $timezone) : null);
 
         $argument = new ArgumentMetadata('dummy', \DateTimeImmutable::class, false, false, null);
         $request = self::requestWithAttributes(['dummy' => '2012-07-21 00:00:00']);
@@ -103,7 +103,7 @@ class DateTimeValueResolverTest extends TestCase
      */
     public function testUnixTimestamp(string $timezone, bool $withClock)
     {
-        date_default_timezone_set($timezone);
+        date_default_timezone_set($withClock ? 'UTC' : $timezone);
         $resolver = new DateTimeValueResolver($withClock ? new MockClock('now', $timezone) : null);
 
         $argument = new ArgumentMetadata('dummy', \DateTimeImmutable::class, false, false, null);
@@ -212,7 +212,7 @@ class DateTimeValueResolverTest extends TestCase
      */
     public function testDateTimeImmutable(string $timezone, bool $withClock)
     {
-        date_default_timezone_set($timezone);
+        date_default_timezone_set($withClock ? 'UTC' : $timezone);
         $resolver = new DateTimeValueResolver($withClock ? new MockClock('now', $timezone) : null);
 
         $argument = new ArgumentMetadata('dummy', \DateTimeImmutable::class, false, false, null);
@@ -231,7 +231,7 @@ class DateTimeValueResolverTest extends TestCase
      */
     public function testWithFormat(string $timezone, bool $withClock)
     {
-        date_default_timezone_set($timezone);
+        date_default_timezone_set($withClock ? 'UTC' : $timezone);
         $resolver = new DateTimeValueResolver($withClock ? new MockClock('now', $timezone) : null);
 
         $argument = new ArgumentMetadata('dummy', \DateTimeInterface::class, false, false, null, false, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixing #48098 + making tests green by using legit TZ names.
