### PR TITLE
[Notifier] Mention Prisma Media as backer of v6.2

### DIFF
--- a/src/Symfony/Component/Notifier/README.md
+++ b/src/Symfony/Component/Notifier/README.md
@@ -3,6 +3,23 @@ Notifier Component
 
 The Notifier component sends notifications via one or more channels (email, SMS, ...).
 
+Sponsor
+-------
+
+The Notifier component for Symfony 6.2 is [backed][1] by [Prisma Media][2].
+
+Prisma Media has become in 40 years the n°1 French publishing group, on print and
+digitally, with 20 flagship brands of the news magazines : Femme Actuelle, GEO,
+Capital, Gala or Télé-Loisirs… Today, more than 42 million French people are in
+contact with one of our brand each month, either by leafing through a magazine,
+surfing the web, subscribing one our mobile or tablet application or listening to
+our podcasts' series. Prisma Media has successfully transformed one's business
+model : from a historic player in the world of paper, it has become in 5 years
+one of the first publishers of multi-media editorial content, and one of the
+first creators of digital solutions.
+
+Help Symfony by [sponsoring][3] its development!
+
 Resources
 ---------
 
@@ -11,3 +28,7 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
+
+[1]: https://symfony.com/backers
+[2]: https://www.prismamedia.com
+[3]: https://symfony.com/sponsor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Prisma Media decided to sponsor Notifier instead of HttpClient for v6.2.

Thanks to them! /cc @GromNaN 