### PR TITLE
[Validator] Handle object properties in Unique validator

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -450,6 +450,7 @@ CHANGELOG
  * Add support for multiple fields containing nested constraints in `Composite` constraints
  * Add the `stopOnFirstError` option to the `Unique` constraint to validate all elements
  * Add support for closures in the `When` constraint
+ * Add support for reading objects properties with `Unique` constraint `fields` option
 
 7.2
 ---

--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\PropertyAccess\Exception\AccessException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\LogicException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
@@ -21,6 +25,11 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
  */
 class UniqueValidator extends ConstraintValidator
 {
+    public function __construct(
+        private ?PropertyAccessorInterface $propertyAccessor = null,
+    ) {
+    }
+
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof Unique) {
@@ -42,7 +51,7 @@ class UniqueValidator extends ConstraintValidator
         foreach ($value as $index => $element) {
             $element = $normalizer($element);
 
-            if ($fields && !(\is_array($element) && $element = $this->reduceElementKeys($fields, $element))) {
+            if ($fields && !((\is_array($element) || \is_object($element)) && $element = $this->reduceElementKeys($fields, $element))) {
                 continue;
             }
 
@@ -72,18 +81,43 @@ class UniqueValidator extends ConstraintValidator
         return $unique->normalizer ?? static fn ($value) => $value;
     }
 
-    private function reduceElementKeys(array $fields, array $element): array
+    private function reduceElementKeys(array $fields, array|object $element): array
     {
         $output = [];
         foreach ($fields as $field) {
             if (!\is_string($field)) {
                 throw new UnexpectedTypeException($field, 'string');
             }
-            if (\array_key_exists($field, $element)) {
-                $output[$field] = $element[$field];
+
+            $elementAsArray = null;
+            // handle public object property
+            if (\is_object($element) && property_exists($element, $field)) {
+                $elementAsArray = (array) $element;
+            } elseif (\is_array($element)) {
+                $elementAsArray = $element;
+            }
+
+            if ($elementAsArray && \array_key_exists($field, $elementAsArray)) {
+                $output[$field] = $elementAsArray[$field];
+                continue;
+            }
+
+            try {
+                $output[$field] = $this->getPropertyAccessor()->getValue($element, $field);
+            } catch (AccessException) {
+                // fields are optional
             }
         }
 
         return $output;
+    }
+
+    private function getPropertyAccessor(): PropertyAccessorInterface
+    {
+        if (!class_exists(PropertyAccess::class)) {
+            throw new LogicException('Property path requires symfony/property-access package to be installed. Try running "composer require symfony/property-access".');
+        }
+
+        return $this->propertyAccessor ??= PropertyAccess::createPropertyAccessor();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -33,9 +33,9 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     }
 
     #[DataProvider('getValidValues')]
-    public function testValidValues($value)
+    public function testValidValues($value, array $fields = [])
     {
-        $this->validate($value, new Unique());
+        $this->validate($value, new Unique(fields: $fields));
 
         $this->assertNoViolation();
     }
@@ -54,6 +54,66 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
             yield 'unique strings' => [['a', 'b', 'c']],
             yield 'unique arrays' => [[[1, 2], [2, 4], [4, 6]]],
             yield 'unique objects' => [[new \stdClass(), new \stdClass()]],
+            yield 'unique objects public field' => [
+                [
+                    new class {
+                        public int $fieldA = 1;
+                    },
+                    new class {
+                        public int $fieldA = 2;
+                    },
+                ],
+                ['fieldA'],
+            ],
+            yield 'unique objects private field' => [
+                [
+                    new class {
+                        private int $fieldB = 1;
+
+                        public function getFieldB(): int
+                        {
+                            return $this->fieldB;
+                        }
+                    },
+                    new class {
+                        private int $fieldB = 2;
+
+                        public function getFieldB(): int
+                        {
+                            return $this->fieldB;
+                        }
+                    },
+                ],
+                ['fieldB'],
+            ],
+            yield 'unique objects property path field' => [
+                [
+                    new class {
+                        public array $fieldA = ['fieldB' => 1];
+                    },
+                    new class {
+                        public array $fieldA = ['fieldB' => 2];
+                    },
+                ],
+                ['fieldA[fieldB]'],
+            ],
+            yield 'mixed objects and arrays' => [
+                [
+                    new class {
+                        private int $fieldB = 1;
+
+                        public function getFieldB(): int
+                        {
+                            return $this->fieldB;
+                        }
+                    },
+                    new class {
+                        public int $fieldB = 2;
+                    },
+                    ['fieldB' => 3],
+                ],
+                ['fieldB'],
+            ],
         ];
     }
 
@@ -208,6 +268,42 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    public function testCollectionObjectFieldsAreOptional()
+    {
+        $this->validate([
+            new class {
+                public int $value = 5;
+            },
+            new class {
+                public int $id = 1;
+                public int $value = 5;
+            },
+        ], new Unique(fields: 'id'));
+
+        $this->assertNoViolation();
+    }
+
+    public function testCollectionObjectPrivateFieldsAreOptional()
+    {
+        $this->validate([
+            new class {
+                private int $id = 2;
+                public int $value = 5;
+            },
+            new class {
+                private int $id = 2;
+                public int $value = 5;
+
+                public function getId(): int
+                {
+                    return $this->id;
+                }
+            },
+        ], new Unique(fields: 'id'));
+
+        $this->assertNoViolation();
+    }
+
     #[DataProvider('getInvalidFieldNames')]
     public function testCollectionFieldNamesMustBeString(string $type, mixed $field)
     {
@@ -288,6 +384,58 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
                 ['nullField'],
                 'array',
             ],
+            'unique object string' => [[
+                (object) ['lang' => 'eng', 'translation' => 'hi'],
+                (object) ['lang' => 'eng', 'translation' => 'hello'],
+            ], ['lang'], 'array'],
+            'unique objects public field' => [[
+                new class {
+                    public int $fieldA = 1;
+                },
+                new class {
+                    public int $fieldA = 1;
+                },
+            ], ['fieldA'], 'array'],
+            'unique objects property path field' => [[
+                new class {
+                    public array $fieldA = ['fieldB' => 1];
+                },
+                new class {
+                    public array $fieldA = ['fieldB' => 1];
+                },
+            ], ['fieldA[fieldB]'], 'array'],
+            'unique objects private field' => [[
+                new class {
+                    private int $fieldB = 1;
+
+                    public function getFieldB(): int
+                    {
+                        return $this->fieldB;
+                    }
+                },
+                new class {
+                    private int $fieldB = 1;
+
+                    public function getFieldB(): int
+                    {
+                        return $this->fieldB;
+                    }
+                },
+            ], ['fieldB'], 'array'],
+            'mixed objects and arrays' => [[
+                new class {
+                    private int $fieldB = 1;
+
+                    public function getFieldB(): int
+                    {
+                        return $this->fieldB;
+                    }
+                },
+                new class {
+                    public int $fieldB = 1;
+                },
+                ['fieldB' => 1],
+            ], ['fieldB'], 'array'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #48072
| License       | MIT

The `fields` option of `Unique` only read array keys, so a collection of objects could not be checked for uniqueness on a property. Objects are now read as well.

```php
#[Assert\Unique(fields: ['sku'])]
private array $items;   // [new Item('a'), new Item('a')] is now a violation
```

Public properties are read directly. Anything else goes through PropertyAccess, so getters work and so do property paths:

```php
#[Assert\Unique(fields: ['fieldA[fieldB]'])]
```

Fields that cannot be read stay optional, exactly as they already are for arrays: the element is compared on the fields that could be read. Non-array, non-object elements such as `''`, `1` and `null` keep being skipped when `fields` is set.

`UniqueValidator` takes an optional `PropertyAccessorInterface`, and builds one on demand otherwise, the same way `AbstractComparisonValidator` and `RangeValidator` already do. `symfony/property-access` stays a dev dependency; the validator throws a clear `LogicException` naming the package if a property path is used without it.

Documentation should cover: `fields` now accepting object properties, that public properties are read directly and everything else through PropertyAccess, that property paths are supported, and that unreadable fields are ignored rather than raising.
