### PR TITLE
[6.2] Remove mentions of v6.1 backers

### DIFF
--- a/src/Symfony/Component/HttpClient/README.md
+++ b/src/Symfony/Component/HttpClient/README.md
@@ -3,23 +3,6 @@ HttpClient component
 
 The HttpClient component provides powerful methods to fetch HTTP resources synchronously or asynchronously.
 
-Sponsor
--------
-
-The Httpclient component for Symfony 6.1 is [backed][1] by [Prisma Media][2].
-
-Prisma Media has become in 40 years the n°1 French publishing group, on print and
-digitally, with 20 flagship brands of the news magazines : Femme Actuelle, GEO,
-Capital, Gala or Télé-Loisirs… Today, more than 42 million French people are in
-contact with one of our brand each month, either by leafing through a magazine,
-surfing the web, subscribing one our mobile or tablet application or listening to
-our podcasts' series. Prisma Media has successfully transformed one's business
-model : from a historic player in the world of paper, it has become in 5 years
-one of the first publishers of multi-media editorial content, and one of the
-first creators of digital solutions.
-
-Help Symfony by [sponsoring][3] its development!
-
 Resources
 ---------
 
@@ -28,7 +11,3 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
-
-[1]: https://symfony.com/backers
-[2]: https://www.prismamedia.com
-[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Notifier/README.md
+++ b/src/Symfony/Component/Notifier/README.md
@@ -3,19 +3,6 @@ Notifier Component
 
 The Notifier component sends notifications via one or more channels (email, SMS, ...).
 
-Sponsor
--------
-
-The Notifier component for Symfony 6.1 is [backed][1] by [Mercure.rocks][2].
-
-Create real-time experiences in minutes! Mercure.rocks provides a realtime API service
-that is tightly integrated with Symfony: create UIs that update in live with UX Turbo,
-send notifications with the Notifier component, expose async APIs with API Platform and
-create low level stuffs with the Mercure component. We maintain and scale the complex
-infrastructure for you!
-
-Help Symfony by [sponsoring][3] its development!
-
 Resources
 ---------
 
@@ -24,7 +11,3 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
-
-[1]: https://symfony.com/backers
-[2]: https://mercure.rocks
-[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Process/README.md
+++ b/src/Symfony/Component/Process/README.md
@@ -3,17 +3,6 @@ Process Component
 
 The Process component executes commands in sub-processes.
 
-Sponsor
--------
-
-The Process component for Symfony 6.1 is [backed][1] by [SensioLabs][2].
-
-As the creator of Symfony, SensioLabs supports companies using Symfony, with an
-offering encompassing consultancy, expertise, services, training, and technical
-assistance to ensure the success of web application development projects.
-
-Help Symfony by [sponsoring][3] its development!
-
 Resources
 ---------
 
@@ -22,7 +11,3 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
-
-[1]: https://symfony.com/backers
-[2]: https://sensiolabs.com
-[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Runtime/README.md
+++ b/src/Symfony/Component/Runtime/README.md
@@ -3,17 +3,6 @@ Runtime Component
 
 Symfony Runtime enables decoupling applications from global state.
 
-Sponsor
--------
-
-The Runtime component for Symfony 6.1 is [backed][1] by [Fulgens][2].
-
-Fulgens is a human-sized company founded in 2018. Specialized in development, we
-provide support, analysis and training. Symfony being at the heart of our work,
-we are committed to contribute to its development at our own scale.
-
-Help Symfony by [sponsoring][3] its development!
-
 Resources
 ---------
 
@@ -22,7 +11,3 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
-
-[1]: https://symfony.com/backers
-[2]: https://fulgens.be
-[3]: https://symfony.com/sponsor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Their sponsoring terms for v6.1 ended. Thanks to them! If you read this message, please consider taking over. Every company using Symfony can afford sponsoring one component for at least one version.

- Fulgens for Runtime v6.1 /cc @alexandre-castelain
- Prisma Media for HttpClient v6.1 /cc @GromNaN 
- Mercure.rocks for Notifier v6.1 /cc @dunglas 
- SensioLabs for Process /cc @Jean-Beru @hadriengem et al.

