### PR TITLE
[Serializer] Replace the MissingConstructorArgumentsException class with MissingConstructorArgumentException

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -929,7 +929,7 @@ index 12c778cb80..4ad55fb3e1 100644
      {
          $ignoredAttributes = $context[self::IGNORED_ATTRIBUTES] ?? $this->defaultContext[self::IGNORED_ATTRIBUTES];
 @@ -311,5 +311,5 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
-      * @throws MissingConstructorArgumentsException
+      * @throws MissingConstructorArgumentException
       */
 -    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null)
 +    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null): object

--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -66,3 +66,8 @@ Validator
 ---------
 
  * Implementing the `ConstraintViolationInterface` without implementing the `getConstraint()` method is deprecated
+
+Serializer
+----------
+
+ * Deprecate `MissingConstructorArgumentsException` in favor of `MissingConstructorArgumentException`

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `XmlEncoder::SAVE_OPTIONS` context option
+ * Deprecate `MissingConstructorArgumentsException` in favor of `MissingConstructorArgumentException`
 
 6.2
 ---

--- a/src/Symfony/Component/Serializer/Exception/MissingConstructorArgumentException.php
+++ b/src/Symfony/Component/Serializer/Exception/MissingConstructorArgumentException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+class MissingConstructorArgumentException extends MissingConstructorArgumentsException
+{
+    private string $class;
+    private string $missingArgument;
+
+    /**
+     * @param class-string $class
+     */
+    public function __construct(string $class, string $missingArgument, int $code = 0, \Throwable $previous = null)
+    {
+        $this->class = $class;
+        $this->missingArgument = $missingArgument;
+
+        $message = sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires parameter "%s" to be present.', $class, $missingArgument);
+
+        parent::__construct($message, $code, $previous, [$missingArgument]);
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getMissingArgument(): string
+    {
+        return $this->missingArgument;
+    }
+}

--- a/src/Symfony/Component/Serializer/Exception/MissingConstructorArgumentsException.php
+++ b/src/Symfony/Component/Serializer/Exception/MissingConstructorArgumentsException.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Serializer\Exception;
 
 /**
+ * @deprecated since Symfony 6.3, use {@see MissingConstructorArgumentException} instead
+ *
  * @author Maxime VEBER <maxime.veber@nekland.fr>
  */
 class MissingConstructorArgumentsException extends RuntimeException
@@ -23,16 +25,24 @@ class MissingConstructorArgumentsException extends RuntimeException
 
     public function __construct(string $message, int $code = 0, \Throwable $previous = null, array $missingArguments = [])
     {
+        if (!$this instanceof MissingConstructorArgumentException) {
+            trigger_deprecation('symfony/serializer', '6.3', 'The "%s" class is deprecated, use "%s" instead.', __CLASS__, MissingConstructorArgumentException::class);
+        }
+
         $this->missingArguments = $missingArguments;
 
         parent::__construct($message, $code, $previous);
     }
 
     /**
+     * @deprecated since Symfony 6.3, use {@see MissingConstructorArgumentException::getMissingArgument()} instead
+     *
      * @return string[]
      */
     public function getMissingConstructorArguments(): array
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "%s::getMissingArgument()" instead.', __METHOD__, MissingConstructorArgumentException::class);
+
         return $this->missingArguments;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Serializer\Normalizer;
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
-use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
+use Symfony\Component\Serializer\Exception\MissingConstructorArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
@@ -308,7 +308,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      * @return object
      *
      * @throws RuntimeException
-     * @throws MissingConstructorArgumentsException
+     * @throws MissingConstructorArgumentException
      */
     protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null)
     {
@@ -381,7 +381,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                     $params[] = null;
                 } else {
                     if (!isset($context['not_normalizable_value_exceptions'])) {
-                        throw new MissingConstructorArgumentsException(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires parameter "%s" to be present.', $class, $constructorParameter->name), 0, null, [$constructorParameter->name]);
+                        throw new MissingConstructorArgumentException($class, $constructorParameter->name);
                     }
 
                     $exception = NotNormalizableValueException::createForUnexpectedDataType(
@@ -425,7 +425,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             }
         } catch (\ReflectionException $e) {
             throw new RuntimeException(sprintf('Could not determine the class of the parameter "%s".', $parameterName), 0, $e);
-        } catch (MissingConstructorArgumentsException $e) {
+        } catch (MissingConstructorArgumentException $e) {
             if (!$parameter->getType()->allowsNull()) {
                 throw $e;
             }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -22,7 +22,7 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\LogicException;
-use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
+use Symfony\Component\Serializer\Exception\MissingConstructorArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
@@ -417,7 +417,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      *
      * @throws NotNormalizableValueException
      * @throws ExtraAttributesException
-     * @throws MissingConstructorArgumentsException
+     * @throws MissingConstructorArgumentException
      * @throws LogicException
      */
     private function validateAndDenormalize(array $types, string $currentClass, string $attribute, mixed $data, ?string $format, array $context): mixed
@@ -565,7 +565,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 }
 
                 $extraAttributesException ??= $e;
-            } catch (MissingConstructorArgumentsException $e) {
+            } catch (MissingConstructorArgumentException $e) {
                 if (!$isUnionType) {
                     throw $e;
                 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ConstructorArgumentsTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ConstructorArgumentsTestTrait.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 
-use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
+use Symfony\Component\Serializer\Exception\MissingConstructorArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\NotSerializedConstructorArgumentDummy;
 
@@ -63,8 +63,13 @@ trait ConstructorArgumentsTestTrait
 
         $normalizer = $this->getDenormalizerForConstructArguments();
 
-        $this->expectException(MissingConstructorArgumentsException::class);
-        $this->expectExceptionMessage('Cannot create an instance of "'.ConstructorArgumentsObject::class.'" from serialized data because its constructor requires parameter "bar" to be present.');
-        $normalizer->denormalize($data, ConstructorArgumentsObject::class);
+        try {
+            $normalizer->denormalize($data, ConstructorArgumentsObject::class);
+            self::fail(sprintf('Failed asserting that exception of type "%s" is thrown.', MissingConstructorArgumentException::class));
+        } catch (MissingConstructorArgumentException $e) {
+            self::assertSame(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires parameter "bar" to be present.', ConstructorArgumentsObject::class), $e->getMessage());
+            self::assertSame(ConstructorArgumentsObject::class, $e->getClass());
+            self::assertSame('bar', $e->getMissingArgument());
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Followup to #42712.

Currently only the missing arguments are saved in the `MissingConstructorArgumentsException`, so there's no way of knowing which class is missing those arguments when nested objects are being deserialized. This PR adds this information to the exception.

Also, while working on this I've noticed that the `$missingArguments` argument accepts an array of missing arguments, but only one is ever passed. I'm not sure if this was done intentionally or by accident, but I've changed it so that only one is expected. Please let me know if this change is ok.

UPDATE:
I've added a new `MissingConstructorArgumentException` class which accepts only one argument and the class name and deprecated the `MissingConstructorArgumentsException` class. However, since the main goal of this PR is to add the class to the exception, I can revert the renaming part if you think the change is not worth it.