### PR TITLE
[HttpFoundation] Improve return type of Header::all

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -63,7 +63,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      *
      * @param string|null $key The name of the headers to return or null to get them all
      *
-     * @return array<string, array<int, string|null>>|array<int, string|null>
+     * @return ($key is null ? array<string, array<int, string|null>> : array<int, string|null>)
      */
     public function all(string $key = null): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/phpstan/phpstan-symfony/issues/264 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

The syntax is supported by PHPStorm since
[youtrack.jetbrains.com/issue/WI-66465/Support-parsing-of-PhpStans-conditional-return-types](https://youtrack.jetbrains.com/issue/WI-66465/Support-parsing-of-PhpStans-conditional-return-types)

It's supported by psalm: https://psalm.dev/r/0c03bec576
And also by phpstan.

Not sure which syntax is preferred by Symfony:
- I found a non prefixed version: https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php#L162
- I found multiple prefixed version like: https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/HttpFoundation/Request.php#L1437