### PR TITLE
[PropertyInfo] Fixes constructor extractor for mixed type

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -200,7 +200,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             }
         }
 
-        if (!isset($types[0])) {
+        if (!isset($types[0]) || [] === $types[0]) {
             return null;
         }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -443,6 +443,7 @@ class PhpDocExtractorTest extends TestCase
             ['dateObject', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTimeInterface')]],
             ['dateTime', null],
             ['ddd', null],
+            ['mixed', null],
         ];
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ConstructorDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ConstructorDummy.php
@@ -29,8 +29,9 @@ class ConstructorDummy
      * @param \DateTimeZone      $timezone
      * @param int                $date       Timestamp
      * @param \DateTimeInterface $dateObject
+     * @param mixed              $mixed
      */
-    public function __construct(\DateTimeZone $timezone, $date, $dateObject, \DateTime $dateTime)
+    public function __construct(\DateTimeZone $timezone, $date, $dateObject, \DateTime $dateTime, $mixed)
     {
         $this->timezone = $timezone->getName();
         $this->date = \DateTime::createFromFormat('U', $date);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

`ConstructorExtractor` when configured with `PhpDocExtractor` returns an empty array instead of null for properties with `mixed` type.

This configuration breaks for example with Messenger.
```
Message: "Could not decode stamp: The type of the "id" attribute for class "Symfony\Component\Messenger\Stamp\TransportMessageIdStamp" must be one of "" ("string" given)." {"exception":"[object] (Symfony\\Component\\Messenger\\Exception\\MessageDecodingFailedException(code: 0): Could not decode stamp: The type of the \"id\" attribute for class \"Symfony\\Component\\Messenger\\Stamp\\TransportMessageIdStamp\" must be one of \"\" (\"string\" given). at /var/www/vendor/symfony/messenger/Transport/Serialization/Serializer.php:123)
```