### PR TITLE
[HttpFoundation] Fix bad return type in IpUtils::checkIp4()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -86,7 +86,7 @@ class IpUtils
             [$address, $netmask] = explode('/', $ip, 2);
 
             if ('0' === $netmask) {
-                return self::$checkedIps[$cacheKey] = filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4);
+                return self::$checkedIps[$cacheKey] = false !== filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4);
             }
 
             if ($netmask < 0 || $netmask > 32) {

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -164,4 +164,21 @@ class IpUtilsTest extends TestCase
             ['::123.234.235.236', '::123.234.235.0'], // deprecated IPv4-compatible IPv6 address
         ];
     }
+
+    /**
+     * @dataProvider getIp4SubnetMaskZeroData
+     */
+    public function testIp4SubnetMaskZero($matches, $remoteAddr, $cidr)
+    {
+        $this->assertSame($matches, IpUtils::checkIp4($remoteAddr, $cidr));
+    }
+
+    public function getIp4SubnetMaskZeroData()
+    {
+        return [
+            [true, '1.2.3.4', '0.0.0.0/0'],
+            [true, '1.2.3.4', '192.168.1.0/0'],
+            [false, '1.2.3.4', '256.256.256/0'], // invalid CIDR notation
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | see below
| License       | MIT
| Doc PR        | -

`filter_var` returns the value if it passes the applied filters. This leads to `IpUtils::checkIp4()` returning the address part of the CIDR notation (instead of `true` which is expected) if it is a valid IPv4 address with subnet mask 0.

This change fixes this behaviour.