### PR TITLE
[Form] Deprecate not honoring with_seconds => false for HTML5 datetime inputs in DateTimeType

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -52,6 +52,11 @@ FrameworkBundle
    </framework:config>
    ```
 
+Form
+----
+
+ * Deprecate not honoring the `with_seconds` option when it's set to `false` for HTML5 datetime inputs in `DateTimeType`, set it to `true` before upgrading to 7.0
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
@@ -1746,6 +1746,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
             'widget' => 'single_text',
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
+            'with_seconds' => true,
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add the `bool $withSeconds` optional argument to the constructor of `DateTimeToHtml5LocalDateTimeTransformer`
+ * Deprecate not honoring the `with_seconds` option when it's set to `false` for HTML5 datetime inputs in `DateTimeType`
+
 6.2
 ---
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
@@ -23,6 +23,12 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 class DateTimeToHtml5LocalDateTimeTransformer extends BaseDateTimeTransformer
 {
     public const HTML5_FORMAT = 'Y-m-d\\TH:i:s';
+    public const HTML5_WITHOUT_SECONDS_FORMAT = 'Y-m-d\\TH:i';
+
+    public function __construct(string $inputTimezone = null, string $outputTimezone = null, private readonly bool $withSeconds = true)
+    {
+        parent::__construct($inputTimezone, $outputTimezone);
+    }
 
     /**
      * Transforms a \DateTime into a local date and time string.
@@ -54,7 +60,7 @@ class DateTimeToHtml5LocalDateTimeTransformer extends BaseDateTimeTransformer
             $dateTime = $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
         }
 
-        return $dateTime->format(self::HTML5_FORMAT);
+        return $dateTime->format($this->withSeconds ? self::HTML5_FORMAT : self::HTML5_WITHOUT_SECONDS_FORMAT);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -77,10 +77,22 @@ class DateTimeType extends AbstractType
 
         if ('single_text' === $options['widget']) {
             if (self::HTML5_FORMAT === $pattern) {
-                $builder->addViewTransformer(new DateTimeToHtml5LocalDateTimeTransformer(
-                    $options['model_timezone'],
-                    $options['view_timezone']
-                ));
+                // Keep only the code inside this if in Symfony 7.0
+                if ($options['with_seconds']) {
+                    $builder->addViewTransformer(new DateTimeToHtml5LocalDateTimeTransformer(
+                        $options['model_timezone'],
+                        $options['view_timezone'],
+                        $options['with_seconds'],
+                    ));
+                } else {
+                    trigger_deprecation('symfony/form', '6.3', 'The "with_seconds" option for HTML5 datetime inputs in "%s" will be honored in Symfony 7.0, set it to "true" to keep the current behavior and get rid of this deprecation.', self::class);
+
+                    $builder->addViewTransformer(new DateTimeToHtml5LocalDateTimeTransformer(
+                        $options['model_timezone'],
+                        $options['view_timezone'],
+                        true,
+                    ));
+                }
             } else {
                 $builder->addViewTransformer(new DateTimeToLocalizedStringTransformer(
                     $options['model_timezone'],

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTestCase.php
@@ -1517,6 +1517,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
             'widget' => 'single_text',
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
+            'with_seconds' => true,
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
@@ -23,12 +23,16 @@ class DateTimeToHtml5LocalDateTimeTransformerTest extends BaseDateTimeTransforme
     public static function transformProvider()
     {
         return [
-            ['UTC', 'UTC', '2010-02-03 04:05:06 UTC', '2010-02-03T04:05:06'],
-            ['UTC', 'UTC', null, ''],
-            ['America/New_York', 'Asia/Hong_Kong', '2010-02-03 04:05:06 America/New_York', '2010-02-03T17:05:06'],
-            ['America/New_York', 'Asia/Hong_Kong', null, ''],
-            ['UTC', 'Asia/Hong_Kong', '2010-02-03 04:05:06 UTC', '2010-02-03T12:05:06'],
-            ['America/New_York', 'UTC', '2010-02-03 04:05:06 America/New_York', '2010-02-03T09:05:06'],
+            ['UTC', 'UTC', '2010-02-03 04:05:06 UTC', '2010-02-03T04:05:06', true],
+            ['UTC', 'UTC', null, '', true],
+            ['America/New_York', 'Asia/Hong_Kong', '2010-02-03 04:05:06 America/New_York', '2010-02-03T17:05:06', true],
+            ['America/New_York', 'Asia/Hong_Kong', null, '', true],
+            ['UTC', 'Asia/Hong_Kong', '2010-02-03 04:05:06 UTC', '2010-02-03T12:05:06', true],
+            ['America/New_York', 'UTC', '2010-02-03 04:05:06 America/New_York', '2010-02-03T09:05:06', true],
+            ['UTC', 'UTC', '2010-02-03 04:05:06 UTC', '2010-02-03T04:05', false],
+            ['America/New_York', 'Asia/Hong_Kong', '2010-02-03 04:05:06 America/New_York', '2010-02-03T17:05', false],
+            ['UTC', 'Asia/Hong_Kong', '2010-02-03 04:05:06 UTC', '2010-02-03T12:05', false],
+            ['America/New_York', 'UTC', '2010-02-03 04:05:06 America/New_York', '2010-02-03T09:05', false],
         ];
     }
 
@@ -55,9 +59,9 @@ class DateTimeToHtml5LocalDateTimeTransformerTest extends BaseDateTimeTransforme
     /**
      * @dataProvider transformProvider
      */
-    public function testTransform($fromTz, $toTz, $from, $to)
+    public function testTransform($fromTz, $toTz, $from, $to, bool $withSeconds)
     {
-        $transformer = new DateTimeToHtml5LocalDateTimeTransformer($fromTz, $toTz);
+        $transformer = new DateTimeToHtml5LocalDateTimeTransformer($fromTz, $toTz, $withSeconds);
 
         $this->assertSame($to, $transformer->transform(null !== $from ? new \DateTime($from) : null));
     }
@@ -65,9 +69,9 @@ class DateTimeToHtml5LocalDateTimeTransformerTest extends BaseDateTimeTransforme
     /**
      * @dataProvider transformProvider
      */
-    public function testTransformDateTimeImmutable($fromTz, $toTz, $from, $to)
+    public function testTransformDateTimeImmutable($fromTz, $toTz, $from, $to, bool $withSeconds)
     {
-        $transformer = new DateTimeToHtml5LocalDateTimeTransformer($fromTz, $toTz);
+        $transformer = new DateTimeToHtml5LocalDateTimeTransformer($fromTz, $toTz, $withSeconds);
 
         $this->assertSame($to, $transformer->transform(null !== $from ? new \DateTimeImmutable($from) : null));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 
 class DateTimeTypeTest extends BaseTypeTestCase
 {
+    use ExpectDeprecationTrait;
+
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\DateTimeType';
 
     private $defaultLocale;
@@ -243,6 +246,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
             'view_timezone' => 'Pacific/Tahiti',
             'widget' => 'single_text',
             'input' => 'datetime',
+            'with_seconds' => true,
         ]);
 
         $outputTime = new \DateTime('2010-06-02 03:04:00 Pacific/Tahiti');
@@ -262,6 +266,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
             'view_timezone' => 'Pacific/Tahiti',
             'widget' => 'single_text',
             'input' => 'datetime_immutable',
+            'with_seconds' => true,
         ]);
 
         $outputTime = new \DateTimeImmutable('2010-06-02 03:04:00 Pacific/Tahiti');
@@ -282,6 +287,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
             'view_timezone' => 'UTC',
             'input' => 'string',
             'widget' => 'single_text',
+            'with_seconds' => true,
         ]);
 
         $form->submit('2010-06-02T03:04:00');
@@ -337,6 +343,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'widget' => 'single_text',
+            'with_seconds' => true,
         ])
             ->createView();
 
@@ -462,6 +469,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'widget' => 'single_text',
+            'with_seconds' => true,
         ])
             ->createView();
 
@@ -473,6 +481,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'widget' => 'single_text',
             'html5' => false,
+            'with_seconds' => true,
         ])
             ->createView();
 
@@ -663,6 +672,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'widget' => 'single_text',
+            'with_seconds' => true,
         ]);
         $form->submit(null);
 
@@ -695,6 +705,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'widget' => $widget,
             'empty_data' => $emptyData,
+            'with_seconds' => 'single_text' === $widget,
         ]);
         $form->submit(null);
 
@@ -729,10 +740,23 @@ class DateTimeTypeTest extends BaseTypeTestCase
             'input' => 'string',
             'widget' => 'single_text',
             'input_format' => 'd/m/Y H:i:s P',
+            'with_seconds' => true,
         ]);
 
         $form->submit('2018-01-14T21:29:00');
 
         $this->assertSame('14/01/2018 21:29:00 +00:00', $form->getData());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testHTML5DateTimeInputWithoutSecondsTriggersADeprecation()
+    {
+        $this->expectDeprecation('Since symfony/form 6.3: The "with_seconds" option for HTML5 datetime inputs in "Symfony\Component\Form\Extension\Core\Type\DateTimeType" will be honored in Symfony 7.0, set it to "true" to keep the current behavior and get rid of this deprecation.');
+
+        $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'single_text',
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/issues/48076
| License       | MIT
| Doc PR        | -

The `with_seconds` option defaults to false. It is honored when the form doesn't have data (and when the browser doesn't display the seconds). But it's not honored when the form has data because `DateTimeToHtml5LocalDateTimeTransformer` format the `\DateTimeInterface` to `Y-m-d\\TH:i:s` unconditionally.

In this PR, we add a new argument to `DateTimeToHtml5LocalDateTimeTransformer` to allow formatting to a datetime string without seconds (`Y-m-d\\TH:i`).

Moreover, we deprecate not setting `with_seconds => true` on all forms using HTML5 datetime inputs since they rely on that behavior (and it's the default value of the `with_seconds` option).

In Symfony 7.0, we can honor the option (by forwarding its value to the transformer) because every project should be using `with_seconds => true` before upgrading.

I don't really know if forcing everyone to add/set the option is the best strategy but I did not find another one.