### PR TITLE
[Security] Return default value instead of deferring to lower prio resolvers when using #[CurrentUser] and no user is found

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Security\Http\Controller\UserValueResolver;
 class UserValueResolverTest extends TestCase
 {
     /**
-     * In Symfony 7, keep this test case but remove the call to supports()
+     * In Symfony 7, keep this test case but remove the call to supports().
      *
      * @group legacy
      */
@@ -43,7 +43,7 @@ class UserValueResolverTest extends TestCase
     }
 
     /**
-     * In Symfony 7, keep this test case but remove the call to supports()
+     * In Symfony 7, keep this test case but remove the call to supports().
      *
      * @group legacy
      */
@@ -51,10 +51,10 @@ class UserValueResolverTest extends TestCase
     {
         $tokenStorage = new TokenStorage();
         $resolver = new UserValueResolver($tokenStorage);
-        $metadata = new ArgumentMetadata('foo', UserInterface::class, false, true, new InMemoryUser('username', 'password'));
+        $metadata = new ArgumentMetadata('foo', UserInterface::class, false, true, $default = new InMemoryUser('username', 'password'));
 
-        $this->assertSame([], $resolver->resolve(Request::create('/'), $metadata));
-        $this->assertFalse($resolver->supports(Request::create('/'), $metadata));
+        $this->assertSame([$default], $resolver->resolve(Request::create('/'), $metadata));
+        $this->assertTrue($resolver->supports(Request::create('/'), $metadata));
     }
 
     public function testResolveSucceedsWithUserInterface()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The issue here is that if you have an action with `fooAction(string $email, #[CurrentUser] User $user = null)` i.e. you want the current user if logged in but otherwise null, if there is no user logged in the EntityValueResolver gets called after UserValueResolver, and if you also have another param which would allow it to try to resolve a User it will do so as it is a mapped entity. But if it gives you a random user here instead of the logged user this is BAD :)
