### PR TITLE
[Form] Fix `PasswordHasherListener` to work with empty data

### DIFF
--- a/src/Symfony/Component/Form/Extension/PasswordHasher/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/PasswordHasher/EventListener/PasswordHasherListener.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\PasswordHasher\EventListener;
 use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -21,6 +22,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
 /**
  * @author Sébastien Alfaiate <s.alfaiate@webarea.fr>
+ * @author Gábor Egyed <gabor.egyed@gmail.com>
  */
 class PasswordHasherListener
 {
@@ -35,26 +37,11 @@ class PasswordHasherListener
 
     public function registerPassword(FormEvent $event)
     {
-        $form = $event->getForm();
-        $parentForm = $form->getParent();
-        $mapped = $form->getConfig()->getMapped();
-
-        if ($parentForm && $parentForm->getConfig()->getType()->getInnerType() instanceof RepeatedType) {
-            $mapped = $parentForm->getConfig()->getMapped();
-            $parentForm = $parentForm->getParent();
-        }
-
-        if ($mapped) {
-            throw new InvalidConfigurationException('The "hash_property_path" option cannot be used on mapped field.');
-        }
-
-        if (!($user = $parentForm?->getData()) || !$user instanceof PasswordAuthenticatedUserInterface) {
-            throw new InvalidConfigurationException(sprintf('The "hash_property_path" option only supports "%s" objects, "%s" given.', PasswordAuthenticatedUserInterface::class, get_debug_type($user)));
-        }
+        $this->assertNotMapped($event->getForm());
 
         $this->passwords[] = [
-            'user' => $user,
-            'property_path' => $form->getConfig()->getOption('hash_property_path'),
+            'form' => $event->getForm(),
+            'property_path' => $event->getForm()->getConfig()->getOption('hash_property_path'),
             'password' => $event->getData(),
         ];
     }
@@ -69,14 +56,45 @@ class PasswordHasherListener
 
         if ($form->isValid()) {
             foreach ($this->passwords as $password) {
+                $user = $this->getUser($password['form']);
+
                 $this->propertyAccessor->setValue(
-                    $password['user'],
+                    $user,
                     $password['property_path'],
-                    $this->passwordHasher->hashPassword($password['user'], $password['password'])
+                    $this->passwordHasher->hashPassword($user, $password['password'])
                 );
             }
         }
 
         $this->passwords = [];
+    }
+
+    private function getTargetForm(FormInterface $form): FormInterface
+    {
+        $parent = $form->getParent();
+
+        if ($parent && $parent->getConfig()->getType()->getInnerType() instanceof RepeatedType) {
+            return $parent;
+        }
+
+        return $form;
+    }
+
+    private function getUser(FormInterface $form): PasswordAuthenticatedUserInterface
+    {
+        $parent = $this->getTargetForm($form)->getParent();
+
+        if (!($user = $parent?->getData()) || !$user instanceof PasswordAuthenticatedUserInterface) {
+            throw new InvalidConfigurationException(sprintf('The "hash_property_path" option only supports "%s" objects, "%s" given.', PasswordAuthenticatedUserInterface::class, get_debug_type($user)));
+        }
+
+        return $user;
+    }
+
+    private function assertNotMapped(FormInterface $form): void
+    {
+        if ($this->getTargetForm($form)->getConfig()->getMapped()) {
+            throw new InvalidConfigurationException('The "hash_property_path" option cannot be used on mapped field.');
+        }
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
@@ -77,6 +77,42 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
         $this->assertSame($user->getPassword(), $hashedPassword);
     }
 
+    public function testPasswordHashSuccessWitnEmptyData()
+    {
+        $user = new User();
+
+        $plainPassword = 'PlainPassword';
+        $hashedPassword = 'HashedPassword';
+
+        $this->passwordHasher
+            ->expects($this->once())
+            ->method('hashPassword')
+            ->with($user, $plainPassword)
+            ->willReturn($hashedPassword)
+        ;
+
+        $this->assertNull($user->getPassword());
+
+        $form = $this->factory
+            ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
+                'data_class' => User::class,
+                'empty_data' => function () use ($user) {
+                    return $user;
+                },
+            ])
+            ->add('plainPassword', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', [
+                'hash_property_path' => 'password',
+                'mapped' => false,
+            ])
+            ->getForm()
+        ;
+
+        $form->submit(['plainPassword' => $plainPassword]);
+
+        $this->assertTrue($form->isValid());
+        $this->assertSame($user->getPassword(), $hashedPassword);
+    }
+
     public function testPasswordHashOnInvalidForm()
     {
         $user = new User();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This fixes the case when a new user is created by the form,              
for example in a registration form. Before this the listener
thrown an exception, because when it tried to get the user
it was not available yet. With this the user resolved later
at the root form when empty data already ran. Other then that
the logic is the same just refactored a code a bit to make it              
more readable.