### PR TITLE
[WebProfilerBundle] Disable Turbo for debug toolbar links

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -1,5 +1,5 @@
 <!-- START of Symfony Web Debug Toolbar -->
-<div id="sfMiniToolbar-{{ token }}" class="sf-minitoolbar" data-no-turbolink>
+<div id="sfMiniToolbar-{{ token }}" class="sf-minitoolbar" data-no-turbolink data-turbo="false">
     <button type="button" title="Show Symfony toolbar" id="sfToolbarMiniToggler-{{ token }}" accesskey="D" aria-expanded="false" aria-controls="sfToolbarMainContent-{{ token }}">
         {{ include('@WebProfiler/Icon/symfony.svg') }}
     </button>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

@stof suggested this change to me. I think it makes sense to merge it in 5.4 as a bug fix because otherwise, Symfony UX Turbo could mess with the links of the Web Debug Toolbar.