### PR TITLE
[Security] Introduce template for Voter phpdoc

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
@@ -18,6 +18,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  *
  * @author Roman Marintšenko <inoryy@gmail.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @template TAttribute of string
+ * @template TSubject of mixed
  */
 abstract class Voter implements VoterInterface, CacheableVoterInterface
 {
@@ -74,13 +77,19 @@ abstract class Voter implements VoterInterface, CacheableVoterInterface
     /**
      * Determines if the attribute and subject are supported by this voter.
      *
-     * @param $subject The subject to secure, e.g. an object the user wants to access or any other PHP type
+     * @param mixed $subject The subject to secure, e.g. an object the user wants to access or any other PHP type
+     *
+     * @psalm-assert-if-true TSubject $subject
+     * @psalm-assert-if-true TAttribute $attribute
      */
     abstract protected function supports(string $attribute, mixed $subject): bool;
 
     /**
      * Perform a single access check operation on a given attribute, subject and token.
      * It is safe to assume that $attribute and $subject already passed the "supports()" method check.
+     *
+     * @param TAttribute $attribute
+     * @param TSubject   $subject
      */
     abstract protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This template allows phpstan/psam/PHPStorm to fully understand the type of `$attribute` and `$subject` when writing a Voter. For instance, if I write
```
return $subject instance User && $attribute === 'EDIT';
```
I can annotate the Voter as `Voter<'EDIT', User>` and
- Static analysis will check that supports is doing the right checks.
- PHPStorm will autocomplete calls like `$subject->getId()` when writing inside the `voteOnAttribute`.
- SA tools will not complain about non existing methods on mixed.

The last two points are considered as valid because of the comment
> It is safe to assume that $attribute and $subject already passed the "supports()" method check.

Since this is an important point for Sf, all those annotations are supported by both psalm and phpstan, and understood (or ignored for psalm-assert-if-true) by PHPStorm.