### PR TITLE
[Serializer] Remove datetime serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,8 @@
         "symfony/security-acl": "~2.8|~3.0",
         "twig/cssinliner-extra": "^2.12|^3",
         "twig/inky-extra": "^2.12|^3",
-        "twig/markdown-extra": "^2.12|^3"
+        "twig/markdown-extra": "^2.12|^3",
+        "vimeo/psalm": "^5.0@dev"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -27,14 +27,13 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
     public const TIMEZONE_KEY = 'datetime_timezone';
 
     private $defaultContext = [
-        self::FORMAT_KEY => \DateTime::RFC3339,
+        self::FORMAT_KEY => \DateTimeInterface::RFC3339,
         self::TIMEZONE_KEY => null,
     ];
 
     private const SUPPORTED_TYPES = [
         \DateTimeInterface::class => true,
         \DateTimeImmutable::class => true,
-        \DateTime::class => true,
     ];
 
     public function __construct(array $defaultContext = [])
@@ -88,13 +87,13 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         }
 
         if (null !== $dateTimeFormat) {
-            $object = \DateTime::class === $type ? \DateTime::createFromFormat($dateTimeFormat, $data, $timezone) : \DateTimeImmutable::createFromFormat($dateTimeFormat, $data, $timezone);
+            $object = \DateTimeImmutable::createFromFormat($dateTimeFormat, $data, $timezone);
 
             if (false !== $object) {
                 return $object;
             }
 
-            $dateTimeErrors = \DateTime::class === $type ? \DateTime::getLastErrors() : \DateTimeImmutable::getLastErrors();
+            $dateTimeErrors = \DateTimeImmutable::getLastErrors();
 
             throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('Parsing datetime string "%s" using format "%s" resulted in %d errors: ', $data, $dateTimeFormat, $dateTimeErrors['error_count'])."\n".implode("\n", $this->formatDateTimeErrors($dateTimeErrors['errors'])), $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
         }
@@ -102,7 +101,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         $defaultDateTimeFormat = $this->defaultContext[self::FORMAT_KEY] ?? null;
 
         if (null !== $defaultDateTimeFormat) {
-            $object = \DateTime::class === $type ? \DateTime::createFromFormat($defaultDateTimeFormat, $data, $timezone) : \DateTimeImmutable::createFromFormat($defaultDateTimeFormat, $data, $timezone);
+            $object = \DateTimeImmutable::createFromFormat($defaultDateTimeFormat, $data, $timezone);
 
             if (false !== $object) {
                 return $object;
@@ -110,7 +109,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         }
 
         try {
-            return \DateTime::class === $type ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
+            return new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
             throw NotNormalizableValueException::createForUnexpectedDataType($e->getMessage(), $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, false, $e->getCode(), $e);
         }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -826,7 +826,7 @@ XML;
     {
         $xmlEncoder = $this->createXmlEncoderWithDateTimeNormalizer();
 
-        $actualXml = $xmlEncoder->encode(['dateTime' => new \DateTime($this->exampleDateTimeString)], 'xml');
+        $actualXml = $xmlEncoder->encode(['dateTime' => new \DateTimeImmutable($this->exampleDateTimeString)], 'xml');
 
         $this->assertEquals($this->createXmlWithDateTime(), $actualXml);
     }
@@ -835,7 +835,7 @@ XML;
     {
         $xmlEncoder = $this->createXmlEncoderWithDateTimeNormalizer();
 
-        $actualXml = $xmlEncoder->encode(['foo' => ['@dateTime' => new \DateTime($this->exampleDateTimeString)]], 'xml');
+        $actualXml = $xmlEncoder->encode(['foo' => ['@dateTime' => new \DateTimeImmutable($this->exampleDateTimeString)]], 'xml');
 
         $this->assertEquals($this->createXmlWithDateTimeField(), $actualXml);
     }
@@ -939,13 +939,13 @@ XML;
         $mock
             ->expects($this->once())
             ->method('normalize')
-            ->with(new \DateTime($this->exampleDateTimeString), 'xml', [])
+            ->with(new \DateTimeImmutable($this->exampleDateTimeString), 'xml', [])
             ->willReturn($this->exampleDateTimeString);
 
         $mock
             ->expects($this->once())
             ->method('supportsNormalization')
-            ->with(new \DateTime($this->exampleDateTimeString), 'xml')
+            ->with(new \DateTimeImmutable($this->exampleDateTimeString), 'xml')
             ->willReturn(true);
 
         return $mock;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
@@ -19,7 +19,7 @@ final class Php74Full
     public int $int;
     public float $float;
     public bool $bool;
-    public \DateTime $dateTime;
+    public \DateTimeInterface $dateTime;
     public \DateTimeImmutable $dateTimeImmutable;
     public \DateTimeZone $dateTimeZone;
     public \SplFileInfo $splFileInfo;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/object-metadata.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/object-metadata.php
@@ -1,3 +1,3 @@
 <?php
 
-return new DateTime();
+return new DateTimeImmutable();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -39,7 +39,6 @@ class DateTimeNormalizerTest extends TestCase
 
     public function testNormalize()
     {
-        $this->assertEquals('2016-01-01T00:00:00+00:00', $this->normalizer->normalize(new \DateTime('2016/01/01', new \DateTimeZone('UTC'))));
         $this->assertEquals('2016-01-01T00:00:00+00:00', $this->normalizer->normalize(new \DateTimeImmutable('2016/01/01', new \DateTimeZone('UTC'))));
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -33,7 +33,6 @@ class DateTimeNormalizerTest extends TestCase
 
     public function testSupportsNormalization()
     {
-        $this->assertTrue($this->normalizer->supportsNormalization(new \DateTime()));
         $this->assertTrue($this->normalizer->supportsNormalization(new \DateTimeImmutable()));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
@@ -46,21 +45,21 @@ class DateTimeNormalizerTest extends TestCase
 
     public function testNormalizeUsingFormatPassedInContext()
     {
-        $this->assertEquals('2016', $this->normalizer->normalize(new \DateTime('2016/01/01'), null, [DateTimeNormalizer::FORMAT_KEY => 'Y']));
+        $this->assertEquals('2016', $this->normalizer->normalize(new \DateTimeImmutable('2016/01/01'), null, [DateTimeNormalizer::FORMAT_KEY => 'Y']));
     }
 
     public function testNormalizeUsingFormatPassedInConstructor()
     {
         $normalizer = new DateTimeNormalizer([DateTimeNormalizer::FORMAT_KEY => 'y']);
-        $this->assertEquals('16', $normalizer->normalize(new \DateTime('2016/01/01', new \DateTimeZone('UTC'))));
+        $this->assertEquals('16', $normalizer->normalize(new \DateTimeImmutable('2016/01/01', new \DateTimeZone('UTC'))));
     }
 
     public function testNormalizeUsingTimeZonePassedInConstructor()
     {
         $normalizer = new DateTimeNormalizer([DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('Japan')]);
 
-        $this->assertSame('2016-12-01T00:00:00+09:00', $normalizer->normalize(new \DateTime('2016/12/01', new \DateTimeZone('Japan'))));
-        $this->assertSame('2016-12-01T09:00:00+09:00', $normalizer->normalize(new \DateTime('2016/12/01', new \DateTimeZone('UTC'))));
+        $this->assertSame('2016-12-01T00:00:00+09:00', $normalizer->normalize(new \DateTimeImmutable('2016/12/01', new \DateTimeZone('Japan'))));
+        $this->assertSame('2016-12-01T09:00:00+09:00', $normalizer->normalize(new \DateTimeImmutable('2016/12/01', new \DateTimeZone('UTC'))));
     }
 
     /**
@@ -75,9 +74,9 @@ class DateTimeNormalizerTest extends TestCase
 
     public function normalizeUsingTimeZonePassedInContextProvider()
     {
-        yield ['2016-12-01T00:00:00+00:00', new \DateTime('2016/12/01', new \DateTimeZone('UTC')), null];
-        yield ['2016-12-01T00:00:00+09:00', new \DateTime('2016/12/01', new \DateTimeZone('Japan')), new \DateTimeZone('Japan')];
-        yield ['2016-12-01T09:00:00+09:00', new \DateTime('2016/12/01', new \DateTimeZone('UTC')), new \DateTimeZone('Japan')];
+        yield ['2016-12-01T00:00:00+00:00', new \DateTimeImmutable('2016/12/01', new \DateTimeZone('UTC')), null];
+        yield ['2016-12-01T00:00:00+09:00', new \DateTimeImmutable('2016/12/01', new \DateTimeZone('Japan')), new \DateTimeZone('Japan')];
+        yield ['2016-12-01T09:00:00+09:00', new \DateTimeImmutable('2016/12/01', new \DateTimeZone('UTC')), new \DateTimeZone('Japan')];
         yield ['2016-12-01T09:00:00+09:00', new \DateTimeImmutable('2016/12/01', new \DateTimeZone('UTC')), new \DateTimeZone('Japan')];
     }
 
@@ -104,7 +103,7 @@ class DateTimeNormalizerTest extends TestCase
         yield [
             '2018-12-01T18:03:06.067634',
             'Y-m-d\TH:i:s.u',
-            \DateTime::createFromFormat(
+            \DateTimeImmutable::createFromFormat(
                 'Y-m-d\TH:i:s.u',
                 '2018-12-01T18:03:06.067634',
                 new \DateTimeZone('UTC')
@@ -115,7 +114,7 @@ class DateTimeNormalizerTest extends TestCase
         yield [
             '2018-12-01T18:03:06.067634',
             'Y-m-d\TH:i:s.u',
-            \DateTime::createFromFormat(
+            \DateTimeImmutable::createFromFormat(
                 'Y-m-d\TH:i:s.u',
                 '2018-12-01T18:03:06.067634',
                 new \DateTimeZone('UTC')
@@ -137,7 +136,7 @@ class DateTimeNormalizerTest extends TestCase
         yield [
             '2018-12-01T20:03:06.067634+02:00',
             'Y-m-d\TH:i:s.uP',
-            \DateTime::createFromFormat(
+            \DateTimeImmutable::createFromFormat(
                 'Y-m-d\TH:i:s.u',
                 '2018-12-01T18:03:06.067634',
                 new \DateTimeZone('UTC')
@@ -148,7 +147,7 @@ class DateTimeNormalizerTest extends TestCase
         yield [
             '2018-12-01T19:03:06.067634',
             'Y-m-d\TH:i:s.u',
-            \DateTime::createFromFormat(
+            \DateTimeImmutable::createFromFormat(
                 'Y-m-d\TH:i:s.u',
                 '2018-12-01T18:03:06.067634',
                 new \DateTimeZone('UTC')
@@ -167,7 +166,6 @@ class DateTimeNormalizerTest extends TestCase
     public function testSupportsDenormalization()
     {
         $this->assertTrue($this->normalizer->supportsDenormalization('2016-01-01T00:00:00+00:00', \DateTimeInterface::class));
-        $this->assertTrue($this->normalizer->supportsDenormalization('2016-01-01T00:00:00+00:00', \DateTime::class));
         $this->assertTrue($this->normalizer->supportsDenormalization('2016-01-01T00:00:00+00:00', \DateTimeImmutable::class));
         $this->assertFalse($this->normalizer->supportsDenormalization('foo', 'Bar'));
     }
@@ -176,17 +174,15 @@ class DateTimeNormalizerTest extends TestCase
     {
         $this->assertEquals(new \DateTimeImmutable('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', \DateTimeInterface::class));
         $this->assertEquals(new \DateTimeImmutable('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', \DateTimeImmutable::class));
-        $this->assertEquals(new \DateTime('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', \DateTime::class));
-        $this->assertEquals(new \DateTime('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('  2016-01-01T00:00:00+00:00  ', \DateTime::class));
     }
 
     public function testDenormalizeUsingTimezonePassedInConstructor()
     {
         $timezone = new \DateTimeZone('Japan');
-        $expected = new \DateTime('2016/12/01 17:35:00', $timezone);
+        $expected = new \DateTimeImmutable('2016/12/01 17:35:00', $timezone);
         $normalizer = new DateTimeNormalizer([DateTimeNormalizer::TIMEZONE_KEY => $timezone]);
 
-        $this->assertEquals($expected, $normalizer->denormalize('2016.12.01 17:35:00', \DateTime::class, null, [
+        $this->assertEquals($expected, $normalizer->denormalize('2016.12.01 17:35:00', \DateTimeImmutable::class, null, [
             DateTimeNormalizer::FORMAT_KEY => 'Y.m.d H:i:s',
         ]));
     }
@@ -195,7 +191,6 @@ class DateTimeNormalizerTest extends TestCase
     {
         $this->assertEquals(new \DateTimeImmutable('2016/01/01'), $this->normalizer->denormalize('2016.01.01', \DateTimeInterface::class, null, [DateTimeNormalizer::FORMAT_KEY => 'Y.m.d|']));
         $this->assertEquals(new \DateTimeImmutable('2016/01/01'), $this->normalizer->denormalize('2016.01.01', \DateTimeImmutable::class, null, [DateTimeNormalizer::FORMAT_KEY => 'Y.m.d|']));
-        $this->assertEquals(new \DateTime('2016/01/01'), $this->normalizer->denormalize('2016.01.01', \DateTime::class, null, [DateTimeNormalizer::FORMAT_KEY => 'Y.m.d|']));
     }
 
     /**
@@ -268,7 +263,7 @@ class DateTimeNormalizerTest extends TestCase
     {
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage("Parsing datetime string \"  2016.01.01  \" using format \"Y.m.d|\" resulted in 2 errors: \nat position 0: Unexpected data found.\nat position 12: Trailing data");
-        $this->normalizer->denormalize('  2016.01.01  ', \DateTime::class, null, [DateTimeNormalizer::FORMAT_KEY => 'Y.m.d|']);
+        $this->normalizer->denormalize('  2016.01.01  ', \DateTimeImmutable::class, null, [DateTimeNormalizer::FORMAT_KEY => 'Y.m.d|']);
     }
 
     public function testDenormalizeDateTimeStringWithDefaultContextFormat()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
@@ -156,12 +156,12 @@ trait CallbacksTestTrait
             'Format a date' => [
                 [
                     'bar' => function ($bar) {
-                        $this->assertInstanceOf(\DateTime::class, $bar);
+                        $this->assertInstanceOf(\DateTimeInterface::class, $bar);
 
                         return $bar->format('d-m-Y H:i:s');
                     },
                 ],
-                new \DateTime('2011-09-10 06:30:00'),
+                new \DateTimeImmutable('2011-09-10 06:30:00'),
                 ['bar' => '10-09-2011 06:30:00', 'foo' => null],
             ],
             'Collect a property' => [
@@ -220,11 +220,11 @@ trait CallbacksTestTrait
                     'bar' => function ($bar) {
                         $this->assertIsString($bar);
 
-                        return \DateTime::createFromFormat('d-m-Y H:i:s', $bar);
+                        return \DateTimeImmutable::createFromFormat('d-m-Y H:i:s', $bar);
                     },
                 ],
                 '10-09-2011 06:30:00',
-                new CallbacksObject(new \DateTime('2011-09-10 06:30:00')),
+                new CallbacksObject(new \DateTimeImmutable('2011-09-10 06:30:00')),
             ],
             'Collect a property' => [
                 [

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
@@ -39,7 +39,7 @@ trait ContextMetadataTestTrait
         new Serializer([new DateTimeNormalizer(), $normalizer]);
 
         $dummy = new $contextMetadataDummyClass();
-        $dummy->date = new \DateTime('2011-07-28T08:44:00.123+00:00');
+        $dummy->date = new \DateTimeImmutable('2011-07-28T08:44:00.123+00:00');
 
         self::assertEquals(['date' => '2011-07-28T08:44:00+00:00'], $normalizer->normalize($dummy));
 
@@ -63,13 +63,13 @@ trait ContextMetadataTestTrait
 
         /** @var ContextMetadataDummy|ContextChildMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '2011-07-28T08:44:00+00:00'], $contextMetadataDummyClass);
-        self::assertEquals(new \DateTime('2011-07-28T08:44:00+00:00'), $dummy->date);
+        self::assertEquals(new \DateTimeImmutable('2011-07-28T08:44:00+00:00'), $dummy->date);
 
         /** @var ContextMetadataDummy|ContextChildMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '2011-07-28T08:44:00+00:00'], ContextMetadataDummy::class, null, [
             ObjectNormalizer::GROUPS => 'extended',
         ]);
-        self::assertEquals(new \DateTime('2011-07-28T08:44:00+00:00'), $dummy->date, 'base denormalization context is unchanged for this group');
+        self::assertEquals(new \DateTimeImmutable('2011-07-28T08:44:00+00:00'), $dummy->date, 'base denormalization context is unchanged for this group');
 
         /** @var ContextMetadataDummy|ContextChildMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '28/07/2011'], $contextMetadataDummyClass, null, [

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -733,20 +733,20 @@ class SerializerTest extends TestCase
         );
 
         $actual = $serializer->deserialize('{ "changed": null }', DummyUnionType::class, 'json', [
-            DateTimeNormalizer::FORMAT_KEY => \DateTime::ISO8601,
+            DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::ISO8601,
         ]);
 
         $this->assertEquals((new DummyUnionType())->setChanged(null), $actual, 'Union type denormalization first case failed.');
 
         $actual = $serializer->deserialize('{ "changed": "2022-03-22T16:15:05+0000" }', DummyUnionType::class, 'json', [
-            DateTimeNormalizer::FORMAT_KEY => \DateTime::ISO8601,
+            DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::ISO8601,
         ]);
 
-        $expectedDateTime = \DateTime::createFromFormat(\DateTime::ISO8601, '2022-03-22T16:15:05+0000');
+        $expectedDateTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ISO8601, '2022-03-22T16:15:05+0000');
         $this->assertEquals((new DummyUnionType())->setChanged($expectedDateTime), $actual, 'Union type denormalization second case failed.');
 
         $actual = $serializer->deserialize('{ "changed": false }', DummyUnionType::class, 'json', [
-            DateTimeNormalizer::FORMAT_KEY => \DateTime::ISO8601,
+            DateTimeNormalizer::FORMAT_KEY => \DateTimeInterface::ISO8601,
         ]);
 
         $this->assertEquals(new DummyUnionType(), $actual, 'Union type denormalization third case failed.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  #47580
| License       | MIT
| Doc PR        | symfony/symfony-docs

Remove DateTime from all core bundles.
