### PR TITLE
[Ldap] Allow multiple values on `extra_fields`

### DIFF
--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -187,6 +187,9 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
         }
 
         $values = $entry->getAttribute($attribute);
+        if (!\in_array($attribute, [$this->uidKey, $this->passwordAttribute])) {
+            return $values;
+        }
 
         if (1 !== \count($values)) {
             throw new InvalidArgumentException(sprintf('Attribute "%s" has multiple values.', $attribute));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | ~
| License       | MIT
| Doc PR        | 

Loading users with the `LdapUserProvider`, using `extra_fields` fails if I want to get `memberOf` attribute.
This happens, if my user has multiple attributes set. After taking a look at `Ldap\Entry` (which supports multiple values per attribute). Looking at `LdapUserProvider::getAttributeValue()` it was very clear, that every attribute must be unique. 

The method `getAttributeValue()` has originated from `getPassword` https://github.com/symfony/symfony/commit/dbf45e4a76b7f424fda62946546336e584852463, forcing the password attribute to be unique. Same goes for `uidKey` https://github.com/symfony/symfony/commit/c91689ba2d395b9af5e5d7b07c4f22742bca3f01. Loading `extra_fields` should allow for multiple values per attribute (like `memberOf`).

Did I break backward compatibility? No, I didn't. Simply because it was never usable as array while loading users via `LdapUserProvider`, instead an `InvalidArgumentException` was thrown.

<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
