### PR TITLE
[DependencyInjection] Introduce `#[AsAlias]` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -49,6 +49,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -684,6 +685,10 @@ class FrameworkExtension extends Extension
                 $tagAttributes['method'] = $reflector->getName();
             }
             $definition->addTag('messenger.message_handler', $tagAttributes);
+        });
+
+        $container->registerAttributeForAutoconfiguration(AsAlias::class, static function (ChildDefinition $definition, AsAlias $attribute, \ReflectionClass $reflector): void {
+            $definition->addTag(AsAlias::class, ['alias' => $attribute->alias]);
         });
 
         if (!$container->getParameter('kernel.debug')) {

--- a/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsAlias
+{
+    public function __construct(
+        public string $alias,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/AliasPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AliasPass.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+final class AliasPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->findTaggedServiceIds(AsAlias::class) as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                if (false === isset($tag['alias'])) {
+                    throw new InvalidArgumentException(sprintf('The "alias" attribute is mandatory for the "%s" tag.', AsAlias::class));
+                }
+
+                $container->setAlias($tag['alias'], $serviceId);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -76,6 +76,7 @@ class PassConfig
             new CheckCircularReferencesPass(),
             new CheckReferenceValidityPass(),
             new CheckArgumentsValidityPass(false),
+            new AliasPass(),
         ]];
 
         $this->removingPasses = [[

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AsAliasAttributeTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AsAliasAttributeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\AliasPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AsAliasAttributeTest extends TestCase
+{
+    public function testProcessWithMissingAliasAttribute()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', \DateTimeImmutable::class)
+            ->addTag(AsAlias::class, []);
+
+        self::expectException(\InvalidArgumentException::class);
+
+        (new AliasPass())->process($container);
+    }
+
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(HelloWorldService::class)
+            ->setAutowired(true)
+            ->setAutoconfigured(true);
+
+        $container->registerAttributeForAutoconfiguration(AsAlias::class, static function (ChildDefinition $definition, AsAlias $attribute, \ReflectionClass $reflector): void {
+            $definition->addTag(
+                AsAlias::class,
+                [
+                    'alias' => $attribute->alias,
+                ]
+            );
+        });
+
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->compile();
+
+        self::assertTrue($container->hasAlias('bar'));
+        self::assertSame(HelloWorldService::class, (string) $container->getAlias('bar'));
+    }
+}
+
+#[AsAlias(alias: 'bar')]
+class HelloWorldService
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Sometimes we want to alias something in the container with another service. This is usually done in less visible config files like `services.php` or a `Bundle` file. To make these aliases configurations more visible, the `#[AsAlias]` attribute is introduced. The attribute can be used on class that you want your e.g. Interface to alias to.

This allows doing:

```php
#[AsAlias(alias: 'bar')]
class HelloWorldService
{
}
```

instead of

```php
$services->setAlias('bar', HelloWorldService::class);
```
