### PR TITLE
[Security/Http] Fix compat of persistent remember-me with legacy tokens

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -34,7 +34,6 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
 {
     private $tokenProvider;
     private $tokenVerifier;
-    private $secret;
 
     public function __construct(TokenProviderInterface $tokenProvider, string $secret, UserProviderInterface $userProvider, RequestStack $requestStack, array $options, LoggerInterface $logger = null, TokenVerifierInterface $tokenVerifier = null)
     {
@@ -45,7 +44,6 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         }
         $this->tokenProvider = $tokenProvider;
         $this->tokenVerifier = $tokenVerifier;
-        $this->secret = $secret;
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeDetails.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeDetails.php
@@ -36,6 +36,9 @@ class RememberMeDetails
 
     public static function fromRawCookie(string $rawCookie): self
     {
+        if (!str_contains($rawCookie, self::COOKIE_DELIMITER)) {
+            $rawCookie = base64_decode($rawCookie);
+        }
         $cookieParts = explode(self::COOKIE_DELIMITER, $rawCookie, 4);
         if (4 !== \count($cookieParts)) {
             throw new AuthenticationException('The cookie contains invalid data.');

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -156,4 +156,19 @@ class PersistentRememberMeHandlerTest extends TestCase
 
         $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
     }
+
+    public function testBase64EncodedTokens()
+    {
+        $this->tokenProvider->expects($this->any())
+            ->method('loadTokenBySeries')
+            ->with('series1')
+            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('-10 min')))
+        ;
+
+        $this->tokenProvider->expects($this->once())->method('updateToken')->with('series1');
+
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue');
+        $rememberMeDetails = RememberMeDetails::fromRawCookie(base64_encode($rememberMeDetails->toString()));
+        $this->handler->consumeRememberMeCookie($rememberMeDetails);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49100
| License       | MIT
| Doc PR        | -

In #49078, we changed the format of remember-me tokens, effectively invalidating them all.
While the invalidation is intentional for signature-based remember-me handlers, persistent remember-me handlers could accept both legacy and updated tokens.
This PR fixes compat with legacy tokens for persistent remember-me handlers.