### PR TITLE
[Config] Allow enum values in EnumNode

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -426,7 +426,7 @@ public function NAME($value): static
             }
 
             if ($node instanceof EnumNode) {
-                $comment .= sprintf(' * @param ParamConfigurator|%s $value', implode('|', array_unique(array_map(fn ($a) => var_export($a, true), $node->getValues()))))."\n";
+                $comment .= sprintf(' * @param ParamConfigurator|%s $value', implode('|', array_unique(array_map(fn ($a) => !$a instanceof \UnitEnum ? var_export($a, true) : '\\'.ltrim(var_export($a, true), '\\'), $node->getValues()))))."\n";
             } else {
                 $parameterTypes = $this->getParameterTypes($node);
                 $comment .= ' * @param ParamConfigurator|'.implode('|', $parameterTypes).' $value'."\n";

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Allow enum values in `EnumNode`
+
 6.2
 ---
 

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -107,7 +107,7 @@ class XmlReferenceDumper
                             FloatNode::class,
                             IntegerNode::class => 'numeric value',
                             BooleanNode::class => 'true|false',
-                            EnumNode::class => implode('|', array_unique(array_map('json_encode', $prototype->getValues()))),
+                            EnumNode::class => $prototype->getPermissibleValues('|'),
                             default => 'value',
                         };
                     }
@@ -149,7 +149,7 @@ class XmlReferenceDumper
                 }
 
                 if ($child instanceof EnumNode) {
-                    $comments[] = 'One of '.implode('; ', array_unique(array_map('json_encode', $child->getValues())));
+                    $comments[] = 'One of '.$child->getPermissibleValues('; ');
                 }
 
                 if (\count($comments)) {

--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -98,7 +98,7 @@ class YamlReferenceDumper
                 }
             }
         } elseif ($node instanceof EnumNode) {
-            $comments[] = 'One of '.implode('; ', array_unique(array_map('json_encode', $node->getValues())));
+            $comments[] = 'One of '.$node->getPermissibleValues('; ');
             $default = $node->hasDefaultValue() ? Inline::dump($node->getDefaultValue()) : '~';
         } elseif (VariableNode::class === $node::class && \is_array($example)) {
             // If there is an array example, we are sure we dont need to print a default value

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -29,8 +29,16 @@ class EnumNode extends ScalarNode
         }
 
         foreach ($values as $value) {
-            if (null !== $value && !\is_scalar($value)) {
-                throw new \InvalidArgumentException(sprintf('"%s" only supports scalar or null values, "%s" given.', __CLASS__, get_debug_type($value)));
+            if (null === $value || \is_scalar($value)) {
+                continue;
+            }
+
+            if (!$value instanceof \UnitEnum) {
+                throw new \InvalidArgumentException(sprintf('"%s" only supports scalar, enum, or null values, "%s" given.', __CLASS__, get_debug_type($value)));
+            }
+
+            if ($value::class !== ($enumClass ??= $value::class)) {
+                throw new \InvalidArgumentException(sprintf('"%s" only supports one type of enum, "%s" and "%s" passed.', __CLASS__, $enumClass, $value::class));
             }
         }
 
@@ -43,12 +51,35 @@ class EnumNode extends ScalarNode
         return $this->values;
     }
 
+    /**
+     * @internal
+     */
+    public function getPermissibleValues(string $separator): string
+    {
+        return implode($separator, array_unique(array_map(static function (mixed $value): string {
+            if (!$value instanceof \UnitEnum) {
+                return json_encode($value);
+            }
+
+            return ltrim(var_export($value, true), '\\');
+        }, $this->values)));
+    }
+
+    protected function validateType(mixed $value)
+    {
+        if ($value instanceof \UnitEnum) {
+            return;
+        }
+
+        parent::validateType($value);
+    }
+
     protected function finalizeValue(mixed $value): mixed
     {
         $value = parent::finalizeValue($value);
 
         if (!\in_array($value, $this->values, true)) {
-            $ex = new InvalidConfigurationException(sprintf('The value %s is not allowed for path "%s". Permissible values: %s', json_encode($value), $this->getPath(), implode(', ', array_unique(array_map('json_encode', $this->values)))));
+            $ex = new InvalidConfigurationException(sprintf('The value %s is not allowed for path "%s". Permissible values: %s', json_encode($value), $this->getPath(), $this->getPermissibleValues(', ')));
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Config\Tests\Builder\Fixtures;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Tests\Fixtures\TestEnum;
 
 class PrimitiveTypes implements ConfigurationInterface
 {
@@ -23,7 +24,7 @@ class PrimitiveTypes implements ConfigurationInterface
         $rootNode
             ->children()
                 ->booleanNode('boolean_node')->end()
-                ->enumNode('enum_node')->values(['foo', 'bar', 'baz'])->end()
+                ->enumNode('enum_node')->values(['foo', 'bar', 'baz', TestEnum::Bar])->end()
                 ->floatNode('float_node')->end()
                 ->integerNode('integer_node')->end()
                 ->scalarNode('scalar_node')->end()

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
@@ -33,7 +33,7 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
 
     /**
      * @default null
-     * @param ParamConfigurator|'foo'|'bar'|'baz' $value
+     * @param ParamConfigurator|'foo'|'bar'|'baz'|\Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar $value
      * @return $this
      */
     public function enumNode($value): static

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
@@ -41,7 +41,7 @@ class XmlReferenceDumperTest extends TestCase
 <!-- scalar-deprecated: Deprecated (Since vendor/package 1.1: The child node "scalar_deprecated" at path "acme_root" is deprecated.) -->
 <!-- scalar-deprecated-with-message: Deprecated (Since vendor/package 1.1: Deprecation custom message for "scalar_deprecated_with_message" at "acme_root") -->
 <!-- enum-with-default: One of "this"; "that" -->
-<!-- enum: One of "this"; "that" -->
+<!-- enum: One of "this"; "that"; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc -->
 <!-- variable: Example: foo, bar -->
 <config
     boolean="true"

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -102,7 +102,7 @@ acme_root:
     scalar_deprecated_with_message: ~ # Deprecated (Since vendor/package 1.1: Deprecation custom message for "scalar_deprecated_with_message" at "acme_root")
     node_with_a_looong_name: ~
     enum_with_default:    this # One of "this"; "that"
-    enum:                 ~ # One of "this"; "that"
+    enum:                 ~ # One of "this"; "that"; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
 
     # some info
     array:

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -14,13 +14,16 @@ namespace Symfony\Component\Config\Tests\Definition;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\EnumNode;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Tests\Fixtures\TestEnum;
+use Symfony\Component\Config\Tests\Fixtures\TestEnum2;
 
 class EnumNodeTest extends TestCase
 {
     public function testFinalizeValue()
     {
-        $node = new EnumNode('foo', null, ['foo', 'bar']);
+        $node = new EnumNode('foo', null, ['foo', 'bar', TestEnum::Bar]);
         $this->assertSame('foo', $node->finalize('foo'));
+        $this->assertSame(TestEnum::Bar, $node->finalize(TestEnum::Bar));
     }
 
     public function testConstructionWithNoValues()
@@ -51,8 +54,8 @@ class EnumNodeTest extends TestCase
     public function testFinalizeWithInvalidValue()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The value "foobar" is not allowed for path "foo". Permissible values: "foo", "bar"');
-        $node = new EnumNode('foo', null, ['foo', 'bar']);
+        $this->expectExceptionMessage('The value "foobar" is not allowed for path "foo". Permissible values: "foo", "bar", Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo');
+        $node = new EnumNode('foo', null, ['foo', 'bar', TestEnum::Foo]);
         $node->finalize('foobar');
     }
 
@@ -80,11 +83,19 @@ class EnumNodeTest extends TestCase
         $this->assertNull($node->finalize(null));
     }
 
-    public function testNonScalarOrNullValueThrows()
+    public function testNonScalarOrEnumOrNullValueThrows()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('"Symfony\Component\Config\Definition\EnumNode" only supports scalar or null values, "stdClass" given.');
+        $this->expectExceptionMessage('"Symfony\Component\Config\Definition\EnumNode" only supports scalar, enum, or null values, "stdClass" given.');
 
         new EnumNode('ccc', null, [new \stdClass()]);
+    }
+
+    public function testTwoDifferentEnumsThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"Symfony\Component\Config\Definition\EnumNode" only supports one type of enum, "Symfony\Component\Config\Tests\Fixtures\TestEnum" and "Symfony\Component\Config\Tests\Fixtures\TestEnum2" passed.');
+
+        new EnumNode('ccc', null, [...TestEnum::cases(), TestEnum2::Ccc]);
     }
 }

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Config\Tests\Fixtures\Configuration;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Tests\Fixtures\TestEnum;
 
 class ExampleConfiguration implements ConfigurationInterface
 {
@@ -38,7 +39,7 @@ class ExampleConfiguration implements ConfigurationInterface
                 ->scalarNode('scalar_deprecated_with_message')->setDeprecated('vendor/package', '1.1', 'Deprecation custom message for "%node%" at "%path%"')->end()
                 ->scalarNode('node_with_a_looong_name')->end()
                 ->enumNode('enum_with_default')->values(['this', 'that'])->defaultValue('this')->end()
-                ->enumNode('enum')->values(['this', 'that'])->end()
+                ->enumNode('enum')->values(['this', 'that', TestEnum::Ccc])->end()
                 ->arrayNode('array')
                     ->info('some info')
                     ->canBeUnset()

--- a/src/Symfony/Component/Config/Tests/Fixtures/TestEnum.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/TestEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Config\Tests\Fixtures;
+
+enum TestEnum
+{
+    case Foo;
+    case Bar;
+    case Ccc;
+}

--- a/src/Symfony/Component/Config/Tests/Fixtures/TestEnum2.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/TestEnum2.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Config\Tests\Fixtures;
+
+enum TestEnum2
+{
+    case Foo;
+    case Bar;
+    case Ccc;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR allows adding 1..N case(s) from the same enum to the allowed values of `EnumNode`:
```php
// Allow all cases
->enumNode('foo', FooEnum::cases())

// Allow some cases with some other scalar values
->enumNode('foo', [true, false, FooEnum::Foo, FooEnum::Bar])
```

The two benefits are not having to reconstruct the enum instance at process time and being able to use the real enum directly in PHP config files:
```php
$config
    ->foo(FooEnum::Bar);
```

YAML config files can also pass an enum value:
```yaml
foo: !php/enum \App\Enum\FooEnum::Bar
```

AFAIK, XML config files can't pass an enum value, which would mean they could not be used in this case.