### PR TITLE
Fix PHP8.2 str_split function returns empty arrays for empty strings

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1209,7 +1209,7 @@ class Application implements ResetInterface
         // additionally, array_slice() is not enough as some character has doubled width.
         // we need a function to split string not by character count but by string width
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
-            return str_split($string, $width);
+            return mb_str_split($string, $width);
         }
 
         $utf8String = mb_convert_encoding($string, 'utf8', $encoding);

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -804,7 +804,7 @@ class Table
                             $textContent = Helper::removeDecoration($this->output->getFormatter(), $cell);
                             $textLength = Helper::width($textContent);
                             if ($textLength > 0) {
-                                $contentColumns = str_split($textContent, ceil($textLength / $cell->getColspan()));
+                                $contentColumns = mb_str_split($textContent, ceil($textLength / $cell->getColspan()));
                                 foreach ($contentColumns as $position => $content) {
                                     $row[$i + $position] = $content;
                                 }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -547,7 +547,7 @@ class Request
 
         $_REQUEST = [[]];
 
-        foreach (str_split($requestOrder) as $order) {
+        foreach (mb_str_split($requestOrder) as $order) {
             $_REQUEST[] = $request[$order];
         }
 

--- a/src/Symfony/Component/Mime/CharacterStream.php
+++ b/src/Symfony/Component/Mime/CharacterStream.php
@@ -135,7 +135,7 @@ final class CharacterStream
     public function readBytes(int $length): ?array
     {
         if (null !== $read = $this->read($length)) {
-            return array_map('ord', str_split($read, 1));
+            return array_map('ord', mb_str_split($read, 1));
         }
 
         return null;

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -124,7 +124,7 @@ class ByteString extends AbstractString
         $str = clone $this;
         $chunks = [];
 
-        foreach (str_split($this->string, $length) as $chunk) {
+        foreach (mb_str_split($this->string, $length) as $chunk) {
             $str->string = $chunk;
             $chunks[] = clone $str;
         }

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -224,7 +224,7 @@ class IbanValidator extends ConstraintValidator
 
     private static function toBigInt(string $string): string
     {
-        $chars = str_split($string);
+        $chars = mb_str_split($string);
         $bigInt = '';
 
         foreach ($chars as $char) {
@@ -244,7 +244,7 @@ class IbanValidator extends ConstraintValidator
 
     private static function bigModulo97(string $bigInt): int
     {
-        $parts = str_split($bigInt, 7);
+        $parts = mb_str_split($bigInt, 7);
         $rest = 0;
 
         foreach ($parts as $part) {

--- a/src/Symfony/Component/Validator/Constraints/IsinValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsinValidator.php
@@ -67,7 +67,7 @@ class IsinValidator extends ConstraintValidator
 
     private function isCorrectChecksum(string $input): bool
     {
-        $characters = str_split($input);
+        $characters = mb_str_split($input);
         foreach ($characters as $i => $char) {
             $characters[$i] = \intval($char, 36);
         }

--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -76,7 +76,7 @@ class LuhnValidator extends ConstraintValidator
         //         ^     ^     ^     ^     ^
         //    =    1+8 + 4  +  6  +  1+6 + 2
         for ($i = $length - 2; $i >= 0; $i -= 2) {
-            $checkSum += array_sum(str_split((int) $value[$i] * 2));
+            $checkSum += array_sum(mb_str_split((int) $value[$i] * 2));
         }
 
         if (0 === $checkSum || 0 !== $checkSum % 10) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.2 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49213
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
