### PR TITLE
[Finder] Allow Finder filter to be a callable

### DIFF
--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+6.3
+---
+ * Change the method signature of `Finder::filter` to allow `callable` as opposed to purely Closures
+
 6.2
 ---
 

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -582,7 +582,7 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * @see CustomFilterIterator
      */
-    public function filter(\Closure $closure): static
+    public function filter(callable $closure): static
     {
         $this->filters[] = $closure;
 

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1018,6 +1018,19 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsolute(['test.php', 'test.py']), $finder->in(self::$tmpDir)->getIterator());
     }
 
+    public function testFilterAcceptsCallable()
+    {
+        $filter = new class() {
+            public function __invoke(\SplFileInfo $f)
+            {
+                return str_contains($f, 'test');
+            }
+        };
+        $finder = $this->buildFinder();
+        $this->assertSame($finder, $finder->filter($filter));
+        $this->assertIterator($this->toAbsolute(['test.php', 'test.py']), $finder->in(self::$tmpDir)->getIterator());
+    }
+
     public function testFollowLinks()
     {
         if ('\\' == \DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
Allow filter to be a callable, to allow use of more complex filters a…s classes implementing __invoke(\SplFileInfo $file)

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | There is currently no 6.3 branch but a PR will be ready to go swiftly.

Currently, the `Finder` component accepts only `Closure` as an argument to `filter()`. This PR widens the method to accept `callable`, which allows classes that implement `__invoke(SplFileInfo $file)` to be used as custom filters. In the case where a custom filter is necessary beyond those available through the default set of filters built into the `Finder` component, it would make sense to also test the filter itself. From a unit test perspective, a class is generally more testable, and has advantages in many cases over anonymous functions in having constructor arguments available, etc.
<!--
Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
