### PR TITLE
Release v6.2.6

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -7,6 +7,15 @@ in 6.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.2.0...v6.2.1
 
+* 6.2.6 (2023-02-01)
+
+ * bug #49141 [HttpFoundation] Fix bad return type in IpUtils::checkIp4() (tristankretzer)
+ * bug #49126 [DependencyInjection] Fix order of arguments when mixing positional and named ones (nicolas-grekas)
+ * bug #49104 [HttpClient] Fix collecting data non-late for the profiler (nicolas-grekas)
+ * bug #49103 [Security/Http] Fix compat of persistent remember-me with legacy tokens (nicolas-grekas)
+ * security #cve-2022-24895 [Security/Http] Remove CSRF tokens from storage on successful login (nicolas-grekas)
+ * security #cve-2022-24894 [HttpKernel] Remove private headers before storing responses with HttpCache (nicolas-grekas)
+
 * 6.2.5 (2023-01-24)
 
  * bug #49078 [Security/Http] Check tokens before loading users from providers (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -75,12 +75,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.2.6-DEV';
+    public const VERSION = '6.2.6';
     public const VERSION_ID = 60206;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 2;
     public const RELEASE_VERSION = 6;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2023';
     public const END_OF_LIFE = '07/2023';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.2.5...v6.2.6)

 * bug #49141 [HttpFoundation] Fix bad return type in IpUtils::checkIp4() (@tristankretzer)
 * bug #49126 [DependencyInjection] Fix order of arguments when mixing positional and named ones (@nicolas-grekas)
 * bug #49104 [HttpClient] Fix collecting data non-late for the profiler (@nicolas-grekas)
 * bug #49103 [Security/Http] Fix compat of persistent remember-me with legacy tokens (@nicolas-grekas)
 * security #cve-2022-24895 [Security/Http] Remove CSRF tokens from storage on successful login (@nicolas-grekas)
 * security #cve-2022-24894 [HttpKernel] Remove private headers before storing responses with HttpCache (@nicolas-grekas)
