### PR TITLE
[Routing] Convert backed enums to their value when generating default routes

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -205,7 +205,8 @@ abstract class AnnotationClassLoader implements LoaderInterface
             }
             foreach ($paths as $locale => $path) {
                 if (preg_match(sprintf('/\{%s(?:<.*?>)?\}/', preg_quote($param->name)), $path)) {
-                    $defaults[$param->name] = $param->getDefaultValue();
+                    $defaultValue = $param->getDefaultValue();
+                    $defaults[$param->name] = $defaultValue instanceof \BackedEnum ? $defaultValue->value : $defaultValue;
                     break;
                 }
             }

--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
@@ -467,6 +467,9 @@ EOF;
         }
         if (!\is_array($value)) {
             if (\is_object($value)) {
+                if ($value instanceof \BackedEnum) {
+                    return "'$value->value'";
+                }
                 throw new \InvalidArgumentException('Symfony\Component\Routing\Route cannot contain objects.');
             }
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
@@ -467,9 +467,6 @@ EOF;
         }
         if (!\is_array($value)) {
             if (\is_object($value)) {
-                if ($value instanceof \BackedEnum) {
-                    return "'$value->value'";
-                }
                 throw new \InvalidArgumentException('Symfony\Component\Routing\Route cannot contain objects.');
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49203 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This is a working update to allow usage of enums as php defaults in controllers. 

