### PR TITLE
[Crawler] Fix regression where cdata nodes will return empty string

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -588,7 +588,7 @@ class Crawler implements \Countable, \IteratorAggregate
         $normalizeWhitespace = 1 <= \func_num_args() ? func_get_arg(0) : true;
 
         foreach ($this->getNode(0)->childNodes as $childNode) {
-            if (\XML_TEXT_NODE !== $childNode->nodeType) {
+            if (\XML_TEXT_NODE !== $childNode->nodeType && \XML_CDATA_SECTION_NODE !== $childNode->nodeType) {
                 continue;
             }
             if (!$normalizeWhitespace) {

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
@@ -377,6 +377,12 @@ abstract class AbstractCrawlerTestCase extends TestCase
                 '',
                 '  ',
             ],
+            [
+                '//*[@id="complex-elements"]/*[@class="six"]',
+                'console.log("Test JavaScript content");',
+                'console.log("Test JavaScript content");',
+                ' console.log("Test JavaScript content"); ',
+            ],
         ];
     }
 
@@ -1311,6 +1317,7 @@ HTML;
                         <div class="three"> Parent text <span>Child text</span> Parent text </div>
                         <div class="four">  <span>Child text</span>  </div>
                         <div class="five"><span>Child text</span>  <span>Another child</span></div>
+                        <script class="six" type="text/javascript"> console.log("Test JavaScript content"); </script>
                     </div>
                 </body>
             </html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
Fixes a regression caused by the fix to https://github.com/symfony/symfony/issues/48682 where `<script>` tags would return empty string on the innerContent call, where in 6.2 this did work.

Attached is a zipped PHPUnit test case used to verify the regression on 6.2 with a screenshot of its result.

[CrawlerInnerTextTest.zip](https://github.com/symfony/symfony/files/10567760/CrawlerInnerTextTest.zip)
![image](https://user-images.githubusercontent.com/1280380/216297235-1eda66d3-6768-4e49-9812-2857cff67086.png)
