### PR TITLE
[WebProfilerBundle] right blocks: fix display

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -38,7 +38,7 @@
     --sf-toolbar-green-100: #deeaea;
     --sf-toolbar-green-200: #bbd5d5;
     --sf-toolbar-green-300: #99bfbf;
-    --sf-toolbar-green-400: #76a9a9;
+    --sf-toolbar-green-400: #1dc9a4;
     --sf-toolbar-green-500: #598e8e;
     --sf-toolbar-green-600: #436c6c;
     --sf-toolbar-green-700: #2e4949;
@@ -258,6 +258,11 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     position: absolute;
 }
 
+.sf-toolbar-block.sf-toolbar-block-right .sf-toolbar-info {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 0;
+}
+
 .sf-toolbar-block .sf-toolbar-info:empty {
     visibility: hidden;
 }
@@ -273,9 +278,10 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     text-align: center;
 }
 
-.sf-toolbar-block .sf-toolbar-status-green,
-.sf-toolbar-block .sf-toolbar-info .sf-toolbar-status-green {
-    background-color: #059669;
+.sf-toolbar-block .sf-toolbar-status.sf-toolbar-status-green,
+.sf-toolbar-block .sf-toolbar-info .sf-toolbar-status.sf-toolbar-status-green {
+    background-color: var(--sf-toolbar-green-400);
+    color: var(--sf-toolbar-green-50);
 }
 .sf-toolbar-block .sf-toolbar-status.sf-toolbar-status-red,
 .sf-toolbar-block .sf-toolbar-info .sf-toolbar-status.sf-toolbar-status-red {
@@ -288,10 +294,7 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     color: var(--sf-toolbar-yellow-800);
 }
 
-.sf-toolbar-block.sf-toolbar-status-green {
-    background-color: #059669;
-    color: var(--sf-toolbar-white);
-}
+.sf-toolbar-block.sf-toolbar-status-green::before,
 .sf-toolbar-block.sf-toolbar-status-red::before,
 .sf-toolbar-block.sf-toolbar-status-yellow::before {
     background: var(--sf-toolbar-yellow-400);
@@ -307,6 +310,10 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
 .sf-toolbar-block.sf-toolbar-status-red::before {
     background: var(--sf-toolbar-red-400);
 }
+.sf-toolbar-block.sf-toolbar-status-green::before {
+    background: var(--sf-toolbar-green-400);
+}
+.sf-toolbar-block-request.sf-toolbar-block.sf-toolbar-status-green::before,
 .sf-toolbar-block-request.sf-toolbar-block.sf-toolbar-status-red::before,
 .sf-toolbar-block-request.sf-toolbar-block.sf-toolbar-status-yellow::before {
     display: none;
@@ -384,7 +391,7 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     box-shadow: 1px 0 0 var(--sf-toolbar-black), inset 0 -1px 0 var(--sf-toolbar-black);
 }
 .sf-toolbar-block.sf-toolbar-block-right:hover .sf-toolbar-icon {
-    box-shadow: -2px 0 0 var(--sf-toolbar-black), inset 0 -2px 0 var(--sf-toolbar-black);
+    box-shadow: -1px 0 0 var(--sf-toolbar-black), inset 0 -1px 0 var(--sf-toolbar-black);
 }
 
 .sf-toolbar-block-request .sf-toolbar-icon {
@@ -408,9 +415,6 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
 .sf-toolbar-block-config .sf-toolbar-icon .sf-toolbar-label,
 .sf-toolbar-block.sf-toolbar-block-sf-cli .sf-toolbar-label {
     margin-left: 0;
-}
-.sf-toolbar-block.sf-toolbar-block-sf-cli:hover .sf-toolbar-icon {
-    box-shadow: 2px 0 0 var(--sf-toolbar-black), inset 0 -2px 0 var(--sf-toolbar-black);
 }
 
 .sf-toolbar-block:hover,
@@ -538,7 +542,8 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
 .sf-toolbar-icon .sf-toolbar-value {
     display: none;
 }
-.sf-toolbar-block-config .sf-toolbar-icon .sf-toolbar-label {
+.sf-toolbar-block-config .sf-toolbar-icon .sf-toolbar-label,
+.sf-cli .sf-toolbar-icon .sf-toolbar-label {
     display: inline-block;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes?
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Hi, since Symfony 6.2 there's a design issue that bothers me with the toolbar: the hover effect seems "wrong" when hovering one of the right blocks.

This PR fixes the following issues on hover:

* removes green background color
* removes the extra box shadow
* moves the remaining box shadow to the left
* moves the non-radius border from left to right
* uses CSS variables for -green color
* fixes non visible Symfony CLI icon on small screen
* uses same style for green status (bottom colored line instead of full background)

| Before | After |
| --- | --- |
| ![cli-before](https://user-images.githubusercontent.com/3929498/212657956-7ec827b6-e4cc-4d86-8128-3b8ca31fd0c0.png) | ![cli-after](https://user-images.githubusercontent.com/3929498/212658006-a5fc12dd-2c93-474c-a6bb-342abe4b048d.png) |
| ![cli-hover-before](https://user-images.githubusercontent.com/3929498/212658093-7d0bf364-3831-431d-92ec-a7f9d9e76d17.png) | ![cli-hover-after](https://user-images.githubusercontent.com/3929498/212658116-bb38cdc6-af55-449c-acde-23d1846199b8.png) |
| ![toolbar-before](https://user-images.githubusercontent.com/3929498/212658148-ec863d1c-1de7-4306-b74a-9dd4120c660b.png) | ![toolbar-after](https://user-images.githubusercontent.com/3929498/212658177-c20eff49-33ce-4ff9-8c51-0f66f509d4ac.png) |