### PR TITLE
[Validator] Allow Nested Valid Constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -71,17 +71,13 @@ abstract class Composite extends Constraint
 
                 throw new ConstraintDefinitionException(sprintf('The value "%s" is not an instance of Constraint in constraint "%s".', $constraint, static::class));
             }
-
-            if ($constraint instanceof Valid) {
-                throw new ConstraintDefinitionException(sprintf('The constraint Valid cannot be nested inside constraint "%s". You can only declare the Valid constraint directly on a field or method.', static::class));
-            }
         }
 
         if (!isset(((array) $this)['groups'])) {
             $mergedGroups = [];
 
             foreach ($nestedConstraints as $constraint) {
-                foreach ($constraint->groups as $group) {
+                foreach ($constraint->groups ?? [self::DEFAULT_GROUP] as $group) {
                     $mergedGroups[$group] = true;
                 }
             }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
@@ -155,11 +155,11 @@ class CompositeTest extends TestCase
         ]);
     }
 
-    public function testValidCantBeNested()
+    public function testValidCanBeNested()
     {
-        $this->expectException(ConstraintDefinitionException::class);
-        new ConcreteComposite([
-            new Valid(),
-        ]);
+        $nestedConstraint = new Valid();
+        $constraint = new ConcreteComposite($nestedConstraint);
+
+        $this->assertEquals([$nestedConstraint], $constraint->constraints);
     }
 }


### PR DESCRIPTION
Removes the restriction that the `Valid` constraint cannot be nested inside a `Composite` constraint.

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | None

My use case is attempting naively to use `Valid` with a `When` constraint, like so...

```php
#[Constraint\When(expression: 'some condition', constraints: [new Constraint\Valid()])]
public Foo $foo;
```

ie. Only descend to validate this property when some condition is met, in my case when another boolean field is true.

This functionality seems to have been added [some time ago](https://github.com/symfony/symfony/commit/1fe39962fd100889f375bc99715fd92bed4a1f36) and while I can see other constraints have been added with the same restriction, I can't see the precise reason so I'm hoping something has changed in the meantime.  A warning sign is that the `groups` property is not defined on the `Valid` constraint when used this way, hence the addition of the default. Any pointers appreciated.

Apologies if this case has been brought up before but I couldn't find an issue, or if there is a [workaround](https://stackoverflow.com/questions/68871451/symfony-validate-object-on-condition) or better approach. I'll hold on updating tests until this can be verified or rejected.