### PR TITLE
[FrameworkBundle][Workflow] Register alias for argument for workflow services with workflow name only

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate `framework:exceptions` tag, unwrap it and replace `framework:exception` tags' `name` attribute by `class`
  * Deprecate the `notifier.logger_notification_listener` service, use the `notifier.notification_logger_listener` service instead
  * Allow setting private services with the test container
+ * Register alias for argument for workflow services with workflow name only
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1006,6 +1006,7 @@ class FrameworkExtension extends Extension
             $container->setDefinition($workflowId, $workflowDefinition);
             $container->setDefinition(sprintf('%s.definition', $workflowId), $definitionDefinition);
             $container->registerAliasForArgument($workflowId, WorkflowInterface::class, $name.'.'.$type);
+            $container->registerAliasForArgument($workflowId, WorkflowInterface::class, $name);
 
             // Validate Workflow
             if ('state_machine' === $workflow['type']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |
| Tickets       |
| License       | MIT
| Doc PR        |

---

This allows to write:

```php
    public function __construct(
        #[Target('rules')]
        private readonly WorkflowInterface $rulesStateMachine,
    ) {
```

instead of:
```php
    public function __construct(
        #[Target('rulesStateMachine')]
        private readonly WorkflowInterface $rulesStateMachine,
    ) {
```
