### PR TITLE
[SecurityBundle] Make firewalls event dispatcher traceable on debug mode

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Modify "icon.svg" to improve accessibility for blind/low vision users
  * Make `Security::login()` return the authenticator response
  * Deprecate the `security.firewalls.logout.csrf_token_generator` config option, use `security.firewalls.logout.csrf_token_manager` instead
+ * Make firewalls event dispatcher traceable on debug mode
 
 6.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/MakeFirewallsEventDispatcherTraceablePass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/MakeFirewallsEventDispatcherTraceablePass.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
+
+/**
+ * @author Mathieu Lechat <mathieu.lechat@les-tilleuls.coop>
+ */
+class MakeFirewallsEventDispatcherTraceablePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('event_dispatcher') || !$container->hasParameter('security.firewalls')) {
+            return;
+        }
+
+        if (!$container->getParameter('kernel.debug') || !$container->has('debug.stopwatch')) {
+            return;
+        }
+
+        $dispatchersId = [];
+
+        foreach ($container->getParameter('security.firewalls') as $firewallName) {
+            $dispatcherId = 'security.event_dispatcher.'.$firewallName;
+
+            if (!$container->has($dispatcherId)) {
+                continue;
+            }
+
+            $dispatchersId[$dispatcherId] = 'debug.'.$dispatcherId;
+
+            $container->register($dispatchersId[$dispatcherId], TraceableEventDispatcher::class)
+                ->setDecoratedService($dispatcherId)
+                ->setArguments([
+                    new Reference($dispatchersId[$dispatcherId].'.inner'),
+                    new Reference('debug.stopwatch'),
+                    new Reference('logger', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                    new Reference('request_stack', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                ]);
+        }
+
+        foreach (['kernel.event_subscriber', 'kernel.event_listener'] as $tagName) {
+            foreach ($container->findTaggedServiceIds($tagName) as $taggedServiceId => $tags) {
+                $taggedServiceDefinition = $container->findDefinition($taggedServiceId);
+                $taggedServiceDefinition->clearTag($tagName);
+
+                foreach ($tags as $tag) {
+                    if ($dispatcherId = $tag['dispatcher'] ?? null) {
+                        $tag['dispatcher'] = $dispatchersId[$dispatcherId] ?? $dispatcherId;
+                    }
+                    $taggedServiceDefinition->addTag($tagName, $tag);
+                }
+            }
+        }
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddExpressionLang
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSessionDomainConstraintPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\CleanRememberMeVerifierPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\MakeFirewallsEventDispatcherTraceablePass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterCsrfFeaturesPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterEntryPointPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterGlobalSecurityEventListenersPass;
@@ -92,5 +93,8 @@ class SecurityBundle extends Bundle
             AuthenticationEvents::ALIASES,
             SecurityEvents::ALIASES
         )));
+
+        // must be registered before DecoratorServicePass
+        $container->addCompilerPass(new MakeFirewallsEventDispatcherTraceablePass(), PassConfig::TYPE_OPTIMIZE, 10);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/MakeFirewallsEventDispatcherTraceablePassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/MakeFirewallsEventDispatcherTraceablePassTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class MakeFirewallsEventDispatcherTraceablePassTest extends TestCase
+{
+    private $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new ContainerBuilder();
+        $this->container->register('request_stack', \stdClass::class);
+        $this->container->register('event_dispatcher', EventDispatcher::class);
+        $this->container->register('debug.stopwatch', Stopwatch::class);
+
+        $this->container->registerExtension(new SecurityExtension());
+        $this->container->loadFromExtension('security', [
+            'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
+        ]);
+
+        $this->container->addCompilerPass(new DecoratorServicePass(), PassConfig::TYPE_OPTIMIZE);
+        $this->container->getCompilerPassConfig()->setRemovingPasses([]);
+        $this->container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+
+        $securityBundle = new SecurityBundle();
+        $securityBundle->build($this->container);
+    }
+
+    public function testEventDispatcherIsDecoratedOnDebugMode()
+    {
+        $this->container->setParameter('kernel.debug', true);
+
+        $this->container->compile();
+
+        $dispatcherDefinition = $this->container->findDefinition('security.event_dispatcher.main');
+
+        $this->assertSame(TraceableEventDispatcher::class, $dispatcherDefinition->getClass());
+        $this->assertSame(
+            [['name' => 'security.event_dispatcher.main']],
+            $dispatcherDefinition->getTag('event_dispatcher.dispatcher')
+        );
+    }
+
+    public function testEventDispatcherIsNotDecoratedOnNonDebugMode()
+    {
+        $this->container->setParameter('kernel.debug', false);
+
+        $this->container->compile();
+
+        $dispatcherDefinition = $this->container->findDefinition('security.event_dispatcher.main');
+
+        $this->assertSame(EventDispatcher::class, $dispatcherDefinition->getClass());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #42973
| License       | MIT
| Doc PR        | N/A

This PR decorates firewalls event dispatcher with `TraceableEventDispatcher` on debug mode. This will display security events and listeners in the profiler’s `time` panel.

<details><summary>Before</summary>
<img src="https://user-images.githubusercontent.com/1898254/213448612-74385c7b-2a95-4615-be7a-d0ac84fa15d9.png">
</details>
<details><summary>After</summary>
<img src="https://user-images.githubusercontent.com/1898254/213448822-5a9cfda1-e843-4c03-b596-9c04bac80b1d.png">
</details>

They still won’t appear in the `events` panel (because the `EventDataCollector` is only injected `debug.event_dispatcher`) but I think it will be best handled in a separate PR.