### PR TITLE
[Validator] Make ConstraintValidatorTestCase compatible with PHPUnit 10

### DIFF
--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -130,16 +130,22 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
         $context->setConstraint($this->constraint);
 
-        $contextualValidator = $this->getMockBuilder(AssertingContextualValidator::class)
-            ->setConstructorArgs([$context])
-            ->setMethods([
-                'atPath',
-                'validate',
-                'validateProperty',
-                'validatePropertyValue',
-                'getViolations',
-            ])
-            ->getMock();
+        $contextualValidatorMockBuilder = $this->getMockBuilder(AssertingContextualValidator::class)
+            ->setConstructorArgs([$context]);
+        $contextualValidatorMethods = [
+            'atPath',
+            'validate',
+            'validateProperty',
+            'validatePropertyValue',
+            'getViolations',
+        ];
+        // PHPUnit 10 removed MockBuilder::setMethods()
+        if (method_exists($contextualValidatorMockBuilder, 'onlyMethods')) {
+            $contextualValidatorMockBuilder->onlyMethods($contextualValidatorMethods);
+        } else {
+            $contextualValidatorMockBuilder->setMethods($contextualValidatorMethods);
+        }
+        $contextualValidator = $contextualValidatorMockBuilder->getMock();
         $contextualValidator->expects($this->any())
             ->method('atPath')
             ->willReturnCallback(function ($path) use ($contextualValidator) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49218
| License       | MIT

As explained in #49218 `MockBuilder::setMethods()` has been removed from PHPUnit 10 and replaced with `MockBuilder::onlyMethods()`. This change checks if `onlyMethods()` is defined and if not falls back to old version that uses `setMethods()`.