### PR TITLE
[FrameworkBundle][HttpKernel] Add `uri_max_length` option and `UriTooLongHttpException`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate `framework:exceptions` tag, unwrap it and replace `framework:exception` tags' `name` attribute by `class`
  * Deprecate the `notifier.logger_notification_listener` service, use the `notifier.notification_logger_listener` service instead
  * Allow setting private services with the test container
+ * Add `framework.uri_max_length` option
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -134,6 +134,11 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('error_controller')
                 ->end()
                 ->booleanNode('handle_all_throwables')->info('HttpKernel will handle all kinds of \Throwable')->end()
+                ->integerNode('uri_max_length')
+                    ->min(0)
+                    ->defaultNull()
+                    ->info('The maximum length of URLs the HttpKernel should handle')
+                ->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -336,6 +336,7 @@ class FrameworkExtension extends Extension
         $container->getDefinition('locale_listener')->replaceArgument(3, $config['set_locale_from_accept_language']);
         $container->getDefinition('response_listener')->replaceArgument(1, $config['set_content_language_from_locale']);
         $container->getDefinition('http_kernel')->replaceArgument(4, $config['handle_all_throwables'] ?? false);
+        $container->getDefinition('http_kernel')->replaceArgument(5, $config['uri_max_length'] ?? null);
 
         // If the slugger is used but the String component is not available, we should throw an error
         if (!ContainerBuilder::willBeAvailable('symfony/string', SluggerInterface::class, ['symfony/framework-bundle'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -91,6 +91,7 @@ return static function (ContainerConfigurator $container) {
                 service('request_stack'),
                 service('argument_resolver'),
                 false,
+                null,
             ])
             ->tag('container.hot_path')
             ->tag('container.preload', ['class' => HttpKernelRunner::class])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -687,6 +687,7 @@ class ConfigurationTest extends TestCase
                 'sanitizers' => [],
             ],
             'exceptions' => [],
+            'uri_max_length' => null,
         ];
     }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `#[WithHttpStatus]` for defining status codes for exceptions
  * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
  * Add `#[WithLogLevel]` for defining log levels for exceptions
+ * Add `UriTooLongHttpException` and allow setting a length limit to URL being handled by `HttpKernel`
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Exception/UriTooLongHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UriTooLongHttpException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class UriTooLongHttpException extends HttpException
+{
+    public function __construct(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
+    {
+        parent::__construct(414, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UriTooLongHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UriTooLongHttpExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\UriTooLongHttpException;
+
+class UriTooLongHttpExceptionTest extends HttpExceptionTest
+{
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
+    {
+        return new UriTooLongHttpException($message, $previous, $code, $headers);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | _NA_
| License       | MIT

This PR aims to prevent going any further in the different Kernel events if the URI is too long and should not be processed. [To quote MDN](https://developer.mozilla.org/fr/docs/Web/HTTP/Status/414), this is particularly useful in the case of an accidental redirection loop for instance.