### PR TITLE
[EvaluationLanguage] Fix null safe expressions on deep objects

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.2
 ---
 
+ * Fix null-coalescing support for undefined object properties
  * Add support for null-coalescing syntax
 
 6.1

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -85,7 +85,7 @@ class GetAttrNode extends Node
 
                 $property = $this->nodes['attribute']->attributes['value'];
 
-                if ($this->attributes['is_null_coalesce']) {
+                if ($this->attributes['is_null_coalesce'] || $this->nodes['attribute']->isNullSafe) {
                     return $obj->$property ?? null;
                 }
 
@@ -140,6 +140,10 @@ class GetAttrNode extends Node
     {
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
+                if ($this->nodes['attribute']->isNullSafe ?? null) {
+                    return [$this->nodes['node'], '?.', $this->nodes['attribute']];
+                }
+
                 return [$this->nodes['node'], '.', $this->nodes['attribute']];
 
             case self::METHOD_CALL:
@@ -151,7 +155,7 @@ class GetAttrNode extends Node
     }
 
     /**
-     * Provides BC with instances serialized before v6.2
+     * Provides BC with instances serialized before v6.2.
      */
     public function __unserialize(array $data): void
     {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -25,6 +25,7 @@ class GetAttrNodeTest extends AbstractNodeTest
             ['a', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), static::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b']]],
 
             ['bar', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            [null, new GetAttrNode(new NameNode('foo'), new ConstantNode('baz', false, true), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
 
             ['baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
             ['a', new GetAttrNode(new NameNode('foo'), new NameNode('index'), static::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b'], 'index' => 'b']],
@@ -38,6 +39,7 @@ class GetAttrNodeTest extends AbstractNodeTest
             ['$foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
 
             ['$foo->foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            ['$foo?->baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('baz', false, true), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
 
             ['$foo->foo(["b" => "a", 0 => "b"])', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
             ['$foo[$index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
@@ -51,6 +53,7 @@ class GetAttrNodeTest extends AbstractNodeTest
             ['foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
 
             ['foo.foo', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            ['foo?.baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('baz', true, true), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
 
             ['foo.foo({"b": "a", 0: "b"})', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), static::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
             ['foo[index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47192
| License       | MIT
| Doc PR        | n/a

This fixes #47192 by checking for `isNullSafe` when appropriate.

Also tests compiling and dumping with null coalescing.