### PR TITLE
[Security] deprecate the $secret argument of the PersistentRememberMeHandler constructor

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -96,6 +96,11 @@ Notifier
  * [BC BREAK] The following data providers for `TransportTestCase` are now static: `toStringProvider()`, `supportedMessagesProvider()` and `unsupportedMessagesProvider()`
  * [BC BREAK] The `TransportTestCase::createTransport()` method is now static
 
+Security
+--------
+
+ * Deprecate passing a secret as the 2nd argument to the constructor of `Symfony\Component\Security\Http\RememberMe\PersistentRememberMeHandler`
+
 SecurityBundle
 --------------
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
@@ -50,7 +50,6 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->args([
                 abstract_arg('token provider'),
-                param('kernel.secret'),
                 abstract_arg('user provider'),
                 service('request_stack'),
                 abstract_arg('options'),

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -27,7 +27,7 @@
         "symfony/password-hasher": "^5.4|^6.0",
         "symfony/security-core": "^6.2",
         "symfony/security-csrf": "^5.4|^6.0",
-        "symfony/security-http": "^6.2.6"
+        "symfony/security-http": "^6.3"
     },
     "require-dev": {
         "doctrine/annotations": "^1.10.4|^2",

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `RememberMeBadge` to `JsonLoginAuthenticator` and enable reading parameter in JSON request body
  * Add argument `$exceptionCode` to `#[IsGranted]`
+ * Deprecate passing a secret as the 2nd argument to the constructor of `Symfony\Component\Security\Http\RememberMe\PersistentRememberMeHandler`
 
 6.2
 ---

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -35,8 +35,45 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
     private TokenProviderInterface $tokenProvider;
     private ?TokenVerifierInterface $tokenVerifier;
 
-    public function __construct(TokenProviderInterface $tokenProvider, #[\SensitiveParameter] string $secret, UserProviderInterface $userProvider, RequestStack $requestStack, array $options, LoggerInterface $logger = null, TokenVerifierInterface $tokenVerifier = null)
+    /**
+     * @param UserProviderInterface       $userProvider
+     * @param RequestStack                $requestStack
+     * @param array                       $options
+     * @param LoggerInterface|null        $logger
+     * @param TokenVerifierInterface|null $tokenVerifier
+     */
+    public function __construct(TokenProviderInterface $tokenProvider, #[\SensitiveParameter] $userProvider, $requestStack, $options, $logger = null, $tokenVerifier = null)
     {
+        if (\is_string($userProvider)) {
+            trigger_deprecation('symfony/security-http', '6.3', 'Calling "%s()" with the secret as the second argument is deprecated. The argument will be dropped in 7.0.', __CLASS__);
+
+            $userProvider = $requestStack;
+            $requestStack = $options;
+            $options = $logger;
+            $logger = $tokenVerifier;
+            $tokenVerifier = \func_num_args() > 6 ? func_get_arg(6) : null;
+        }
+
+        if (!$userProvider instanceof UserProviderInterface) {
+            throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, UserProviderInterface::class, get_debug_type($userProvider)));
+        }
+
+        if (!$requestStack instanceof RequestStack) {
+            throw new \TypeError(sprintf('Argument 3 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, RequestStack::class, get_debug_type($userProvider)));
+        }
+
+        if (!\is_array($options)) {
+            throw new \TypeError(sprintf('Argument 4 passed to "%s()" must be an array, "%s" given.', __CLASS__, get_debug_type($userProvider)));
+        }
+
+        if (null !== $logger && !$logger instanceof LoggerInterface) {
+            throw new \TypeError(sprintf('Argument 5 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, LoggerInterface::class, get_debug_type($userProvider)));
+        }
+
+        if (null !== $tokenVerifier && !$tokenVerifier instanceof TokenVerifierInterface) {
+            throw new \TypeError(sprintf('Argument 6 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, TokenVerifierInterface::class, get_debug_type($userProvider)));
+        }
+
         parent::__construct($userProvider, $requestStack, $options, $logger);
 
         if (!$tokenVerifier && $tokenProvider instanceof TokenVerifierInterface) {

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -42,7 +42,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->requestStack = new RequestStack();
         $this->request = Request::create('/login');
         $this->requestStack->push($this->request);
-        $this->handler = new PersistentRememberMeHandler($this->tokenProvider, 'secret', $this->userProvider, $this->requestStack, []);
+        $this->handler = new PersistentRememberMeHandler($this->tokenProvider, $this->userProvider, $this->requestStack, []);
     }
 
     public function testCreateRememberMeCookie()
@@ -104,7 +104,7 @@ class PersistentRememberMeHandlerTest extends TestCase
     public function testConsumeRememberMeCookieValidByValidatorWithoutUpdate()
     {
         $verifier = $this->createMock(TokenVerifierInterface::class);
-        $handler = new PersistentRememberMeHandler($this->tokenProvider, 'secret', $this->userProvider, $this->requestStack, [], null, $verifier);
+        $handler = new PersistentRememberMeHandler($this->tokenProvider, $this->userProvider, $this->requestStack, [], null, $verifier);
 
         $persistentToken = new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('30 seconds'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/pull/49103#discussion_r1086685189
| License       | MIT
| Doc PR        | 
