### PR TITLE
[Clock] Make ClockAwareTrait use the global clock by default

### DIFF
--- a/src/Symfony/Component/Clock/ClockAwareTrait.php
+++ b/src/Symfony/Component/Clock/ClockAwareTrait.php
@@ -31,6 +31,6 @@ trait ClockAwareTrait
 
     protected function now(): \DateTimeImmutable
     {
-        return ($this->clock ??= new NativeClock())->now();
+        return ($this->clock ??= new Clock())->now();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Let's make `ClockAwareTrait` compatible with `Clock::now()` from #48642 by default.