### PR TITLE
[Runtime] Fix for Windows when projects are deployed on junctions/symlinks

### DIFF
--- a/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php
+++ b/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php
@@ -58,7 +58,7 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
 
     public function updateAutoloadFile(): void
     {
-        $vendorDir = $this->composer->getConfig()->get('vendor-dir');
+        $vendorDir = realpath($this->composer->getConfig()->get('vendor-dir'));
 
         if (!is_file($autoloadFile = $vendorDir.'/autoload.php')
             || false === $extra = $this->composer->getPackage()->getExtra()['runtime'] ?? []


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49041
| License       | MIT
| Doc PR        | none

On windows systems where a project directory may be located at a directory that is a junction to a path on another drive, realpath() must be called on both sides of a call to `Filesystem::makePathRelative($path1,$path2)`. Otherwise the result will be an irresolvable comparison across filesystems and the return value will be the value of $path1, not a relative path. 
