### PR TITLE
[Security] Return 403 instead of 500 when no firewall is defined

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
@@ -71,15 +71,17 @@ class ErrorListener implements EventSubscriberInterface
         // There's no specific status code defined in the configuration for this exception
         if (!$throwable instanceof HttpExceptionInterface) {
             $class = new \ReflectionClass($throwable);
-            $attributes = $class->getAttributes(WithHttpStatus::class, \ReflectionAttribute::IS_INSTANCEOF);
 
-            if ($attributes) {
-                /** @var WithHttpStatus $instance */
-                $instance = $attributes[0]->newInstance();
+            do {
+                if ($attributes = $class->getAttributes(WithHttpStatus::class, \ReflectionAttribute::IS_INSTANCEOF)) {
+                    /** @var WithHttpStatus $instance */
+                    $instance = $attributes[0]->newInstance();
 
-                $throwable = new HttpException($instance->statusCode, $throwable->getMessage(), $throwable, $instance->headers);
-                $event->setThrowable($throwable);
-            }
+                    $throwable = new HttpException($instance->statusCode, $throwable->getMessage(), $throwable, $instance->headers);
+                    $event->setThrowable($throwable);
+                    break;
+                }
+            } while ($class = $class->getParentClass());
         }
 
         $e = FlattenException::createFromThrowable($throwable);
@@ -185,14 +187,16 @@ class ErrorListener implements EventSubscriberInterface
             }
         }
 
-        $attributes = (new \ReflectionClass($throwable))->getAttributes(WithLogLevel::class);
+        $class = new \ReflectionClass($throwable);
 
-        if ($attributes) {
-            /** @var WithLogLevel $instance */
-            $instance = $attributes[0]->newInstance();
+        do {
+            if ($attributes = $class->getAttributes(WithLogLevel::class)) {
+                /** @var WithLogLevel $instance */
+                $instance = $attributes[0]->newInstance();
 
-            return $instance->level;
-        }
+                return $instance->level;
+            }
+        } while ($class = $class->getParentClass());
 
         if (!$throwable instanceof HttpExceptionInterface || $throwable->getStatusCode() >= 500) {
             return LogLevel::CRITICAL;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -123,7 +123,7 @@ class ErrorListenerTest extends TestCase
     public function testHandleWithLogLevelAttribute()
     {
         $request = new Request();
-        $event = new ExceptionEvent(new TestKernel(), $request, HttpKernelInterface::MAIN_REQUEST, new WarningWithLogLevelAttribute());
+        $event = new ExceptionEvent(new TestKernel(), $request, HttpKernelInterface::MAIN_REQUEST, new ChildOfWarningWithLogLevelAttribute());
         $logger = new TestLogger();
         $l = new ErrorListener('not used', $logger);
 
@@ -280,6 +280,7 @@ class ErrorListenerTest extends TestCase
     {
         yield [new WithCustomUserProvidedAttribute(), 208, ['name' => 'value']];
         yield [new WithGeneralAttribute(), 412, ['some' => 'thing']];
+        yield [new ChildOfWithGeneralAttribute(), 412, ['some' => 'thing']];
     }
 }
 
@@ -341,7 +342,15 @@ class WithGeneralAttribute extends \Exception
 {
 }
 
+class ChildOfWithGeneralAttribute extends WithGeneralAttribute
+{
+}
+
 #[WithLogLevel(LogLevel::WARNING)]
 class WarningWithLogLevelAttribute extends \Exception
+{
+}
+
+class ChildOfWarningWithLogLevelAttribute extends WarningWithLogLevelAttribute
 {
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\Security\Core\Exception;
 
+use Symfony\Component\HttpKernel\Attribute\WithHttpStatus;
+
 /**
  * AccessDeniedException is thrown when the account has not the required role.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
+#[WithHttpStatus(403)]
 class AccessDeniedException extends RuntimeException
 {
     private array $attributes = [];

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Exception;
 
+use Symfony\Component\HttpKernel\Attribute\WithHttpStatus;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
@@ -19,6 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Alexander <iam.asm89@gmail.com>
  */
+#[WithHttpStatus(401)]
 class AuthenticationException extends RuntimeException
 {
     /** @internal */

--- a/src/Symfony/Component/Security/Http/EntryPoint/Exception/NotAnEntryPointException.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/Exception/NotAnEntryPointException.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Security\Http\EntryPoint\Exception;
 
+use Symfony\Component\HttpKernel\Attribute\WithHttpStatus;
+
 /**
  * Thrown by generic decorators when a decorated authenticator does not implement
  * {@see AuthenticationEntryPointInterface}.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
+#[WithHttpStatus(401)]
 class NotAnEntryPointException extends \RuntimeException
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #34148
| License       | MIT
| Doc PR        | -

Looks like ranting on Twitter may pay of sometimes ;)

https://twitter.com/zodman/status/1620954291187097600

The changes on ErrorListener make `#[WithHttpStatus]` and `#[WithLogLevel]` propagate to child classes.

Best reviewed [ignoring white spaces](https://github.com/symfony/symfony/pull/49193/files?w=1).