### PR TITLE
[FrameworkBundle] conflict with symfony/dom-crawler < 6.3

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -80,7 +80,7 @@
         "symfony/console": "<5.4",
         "symfony/dotenv": "<5.4",
         "symfony/dom-crawler": "<5.4",
-        "symfony/http-client": "<5.4",
+        "symfony/http-client": "<6.3",
         "symfony/form": "<5.4",
         "symfony/lock": "<5.4",
         "symfony/mailer": "<5.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This way we avoid surprising exceptions when the DomCrawlerAssertionsTrait's assertSelectorCount() method is used with an older version of the DomCrawler component.