### PR TITLE
[HttpFoundation] Feature: Introduce flashbag cache to Twig AppVariable

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Flash/CachedFlashBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/CachedFlashBag.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Flash;
+
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * FlashBag decorator to allow multiple reads from a wrapped FlashBag.
+ * Intended to be used for a complete rendering of a response and disposed afterwards to keep the FlashBag behaviour.
+ *
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+class CachedFlashBag implements FlashBagInterface, ResetInterface
+{
+    /**
+     * @var array<string, array>
+     */
+    private array $cache = [];
+
+    public function __construct(private readonly FlashBagInterface $decorated)
+    {
+    }
+
+    public function getName(): string
+    {
+        return $this->getDecorated()->getName();
+    }
+
+    public function initialize(array &$flashes)
+    {
+        return $this->getDecorated()->initialize($flashes);
+    }
+
+    public function add(string $type, mixed $message)
+    {
+        return $this->getDecorated()->add($type, $message);
+    }
+
+    public function peek(string $type, array $default = []): array
+    {
+        $uncached = $this->getDecorated()->peek($type, $default);
+
+        return $this->mergeWithCached([$type => $uncached], $type);
+    }
+
+    public function peekAll(): array
+    {
+        return $this->mergeWithAllCached($this->getDecorated()->peekAll());
+    }
+
+    public function get(string $type, array $default = []): array
+    {
+        $uncached = $this->getDecorated()->get($type, $default);
+        $result = $this->mergeWithCached([$type => $uncached], $type);
+        $this->addToCache([$type => $uncached]);
+
+        return $result;
+    }
+
+    public function all(): array
+    {
+        return $this->mergeWithAllCached($this->getDecorated()->all());
+    }
+
+    public function set(string $type, string|array $messages)
+    {
+        $this->removeFromCache([$type]);
+
+        return $this->getDecorated()->set($type, $messages);
+    }
+
+    public function setAll(array $messages)
+    {
+        $this->removeFromCache(\array_keys($messages));
+
+        return $this->getDecorated()->setAll($messages);
+    }
+
+    public function has(string $type): bool
+    {
+        return $this->getDecorated()->has($type) || isset($this->cache[$type]);
+    }
+
+    public function keys(): array
+    {
+        return $this->mergeWithCachedKeys($this->getDecorated()->keys());
+    }
+
+    public function getStorageKey(): string
+    {
+        return $this->getDecorated()->getStorageKey();
+    }
+
+    public function clear(): mixed
+    {
+        return $this->getDecorated()->clear();
+    }
+
+    public function reset(): void
+    {
+        $this->cache = [];
+    }
+
+    public function getDecorated(): FlashBagInterface
+    {
+        return $this->decorated;
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     * @return array<string, mixed>
+     */
+    private function mergeWithCached(array $array, string $type): array
+    {
+        return \array_merge_recursive($array, $this->cache[$type] ?? []);
+    }
+
+    /**
+     * @param array<string, array> $array
+     * @return array<string, array>
+     */
+    private function mergeWithAllCached(array $array): array
+    {
+        $result = $array;
+
+        foreach ($this->cache as $type => $messages) {
+            $result[$type] = $this->mergeWithCached($messages, $type);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string[] $keys
+     * @return string[]
+     */
+    private function mergeWithCachedKeys(array $keys): array
+    {
+        return \array_unique(\array_merge($keys, \array_keys($this->cache)));
+    }
+
+    /**
+     * @param string[] $cacheKeys
+     */
+    private function removeFromCache(array $cacheKeys): void
+    {
+        foreach ($cacheKeys as $key) {
+            unset($this->cache[$key]);
+        }
+    }
+
+    /**
+     * @param array<string, array> $messages
+     */
+    private function addToCache(array $messages): void
+    {
+        foreach ($messages as $key => $value) {
+            $this->cache[$key] = \array_merge_recursive($value, $this->cache[$key] ?? []);
+        }
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpFoundation\Session;
 
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpFoundation\Session\Flash\CachedFlashBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
@@ -50,6 +51,11 @@ class Session implements FlashBagAwareSessionInterface, \IteratorAggregate, \Cou
         $this->registerBag($attributes);
 
         $flashes ??= new FlashBag();
+
+        if (!$flashes instanceof CachedFlashBag) {
+            $flashes = new CachedFlashBag($flashes);
+        }
+
         $this->flashName = $flashes->getName();
         $this->registerBag($flashes);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

So this change is coming from a [PR at Shopware](https://github.com/shopware/platform/pull/2694/) which shall help intercompatibility of flashbag usage in a multi vendor application when using plugins trying to access the flashbag content.

In Shopware you have a section in the checkout that renders flashbag entries containing error/warning/info messages:

https://github.com/shopware/platform/blob/d6c853ca3b6b167d61d70e6329f4fcface5c5245/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig#L12-L18

```
{% block base_flashbags_checkout %}
    <div class="flashbags">
        {% for type, messages in app.flashes %}
            {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: type, list: messages } %}
        {% endfor %}
    </div>
{% endblock %}
```

This happens not as early in the template as some like to want. The content is also not stored in a variable which makes it difficult to re-access the content.

So now I want to display the content in a different form for mobile users. For that I have to move it somewhere else, store it in a variable and override the block and use a stored variation of the flashbag:

```
{% extends ... %}

{% block other_block %}
    {% set myPluginFlashes = app.flashes %}
    {% set myPluginErrorMessages in myPluginFlashes.error|default([]) %}

    {% for error in myPluginErrorMessages %}
        {# Do some fancy mobile notification popup style stuff #}
    {% endfor %}
{% endblock %}

{% block base_flashbags_checkout %}
    <div class="flashbags">
        {% for type, messages in myPluginFlashes %}
            {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: type, list: messages } %}
        {% endfor %}
    </div>
{% endblock %}
```

Now imagine every Shopware extension does it this way. This will break easily and will not work well together.

In a perfect world I could just write:

```
{% extends ... %}

{% block other_block %}
    {% for error in app.flashes('error') %}
        {# Do some fancy mobile notification popup style stuff #}
    {% endfor %}
{% endblock %}
```

My thoughts/journey:
So therefore I just cache it in the flashbag. But wait. The flashbag is made to forget. But it has a peek method. I could use the peek instead of the get in the AppVariable. But then the flashbag never forgets what has been used. I could forward the flashbag peek to the AppVariable as new method. But then everyone has to use "the right method". To difficult to migrate to, still likely to break. Ok, then I make a cache in the AppVariable so it can forget what it was asked but keep it for the rest of the rendering.

I am not sure whether this is a feature or a bugfix. It does not really feel like a bugfix as it contains a breaking change. But really does not feel like a feature either.


TODOs I was not aware of at the time of writing:

please update src/**/CHANGELOG.md files --- Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
symfony/symfony-docs#... 
 - Always add tests and ensure they pass. (ok, yes I assumed to have to write a test)
