### PR TITLE
[Stopwatch] Restart (reset) an event

### DIFF
--- a/src/Symfony/Component/Stopwatch/CHANGELOG.md
+++ b/src/Symfony/Component/Stopwatch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+* Added the `Stopwatch::restart()` method
+
 5.2
 ---
 

--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -100,6 +100,18 @@ class Section
     }
 
     /**
+     * Starts an event.
+     *
+     * If an event with the same name already exists, replaces it.
+     */
+    public function restartEvent(string $name, ?string $category): StopwatchEvent
+    {
+        $this->events[$name] = new StopwatchEvent($this->origin ?: microtime(true) * 1000, $category, $this->morePrecision, $name);
+
+        return $this->events[$name]->start();
+    }
+
+    /**
      * Checks if the event was started.
      */
     public function isEventStarted(string $name): bool

--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -106,6 +106,16 @@ class Stopwatch implements ResetInterface
     }
 
     /**
+     * Starts an event.
+     *
+     * If an event with the same name already exists, removes it.
+     */
+    public function restart(string $name, string $category = null): StopwatchEvent
+    {
+        return end($this->activeSections)->restartEvent($name, $category);
+    }
+
+    /**
      * Checks if the event was started.
      */
     public function isStarted(string $name): bool

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -37,6 +37,20 @@ class StopwatchTest extends TestCase
         $this->assertSame($event, $stopwatch->getEvent('foo'));
     }
 
+    public function testRestart()
+    {
+        $stopwatch = new Stopwatch();
+        $stopwatch->start('foo');
+        $foo1 = $stopwatch->stop('foo');
+        $stopwatch->start('foo');
+        $foo2 = $stopwatch->stop('foo');
+
+        $this->assertSame($foo2, $stopwatch->getEvent('foo'));
+        $this->assertNotSame($foo1, $stopwatch->getEvent('foo'));
+        $this->assertNotSame($foo1, $foo2);
+        $this->assertCount(1, $foo2->getPeriods());
+    }
+
     public function testStartWithoutCategory()
     {
         $stopwatch = new Stopwatch();

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -42,7 +42,7 @@ class StopwatchTest extends TestCase
         $stopwatch = new Stopwatch();
         $stopwatch->start('foo');
         $foo1 = $stopwatch->stop('foo');
-        $stopwatch->start('foo');
+        $stopwatch->restart('foo');
         $foo2 = $stopwatch->stop('foo');
 
         $this->assertSame($foo2, $stopwatch->getEvent('foo'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42643
| License       | MIT

When you stop a stopwatch event, if you start an event with the same name, it doesn't create an new event, it uses the one previously created. 

This can lead to false time and memory execution reccords when you mesure an event iterated several time with different amounts of data :

```php
$stopwatch = new Stopwatch();

$stopwatch->start('event');
usleep(3000);
$event = $stopwatch->stop('event');
echo $event->getDuration(); // 3000
unset($event); 

$stopwatch->start('event');
usleep(3000);
$event = $stopwatch->stop('event');
echo $event->getDuration(); // 6000
```
Now `Stopwatch::restart()` methods allow to create a new event or recreate one with a name already used.
