### PR TITLE
[HtmlSanitizer] Don't HTML encode Base64 data passed in `src` attribute

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -447,6 +447,14 @@ class HtmlSanitizerAllTest extends TestCase
                 '<img title />',
             ],
             [
+                '<img src="data:image/jpg;base64,aMf+Tct/RLn2WQ==" />',
+                '<img src="data:image/jpg;base64,aMf+Tct/RLn2WQ==" />',
+            ],
+            [
+                '<img src="aMf+Tct/RLn2WQ==" />',
+                '<img src="aMf&#43;Tct/RLn2WQ&#61;&#61;" />',
+            ],
+            [
                 '<i>Lorem ipsum</i>',
                 '<i>Lorem ipsum</i>',
             ],

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
@@ -39,6 +39,10 @@ final class Node implements NodeInterface
         'wbr' => true,
     ];
 
+    private const VALID_BASE64_ATTRIBUTES = [
+        'src',
+    ];
+
     private NodeInterface $parent;
     private string $tagName;
     private array $attributes = [];
@@ -114,12 +118,23 @@ final class Node implements NodeInterface
                     $value .= ' ';
                 }
 
-                $attr .= '="'.StringSanitizer::encodeHtmlEntities($value).'"';
+                if (\in_array($name, self::VALID_BASE64_ATTRIBUTES, true) && $this->isValidBase64Src($value)) {
+                    $attr .= '="'.$value.'"';
+                } else {
+                    $attr .= '="'.StringSanitizer::encodeHtmlEntities($value).'"';
+                }
             }
 
             $rendered[] = $attr;
         }
 
         return $rendered ? ' '.implode(' ', $rendered) : '';
+    }
+
+    private function isValidBase64Src(string $string): bool
+    {
+        $string = preg_replace('/data:(.+);base64,/', '', $string, -1, $count);
+
+        return 0 !== $count && false !== base64_decode($string, true);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #49040 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | _NA_
