### PR TITLE
[WebProfilerBundle] Mailer panel tweaks

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -177,56 +177,59 @@
                             </div>
                         {% endif %}
 
-                        {% if message.htmlBody or message.textBody %}
-                            <div class="card-block">
-                                <div class="sf-tabs sf-tabs-sm">
-                                    {% if message.htmlBody %}
-                                        {% set htmlBody = message.htmlBody() %}
-                                        <div class="tab">
-                                            <h3 class="tab-title">HTML content</h3>
-                                            <div class="tab-content">
-                                                <pre class="prewrap" style="max-height: 600px">
-                                                    {%- if message.htmlCharset() %}
-                                                        {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
-                                                    {%- else %}
-                                                        {{- htmlBody }}
-                                                    {%- endif -%}
-                                                </pre>
+                        <div class="card-block">
+                            {% set textBody = message.textBody %}
+                            {% set htmlBody = message.htmlBody %}
+                            <div class="sf-tabs sf-tabs-sm">
+                                <div class="tab {{ not textBody ? 'disabled' }} {{ textBody ? 'active' }}">
+                                    <h3 class="tab-title">Text content</h3>
+                                    <div class="tab-content">
+                                        {% if textBody %}
+                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                                {%- if message.textCharset() %}
+                                                    {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
+                                                {%- else %}
+                                                    {{- textBody }}
+                                                {%- endif -%}
+                                            </pre>
+                                        {% else %}
+                                            <div class="mailer-empty-email-body">
+                                                <p>The text body is empty.</p>
                                             </div>
-                                        </div>
-
-                                        <div class="tab">
-                                            <h3 class="tab-title">HTML preview</h3>
-                                            <div class="tab-content">
-                                                <pre class="prewrap" style="max-height: 600px">
-                                                    <iframe
-                                                        src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}"
-                                                        style="height: 80vh;width: 100%;"
-                                                    >
-                                                    </iframe>
-                                                </pre>
-                                            </div>
-                                        </div>
-                                    {% endif %}
-
-                                    {% if message.textBody %}
-                                        {% set textBody = message.textBody() %}
-                                        <div class="tab">
-                                            <h3 class="tab-title">Text content</h3>
-                                            <div class="tab-content">
-                                                <pre class="prewrap" style="max-height: 600px">
-                                                    {%- if message.textCharset() %}
-                                                        {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
-                                                    {%- else %}
-                                                        {{- textBody }}
-                                                    {%- endif -%}
-                                                </pre>
-                                            </div>
-                                        </div>
-                                    {% endif %}
+                                        {% endif %}
+                                    </div>
                                 </div>
+
+                                <div class="tab {{ not htmlBody ? 'disabled' }} {{ not textBody and htmlBody ? 'active' }}">
+                                    <h3 class="tab-title">HTML content</h3>
+                                    <div class="tab-content">
+                                        {% if htmlBody %}
+                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                                {%- if message.htmlCharset() %}
+                                                    {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
+                                                {%- else %}
+                                                    {{- htmlBody }}
+                                                {%- endif -%}
+                                            </pre>
+                                        {% else %}
+                                            <div class="mailer-empty-email-body">
+                                                <p>The HTML body is empty.</p>
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+
+                                {% if htmlBody %}
+                                    <div class="tab">
+                                        <h3 class="tab-title">HTML preview</h3>
+                                        <div class="tab-content">
+                                            <pre class="prewrap" style="max-height: 600px"><iframe src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}" style="height: 80vh;width: 100%;"></iframe>
+                                            </pre>
+                                        </div>
+                                    </div>
+                                {% endif %}
                             </div>
-                        {% endif %}
+                        </div>
                     </div>
                 </div>
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -668,8 +668,7 @@ table tbody td.num-col {
 .empty p {
     font-size: var(--font-size-body);
     max-width: 60ch;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 1em auto;
     text-align: center;
 }
 .empty.empty-panel {
@@ -2081,6 +2080,26 @@ tr.log-status-silenced > td:first-child:before {
 .mailer-message-attachments-list li a {
     margin-left: 5px;
 }
+.mailer-email-body {
+    margin: 0;
+    padding: 6px 8px;
+}
+.mailer-empty-email-body {
+    background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' stroke='%23e5e5e5' stroke-width='4' stroke-dasharray='6%2c 14' stroke-dashoffset='0' stroke-linecap='square'/%3e%3c/svg%3e");
+    border-radius: 6px;
+    color: var(--color-muted);
+    margin: 1em 0 0;
+    padding: .5em 1em;
+}
+.theme-dark .mailer-empty-email-body {
+    background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' stroke='%23737373' stroke-width='4' stroke-dasharray='6%2c 14' stroke-dashoffset='0' stroke-linecap='square'/%3e%3c/svg%3e");
+}
+.mailer-empty-email-body p {
+    font-size: var(--font-size-body);
+    margin: 0;
+    padding: 0.5em 0;
+}
+
 .mailer-message-download-raw {
     align-items: center;
     display: flex;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

_Note: it looks like this PR changes lots of lines, but it just reorders some HTML contents and changes some indentations, so the real changes are minimal_

Currently, the email details only shows the bodies defined in the email. E.g. if some email has a text body and not an HTML body, you see this:

<img width="365" alt="mailer-panel-before" src="https://user-images.githubusercontent.com/73419/212718244-8882df5f-37f0-453f-b2b1-58a3c1f5097a.png">

I think this doesn't look nice. I think it's better to always display text content + HTML content and display a message if some of them (or both) are empty.

This is how it'd look after this PR:

## Email with text and HTML bodies

![text-and-html](https://user-images.githubusercontent.com/73419/212718463-649a1bd4-059c-4e65-8fd7-e039b878b032.png)

## Email with text body and no HTML body

![text-but-no-html](https://user-images.githubusercontent.com/73419/212718500-d61d257e-46c3-447a-8044-929e81c15645.png)

If you click on HTML tab:

![text-but-no-html-empty-body](https://user-images.githubusercontent.com/73419/212718544-973d66f3-2f8d-44b5-833b-581420c8ab7d.png)

## Email with HTML body and no text body

![html-but-no-text](https://user-images.githubusercontent.com/73419/212718601-bc4a5e09-5a52-4130-b03b-5c169c323d73.png)

## Email without text and HTML bodies

![no-text-no-html](https://user-images.githubusercontent.com/73419/212718662-1033d766-b895-4662-80cf-ab0498868ca5.png)

