### PR TITLE
Remove full DSNs from exception messages

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -126,7 +126,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
             return CouchbaseCollectionAdapter::createConnection($dsn, $options);
         }
 
-        throw new InvalidArgumentException(sprintf('Unsupported DSN: "%s".', $dsn));
+        throw new InvalidArgumentException('Unsupported DSN: it does not start with "redis[s]:", "memcached:" nor "couchbase:".');
     }
 
     public function commit(): bool

--- a/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
@@ -78,7 +78,7 @@ class CouchbaseBucketAdapter extends AbstractAdapter
 
             foreach ($servers as $dsn) {
                 if (!str_starts_with($dsn, 'couchbase:')) {
-                    throw new InvalidArgumentException(sprintf('Invalid Couchbase DSN: "%s" does not start with "couchbase:".', $dsn));
+                    throw new InvalidArgumentException('Invalid Couchbase DSN: it does not start with "couchbase:".');
                 }
 
                 preg_match($dsnPattern, $dsn, $matches);

--- a/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
@@ -71,7 +71,7 @@ class CouchbaseCollectionAdapter extends AbstractAdapter
 
             foreach ($dsn as $server) {
                 if (!str_starts_with($server, 'couchbase:')) {
-                    throw new InvalidArgumentException(sprintf('Invalid Couchbase DSN: "%s" does not start with "couchbase:".', $server));
+                    throw new InvalidArgumentException('Invalid Couchbase DSN: it does not start with "couchbase:".');
                 }
 
                 preg_match($dsnPattern, $server, $matches);

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -64,7 +64,7 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
             $this->conn = $connOrDsn;
         } else {
             if (!class_exists(DriverManager::class)) {
-                throw new InvalidArgumentException(sprintf('Failed to parse the DSN "%s". Try running "composer require doctrine/dbal".', $connOrDsn));
+                throw new InvalidArgumentException('Failed to parse DSN. Try running "composer require doctrine/dbal".');
             }
             $this->conn = DriverManager::getConnection(['url' => $connOrDsn]);
         }

--- a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
@@ -113,7 +113,7 @@ class MemcachedAdapter extends AbstractAdapter
                     continue;
                 }
                 if (!str_starts_with($dsn, 'memcached:')) {
-                    throw new InvalidArgumentException(sprintf('Invalid Memcached DSN: "%s" does not start with "memcached:".', $dsn));
+                    throw new InvalidArgumentException('Invalid Memcached DSN: it does not start with "memcached:".');
                 }
                 $params = preg_replace_callback('#^memcached:(//)?(?:([^@]*+)@)?#', function ($m) use (&$username, &$password) {
                     if (!empty($m[2])) {
@@ -123,7 +123,7 @@ class MemcachedAdapter extends AbstractAdapter
                     return 'file:'.($m[1] ?? '');
                 }, $dsn);
                 if (false === $params = parse_url($params)) {
-                    throw new InvalidArgumentException(sprintf('Invalid Memcached DSN: "%s".', $dsn));
+                    throw new InvalidArgumentException('Invalid Memcached DSN.');
                 }
                 $query = $hosts = [];
                 if (isset($params['query'])) {
@@ -131,7 +131,7 @@ class MemcachedAdapter extends AbstractAdapter
 
                     if (isset($query['host'])) {
                         if (!\is_array($hosts = $query['host'])) {
-                            throw new InvalidArgumentException(sprintf('Invalid Memcached DSN: "%s".', $dsn));
+                            throw new InvalidArgumentException('Invalid Memcached DSN: query parameter "host" must be an array.');
                         }
                         foreach ($hosts as $host => $weight) {
                             if (false === $port = strrpos($host, ':')) {
@@ -150,7 +150,7 @@ class MemcachedAdapter extends AbstractAdapter
                     }
                 }
                 if (!isset($params['host']) && !isset($params['path'])) {
-                    throw new InvalidArgumentException(sprintf('Invalid Memcached DSN: "%s".', $dsn));
+                    throw new InvalidArgumentException('Invalid Memcached DSN: missing host or path.');
                 }
                 if (isset($params['path']) && preg_match('#/(\d+)$#', $params['path'], $m)) {
                     $params['weight'] = $m[1];

--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -58,7 +58,7 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
     public function __construct(#[\SensitiveParameter] \PDO|string $connOrDsn, string $namespace = '', int $defaultLifetime = 0, array $options = [], MarshallerInterface $marshaller = null)
     {
         if (\is_string($connOrDsn) && str_contains($connOrDsn, '://')) {
-            throw new InvalidArgumentException(sprintf('Usage of Doctrine DBAL URL with "%s" is not supported. Use a PDO DSN or "%s" instead. Got "%s".', __CLASS__, DoctrineDbalAdapter::class, $connOrDsn));
+            throw new InvalidArgumentException(sprintf('Usage of Doctrine DBAL URL with "%s" is not supported. Use a PDO DSN or "%s" instead.', __CLASS__, DoctrineDbalAdapter::class));
         }
 
         if (isset($namespace[0]) && preg_match('#[^-+.A-Za-z0-9]#', $namespace, $match)) {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
@@ -54,7 +54,7 @@ class SessionHandlerFactory
             case str_starts_with($connection, 'rediss:'):
             case str_starts_with($connection, 'memcached:'):
                 if (!class_exists(AbstractAdapter::class)) {
-                    throw new \InvalidArgumentException(sprintf('Unsupported DSN "%s". Try running "composer require symfony/cache".', $connection));
+                    throw new \InvalidArgumentException('Unsupported Redis or Memcached DSN. Try running "composer require symfony/cache".');
                 }
                 $handlerClass = str_starts_with($connection, 'memcached:') ? MemcachedSessionHandler::class : RedisSessionHandler::class;
                 $connection = AbstractAdapter::createConnection($connection, ['lazy' => true]);
@@ -63,7 +63,7 @@ class SessionHandlerFactory
 
             case str_starts_with($connection, 'pdo_oci://'):
                 if (!class_exists(DriverManager::class)) {
-                    throw new \InvalidArgumentException(sprintf('Unsupported DSN "%s". Try running "composer require doctrine/dbal".', $connection));
+                    throw new \InvalidArgumentException('Unsupported PDO OCI DSN. Try running "composer require doctrine/dbal".');
                 }
                 $connection = DriverManager::getConnection(['url' => $connection])->getWrappedConnection();
                 // no break;

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
@@ -47,7 +47,7 @@ class DoctrineDbalPostgreSqlStore implements BlockingSharedLockStoreInterface, B
             $this->conn = $connOrUrl;
         } else {
             if (!class_exists(DriverManager::class)) {
-                throw new InvalidArgumentException(sprintf('Failed to parse the DSN "%s". Try running "composer require doctrine/dbal".', $connOrUrl));
+                throw new InvalidArgumentException('Failed to parse DSN. Try running "composer require doctrine/dbal".');
             }
             $this->conn = DriverManager::getConnection(['url' => $this->filterDsn($connOrUrl)]);
         }
@@ -246,7 +246,7 @@ class DoctrineDbalPostgreSqlStore implements BlockingSharedLockStoreInterface, B
     private function filterDsn(#[\SensitiveParameter] string $dsn): string
     {
         if (!str_contains($dsn, '://')) {
-            throw new InvalidArgumentException(sprintf('String "%" is not a valid DSN for Doctrine DBAL.', $dsn));
+            throw new InvalidArgumentException('DSN is invalid for Doctrine DBAL.');
         }
 
         [$scheme, $rest] = explode(':', $dsn, 2);

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -66,7 +66,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
             $this->conn = $connOrUrl;
         } else {
             if (!class_exists(DriverManager::class)) {
-                throw new InvalidArgumentException(sprintf('Failed to parse the DSN "%s". Try running "composer require doctrine/dbal".', $connOrUrl));
+                throw new InvalidArgumentException('Failed to parse the DSN. Try running "composer require doctrine/dbal".');
             }
             $this->conn = DriverManager::getConnection(['url' => $connOrUrl]);
         }

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -23,7 +23,7 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  */
 class StoreFactory
 {
-    public static function createStore(object|string $connection): PersistingStoreInterface
+    public static function createStore(#[\SensitiveParameter] object|string $connection): PersistingStoreInterface
     {
         switch (true) {
             case $connection instanceof \Redis:
@@ -62,7 +62,7 @@ class StoreFactory
             case str_starts_with($connection, 'rediss:'):
             case str_starts_with($connection, 'memcached:'):
                 if (!class_exists(AbstractAdapter::class)) {
-                    throw new InvalidArgumentException(sprintf('Unsupported DSN "%s". Try running "composer require symfony/cache".', $connection));
+                    throw new InvalidArgumentException('Unsupported Redis or Memcached DSN. Try running "composer require symfony/cache".');
                 }
                 $storeClass = str_starts_with($connection, 'memcached:') ? MemcachedStore::class : RedisStore::class;
                 $connection = AbstractAdapter::createConnection($connection, ['lazy' => true]);

--- a/src/Symfony/Component/Lock/Store/ZookeeperStore.php
+++ b/src/Symfony/Component/Lock/Store/ZookeeperStore.php
@@ -37,11 +37,11 @@ class ZookeeperStore implements PersistingStoreInterface
     public static function createConnection(#[\SensitiveParameter] string $dsn): \Zookeeper
     {
         if (!str_starts_with($dsn, 'zookeeper:')) {
-            throw new InvalidArgumentException(sprintf('Unsupported DSN: "%s".', $dsn));
+            throw new InvalidArgumentException('Unsupported DSN for Zookeeper.');
         }
 
         if (false === $params = parse_url($dsn)) {
-            throw new InvalidArgumentException(sprintf('Invalid Zookeeper DSN: "%s".', $dsn));
+            throw new InvalidArgumentException('Invalid Zookeeper DSN.');
         }
 
         $host = $params['host'] ?? '';

--- a/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
@@ -92,17 +92,17 @@ class DsnTest extends TestCase
     {
         yield [
             'some://',
-            'The "some://" mailer DSN is invalid.',
+            'The mailer DSN is invalid.',
         ];
 
         yield [
             '//sendmail',
-            'The "//sendmail" mailer DSN must contain a scheme.',
+            'The mailer DSN must contain a scheme.',
         ];
 
         yield [
             'file:///some/path',
-            'The "file:///some/path" mailer DSN must contain a host (use "default" by default).',
+            'The mailer DSN must contain a host (use "default" by default).',
         ];
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -90,11 +90,11 @@ class TransportTest extends TestCase
 
     public function fromWrongStringProvider(): iterable
     {
-        yield 'garbage at the end' => ['dummy://a some garbage here', 'The DSN has some garbage at the end: " some garbage here".'];
+        yield 'garbage at the end' => ['dummy://a some garbage here', 'The mailer DSN has some garbage at the end.'];
 
-        yield 'not a valid DSN' => ['something not a dsn', 'The "something" mailer DSN must contain a scheme.'];
+        yield 'not a valid DSN' => ['something not a dsn', 'The mailer DSN must contain a scheme.'];
 
-        yield 'failover not closed' => ['failover(dummy://a', 'The "(dummy://a" mailer DSN must contain a scheme.'];
+        yield 'failover not closed' => ['failover(dummy://a', 'The mailer DSN must contain a scheme.'];
 
         yield 'not a valid keyword' => ['foobar(dummy://a)', 'The "foobar" keyword is not valid (valid ones are "failover", "roundrobin")'];
     }

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -94,7 +94,7 @@ final class Transport
     {
         [$transport, $offset] = $this->parseDsn($dsn);
         if ($offset !== \strlen($dsn)) {
-            throw new InvalidArgumentException(sprintf('The DSN has some garbage at the end: "%s".', substr($dsn, $offset)));
+            throw new InvalidArgumentException('The mailer DSN has some garbage at the end.');
         }
 
         return $transport;

--- a/src/Symfony/Component/Mailer/Transport/Dsn.php
+++ b/src/Symfony/Component/Mailer/Transport/Dsn.php
@@ -38,15 +38,15 @@ final class Dsn
     public static function fromString(#[\SensitiveParameter] string $dsn): self
     {
         if (false === $parsedDsn = parse_url($dsn)) {
-            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN is invalid.', $dsn));
+            throw new InvalidArgumentException('The mailer DSN is invalid.');
         }
 
         if (!isset($parsedDsn['scheme'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a scheme.', $dsn));
+            throw new InvalidArgumentException('The mailer DSN must contain a scheme.');
         }
 
         if (!isset($parsedDsn['host'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a host (use "default" by default).', $dsn));
+            throw new InvalidArgumentException('The mailer DSN must contain a host (use "default" by default).');
         }
 
         $user = '' !== ($parsedDsn['user'] ?? '') ? urldecode($parsedDsn['user']) : null;

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -77,7 +77,7 @@ class ConnectionTest extends TestCase
     public function testFromInvalidDsn()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given Amazon SQS DSN "sqs://" is invalid.');
+        $this->expectExceptionMessage('The given Amazon SQS DSN is invalid.');
 
         Connection::fromDsn('sqs://');
     }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -26,6 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
  * @internal
+ *
  * @final
  */
 class Connection
@@ -102,7 +103,7 @@ class Connection
     public static function fromDsn(#[\SensitiveParameter] string $dsn, array $options = [], HttpClientInterface $client = null, LoggerInterface $logger = null): self
     {
         if (false === $parsedUrl = parse_url($dsn)) {
-            throw new InvalidArgumentException(sprintf('The given Amazon SQS DSN "%s" is invalid.', $dsn));
+            throw new InvalidArgumentException('The given Amazon SQS DSN is invalid.');
         }
 
         $query = [];

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -30,7 +30,7 @@ class ConnectionTest extends TestCase
     public function testItCannotBeConstructedWithAWrongDsn()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given AMQP DSN "amqp://:" is invalid.');
+        $this->expectExceptionMessage('The given AMQP DSN is invalid.');
         Connection::fromDsn('amqp://:');
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -165,7 +165,7 @@ class Connection
         if (false === $parsedUrl = parse_url($dsn)) {
             // this is a valid URI that parse_url cannot handle when you want to pass all parameters as options
             if (!\in_array($dsn, ['amqp://', 'amqps://'])) {
-                throw new InvalidArgumentException(sprintf('The given AMQP DSN "%s" is invalid.', $dsn));
+                throw new InvalidArgumentException('The given AMQP DSN is invalid.');
             }
 
             $parsedUrl = [];

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/ConnectionTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Messenger\Bridge\Beanstalkd\Tests\Transport;
 
-use InvalidArgumentException;
 use Pheanstalk\Contract\PheanstalkInterface;
 use Pheanstalk\Exception;
 use Pheanstalk\Exception\ClientException;
@@ -30,8 +29,8 @@ final class ConnectionTest extends TestCase
 {
     public function testFromInvalidDsn()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given Beanstalkd DSN "beanstalkd://" is invalid.');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given Beanstalkd DSN is invalid.');
 
         Connection::fromDsn('beanstalkd://');
     }

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
@@ -23,6 +23,7 @@ use Symfony\Component\Messenger\Exception\TransportException;
  * @author Antonio Pauletich <antonio.pauletich95@gmail.com>
  *
  * @internal
+ *
  * @final
  */
 class Connection
@@ -58,7 +59,7 @@ class Connection
     public static function fromDsn(#[\SensitiveParameter] string $dsn, array $options = []): self
     {
         if (false === $components = parse_url($dsn)) {
-            throw new InvalidArgumentException(sprintf('The given Beanstalkd DSN "%s" is invalid.', $dsn));
+            throw new InvalidArgumentException('The given Beanstalkd DSN is invalid.');
         }
 
         $connectionCredentials = [

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportFactoryTest.php
@@ -90,7 +90,7 @@ class DoctrineTransportFactoryTest extends TestCase
     public function testCreateTransportMustThrowAnExceptionIfManagerIsNotFound()
     {
         $this->expectException(TransportException::class);
-        $this->expectExceptionMessage('Could not find Doctrine connection from Messenger DSN "doctrine://default".');
+        $this->expectExceptionMessage('Could not find Doctrine connection from Messenger DSN.');
         $registry = $this->createMock(ConnectionRegistry::class);
         $registry->expects($this->once())
             ->method('getConnection')

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -87,7 +87,7 @@ class Connection implements ResetInterface
     public static function buildConfiguration(#[\SensitiveParameter] string $dsn, array $options = []): array
     {
         if (false === $components = parse_url($dsn)) {
-            throw new InvalidArgumentException(sprintf('The given Doctrine Messenger DSN "%s" is invalid.', $dsn));
+            throw new InvalidArgumentException('The given Doctrine Messenger DSN is invalid.');
         }
 
         $query = [];

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
@@ -40,7 +40,7 @@ class DoctrineTransportFactory implements TransportFactoryInterface
         try {
             $driverConnection = $this->registry->getConnection($configuration['connection']);
         } catch (\InvalidArgumentException $e) {
-            throw new TransportException(sprintf('Could not find Doctrine connection from Messenger DSN "%s".', $dsn), 0, $e);
+            throw new TransportException('Could not find Doctrine connection from Messenger DSN.', 0, $e);
         }
 
         if ($useNotify && $driverConnection->getDatabasePlatform() instanceof PostgreSQLPlatform) {

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -23,7 +23,7 @@ class ConnectionTest extends TestCase
     public function testFromInvalidDsn()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given Redis DSN "redis://" is invalid.');
+        $this->expectExceptionMessage('The given Redis DSN is invalid.');
 
         Connection::fromDsn('redis://');
     }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -176,9 +176,9 @@ class Connection
             $tls = 'rediss' === $parsedUrl['scheme'];
 
             // Regroup all the hosts in an array interpretable by RedisCluster
-            $parsedUrl['host'] = array_map(function ($parsedUrl, $dsn) use ($tls) {
+            $parsedUrl['host'] = array_map(function ($parsedUrl) use ($tls) {
                 if (!isset($parsedUrl['host'])) {
-                    throw new InvalidArgumentException(sprintf('Missing host in DSN part "%s", it must be defined when using Redis Cluster.', $dsn));
+                    throw new InvalidArgumentException('Missing host in DSN, it must be defined when using Redis Cluster.');
                 }
                 if ($tls) {
                     $parsedUrl['host'] = 'tls://'.$parsedUrl['host'];
@@ -242,7 +242,7 @@ class Connection
         }, $url);
 
         if (false === $parsedUrl = parse_url($url)) {
-            throw new InvalidArgumentException(sprintf('The given Redis DSN "%s" is invalid.', $dsn));
+            throw new InvalidArgumentException('The given Redis DSN is invalid.');
         }
 
         if (null !== $auth) {

--- a/src/Symfony/Component/Messenger/Transport/TransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/TransportFactory.php
@@ -51,7 +51,7 @@ class TransportFactory implements TransportFactoryInterface
             $packageSuggestion = ' Run "composer require symfony/beanstalkd-messenger" to install Beanstalkd transport.';
         }
 
-        throw new InvalidArgumentException(sprintf('No transport supports the given Messenger DSN "%s".%s.', $dsn, $packageSuggestion));
+        throw new InvalidArgumentException('No transport supports the given Messenger DSN.'.$packageSuggestion);
     }
 
     public function supports(#[\SensitiveParameter] string $dsn, array $options): bool

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransportFactory.php
@@ -33,7 +33,7 @@ final class MicrosoftTeamsTransportFactory extends AbstractTransportFactory
         $path = $dsn->getPath();
 
         if (null === $path) {
-            throw new IncompleteDsnException('Path is not set.', $dsn->getOriginalDsn());
+            throw new IncompleteDsnException('Path is not set.', 'microsoftteams://'.$dsn->getHost());
         }
 
         $host = $dsn->getHost();

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -35,7 +35,7 @@ final class OvhCloudTransport extends AbstractTransport
     private ?string $sender = null;
     private bool $noStopClause = false;
 
-    public function __construct(string $applicationKey, #[\SensitiveParameter] string $applicationSecret, string $consumerKey, string $serviceName, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $applicationKey, #[\SensitiveParameter] string $applicationSecret, #[\SensitiveParameter] string $consumerKey, string $serviceName, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->applicationKey = $applicationKey;
         $this->applicationSecret = $applicationSecret;
@@ -48,10 +48,10 @@ final class OvhCloudTransport extends AbstractTransport
     public function __toString(): string
     {
         if (null !== $this->sender) {
-            return sprintf('ovhcloud://%s?consumer_key=%s&service_name=%s&sender=%s&no_stop_clause=%s', $this->getEndpoint(), $this->consumerKey, $this->serviceName, $this->sender, (int) $this->noStopClause);
+            return sprintf('ovhcloud://%s?service_name=%s&sender=%s', $this->getEndpoint(), $this->serviceName, $this->sender);
         }
 
-        return sprintf('ovhcloud://%s?consumer_key=%s&service_name=%s&no_stop_clause=%s', $this->getEndpoint(), $this->consumerKey, $this->serviceName, (int) $this->noStopClause);
+        return sprintf('ovhcloud://%s?service_name=%s', $this->getEndpoint(), $this->serviceName);
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
@@ -24,27 +24,27 @@ final class OvhCloudTransportFactoryTest extends TransportFactoryTestCase
     public function createProvider(): iterable
     {
         yield [
-            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=0',
+            'ovhcloud://host.test?service_name=serviceName',
             'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName',
         ];
 
         yield [
-            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&sender=sender&no_stop_clause=0',
+            'ovhcloud://host.test?service_name=serviceName&sender=sender',
             'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName&sender=sender',
         ];
 
         yield [
-            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=0',
+            'ovhcloud://host.test?service_name=serviceName',
             'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=0',
         ];
 
         yield [
-            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=1',
+            'ovhcloud://host.test?service_name=serviceName',
             'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=1',
         ];
 
         yield [
-            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=1',
+            'ovhcloud://host.test?service_name=serviceName',
             'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=true',
         ];
     }

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -30,9 +30,9 @@ final class OvhCloudTransportTest extends TransportTestCase
 
     public function toStringProvider(): iterable
     {
-        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=0', $this->createTransport()];
-        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&no_stop_clause=1', $this->createTransport(null, null, true)];
-        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&sender=sender&no_stop_clause=0', $this->createTransport(null, 'sender')];
+        yield ['ovhcloud://eu.api.ovh.com?service_name=serviceName', $this->createTransport()];
+        yield ['ovhcloud://eu.api.ovh.com?service_name=serviceName', $this->createTransport(null, null, true)];
+        yield ['ovhcloud://eu.api.ovh.com?service_name=serviceName&sender=sender', $this->createTransport(null, 'sender')];
     }
 
     public function supportedMessagesProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/PagerDuty/PagerDutyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/PagerDuty/PagerDutyTransportFactory.php
@@ -44,11 +44,11 @@ final class PagerDutyTransportFactory extends AbstractTransportFactory
     {
         $host = $dsn->getHost();
         if ('default' === $host) {
-            throw new IncompleteDsnException('Host is not set.', $dsn->getOriginalDsn());
+            throw new IncompleteDsnException('Host is not set.', 'pagerduty://default');
         }
 
         if (!str_ends_with($host, '.pagerduty.com')) {
-            throw new IncompleteDsnException('Host must be in format: "subdomain.pagerduty.com".', $dsn->getOriginalDsn());
+            throw new IncompleteDsnException('Host must be in format: "subdomain.pagerduty.com".', 'pagerduty://'.$host);
         }
 
         return $host;

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
@@ -46,7 +46,7 @@ final class SendberryTransport extends AbstractTransport
 
     public function __toString(): string
     {
-        return sprintf('sendberry://%s:%s@%s?auth_key=%s&from=%s', $this->username, $this->password, $this->getEndpoint(), $this->authKey, $this->from);
+        return sprintf('sendberry://%s?from=%s', $this->getEndpoint(), $this->from);
     }
 
     public function supports(MessageInterface $message): bool

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/Tests/SendberryTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/Tests/SendberryTransportFactoryTest.php
@@ -24,7 +24,7 @@ final class SendberryTransportFactoryTest extends TransportFactoryTestCase
     public function createProvider(): iterable
     {
         yield [
-            'sendberry://user:password@host.test?auth_key=auth_key&from=+0611223344',
+            'sendberry://host.test?from=+0611223344',
             'sendberry://user:password@host.test?auth_key=auth_key&from=%2B0611223344',
         ];
     }

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/Tests/SendberryTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/Tests/SendberryTransportTest.php
@@ -27,7 +27,7 @@ final class SendberryTransportTest extends TransportTestCase
 
     public function toStringProvider(): iterable
     {
-        yield ['sendberry://username:password@api.sendberry.com?auth_key=auth_key&from=from', $this->createTransport()];
+        yield ['sendberry://api.sendberry.com?from=from', $this->createTransport()];
     }
 
     public function supportedMessagesProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
@@ -45,11 +45,11 @@ final class TelegramTransportFactory extends AbstractTransportFactory
     private function getToken(Dsn $dsn): string
     {
         if (null === $dsn->getUser() && null === $dsn->getPassword()) {
-            throw new IncompleteDsnException('Missing token.', $dsn->getOriginalDsn());
+            throw new IncompleteDsnException('Missing token.', 'telegram://'.$dsn->getHost());
         }
 
         if (null === $dsn->getPassword()) {
-            throw new IncompleteDsnException('Malformed token.', $dsn->getOriginalDsn());
+            throw new IncompleteDsnException('Malformed token.', 'telegram://'.$dsn->getHost());
         }
 
         return sprintf('%s:%s', $dsn->getUser(), $dsn->getPassword());

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/Tests/TwitterTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/Tests/TwitterTransportFactoryTest.php
@@ -39,6 +39,6 @@ class TwitterTransportFactoryTest extends TransportFactoryTestCase
 
     public function incompleteDsnProvider(): iterable
     {
-        yield ['twitter://A:B@default', 'Invalid "twitter://A:B@default" notifier DSN: Access Token is missing'];
+        yield ['twitter://A:B@default', 'Invalid "twitter://default" notifier DSN: Access Token is missing'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransportFactory.php
@@ -34,7 +34,7 @@ final class TwitterTransportFactory extends AbstractTransportFactory
 
         foreach (['API Key' => $apiKey, 'API Key Secret' => $apiSecret, 'Access Token' => $accessToken, 'Access Token Secret' => $accessSecret] as $name => $key) {
             if (!$key) {
-                throw new IncompleteDsnException($name.' is missing.', $dsn->getOriginalDsn());
+                throw new IncompleteDsnException($name.' is missing.', 'twitter://'.$dsn->getHost());
             }
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Zendesk/ZendeskTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zendesk/ZendeskTransportFactory.php
@@ -45,11 +45,11 @@ final class ZendeskTransportFactory extends AbstractTransportFactory
     {
         $host = $dsn->getHost();
         if ('default' === $host) {
-            throw new IncompleteDsnException('Host is not set.', $dsn->getOriginalDsn());
+            throw new IncompleteDsnException('Host is not set.', 'zendesk://default');
         }
 
         if (!str_ends_with($host, '.zendesk.com')) {
-            throw new IncompleteDsnException('Host must be in format: "subdomain.zendesk.com".', $dsn->getOriginalDsn());
+            throw new IncompleteDsnException('Host must be in format: "subdomain.zendesk.com".', 'zendesk://'.$dsn->getHost());
         }
 
         return $host;

--- a/src/Symfony/Component/Notifier/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/DsnTest.php
@@ -155,17 +155,17 @@ final class DsnTest extends TestCase
     {
         yield [
             'some://',
-            'The "some://" notifier DSN is invalid.',
+            'The notifier DSN is invalid.',
         ];
 
         yield [
             '//slack',
-            'The "//slack" notifier DSN must contain a scheme.',
+            'The notifier DSN must contain a scheme.',
         ];
 
         yield [
             'file:///some/path',
-            'The "file:///some/path" notifier DSN must contain a host (use "default" by default).',
+            'The notifier DSN must contain a host (use "default" by default).',
         ];
     }
 

--- a/src/Symfony/Component/Notifier/Transport/AbstractTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Transport/AbstractTransportFactory.php
@@ -42,11 +42,11 @@ abstract class AbstractTransportFactory implements TransportFactoryInterface
 
     protected function getUser(Dsn $dsn): string
     {
-        return $dsn->getUser() ?? throw new IncompleteDsnException('User is not set.', $dsn->getOriginalDsn());
+        return $dsn->getUser() ?? throw new IncompleteDsnException('User is not set.', $dsn->getScheme().'://'.$dsn->getHost());
     }
 
     protected function getPassword(Dsn $dsn): string
     {
-        return $dsn->getPassword() ?? new IncompleteDsnException('Password is not set.', $dsn->getOriginalDsn());
+        return $dsn->getPassword() ?? throw new IncompleteDsnException('Password is not set.', $dsn->getOriginalDsn());
     }
 }

--- a/src/Symfony/Component/Notifier/Transport/Dsn.php
+++ b/src/Symfony/Component/Notifier/Transport/Dsn.php
@@ -34,16 +34,16 @@ final class Dsn
         $this->originalDsn = $dsn;
 
         if (false === $parsedDsn = parse_url($dsn)) {
-            throw new InvalidArgumentException(sprintf('The "%s" notifier DSN is invalid.', $dsn));
+            throw new InvalidArgumentException('The notifier DSN is invalid.');
         }
 
         if (!isset($parsedDsn['scheme'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" notifier DSN must contain a scheme.', $dsn));
+            throw new InvalidArgumentException('The notifier DSN must contain a scheme.');
         }
         $this->scheme = $parsedDsn['scheme'];
 
         if (!isset($parsedDsn['host'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" notifier DSN must contain a host (use "default" by default).', $dsn));
+            throw new InvalidArgumentException('The notifier DSN must contain a host (use "default" by default).');
         }
         $this->host = $parsedDsn['host'];
 

--- a/src/Symfony/Component/Semaphore/Store/StoreFactory.php
+++ b/src/Symfony/Component/Semaphore/Store/StoreFactory.php
@@ -22,7 +22,7 @@ use Symfony\Component\Semaphore\PersistingStoreInterface;
  */
 class StoreFactory
 {
-    public static function createStore(object|string $connection): PersistingStoreInterface
+    public static function createStore(#[\SensitiveParameter] object|string $connection): PersistingStoreInterface
     {
         switch (true) {
             case $connection instanceof \Redis:
@@ -33,10 +33,11 @@ class StoreFactory
 
             case !\is_string($connection):
                 throw new InvalidArgumentException(sprintf('Unsupported Connection: "%s".', $connection::class));
+
             case str_starts_with($connection, 'redis://'):
             case str_starts_with($connection, 'rediss://'):
                 if (!class_exists(AbstractAdapter::class)) {
-                    throw new InvalidArgumentException(sprintf('Unsupported DSN "%s". Try running "composer require symfony/cache".', $connection));
+                    throw new InvalidArgumentException('Unsupported Redis DSN. Try running "composer require symfony/cache".');
                 }
                 $connection = AbstractAdapter::createConnection($connection, ['lazy' => true]);
 

--- a/src/Symfony/Component/Translation/Provider/AbstractProviderFactory.php
+++ b/src/Symfony/Component/Translation/Provider/AbstractProviderFactory.php
@@ -27,7 +27,7 @@ abstract class AbstractProviderFactory implements ProviderFactoryInterface
 
     protected function getUser(Dsn $dsn): string
     {
-        return $dsn->getUser() ?? throw new IncompleteDsnException('User is not set.', $dsn->getOriginalDsn());
+        return $dsn->getUser() ?? throw new IncompleteDsnException('User is not set.', $dsn->getScheme().'://'.$dsn->getHost());
     }
 
     protected function getPassword(Dsn $dsn): string

--- a/src/Symfony/Component/Translation/Provider/Dsn.php
+++ b/src/Symfony/Component/Translation/Provider/Dsn.php
@@ -34,16 +34,16 @@ final class Dsn
         $this->originalDsn = $dsn;
 
         if (false === $parsedDsn = parse_url($dsn)) {
-            throw new InvalidArgumentException(sprintf('The "%s" translation provider DSN is invalid.', $dsn));
+            throw new InvalidArgumentException('The translation provider DSN is invalid.');
         }
 
         if (!isset($parsedDsn['scheme'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" translation provider DSN must contain a scheme.', $dsn));
+            throw new InvalidArgumentException('The translation provider DSN must contain a scheme.');
         }
         $this->scheme = $parsedDsn['scheme'];
 
         if (!isset($parsedDsn['host'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" translation provider DSN must contain a host (use "default" by default).', $dsn));
+            throw new InvalidArgumentException('The translation provider DSN must contain a host (use "default" by default).');
         }
         $this->host = $parsedDsn['host'];
 

--- a/src/Symfony/Component/Translation/Tests/Provider/DsnTest.php
+++ b/src/Symfony/Component/Translation/Tests/Provider/DsnTest.php
@@ -155,17 +155,17 @@ final class DsnTest extends TestCase
     {
         yield [
             'some://',
-            'The "some://" translation provider DSN is invalid.',
+            'The translation provider DSN is invalid.',
         ];
 
         yield [
             '//loco',
-            'The "//loco" translation provider DSN must contain a scheme.',
+            'The translation provider DSN must contain a scheme.',
         ];
 
         yield [
             'file:///some/path',
-            'The "file:///some/path" translation provider DSN must contain a host (use "default" by default).',
+            'The translation provider DSN must contain a host (use "default" by default).',
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follow up of #49065

We should be careful when reviewing notifier bridges, to ensure that transports' `__toString()` don't embed any secrets. /cc @OskarStark 