### PR TITLE
[PHPUnit 10] Use `TestCase` suffix for abstract tests in `/Tests/`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -35,12 +35,12 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Forms;
-use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTest;
+use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTestCase;
 use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 
-class EntityTypeTest extends BaseTypeTest
+class EntityTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Bridge\Doctrine\Form\Type\EntityType';
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3HorizontalLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3HorizontalLayoutTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
-abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3LayoutTest
+abstract class AbstractBootstrap3HorizontalLayoutTestCase extends AbstractBootstrap3LayoutTestCase
 {
     public function testLabelOnForm()
     {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
@@ -13,9 +13,9 @@ namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\Tests\AbstractLayoutTest;
+use Symfony\Component\Form\Tests\AbstractLayoutTestCase;
 
-abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
+abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 {
     public function testLabelOnForm()
     {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormError;
  *
  * @author Hidde Wieringa <hidde@hiddewieringa.nl>
  */
-abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4LayoutTest
+abstract class AbstractBootstrap4HorizontalLayoutTestCase extends AbstractBootstrap4LayoutTestCase
 {
     public function testRow()
     {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
@@ -28,7 +28,7 @@ use Symfony\Component\Form\FormError;
  *
  * @author Hidde Wieringa <hidde@hiddewieringa.nl>
  */
-abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
+abstract class AbstractBootstrap4LayoutTestCase extends AbstractBootstrap3LayoutTestCase
 {
     public function testRow()
     {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5HorizontalLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5HorizontalLayoutTestCase.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\FormError;
  *
  * @author Romain Monteil <monteil.romain@gmail.com>
  */
-abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5LayoutTest
+abstract class AbstractBootstrap5HorizontalLayoutTestCase extends AbstractBootstrap5LayoutTestCase
 {
     public function testRow()
     {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
@@ -36,7 +36,7 @@ use Symfony\Component\Form\FormError;
  *
  * @author Romain Monteil <monteil.romain@gmail.com>
  */
-abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
+abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4LayoutTestCase
 {
     public function testRow()
     {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
-class FormExtensionBootstrap3HorizontalLayoutTest extends AbstractBootstrap3HorizontalLayoutTest
+class FormExtensionBootstrap3HorizontalLayoutTest extends AbstractBootstrap3HorizontalLayoutTestCase
 {
     use RuntimeLoaderProvider;
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
-class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTest
+class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTestCase
 {
     use RuntimeLoaderProvider;
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
@@ -26,7 +26,7 @@ use Twig\Loader\FilesystemLoader;
  *
  * @author Hidde Wieringa <hidde@hiddewieringa.nl>
  */
-class FormExtensionBootstrap4HorizontalLayoutTest extends AbstractBootstrap4HorizontalLayoutTest
+class FormExtensionBootstrap4HorizontalLayoutTest extends AbstractBootstrap4HorizontalLayoutTestCase
 {
     use RuntimeLoaderProvider;
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -26,7 +26,7 @@ use Twig\Loader\FilesystemLoader;
  *
  * @author Hidde Wieringa <hidde@hiddewieringa.nl>
  */
-class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTest
+class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTestCase
 {
     use RuntimeLoaderProvider;
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5HorizontalLayoutTest.php
@@ -26,7 +26,7 @@ use Twig\Loader\FilesystemLoader;
  *
  * @author Romain Monteil <monteil.romain@gmail.com>
  */
-class FormExtensionBootstrap5HorizontalLayoutTest extends AbstractBootstrap5HorizontalLayoutTest
+class FormExtensionBootstrap5HorizontalLayoutTest extends AbstractBootstrap5HorizontalLayoutTestCase
 {
     use RuntimeLoaderProvider;
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
@@ -28,7 +28,7 @@ use Twig\Loader\FilesystemLoader;
  *
  * @author Romain Monteil <monteil.romain@gmail.com>
  */
-class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTest
+class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTestCase
 {
     use RuntimeLoaderProvider;
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -18,12 +18,12 @@ use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubTranslator;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Tests\AbstractDivLayoutTest;
+use Symfony\Component\Form\Tests\AbstractDivLayoutTestCase;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
-class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
+class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
 {
     use RuntimeLoaderProvider;
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -17,12 +17,12 @@ use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubTranslator;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Tests\AbstractTableLayoutTest;
+use Symfony\Component\Form\Tests\AbstractTableLayoutTestCase;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
-class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
+class FormExtensionTableLayoutTest extends AbstractTableLayoutTestCase
 {
     use RuntimeLoaderProvider;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
@@ -24,7 +24,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
-abstract class AbstractDescriptorTest extends TestCase
+abstract class AbstractDescriptorTestCase extends TestCase
 {
     private $colSize;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/JsonDescriptorTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 
 use Symfony\Bundle\FrameworkBundle\Console\Descriptor\JsonDescriptor;
 
-class JsonDescriptorTest extends AbstractDescriptorTest
+class JsonDescriptorTest extends AbstractDescriptorTestCase
 {
     protected static function getDescriptor()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/MarkdownDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/MarkdownDescriptorTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 
 use Symfony\Bundle\FrameworkBundle\Console\Descriptor\MarkdownDescriptor;
 
-class MarkdownDescriptorTest extends AbstractDescriptorTest
+class MarkdownDescriptorTest extends AbstractDescriptorTestCase
 {
     protected static function getDescriptor()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -15,7 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Descriptor\TextDescriptor;
 use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 use Symfony\Component\Routing\Route;
 
-class TextDescriptorTest extends AbstractDescriptorTest
+class TextDescriptorTest extends AbstractDescriptorTestCase
 {
     private static $fileLinkFormatter = null;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/XmlDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/XmlDescriptorTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 
 use Symfony\Bundle\FrameworkBundle\Console\Descriptor\XmlDescriptor;
 
-class XmlDescriptorTest extends AbstractDescriptorTest
+class XmlDescriptorTest extends AbstractDescriptorTestCase
 {
     protected static function getDescriptor()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_not_valid.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_not_valid.php
@@ -1,13 +1,13 @@
 <?php
 
-use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
     'workflows' => [
         'my_workflow' => [
             'type' => 'state_machine',
             'supports' => [
-                FrameworkExtensionTest::class,
+                FrameworkExtensionTestCase::class,
             ],
             'places' => [
                 'first',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
@@ -1,13 +1,13 @@
 <?php
 
-use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
     'workflows' => [
         'article' => [
             'type' => 'workflow',
             'supports' => [
-                FrameworkExtensionTest::class,
+                FrameworkExtensionTestCase::class,
             ],
             'initial_marking' => ['draft'],
             'places' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_multiple_transitions_with_same_name.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_multiple_transitions_with_same_name.php
@@ -1,13 +1,13 @@
 <?php
 
-use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
     'workflows' => [
         'article' => [
             'type' => 'workflow',
             'supports' => [
-                FrameworkExtensionTest::class,
+                FrameworkExtensionTestCase::class,
             ],
             'initial_marking' => ['draft'],
             'places' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_no_events_to_dispatch.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_no_events_to_dispatch.php
@@ -1,6 +1,6 @@
 <?php
 
-use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
     'workflows' => [
@@ -11,7 +11,7 @@ $container->loadFromExtension('framework', [
                 'property' => 'state',
             ],
             'supports' => [
-                FrameworkExtensionTest::class,
+                FrameworkExtensionTestCase::class,
             ],
             'events_to_dispatch' => [],
             'places' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_events_to_dispatch.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_events_to_dispatch.php
@@ -1,6 +1,6 @@
 <?php
 
-use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
     'workflows' => [
@@ -11,7 +11,7 @@ $container->loadFromExtension('framework', [
                 'property' => 'state',
             ],
             'supports' => [
-                FrameworkExtensionTest::class,
+                FrameworkExtensionTestCase::class,
             ],
             'events_to_dispatch' => [
                 'workflow.leave',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_support_and_support_strategy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_support_and_support_strategy.php
@@ -1,13 +1,13 @@
 <?php
 
-use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
     'workflows' => [
         'my_workflow' => [
             'type' => 'workflow',
             'supports' => [
-                FrameworkExtensionTest::class,
+                FrameworkExtensionTestCase::class,
             ],
             'support_strategy' => 'foobar',
             'places' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
@@ -1,13 +1,13 @@
 <?php
 
-use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [
     'workflows' => [
         'article' => [
             'type' => 'workflow',
             'supports' => [
-                FrameworkExtensionTest::class,
+                FrameworkExtensionTestCase::class,
             ],
             'initial_marking' => ['draft'],
             'metadata' => [
@@ -43,7 +43,7 @@ $container->loadFromExtension('framework', [
         ],
         'pull_request' => [
             'supports' => [
-                FrameworkExtensionTest::class,
+                FrameworkExtensionTestCase::class,
             ],
             'initial_marking' => 'start',
             'metadata' => [
@@ -102,7 +102,7 @@ $container->loadFromExtension('framework', [
                 'service' => 'workflow_service',
             ],
             'supports' => [
-                FrameworkExtensionTest::class,
+                FrameworkExtensionTestCase::class,
             ],
             'places' => [
                 ['name' => 'first'],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled.php
@@ -5,7 +5,7 @@ $container->loadFromExtension('framework', [
         'enabled' => true,
         'foo' => [
             'type' => 'workflow',
-            'supports' => ['Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest'],
+            'supports' => ['Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase'],
             'initial_marking' => ['bar'],
             'places' => ['bar', 'baz'],
             'transitions' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled_named_workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_explicitly_enabled_named_workflows.php
@@ -5,7 +5,7 @@ $container->loadFromExtension('framework', [
         'enabled' => true,
         'workflows' => [
             'type' => 'workflow',
-            'supports' => ['Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest'],
+            'supports' => ['Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase'],
             'initial_marking' => ['bar'],
             'places' => ['bar', 'baz'],
             'transitions' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -79,7 +79,7 @@ use Symfony\Component\Workflow\WorkflowEvents;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
-abstract class FrameworkExtensionTest extends TestCase
+abstract class FrameworkExtensionTestCase extends TestCase
 {
     use ExpectDeprecationTrait;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 
-class PhpFrameworkExtensionTest extends FrameworkExtensionTest
+class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
 {
     protected function loadFromFile(ContainerBuilder $container, $file)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-class XmlFrameworkExtensionTest extends FrameworkExtensionTest
+class XmlFrameworkExtensionTest extends FrameworkExtensionTestCase
 {
     protected function loadFromFile(ContainerBuilder $container, $file)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/YamlFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/YamlFrameworkExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-class YamlFrameworkExtensionTest extends FrameworkExtensionTest
+class YamlFrameworkExtensionTest extends FrameworkExtensionTestCase
 {
     protected function loadFromFile(ContainerBuilder $container, $file)
     {

--- a/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTestCase.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTestCase.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-abstract class AbstractDescriptorTest extends TestCase
+abstract class AbstractDescriptorTestCase extends TestCase
 {
     /** @dataProvider getDescribeInputArgumentTestData */
     public function testDescribeInputArgument(InputArgument $argument, $expectedDescription)

--- a/src/Symfony/Component/Console/Tests/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/JsonDescriptorTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Console\Tests\Descriptor;
 
 use Symfony\Component\Console\Descriptor\JsonDescriptor;
 
-class JsonDescriptorTest extends AbstractDescriptorTest
+class JsonDescriptorTest extends AbstractDescriptorTestCase
 {
     protected function getDescriptor()
     {

--- a/src/Symfony/Component/Console/Tests/Descriptor/MarkdownDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/MarkdownDescriptorTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Descriptor\MarkdownDescriptor;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorApplicationMbString;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString;
 
-class MarkdownDescriptorTest extends AbstractDescriptorTest
+class MarkdownDescriptorTest extends AbstractDescriptorTestCase
 {
     public function getDescribeCommandTestData()
     {

--- a/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Tests\Fixtures\DescriptorApplication2;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorApplicationMbString;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString;
 
-class TextDescriptorTest extends AbstractDescriptorTest
+class TextDescriptorTest extends AbstractDescriptorTestCase
 {
     public function getDescribeCommandTestData()
     {

--- a/src/Symfony/Component/Console/Tests/Descriptor/XmlDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/XmlDescriptorTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Console\Tests\Descriptor;
 
 use Symfony\Component\Console\Descriptor\XmlDescriptor;
 
-class XmlDescriptorTest extends AbstractDescriptorTest
+class XmlDescriptorTest extends AbstractDescriptorTestCase
 {
     protected function getDescriptor()
     {

--- a/src/Symfony/Component/Console/Tests/Helper/AbstractQuestionHelperTestCase.php
+++ b/src/Symfony/Component/Console/Tests/Helper/AbstractQuestionHelperTestCase.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Console\Tests\Helper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\StreamableInputInterface;
 
-abstract class AbstractQuestionHelperTest extends TestCase
+abstract class AbstractQuestionHelperTestCase extends TestCase
 {
     protected function createStreamableInputInterfaceMock($stream = null, $interactive = true)
     {

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Tester\ApplicationTester;
 /**
  * @group tty
  */
-class QuestionHelperTest extends AbstractQuestionHelperTest
+class QuestionHelperTest extends AbstractQuestionHelperTestCase
 {
     public function testAskChoice()
     {

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Question\Question;
 /**
  * @group tty
  */
-class SymfonyQuestionHelperTest extends AbstractQuestionHelperTest
+class SymfonyQuestionHelperTest extends AbstractQuestionHelperTestCase
 {
     public function testAskChoice()
     {

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTestCase.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Security\Csrf\CsrfToken;
 
-abstract class AbstractDivLayoutTest extends AbstractLayoutTest
+abstract class AbstractDivLayoutTestCase extends AbstractLayoutTestCase
 {
     public function testRow()
     {

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTestCase.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\Test\FormIntegrationTestCase;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Translation\TranslatableMessage;
 
-abstract class AbstractLayoutTest extends FormIntegrationTestCase
+abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
 {
     use VersionAwareTest;
 

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\Form\Util\ServerParams;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class AbstractRequestHandlerTest extends TestCase
+abstract class AbstractRequestHandlerTestCase extends TestCase
 {
     /**
      * @var RequestHandlerInterface

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTestCase.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Security\Csrf\CsrfToken;
 
-abstract class AbstractTableLayoutTest extends AbstractLayoutTest
+abstract class AbstractTableLayoutTestCase extends AbstractLayoutTestCase
 {
     public function testRow()
     {

--- a/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTestCase.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTestCase.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class AbstractChoiceListTest extends TestCase
+abstract class AbstractChoiceListTestCase extends TestCase
 {
     /**
      * @var ChoiceListInterface

--- a/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class ArrayChoiceListTest extends AbstractChoiceListTest
+class ArrayChoiceListTest extends AbstractChoiceListTestCase
 {
     private $object;
 

--- a/src/Symfony/Component/Form/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
@@ -26,7 +26,7 @@ use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
-abstract class AbstractDescriptorTest extends TestCase
+abstract class AbstractDescriptorTestCase extends TestCase
 {
     private $colSize;
 

--- a/src/Symfony/Component/Form/Tests/Console/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Component/Form/Tests/Console/Descriptor/JsonDescriptorTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Console\Descriptor;
 
 use Symfony\Component\Form\Console\Descriptor\JsonDescriptor;
 
-class JsonDescriptorTest extends AbstractDescriptorTest
+class JsonDescriptorTest extends AbstractDescriptorTestCase
 {
     protected function getDescriptor()
     {

--- a/src/Symfony/Component/Form/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Component/Form/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Console\Descriptor;
 
 use Symfony\Component\Form\Console\Descriptor\TextDescriptor;
 
-class TextDescriptorTest extends AbstractDescriptorTest
+class TextDescriptorTest extends AbstractDescriptorTestCase
 {
     protected function getDescriptor()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BaseDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BaseDateTimeTransformerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransformer;
 
-abstract class BaseDateTimeTransformerTest extends TestCase
+abstract class BaseDateTimeTransformerTestCase extends TestCase
 {
     public function testConstructFailsIfInputTimezoneIsInvalid()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToArrayTransformer;
 
-class DateTimeToArrayTransformerTest extends BaseDateTimeTransformerTest
+class DateTimeToArrayTransformerTest extends BaseDateTimeTransformerTestCase
 {
     public function testTransform()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransforme
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToHtml5LocalDateTimeTransformer;
 use Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits\DateTimeEqualsTrait;
 
-class DateTimeToHtml5LocalDateTimeTransformerTest extends BaseDateTimeTransformerTest
+class DateTimeToHtml5LocalDateTimeTransformerTest extends BaseDateTimeTransformerTestCase
 {
     use DateTimeEqualsTrait;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToLocalizedStr
 use Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits\DateTimeEqualsTrait;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTest
+class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTestCase
 {
     use DateTimeEqualsTrait;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransforme
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToRfc3339Transformer;
 use Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits\DateTimeEqualsTrait;
 
-class DateTimeToRfc3339TransformerTest extends BaseDateTimeTransformerTest
+class DateTimeToRfc3339TransformerTest extends BaseDateTimeTransformerTestCase
 {
     use DateTimeEqualsTrait;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToStringTransformer;
 
-class DateTimeToStringTransformerTest extends BaseDateTimeTransformerTest
+class DateTimeToStringTransformerTest extends BaseDateTimeTransformerTestCase
 {
     public function dataProvider(): array
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToTimestampTransformer;
 
-class DateTimeToTimestampTransformerTest extends BaseDateTimeTransformerTest
+class DateTimeToTimestampTransformerTest extends BaseDateTimeTransformerTestCase
 {
     public function testTransform()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerArrayObjectTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerArrayObjectTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormFactoryBuilder;
 
-class MergeCollectionListenerArrayObjectTest extends MergeCollectionListenerTest
+class MergeCollectionListenerArrayObjectTest extends MergeCollectionListenerTestCase
 {
     protected function getData(array $data)
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerArrayTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerArrayTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormFactoryBuilder;
 
-class MergeCollectionListenerArrayTest extends MergeCollectionListenerTest
+class MergeCollectionListenerArrayTest extends MergeCollectionListenerTestCase
 {
     protected function getData(array $data)
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerCustomArrayObjectTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerCustomArrayObjectTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormFactoryBuilder;
 use Symfony\Component\Form\Tests\Fixtures\CustomArrayObject;
 
-class MergeCollectionListenerCustomArrayObjectTest extends MergeCollectionListenerTest
+class MergeCollectionListenerCustomArrayObjectTest extends MergeCollectionListenerTestCase
 {
     protected function getData(array $data)
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Extension\Core\EventListener\MergeCollectionListener;
 use Symfony\Component\Form\FormEvent;
 
-abstract class MergeCollectionListenerTest extends TestCase
+abstract class MergeCollectionListenerTestCase extends TestCase
 {
     protected $form;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Tests\VersionAwareTest;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class BaseTypeTest extends TypeTestCase
+abstract class BaseTypeTestCase extends TypeTestCase
 {
     use VersionAwareTest;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\Extension\Core\Type\FormType;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class ButtonTypeTest extends BaseTypeTest
+class ButtonTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\ButtonType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
-class CheckboxTypeTest extends BaseTypeTest
+class CheckboxTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\CheckboxType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Tests\Fixtures\ChoiceList\DeprecatedChoiceListFactory;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
-class ChoiceTypeTest extends BaseTypeTest
+class ChoiceTypeTest extends BaseTypeTestCase
 {
     use ExpectDeprecationTrait;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\AuthorType;
 use Symfony\Component\Form\Tests\Fixtures\BlockPrefixedFooTextType;
 
-class CollectionTypeTest extends BaseTypeTest
+class CollectionTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\CollectionType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\FormError;
 
-final class ColorTypeTest extends BaseTypeTest
+final class ColorTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = ColorType::class;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class CountryTypeTest extends BaseTypeTest
+class CountryTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\CountryType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class CurrencyTypeTest extends BaseTypeTest
+class CurrencyTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\CurrencyType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\Extension\Core\Type\DateIntervalType;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 
-class DateIntervalTypeTest extends BaseTypeTest
+class DateIntervalTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = DateIntervalType::class;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 
-class DateTimeTypeTest extends BaseTypeTest
+class DateTimeTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\DateTimeType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
-class DateTypeTest extends BaseTypeTest
+class DateTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\DateType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
@@ -12,7 +12,7 @@
 namespace Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
-use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTest;
+use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTestCase;
 use Symfony\Component\Form\Tests\Fixtures\Answer;
 use Symfony\Component\Form\Tests\Fixtures\Number;
 use Symfony\Component\Form\Tests\Fixtures\Suit;
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 /**
  * @requires PHP 8.1
  */
-final class EnumTypeTest extends BaseTypeTest
+final class EnumTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = EnumType::class;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Translation\IdentityTranslator;
 
-class FileTypeTest extends BaseTypeTest
+class FileTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\FileType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -62,7 +62,7 @@ class FormTest_AuthorWithoutRefSetter
     }
 }
 
-class FormTypeTest extends BaseTypeTest
+class FormTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\FormType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class IntegerTypeTest extends BaseTypeTest
+class IntegerTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\IntegerType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class LanguageTypeTest extends BaseTypeTest
+class LanguageTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\LanguageType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class LocaleTypeTest extends BaseTypeTest
+class LocaleTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\LocaleType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class MoneyTypeTest extends BaseTypeTest
+class MoneyTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\MoneyType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class NumberTypeTest extends BaseTypeTest
+class NumberTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\NumberType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-class PasswordTypeTest extends BaseTypeTest
+class PasswordTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\PasswordType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Tests\Fixtures\NotMappedType;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
-class RepeatedTypeTest extends BaseTypeTest
+class RepeatedTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\RepeatedType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-class TextTypeTest extends BaseTypeTest
+class TextTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\TextType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
-class TimeTypeTest extends BaseTypeTest
+class TimeTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\TimeType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class TimezoneTypeTest extends BaseTypeTest
+class TimezoneTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\TimezoneType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UlidTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UlidTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\Extension\Core\Type\UlidType;
 use Symfony\Component\Uid\Ulid;
 
-final class UlidTypeTest extends BaseTypeTest
+final class UlidTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = UlidType::class;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UuidTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UuidTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\Extension\Core\Type\UuidType;
 use Symfony\Component\Uid\Uuid;
 
-final class UuidTypeTest extends BaseTypeTest
+final class UuidTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = UuidType::class;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/WeekTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/WeekTypeTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\FormError;
 
-class WeekTypeTest extends BaseTypeTest
+class WeekTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\WeekType';
 

--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
@@ -13,14 +13,14 @@ namespace Symfony\Component\Form\Tests\Extension\HttpFoundation;
 
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
-use Symfony\Component\Form\Tests\AbstractRequestHandlerTest;
+use Symfony\Component\Form\Tests\AbstractRequestHandlerTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class HttpFoundationRequestHandlerTest extends AbstractRequestHandlerTest
+class HttpFoundationRequestHandlerTest extends AbstractRequestHandlerTestCase
 {
     public function testRequestShouldNotBeNull()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class BaseValidatorExtensionTest extends TypeTestCase
+abstract class BaseValidatorExtensionTestCase extends TypeTestCase
 {
     public function testValidationGroupNullByDefault()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BirthdayTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BirthdayTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class BirthdayTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class BirthdayTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CheckboxTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CheckboxTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class CheckboxTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class CheckboxTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ChoiceTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ChoiceTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class ChoiceTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class ChoiceTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CollectionTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CollectionTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class CollectionTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class CollectionTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ColorTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ColorTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class ColorTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class ColorTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CountryTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CountryTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class CountryTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class CountryTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CurrencyTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CurrencyTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class CurrencyTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class CurrencyTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateIntervalTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateIntervalTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\DateIntervalType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class DateIntervalTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class DateIntervalTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTimeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTimeTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class DateTimeTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class DateTimeTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class DateTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class DateTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/EmailTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/EmailTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class EmailTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class EmailTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FileTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FileTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class FileTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class FileTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Validation;
 
-class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/HiddenTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/HiddenTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class HiddenTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class HiddenTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/IntegerTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/IntegerTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class IntegerTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class IntegerTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LanguageTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LanguageTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\LanguageType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class LanguageTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class LanguageTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LocaleTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LocaleTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\LocaleType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class LocaleTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class LocaleTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/MoneyTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/MoneyTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class MoneyTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class MoneyTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/NumberTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/NumberTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class NumberTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class NumberTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PasswordTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PasswordTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class PasswordTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class PasswordTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PercentTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PercentTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class PercentTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class PercentTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RadioTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RadioTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\RadioType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class RadioTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class RadioTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RangeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RangeTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class RangeTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class RangeTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RepeatedTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RepeatedTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class RepeatedTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class RepeatedTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SearchTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SearchTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\SearchType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class SearchTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class SearchTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class SubmitTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class SubmitTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ValidatorExtensionTrait;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TelTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TelTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class TelTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class TelTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimeTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class TimeTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class TimeTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimezoneTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimezoneTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class TimezoneTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class TimezoneTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
-class UrlTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+class UrlTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
     use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;

--- a/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\NativeRequestHandler;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class NativeRequestHandlerTest extends AbstractRequestHandlerTest
+class NativeRequestHandlerTest extends AbstractRequestHandlerTestCase
 {
     private static $serverBackup;
 

--- a/src/Symfony/Component/Intl/Tests/Collator/AbstractCollatorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Collator/AbstractCollatorTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Intl\Collator\Collator;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class AbstractCollatorTest extends TestCase
+abstract class AbstractCollatorTestCase extends TestCase
 {
     /**
      * @dataProvider asortProvider

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Intl\Util\IcuVersion;
  *
  * @group legacy
  */
-abstract class AbstractIntlDateFormatterTest extends TestCase
+abstract class AbstractIntlDateFormatterTestCase extends TestCase
 {
     private $defaultLocale;
 

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Intl\Globals\IntlGlobals;
 /**
  * @group legacy
  */
-class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
+class IntlDateFormatterTest extends AbstractIntlDateFormatterTestCase
 {
     public function testConstructor()
     {

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
@@ -12,16 +12,16 @@
 namespace Symfony\Component\Intl\Tests\DateFormatter\Verification;
 
 use Symfony\Component\Intl\DateFormatter\IntlDateFormatter;
-use Symfony\Component\Intl\Tests\DateFormatter\AbstractIntlDateFormatterTest;
+use Symfony\Component\Intl\Tests\DateFormatter\AbstractIntlDateFormatterTestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
- * Verifies that {@link AbstractIntlDateFormatterTest} matches the behavior of
+ * Verifies that {@link AbstractIntlDateFormatterTestCase} matches the behavior of
  * the {@link \IntlDateFormatter} class in a specific version of ICU.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
+class IntlDateFormatterTest extends AbstractIntlDateFormatterTestCase
 {
     protected function setUp(): void
     {

--- a/src/Symfony/Component/Intl/Tests/Globals/AbstractIntlGlobalsTest.php
+++ b/src/Symfony/Component/Intl/Tests/Globals/AbstractIntlGlobalsTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @group legacy
  */
-abstract class AbstractIntlGlobalsTest extends TestCase
+abstract class AbstractIntlGlobalsTestCase extends TestCase
 {
     public function errorNameProvider()
     {

--- a/src/Symfony/Component/Intl/Tests/Globals/IntlGlobalsTest.php
+++ b/src/Symfony/Component/Intl/Tests/Globals/IntlGlobalsTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Intl\Globals\IntlGlobals;
 /**
  * @group legacy
  */
-class IntlGlobalsTest extends AbstractIntlGlobalsTest
+class IntlGlobalsTest extends AbstractIntlGlobalsTestCase
 {
     protected function getIntlErrorName($errorCode)
     {

--- a/src/Symfony/Component/Intl/Tests/Globals/Verification/IntlGlobalsTest.php
+++ b/src/Symfony/Component/Intl/Tests/Globals/Verification/IntlGlobalsTest.php
@@ -11,18 +11,18 @@
 
 namespace Symfony\Component\Intl\Tests\Globals\Verification;
 
-use Symfony\Component\Intl\Tests\Globals\AbstractIntlGlobalsTest;
+use Symfony\Component\Intl\Tests\Globals\AbstractIntlGlobalsTestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
- * Verifies that {@link AbstractIntlGlobalsTest} matches the behavior of the
+ * Verifies that {@link AbstractIntlGlobalsTestCase} matches the behavior of the
  * intl functions with a specific version of ICU.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @group legacy
  */
-class IntlGlobalsTest extends AbstractIntlGlobalsTest
+class IntlGlobalsTest extends AbstractIntlGlobalsTestCase
 {
     protected function setUp(): void
     {

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  *
  * @group legacy
  */
-abstract class AbstractNumberFormatterTest extends TestCase
+abstract class AbstractNumberFormatterTestCase extends TestCase
 {
     /**
      * @dataProvider formatCurrencyWithDecimalStyleProvider

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
  *
  * @group legacy
  */
-class NumberFormatterTest extends AbstractNumberFormatterTest
+class NumberFormatterTest extends AbstractNumberFormatterTestCase
 {
     public function testConstructorWithUnsupportedLocale()
     {

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
@@ -11,14 +11,14 @@
 
 namespace Symfony\Component\Intl\Tests\NumberFormatter\Verification;
 
-use Symfony\Component\Intl\Tests\NumberFormatter\AbstractNumberFormatterTest;
+use Symfony\Component\Intl\Tests\NumberFormatter\AbstractNumberFormatterTestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
  * Note that there are some values written like -2147483647 - 1. This is the lower 32bit int max and is a known
  * behavior of PHP.
  */
-class NumberFormatterTest extends AbstractNumberFormatterTest
+class NumberFormatterTest extends AbstractNumberFormatterTestCase
 {
     protected function setUp(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Refs #49233
| License       | MIT
| Doc PR        | -

Using `Test` suffix is deprecated since PHPUnit 10

Spotted in
* https://github.com/symfony/symfony/pull/49233

cc @derrabus 
