### PR TITLE
[Messenger] Mention the transport which failed during the setup command

### DIFF
--- a/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
+++ b/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
@@ -71,11 +71,16 @@ EOF
 
         foreach ($transportNames as $id => $transportName) {
             $transport = $this->transportLocator->get($transportName);
-            if ($transport instanceof SetupableTransportInterface) {
+            if (!$transport instanceof SetupableTransportInterface) {
+                $io->note(sprintf('The "%s" transport does not support setup.', $transportName));
+                continue;
+            }
+
+            try {
                 $transport->setup();
                 $io->success(sprintf('The "%s" transport was set up successfully.', $transportName));
-            } else {
-                $io->note(sprintf('The "%s" transport does not support setup.', $transportName));
+            } catch (\Exception $e) {
+                throw new \RuntimeException(sprintf('An error occurred while setting up the "%s" transport: ', $transportName).$e->getMessage(), 0, $e);
             }
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
@@ -72,8 +72,6 @@ class SetupTransportsCommandTest extends TestCase
 
     public function testReceiverNameArgumentNotFound()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The "not_found" transport does not exist.');
         // mock a service locator
         /** @var MockObject&ServiceLocator $serviceLocator */
         $serviceLocator = $this->createMock(ServiceLocator::class);
@@ -86,7 +84,38 @@ class SetupTransportsCommandTest extends TestCase
 
         $command = new SetupTransportsCommand($serviceLocator, ['amqp', 'other_transport']);
         $tester = new CommandTester($command);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The "not_found" transport does not exist.');
         $tester->execute(['transport' => 'not_found']);
+    }
+
+    public function testThrowsExceptionOnTransportSetup()
+    {
+        // mock a setupable-transport, that throws
+        $amqpTransport = $this->createMock(SetupableTransportInterface::class);
+        $amqpTransport->expects($this->exactly(1))
+            ->method('setup')
+            ->willThrowException(new \RuntimeException('Server not found'));
+
+        // mock a service locator
+        /** @var MockObject&ServiceLocator $serviceLocator */
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator->expects($this->exactly(1))
+            ->method('get')
+            ->will($this->onConsecutiveCalls(
+                $amqpTransport
+            ));
+        $serviceLocator
+            ->method('has')
+            ->willReturn(true);
+
+        $command = new SetupTransportsCommand($serviceLocator, ['amqp']);
+        $tester = new CommandTester($command);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('An error occurred while setting up the "amqp" transport: Server not found');
+        $tester->execute(['transport' => 'amqp']);
     }
 
     /**


### PR DESCRIPTION
The transport name can help to further investigate the underlying reasons of the failure

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | -

I am not sure if this can be labelled as a new feature, but the addition from this PR can help to further investigate errors while setting up an application's transports.

At the moment, if an error occurs while setting up a transport just the exception is thrown, with no context on which transport was being setup.