### PR TITLE
[DependencyInjection] Add missing template notation on ServiceLocator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
@@ -23,6 +23,9 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
 /**
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @template-covariant T of mixed
+ * @implements ServiceProviderInterface<T>
  */
 class ServiceLocator implements ServiceProviderInterface, \Countable
 {

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -384,7 +384,7 @@ class DebugClassLoader
 
         // Detect annotations on the class
         if ($doc = $this->parsePhpDoc($refl)) {
-            $classIsTemplate = isset($doc['template']);
+            $classIsTemplate = isset($doc['template']) || isset($doc['template-covariant']);
 
             foreach (['final', 'deprecated', 'internal'] as $annotation) {
                 if (null !== $description = $doc[$annotation][0] ?? null) {
@@ -531,7 +531,7 @@ class DebugClassLoader
             // To read method annotations
             $doc = $this->parsePhpDoc($method);
 
-            if (($classIsTemplate || isset($doc['template'])) && $method->hasReturnType()) {
+            if (($classIsTemplate || isset($doc['template']) || isset($doc['template-covariant'])) && $method->hasReturnType()) {
                 unset($doc['return']);
             }
 

--- a/src/Symfony/Contracts/Service/ServiceProviderInterface.php
+++ b/src/Symfony/Contracts/Service/ServiceProviderInterface.php
@@ -19,7 +19,7 @@ use Psr\Container\ContainerInterface;
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Mateusz Sip <mateusz.sip@gmail.com>
  *
- * @template T of mixed
+ * @template-covariant T of mixed
  */
 interface ServiceProviderInterface extends ContainerInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Simply adding a missing `@template` on ServiceLocator. As explained in the docs here : https://phpstan.org/blog/generics-by-examples#specify-template-type-variable-of-a-generic-interface-when-implementing-it any child class that is also a generic must redeclare it.