### PR TITLE
[HttpFoundation] Constraint ResponseHeaderSame now shows the actual header value

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -79,7 +79,7 @@ trait BrowserKitAssertionsTrait
 
     public static function assertResponseHeaderNotSame(string $headerName, string $expectedValue, string $message = ''): void
     {
-        self::assertThatForResponse(new LogicalNot(new ResponseConstraint\ResponseHeaderSame($headerName, $expectedValue)), $message);
+        self::assertThatForResponse(new LogicalNot(new ResponseConstraint\ResponseHeaderSame($headerName, $expectedValue, true)), $message);
     }
 
     public static function assertResponseHasCookie(string $name, string $path = '/', string $domain = null, string $message = ''): void

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -121,7 +121,7 @@ class WebTestCaseTest extends TestCase
     {
         $this->getResponseTester(new Response())->assertResponseHeaderSame('Cache-Control', 'no-cache, private');
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public".');
+        $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public", value of header "Cache-Control" is "no-cache, private".');
         $this->getResponseTester(new Response())->assertResponseHeaderSame('Cache-Control', 'public');
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -124,7 +124,7 @@ class WebTestCaseTest extends TestCase
     {
         $this->getResponseTester(new Response())->assertResponseHeaderSame('Cache-Control', 'no-cache, private');
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public".');
+        $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public", value of header "Cache-Control" is "no-cache, private".');
         $this->getResponseTester(new Response())->assertResponseHeaderSame('Cache-Control', 'public');
     }
 

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `ParameterBag::filterCallback()` to filter a parameter value through a callback
  * Reject a `Cookie` whose name uses the `__Secure-`/`__Host-` prefix when its attributes break the prefix contract
  * Deprecate the `Request::$trustedHosts` property, it is never populated anymore
+ * Report the actual header value when the `ResponseHeaderSame` constraint fails
 
 8.1
 ---

--- a/src/Symfony/Component/HttpFoundation/Test/Constraint/ResponseHeaderSame.php
+++ b/src/Symfony/Component/HttpFoundation/Test/Constraint/ResponseHeaderSame.php
@@ -18,6 +18,7 @@ final class ResponseHeaderSame extends Constraint
 {
     private string $headerName;
     private string $expectedValue;
+    private ?string $actualValue = null;
 
     public function __construct(string $headerName, string $expectedValue)
     {
@@ -27,7 +28,17 @@ final class ResponseHeaderSame extends Constraint
 
     public function toString(): string
     {
-        return sprintf('has header "%s" with value "%s"', $this->headerName, $this->expectedValue);
+        $output = sprintf('has header "%s" with value "%s"', $this->headerName, $this->expectedValue);
+
+        if (null === $this->actualValue) {
+            $output .= sprintf(', header "%s" is not set', $this->headerName);
+        }
+
+        if (null !== $this->actualValue) {
+            $output .= sprintf(', value of header "%s" is "%s"', $this->headerName, $this->actualValue);
+        }
+
+        return $output;
     }
 
     /**
@@ -35,7 +46,9 @@ final class ResponseHeaderSame extends Constraint
      */
     protected function matches($response): bool
     {
-        return $this->expectedValue === $response->headers->get($this->headerName, null);
+        $this->actualValue = $response->headers->get($this->headerName);
+
+        return $this->expectedValue === $this->actualValue;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Test/Constraint/ResponseHeaderSame.php
+++ b/src/Symfony/Component/HttpFoundation/Test/Constraint/ResponseHeaderSame.php
@@ -18,12 +18,14 @@ final class ResponseHeaderSame extends Constraint
 {
     private string $headerName;
     private string $expectedValue;
+    private bool $logicalNot;
     private ?string $actualValue = null;
 
-    public function __construct(string $headerName, string $expectedValue)
+    public function __construct(string $headerName, string $expectedValue, bool $logicalNot = false)
     {
         $this->headerName = $headerName;
         $this->expectedValue = $expectedValue;
+        $this->logicalNot = $logicalNot;
     }
 
     public function toString(): string
@@ -34,7 +36,7 @@ final class ResponseHeaderSame extends Constraint
             $output .= sprintf(', header "%s" is not set', $this->headerName);
         }
 
-        if (null !== $this->actualValue) {
+        if (null !== $this->actualValue && !$this->logicalNot) {
             $output .= sprintf(', value of header "%s" is "%s"', $this->headerName, $this->actualValue);
         }
 

--- a/src/Symfony/Component/HttpFoundation/Test/Constraint/ResponseHeaderSame.php
+++ b/src/Symfony/Component/HttpFoundation/Test/Constraint/ResponseHeaderSame.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class ResponseHeaderSame extends Constraint
 {
+    private ?string $actualValue = null;
+
     public function __construct(
         private string $headerName,
         private string $expectedValue,
@@ -32,7 +34,9 @@ final class ResponseHeaderSame extends Constraint
      */
     protected function matches($response): bool
     {
-        return $this->expectedValue === $response->headers->get($this->headerName, null);
+        $this->actualValue = $response->headers->get($this->headerName, null);
+
+        return $this->expectedValue === $this->actualValue;
     }
 
     /**
@@ -40,6 +44,17 @@ final class ResponseHeaderSame extends Constraint
      */
     protected function failureDescription($response): string
     {
-        return 'the Response '.$this->toString();
+        $description = 'the Response '.$this->toString();
+
+        if (null === $this->actualValue) {
+            return $description.\sprintf(', header "%s" is not set', $this->headerName);
+        }
+
+        // nothing to add when both values match, which is the case when the assertion is negated
+        if ($this->expectedValue !== $this->actualValue) {
+            $description .= \sprintf(', value of header "%s" is "%s"', $this->headerName, $this->actualValue);
+        }
+
+        return $description;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
@@ -19,17 +19,48 @@ use Symfony\Component\HttpFoundation\Test\Constraint\ResponseHeaderSame;
 
 class ResponseHeaderSameTest extends TestCase
 {
-    public function testConstraint()
+    public function testResponseHeaderSameWithExpectedHeaderValueIsSame()
     {
-        $constraint = new ResponseHeaderSame('Cache-Control', 'no-cache, private');
-        $this->assertTrue($constraint->evaluate(new Response(), '', true));
-        $constraint = new ResponseHeaderSame('Cache-Control', 'public');
-        $this->assertFalse($constraint->evaluate(new Response(), '', true));
+        $constraint = new ResponseHeaderSame('X-Token', 'custom-token');
+
+        $response = new Response();
+        $response->headers->set('X-Token', 'custom-token');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testResponseHeaderSameWithExpectedHeaderValueIsDifferent()
+    {
+        $constraint = new ResponseHeaderSame('X-Token', 'custom-token');
+
+        $response = new Response();
+        $response->headers->set('X-Token', 'default-token');
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
 
         try {
-            $constraint->evaluate(new Response());
+            $constraint->evaluate($response);
         } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Response has header \"Cache-Control\" with value \"public\".\n", TestFailure::exceptionToString($e));
+            $this->assertEquals("Failed asserting that the Response has header \"X-Token\" with value \"custom-token\", value of header \"X-Token\" is \"default-token\".\n", TestFailure::exceptionToString($e));
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testResponseHeaderSameWithExpectedHeaderIsNotPresent()
+    {
+        $constraint = new ResponseHeaderSame('X-Token', 'custom-token');
+
+        $response = new Response();
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+
+        try {
+            $constraint->evaluate($response);
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals("Failed asserting that the Response has header \"X-Token\" with value \"custom-token\", header \"X-Token\" is not set.\n", TestFailure::exceptionToString($e));
 
             return;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
 
+use PHPUnit\Framework\Constraint\LogicalNot;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +27,27 @@ class ResponseHeaderSameTest extends TestCase
         $this->assertFalse($constraint->evaluate(new Response(), '', true));
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public".');
+        $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public", value of header "Cache-Control" is "no-cache, private".');
+
+        $constraint->evaluate(new Response());
+    }
+
+    public function testConstraintReportsMissingHeader()
+    {
+        $constraint = new ResponseHeaderSame('X-Missing', 'expected');
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Response has header "X-Missing" with value "expected", header "X-Missing" is not set.');
+
+        $constraint->evaluate(new Response());
+    }
+
+    public function testNegatedConstraintDoesNotRepeatTheValue()
+    {
+        $constraint = new LogicalNot(new ResponseHeaderSame('Cache-Control', 'no-cache, private'));
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the Response does not have header "Cache-Control" with value "no-cache, private".');
 
         $constraint->evaluate(new Response());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I am using the `BrowserKitAssertionsTrait::assertResponseHeaderSame(...)` quite a lot in my functional tests and it would be nice to see the actual header value in case the expected one doesn't match. So instead of just seeing:

> Failed asserting that the Response has header "Cache-Control" with value \"public\".

it would be helpful to see:

> Failed asserting that the Response has header "Cache-Control" with value "public", value of header "Cache-Control" is "no-cache, private".


