### PR TITLE
[DependencyInjection] fixes validation of non-scalar attribute values

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -63,13 +63,14 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
         return $this->parent->instanceof($fqcn);
     }
 
-    private function validateAttributes(string $tagName, array $attributes, string $prefix = ''): void
+    private function validateAttributes(string $tag, array $attributes, array $path = []): void
     {
-        foreach ($attributes as $attribute => $value) {
+        foreach ($attributes as $name => $value) {
             if (\is_array($value)) {
-                $this->validateAttributes($tagName, $value, $attribute.'.');
+                $this->validateAttributes($tag, $value, [...$path, $name]);
             } elseif (!\is_scalar($value ?? '')) {
-                throw new InvalidArgumentException(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type or an array of scalar-type.', $tagName, $prefix.$attribute));
+                $name = implode('.', [...$path, $name]);
+                throw new InvalidArgumentException(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type or an array of scalar-type.', $tag, $name));
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
@@ -33,13 +33,14 @@ trait TagTrait
         return $this;
     }
 
-    private function validateAttributes(string $tagName, array $attributes, string $prefix = ''): void
+    private function validateAttributes(string $tag, array $attributes, array $path = []): void
     {
-        foreach ($attributes as $attribute => $value) {
+        foreach ($attributes as $name => $value) {
             if (\is_array($value)) {
-                $this->validateAttributes($tagName, $value, $attribute.'.');
+                $this->validateAttributes($tag, $value, [...$path, $name]);
             } elseif (!\is_scalar($value ?? '')) {
-                throw new InvalidArgumentException(sprintf('A tag attribute must be of a scalar-type or an array of scalar-types for service "%s", tag "%s", attribute "%s".', $this->id, $tagName, $prefix.$attribute));
+                $name = implode('.', [...$path, $name]);
+                throw new InvalidArgumentException(sprintf('A tag attribute must be of a scalar-type or an array of scalar-types for service "%s", tag "%s", attribute "%s".', $this->id, $tag, $name));
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -937,13 +937,14 @@ class YamlFileLoader extends FileLoader
         }
     }
 
-    private function validateAttributes(string $message, array $attributes, string $prefix = ''): void
+    private function validateAttributes(string $message, array $attributes, array $path = []): void
     {
-        foreach ($attributes as $attribute => $value) {
+        foreach ($attributes as $name => $value) {
             if (\is_array($value)) {
-                $this->validateAttributes($message, $value, $attribute.'.');
+                $this->validateAttributes($message, $value, [...$path, $name]);
             } elseif (!\is_scalar($value ?? '')) {
-                throw new InvalidArgumentException(sprintf($message, $prefix.$attribute));
+                $name = implode('.', [...$path, $name]);
+                throw new InvalidArgumentException(sprintf($message, $name));
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48956
| License       | MIT
| Doc PR        | None

As a follow-up to #47364, this PR updates the `CheckDefinitionValidityPass` to allow (possibly nested) arrays of scalars in service tags attribute values.
Please see #48956 for context.
