### PR TITLE
[Yaml] Feature #48920  Allow milliseconds and microseconds in dates

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -922,6 +922,52 @@ YAML;
         ], 2));
     }
 
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDumpDateTime(array $input, string $expected)
+    {
+        $this->assertSame($expected, rtrim($this->dumper->dump($input, 1)));
+    }
+
+    public function getDateTimeData()
+    {
+        yield 'Date without subsecond precision' => [
+            ['date' => new \DateTimeImmutable('2023-01-24T01:02:03Z')],
+            'date: 2023-01-24T01:02:03+00:00',
+        ];
+
+        yield 'Date with one digit for milliseconds' => [
+            ['date' => new \DateTimeImmutable('2023-01-24T01:02:03.4Z')],
+            'date: 2023-01-24T01:02:03.400+00:00',
+        ];
+
+        yield 'Date with two digits for milliseconds' => [
+            ['date' => new \DateTimeImmutable('2023-01-24T01:02:03.45Z')],
+            'date: 2023-01-24T01:02:03.450+00:00',
+        ];
+
+        yield 'Date with full milliseconds' => [
+            ['date' => new \DateTimeImmutable('2023-01-24T01:02:03.456Z')],
+            'date: 2023-01-24T01:02:03.456+00:00',
+        ];
+
+        yield 'Date with four digits for microseconds' => [
+            ['date' => new \DateTimeImmutable('2023-01-24T01:02:03.4567Z')],
+            'date: 2023-01-24T01:02:03.456700+00:00',
+        ];
+
+        yield 'Date with five digits for microseconds' => [
+            ['date' => new \DateTimeImmutable('2023-01-24T01:02:03.45678Z')],
+            'date: 2023-01-24T01:02:03.456780+00:00',
+        ];
+
+        yield 'Date with full microseconds' => [
+            ['date' => new \DateTimeImmutable('2023-01-24T01:02:03.456789Z')],
+            'date: 2023-01-24T01:02:03.456789+00:00',
+        ];
+    }
+
     private function assertSameData($expected, $actual)
     {
         $this->assertEquals($expected, $actual);

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -563,9 +563,10 @@ class InlineTest extends TestCase
     /**
      * @dataProvider getTimestampTests
      */
-    public function testParseTimestampAsUnixTimestampByDefault(string $yaml, int $year, int $month, int $day, int $hour, int $minute, int $second)
+    public function testParseTimestampAsUnixTimestampByDefault(string $yaml, int $year, int $month, int $day, int $hour, int $minute, int $second, int $microsecond)
     {
-        $this->assertSame(gmmktime($hour, $minute, $second, $month, $day, $year), Inline::parse($yaml));
+        $expectedDate = (new \DateTimeImmutable($yaml))->format('U');
+        $this->assertSame($microsecond ? (float) "$expectedDate.$microsecond" : (int) $expectedDate, Inline::parse($yaml));
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1541,6 +1541,15 @@ EOT
         ];
     }
 
+    public function testParseDateWithSubseconds()
+    {
+        $yaml = <<<'EOT'
+date: 2002-12-14T01:23:45.670000Z
+EOT;
+
+        $this->assertSameData(['date' => 1039829025.67], $this->parser->parse($yaml));
+    }
+
     public function testParseDateAsMappingValue()
     {
         $yaml = <<<'EOT'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Feature #48920
| License       | MIT
| Doc PR        | forthcoming

Allows Yaml to parse dates with milliseconds or microseconds and to dump them as well.
