### PR TITLE
[HttpKernel] Introduce pinnable value resolvers with `#[ValueResolver]` and `#[AsPinnedValueResolver]`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Bridge\Doctrine\Attribute;
 
+use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
+
 /**
  * Indicates that a controller argument should receive an Entity.
  */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class MapEntity
+class MapEntity extends ValueResolver
 {
     public function __construct(
         public ?string $class = null,
@@ -26,8 +29,10 @@ class MapEntity
         public ?bool $stripNull = null,
         public array|string|null $id = null,
         public ?bool $evictCache = null,
-        public bool $disabled = false,
+        bool $disabled = false,
+        string $resolver = EntityValueResolver::class,
     ) {
+        parent::__construct($resolver, $disabled);
     }
 
     public function withDefaults(self $defaults, ?string $class): static

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -30,7 +30,7 @@
         "symfony/config": "^5.4|^6.0",
         "symfony/dependency-injection": "^6.2",
         "symfony/form": "^5.4.21|^6.2.7",
-        "symfony/http-kernel": "^6.2",
+        "symfony/http-kernel": "^6.3",
         "symfony/messenger": "^5.4|^6.0",
         "symfony/doctrine-messenger": "^5.4|^6.0",
         "symfony/property-access": "^5.4|^6.0",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -83,6 +83,7 @@ use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpClient\UriTemplateHttpClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Attribute\AsPinnedValueResolver;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\BackedEnumValueResolver;
@@ -689,6 +690,10 @@ class FrameworkExtension extends Extension
                 $tagAttributes['method'] = $reflector->getName();
             }
             $definition->addTag('messenger.message_handler', $tagAttributes);
+        });
+
+        $container->registerAttributeForAutoconfiguration(AsPinnedValueResolver::class, static function (ChildDefinition $definition, AsPinnedValueResolver $attribute): void {
+            $definition->addTag('controller.pinned_value_resolver', $attribute->name ? ['name' => $attribute->name] : []);
         });
 
         if (!$container->getParameter('kernel.debug')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -46,40 +46,41 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('argument_metadata_factory'),
                 abstract_arg('argument value resolvers'),
+                abstract_arg('pinned value resolvers'),
             ])
 
         ->set('argument_resolver.backed_enum_resolver', BackedEnumValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => 100])
+            ->tag('controller.argument_value_resolver', ['priority' => 100, 'name' => BackedEnumValueResolver::class])
 
         ->set('argument_resolver.uid', UidValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => 100])
+            ->tag('controller.argument_value_resolver', ['priority' => 100, 'name' => UidValueResolver::class])
 
         ->set('argument_resolver.datetime', DateTimeValueResolver::class)
             ->args([
                 service('clock')->nullOnInvalid(),
             ])
-            ->tag('controller.argument_value_resolver', ['priority' => 100])
+            ->tag('controller.argument_value_resolver', ['priority' => 100, 'name' => DateTimeValueResolver::class])
 
         ->set('argument_resolver.request_attribute', RequestAttributeValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => 100])
+            ->tag('controller.argument_value_resolver', ['priority' => 100, 'name' => RequestAttributeValueResolver::class])
 
         ->set('argument_resolver.request', RequestValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => 50])
+            ->tag('controller.argument_value_resolver', ['priority' => 50, 'name' => RequestValueResolver::class])
 
         ->set('argument_resolver.session', SessionValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => 50])
+            ->tag('controller.argument_value_resolver', ['priority' => 50, 'name' => SessionValueResolver::class])
 
         ->set('argument_resolver.service', ServiceValueResolver::class)
             ->args([
                 abstract_arg('service locator, set in RegisterControllerArgumentLocatorsPass'),
             ])
-            ->tag('controller.argument_value_resolver', ['priority' => -50])
+            ->tag('controller.argument_value_resolver', ['priority' => -50, 'name' => ServiceValueResolver::class])
 
         ->set('argument_resolver.default', DefaultValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => -100])
+            ->tag('controller.argument_value_resolver', ['priority' => -100, 'name' => DefaultValueResolver::class])
 
         ->set('argument_resolver.variadic', VariadicValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => -150])
+            ->tag('controller.argument_value_resolver', ['priority' => -150, 'name' => VariadicValueResolver::class])
 
         ->set('response_listener', ResponseListener::class)
             ->args([

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -100,7 +100,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('security.token_storage'),
             ])
-            ->tag('controller.argument_value_resolver', ['priority' => 120])
+            ->tag('controller.argument_value_resolver', ['priority' => 120, 'name' => UserValueResolver::class])
 
         // Authentication related services
         ->set('security.authentication.trust_resolver', AuthenticationTrustResolver::class)

--- a/src/Symfony/Component/HttpKernel/Attribute/AsPinnedValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/AsPinnedValueResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+/**
+ * Service tag to autoconfigure pinned value resolvers.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsPinnedValueResolver
+{
+    public function __construct(
+        public readonly ?string $name = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Attribute/MapDateTime.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapDateTime.php
@@ -11,14 +11,19 @@
 
 namespace Symfony\Component\HttpKernel\Attribute;
 
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DateTimeValueResolver;
+
 /**
  * Controller parameter tag to configure DateTime arguments.
  */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class MapDateTime
+class MapDateTime extends ValueResolver
 {
     public function __construct(
-        public readonly ?string $format = null
+        public readonly ?string $format = null,
+        bool $disabled = false,
+        string $resolver = DateTimeValueResolver::class,
     ) {
+        parent::__construct($resolver, $disabled);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Attribute/ValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/ValueResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+class ValueResolver
+{
+    /**
+     * @param class-string<ValueResolverInterface>|string $name
+     */
+    public function __construct(
+        public string $name,
+        public bool $disabled = false,
+    ) {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
  * Add `#[WithLogLevel]` for defining log levels for exceptions
  * Add `skip_response_headers` to the `HttpCache` options
+ * Introduce pinnable value resolvers with `#[ValueResolver]` and `#[AsPinnedValueResolver]`
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\HttpKernel\Controller;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver;
@@ -20,6 +22,8 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\TraceableValueResol
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\VariadicValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface;
+use Symfony\Component\HttpKernel\Exception\ResolverNotFoundException;
+use Symfony\Contracts\Service\ServiceProviderInterface;
 
 /**
  * Responsible for resolving the arguments passed to an action.
@@ -30,14 +34,16 @@ final class ArgumentResolver implements ArgumentResolverInterface
 {
     private ArgumentMetadataFactoryInterface $argumentMetadataFactory;
     private iterable $argumentValueResolvers;
+    private ?ContainerInterface $namedResolvers;
 
     /**
      * @param iterable<mixed, ArgumentValueResolverInterface|ValueResolverInterface> $argumentValueResolvers
      */
-    public function __construct(ArgumentMetadataFactoryInterface $argumentMetadataFactory = null, iterable $argumentValueResolvers = [])
+    public function __construct(ArgumentMetadataFactoryInterface $argumentMetadataFactory = null, iterable $argumentValueResolvers = [], ContainerInterface $namedResolvers = null)
     {
         $this->argumentMetadataFactory = $argumentMetadataFactory ?? new ArgumentMetadataFactory();
         $this->argumentValueResolvers = $argumentValueResolvers ?: self::getDefaultArgumentValueResolvers();
+        $this->namedResolvers = $namedResolvers;
     }
 
     public function getArguments(Request $request, callable $controller, \ReflectionFunctionAbstract $reflector = null): array
@@ -45,8 +51,35 @@ final class ArgumentResolver implements ArgumentResolverInterface
         $arguments = [];
 
         foreach ($this->argumentMetadataFactory->createArgumentMetadata($controller, $reflector) as $metadata) {
-            foreach ($this->argumentValueResolvers as $resolver) {
+            $argumentValueResolvers = $this->argumentValueResolvers;
+            $disabledResolvers = [];
+
+            if ($this->namedResolvers && $attributes = $metadata->getAttributesOfType(ValueResolver::class, $metadata::IS_INSTANCEOF)) {
+                $resolverName = null;
+                foreach ($attributes as $attribute) {
+                    if ($attribute->disabled) {
+                        $disabledResolvers[$attribute->name] = true;
+                    } elseif ($resolverName) {
+                        throw new \LogicException(sprintf('You can only pin one resolver per argument, but argument "$%s" of "%s()" has more.', $metadata->getName(), $this->getPrettyName($controller)));
+                    } else {
+                        $resolverName = $attribute->name;
+                    }
+                }
+
+                if ($resolverName) {
+                    if (!$this->namedResolvers->has($resolverName)) {
+                        throw new ResolverNotFoundException($resolverName, $this->namedResolvers instanceof ServiceProviderInterface ? array_keys($this->namedResolvers->getProvidedServices()) : []);
+                    }
+
+                    $argumentValueResolvers = [$this->namedResolvers->get($resolverName)];
+                }
+            }
+
+            foreach ($argumentValueResolvers as $name => $resolver) {
                 if ((!$resolver instanceof ValueResolverInterface || $resolver instanceof TraceableValueResolver) && !$resolver->supports($request, $metadata)) {
+                    continue;
+                }
+                if (isset($disabledResolvers[\is_int($name) ? $resolver::class : $name])) {
                     continue;
                 }
 
@@ -70,15 +103,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
                 }
             }
 
-            $representative = $controller;
-
-            if (\is_array($representative)) {
-                $representative = sprintf('%s::%s()', $representative[0]::class, $representative[1]);
-            } elseif (\is_object($representative)) {
-                $representative = get_debug_type($representative);
-            }
-
-            throw new \RuntimeException(sprintf('Controller "%s" requires that you provide a value for the "$%s" argument. Either the argument is nullable and no null value has been provided, no default value has been provided or because there is a non optional argument after this one.', $representative, $metadata->getName()));
+            throw new \RuntimeException(sprintf('Controller "%s" requires that you provide a value for the "$%s" argument. Either the argument is nullable and no null value has been provided, no default value has been provided or because there is a non optional argument after this one.', $this->getPrettyName($controller), $metadata->getName()));
         }
 
         return $arguments;
@@ -96,5 +121,18 @@ final class ArgumentResolver implements ArgumentResolverInterface
             new DefaultValueResolver(),
             new VariadicValueResolver(),
         ];
+    }
+
+    private function getPrettyName($controller): string
+    {
+        if (\is_array($controller)) {
+            return $controller[0]::class.'::'.$controller[1];
+        }
+
+        if (\is_object($controller)) {
+            return get_debug_type($controller);
+        }
+
+        return $controller;
     }
 }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\HttpKernel\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -37,10 +39,24 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
             return;
         }
 
-        $resolvers = $this->findAndSortTaggedServices('controller.argument_value_resolver', $container);
+        $definitions = $container->getDefinitions();
+        $namedResolvers = $this->findAndSortTaggedServices(new TaggedIteratorArgument('controller.pinned_value_resolver', 'name', needsIndexes: true), $container);
+        $resolvers = $this->findAndSortTaggedServices(new TaggedIteratorArgument('controller.argument_value_resolver', 'name', needsIndexes: true), $container);
+
+        foreach ($resolvers as $name => $resolverReference) {
+            $id = (string) $resolverReference;
+
+            if ($definitions[$id]->hasTag('controller.pinned_value_resolver')) {
+                unset($resolvers[$name]);
+            } else {
+                $namedResolvers[$name] ??= clone $resolverReference;
+            }
+        }
+
+        $resolvers = array_values($resolvers);
 
         if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class) && $container->has('debug.stopwatch')) {
-            foreach ($resolvers as $resolverReference) {
+            foreach ($resolvers + $namedResolvers as $resolverReference) {
                 $id = (string) $resolverReference;
                 $container->register("debug.$id", TraceableValueResolver::class)
                     ->setDecoratedService($id)
@@ -51,6 +67,7 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
         $container
             ->getDefinition('argument_resolver')
             ->replaceArgument(1, new IteratorArgument($resolvers))
+            ->setArgument(2, new ServiceLocatorArgument($namedResolvers))
         ;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/ResolverNotFoundException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ResolverNotFoundException.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+class ResolverNotFoundException extends \RuntimeException
+{
+    /**
+     * @param string[] $alternatives
+     */
+    public function __construct(string $name, array $alternatives = [])
+    {
+        $msg = sprintf('You have requested a non-existent resolver "%s".', $name);
+        if ($alternatives) {
+            if (1 === \count($alternatives)) {
+                $msg .= ' Did you mean this: "';
+            } else {
+                $msg .= ' Did you mean one of these: "';
+            }
+            $msg .= implode('", "', $alternatives).'"?';
+        }
+
+        parent::__construct($msg);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -12,14 +12,18 @@
 namespace Symfony\Component\HttpKernel\Tests\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
+use Symfony\Component\HttpKernel\Exception\ResolverNotFoundException;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\ExtendingRequest;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\ExtendingSession;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\NullableController;
@@ -27,20 +31,19 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\VariadicController;
 
 class ArgumentResolverTest extends TestCase
 {
-    /** @var ArgumentResolver */
-    private static $resolver;
-
-    public static function setUpBeforeClass(): void
+    public static function getResolver(array $chainableResolvers = [], array $namedResolvers = null): ArgumentResolver
     {
-        $factory = new ArgumentMetadataFactory();
+        if (null !== $namedResolvers) {
+            $namedResolvers = new ServiceLocator(array_map(fn ($resolver) => fn () => $resolver, $namedResolvers));
+        }
 
-        self::$resolver = new ArgumentResolver($factory);
+        return new ArgumentResolver(new ArgumentMetadataFactory(), $chainableResolvers, $namedResolvers);
     }
 
     public function testDefaultState()
     {
-        $this->assertEquals(self::$resolver, new ArgumentResolver());
-        $this->assertNotEquals(self::$resolver, new ArgumentResolver(null, [new RequestAttributeValueResolver()]));
+        $this->assertEquals(self::getResolver(), new ArgumentResolver());
+        $this->assertNotEquals(self::getResolver(), new ArgumentResolver(null, [new RequestAttributeValueResolver()]));
     }
 
     public function testGetArguments()
@@ -49,7 +52,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('foo', 'foo');
         $controller = [new self(), 'controllerWithFoo'];
 
-        $this->assertEquals(['foo'], self::$resolver->getArguments($request, $controller), '->getArguments() returns an array of arguments for the controller method');
+        $this->assertEquals(['foo'], self::getResolver()->getArguments($request, $controller), '->getArguments() returns an array of arguments for the controller method');
     }
 
     public function testGetArgumentsReturnsEmptyArrayWhenNoArguments()
@@ -57,7 +60,7 @@ class ArgumentResolverTest extends TestCase
         $request = Request::create('/');
         $controller = [new self(), 'controllerWithoutArguments'];
 
-        $this->assertEquals([], self::$resolver->getArguments($request, $controller), '->getArguments() returns an empty array if the method takes no arguments');
+        $this->assertEquals([], self::getResolver()->getArguments($request, $controller), '->getArguments() returns an empty array if the method takes no arguments');
     }
 
     public function testGetArgumentsUsesDefaultValue()
@@ -66,7 +69,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('foo', 'foo');
         $controller = [new self(), 'controllerWithFooAndDefaultBar'];
 
-        $this->assertEquals(['foo', null], self::$resolver->getArguments($request, $controller), '->getArguments() uses default values if present');
+        $this->assertEquals(['foo', null], self::getResolver()->getArguments($request, $controller), '->getArguments() uses default values if present');
     }
 
     public function testGetArgumentsOverrideDefaultValueByRequestAttribute()
@@ -76,7 +79,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('bar', 'bar');
         $controller = [new self(), 'controllerWithFooAndDefaultBar'];
 
-        $this->assertEquals(['foo', 'bar'], self::$resolver->getArguments($request, $controller), '->getArguments() overrides default values if provided in the request attributes');
+        $this->assertEquals(['foo', 'bar'], self::getResolver()->getArguments($request, $controller), '->getArguments() overrides default values if provided in the request attributes');
     }
 
     public function testGetArgumentsFromClosure()
@@ -85,7 +88,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('foo', 'foo');
         $controller = function ($foo) {};
 
-        $this->assertEquals(['foo'], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals(['foo'], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetArgumentsUsesDefaultValueFromClosure()
@@ -94,7 +97,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('foo', 'foo');
         $controller = function ($foo, $bar = 'bar') {};
 
-        $this->assertEquals(['foo', 'bar'], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals(['foo', 'bar'], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetArgumentsFromInvokableObject()
@@ -103,12 +106,12 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('foo', 'foo');
         $controller = new self();
 
-        $this->assertEquals(['foo', null], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals(['foo', null], self::getResolver()->getArguments($request, $controller));
 
         // Test default bar overridden by request attribute
         $request->attributes->set('bar', 'bar');
 
-        $this->assertEquals(['foo', 'bar'], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals(['foo', 'bar'], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetArgumentsFromFunctionName()
@@ -118,7 +121,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('foobar', 'foobar');
         $controller = __NAMESPACE__.'\controller_function';
 
-        $this->assertEquals(['foo', 'foobar'], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals(['foo', 'foobar'], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetArgumentsFailsOnUnresolvedValue()
@@ -129,7 +132,7 @@ class ArgumentResolverTest extends TestCase
         $controller = [new self(), 'controllerWithFooBarFoobar'];
 
         try {
-            self::$resolver->getArguments($request, $controller);
+            self::getResolver()->getArguments($request, $controller);
             $this->fail('->getArguments() throws a \RuntimeException exception if it cannot determine the argument value');
         } catch (\Exception $e) {
             $this->assertInstanceOf(\RuntimeException::class, $e, '->getArguments() throws a \RuntimeException exception if it cannot determine the argument value');
@@ -141,7 +144,7 @@ class ArgumentResolverTest extends TestCase
         $request = Request::create('/');
         $controller = [new self(), 'controllerWithRequest'];
 
-        $this->assertEquals([$request], self::$resolver->getArguments($request, $controller), '->getArguments() injects the request');
+        $this->assertEquals([$request], self::getResolver()->getArguments($request, $controller), '->getArguments() injects the request');
     }
 
     public function testGetArgumentsInjectsExtendingRequest()
@@ -149,7 +152,7 @@ class ArgumentResolverTest extends TestCase
         $request = ExtendingRequest::create('/');
         $controller = [new self(), 'controllerWithExtendingRequest'];
 
-        $this->assertEquals([$request], self::$resolver->getArguments($request, $controller), '->getArguments() injects the request when extended');
+        $this->assertEquals([$request], self::getResolver()->getArguments($request, $controller), '->getArguments() injects the request when extended');
     }
 
     public function testGetVariadicArguments()
@@ -159,7 +162,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('bar', ['foo', 'bar']);
         $controller = [new VariadicController(), 'action'];
 
-        $this->assertEquals(['foo', 'foo', 'bar'], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals(['foo', 'foo', 'bar'], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetVariadicArgumentsWithoutArrayInRequest()
@@ -170,7 +173,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('bar', 'foo');
         $controller = [new VariadicController(), 'action'];
 
-        self::$resolver->getArguments($request, $controller);
+        self::getResolver()->getArguments($request, $controller);
     }
 
     /**
@@ -179,9 +182,8 @@ class ArgumentResolverTest extends TestCase
     public function testGetArgumentWithoutArray()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $factory = new ArgumentMetadataFactory();
         $valueResolver = $this->createMock(ArgumentValueResolverInterface::class);
-        $resolver = new ArgumentResolver($factory, [$valueResolver]);
+        $resolver = self::getResolver([$valueResolver]);
 
         $valueResolver->expects($this->any())->method('supports')->willReturn(true);
         $valueResolver->expects($this->any())->method('resolve')->willReturn([]);
@@ -199,7 +201,7 @@ class ArgumentResolverTest extends TestCase
         $request = Request::create('/');
         $controller = $this->controllerWithFoo(...);
 
-        self::$resolver->getArguments($request, $controller);
+        self::getResolver()->getArguments($request, $controller);
     }
 
     public function testGetNullableArguments()
@@ -210,7 +212,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('last', 'last');
         $controller = [new NullableController(), 'action'];
 
-        $this->assertEquals(['foo', new \stdClass(), 'value', 'last'], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals(['foo', new \stdClass(), 'value', 'last'], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetNullableArgumentsWithDefaults()
@@ -219,7 +221,7 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('last', 'last');
         $controller = [new NullableController(), 'action'];
 
-        $this->assertEquals([null, null, 'value', 'last'], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals([null, null, 'value', 'last'], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetSessionArguments()
@@ -229,7 +231,7 @@ class ArgumentResolverTest extends TestCase
         $request->setSession($session);
         $controller = $this->controllerWithSession(...);
 
-        $this->assertEquals([$session], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals([$session], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetSessionArgumentsWithExtendedSession()
@@ -239,7 +241,7 @@ class ArgumentResolverTest extends TestCase
         $request->setSession($session);
         $controller = $this->controllerWithExtendingSession(...);
 
-        $this->assertEquals([$session], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals([$session], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetSessionArgumentsWithInterface()
@@ -249,7 +251,7 @@ class ArgumentResolverTest extends TestCase
         $request->setSession($session);
         $controller = $this->controllerWithSessionInterface(...);
 
-        $this->assertEquals([$session], self::$resolver->getArguments($request, $controller));
+        $this->assertEquals([$session], self::getResolver()->getArguments($request, $controller));
     }
 
     public function testGetSessionMissMatchWithInterface()
@@ -260,7 +262,7 @@ class ArgumentResolverTest extends TestCase
         $request->setSession($session);
         $controller = $this->controllerWithExtendingSession(...);
 
-        self::$resolver->getArguments($request, $controller);
+        self::getResolver()->getArguments($request, $controller);
     }
 
     public function testGetSessionMissMatchWithImplementation()
@@ -271,7 +273,7 @@ class ArgumentResolverTest extends TestCase
         $request->setSession($session);
         $controller = $this->controllerWithExtendingSession(...);
 
-        self::$resolver->getArguments($request, $controller);
+        self::getResolver()->getArguments($request, $controller);
     }
 
     public function testGetSessionMissMatchOnNull()
@@ -280,7 +282,51 @@ class ArgumentResolverTest extends TestCase
         $request = Request::create('/');
         $controller = $this->controllerWithExtendingSession(...);
 
-        self::$resolver->getArguments($request, $controller);
+        self::getResolver()->getArguments($request, $controller);
+    }
+
+    public function testPinnedResolver()
+    {
+        $resolver = self::getResolver([], [DefaultValueResolver::class => new DefaultValueResolver()]);
+
+        $request = Request::create('/');
+        $request->attributes->set('foo', 'bar');
+        $controller = $this->controllerPinningResolver(...);
+
+        $this->assertSame([1], $resolver->getArguments($request, $controller));
+    }
+
+    public function testDisabledResolver()
+    {
+        $resolver = self::getResolver(namedResolvers: []);
+
+        $request = Request::create('/');
+        $request->attributes->set('foo', 'bar');
+        $controller = $this->controllerDisablingResolver(...);
+
+        $this->assertSame([1], $resolver->getArguments($request, $controller));
+    }
+
+    public function testManyPinnedResolvers()
+    {
+        $resolver = self::getResolver(namedResolvers: []);
+
+        $request = Request::create('/');
+        $controller = $this->controllerPinningManyResolvers(...);
+
+        $this->expectException(\LogicException::class);
+        $resolver->getArguments($request, $controller);
+    }
+
+    public function testUnknownPinnedResolver()
+    {
+        $resolver = self::getResolver(namedResolvers: []);
+
+        $request = Request::create('/');
+        $controller = $this->controllerPinningUnknownResolver(...);
+
+        $this->expectException(ResolverNotFoundException::class);
+        $resolver->getArguments($request, $controller);
     }
 
     public function __invoke($foo, $bar = null)
@@ -321,6 +367,27 @@ class ArgumentResolverTest extends TestCase
 
     public function controllerWithExtendingSession(ExtendingSession $session)
     {
+    }
+
+    public function controllerPinningResolver(#[ValueResolver(DefaultValueResolver::class)] int $foo = 1)
+    {
+    }
+
+    public function controllerDisablingResolver(#[ValueResolver(RequestAttributeValueResolver::class, disabled: true)] int $foo = 1)
+    {
+    }
+
+    public function controllerPinningManyResolvers(
+        #[ValueResolver(RequestAttributeValueResolver::class)]
+        #[ValueResolver(DefaultValueResolver::class)]
+        int $foo
+    ) {
+    }
+
+    public function controllerPinningUnknownResolver(
+        #[ValueResolver('foo')]
+        int $bar
+    ) {
     }
 }
 

--- a/src/Symfony/Component/Security/Http/Attribute/CurrentUser.php
+++ b/src/Symfony/Component/Security/Http/Attribute/CurrentUser.php
@@ -11,10 +11,17 @@
 
 namespace Symfony\Component\Security\Http\Attribute;
 
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
+use Symfony\Component\Security\Http\Controller\UserValueResolver;
+
 /**
  * Indicates that a controller argument should receive the current logged user.
  */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class CurrentUser
+class CurrentUser extends ValueResolver
 {
+    public function __construct(bool $disabled = false, string $resolver = UserValueResolver::class)
+    {
+        parent::__construct($resolver, $disabled);
+    }
 }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -20,7 +20,7 @@
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/security-core": "~6.0.19|~6.1.11|^6.2.5",
         "symfony/http-foundation": "^5.4|^6.0",
-        "symfony/http-kernel": "^6.2",
+        "symfony/http-kernel": "^6.3",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/property-access": "^5.4|^6.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #48927
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/17763

Introducing a new `ValueResolver` attribute, which allows to
- “pin” a value resolver to an argument, meaning only said resolver will be called
- prevent a resolver to be called for an argument

Every existing resolver-related attribute (`MapEntity`, `CurrentUser`…) now extends `ValueResolver`.

Each `controller.argument_value_resolver` tag is added a `name` attribute, which is the resolver’s FQCN. This is the first argument `ValueResolver` expects.

A new  `AsPinnedValueResolver` attribute is added for autoconfiguration, adding the `controller.pinned_value_resolver` tag. Such resolvers can only be “pinned”, meaning they won’t ever be called for an argument missing the `ValueResolver` attribute.