### PR TITLE
[HttpKernel] Add `#[MapQueryParameter]` to map and validate individual query parameters to controller arguments

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -45,6 +45,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'container.service_subscriber',
         'container.stack',
         'controller.argument_value_resolver',
+        'controller.targeted_value_resolver',
         'controller.service_arguments',
         'controller.targeted_value_resolver',
         'data_collector',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\BackedEnumValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DateTimeValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\QueryParameterValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver;
@@ -89,6 +90,9 @@ return static function (ContainerConfigurator $container) {
 
         ->set('argument_resolver.variadic', VariadicValueResolver::class)
             ->tag('controller.argument_value_resolver', ['priority' => -150, 'name' => VariadicValueResolver::class])
+
+        ->set('argument_resolver.query_parameter_value_resolver', QueryParameterValueResolver::class)
+            ->tag('controller.targeted_value_resolver', ['name' => QueryParameterValueResolver::class])
 
         ->set('response_listener', ResponseListener::class)
             ->args([

--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryParameter.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryParameter.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+/**
+ * Can be used to pass a query parameter to a controller argument.
+ *
+ * @author Ruud Kamphuis <ruud@ticketswap.com>
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class MapQueryParameter
+{
+    /**
+     * @see https://php.net/filter.filters.validate for filter, flags and options
+     *
+     * @param string|null $name The name of the query parameter. If null, the name of the argument in the controller will be used.
+     */
+    public function __construct(
+        public ?string $name = null,
+        public ?int $filter = null,
+        public int $flags = 0,
+        public array $options = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryParameter.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryParameter.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Component\HttpKernel\Attribute;
 
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\QueryParameterValueResolver;
+
 /**
  * Can be used to pass a query parameter to a controller argument.
  *
  * @author Ruud Kamphuis <ruud@ticketswap.com>
  */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-final class MapQueryParameter
+final class MapQueryParameter extends ValueResolver
 {
     /**
      * @see https://php.net/filter.filters.validate for filter, flags and options
@@ -29,6 +31,8 @@ final class MapQueryParameter
         public ?int $filter = null,
         public int $flags = 0,
         public array $options = [],
+        string $resolver = QueryParameterValueResolver::class,
     ) {
+        parent::__construct($resolver);
     }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Introduce targeted value resolvers with `#[ValueResolver]` and `#[AsTargetedValueResolver]`
  * Add `#[MapRequestPayload]` to map and validate request payload from `Request::getContent()` or `Request::$request->all()` to typed objects
  * Add `#[MapQueryString]` to map and validate request query string from `Request::$query->all()` to typed objects
+ * Add `#[MapQueryParameter]` to map and validate individual query parameters to controller arguments
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @author Ruud Kamphuis <ruud@ticketswap.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class QueryParameterValueResolver implements ValueResolverInterface
+{
+    public function resolve(Request $request, ArgumentMetadata $argument): array
+    {
+        if (!$attribute = $argument->getAttributesOfType(MapQueryParameter::class)[0] ?? null) {
+            return [];
+        }
+
+        $name = $attribute->name ?? $argument->getName();
+        if (!$request->query->has($name)) {
+            if ($argument->isNullable() || $argument->hasDefaultValue()) {
+                return [];
+            }
+
+            throw new NotFoundHttpException(sprintf('Missing query parameter "%s".', $name));
+        }
+
+        $value = $request->query->all()[$name];
+
+        if (null === $attribute->filter && 'array' === $argument->getType()) {
+            if (!$argument->isVariadic()) {
+                return [(array) $value];
+            }
+
+            $filtered = array_values(array_filter((array) $value, \is_array(...)));
+
+            if ($filtered !== $value && !($attribute->flags & \FILTER_NULL_ON_FAILURE)) {
+                throw new NotFoundHttpException(sprintf('Invalid query parameter "%s".', $name));
+            }
+
+            return $filtered;
+        }
+
+        $options = [
+            'flags' => $attribute->flags | \FILTER_NULL_ON_FAILURE,
+            'options' => $attribute->options,
+        ];
+
+        if ('array' === $argument->getType() || $argument->isVariadic()) {
+            $value = (array) $value;
+            $options['flags'] |= \FILTER_REQUIRE_ARRAY;
+        }
+
+        $filter = match ($argument->getType()) {
+            'array' => \FILTER_DEFAULT,
+            'string' => \FILTER_DEFAULT,
+            'int' => \FILTER_VALIDATE_INT,
+            'float' => \FILTER_VALIDATE_FLOAT,
+            'bool' => \FILTER_VALIDATE_BOOL,
+            default => throw new \LogicException(sprintf('#[MapQueryParameter] cannot be used on controller argument "%s$%s" of type "%s"; one of array, string, int, float or bool should be used.', $argument->isVariadic() ? '...' : '', $argument->getName(), $argument->getType() ?? 'mixed'))
+        };
+
+        $value = filter_var($value, $attribute->filter ?? $filter, $options);
+
+        if (null === $value && !($attribute->flags & \FILTER_NULL_ON_FAILURE)) {
+            throw new NotFoundHttpException(sprintf('Invalid query parameter "%s".', $name));
+        }
+
+        if (!\is_array($value)) {
+            return [$value];
+        }
+
+        $filtered = array_filter($value, static fn ($v) => null !== $v);
+
+        if ($argument->isVariadic()) {
+            $filtered = array_values($filtered);
+        }
+
+        if ($filtered !== $value && !($attribute->flags & \FILTER_NULL_ON_FAILURE)) {
+            throw new NotFoundHttpException(sprintf('Invalid query parameter "%s".', $name));
+        }
+
+        return $argument->isVariadic() ? $filtered : [$filtered];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
@@ -62,6 +62,8 @@ final class QueryParameterValueResolver implements ValueResolverInterface
         if ('array' === $argument->getType() || $argument->isVariadic()) {
             $value = (array) $value;
             $options['flags'] |= \FILTER_REQUIRE_ARRAY;
+        } else {
+            $options['flags'] |= \FILTER_REQUIRE_SCALAR;
         }
 
         $filter = match ($argument->getType()) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/QueryParameterValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/QueryParameterValueResolverTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\QueryParameterValueResolver;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class QueryParameterValueResolverTest extends TestCase
+{
+    private ValueResolverInterface $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new QueryParameterValueResolver();
+    }
+
+    /**
+     * @dataProvider provideTestResolve
+     */
+    public function testResolve(Request $request, ArgumentMetadata $metadata, array $expected, string $exceptionClass = null, string $exceptionMessage = null)
+    {
+        if ($exceptionMessage) {
+            self::expectException($exceptionClass);
+            self::expectExceptionMessage($exceptionMessage);
+        }
+
+        self::assertSame($expected, $this->resolver->resolve($request, $metadata));
+    }
+
+    /**
+     * @return iterable<string, array{
+     *   Request,
+     *   ArgumentMetadata,
+     *   array<mixed>,
+     *   null|class-string<\Exception>,
+     *   null|string
+     * }>
+     */
+    public static function provideTestResolve(): iterable
+    {
+        yield 'parameter found and array' => [
+            Request::create('/', 'GET', ['ids' => ['1', '2']]),
+            new ArgumentMetadata('ids', 'array', false, false, false, attributes: [new MapQueryParameter()]),
+            [['1', '2']],
+            null,
+        ];
+        yield 'parameter found and array variadic' => [
+            Request::create('/', 'GET', ['ids' => [['1', '2'], ['2']]]),
+            new ArgumentMetadata('ids', 'array', true, false, false, attributes: [new MapQueryParameter()]),
+            [['1', '2'], ['2']],
+            null,
+        ];
+        yield 'parameter found and string' => [
+            Request::create('/', 'GET', ['firstName' => 'John']),
+            new ArgumentMetadata('firstName', 'string', false, false, false, attributes: [new MapQueryParameter()]),
+            ['John'],
+            null,
+        ];
+        yield 'parameter found and string variadic' => [
+            Request::create('/', 'GET', ['ids' => ['1', '2']]),
+            new ArgumentMetadata('ids', 'string', true, false, false, attributes: [new MapQueryParameter()]),
+            ['1', '2'],
+            null,
+        ];
+        yield 'parameter found and string with regexp filter that matches' => [
+            Request::create('/', 'GET', ['firstName' => 'John']),
+            new ArgumentMetadata('firstName', 'string', false, false, false, attributes: [new MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, flags: \FILTER_NULL_ON_FAILURE, options: ['regexp' => '/John/'])]),
+            ['John'],
+            null,
+        ];
+        yield 'parameter found and string with regexp filter that falls back to null on failure' => [
+            Request::create('/', 'GET', ['firstName' => 'Fabien']),
+            new ArgumentMetadata('firstName', 'string', false, false, false, attributes: [new MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, flags: \FILTER_NULL_ON_FAILURE, options: ['regexp' => '/John/'])]),
+            [null],
+            null,
+        ];
+        yield 'parameter found and string with regexp filter that does not match' => [
+            Request::create('/', 'GET', ['firstName' => 'Fabien']),
+            new ArgumentMetadata('firstName', 'string', false, false, false, attributes: [new MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/John/'])]),
+            [],
+            NotFoundHttpException::class,
+            'Invalid query parameter "firstName".',
+        ];
+        yield 'parameter found and string variadic with regexp filter that matches' => [
+            Request::create('/', 'GET', ['firstName' => ['John', 'John']]),
+            new ArgumentMetadata('firstName', 'string', true, false, false, attributes: [new MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, flags: \FILTER_NULL_ON_FAILURE, options: ['regexp' => '/John/'])]),
+            ['John', 'John'],
+            null,
+        ];
+        yield 'parameter found and string variadic with regexp filter that falls back to null on failure' => [
+            Request::create('/', 'GET', ['firstName' => ['John', 'Fabien']]),
+            new ArgumentMetadata('firstName', 'string', true, false, false, attributes: [new MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, flags: \FILTER_NULL_ON_FAILURE, options: ['regexp' => '/John/'])]),
+            ['John'],
+            null,
+        ];
+        yield 'parameter found and string variadic with regexp filter that does not match' => [
+            Request::create('/', 'GET', ['firstName' => ['Fabien']]),
+            new ArgumentMetadata('firstName', 'string', true, false, false, attributes: [new MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/John/'])]),
+            [],
+            NotFoundHttpException::class,
+            'Invalid query parameter "firstName".',
+        ];
+        yield 'parameter found and integer' => [
+            Request::create('/', 'GET', ['age' => 123]),
+            new ArgumentMetadata('age', 'int', false, false, false, attributes: [new MapQueryParameter()]),
+            [123],
+            null,
+        ];
+        yield 'parameter found and integer variadic' => [
+            Request::create('/', 'GET', ['age' => [123, 222]]),
+            new ArgumentMetadata('age', 'int', true, false, false, attributes: [new MapQueryParameter()]),
+            [123, 222],
+            null,
+        ];
+        yield 'parameter found and float' => [
+            Request::create('/', 'GET', ['price' => 10.99]),
+            new ArgumentMetadata('price', 'float', false, false, false, attributes: [new MapQueryParameter()]),
+            [10.99],
+            null,
+        ];
+        yield 'parameter found and float variadic' => [
+            Request::create('/', 'GET', ['price' => [10.99, 5.99]]),
+            new ArgumentMetadata('price', 'float', true, false, false, attributes: [new MapQueryParameter()]),
+            [10.99, 5.99],
+            null,
+        ];
+        yield 'parameter found and boolean yes' => [
+            Request::create('/', 'GET', ['isVerified' => 'yes']),
+            new ArgumentMetadata('isVerified', 'bool', false, false, false, attributes: [new MapQueryParameter()]),
+            [true],
+            null,
+        ];
+        yield 'parameter found and boolean yes variadic' => [
+            Request::create('/', 'GET', ['isVerified' => ['yes', 'yes']]),
+            new ArgumentMetadata('isVerified', 'bool', true, false, false, attributes: [new MapQueryParameter()]),
+            [true, true],
+            null,
+        ];
+        yield 'parameter found and boolean true' => [
+            Request::create('/', 'GET', ['isVerified' => 'true']),
+            new ArgumentMetadata('isVerified', 'bool', false, false, false, attributes: [new MapQueryParameter()]),
+            [true],
+            null,
+        ];
+        yield 'parameter found and boolean 1' => [
+            Request::create('/', 'GET', ['isVerified' => '1']),
+            new ArgumentMetadata('isVerified', 'bool', false, false, false, attributes: [new MapQueryParameter()]),
+            [true],
+            null,
+        ];
+        yield 'parameter found and boolean no' => [
+            Request::create('/', 'GET', ['isVerified' => 'no']),
+            new ArgumentMetadata('isVerified', 'bool', false, false, false, attributes: [new MapQueryParameter()]),
+            [false],
+            null,
+        ];
+        yield 'parameter found and boolean invalid' => [
+            Request::create('/', 'GET', ['isVerified' => 'whatever']),
+            new ArgumentMetadata('isVerified', 'bool', false, false, false, attributes: [new MapQueryParameter()]),
+            [],
+            NotFoundHttpException::class,
+            'Invalid query parameter "isVerified".',
+        ];
+
+        yield 'parameter not found but nullable' => [
+            Request::create('/', 'GET'),
+            new ArgumentMetadata('firstName', 'string', false, false, false, true, [new MapQueryParameter()]),
+            [],
+            null,
+        ];
+
+        yield 'parameter not found but optional' => [
+            Request::create('/', 'GET'),
+            new ArgumentMetadata('firstName', 'string', false, true, false, attributes: [new MapQueryParameter()]),
+            [],
+            null,
+        ];
+
+        yield 'parameter not found' => [
+            Request::create('/', 'GET'),
+            new ArgumentMetadata('firstName', 'string', false, false, false, attributes: [new MapQueryParameter()]),
+            [],
+            NotFoundHttpException::class,
+            'Missing query parameter "firstName".',
+        ];
+
+        yield 'unsupported type' => [
+            Request::create('/', 'GET', ['standardClass' => 'test']),
+            new ArgumentMetadata('standardClass', \stdClass::class, false, false, false, attributes: [new MapQueryParameter()]),
+            [],
+            \LogicException::class,
+            '#[MapQueryParameter] cannot be used on controller argument "$standardClass" of type "stdClass"; one of array, string, int, float or bool should be used.',
+        ];
+        yield 'unsupported type variadic' => [
+            Request::create('/', 'GET', ['standardClass' => 'test']),
+            new ArgumentMetadata('standardClass', \stdClass::class, true, false, false, attributes: [new MapQueryParameter()]),
+            [],
+            \LogicException::class,
+            '#[MapQueryParameter] cannot be used on controller argument "...$standardClass" of type "stdClass"; one of array, string, int, float or bool should be used.',
+        ];
+    }
+
+    public function testSkipWhenNoAttribute()
+    {
+        $metadata = new ArgumentMetadata('firstName', 'string', false, true, false);
+
+        self::assertSame([], $this->resolver->resolve(Request::create('/'), $metadata));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      |no
| New feature?  | yes
| Deprecations? |no 
| Tickets       | 
| License       | MIT
| Doc PR        | 


We increased the PHPStan level from 8 to 9. This lead to some problems when working with query or request parameters.

For example:
```php
$firstName = $request->get('firstName');
```

Because Symfony types `Request::get()` as `mixed` there is no type safety and you have to assert everything manually.

We then learned that we shouldn't use `Request::get()` but use the explicit parameter bag like:
```php
$request->query->get('firstName');
```

This `ParameterBag` is used for `request` and `query`. It contains interesting methods like:
```php
$request->query->getAlpha('firstName') : string;
$request->query->getInt('age') : int;
```

This has the benefit that now the returned value is of a correct type.

Why aren't we being explicit by requiring the parameters and their types in the controller action instead?

Luckily Symfony has a concept called [ValueResolver](https://symfony.com/doc/current/controller/value_resolver.html).

It allows you to do dynamically alter what is injected into a controller action.

So in this PR, we introduces a new attribute: `#[MapQueryParameter]` that can be used in controller arguments.

It allows you to define which parameters your controller is using and which type they should be. For example:

```php
#[Route(path: '/', name: 'admin_dashboard')]
public function indexAction(
  #[MapQueryParameter]
  array $ids,
  #[MapQueryParameter]
  string $firstName,
  #[MapQueryParameter]
  bool $required,
  #[MapQueryParameter]
  int $age,
  #[MapQueryParameter]
  string $category = '',
  #[MapQueryParameter]
  ?string $theme = null,
)
```

When requesting `/?ids[]=1&ids[]=2&firstName=Ruud&required=3&age=123` you'll get:
```
$ids = ['1', '2']
$firstName = "Ruud"
$required = false
$age = 123
$category = ''
$theme = null
```

It even supports variadic arguments like this:
```php
#[Route(path: '/', name: 'admin_dashboard')]
public function indexAction(
  #[MapQueryParameter]
  string ...$ids,
)
```

When requesting `/?ids[]=111&ids[]=222` the `$ids` argument will have an array with values ['111','222'].

Unit testing the controller now also becomes a bit easier, as you only have to pass the required parameters instead of constructing the `Request` object.

It's possible to use `FILTER_VALIDATE_*` consts for more precise type descriptions.

For example, this ensures that `$ids` is an array of integers:
```php
#[MapQueryParameter(filter: \FILTER_VALIDATE_INT)]
array $ids
```

And this declares a string that must match a regexp:
```php
#[MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/^\w++$/'])]
string $name
```

When a filter fails, a 404 is returned.