### PR TITLE
[HttpKernel] Collect data from every event dispatcher

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
@@ -47,7 +47,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('data_collector.events', EventDataCollector::class)
             ->args([
-                service('debug.event_dispatcher')->ignoreOnInvalid(),
+                tagged_iterator('event_dispatcher.dispatcher', 'name'),
                 service('request_stack')->ignoreOnInvalid(),
             ])
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/events.html.twig', 'id' => 'events', 'priority' => 290])

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
@@ -8,76 +8,85 @@
 {% endblock %}
 
 {% block panel %}
-    <h2>Event Dispatcher</h2>
+    <h2>Dispatched Events</h2>
 
-    {% if collector.calledlisteners is empty %}
-        <div class="empty empty-panel">
-            <p>No events have been recorded. Check that debugging is enabled in the kernel.</p>
-        </div>
-    {% else %}
-        <div class="sf-tabs">
+    <div class="sf-tabs">
+        {% for dispatcherName, dispatcherData in collector.data %}
             <div class="tab">
-                <h3 class="tab-title">Called Listeners <span class="badge">{{ collector.calledlisteners|length }}</span></h3>
-
+                <h3 class="tab-title">{{ dispatcherName }}</h3>
                 <div class="tab-content">
-                    {{ _self.render_table(collector.calledlisteners) }}
-                </div>
-            </div>
-
-            <div class="tab">
-                <h3 class="tab-title">Not Called Listeners <span class="badge">{{ collector.notcalledlisteners|length }}</span></h3>
-                <div class="tab-content">
-                    {% if collector.notcalledlisteners is empty %}
-                        <div class="empty">
-                            <p>
-                                <strong>There are no uncalled listeners</strong>.
-                            </p>
-                            <p>
-                                All listeners were called for this request or an error occurred
-                                when trying to collect uncalled listeners (in which case check the
-                                logs to get more information).
-                            </p>
+                    {% if dispatcherData['called_listeners'] is empty %}
+                        <div class="empty empty-panel">
+                            <p>No events have been recorded. Check that debugging is enabled in the kernel.</p>
                         </div>
                     {% else %}
-                        {{ _self.render_table(collector.notcalledlisteners) }}
+                        <div class="sf-tabs">
+                            <div class="tab">
+                                <h3 class="tab-title">Called Listeners <span class="badge">{{ dispatcherData['called_listeners']|length }}</span></h3>
+
+                                <div class="tab-content">
+                                    {{ _self.render_table(dispatcherData['called_listeners']) }}
+                                </div>
+                            </div>
+
+                            <div class="tab">
+                                <h3 class="tab-title">Not Called Listeners <span class="badge">{{ dispatcherData['not_called_listeners']|length }}</span></h3>
+                                <div class="tab-content">
+                                    {% if dispatcherData['not_called_listeners'] is empty %}
+                                        <div class="empty">
+                                            <p>
+                                                <strong>There are no uncalled listeners</strong>.
+                                            </p>
+                                            <p>
+                                                All listeners were called for this request or an error occurred
+                                                when trying to collect uncalled listeners (in which case check the
+                                                logs to get more information).
+                                            </p>
+                                        </div>
+                                    {% else %}
+                                        {{ _self.render_table(dispatcherData['not_called_listeners']) }}
+                                    {% endif %}
+                                </div>
+                            </div>
+
+                            <div class="tab">
+                                <h3 class="tab-title">Orphaned Events <span class="badge">{{ dispatcherData['orphaned_events']|length }}</span></h3>
+                                <div class="tab-content">
+                                    {% if dispatcherData['orphaned_events'] is empty %}
+                                        <div class="empty">
+                                            <p>
+                                                <strong>There are no orphaned events</strong>.
+                                            </p>
+                                            <p>
+                                                All dispatched events were handled or an error occurred
+                                                when trying to collect orphaned events (in which case check the
+                                                logs to get more information).
+                                            </p>
+                                        </div>
+                                    {% else %}
+                                        <table>
+                                            <thead>
+                                                <tr>
+                                                    <th>Event</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {% for event in dispatcherData['orphaned_events'] %}
+                                                    <tr>
+                                                        <td class="font-normal">{{ event }}</td>
+                                                    </tr>
+                                                {% endfor %}
+                                            </tbody>
+                                        </table>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
                     {% endif %}
                 </div>
             </div>
-
-            <div class="tab">
-                <h3 class="tab-title">Orphaned Events <span class="badge">{{ collector.orphanedEvents|length }}</span></h3>
-                <div class="tab-content">
-                    {% if collector.orphanedEvents is empty %}
-                        <div class="empty">
-                            <p>
-                                <strong>There are no orphaned events</strong>.
-                            </p>
-                            <p>
-                                All dispatched events were handled or an error occurred
-                                when trying to collect orphaned events (in which case check the
-                                logs to get more information).
-                            </p>
-                        </div>
-                    {% else %}
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Event</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for event in collector.orphanedEvents %}
-                                    <tr>
-                                        <td class="font-normal">{{ event }}</td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-    {% endif %}
+        {% endfor %}
+    </div>
 {% endblock %}
 
 {% macro render_table(listeners) %}

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "symfony/config": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
-        "symfony/http-kernel": "^6.1",
+        "symfony/http-kernel": "^6.3",
         "symfony/routing": "^5.4|^6.0",
         "symfony/twig-bundle": "^5.4|^6.0",
         "twig/twig": "^2.13|^3.0.4"

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add `#[MapRequestPayload]` to map and validate request payload from `Request::getContent()` or `Request::$request->all()` to typed objects
  * Add `#[MapQueryString]` to map and validate request query string from `Request::$query->all()` to typed objects
  * Add `#[MapQueryParameter]` to map and validate individual query parameters to controller arguments
+ * Collect data from every event dispatcher
 
 6.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follow-up of #49021: instead of only passing the main event dispatcher to the `EventDataCollector`, we pass them all (thanks to the `event_dispatcher.dispatcher` tag).

![](https://user-images.githubusercontent.com/1898254/215503546-9a223574-1d70-445a-931e-2fa80f0a588a.png)
(The heading is now “Dispatched Events”.)

Check “Hide whitespace” when reviewing.