### PR TITLE
[Form] Cast choices value callback result to string

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/Loader/AbstractChoiceLoader.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/AbstractChoiceLoader.php
@@ -59,7 +59,7 @@ abstract class AbstractChoiceLoader implements ChoiceLoaderInterface
 
         if ($value) {
             // if a value callback exists, use it
-            return array_map($value, $choices);
+            return array_map(function ($item) use ($value): string { return $value($item); }, $choices);
         }
 
         return $this->doLoadValuesForChoices($choices);

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
@@ -90,6 +90,18 @@ class CallbackChoiceLoaderTest extends TestCase
         );
     }
 
+    public function testLoadValuesForChoicesCastsCallbackItemsToString()
+    {
+        $choices = [
+           (object) ['id' => 2],
+           (object) ['id' => 3],
+        ];
+
+        $value = function ($item) { return $item->id; };
+
+        $this->assertSame(['2', '3'], self::$loader->loadValuesForChoices($choices, $value));
+    }
+
     public function testLoadValuesForChoicesLoadsChoiceListOnFirstCall()
     {
         $this->assertSame(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #42394 
| License       | MIT
| Doc PR        | X

When using "multiple" and "choice_value" callback on a CollectionType or EntityType, the result for the callback needs to be a string. By forcing a string cast, default values will show  up in the form view.