### PR TITLE
[DependencyInjection] Revert "bug #48791 Fix deduplicating service instances in circular graphs"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -491,13 +491,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected function getDoctrine_ListenerService()
     {
-        $a = ($this->services['doctrine.entity_manager'] ?? $this->getDoctrine_EntityManagerService());
-
-        if (isset($this->privates['doctrine.listener'])) {
-            return $this->privates['doctrine.listener'];
-        }
-
-        return $this->privates['doctrine.listener'] = new \stdClass($a);
+        return $this->privates['doctrine.listener'] = new \stdClass(($this->services['doctrine.entity_manager'] ?? $this->getDoctrine_EntityManagerService()));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -285,16 +285,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected function getDoctrine_EntityManagerService()
     {
-        $a = ($this->services['doctrine.entity_listener_resolver'] ?? $this->getDoctrine_EntityListenerResolverService());
+        $a = new \stdClass();
+        $a->resolver = ($this->services['doctrine.entity_listener_resolver'] ?? $this->getDoctrine_EntityListenerResolverService());
+        $a->flag = 'ok';
 
-        if (isset($this->services['doctrine.entity_manager'])) {
-            return $this->services['doctrine.entity_manager'];
-        }
-        $b = new \stdClass();
-        $b->resolver = $a;
-        $b->flag = 'ok';
-
-        return $this->services['doctrine.entity_manager'] = \FactoryChecker::create($b);
+        return $this->services['doctrine.entity_manager'] = \FactoryChecker::create($a);
     }
 
     /**
@@ -304,13 +299,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected function getDoctrine_ListenerService()
     {
-        $a = ($this->services['doctrine.entity_manager'] ?? $this->getDoctrine_EntityManagerService());
-
-        if (isset($this->services['doctrine.listener'])) {
-            return $this->services['doctrine.listener'];
-        }
-
-        return $this->services['doctrine.listener'] = new \stdClass($a);
+        return $this->services['doctrine.listener'] = new \stdClass(($this->services['doctrine.entity_manager'] ?? $this->getDoctrine_EntityManagerService()));
     }
 
     /**
@@ -506,13 +495,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected function getMailer_TransportService()
     {
-        $a = ($this->services['mailer.transport_factory'] ?? $this->getMailer_TransportFactoryService());
-
-        if (isset($this->services['mailer.transport'])) {
-            return $this->services['mailer.transport'];
-        }
-
-        return $this->services['mailer.transport'] = $a->create();
+        return $this->services['mailer.transport'] = ($this->services['mailer.transport_factory'] ?? $this->getMailer_TransportFactoryService())->create();
     }
 
     /**
@@ -535,13 +518,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected function getMailer_TransportFactory_AmazonService()
     {
-        $a = ($this->services['monolog.logger_2'] ?? $this->getMonolog_Logger2Service());
-
-        if (isset($this->services['mailer.transport_factory.amazon'])) {
-            return $this->services['mailer.transport_factory.amazon'];
-        }
-
-        return $this->services['mailer.transport_factory.amazon'] = new \stdClass($a);
+        return $this->services['mailer.transport_factory.amazon'] = new \stdClass(($this->services['monolog.logger_2'] ?? $this->getMonolog_Logger2Service()));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48895
| License       | MIT
| Doc PR        | -

This reverts commit 2a2b72c, reversing changes made to e7ec8a6.

#48791 is causing #48895, let's revert it for now and dig further later on if needed.