### PR TITLE
[HttpFoundation] Add support for `\SplTempFileObject` in `BinaryFileResponse`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `UploadedFile::getClientOriginalPath()`
  * Add `QueryParameterRequestMatcher`
  * Add `HeaderRequestMatcher`
+ * Add support for `\SplTempFileObject` in `BinaryFileResponse`
 
 7.0
 ---

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -434,4 +434,25 @@ class BinaryFileResponseTest extends ResponseTestCase
             @unlink($path);
         }
     }
+
+    public function testCreateFromTemporaryFile()
+    {
+        $file = new \SplTempFileObject();
+        $file->fwrite('foo,bar');
+
+        $response = new BinaryFileResponse($file, 201, [
+            'Content-Type' => 'text/csv',
+        ]);
+
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertSame('text/csv', $response->headers->get('Content-Type'));
+        $this->assertEquals('attachment; filename=temp', $response->headers->get('Content-Disposition'));
+
+        ob_start();
+        $response->sendContent();
+        $string = ob_get_clean();
+        $this->assertSame('foo,bar', $string);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #48530
| License       | MIT
| Doc PR        | Todo

Add support for `\SplTempFileObject` in `BinaryFileResponse`