### PR TITLE
Use PHPUnit 9.6 to run Symfony's test suite

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -10,12 +10,10 @@ if (!file_exists(__DIR__.'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
     exit(1);
 }
 if (!getenv('SYMFONY_PHPUNIT_VERSION')) {
-    if (\PHP_VERSION_ID < 70200) {
-        putenv('SYMFONY_PHPUNIT_VERSION=7.5');
-    } elseif (\PHP_VERSION_ID < 70300) {
+    if (\PHP_VERSION_ID < 70300) {
         putenv('SYMFONY_PHPUNIT_VERSION=8.5.26');
     } else {
-        putenv('SYMFONY_PHPUNIT_VERSION=9.5');
+        putenv('SYMFONY_PHPUNIT_VERSION=9.6');
     }
 }
 if (!getenv('SYMFONY_PATCH_TYPE_DECLARATIONS') && \PHP_VERSION_ID >= 70300) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
@@ -72,7 +72,7 @@ class ButtonTypeTest extends BaseTypeTestCase
     public function testFormAttrAsBoolWithNoId()
     {
         $this->expectException(LogicException::class);
-        $this->expectErrorMessage('form_attr');
+        $this->expectExceptionMessage('form_attr');
         $this->factory
             ->createNamedBuilder('', FormType::class, null, [
                 'form_attr' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -809,7 +809,7 @@ class FormTypeTest extends BaseTypeTestCase
     public function testFormAttrAsBoolWithNoId()
     {
         $this->expectException(LogicException::class);
-        $this->expectErrorMessage('form_attr');
+        $this->expectExceptionMessage('form_attr');
         $this->factory
             ->createNamedBuilder('', self::TESTED_TYPE, null, [
                 'form_attr' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Let's use PHPUnit 9.6 to run test test suite if we can.