### PR TITLE
[DoctrineBridge] Throw an exception in case of circular dependencies in event listeners

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Exception/EventListenerCircularException.php
+++ b/src/Symfony/Bridge/Doctrine/Exception/EventListenerCircularException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Exception;
+
+/**
+ * This exception is thrown when a circular dependency is detected during event listeners/subscribers initialization.
+ * It may be fixed by making code or service lazy.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+class EventListenerCircularException extends \RuntimeException
+{
+    public function setMessage(string $message): self
+    {
+        if ($this->message) {
+            throw new \LogicException('EventSubscriberCircularException message cannot be set more than once.', 0, $this);
+        }
+
+        $this->message = $message;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #46168
| License       | MIT
| Doc PR        | n/a

When a doctrine event listener or subscriber calls the event manager in its constructor, the event manager has an incomplete initialization status. This can cause errors that are difficult to figure (for event listener) or invisible (for event subscribers).

This PR introduces `EventSubscriberCircularException` as a new feature to help debugging circular dependencies. This is not a bugfix since there is no broken behavior.