### PR TITLE
[Workflow] remove unused parameter transitionId in MermaidDumper

### DIFF
--- a/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
@@ -105,7 +105,6 @@ class MermaidDumper implements DumperInterface
                         $transitionOutput = $this->styleStatemachineTransition(
                             $from,
                             $to,
-                            $transitionId,
                             $transitionLabel,
                             $transitionMeta
                         );
@@ -211,7 +210,6 @@ class MermaidDumper implements DumperInterface
     private function styleStatemachineTransition(
         string $from,
         string $to,
-        int $transitionId,
         string $transitionLabel,
         array $transitionMeta
     ): array {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49175
| License       | MIT
| Doc PR        | 

We can remove this parameter safely since it's in a private function.