### PR TITLE
[Tests] New iteration of removing `$this` occurrences in future static data providers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -45,9 +45,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $routes);
     }
 
-    public function getDescribeRouteCollectionTestData()
+    public static function getDescribeRouteCollectionTestData(): array
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getRouteCollections());
+        return static::getDescriptionTestData(ObjectsProvider::getRouteCollections());
     }
 
     /** @dataProvider getDescribeRouteTestData */
@@ -56,9 +56,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $route);
     }
 
-    public function getDescribeRouteTestData()
+    public static function getDescribeRouteTestData(): array
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getRoutes());
+        return static::getDescriptionTestData(ObjectsProvider::getRoutes());
     }
 
     /** @dataProvider getDescribeContainerParametersTestData */
@@ -67,9 +67,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $parameters);
     }
 
-    public function getDescribeContainerParametersTestData()
+    public static function getDescribeContainerParametersTestData(): array
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getContainerParameters());
+        return static::getDescriptionTestData(ObjectsProvider::getContainerParameters());
     }
 
     /** @dataProvider getDescribeContainerBuilderTestData */
@@ -78,9 +78,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $builder, $options);
     }
 
-    public function getDescribeContainerBuilderTestData()
+    public static function getDescribeContainerBuilderTestData(): array
     {
-        return $this->getContainerBuilderDescriptionTestData(ObjectsProvider::getContainerBuilders());
+        return static::getContainerBuilderDescriptionTestData(ObjectsProvider::getContainerBuilders());
     }
 
     /**
@@ -91,9 +91,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $definition);
     }
 
-    public function getDescribeContainerExistingClassDefinitionTestData()
+    public static function getDescribeContainerExistingClassDefinitionTestData(): array
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getContainerDefinitionsWithExistingClasses());
+        return static::getDescriptionTestData(ObjectsProvider::getContainerDefinitionsWithExistingClasses());
     }
 
     /** @dataProvider getDescribeContainerDefinitionTestData */
@@ -102,9 +102,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $definition);
     }
 
-    public function getDescribeContainerDefinitionTestData()
+    public static function getDescribeContainerDefinitionTestData(): array
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getContainerDefinitions());
+        return static::getDescriptionTestData(ObjectsProvider::getContainerDefinitions());
     }
 
     /** @dataProvider getDescribeContainerDefinitionWithArgumentsShownTestData */
@@ -113,7 +113,7 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $definition, ['show_arguments' => true]);
     }
 
-    public function getDescribeContainerDefinitionWithArgumentsShownTestData()
+    public static function getDescribeContainerDefinitionWithArgumentsShownTestData(): array
     {
         $definitions = ObjectsProvider::getContainerDefinitions();
         $definitionsWithArgs = [];
@@ -126,7 +126,7 @@ abstract class AbstractDescriptorTest extends TestCase
             $definitionsWithArgs['definition_arguments_with_enum'] = (new Definition('definition_with_enum'))->setArgument(0, FooUnitEnum::FOO);
         }
 
-        return $this->getDescriptionTestData($definitionsWithArgs);
+        return static::getDescriptionTestData($definitionsWithArgs);
     }
 
     /** @dataProvider getDescribeContainerAliasTestData */
@@ -135,9 +135,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $alias);
     }
 
-    public function getDescribeContainerAliasTestData()
+    public static function getDescribeContainerAliasTestData(): array
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getContainerAliases());
+        return static::getDescriptionTestData(ObjectsProvider::getContainerAliases());
     }
 
     /** @dataProvider getDescribeContainerDefinitionWhichIsAnAliasTestData */
@@ -146,7 +146,7 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $builder, $options);
     }
 
-    public function getDescribeContainerDefinitionWhichIsAnAliasTestData()
+    public static function getDescribeContainerDefinitionWhichIsAnAliasTestData(): array
     {
         $builder = current(ObjectsProvider::getContainerBuilders());
         $builder->setDefinition('service_1', $builder->getDefinition('definition_1'));
@@ -159,7 +159,7 @@ abstract class AbstractDescriptorTest extends TestCase
         }
 
         $i = 0;
-        $data = $this->getDescriptionTestData($aliasesWithDefinitions);
+        $data = static::getDescriptionTestData($aliasesWithDefinitions);
         foreach ($aliases as $name => $alias) {
             $file = array_pop($data[$i]);
             $data[$i][] = $builder;
@@ -177,9 +177,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $parameter, $options);
     }
 
-    public function getDescribeContainerParameterTestData()
+    public static function getDescribeContainerParameterTestData(): array
     {
-        $data = $this->getDescriptionTestData(ObjectsProvider::getContainerParameter());
+        $data = static::getDescriptionTestData(ObjectsProvider::getContainerParameter());
 
         $file = array_pop($data[0]);
         $data[0][] = ['parameter' => 'database_name'];
@@ -197,9 +197,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $eventDispatcher, $options);
     }
 
-    public function getDescribeEventDispatcherTestData()
+    public static function getDescribeEventDispatcherTestData(): array
     {
-        return $this->getEventDispatcherDescriptionTestData(ObjectsProvider::getEventDispatchers());
+        return static::getEventDispatcherDescriptionTestData(ObjectsProvider::getEventDispatchers());
     }
 
     /** @dataProvider getDescribeCallableTestData */
@@ -208,13 +208,14 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $callable);
     }
 
-    public function getDescribeCallableTestData(): array
+    public static function getDescribeCallableTestData(): array
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getCallables());
+        return static::getDescriptionTestData(ObjectsProvider::getCallables());
     }
 
     /**
      * @group legacy
+     *
      * @dataProvider getDescribeDeprecatedCallableTestData
      */
     public function testDescribeDeprecatedCallable($callable, $expectedDescription)
@@ -222,9 +223,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $callable);
     }
 
-    public function getDescribeDeprecatedCallableTestData(): array
+    public static function getDescribeDeprecatedCallableTestData(): array
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getDeprecatedCallables());
+        return static::getDescriptionTestData(ObjectsProvider::getDeprecatedCallables());
     }
 
     /** @dataProvider getClassDescriptionTestData */
@@ -233,7 +234,7 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertEquals($expectedDescription, $this->getDescriptor()->getClassDescription($object));
     }
 
-    public function getClassDescriptionTestData()
+    public static function getClassDescriptionTestData(): array
     {
         return [
             [ClassWithDocCommentOnMultipleLines::class, 'This is the first line of the description. This is the second line.'],
@@ -251,14 +252,14 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $builder, ['deprecations' => true]);
     }
 
-    public function getDeprecationsTestData()
+    public static function getDeprecationsTestData(): array
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getContainerDeprecations());
+        return static::getDescriptionTestData(ObjectsProvider::getContainerDeprecations());
     }
 
-    abstract protected function getDescriptor();
+    abstract protected static function getDescriptor();
 
-    abstract protected function getFormat();
+    abstract protected static function getFormat();
 
     private function assertDescription($expectedDescription, $describedObject, array $options = [])
     {
@@ -280,11 +281,11 @@ abstract class AbstractDescriptorTest extends TestCase
         }
     }
 
-    private function getDescriptionTestData(iterable $objects)
+    private static function getDescriptionTestData(iterable $objects): array
     {
         $data = [];
         foreach ($objects as $name => $object) {
-            $file = sprintf('%s.%s', trim($name, '.'), $this->getFormat());
+            $file = sprintf('%s.%s', trim($name, '.'), static::getFormat());
             $description = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
             $data[] = [$object, $description, $file];
         }
@@ -292,7 +293,7 @@ abstract class AbstractDescriptorTest extends TestCase
         return $data;
     }
 
-    private function getContainerBuilderDescriptionTestData(array $objects)
+    private static function getContainerBuilderDescriptionTestData(array $objects): array
     {
         $variations = [
             'services' => ['show_hidden' => true],
@@ -305,7 +306,7 @@ abstract class AbstractDescriptorTest extends TestCase
         $data = [];
         foreach ($objects as $name => $object) {
             foreach ($variations as $suffix => $options) {
-                $file = sprintf('%s_%s.%s', trim($name, '.'), $suffix, $this->getFormat());
+                $file = sprintf('%s_%s.%s', trim($name, '.'), $suffix, static::getFormat());
                 $description = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
                 $data[] = [$object, $description, $options, $file];
             }
@@ -314,7 +315,7 @@ abstract class AbstractDescriptorTest extends TestCase
         return $data;
     }
 
-    private function getEventDispatcherDescriptionTestData(array $objects)
+    private static function getEventDispatcherDescriptionTestData(array $objects): array
     {
         $variations = [
             'events' => [],
@@ -324,7 +325,7 @@ abstract class AbstractDescriptorTest extends TestCase
         $data = [];
         foreach ($objects as $name => $object) {
             foreach ($variations as $suffix => $options) {
-                $file = sprintf('%s_%s.%s', trim($name, '.'), $suffix, $this->getFormat());
+                $file = sprintf('%s_%s.%s', trim($name, '.'), $suffix, static::getFormat());
                 $description = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
                 $data[] = [$object, $description, $options, $file];
             }
@@ -339,13 +340,13 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $builder, $options);
     }
 
-    public function getDescribeContainerBuilderWithPriorityTagsTestData(): array
+    public static function getDescribeContainerBuilderWithPriorityTagsTestData(): array
     {
         $variations = ['priority_tag' => ['tag' => 'tag1']];
         $data = [];
         foreach (ObjectsProvider::getContainerBuildersWithPriorityTags() as $name => $object) {
             foreach ($variations as $suffix => $options) {
-                $file = sprintf('%s_%s.%s', trim($name, '.'), $suffix, $this->getFormat());
+                $file = sprintf('%s_%s.%s', trim($name, '.'), $suffix, static::getFormat());
                 $description = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
                 $data[] = [$object, $description, $options];
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/JsonDescriptorTest.php
@@ -15,12 +15,12 @@ use Symfony\Bundle\FrameworkBundle\Console\Descriptor\JsonDescriptor;
 
 class JsonDescriptorTest extends AbstractDescriptorTest
 {
-    protected function getDescriptor()
+    protected static function getDescriptor()
     {
         return new JsonDescriptor();
     }
 
-    protected function getFormat()
+    protected static function getFormat()
     {
         return 'json';
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/MarkdownDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/MarkdownDescriptorTest.php
@@ -15,12 +15,12 @@ use Symfony\Bundle\FrameworkBundle\Console\Descriptor\MarkdownDescriptor;
 
 class MarkdownDescriptorTest extends AbstractDescriptorTest
 {
-    protected function getDescriptor()
+    protected static function getDescriptor()
     {
         return new MarkdownDescriptor();
     }
 
-    protected function getFormat()
+    protected static function getFormat()
     {
         return 'md';
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -17,21 +17,21 @@ use Symfony\Component\Routing\Route;
 
 class TextDescriptorTest extends AbstractDescriptorTest
 {
-    private $fileLinkFormatter = null;
+    private static $fileLinkFormatter = null;
 
-    protected function getDescriptor()
+    protected static function getDescriptor()
     {
-        return new TextDescriptor($this->fileLinkFormatter);
+        return new TextDescriptor(static::$fileLinkFormatter);
     }
 
-    protected function getFormat()
+    protected static function getFormat()
     {
         return 'txt';
     }
 
-    public function getDescribeRouteWithControllerLinkTestData()
+    public static function getDescribeRouteWithControllerLinkTestData()
     {
-        $getDescribeData = $this->getDescribeRouteTestData();
+        $getDescribeData = static::getDescribeRouteTestData();
 
         foreach ($getDescribeData as $key => &$data) {
             $routeStub = $data[0];
@@ -48,7 +48,7 @@ class TextDescriptorTest extends AbstractDescriptorTest
     /** @dataProvider getDescribeRouteWithControllerLinkTestData */
     public function testDescribeRouteWithControllerLink(Route $route, $expectedDescription)
     {
-        $this->fileLinkFormatter = new FileLinkFormatter('myeditor://open?file=%f&line=%l');
+        static::$fileLinkFormatter = new FileLinkFormatter('myeditor://open?file=%f&line=%l');
         parent::testDescribeRoute($route, str_replace('[:file:]', __FILE__, $expectedDescription));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/XmlDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/XmlDescriptorTest.php
@@ -15,12 +15,12 @@ use Symfony\Bundle\FrameworkBundle\Console\Descriptor\XmlDescriptor;
 
 class XmlDescriptorTest extends AbstractDescriptorTest
 {
-    protected function getDescriptor()
+    protected static function getDescriptor()
     {
         return new XmlDescriptor();
     }
 
-    protected function getFormat()
+    protected static function getFormat()
     {
         return 'xml';
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/AbstractNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/AbstractNodeTest.php
@@ -24,7 +24,7 @@ abstract class AbstractNodeTest extends TestCase
         $this->assertSame($expected, $node->evaluate($functions, $variables));
     }
 
-    abstract public function getEvaluateData();
+    abstract public static function getEvaluateData();
 
     /**
      * @dataProvider getCompileData
@@ -36,7 +36,7 @@ abstract class AbstractNodeTest extends TestCase
         $this->assertSame($expected, $compiler->getSource());
     }
 
-    abstract public function getCompileData();
+    abstract public static function getCompileData();
 
     /**
      * @dataProvider getDumpData
@@ -46,5 +46,5 @@ abstract class AbstractNodeTest extends TestCase
         $this->assertSame($expected, $node->dump());
     }
 
-    abstract public function getDumpData();
+    abstract public static function getDumpData();
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/ArgumentsNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/ArgumentsNodeTest.php
@@ -15,21 +15,21 @@ use Symfony\Component\ExpressionLanguage\Node\ArgumentsNode;
 
 class ArgumentsNodeTest extends ArrayNodeTest
 {
-    public function getCompileData()
+    public static function getCompileData(): array
     {
         return [
-            ['"a", "b"', $this->getArrayNode()],
+            ['"a", "b"', static::getArrayNode()],
         ];
     }
 
-    public function getDumpData()
+    public static function getDumpData(): \Generator
     {
-        return [
-            ['"a", "b"', $this->getArrayNode()],
+        yield from [
+            ['"a", "b"', static::getArrayNode()],
         ];
     }
 
-    protected function createArrayNode()
+    protected static function createArrayNode(): \Symfony\Component\ExpressionLanguage\Node\ArrayNode
     {
         return new ArgumentsNode();
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/ArrayNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/ArrayNodeTest.php
@@ -28,45 +28,45 @@ class ArrayNodeTest extends AbstractNodeTest
         $this->assertNotEquals($this->createArrayNode(), $unserializedNode);
     }
 
-    public function getEvaluateData()
+    public static function getEvaluateData(): array
     {
         return [
-            [['b' => 'a', 'b'], $this->getArrayNode()],
+            [['b' => 'a', 'b'], static::getArrayNode()],
         ];
     }
 
-    public function getCompileData()
+    public static function getCompileData(): array
     {
         return [
-            ['["b" => "a", 0 => "b"]', $this->getArrayNode()],
+            ['["b" => "a", 0 => "b"]', static::getArrayNode()],
         ];
     }
 
-    public function getDumpData()
+    public static function getDumpData(): \Generator
     {
-        yield ['{"b": "a", 0: "b"}', $this->getArrayNode()];
+        yield ['{"b": "a", 0: "b"}', static::getArrayNode()];
 
-        $array = $this->createArrayNode();
+        $array = static::createArrayNode();
         $array->addElement(new ConstantNode('c'), new ConstantNode('a"b'));
         $array->addElement(new ConstantNode('d'), new ConstantNode('a\b'));
         yield ['{"a\\"b": "c", "a\\\\b": "d"}', $array];
 
-        $array = $this->createArrayNode();
+        $array = static::createArrayNode();
         $array->addElement(new ConstantNode('c'));
         $array->addElement(new ConstantNode('d'));
         yield ['["c", "d"]', $array];
     }
 
-    protected function getArrayNode()
+    protected static function getArrayNode(): ArrayNode
     {
-        $array = $this->createArrayNode();
+        $array = static::createArrayNode();
         $array->addElement(new ConstantNode('a'), new ConstantNode('b'));
         $array->addElement(new ConstantNode('b'));
 
         return $array;
     }
 
-    protected function createArrayNode()
+    protected static function createArrayNode(): ArrayNode
     {
         return new ArrayNode();
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\ExpressionLanguage\SyntaxError;
 
 class BinaryNodeTest extends AbstractNodeTest
 {
-    public function getEvaluateData()
+    public static function getEvaluateData(): array
     {
         $array = new ArrayNode();
         $array->addElement(new ConstantNode('a'));
@@ -71,7 +71,7 @@ class BinaryNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getCompileData()
+    public static function getCompileData(): array
     {
         $array = new ArrayNode();
         $array->addElement(new ConstantNode('a'));
@@ -120,7 +120,7 @@ class BinaryNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getDumpData()
+    public static function getDumpData(): array
     {
         $array = new ArrayNode();
         $array->addElement(new ConstantNode('a'));

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/ConditionalNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/ConditionalNodeTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
 
 class ConditionalNodeTest extends AbstractNodeTest
 {
-    public function getEvaluateData()
+    public static function getEvaluateData(): array
     {
         return [
             [1, new ConditionalNode(new ConstantNode(true), new ConstantNode(1), new ConstantNode(2))],
@@ -24,7 +24,7 @@ class ConditionalNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getCompileData()
+    public static function getCompileData(): array
     {
         return [
             ['((true) ? (1) : (2))', new ConditionalNode(new ConstantNode(true), new ConstantNode(1), new ConstantNode(2))],
@@ -32,7 +32,7 @@ class ConditionalNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getDumpData()
+    public static function getDumpData(): array
     {
         return [
             ['(true ? 1 : 2)', new ConditionalNode(new ConstantNode(true), new ConstantNode(1), new ConstantNode(2))],

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/ConstantNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/ConstantNodeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
 
 class ConstantNodeTest extends AbstractNodeTest
 {
-    public function getEvaluateData()
+    public static function getEvaluateData(): array
     {
         return [
             [false, new ConstantNode(false)],
@@ -28,7 +28,7 @@ class ConstantNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getCompileData()
+    public static function getCompileData(): array
     {
         return [
             ['false', new ConstantNode(false)],
@@ -41,7 +41,7 @@ class ConstantNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getDumpData()
+    public static function getDumpData(): array
     {
         return [
             ['false', new ConstantNode(false)],

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/FunctionNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/FunctionNodeTest.php
@@ -17,28 +17,28 @@ use Symfony\Component\ExpressionLanguage\Node\Node;
 
 class FunctionNodeTest extends AbstractNodeTest
 {
-    public function getEvaluateData()
+    public static function getEvaluateData(): array
     {
         return [
-            ['bar', new FunctionNode('foo', new Node([new ConstantNode('bar')])), [], ['foo' => $this->getCallables()]],
+            ['bar', new FunctionNode('foo', new Node([new ConstantNode('bar')])), [], ['foo' => static::getCallables()]],
         ];
     }
 
-    public function getCompileData()
+    public static function getCompileData(): array
     {
         return [
-            ['foo("bar")', new FunctionNode('foo', new Node([new ConstantNode('bar')])), ['foo' => $this->getCallables()]],
+            ['foo("bar")', new FunctionNode('foo', new Node([new ConstantNode('bar')])), ['foo' => static::getCallables()]],
         ];
     }
 
-    public function getDumpData()
+    public static function getDumpData(): array
     {
         return [
-            ['foo("bar")', new FunctionNode('foo', new Node([new ConstantNode('bar')])), ['foo' => $this->getCallables()]],
+            ['foo("bar")', new FunctionNode('foo', new Node([new ConstantNode('bar')])), ['foo' => static::getCallables()]],
         ];
     }
 
-    protected function getCallables()
+    protected static function getCallables(): array
     {
         return [
             'compiler' => function ($arg) {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -18,46 +18,46 @@ use Symfony\Component\ExpressionLanguage\Node\NameNode;
 
 class GetAttrNodeTest extends AbstractNodeTest
 {
-    public function getEvaluateData()
+    public static function getEvaluateData(): array
     {
         return [
-            ['b', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b']]],
-            ['a', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b']]],
+            ['b', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), static::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b']]],
+            ['a', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), static::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b']]],
 
-            ['bar', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            ['bar', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
 
-            ['baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
-            ['a', new GetAttrNode(new NameNode('foo'), new NameNode('index'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b'], 'index' => 'b']],
+            ['baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
+            ['a', new GetAttrNode(new NameNode('foo'), new NameNode('index'), static::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b'], 'index' => 'b']],
         ];
     }
 
-    public function getCompileData()
+    public static function getCompileData(): array
     {
         return [
-            ['$foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)],
-            ['$foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['$foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['$foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
 
-            ['$foo->foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            ['$foo->foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
 
-            ['$foo->foo(["b" => "a", 0 => "b"])', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
-            ['$foo[$index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['$foo->foo(["b" => "a", 0 => "b"])', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
+            ['$foo[$index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
         ];
     }
 
-    public function getDumpData()
+    public static function getDumpData(): array
     {
         return [
-            ['foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)],
-            ['foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
 
-            ['foo.foo', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            ['foo.foo', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
 
-            ['foo.foo({"b": "a", 0: "b"})', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
-            ['foo[index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['foo.foo({"b": "a", 0: "b"})', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), static::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
+            ['foo[index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
         ];
     }
 
-    protected function getArrayNode()
+    protected static function getArrayNode(): ArrayNode
     {
         $array = new ArrayNode();
         $array->addElement(new ConstantNode('a'), new ConstantNode('b'));

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/NameNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/NameNodeTest.php
@@ -15,21 +15,21 @@ use Symfony\Component\ExpressionLanguage\Node\NameNode;
 
 class NameNodeTest extends AbstractNodeTest
 {
-    public function getEvaluateData()
+    public static function getEvaluateData(): array
     {
         return [
             ['bar', new NameNode('foo'), ['foo' => 'bar']],
         ];
     }
 
-    public function getCompileData()
+    public static function getCompileData(): array
     {
         return [
             ['$foo', new NameNode('foo')],
         ];
     }
 
-    public function getDumpData()
+    public static function getDumpData(): array
     {
         return [
             ['foo', new NameNode('foo')],

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/UnaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/UnaryNodeTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\ExpressionLanguage\Node\UnaryNode;
 
 class UnaryNodeTest extends AbstractNodeTest
 {
-    public function getEvaluateData()
+    public static function getEvaluateData(): array
     {
         return [
             [-1, new UnaryNode('-', new ConstantNode(1))],
@@ -26,7 +26,7 @@ class UnaryNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getCompileData()
+    public static function getCompileData(): array
     {
         return [
             ['(-1)', new UnaryNode('-', new ConstantNode(1))],
@@ -36,7 +36,7 @@ class UnaryNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getDumpData()
+    public static function getDumpData(): array
     {
         return [
             ['(- 1)', new UnaryNode('-', new ConstantNode(1))],

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Tests\Fixtures\DataCollector\DummyController;
 
 class RequestDataCollectorTest extends TestCase
 {
@@ -91,22 +92,24 @@ class RequestDataCollectorTest extends TestCase
         $this->assertSame($expected, $c->getController()->getValue(true), sprintf('Testing: %s', $name));
     }
 
-    public function provideControllerCallables()
+    public static function provideControllerCallables(): array
     {
         // make sure we always match the line number
-        $r1 = new \ReflectionMethod($this, 'testControllerInspection');
-        $r2 = new \ReflectionMethod($this, 'staticControllerMethod');
-        $r3 = new \ReflectionClass($this);
+        $controller = new DummyController();
+
+        $r1 = new \ReflectionMethod($controller, 'regularCallable');
+        $r2 = new \ReflectionMethod($controller, 'staticControllerMethod');
+        $r3 = new \ReflectionClass($controller);
 
         // test name, callable, expected
         return [
             [
                 '"Regular" callable',
-                [$this, 'testControllerInspection'],
+                [$controller, 'regularCallable'],
                 [
-                    'class' => self::class,
-                    'method' => 'testControllerInspection',
-                    'file' => __FILE__,
+                    'class' => DummyController::class,
+                    'method' => 'regularCallable',
+                    'file' => $r3->getFileName(),
                     'line' => $r1->getStartLine(),
                 ],
             ],
@@ -124,42 +127,42 @@ class RequestDataCollectorTest extends TestCase
 
             [
                 'Static callback as string',
-                __NAMESPACE__.'\RequestDataCollectorTest::staticControllerMethod',
+                DummyController::class.'::staticControllerMethod',
                 [
-                    'class' => 'Symfony\Component\HttpKernel\Tests\DataCollector\RequestDataCollectorTest',
+                    'class' => DummyController::class,
                     'method' => 'staticControllerMethod',
-                    'file' => __FILE__,
+                    'file' => $r3->getFileName(),
                     'line' => $r2->getStartLine(),
                 ],
             ],
 
             [
                 'Static callable with instance',
-                [$this, 'staticControllerMethod'],
+                [$controller, 'staticControllerMethod'],
                 [
-                    'class' => 'Symfony\Component\HttpKernel\Tests\DataCollector\RequestDataCollectorTest',
+                    'class' => DummyController::class,
                     'method' => 'staticControllerMethod',
-                    'file' => __FILE__,
+                    'file' => $r3->getFileName(),
                     'line' => $r2->getStartLine(),
                 ],
             ],
 
             [
                 'Static callable with class name',
-                ['Symfony\Component\HttpKernel\Tests\DataCollector\RequestDataCollectorTest', 'staticControllerMethod'],
+                [DummyController::class, 'staticControllerMethod'],
                 [
-                    'class' => 'Symfony\Component\HttpKernel\Tests\DataCollector\RequestDataCollectorTest',
+                    'class' => DummyController::class,
                     'method' => 'staticControllerMethod',
-                    'file' => __FILE__,
+                    'file' => $r3->getFileName(),
                     'line' => $r2->getStartLine(),
                 ],
             ],
 
             [
                 'Callable with instance depending on __call()',
-                [$this, 'magicMethod'],
+                [$controller, 'magicMethod'],
                 [
-                    'class' => 'Symfony\Component\HttpKernel\Tests\DataCollector\RequestDataCollectorTest',
+                    'class' => DummyController::class,
                     'method' => 'magicMethod',
                     'file' => 'n/a',
                     'line' => 'n/a',
@@ -168,9 +171,9 @@ class RequestDataCollectorTest extends TestCase
 
             [
                 'Callable with class name depending on __callStatic()',
-                ['Symfony\Component\HttpKernel\Tests\DataCollector\RequestDataCollectorTest', 'magicMethod'],
+                [DummyController::class, 'magicMethod'],
                 [
-                    'class' => 'Symfony\Component\HttpKernel\Tests\DataCollector\RequestDataCollectorTest',
+                    'class' => DummyController::class,
                     'method' => 'magicMethod',
                     'file' => 'n/a',
                     'line' => 'n/a',
@@ -179,11 +182,11 @@ class RequestDataCollectorTest extends TestCase
 
             [
                 'Invokable controller',
-                $this,
+                $controller,
                 [
-                    'class' => 'Symfony\Component\HttpKernel\Tests\DataCollector\RequestDataCollectorTest',
+                    'class' => DummyController::class,
                     'method' => null,
-                    'file' => __FILE__,
+                    'file' => $r3->getFileName(),
                     'line' => $r3->getStartLine(),
                 ],
             ],
@@ -390,35 +393,6 @@ class RequestDataCollectorTest extends TestCase
         $collector->onKernelController($event);
     }
 
-    /**
-     * Dummy method used as controller callable.
-     */
-    public static function staticControllerMethod()
-    {
-        throw new \LogicException('Unexpected method call');
-    }
-
-    /**
-     * Magic method to allow non existing methods to be called and delegated.
-     */
-    public function __call(string $method, array $args)
-    {
-        throw new \LogicException('Unexpected method call');
-    }
-
-    /**
-     * Magic method to allow non existing methods to be called and delegated.
-     */
-    public static function __callStatic(string $method, array $args)
-    {
-        throw new \LogicException('Unexpected method call');
-    }
-
-    public function __invoke()
-    {
-        throw new \LogicException('Unexpected method call');
-    }
-
     private function getCookieByName(Response $response, $name)
     {
         foreach ($response->headers->getCookies() as $cookie) {
@@ -445,7 +419,7 @@ class RequestDataCollectorTest extends TestCase
         $this->assertSame($expected, $c->isJsonRequest());
     }
 
-    public function provideJsonContentTypes()
+    public static function provideJsonContentTypes(): array
     {
         return [
             ['text/csv', false],
@@ -472,7 +446,7 @@ class RequestDataCollectorTest extends TestCase
         $this->assertSame($expected, $c->getPrettyJson());
     }
 
-    public function providePrettyJson()
+    public static function providePrettyJson(): array
     {
         return [
             ['null', 'null'],

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/DummyController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/DummyController.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\DataCollector;
+
+class DummyController
+{
+    /**
+     * Dummy method used as controller callable.
+     */
+    public static function staticControllerMethod()
+    {
+        throw new \LogicException('Unexpected method call');
+    }
+
+    /**
+     * Magic method to allow non existing methods to be called and delegated.
+     */
+    public function __call(string $method, array $args)
+    {
+        throw new \LogicException('Unexpected method call');
+    }
+
+    /**
+     * Magic method to allow non existing methods to be called and delegated.
+     */
+    public static function __callStatic(string $method, array $args)
+    {
+        throw new \LogicException('Unexpected method call');
+    }
+
+    public function __invoke()
+    {
+        throw new \LogicException('Unexpected method call');
+    }
+
+    public function regularCallable()
+    {
+        throw new \LogicException('Unexpected method call');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes-ish
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Easing https://github.com/symfony/symfony/pull/48668#issuecomment-1379892415
| License       | MIT
| Doc PR        | _NA_

Follow-up of second iteration being reviewed #48988, split up in a new PR for easier review.