### PR TITLE
Utilize shivammathur/setup-php to install Relay extension

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -134,18 +134,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
-          extensions: "json,couchbase-3.2.2,memcached,mongodb-1.12.0,redis,rdkafka,xsl,ldap,msgpack,igbinary"
+          extensions: "json,couchbase-3.2.2,memcached,mongodb-1.12.0,redis,rdkafka,xsl,ldap,relay-dev"
           ini-values: date.timezone=UTC,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1
           php-version: "${{ matrix.php }}"
           tools: pecl
-
-      - name: Install Relay
-        run: |
-          curl -L "https://builds.r2.relay.so/dev/relay-dev-php${{ matrix.php }}-debian-x86-64.tar.gz" | tar xz
-          cd relay-dev-php${{ matrix.php }}-debian-x86-64
-          sudo cp relay.ini $(php-config --ini-dir)
-          sudo cp relay-pkg.so $(php-config --extension-dir)/relay.so
-          sudo sed -i "s/00000000-0000-0000-0000-000000000000/$(cat /proc/sys/kernel/random/uuid)/" $(php-config --extension-dir)/relay.so
 
       - name: Display versions
         run: |

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -24,17 +24,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-          extensions: "json,couchbase,memcached,mongodb,redis,xsl,ldap,dom"
+          extensions: "json,couchbase,memcached,mongodb,redis,xsl,ldap,dom,relay"
           ini-values: "memory_limit=-1"
           coverage: none
-
-      - name: Install Relay
-        run: |
-          curl -L "https://builds.r2.relay.so/dev/relay-dev-php8.1-debian-x86-64.tar.gz" | tar xz
-          cd relay-dev-php8.1-debian-x86-64
-          sudo cp relay.ini $(php-config --ini-dir)
-          sudo cp relay-pkg.so $(php-config --extension-dir)/relay.so
-          sudo sed -i "s/00000000-0000-0000-0000-000000000000/$(cat /proc/sys/kernel/random/uuid)/" $(php-config --extension-dir)/relay.so
 
       - name: Checkout target branch
         uses: actions/checkout@v3


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Follow-up to #48930
| License       | MIT
| Doc PR        | 

This is possible since https://github.com/shivammathur/setup-php/releases/tag/2.24.0. A bit unfortunate timing since they tagged it one day after we merged relay, but no biggie.