### PR TITLE
[Config] Do not array_unique EnumNode values

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -426,7 +426,7 @@ public function NAME($value): static
             }
 
             if ($node instanceof EnumNode) {
-                $comment .= sprintf(' * @param ParamConfigurator|%s $value', implode('|', array_map(fn ($a) => var_export($a, true), $node->getValues())))."\n";
+                $comment .= sprintf(' * @param ParamConfigurator|%s $value', implode('|', array_unique(array_map(fn ($a) => var_export($a, true), $node->getValues()))))."\n";
             } else {
                 $parameterTypes = $this->getParameterTypes($node);
                 $comment .= ' * @param ParamConfigurator|'.implode('|', $parameterTypes).' $value'."\n";

--- a/src/Symfony/Component/Config/Definition/Builder/EnumNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/EnumNodeDefinition.php
@@ -27,8 +27,6 @@ class EnumNodeDefinition extends ScalarNodeDefinition
      */
     public function values(array $values): static
     {
-        $values = array_unique($values);
-
         if (!$values) {
             throw new \InvalidArgumentException('->values() must be called with at least one value.');
         }

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -107,7 +107,7 @@ class XmlReferenceDumper
                             FloatNode::class,
                             IntegerNode::class => 'numeric value',
                             BooleanNode::class => 'true|false',
-                            EnumNode::class => implode('|', array_map('json_encode', $prototype->getValues())),
+                            EnumNode::class => implode('|', array_unique(array_map('json_encode', $prototype->getValues()))),
                             default => 'value',
                         };
                     }
@@ -149,7 +149,7 @@ class XmlReferenceDumper
                 }
 
                 if ($child instanceof EnumNode) {
-                    $comments[] = 'One of '.implode('; ', array_map('json_encode', $child->getValues()));
+                    $comments[] = 'One of '.implode('; ', array_unique(array_map('json_encode', $child->getValues())));
                 }
 
                 if (\count($comments)) {

--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -98,7 +98,7 @@ class YamlReferenceDumper
                 }
             }
         } elseif ($node instanceof EnumNode) {
-            $comments[] = 'One of '.implode('; ', array_map('json_encode', $node->getValues()));
+            $comments[] = 'One of '.implode('; ', array_unique(array_map('json_encode', $node->getValues())));
             $default = $node->hasDefaultValue() ? Inline::dump($node->getDefaultValue()) : '~';
         } elseif (VariableNode::class === $node::class && \is_array($example)) {
             // If there is an array example, we are sure we dont need to print a default value

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -24,9 +24,14 @@ class EnumNode extends ScalarNode
 
     public function __construct(?string $name, NodeInterface $parent = null, array $values = [], string $pathSeparator = BaseNode::DEFAULT_PATH_SEPARATOR)
     {
-        $values = array_unique($values);
         if (!$values) {
             throw new \InvalidArgumentException('$values must contain at least one element.');
+        }
+
+        foreach ($values as $value) {
+            if (null !== $value && !\is_scalar($value)) {
+                throw new \InvalidArgumentException(sprintf('"%s" only supports scalar or null values, "%s" given.', __CLASS__, get_debug_type($value)));
+            }
         }
 
         parent::__construct($name, $parent, $pathSeparator);

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/EnumNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/EnumNodeDefinitionTest.php
@@ -25,15 +25,6 @@ class EnumNodeDefinitionTest extends TestCase
         $this->assertEquals(['foo'], $node->getValues());
     }
 
-    public function testWithOneDistinctValue()
-    {
-        $def = new EnumNodeDefinition('foo');
-        $def->values(['foo', 'foo']);
-
-        $node = $def->getNode();
-        $this->assertEquals(['foo'], $node->getValues());
-    }
-
     public function testNoValuesPassed()
     {
         $this->expectException(\RuntimeException::class);
@@ -72,5 +63,13 @@ class EnumNodeDefinitionTest extends TestCase
         $this->assertSame('The "foo" node is deprecated.', $deprecation['message']);
         $this->assertSame('vendor/package', $deprecation['package']);
         $this->assertSame('1.1', $deprecation['version']);
+    }
+
+    public function testSameStringCoercedValuesAreDifferent()
+    {
+        $def = new EnumNodeDefinition('ccc');
+        $def->values(['', false, null]);
+
+        $this->assertSame(['', false, null], $def->getNode()->getValues());
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -71,4 +71,20 @@ class EnumNodeTest extends TestCase
         $this->expectExceptionMessage('The value "foo" is not allowed for path "cookie_samesite". Permissible values: "lax", "strict", "none"');
         $node->finalize('custom');
     }
+
+    public function testSameStringCoercedValuesAreDifferent()
+    {
+        $node = new EnumNode('ccc', null, ['', false, null]);
+        $this->assertSame('', $node->finalize(''));
+        $this->assertFalse($node->finalize(false));
+        $this->assertNull($node->finalize(null));
+    }
+
+    public function testNonScalarOrNullValueThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"Symfony\Component\Config\Definition\EnumNode" only supports scalar or null values, "stdClass" given.');
+
+        new EnumNode('ccc', null, [new \stdClass()]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/48913
| License       | MIT
| Doc PR        | -

Using `array_unique` for the values doesn't have an impact on the core behavior of this node but it causes an issue with non-scalar values that get coerced to the same string. Since it never worked, we could apply this change safely on 6.3.