### PR TITLE
[WebProfilerBundle] Fix an accessibility issue in the search form of the header

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/header.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/header.html.twig
@@ -4,7 +4,8 @@
     <div class="search">
         <form method="get" action="https://symfony.com/search" target="_blank">
             <div class="form-row">
-                <input name="q" id="search-id" type="search" placeholder="search on symfony.com">
+                <input name="q" id="search-id" type="search" placeholder="search on symfony.com" aria-label="Search on symfony.com">
+                <button type="submit" class="visually-hidden">Search</button>
             </div>
        </form>
     </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The Profiler redesign introduced in 6.2 had an accessibility issue in the search form of the header. I fixed it following the best practices explained in https://www.w3.org/WAI/tutorials/forms/labels/