### PR TITLE
[VarDumper] Add `#[SensitiveElement]` attribute

### DIFF
--- a/src/Symfony/Component/VarDumper/Attribute/AbstractAttribute.php
+++ b/src/Symfony/Component/VarDumper/Attribute/AbstractAttribute.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Attribute;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+abstract class AbstractAttribute
+{
+}

--- a/src/Symfony/Component/VarDumper/Attribute/SensitiveElement.php
+++ b/src/Symfony/Component/VarDumper/Attribute/SensitiveElement.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Attribute;
+
+/**
+ * Marks an element as sensitive, which indicates its content cloned by cloners.
+ *
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class SensitiveElement extends AbstractAttribute
+{
+    private array $properties;
+
+    public function __construct(array|string $property = [])
+    {
+        $this->properties = (array) $property;
+    }
+
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+}

--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add support of named arguments to `dd()` and `dump()` to display the argument name
  * Add support for `Relay\Relay`
  * Add display of invisible characters
+ * Add `#[SensitiveElement]` attribute
 
 6.2
 ---

--- a/src/Symfony/Component/VarDumper/Caster/SensitiveElementStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/SensitiveElementStub.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class SensitiveElementStub extends ConstStub
+{
+    public function __construct(string $name)
+    {
+        parent::__construct($name.' (🔒 Sensitive element)');
+    }
+}

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Cloner;
 
 use Symfony\Component\VarDumper\Caster\Caster;
+use Symfony\Component\VarDumper\Caster\SensitiveElementStub;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
 
 /**
@@ -351,6 +352,12 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
                     $item->class = $item->value;
                     // no break
                 case Stub::TYPE_OBJECT:
+                    if ($item->sensitive) {
+                        $this->dumpItem($dumper, $cursor, $refs, new SensitiveElementStub($item->class));
+
+                        return;
+                    }
+                    // no break
                 case Stub::TYPE_RESOURCE:
                     $withChildren = $children && $cursor->depth !== $this->maxDepth && $this->maxItemsPerDepth;
                     $dumper->enterHash($cursor, $item->type, $item->class, $withChildren);

--- a/src/Symfony/Component/VarDumper/Cloner/Stub.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Stub.php
@@ -39,6 +39,7 @@ class Stub
     public $refCount = 0;
     public $position = 0;
     public $attr = [];
+    public bool $sensitive = false;
 
     private static array $defaultProperties = [];
 

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\VarDumper\Cloner;
 
+use Symfony\Component\VarDumper\Attribute\SensitiveElement;
+use Symfony\Component\VarDumper\Caster\SensitiveElementStub;
+
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */

--- a/src/Symfony/Component/VarDumper/Cloner/Visibility.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Visibility.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Cloner;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+enum Visibility
+{
+    case Public;
+
+    case Protected;
+
+    case Private;
+}

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -84,6 +84,7 @@ Symfony\Component\VarDumper\Caster\ConstStub {
   +refCount: 0
   +position: 0
   +attr: []
+  +sensitive: false
 }
 EODUMP;
 
@@ -134,6 +135,7 @@ Symfony\Component\VarDumper\Caster\ConstStub {
   +refCount: 0
   +position: 0
   +attr: []
+  +sensitive: false
 }
 EODUMP;
 
@@ -204,6 +206,7 @@ Symfony\Component\VarDumper\Caster\ConstStub {
   +refCount: 0
   +position: 0
   +attr: []
+  +sensitive: false
 }
 EODUMP;
 
@@ -303,6 +306,7 @@ Symfony\Component\VarDumper\Caster\ConstStub {
   +refCount: 0
   +position: 0
   +attr: []
+  +sensitive: false
 }
 EODUMP;
 
@@ -380,6 +384,7 @@ Symfony\Component\VarDumper\Caster\ConstStub {
   +refCount: 0
   +position: 0
   +attr: []
+  +sensitive: false
 }
 EODUMP;
 

--- a/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\VarDumper\Tests\Cloner;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Cloner\AbstractCloner;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Tests\Fixtures\Php74;
 use Symfony\Component\VarDumper\Tests\Fixtures\Php81Enums;
+use Symfony\Component\VarDumper\Tests\Fixtures\SensitiveClass;
+use Symfony\Component\VarDumper\Tests\Fixtures\SensitiveProperties;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -91,6 +94,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                 (
                                 )
 
+                            [sensitive] => 
                         )
 
                 )
@@ -110,6 +114,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                 (
                                 )
 
+                            [sensitive] => 
                         )
 
                     [\000+\0002] => Symfony\Component\VarDumper\Cloner\Stub Object
@@ -125,6 +130,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                 (
                                 )
 
+                            [sensitive] => 
                         )
 
                 )
@@ -293,6 +299,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                 (
                                 )
 
+                            [sensitive] => 
                         )
 
                     [1] => SHORT
@@ -354,7 +361,7 @@ object(Symfony\Component\VarDumper\Cloner\Data)#%d (7) {
     [1]=>
     array(1) {
       ["1"]=>
-      object(Symfony\Component\VarDumper\Cloner\Stub)#%i (8) {
+      object(Symfony\Component\VarDumper\Cloner\Stub)#%i (9) {
         ["type"]=>
         int(4)
         ["class"]=>
@@ -372,6 +379,8 @@ object(Symfony\Component\VarDumper\Cloner\Data)#%d (7) {
         ["attr"]=>
         array(0) {
         }
+        ["sensitive"]=>
+        bool(false)
       }
     }
   }
@@ -427,9 +436,10 @@ Symfony\Component\VarDumper\Cloner\Data Object
                             [attr] => Array
                                 (
                                     [file] => %a%eVarClonerTest.php
-                                    [line] => 22
+                                    [line] => %d
                                 )
 
+                            [sensitive] => 
                         )
 
                 )
@@ -485,6 +495,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                     [line] => 5
                                 )
 
+                            [sensitive] => 
                         )
 
                 )
@@ -509,6 +520,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                         (
                                         )
 
+                                    [sensitive] => 
                                 )
 
                             [cut] => 0
@@ -519,6 +531,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                 (
                                 )
 
+                            [sensitive] => 
                         )
 
                     [p3] => Symfony\Component\VarDumper\Cloner\Stub Object
@@ -538,6 +551,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                         (
                                         )
 
+                                    [sensitive] => 
                                 )
 
                             [cut] => 0
@@ -548,6 +562,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                 (
                                 )
 
+                            [sensitive] => 
                         )
 
                 )
@@ -598,6 +613,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                     [line] => 5
                                 )
 
+                            [sensitive] => 
                         )
 
                 )
@@ -619,6 +635,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                     [line] => 5
                                 )
 
+                            [sensitive] => 
                         )
 
                     [e2] => Symfony\Component\VarDumper\Cloner\Stub Object
@@ -636,6 +653,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                                     [line] => 5
                                 )
 
+                            [sensitive] => 
                         )
 
                 )
@@ -649,6 +667,287 @@ Symfony\Component\VarDumper\Cloner\Data Object
                 (
                     [name] => Diamonds
                     [value] => D
+                )
+
+        )
+
+    [position:Symfony\Component\VarDumper\Cloner\Data:private] => 0
+    [key:Symfony\Component\VarDumper\Cloner\Data:private] => 0
+    [maxDepth:Symfony\Component\VarDumper\Cloner\Data:private] => 20
+    [maxItemsPerDepth:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+    [useRefHandles:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+    [context:Symfony\Component\VarDumper\Cloner\Data:private] => Array
+        (
+        )
+
+)
+
+EOTXT;
+        $this->assertStringMatchesFormat($expected, print_r($clone, true));
+    }
+
+    public function testSensitiveClass()
+    {
+        $data = new SensitiveClass();
+
+        $cloner = new VarCloner();
+        $clone = $cloner->cloneVar($data);
+
+        $expected = <<<'EOTXT'
+Symfony\Component\VarDumper\Cloner\Data Object
+(
+    [data:Symfony\Component\VarDumper\Cloner\Data:private] => Array
+        (
+            [0] => Array
+                (
+                    [0] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 4
+                            [class] => Symfony\Component\VarDumper\Tests\Fixtures\SensitiveClass
+                            [value] => 
+                            [cut] => 0
+                            [handle] => %d
+                            [refCount] => 0
+                            [position] => 0
+                            [attr] => Array
+                                (
+                                    [file] => %s/symfony/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveClass.php
+                                    [line] => %d
+                                )
+
+                            [sensitive] => 1
+                        )
+
+                )
+
+        )
+
+    [position:Symfony\Component\VarDumper\Cloner\Data:private] => 0
+    [key:Symfony\Component\VarDumper\Cloner\Data:private] => 0
+    [maxDepth:Symfony\Component\VarDumper\Cloner\Data:private] => 20
+    [maxItemsPerDepth:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+    [useRefHandles:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+    [context:Symfony\Component\VarDumper\Cloner\Data:private] => Array
+        (
+        )
+
+)
+
+EOTXT;
+        $this->assertStringMatchesFormat($expected, print_r($clone, true));
+    }
+
+    public function testSensitiveProperties()
+    {
+        $data = new SensitiveProperties();
+
+        $cloner = new VarCloner();
+        $clone = $cloner->cloneVar($data);
+
+        $expected = <<<'EOTXT'
+Symfony\Component\VarDumper\Cloner\Data Object
+(
+    [data:Symfony\Component\VarDumper\Cloner\Data:private] => Array
+        (
+            [0] => Array
+                (
+                    [0] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 4
+                            [class] => Symfony\Component\VarDumper\Tests\Fixtures\SensitiveProperties
+                            [value] => 
+                            [cut] => 0
+                            [handle] => %d
+                            [refCount] => 0
+                            [position] => 1
+                            [attr] => Array
+                                (
+                                    [file] => %s/symfony/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveProperties.php
+                                    [line] => %d
+                                )
+
+                            [sensitive] => 
+                        )
+
+                )
+
+            [1] => Array
+                (
+                    [ Symfony\Component\VarDumper\Tests\Fixtures\SensitiveProperties username] => root
+                    [ Symfony\Component\VarDumper\Tests\Fixtures\SensitiveProperties password] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 1
+                            [class] => ~ (🔒 Sensitive element)
+                            [value] => ~ (🔒 Sensitive element)
+                            [cut] => 0
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 0
+                            [attr] => Array
+                                (
+                                )
+
+                            [sensitive] => 
+                        )
+
+                    [ * sensitiveFoo] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 4
+                            [class] => Symfony\Component\VarDumper\Tests\Fixtures\SensitiveFoo
+                            [value] => 
+                            [cut] => 0
+                            [handle] => %d
+                            [refCount] => 0
+                            [position] => 0
+                            [attr] => Array
+                                (
+                                    [file] => %s/symfony/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveProperties.php
+                                    [line] => %d
+                                )
+
+                            [sensitive] => 1
+                        )
+
+                    [sensitiveBarProperties] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 4
+                            [class] => Symfony\Component\VarDumper\Tests\Fixtures\SensitiveBarProperties
+                            [value] => 
+                            [cut] => 0
+                            [handle] => %d
+                            [refCount] => 0
+                            [position] => 2
+                            [attr] => Array
+                                (
+                                    [file] => %s/symfony/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveProperties.php
+                                    [line] => %d
+                                )
+
+                            [sensitive] => 
+                        )
+
+                )
+
+            [2] => Array
+                (
+                    [ Symfony\Component\VarDumper\Tests\Fixtures\SensitiveBarProperties sensitiveInfo] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 1
+                            [class] => ~ (🔒 Sensitive element)
+                            [value] => ~ (🔒 Sensitive element)
+                            [cut] => 0
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 0
+                            [attr] => Array
+                                (
+                                )
+
+                            [sensitive] => 
+                        )
+
+                    [ Symfony\Component\VarDumper\Tests\Fixtures\SensitiveBarProperties publicInfo] => 123
+                )
+
+        )
+
+    [position:Symfony\Component\VarDumper\Cloner\Data:private] => 0
+    [key:Symfony\Component\VarDumper\Cloner\Data:private] => 0
+    [maxDepth:Symfony\Component\VarDumper\Cloner\Data:private] => 20
+    [maxItemsPerDepth:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+    [useRefHandles:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+    [context:Symfony\Component\VarDumper\Cloner\Data:private] => Array
+        (
+        )
+
+)
+
+EOTXT;
+        file_put_contents('expected_zeub.php', print_r($clone, true));
+        $this->assertStringMatchesFormat($expected, print_r($clone, true));
+    }
+    
+    public function testSensitivePropertiesWithDumpSensitiveElementsFlag()
+    {
+        $data = new SensitiveProperties();
+
+        $cloner = new VarCloner();
+        $cloner->setFlags(AbstractCloner::CLONER_WITH_SENSITIVE_ELEMENTS);
+        $clone = $cloner->cloneVar($data);
+
+        $expected = <<<'EOTXT'
+Symfony\Component\VarDumper\Cloner\Data Object
+(
+    [data:Symfony\Component\VarDumper\Cloner\Data:private] => Array
+        (
+            [0] => Array
+                (
+                    [0] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 4
+                            [class] => Symfony\Component\VarDumper\Tests\Fixtures\SensitiveProperties
+                            [value] => 
+                            [cut] => 0
+                            [handle] => %d
+                            [refCount] => 0
+                            [position] => 1
+                            [attr] => Array
+                                (
+                                    [file] => %s/symfony/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveProperties.php
+                                    [line] => %d
+                                )
+
+                            [sensitive] => 
+                        )
+
+                )
+
+            [1] => Array
+                (
+                    [ Symfony\Component\VarDumper\Tests\Fixtures\SensitiveProperties username] => root
+                    [ Symfony\Component\VarDumper\Tests\Fixtures\SensitiveProperties password] => toor
+                    [ * sensitiveFoo] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 4
+                            [class] => Symfony\Component\VarDumper\Tests\Fixtures\SensitiveFoo
+                            [value] => 
+                            [cut] => 0
+                            [handle] => %d
+                            [refCount] => 0
+                            [position] => 0
+                            [attr] => Array
+                                (
+                                    [file] => %s/symfony/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveProperties.php
+                                    [line] => %d
+                                )
+
+                            [sensitive] => 
+                        )
+
+                    [sensitiveBarProperties] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 4
+                            [class] => Symfony\Component\VarDumper\Tests\Fixtures\SensitiveBarProperties
+                            [value] => 
+                            [cut] => 0
+                            [handle] => %d
+                            [refCount] => 0
+                            [position] => 2
+                            [attr] => Array
+                                (
+                                    [file] => %s/symfony/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveProperties.php
+                                    [line] => %d
+                                )
+
+                            [sensitive] => 
+                        )
+
+                )
+
+            [2] => Array
+                (
+                    [ Symfony\Component\VarDumper\Tests\Fixtures\SensitiveBarProperties sensitiveInfo] => password
+                    [ Symfony\Component\VarDumper\Tests\Fixtures\SensitiveBarProperties publicInfo] => 123
                 )
 
         )

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\AbstractDumper;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+use Symfony\Component\VarDumper\Tests\Fixtures\SensitiveClass;
+use Symfony\Component\VarDumper\Tests\Fixtures\SensitiveClassWithAllVisibilities;
+use Symfony\Component\VarDumper\Tests\Fixtures\SensitiveProperties;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -448,6 +451,63 @@ EOTXT
         $dumper->dump($cloner->cloneVar($value));
 
         $this->assertSame($expectedOut, $out);
+    }
+
+    public function testDumpSensitiveClass()
+    {
+        $dumper = new CliDumper();
+        $dumper->setColors(false);
+        $cloner = new VarCloner();
+
+        $data = $cloner->cloneVar(new SensitiveClass());
+        $out = $dumper->dump($data, true);
+
+        $this->assertSame(<<<EOTXT
+Symfony\Component\VarDumper\Tests\Fixtures\SensitiveClass (🔒 Sensitive element)
+
+EOTXT, $out);
+    }
+
+    public function testDumpSensitiveProperties()
+    {
+        $dumper = new CliDumper();
+        $dumper->setColors(false);
+        $cloner = new VarCloner();
+
+        $data = $cloner->cloneVar(new SensitiveProperties());
+        $out = $dumper->dump($data, true);
+
+        $this->assertStringMatchesFormat(<<<EOTXT
+Symfony\Component\VarDumper\Tests\Fixtures\SensitiveProperties {#%d
+  -username: "root"
+  -password: ~ (🔒 Sensitive element)
+  #sensitiveFoo: Symfony\Component\VarDumper\Tests\Fixtures\SensitiveFoo (🔒 Sensitive element)
+  +sensitiveBarProperties: Symfony\Component\VarDumper\Tests\Fixtures\SensitiveBarProperties {#%d
+    -sensitiveInfo: ~ (🔒 Sensitive element)
+    -publicInfo: 123
+  }
+}
+
+EOTXT, $out);
+    }
+
+    public function testDumpSensitiveClassPropertiesWithAllVisibilities()
+    {
+        $dumper = new CliDumper();
+        $dumper->setColors(false);
+        $cloner = new VarCloner();
+
+        $data = $cloner->cloneVar(new SensitiveClassWithAllVisibilities());
+        $out = $dumper->dump($data, true);
+
+        $this->assertStringMatchesFormat(<<<EOTXT
+Symfony\Component\VarDumper\Tests\Fixtures\SensitiveClassWithAllVisibilities {#%d
+  +foo: ~ (🔒 Sensitive element)
+  #bar: ~ (🔒 Sensitive element)
+  -qux: ~ (🔒 Sensitive element)
+}
+
+EOTXT, $out);
     }
 
     private function getSpecialVars()

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveClass.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Fixtures;
+
+use Symfony\Component\VarDumper\Attribute\SensitiveElement;
+
+#[SensitiveElement]
+class SensitiveClass
+{
+}

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveProperties.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/SensitiveProperties.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Fixtures;
+
+use Symfony\Component\VarDumper\Attribute\SensitiveElement;
+
+#[SensitiveElement(property: 'password')]
+class SensitiveProperties
+{
+    private string $username = 'root';
+
+    private string $password = 'toor';
+
+    protected SensitiveFoo $sensitiveFoo;
+
+    public SensitiveBarProperties $sensitiveBarProperties;
+
+    public function __construct()
+    {
+        $this->sensitiveFoo = new SensitiveFoo();
+        $this->sensitiveBarProperties = new SensitiveBarProperties();
+    }
+}
+
+#[SensitiveElement]
+class SensitiveFoo
+{
+}
+
+#[SensitiveElement(['sensitiveInfo'])]
+class SensitiveBarProperties
+{
+    private string $sensitiveInfo = 'password';
+
+    private int $publicInfo = 123;
+}
+
+#[SensitiveElement(property: ['foo', 'bar', 'qux'])]
+class SensitiveClassWithAllVisibilities
+{
+    public $foo;
+
+    protected $bar;
+
+    private $qux;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

Following the same dynamic as PHP 8.2 `#[\SensitiveParameter]`, an attribute to tell the cloners not to clone a set of classes/properties would be nice. Thanks to a new `#[SensitiveElement]` attribute, this allows us to define what we don't want to be cloned because of the sensitive nature of data. Instead, properties and classes marked as sensitive are replace by a new `SensitiveElementStub`. This allows, among other things, to hide the content of these elements when dumping their content with VarDumper. Here is the attribute in action:

```php
namespace App\Controller;

use Symfony\Component\Routing\Annotation\Route;
use Symfony\Component\VarDumper\Attribute\SensitiveElement;

// ...

#[SensitiveElement]
class Foo
{
}

class Qux
{
    #[SensitiveElement]
    private string $ownPassword = "something else";

    private string $publicInfo = 'Public one';
}

class Bar
{
    public Foo $foo;

    public Route $qux;

    public Qux $qux2;

    #[SensitiveElement]
    private string $password = 'root';

    public function __construct()
    {
        $this->foo = new Foo();
        $this->qux = new Route();
        $this->qux2 = new Qux();
    }
}
```

Dumping with VarDumper an instance of `Bar` results on this:

<img width="559" alt="Capture d’écran 2023-02-01 à 22 07 48" src="https://user-images.githubusercontent.com/2144837/216163576-2e824df9-982c-47e1-92dd-1a55e2d863f0.png">
