### PR TITLE
[Contracts] Introduce Symfony StoppableEventInterface

### DIFF
--- a/src/Symfony/Contracts/EventDispatcher/Event.php
+++ b/src/Symfony/Contracts/EventDispatcher/Event.php
@@ -35,13 +35,6 @@ class Event implements StoppableEventInterface
         return $this->propagationStopped;
     }
 
-    /**
-     * Stops the propagation of the event to further event listeners.
-     *
-     * If multiple event listeners are connected to the same event, no
-     * further event listener will be triggered once any trigger calls
-     * stopPropagation().
-     */
     public function stopPropagation(): void
     {
         $this->propagationStopped = true;

--- a/src/Symfony/Contracts/EventDispatcher/Event.php
+++ b/src/Symfony/Contracts/EventDispatcher/Event.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Contracts\EventDispatcher;
 
-use Psr\EventDispatcher\StoppableEventInterface;
-
 /**
  * Event is the base class for classes containing event data.
  *

--- a/src/Symfony/Contracts/EventDispatcher/StoppableEventInterface.php
+++ b/src/Symfony/Contracts/EventDispatcher/StoppableEventInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\EventDispatcher;
+
+use Psr\EventDispatcher\StoppableEventInterface as PsrStoppableEventInterface;
+
+interface StoppableEventInterface extends PsrStoppableEventInterface
+{
+    public function stopPropagation(): void;
+}

--- a/src/Symfony/Contracts/EventDispatcher/StoppableEventInterface.php
+++ b/src/Symfony/Contracts/EventDispatcher/StoppableEventInterface.php
@@ -15,5 +15,12 @@ use Psr\EventDispatcher\StoppableEventInterface as PsrStoppableEventInterface;
 
 interface StoppableEventInterface extends PsrStoppableEventInterface
 {
+    /**
+     * Stops the propagation of the event to further event listeners.
+     *
+     * If multiple event listeners are connected to the same event, no
+     * further event listener will be triggered once any trigger calls
+     * stopPropagation().
+     */
     public function stopPropagation(): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

The StoppableEventInterface from Psr only provide a 
```
public function isPropagationStopped(): bool
```
method, but there is no interface for the 
```
public function stopPropagation(): void
```
method provided in the Event class.

From https://github.com/symfony/symfony/issues/9539, the Event is a value object and no EventInterface should be provided.

But if someone want to create a specific interface for event with more methods:
```
interface MyEventInterface extends PsrStoppableEventInterface
{
     public function getUser(): ?User;
}
```
because he need to have a getUser method on every events, 
then he cannot call `stopPropagation` on it without static analysis errors ; unless doing
```
interface MyEventInterface extends PsrStoppableEventInterface
{
     public function getUser(): ?User;

     public function stopPropagation(): void;
}
```

If Symfony provide a `StoppableEventInterface` with the `stopPropagation` in it, it solve this issue.