### PR TITLE
[FrameworkBundle][HttpKernel] Display warmers duration on debug verbosity for `cache:clear` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Configure the `ErrorHandler` on `FrameworkBundle::boot()`
  * Allow setting `debug.container.dump` to `false` to disable dumping the container to XML
  * Add `framework.http_cache.skip_response_headers` option
+ * Display warmers duration on debug verbosity for `cache:clear` command
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -132,7 +132,7 @@ EOF
                 $warmer = $kernel->getContainer()->get('cache_warmer');
                 // non optional warmers already ran during container compilation
                 $warmer->enableOnlyOptionalWarmers();
-                $preload = (array) $warmer->warmUp($realCacheDir);
+                $preload = (array) $warmer->warmUp($realCacheDir, $io);
 
                 if ($preload && file_exists($preloadFile = $realCacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
                     Preloader::append($preloadFile, $preload);
@@ -145,7 +145,7 @@ EOF
                 if ($output->isVerbose()) {
                     $io->comment('Warming up cache...');
                 }
-                $this->warmup($warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
+                $this->warmup($io, $warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
             }
 
             if (!$fs->exists($warmupDir.'/'.$containerDir)) {
@@ -219,7 +219,7 @@ EOF
         return false;
     }
 
-    private function warmup(string $warmupDir, string $realBuildDir, bool $enableOptionalWarmers = true): void
+    private function warmup(SymfonyStyle $io, string $warmupDir, string $realBuildDir, bool $enableOptionalWarmers = true): void
     {
         // create a temporary kernel
         $kernel = $this->getApplication()->getKernel();
@@ -233,7 +233,7 @@ EOF
             $warmer = $kernel->getContainer()->get('cache_warmer');
             // non optional warmers already ran during container compilation
             $warmer->enableOnlyOptionalWarmers();
-            $preload = (array) $warmer->warmUp($warmupDir);
+            $preload = (array) $warmer->warmUp($warmupDir, $io);
 
             if ($preload && file_exists($preloadFile = $warmupDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
                 Preloader::append($preloadFile, $preload);

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\CacheWarmer;
 
+use Symfony\Component\Console\Style\SymfonyStyle;
+
 /**
  * Aggregates several cache warmers into a single one.
  *
@@ -46,7 +48,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
         $this->onlyOptionalsEnabled = $this->optionalsEnabled = true;
     }
 
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir, SymfonyStyle $io = null): array
     {
         if ($collectDeprecations = $this->debug && !\defined('PHPUNIT_COMPOSER_INSTALL')) {
             $collectedLogs = [];
@@ -93,11 +95,16 @@ class CacheWarmerAggregate implements CacheWarmerInterface
                     continue;
                 }
 
+                $start = microtime(true);
                 foreach ((array) $warmer->warmUp($cacheDir) as $item) {
                     if (is_dir($item) || (str_starts_with($item, \dirname($cacheDir)) && !is_file($item))) {
                         throw new \LogicException(sprintf('"%s::warmUp()" should return a list of files or classes but "%s" is none of them.', $warmer::class, $item));
                     }
                     $preload[] = $item;
+                }
+
+                if ($io?->isDebug()) {
+                    $io->info(sprintf('"%s" completed in %0.2fms.', $warmer::class, 1000 * (microtime(true) - $start)));
                 }
             }
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #48994
| License       | MIT
| Doc PR        | Todo

From the idea of the issue it fixes. When dealing with huge code base, the cache/warmup process can be a bit long. It would be convenient for developers to understand where it does take time during the process. Here is the result of `cache:clear` ran with debug verbosity now:

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/2144837/215203344-ef108571-4a4a-4979-b26c-c64d6a8eea26.png">
