### PR TITLE
[HttpFoundation] inject SessionHandler in PdoSessionHandlerSchemaSubscriber

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaSubscriberTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaSubscriberTest.php
@@ -36,7 +36,7 @@ class PdoSessionHandlerSchemaSubscriberTest extends TestCase
             ->method('configureSchema')
             ->with($schema, fn () => true);
 
-        $subscriber = new PdoSessionHandlerSchemaSubscriber([$pdoSessionHandler]);
+        $subscriber = new PdoSessionHandlerSchemaSubscriber($pdoSessionHandler);
         $subscriber->postGenerateSchema($event);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -178,9 +178,12 @@ class PdoSessionHandler extends AbstractSessionHandler
         $this->ttl = $options['ttl'] ?? null;
     }
 
-    public function configureSchema(Schema $schema, \Closure $isSameDatabase): void
+    /**
+     * Adds the Table to the Schema if it doesn't exist.
+     */
+    public function configureSchema(Schema $schema, \Closure $isSameDatabase = null): void
     {
-        if ($schema->hasTable($this->table) || !$isSameDatabase($this->getConnection()->exec(...))) {
+        if ($schema->hasTable($this->table) || ($isSameDatabase && !$isSameDatabase($this->getConnection()->exec(...)))) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        |  I'm working on it

following the PR https://github.com/symfony/symfony/pull/48059. 

In https://github.com/symfony/symfony/pull/48059, it works only if you put the handler explicitly to PdoSessionHandler in the configuration (handler_id) but it stops working if the session is defined by the factory and we can't use it as follow:
````
handler_id: '%env(resolve:DATABASE_URL)%' 
`````

Linked to DoctrineBundle PR https://github.com/doctrine/DoctrineBundle/pull/1623

Also imho, I think the second argument of configureSchema inPdoSessionHandler should be optional and set to return true if not defined  since the function is public eg. one wants to add the table to the Schema.