### PR TITLE
[PropertyInfo] Add meaningful message when `phpstan/phpdoc-parser` is not installed when using `PhpStanExtractor`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -64,6 +64,10 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
             throw new \LogicException(sprintf('Unable to use the "%s" class as the "phpdocumentor/type-resolver" package is not installed. Try running composer require "phpdocumentor/type-resolver".', __CLASS__));
         }
 
+        if (!class_exists(PhpDocParser::class)) {
+            throw new \LogicException(sprintf('Unable to use the "%s" class as the "phpstan/phpdoc-parser" package is not installed. Try running composer require "phpstan/phpdoc-parser".', __CLASS__));
+        }
+
         $this->phpStanTypeHelper = new PhpStanTypeHelper();
         $this->mutatorPrefixes = $mutatorPrefixes ?? ReflectionExtractor::$defaultMutatorPrefixes;
         $this->accessorPrefixes = $accessorPrefixes ?? ReflectionExtractor::$defaultAccessorPrefixes;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -53,7 +53,7 @@ class PhpDocExtractorTest extends TestCase
         $this->assertNull($this->extractor->getTypes(OmittedParamTagTypeDocBlock::class, 'omittedType'));
     }
 
-    public function invalidTypesProvider()
+    public static function invalidTypesProvider()
     {
         return [
             'pub' => ['pub', null, null],
@@ -83,7 +83,7 @@ class PhpDocExtractorTest extends TestCase
         $this->assertEquals($type, $noPrefixExtractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
     }
 
-    public function typesProvider()
+    public static function typesProvider()
     {
         return [
             ['foo', null, 'Short description.', 'Long description.'],
@@ -166,7 +166,7 @@ class PhpDocExtractorTest extends TestCase
         $this->testExtract($property, $type, $shortDescription, $longDescription);
     }
 
-    public function provideCollectionTypes()
+    public static function provideCollectionTypes()
     {
         return [
             ['iteratorCollection', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Iterator', true, null, new Type(Type::BUILTIN_TYPE_STRING))], null, null],
@@ -230,7 +230,7 @@ class PhpDocExtractorTest extends TestCase
         $this->assertEquals($type, $customExtractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
     }
 
-    public function typesWithCustomPrefixesProvider()
+    public static function typesWithCustomPrefixesProvider()
     {
         return [
             ['foo', null, 'Short description.', 'Long description.'],
@@ -271,7 +271,7 @@ class PhpDocExtractorTest extends TestCase
         ];
     }
 
-    public function typesWithNoPrefixesProvider()
+    public static function typesWithNoPrefixesProvider()
     {
         return [
             ['foo', null, 'Short description.', 'Long description.'],
@@ -317,7 +317,7 @@ class PhpDocExtractorTest extends TestCase
         $this->assertNull($this->extractor->getShortDescription(EmptyDocBlock::class, 'foo'));
     }
 
-    public function dockBlockFallbackTypesProvider()
+    public static function dockBlockFallbackTypesProvider()
     {
         return [
             'pub' => [
@@ -348,7 +348,7 @@ class PhpDocExtractorTest extends TestCase
         $this->assertEquals([$type], $this->extractor->getTypes(DummyUsingTrait::class, $property));
     }
 
-    public function propertiesDefinedByTraitsProvider(): array
+    public static function propertiesDefinedByTraitsProvider(): array
     {
         return [
             ['propertyInTraitPrimitiveType', new Type(Type::BUILTIN_TYPE_STRING)],
@@ -368,7 +368,7 @@ class PhpDocExtractorTest extends TestCase
         $this->assertEquals([$type], $this->extractor->getTypes(DummyUsingTrait::class, $property));
     }
 
-    public function methodsDefinedByTraitsProvider(): array
+    public static function methodsDefinedByTraitsProvider(): array
     {
         return [
             ['methodInTraitPrimitiveType', new Type(Type::BUILTIN_TYPE_STRING)],
@@ -388,7 +388,7 @@ class PhpDocExtractorTest extends TestCase
         $this->assertEquals([$type], $this->extractor->getTypes($class, $property));
     }
 
-    public function propertiesStaticTypeProvider(): array
+    public static function propertiesStaticTypeProvider(): array
     {
         return [
             [ParentDummy::class, 'propertyTypeStatic', new Type(Type::BUILTIN_TYPE_OBJECT, false, ParentDummy::class)],
@@ -404,7 +404,7 @@ class PhpDocExtractorTest extends TestCase
         $this->assertEquals($types, $this->extractor->getTypes($class, $property));
     }
 
-    public function propertiesParentTypeProvider(): array
+    public static function propertiesParentTypeProvider(): array
     {
         return [
             [ParentDummy::class, 'parentAnnotationNoParent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'parent')]],
@@ -435,7 +435,7 @@ class PhpDocExtractorTest extends TestCase
         $this->assertEquals($type, $this->extractor->getTypesFromConstructor('Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy', $property));
     }
 
-    public function constructorTypesProvider()
+    public static function constructorTypesProvider()
     {
         return [
             ['date', [new Type(Type::BUILTIN_TYPE_INT)]],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

Folow-up of https://github.com/symfony/symfony/pull/49146, as `phpstan/phpdoc-parser` is only defined in `require-dev` of PropertyInfo.

Also, I took this opportunity to convert a few data providers to static ones cc @OskarStark 👍 