### PR TITLE
Release v4.4.50

### DIFF
--- a/CHANGELOG-4.4.md
+++ b/CHANGELOG-4.4.md
@@ -7,6 +7,11 @@ in 4.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.4.0...v4.4.1
 
+* 4.4.50 (2023-02-01)
+
+ * security #cve-2022-24895 [Security/Http] Remove CSRF tokens from storage on successful login (nicolas-grekas)
+ * security #cve-2022-24894 [HttpKernel] Remove private headers before storing responses with HttpCache (nicolas-grekas)
+
 * 4.4.49 (2022-11-28)
 
  * bug #48273 [HttpKernel] Fix message for unresovable arguments of invokable controllers (fancyweb)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,11 +76,11 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    public const VERSION = '4.4.49';
-    public const VERSION_ID = 40449;
+    public const VERSION = '4.4.50';
+    public const VERSION_ID = 40450;
     public const MAJOR_VERSION = 4;
     public const MINOR_VERSION = 4;
-    public const RELEASE_VERSION = 49;
+    public const RELEASE_VERSION = 50;
     public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v4.4.49...v4.4.50)

 * security #cve-2022-24895 [Security/Http] Remove CSRF tokens from storage on successful login (@nicolas-grekas)
 * security #cve-2022-24894 [HttpKernel] Remove private headers before storing responses with HttpCache (@nicolas-grekas)
