### PR TITLE
[Notifier] [OvhCloud] handle invalid receiver

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -121,6 +121,10 @@ final class OvhCloudTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
+        if (!isset($success['ids'][0])) {
+            throw new TransportException(sprintf('Attempt to send the SMS to invalid receivers: "%s".', implode(',', $success['invalidReceivers'])), $response);
+        }
+
         $sentMessage = new SentMessage($message, (string) $this);
         $sentMessage->setMessageId($success['ids'][0]);
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\OvhCloud\Tests;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransport;
+use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -91,5 +92,27 @@ final class OvhCloudTransportTest extends TransportTestCase
         $endpoint = 'https://eu.api.ovh.com/1.0/sms/serviceName/jobs';
         $toSign = 'applicationSecret+consumerKey+POST+'.$endpoint.'+'.$body.'+'.$time;
         $this->assertSame('$1$'.sha1($toSign), $signature);
+    }
+
+    public function testInvalidReceiver()
+    {
+        $smsMessage = new SmsMessage('invalid_receiver', 'lorem ipsum');
+
+        $data = json_encode([
+            'totalCreditsRemoved' => '1',
+            'invalidReceivers' => ['invalid_receiver'],
+            'ids' => [],
+            'validReceivers' => [],
+        ]);
+        $responses = [
+            new MockResponse((string) time()),
+            new MockResponse($data),
+        ];
+
+        $transport = $this->createTransport(new MockHttpClient($responses));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Attempt to send the SMS to invalid receivers: "invalid_receiver"');
+        $transport->send($smsMessage);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| License       | MIT

Fix `Undefined offset: 0` error when invalid receiver is provided