### PR TITLE
[Messenger] Allow password in redis dsn when using sockets

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -407,4 +407,65 @@ class ConnectionTest extends TestCase
 
         Connection::fromDsn(sprintf('%s/messenger-clearlasterror', $master), ['delete_after_ack' => true, 'sentinel_master' => $uid], null);
     }
+
+    public function testFromDsnOnUnixSocketWithUserAndPassword()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with(['user', 'password'])
+            ->willReturn(true);
+
+        $this->assertEquals(
+            new Connection([
+                'stream' => 'queue',
+                'delete_after_ack' => true,
+                'host' => '/var/run/redis/redis.sock',
+                'port' => 0,
+                'user' => 'user',
+                'pass' => 'password',
+            ], $redis),
+            Connection::fromDsn('redis://user:password@/var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
+        );
+    }
+
+    public function testFromDsnOnUnixSocketWithPassword()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with('password')
+            ->willReturn(true);
+
+        $this->assertEquals(
+            new Connection([
+                'stream' => 'queue',
+                'delete_after_ack' => true,
+                'host' => '/var/run/redis/redis.sock',
+                'port' => 0,
+                'pass' => 'password',
+            ], $redis),
+            Connection::fromDsn('redis://password@/var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
+        );
+    }
+
+    public function testFromDsnOnUnixSocketWithUser()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with('user')
+            ->willReturn(true);
+
+        $this->assertEquals(
+            new Connection([
+                'stream' => 'queue',
+                'delete_after_ack' => true,
+                'host' => '/var/run/redis/redis.sock',
+                'port' => 0,
+                'user' => 'user',
+            ], $redis),
+            Connection::fromDsn('redis://user:@/var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| Tickets       | Fix #47393 @Arakmar 
| License       | MIT
| Doc PR        | 

When a messenger async transport is configured with Redis (unix socket with a password), it gives DSN parsing errors.

Using a Bunch of copy and pasted code blocks from the Redis cache adapter, this PR fixes the bug that doesn't parse a DSN such as 

`redis://password@/var/run/redis.sock`

Replaces bad rebased #47475