### PR TITLE
[Serializer] use method_exists() instead of catching reflection exceptions

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -152,14 +152,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         $key = \get_class($object).':'.$setter;
 
         if (!isset(self::$setterAccessibleCache[$key])) {
-            try {
-                // We have to use is_callable() here since method_exists()
-                // does not "see" protected/private methods
-                self::$setterAccessibleCache[$key] = \is_callable([$object, $setter]) && !(new \ReflectionMethod($object, $setter))->isStatic();
-            } catch (\ReflectionException $e) {
-                // Method does not exist in the class, probably a magic method
-                self::$setterAccessibleCache[$key] = false;
-            }
+            self::$setterAccessibleCache[$key] = method_exists($object, $setter) && \is_callable([$object, $setter]) && !(new \ReflectionMethod($object, $setter))->isStatic();
         }
 
         if (self::$setterAccessibleCache[$key]) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/48233#issuecomment-1382689996
| License       | MIT
| Doc PR        | 