### PR TITLE
[Security] Added condition to always return the real Authenticator from security events

### DIFF
--- a/src/Symfony/Component/Security/Http/Event/CheckPassportEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/CheckPassportEvent.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Event;
 
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -37,7 +38,7 @@ class CheckPassportEvent extends Event
 
     public function getAuthenticator(): AuthenticatorInterface
     {
-        return $this->authenticator;
+        return $this->authenticator instanceof TraceableAuthenticator ? $this->authenticator->getAuthenticator() : $this->authenticator;
     }
 
     public function getPassport(): Passport

--- a/src/Symfony/Component/Security/Http/Event/LoginFailureEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LoginFailureEvent.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -52,7 +53,7 @@ class LoginFailureEvent extends Event
 
     public function getAuthenticator(): AuthenticatorInterface
     {
-        return $this->authenticator;
+        return $this->authenticator instanceof TraceableAuthenticator ? $this->authenticator->getAuthenticator() : $this->authenticator;
     }
 
     public function getFirewallName(): string

--- a/src/Symfony/Component/Security/Http/Event/LoginSuccessEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LoginSuccessEvent.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -50,7 +51,7 @@ class LoginSuccessEvent extends Event
 
     public function getAuthenticator(): AuthenticatorInterface
     {
-        return $this->authenticator;
+        return $this->authenticator instanceof TraceableAuthenticator ? $this->authenticator->getAuthenticator() : $this->authenticator;
     }
 
     public function getPassport(): Passport


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no / maybe
| New feature?  | yes / maybe
| Deprecations? | no
| Tickets       | Fix #49010 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR aims to uniformise the `getAuthenticator` method of several security Events when using the profiler in dev environement.
