### PR TITLE
[DependencyInjection] Fix order of arguments when mixing positional and named ones

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -240,6 +240,10 @@ class AutowirePass extends AbstractRecursivePass
         foreach ($parameters as $index => $parameter) {
             $this->defaultArgument->names[$index] = $parameter->name;
 
+            if (\array_key_exists($parameter->name, $arguments)) {
+                $arguments[$index] = $arguments[$parameter->name];
+                unset($arguments[$parameter->name]);
+            }
             if (\array_key_exists($index, $arguments) && '' !== $arguments[$index]) {
                 continue;
             }
@@ -341,7 +345,7 @@ class AutowirePass extends AbstractRecursivePass
 
         // it's possible index 1 was set, then index 0, then 2, etc
         // make sure that we re-order so they're injected as expected
-        ksort($arguments);
+        ksort($arguments, \SORT_NATURAL);
 
         return $arguments;
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -177,8 +177,15 @@ class ResolveBindingsPass extends AbstractRecursivePass
                 }
             }
 
+            $names = [];
+
             foreach ($reflectionMethod->getParameters() as $key => $parameter) {
+                $names[$key] = $parameter->name;
+
                 if (\array_key_exists($key, $arguments) && '' !== $arguments[$key]) {
+                    continue;
+                }
+                if (\array_key_exists($parameter->name, $arguments) && '' !== $arguments[$parameter->name]) {
                     continue;
                 }
 
@@ -210,8 +217,15 @@ class ResolveBindingsPass extends AbstractRecursivePass
                 }
             }
 
+            foreach ($names as $key => $name) {
+                if (\array_key_exists($name, $arguments) && (0 === $key || \array_key_exists($key - 1, $arguments))) {
+                    $arguments[$key] = $arguments[$name];
+                    unset($arguments[$name]);
+                }
+            }
+
             if ($arguments !== $call[1]) {
-                ksort($arguments);
+                ksort($arguments, \SORT_NATURAL);
                 $calls[$i][1] = $arguments;
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1204,4 +1204,19 @@ class AutowirePassTest extends TestCase
         static::assertInstanceOf(DecoratedDecorator::class, $container->get(DecoratorInterface::class));
         static::assertInstanceOf(DecoratedDecorator::class, $container->get(DecoratorImpl::class));
     }
+
+    public function testAutowireWithNamedArgs()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', MultipleArgumentsOptionalScalar::class)
+            ->setArguments(['foo' => 'abc'])
+            ->setAutowired(true)
+            ->setPublic(true);
+        $container->register(A::class, A::class);
+
+        (new AutowirePass())->process($container);
+
+        $this->assertEquals([new TypedReference(A::class, A::class), 'abc'], $container->getDefinition('foo')->getArguments());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -249,4 +249,24 @@ class ResolveBindingsPassTest extends TestCase
 
         $this->assertSame('bar', (string) $container->getDefinition('with_target')->getArgument(0));
     }
+
+    public function testBindWithNamedArgs()
+    {
+        $container = new ContainerBuilder();
+
+        $bindings = [
+            '$apiKey' => new BoundArgument('K'),
+        ];
+
+        $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
+        $definition->setArguments(['c' => 'C', 'hostName' => 'H']);
+        $definition->setBindings($bindings);
+
+        $container->register('foo', CaseSensitiveClass::class);
+
+        $pass = new ResolveBindingsPass();
+        $pass->process($container);
+
+        $this->assertEquals(['C', 'K', 'H'], $definition->getArguments());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49118
| License       | MIT
| Doc PR        | -