### PR TITLE
Fix BC user_identifier support after deprecation username

### DIFF
--- a/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
+++ b/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
@@ -85,7 +85,7 @@ class CheckLdapCredentialsListener implements EventSubscriberInterface
                 }
                 // @deprecated since Symfony 5.3, change to $user->getUserIdentifier() in 6.0
                 $username = $ldap->escape(method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername(), '', LdapInterface::ESCAPE_FILTER);
-                $query = str_replace('{username}', $username, $ldapBadge->getQueryString());
+                $query = str_replace(['{username}', '{user_identifier}'], $username, $ldapBadge->getQueryString());
                 $result = $ldap->query($ldapBadge->getDnString(), $query)->execute();
                 if (1 !== $result->count()) {
                     throw new BadCredentialsException('The presented username is invalid.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Starting from Symfony 6.2, the `{username}` string was deprecated in favor of `{user_identifier}` so here fixed BC support, like it was done for `LdapUserProvider` 

https://github.com/symfony/symfony/blob/fe23f0f3e4ebf8793b91a04225dcb6aeb80edbcf/src/Symfony/Component/Ldap/Security/LdapUserProvider.php#L80
