### PR TITLE
[DependencyInjection] Fix named arguments when using ContainerBuilder before compilation

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1089,6 +1089,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             return $this->services[$id] ?? $this->privates[$id];
         }
 
+        if (!array_is_list($arguments)) {
+            $arguments = array_combine(array_map(function ($k) { return preg_replace('/^.*\\$/', '', $k); }, array_keys($arguments)), $arguments);
+        }
+
         if (null !== $factory) {
             $service = $factory(...$arguments);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1777,7 +1777,7 @@ class ContainerBuilderTest extends TestCase
     /**
      * @requires PHP 8
      */
-    public function testNamedArgument()
+    public function testNamedArgumentAfterCompile()
     {
         $container = new ContainerBuilder();
         $container->register(E::class)
@@ -1790,6 +1790,21 @@ class ContainerBuilderTest extends TestCase
 
         $this->assertSame('', $e->first);
         $this->assertSame(2, $e->second);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testNamedArgumentBeforeCompile()
+    {
+        $container = new ContainerBuilder();
+        $container->register(E::class, E::class)
+            ->setPublic(true)
+            ->setArguments(['$first' => 1]);
+
+        $e = $container->get(E::class);
+
+        $this->assertSame(1, $e->first);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49074
| License       | MIT
| Doc PR        | -