### PR TITLE
[Validator] Avoid TypeError and improve DX when null groups

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Exception\RuntimeException;
+use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\ObjectInitializerInterface;
@@ -1112,6 +1113,16 @@ class RecursiveValidatorTest extends TestCase
 
         /* @var ConstraintViolationInterface[] $violations */
         $this->assertCount(2, $violations);
+    }
+
+    public function testValidateMultipleGroupsNull()
+    {
+        $entity = new Entity();
+
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('Value in array of validation groups cannot be null.');
+
+        $this->validate($entity, null, ['Group 1', null]);
     }
 
     public function testReplaceDefaultGroupByGroupSequenceObject()

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Context\ExecutionContextFactory;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Exception\RuntimeException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -1094,6 +1095,49 @@ class RecursiveValidatorTest extends TestCase
 
         /** @var ConstraintViolationInterface[] $violations */
         $this->assertCount(2, $violations);
+    }
+
+    /**
+     * @dataProvider getInvalidGroups
+     */
+    public function testValidateInvalidGroup($invalidGroup, string $type)
+    {
+        $entity = new Entity();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The validation groups must be an array of strings or "Symfony\Component\Validator\Constraints\GroupSequence" instances, but the array contains "%s".', $type));
+
+        $this->validate($entity, null, ['Group 1', $invalidGroup]);
+    }
+
+    public static function getInvalidGroups()
+    {
+        yield 'null' => [null, 'null'];
+        yield 'int' => [123, 'int'];
+        yield 'object' => [new \stdClass(), 'stdClass'];
+    }
+
+    public function testValidateWithStringableGroup()
+    {
+        $entity = new Entity();
+
+        $this->metadata->addConstraint(new Callback([
+            'callback' => static function ($value, ExecutionContextInterface $context) {
+                $context->addViolation('Message');
+            },
+            'groups' => 'Group 1',
+        ]));
+
+        $stringableGroup = new class() implements \Stringable {
+            public function __toString(): string
+            {
+                return 'Group 1';
+            }
+        };
+
+        $violations = $this->validate($entity, null, [$stringableGroup]);
+
+        $this->assertCount(1, $violations);
     }
 
     public function testReplaceDefaultGroupByGroupSequenceObject()

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -277,11 +277,15 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
      */
     protected function normalizeGroups($groups)
     {
-        if (\is_array($groups)) {
-            return $groups;
+        if (!\is_array($groups)) {
+            $groups = [$groups];
         }
 
-        return [$groups];
+        if (\in_array(null, $groups, true)) {
+            throw new ValidatorException('Value in array of validation groups cannot be null.');
+        }
+
+        return $groups;
     }
 
     /**
@@ -419,10 +423,6 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         }
 
         foreach ($groups as $key => $group) {
-            if (null === $group) {
-                throw new ValidatorException('Value in array of validation groups cannot be null.');
-            }
-
             // If the "Default" group is replaced by a group sequence, remember
             // to cascade the "Default" group when traversing the group
             // sequence

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -419,6 +419,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         }
 
         foreach ($groups as $key => $group) {
+            if (null === $group) {
+                throw new ValidatorException('Value in array of validation groups cannot be null.');
+            }
+
             // If the "Default" group is replaced by a group sequence, remember
             // to cascade the "Default" group when traversing the group
             // sequence

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Exception\RuntimeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
@@ -266,11 +267,23 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
      */
     protected function normalizeGroups(string|GroupSequence|array $groups): array
     {
-        if (\is_array($groups)) {
-            return $groups;
+        if (!\is_array($groups)) {
+            return [$groups];
         }
 
-        return [$groups];
+        foreach ($groups as $key => $group) {
+            if ($group instanceof GroupSequence) {
+                continue;
+            }
+
+            if (!\is_string($group) && !$group instanceof \Stringable) {
+                throw new InvalidArgumentException(\sprintf('The validation groups must be an array of strings or "%s" instances, but the array contains "%s".', GroupSequence::class, get_debug_type($group)));
+            }
+
+            $groups[$key] = (string) $group;
+        }
+
+        return $groups;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Improve DX when we pass null value in array of groups

```php
$this->validate($entity, null, ['Group 1', null])
```

Before this PR 
`TypeError: Symfony\Component\Validator\Context\ExecutionContext::isGroupValidated(): Argument #2 ($groupHash) must be of type string, null given,`

