### PR TITLE
[TwigBridge] Allow floats in html5 input type number field

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
@@ -2154,6 +2154,25 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
     [@type="number"]
+    [@step="any"]
+    [@name="name"]
+    [@class="my&class form-control"]
+    [@value="1234.56"]
+'
+        );
+    }
+
+    public function testRenderNumberWithHtml5NumberTypeAndStepAttribute()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\NumberType', 1234.56, [
+            'html5' => true,
+            'attr' => ['step' => '0.1'],
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/input
+    [@type="number"]
+    [@step="0.1"]
     [@name="name"]
     [@class="my&class form-control"]
     [@value="1234.56"]

--- a/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
@@ -47,6 +47,10 @@ class NumberType extends AbstractType
     {
         if ($options['html5']) {
             $view->vars['type'] = 'number';
+
+            if (!isset($view->vars['attr']['step'])) {
+                $view->vars['attr']['step'] = 'any';
+            }
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTestCase.php
@@ -1877,6 +1877,26 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
     [@type="number"]
+    [@step="any"]
+    [@name="name"]
+    [@value="1234.56"]
+'
+        );
+    }
+
+    public function testRenderNumberWithHtml5NumberTypeAndStepAttribute()
+    {
+        $this->requiresFeatureSet(403);
+
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\NumberType', 1234.56, [
+            'html5' => true,
+            'attr' => ['step' => '0.1'],
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+            '/input
+    [@type="number"]
+    [@step="0.1"]
     [@name="name"]
     [@value="1234.56"]
 '


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  |no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Adding the attribute step: any allows for correct use of floats in number input
