### PR TITLE
[Lock] create migration for lock table when DoctrineDbalStore is used

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\SchemaListener;
+
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Store\DoctrineDbalStore;
+
+final class LockStoreSchemaSubscriber extends AbstractSchemaSubscriber
+{
+    /**
+     * @param iterable<mixed, PersistingStoreInterface> $stores
+     */
+    public function __construct(private iterable $stores)
+    {
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
+    {
+        $connection = $event->getEntityManager()->getConnection();
+
+        foreach ($this->stores as $store) {
+            if (!$store instanceof DoctrineDbalStore) {
+                continue;
+            }
+
+            $store->configureSchema($event->getSchema(), $this->getIsSameDatabaseChecker($connection));
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1898,8 +1898,10 @@ class FrameworkExtension extends Extension
             foreach ($resourceStores as $resourceStore) {
                 $storeDsn = $container->resolveEnvPlaceholders($resourceStore, null, $usedEnvs);
                 $storeDefinition = new Definition(PersistingStoreInterface::class);
-                $storeDefinition->setFactory([StoreFactory::class, 'createStore']);
-                $storeDefinition->setArguments([$resourceStore]);
+                $storeDefinition
+                    ->setFactory([StoreFactory::class, 'createStore'])
+                    ->setArguments([$resourceStore])
+                    ->addTag('lock.store');
 
                 $container->setDefinition($storeDefinitionId = '.lock.'.$resourceName.'.store.'.$container->hash($storeDsn), $storeDefinition);
 

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Create migration for lock table when DoctrineDbalStore is used
+
 6.0
 ---
 

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -181,10 +181,18 @@ class DoctrineDbalStore implements PersistingStoreInterface
 
     /**
      * Adds the Table to the Schema if it doesn't exist.
+     *
+     * @param \Closure $isSameDatabase
      */
-    public function configureSchema(Schema $schema): void
+    public function configureSchema(Schema $schema/* , \Closure $isSameDatabase */): void
     {
         if ($schema->hasTable($this->table)) {
+            return;
+        }
+
+        $isSameDatabase = 1 < \func_num_args() ? func_get_arg(1) : static fn () => true;
+
+        if (!$isSameDatabase($this->conn->executeStatement(...))) {
             return;
         }
 

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Lock\Store\PdoStore;
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
  * @requires extension pdo_sqlite
+ *
  * @group integration
  */
 class PdoStoreTest extends AbstractStoreTest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | to do

The purpose of this PR is to automatically generate the lock table with the make migration command when DoctrineDbalStore is used.

DoctrineBundle PR => https://github.com/doctrine/DoctrineBundle/pull/1618