### PR TITLE
[ExpressionLanguage] Fix null coalescing for object properties

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -153,7 +153,7 @@ class GetAttrNode extends Node
     }
 
     /**
-     * Provides BC with instances serialized before v6.2
+     * Provides BC with instances serialized before v6.2.
      */
     public function __unserialize(array $data): void
     {

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -69,6 +69,8 @@ class GetAttrNode extends Node
     {
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
+                $this->nodes['node']->attributes['is_null_coalesce'] = $this->attributes['is_null_coalesce'] ?? false;
+
                 $obj = $this->nodes['node']->evaluate($functions, $values);
                 if (null === $obj && ($this->nodes['attribute']->isNullSafe || $this->attributes['is_null_coalesce'])) {
                     $this->attributes['is_short_circuited'] = true;

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -356,6 +356,7 @@ class ExpressionLanguageTest extends TestCase
         yield ['foo.bar ?? "default"', null];
         yield ['foo.bar.baz ?? "default"', (object) ['bar' => null]];
         yield ['foo.bar ?? foo.baz ?? "default"', null];
+        yield ['foo?.bar?.baz?.qux ?? "default"', (object) ['foo' => null]];
         yield ['foo[0] ?? "default"', []];
         yield ['foo["bar"] ?? "default"', ['bar' => null]];
         yield ['foo["baz"] ?? "default"', ['bar' => null]];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #47192
| License       | MIT
| Doc PR        | n/a

Support deep object traversal that respects null coalescing operator `??`, such as:

```
user.settings.public.dnc ?? false
```
