### PR TITLE
[FrameworkBundle][Messenger] Add `AsRoutedMessage` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -65,6 +65,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'messenger.bus',
         'messenger.message_handler',
         'messenger.receiver',
+        'messenger.routed_message',
         'messenger.transport_factory',
         'mime.mime_type_guesser',
         'monolog.logger',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -110,6 +110,7 @@ use Symfony\Component\Mailer\EventListener\MessengerTransportListener;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mercure\HubRegistry;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Attribute\AsRoutedMessage;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
@@ -686,6 +687,14 @@ class FrameworkExtension extends Extension
                 $tagAttributes['method'] = $reflector->getName();
             }
             $definition->addTag('messenger.message_handler', $tagAttributes);
+        });
+        $container->registerAttributeForAutoconfiguration(AsRoutedMessage::class, static function (ChildDefinition $definition, AsRoutedMessage $attribute, \ReflectionClass $reflector): void {
+            $tagAttributes = [
+                'class' => $reflector->getName(),
+                'transports' => $attribute->getTransports(),
+            ];
+
+            $definition->addTag('messenger.routed_message', $tagAttributes);
         });
 
         if (!$container->getParameter('kernel.debug')) {

--- a/src/Symfony/Component/Messenger/Attribute/AsRoutedMessage.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsRoutedMessage.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Attribute;
+
+/**
+ * Attribute to configure transports to be used to dispatch a message.
+ *
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsRoutedMessage
+{
+    private array $transports;
+
+    public function __construct(array|string $transports)
+    {
+        $this->transports = (array) $transports;
+    }
+
+    public function getTransports(): array
+    {
+        return $this->transports;
+    }
+}

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport` and
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransportFactory`
  * Allow passing a string instead of an array in `TransportNamesStamp`
+ * Add `#[AsRoutedMessage]` attribute
 
 6.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

This PR add a new `#[AsRoutedMessage]` attribute. This allows to configure a transport on a message class directly, without having to write this in config files.

It seems that a try has been made in https://github.com/symfony/symfony/pull/41179, but unfortunately, there is no news for a few months now 😕. This is an alternate solution using a **compile-time solution** whereas the existing PR is using a runtime solution.

The attribute can be used as follow:

```php
use Symfony\Component\Messenger\Attribute\AsRoutedMessage;

#[AsRoutedMessage(transports: ['async'])]
class SmsMessage
{
    private $content;

    public function __construct(string $content)
    {
        $this->content = $content;
    }

    public function getContent(): string
    {
        return $this->content;
    }
}
```

On a behavior side, routings defined thanks to this attribute are **merged** with the ones defined in the configuration.

Finally, I'm not a 100% sure about the attribute naming. Opinons on it are very welcomed!