### PR TITLE
[EventDispatcher] Add `AsEventSubscriber` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -64,6 +64,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Dotenv\Command\DebugCommand;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\EventDispatcher\Attribute\AsEventSubscriber;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Finder\Finder;
@@ -669,6 +670,12 @@ class FrameworkExtension extends Extension
             }
             $definition->addTag('kernel.event_listener', $tagAttributes);
         });
+
+        $container->registerAttributeForAutoconfiguration(AsEventSubscriber::class, static function (ChildDefinition $definition, AsEventSubscriber $attribute) {
+            $tagAttributes = get_object_vars($attribute);
+            $definition->addTag('kernel.event_subscriber', $tagAttributes);
+        });
+
         $container->registerAttributeForAutoconfiguration(AsController::class, static function (ChildDefinition $definition, AsController $attribute): void {
             $definition->addTag('controller.service_arguments');
         });

--- a/src/Symfony/Component/EventDispatcher/Attribute/AsEventSubscriber.php
+++ b/src/Symfony/Component/EventDispatcher/Attribute/AsEventSubscriber.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Attribute;
+
+/**
+ * Service tag to autoconfigure event subscriber.
+ *
+ * @author Alexander Daubois <alex.daubois@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsEventSubscriber
+{
+    public function __construct(
+        public ?array $subscribedEvents = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `#[AsEventSubscriber]` attribute
+
 6.0
 ---
 

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/InvalidTaggedSubscriber.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/InvalidTaggedSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventSubscriber;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+#[AsEventSubscriber([
+    CustomEvent::class => 'onEvent',
+])]
+final class InvalidTaggedSubscriber implements EventSubscriberInterface
+{
+    public function onEvent(CustomEvent $event): void
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CustomEvent::class => 'onEvent',
+        ];
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedSubscriber.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedSubscriber.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventSubscriber;
+
+#[AsEventSubscriber([
+    CustomEvent::class => 'onEvent',
+])]
+final class TaggedSubscriber
+{
+    public function onEvent(CustomEvent $event): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | On it :slightly_smiling_face: 

How to use:

```php
use Symfony\Component\EventDispatcher\Attribute\AsEventSubscriber;

#[AsEventSubscriber(subscribedEvents: [
    MyEvent::class => 'do',
    MyOtherEvent::class => 'doOther',
])]
class MyEventSubscriber
{
    public function do(MyEvent $event)
    {
        dump('Event');
    }

    public function doOther(): void
    {
        dump('Other event');
    }
}
```

I chose to disallow using the attribute in conjunction with `EventSubscriberInterface` as I'm not sure how we would deal with subscribed events declared both ways (with the attribute and with `getSubscribedEvents`). Replacing events? Merge them? What about events declared with a priority in attributes and then redefined in `getSubscribedEvents`?

Because of these questions, I think that simply disallowing using both the interface and the attribute is OK to me, especially that the attribute also autoconfigures tags.