### PR TITLE
Call `markTestSkipped()` method `static`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -227,7 +227,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
     public function testEmbeddedIdentifierName()
     {
         if (Version::compare('2.5.0') > 0) {
-            $this->markTestSkipped('Applicable only for Doctrine >= 2.5.0');
+           self::markTestSkipped('Applicable only for Doctrine >= 2.5.0');
 
             return;
         }

--- a/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
@@ -38,7 +38,7 @@ class MiddlewareTest extends TestCase
         parent::setUp();
 
         if (!interface_exists(MiddlewareInterface::class)) {
-            $this->markTestSkipped(sprintf('%s needed to run this test', MiddlewareInterface::class));
+           self::markTestSkipped(sprintf('%s needed to run this test', MiddlewareInterface::class));
         }
 
         ClockMock::withClockMock(false);

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -90,7 +90,7 @@ class DoctrineExtractorTest extends TestCase
     public function testTestGetPropertiesWithEmbedded()
     {
         if (!class_exists(\Doctrine\ORM\Mapping\Embedded::class)) {
-            $this->markTestSkipped('@Embedded is not available in Doctrine ORM lower than 2.5.');
+           self::markTestSkipped('@Embedded is not available in Doctrine ORM lower than 2.5.');
         }
 
         $this->assertEquals(
@@ -113,7 +113,7 @@ class DoctrineExtractorTest extends TestCase
     public function testExtractWithEmbedded()
     {
         if (!class_exists(\Doctrine\ORM\Mapping\Embedded::class)) {
-            $this->markTestSkipped('@Embedded is not available in Doctrine ORM lower than 2.5.');
+           self::markTestSkipped('@Embedded is not available in Doctrine ORM lower than 2.5.');
         }
 
         $expectedTypes = [new Type(
@@ -137,7 +137,7 @@ class DoctrineExtractorTest extends TestCase
     public function testExtractEnum()
     {
         if (!property_exists(Column::class, 'enumType')) {
-            $this->markTestSkipped('The "enumType" requires doctrine/orm 2.11.');
+           self::markTestSkipped('The "enumType" requires doctrine/orm 2.11.');
         }
         $this->assertEquals([new Type(Type::BUILTIN_TYPE_OBJECT, false, EnumString::class)], $this->createExtractor()->getTypes(DoctrineEnum::class, 'enumString', []));
         $this->assertEquals([new Type(Type::BUILTIN_TYPE_OBJECT, false, EnumInt::class)], $this->createExtractor()->getTypes(DoctrineEnum::class, 'enumInt', []));

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -41,7 +41,7 @@ class DoctrineLoaderTest extends TestCase
     protected function setUp(): void
     {
         if (!trait_exists(AutoMappingTrait::class)) {
-            $this->markTestSkipped('Auto-mapping requires symfony/validation 4.4+');
+           self::markTestSkipped('Auto-mapping requires symfony/validation 4.4+');
         }
     }
 
@@ -157,7 +157,7 @@ class DoctrineLoaderTest extends TestCase
     public function testExtractEnum()
     {
         if (!property_exists(Column::class, 'enumType')) {
-            $this->markTestSkipped('The "enumType" requires doctrine/orm 2.11.');
+           self::markTestSkipped('The "enumType" requires doctrine/orm 2.11.');
         }
 
         $validator = Validation::createValidatorBuilder()

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
@@ -30,7 +30,7 @@ class TokenProcessorTest extends TestCase
     public function testLegacyProcessor()
     {
         if (method_exists(UsernamePasswordToken::class, 'getUserIdentifier')) {
-            $this->markTestSkipped('This test requires symfony/security-core <5.3');
+           self::markTestSkipped('This test requires symfony/security-core <5.3');
         }
 
         $token = new UsernamePasswordToken('user', 'password', 'provider', ['ROLE_USER']);
@@ -49,7 +49,7 @@ class TokenProcessorTest extends TestCase
     public function testProcessor()
     {
         if (!method_exists(UsernamePasswordToken::class, 'getUserIdentifier')) {
-            $this->markTestSkipped('This test requires symfony/security-core 5.3+');
+           self::markTestSkipped('This test requires symfony/security-core 5.3+');
         }
 
         $token = new UsernamePasswordToken(new InMemoryUser('user', 'password', ['ROLE_USER']), 'provider', ['ROLE_USER']);

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -58,7 +58,7 @@ class WebProcessorTest extends TestCase
     public function testCanBeConstructedWithExtraFields()
     {
         if (!$this->isExtraFieldsSupported()) {
-            $this->markTestSkipped('WebProcessor of the installed Monolog version does not support $extraFields parameter');
+           self::markTestSkipped('WebProcessor of the installed Monolog version does not support $extraFields parameter');
         }
 
         [$event, $server] = $this->createRequestEvent();

--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -18,7 +18,7 @@ class CoverageListenerTest extends TestCase
     public function test()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test cannot be run on Windows.');
+           self::markTestSkipped('This test cannot be run on Windows.');
         }
 
         exec('type phpdbg 2> /dev/null', $output, $returnCode);
@@ -28,7 +28,7 @@ class CoverageListenerTest extends TestCase
         } else {
             exec('php --ri xdebug -d zend_extension=xdebug.so 2> /dev/null', $output, $returnCode);
             if (0 !== $returnCode) {
-                $this->markTestSkipped('Xdebug is required to run this test.');
+               self::markTestSkipped('Xdebug is required to run this test.');
             }
             $php = 'php -d zend_extension=xdebug.so';
         }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -59,7 +59,7 @@ class DeprecationTest extends TestCase
         $r = new \ReflectionClass(Deprecation::class);
 
         if (\dirname($r->getFileName(), 2) !== \dirname(__DIR__, 2)) {
-            $this->markTestSkipped('Test case is not compatible with having the bridge in vendor/');
+           self::markTestSkipped('Test case is not compatible with having the bridge in vendor/');
         }
 
         $deprecation = new Deprecation('💩', $this->debugBacktrace(), __FILE__);

--- a/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/coverage/tests/BarCovTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/coverage/tests/BarCovTest.php
@@ -18,7 +18,7 @@ class BarCovTest extends TestCase
     public function testBarCov()
     {
         if (!class_exists(\PhpUnitCoverageTest\FooCov::class)) {
-            $this->markTestSkipped('This test is not part of the main Symfony test suite. It\'s here to test the CoverageListener.');
+           self::markTestSkipped('This test is not part of the main Symfony test suite. It\'s here to test the CoverageListener.');
         }
 
         $foo = new \PhpUnitCoverageTest\FooCov();

--- a/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
@@ -138,7 +138,7 @@ Configured Paths
   (None)      templates%e%A
   %A
   @Twig       templates/bundles/TwigBundle%e%A
-              vendors/twig-bundle/Resources/views%e%A 
+              vendors/twig-bundle/Resources/views%e%A
  ----------- -------------------------------------%A
 
 
@@ -188,12 +188,12 @@ Overridden Files
 Configured Paths
 ----------------
 
- ----------- -------------------------------------- 
+ ----------- --------------------------------------
   Namespace   Paths%A
- ----------- -------------------------------------- 
+ ----------- --------------------------------------
   @Twig       templates/bundles/TwigBundle%e%A
               vendors/twig-bundle/Resources/views%e%A
- ----------- -------------------------------------- 
+ ----------- --------------------------------------
 
 
 TXT
@@ -240,12 +240,12 @@ Matched File
 Configured Paths
 ----------------
 
- ----------- -------------------------------------- 
-  Namespace   Paths                                 
- ----------- -------------------------------------- 
+ ----------- --------------------------------------
+  Namespace   Paths
+ ----------- --------------------------------------
   @Twig       templates/bundles/TwigBundle%e%A
               vendors/twig-bundle/Resources/views%e%A
- ----------- -------------------------------------- 
+ ----------- --------------------------------------
 
 
 TXT
@@ -300,7 +300,7 @@ TXT
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $projectDir = \dirname(__DIR__).\DIRECTORY_SEPARATOR.'Fixtures';

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -142,7 +142,7 @@ class LintCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $tester = new CommandCompletionTester($this->createCommand());

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -1764,7 +1764,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithWidgetSingleTextIgnoreDateAndTimeWidgets()
     {
-        $this->markTestSkipped('Make tests pass with symfony/form 4.4');
+       self::markTestSkipped('Make tests pass with symfony/form 4.4');
     }
 
     public function testDateChoice()

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
@@ -894,7 +894,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testFileLabelIdNotDuplicated()
     {
-        $this->markTestSkipped('The Bootstrap 5 form theme does not use the file widget shipped with the Bootstrap 4 theme.');
+       self::markTestSkipped('The Bootstrap 5 form theme does not use the file widget shipped with the Bootstrap 4 theme.');
     }
 
     public function testFileWithGroup()

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
@@ -61,7 +61,7 @@ class HttpFoundationExtensionTest extends TestCase
     public function testGenerateAbsoluteUrlWithRequestContext($path, $baseUrl, $host, $scheme, $httpPort, $httpsPort, $expected)
     {
         if (!class_exists(RequestContext::class)) {
-            $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
+           self::markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
         }
 
         $requestContext = new RequestContext($baseUrl, 'GET', $host, $scheme, $httpPort, $httpsPort, $path);
@@ -76,7 +76,7 @@ class HttpFoundationExtensionTest extends TestCase
     public function testGenerateAbsoluteUrlWithoutRequestAndRequestContext($path)
     {
         if (!class_exists(RequestContext::class)) {
-            $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
+           self::markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
         }
 
         $extension = new HttpFoundationExtension(new UrlHelper(new RequestStack()));
@@ -119,7 +119,7 @@ class HttpFoundationExtensionTest extends TestCase
     public function testGenerateRelativePath($expected, $path, $pathinfo)
     {
         if (!method_exists(Request::class, 'getRelativeUriForPath')) {
-            $this->markTestSkipped('Your version of Symfony HttpFoundation is too old.');
+           self::markTestSkipped('Your version of Symfony HttpFoundation is too old.');
         }
 
         $stack = new RequestStack();

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -59,7 +59,7 @@ class HttpKernelExtensionTest extends TestCase
     public function testGenerateFragmentUri()
     {
         if (!class_exists(FragmentUriGenerator::class)) {
-            $this->markTestSkipped('HttpKernel 5.3+ is required');
+           self::markTestSkipped('HttpKernel 5.3+ is required');
         }
 
         $requestStack = new RequestStack();

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
@@ -31,7 +31,7 @@ class WorkflowExtensionTest extends TestCase
     protected function setUp(): void
     {
         if (!class_exists(Workflow::class)) {
-            $this->markTestSkipped('The Workflow component is needed to run tests for this extension.');
+           self::markTestSkipped('The Workflow component is needed to run tests for this extension.');
         }
 
         $places = ['ordered', 'waiting_for_payment', 'processed'];
@@ -111,7 +111,7 @@ class WorkflowExtensionTest extends TestCase
     public function testGetMetadata()
     {
         if (!class_exists(InMemoryMetadataStore::class)) {
-            $this->markTestSkipped('This test requires symfony/workflow:4.1.');
+           self::markTestSkipped('This test requires symfony/workflow:4.1.');
         }
         $subject = new Subject();
 
@@ -125,7 +125,7 @@ class WorkflowExtensionTest extends TestCase
     public function testbuildTransitionBlockerList()
     {
         if (!class_exists(TransitionBlockerList::class)) {
-            $this->markTestSkipped('This test requires symfony/workflow:4.1.');
+           self::markTestSkipped('This test requires symfony/workflow:4.1.');
         }
         $subject = new Subject();
 

--- a/src/Symfony/Bundle/DebugBundle/Tests/DependencyInjection/DebugExtensionTest.php
+++ b/src/Symfony/Bundle/DebugBundle/Tests/DependencyInjection/DebugExtensionTest.php
@@ -44,7 +44,7 @@ class DebugExtensionTest extends TestCase
     public function testUnsetClosureFileInfoShouldBeRegisteredInVarCloner()
     {
         if (!method_exists(ReflectionCaster::class, 'unsetClosureFileInfo')) {
-            $this->markTestSkipped('Method not available');
+           self::markTestSkipped('Method not available');
         }
 
         $container = $this->createContainer();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/AboutCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/AboutCommandTest.php
@@ -59,7 +59,7 @@ class AboutCommandTest extends TestCase
 
         // skip test on Windows; PHP can't easily set file as unreadable on Windows
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test cannot run on Windows.');
+           self::markTestSkipped('This test cannot run on Windows.');
         }
 
         $this->fs->dumpFile($kernel->getCacheDir().'/unreadable_file', 'The file content.');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -86,7 +86,7 @@ class AbstractControllerTest extends TestCase
     public function testGetParameter()
     {
         if (!class_exists(ContainerBag::class)) {
-            $this->markTestSkipped('ContainerBag class does not exist');
+           self::markTestSkipped('ContainerBag class does not exist');
         }
 
         $container = new Container(new FrozenParameterBag(['foo' => 'bar']));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/UnusedTagsPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/UnusedTagsPassTest.php
@@ -35,7 +35,7 @@ class UnusedTagsPassTest extends TestCase
     public function testMissingKnownTags()
     {
         if (\dirname((new \ReflectionClass(ContainerBuilder::class))->getFileName(), 3) !== \dirname(__DIR__, 5)) {
-            $this->markTestSkipped('Tests are not run from the root symfony/symfony metapackage.');
+           self::markTestSkipped('Tests are not run from the root symfony/symfony metapackage.');
         }
 
         $this->assertSame(UnusedTagsPassUtils::getDefinedTags(), $this->getKnownTags(), 'The src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php file must be updated; run src/Symfony/Bundle/FrameworkBundle/Resources/bin/check-unused-known-tags.php.');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -171,7 +171,7 @@ abstract class FrameworkExtensionTest extends TestCase
     public function testFormsCsrfIsEnabledByDefault()
     {
         if (class_exists(FullStack::class)) {
-            $this->markTestSkipped('testing with the FullStack prevents verifying default values');
+           self::markTestSkipped('testing with the FullStack prevents verifying default values');
         }
         $container = $this->createContainerFromFile('form_default_csrf');
 
@@ -1215,7 +1215,7 @@ abstract class FrameworkExtensionTest extends TestCase
     public function testFileLinkFormat()
     {
         if (\ini_get('xdebug.file_link_format') || get_cfg_var('xdebug.file_link_format')) {
-            $this->markTestSkipped('A custom file_link_format is defined.');
+           self::markTestSkipped('A custom file_link_format is defined.');
         }
 
         $container = $this->createContainerFromFile('full');
@@ -1357,7 +1357,7 @@ abstract class FrameworkExtensionTest extends TestCase
     public function testValidationAutoMapping()
     {
         if (!class_exists(PropertyInfoLoader::class)) {
-            $this->markTestSkipped('Auto-mapping requires symfony/validation 4.2+');
+           self::markTestSkipped('Auto-mapping requires symfony/validation 4.2+');
         }
 
         $container = $this->createContainerFromFile('validation_auto_mapping');
@@ -2054,7 +2054,7 @@ abstract class FrameworkExtensionTest extends TestCase
     public function testIfNotifierTransportsAreKnownByFrameworkExtension()
     {
         if (!class_exists(FullStack::class)) {
-            $this->markTestSkipped('This test can only run in fullstack test suites');
+           self::markTestSkipped('This test can only run in fullstack test suites');
         }
 
         $container = $this->createContainerFromFile('notifier');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
@@ -25,12 +25,12 @@ class XmlFrameworkExtensionTest extends FrameworkExtensionTest
 
     public function testAssetsHelperIsRemovedWhenPhpTemplatingEngineIsEnabledAndAssetsAreDisabled()
     {
-        $this->markTestSkipped('The assets key cannot be set to false using the XML configuration format.');
+       self::markTestSkipped('The assets key cannot be set to false using the XML configuration format.');
     }
 
     public function testMessengerMiddlewareFactoryErroneousFormat()
     {
-        $this->markTestSkipped('XML configuration will not allow erroneous format.');
+       self::markTestSkipped('XML configuration will not allow erroneous format.');
     }
 
     public function testLegacyExceptionsConfig()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -38,12 +38,12 @@ class CachePoolsTest extends AbstractWebTestCase
             if (!str_starts_with($e->getMessage(), 'unable to connect to')) {
                 throw $e;
             }
-            $this->markTestSkipped($e->getMessage());
+           self::markTestSkipped($e->getMessage());
         } catch (InvalidArgumentException $e) {
             if (!str_starts_with($e->getMessage(), 'Redis connection ')) {
                 throw $e;
             }
-            $this->markTestSkipped($e->getMessage());
+           self::markTestSkipped($e->getMessage());
         }
     }
 
@@ -61,7 +61,7 @@ class CachePoolsTest extends AbstractWebTestCase
             if (!str_starts_with($e->getMessage(), 'unable to connect to')) {
                 throw $e;
             }
-            $this->markTestSkipped($e->getMessage());
+           self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -93,7 +93,7 @@ class RouterDebugCommandTest extends AbstractWebTestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $tester = new CommandCompletionTester($this->application->get('debug:router'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -79,7 +79,7 @@ class WebTestCaseTest extends TestCase
     public function testAssertResponseFormat()
     {
         if (!class_exists(ResponseFormatSame::class)) {
-            $this->markTestSkipped('Too old version of HttpFoundation.');
+           self::markTestSkipped('Too old version of HttpFoundation.');
         }
 
         $this->getResponseTester(new Response('', 200, ['Content-Type' => 'application/vnd.myformat']))->assertResponseFormatSame('custom');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -509,7 +509,7 @@ abstract class CompleteConfigurationTest extends TestCase
     public function testEncodersWithLibsodium()
     {
         if (!SodiumPasswordEncoder::isSupported()) {
-            $this->markTestSkipped('Libsodium is not available.');
+           self::markTestSkipped('Libsodium is not available.');
         }
 
         $container = $this->getContainer('sodium_encoder');
@@ -565,7 +565,7 @@ abstract class CompleteConfigurationTest extends TestCase
     public function testEncodersWithArgon2i()
     {
         if (!($sodium = SodiumPasswordEncoder::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('Argon2i algorithm is not supported.');
+           self::markTestSkipped('Argon2i algorithm is not supported.');
         }
 
         $container = $this->getContainer('argon2i_encoder');
@@ -621,7 +621,7 @@ abstract class CompleteConfigurationTest extends TestCase
     public function testMigratingEncoder()
     {
         if (!($sodium = SodiumPasswordEncoder::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('Argon2i algorithm is not supported.');
+           self::markTestSkipped('Argon2i algorithm is not supported.');
         }
 
         $container = $this->getContainer('migrating_encoder');
@@ -791,7 +791,7 @@ abstract class CompleteConfigurationTest extends TestCase
     public function testHashersWithLibsodium()
     {
         if (!SodiumPasswordHasher::isSupported()) {
-            $this->markTestSkipped('Libsodium is not available.');
+           self::markTestSkipped('Libsodium is not available.');
         }
 
         $container = $this->getContainer('sodium_hasher');
@@ -844,7 +844,7 @@ abstract class CompleteConfigurationTest extends TestCase
     public function testHashersWithArgon2i()
     {
         if (!($sodium = SodiumPasswordHasher::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('Argon2i algorithm is not supported.');
+           self::markTestSkipped('Argon2i algorithm is not supported.');
         }
 
         $container = $this->getContainer('argon2i_hasher');
@@ -897,7 +897,7 @@ abstract class CompleteConfigurationTest extends TestCase
     public function testMigratingHasher()
     {
         if (!($sodium = SodiumPasswordHasher::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('Argon2i algorithm is not supported.');
+           self::markTestSkipped('Argon2i algorithm is not supported.');
         }
 
         $container = $this->getContainer('migrating_hasher');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -114,7 +114,7 @@ class FormLoginTest extends AbstractWebTestCase
     public function testLoginThrottling()
     {
         if (!class_exists(LoginThrottlingListener::class)) {
-            $this->markTestSkipped('Login throttling requires symfony/security-http:^5.2');
+           self::markTestSkipped('Login throttling requires symfony/security-http:^5.2');
         }
 
         $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'login_throttling.yml', 'enable_authenticator_manager' => true]);
@@ -257,7 +257,7 @@ class FormLoginTest extends AbstractWebTestCase
     public function testLegacyLoginThrottling()
     {
         if (!class_exists(LoginThrottlingListener::class)) {
-            $this->markTestSkipped('Login throttling requires symfony/security-http:^5.2');
+           self::markTestSkipped('Login throttling requires symfony/security-http:^5.2');
         }
 
         $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'legacy_login_throttling.yml', 'enable_authenticator_manager' => true]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LoginLinkAuthenticationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LoginLinkAuthenticationTest.php
@@ -25,7 +25,7 @@ class LoginLinkAuthenticationTest extends AbstractWebTestCase
     public function testLoginLinkSuccess()
     {
         if (!class_exists(LoginLinkHandler::class)) {
-            $this->markTestSkipped('Login link auth requires symfony/security-http:^5.2');
+           self::markTestSkipped('Login link auth requires symfony/security-http:^5.2');
         }
 
         $client = $this->createClient(['test_case' => 'LoginLink', 'root_config' => 'config.yml', 'debug' => true]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -77,7 +77,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
     public function testEncodePasswordArgon2i()
     {
         if (!($sodium = SodiumPasswordEncoder::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('Argon2i algorithm not available.');
+           self::markTestSkipped('Argon2i algorithm not available.');
         }
         $this->setupArgon2i();
         $this->passwordEncoderCommandTester->execute([
@@ -98,7 +98,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
     public function testEncodePasswordArgon2id()
     {
         if (!($sodium = (SodiumPasswordEncoder::isSupported() && \defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13'))) && !\defined('PASSWORD_ARGON2ID')) {
-            $this->markTestSkipped('Argon2id algorithm not available.');
+           self::markTestSkipped('Argon2id algorithm not available.');
         }
         $this->setupArgon2id();
         $this->passwordEncoderCommandTester->execute([
@@ -136,7 +136,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
     public function testEncodePasswordSodium()
     {
         if (!SodiumPasswordEncoder::isSupported()) {
-            $this->markTestSkipped('Libsodium is not available.');
+           self::markTestSkipped('Libsodium is not available.');
         }
         $this->setupSodium();
         $this->passwordEncoderCommandTester->execute([
@@ -214,7 +214,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
     public function testEncodePasswordArgon2iOutput()
     {
         if (!(SodiumPasswordEncoder::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('Argon2i algorithm not available.');
+           self::markTestSkipped('Argon2i algorithm not available.');
         }
 
         $this->setupArgon2i();
@@ -230,7 +230,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
     public function testEncodePasswordArgon2idOutput()
     {
         if (!(SodiumPasswordEncoder::isSupported() && \defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2ID')) {
-            $this->markTestSkipped('Argon2id algorithm not available.');
+           self::markTestSkipped('Argon2id algorithm not available.');
         }
 
         $this->setupArgon2id();
@@ -246,7 +246,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
     public function testEncodePasswordSodiumOutput()
     {
         if (!SodiumPasswordEncoder::isSupported()) {
-            $this->markTestSkipped('Libsodium is not available.');
+           self::markTestSkipped('Libsodium is not available.');
         }
 
         $this->setupSodium();

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -43,7 +43,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testGet()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createCachePool();
@@ -91,7 +91,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testRecursiveGet()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createCachePool(0, __FUNCTION__);
@@ -111,7 +111,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testDontSaveWhenAskedNotTo()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createCachePool(0, __FUNCTION__);
@@ -137,7 +137,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testGetMetadata()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createCachePool(0, __FUNCTION__);
@@ -162,7 +162,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testDefaultLifeTime()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createCachePool(2);
@@ -183,7 +183,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testExpiration()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createCachePool();
@@ -203,7 +203,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testNotUnserializable()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createCachePool();
@@ -226,7 +226,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testPrune()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         if (!method_exists($this, 'isPruned')) {
@@ -292,7 +292,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testClearPrefix()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createCachePool(0, __FUNCTION__);
@@ -312,7 +312,7 @@ abstract class AdapterTestCase extends CachePoolTest
     public function testWeirdDataMatchingMetadataWrappedValues()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createCachePool(0, __FUNCTION__);

--- a/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
@@ -27,15 +27,15 @@ class ApcuAdapterTest extends AdapterTestCase
     public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         if (!\function_exists('apcu_fetch') || !filter_var(\ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN)) {
-            $this->markTestSkipped('APCu extension is required.');
+           self::markTestSkipped('APCu extension is required.');
         }
         if ('cli' === \PHP_SAPI && !filter_var(\ini_get('apc.enable_cli'), \FILTER_VALIDATE_BOOLEAN)) {
             if ('testWithCliSapi' !== $this->getName()) {
-                $this->markTestSkipped('apc.enable_cli=1 is required.');
+               self::markTestSkipped('apc.enable_cli=1 is required.');
             }
         }
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Fails transiently on Windows.');
+           self::markTestSkipped('Fails transiently on Windows.');
         }
 
         return new ApcuAdapter(str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -60,7 +60,7 @@ class ChainAdapterTest extends AdapterTestCase
     public function testPrune()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = new ChainAdapter([
@@ -81,7 +81,7 @@ class ChainAdapterTest extends AdapterTestCase
     public function testMultipleCachesExpirationWhenCommonTtlIsNotSet()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $adapter1 = new ArrayAdapter(4);
@@ -137,7 +137,7 @@ class ChainAdapterTest extends AdapterTestCase
     public function testMultipleCachesExpirationWhenCommonTtlIsSet()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $adapter1 = new ArrayAdapter(4);
@@ -199,7 +199,7 @@ class ChainAdapterTest extends AdapterTestCase
     public function testExpirationOnAllAdapters()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $itemValidator = function (CacheItem $item) {

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
@@ -52,7 +52,7 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
     {
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile]);
         if (!interface_exists(Middleware::class)) {
-            $this->markTestSkipped('doctrine/dbal v2 does not support custom drivers using middleware');
+           self::markTestSkipped('doctrine/dbal v2 does not support custom drivers using middleware');
         }
 
         $middleware = $this->createMock(Middleware::class);

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -110,7 +110,7 @@ class MemcachedAdapterTest extends AdapterTestCase
         $this->expectException(CacheException::class);
         $this->expectExceptionMessage('MemcachedAdapter: "serializer" option must be "php" or "igbinary".');
         if (!\Memcached::HAVE_JSON) {
-            $this->markTestSkipped('Memcached::HAVE_JSON required');
+           self::markTestSkipped('Memcached::HAVE_JSON required');
         }
 
         new MemcachedAdapter(MemcachedAdapter::createConnection([], ['serializer' => 'json']));

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
@@ -59,7 +59,7 @@ class PdoDbalAdapterTest extends AdapterTestCase
         $this->expectDeprecation('Since symfony/cache 5.4: Usage of a DBAL Connection with "Symfony\Component\Cache\Adapter\PdoAdapter" is deprecated and will be removed in symfony 6.0. Use "Symfony\Component\Cache\Adapter\DoctrineDbalAdapter" instead.');
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile]);
         if (!interface_exists(Middleware::class)) {
-            $this->markTestSkipped('doctrine/dbal v2 does not support custom drivers using middleware');
+           self::markTestSkipped('doctrine/dbal v2 does not support custom drivers using middleware');
         }
 
         $middleware = $this->createMock(Middleware::class);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -53,7 +53,7 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
     public function testCreateSocketConnection()
     {
         if (!getenv('REDIS_SOCKET') || !file_exists(getenv('REDIS_SOCKET'))) {
-            $this->markTestSkipped('Redis socket not found');
+           self::markTestSkipped('Redis socket not found');
         }
 
         $this->doTestCreateConnection(getenv('REDIS_SOCKET'));

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareTestTrait.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareTestTrait.php
@@ -113,7 +113,7 @@ trait TagAwareTestTrait
     public function testTagItemExpiry()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $pool = $this->createCachePool(10);

--- a/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
+++ b/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
@@ -19,7 +19,7 @@ class LockRegistryTest extends TestCase
     public function testFiles()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('LockRegistry is disabled on Windows');
+           self::markTestSkipped('LockRegistry is disabled on Windows');
         }
         $lockFiles = LockRegistry::setFiles([]);
         LockRegistry::setFiles($lockFiles);

--- a/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
@@ -44,7 +44,7 @@ class DefaultMarshallerTest extends TestCase
     public function testIgbinaryUnserialize()
     {
         if (\PHP_VERSION_ID >= 70400 && version_compare('3.1.6', phpversion('igbinary'), '>')) {
-            $this->markTestSkipped('igbinary is not compatible with PHP 7.4.');
+           self::markTestSkipped('igbinary is not compatible with PHP 7.4.');
         }
 
         $marshaller = new DefaultMarshaller();
@@ -68,7 +68,7 @@ class DefaultMarshallerTest extends TestCase
     public function testIgbinaryUnserializeNotFoundClass()
     {
         if (\PHP_VERSION_ID >= 70400 && version_compare('3.1.6', phpversion('igbinary'), '>')) {
-            $this->markTestSkipped('igbinary is not compatible with PHP 7.4.');
+           self::markTestSkipped('igbinary is not compatible with PHP 7.4.');
         }
 
         $this->expectException(\DomainException::class);
@@ -96,7 +96,7 @@ class DefaultMarshallerTest extends TestCase
     public function testIgbinaryUnserializeInvalid()
     {
         if (\PHP_VERSION_ID >= 70400 && version_compare('3.1.6', phpversion('igbinary'), '>')) {
-            $this->markTestSkipped('igbinary is not compatible with PHP 7.4.');
+           self::markTestSkipped('igbinary is not compatible with PHP 7.4.');
         }
 
         $this->expectException(\DomainException::class);

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -68,7 +68,7 @@ class Psr16CacheTest extends SimpleCacheTest
     public function testDefaultLifeTime()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createSimpleCache(2);
@@ -88,7 +88,7 @@ class Psr16CacheTest extends SimpleCacheTest
     public function testNotUnserializable()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         $cache = $this->createSimpleCache();
@@ -110,7 +110,7 @@ class Psr16CacheTest extends SimpleCacheTest
     public function testPrune()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
-            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+           self::markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
         /** @var PruneableInterface|CacheInterface $cache */

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -37,7 +37,7 @@ class XmlUtilsTest extends TestCase
 
         try {
             if ('\\' === \DIRECTORY_SEPARATOR) {
-                $this->markTestSkipped('chmod is not supported on Windows');
+               self::markTestSkipped('chmod is not supported on Windows');
             }
             chmod($fixtures.'not_readable.xml', 000);
             XmlUtils::loadFile($fixtures.'not_readable.xml');

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -509,12 +509,12 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foos:bar1'], ['decorated' => false]);
         $this->assertSame('
-                                                          
-  There are no commands defined in the "foos" namespace.  
-                                                          
-  Did you mean this?                                      
-      foo                                                 
-                                                          
+
+  There are no commands defined in the "foos" namespace.
+
+  Did you mean this?
+      foo
+
 
 ', $tester->getDisplay(true));
     }
@@ -1946,7 +1946,7 @@ class ApplicationTest extends TestCase
     public function testSetSignalsToDispatchEvent()
     {
         if (!\defined('SIGUSR1')) {
-            $this->markTestSkipped('SIGUSR1 not available');
+           self::markTestSkipped('SIGUSR1 not available');
         }
 
         $command = new BaseSignableCommand();
@@ -1970,7 +1970,7 @@ class ApplicationTest extends TestCase
     public function testSignalableCommandInterfaceWithoutSignals()
     {
         if (!\defined('SIGUSR1')) {
-            $this->markTestSkipped('SIGUSR1 not available');
+           self::markTestSkipped('SIGUSR1 not available');
         }
 
         $command = new SignableCommand(false);
@@ -1986,7 +1986,7 @@ class ApplicationTest extends TestCase
     public function testSignalableCommandHandlerCalledAfterEventListener()
     {
         if (!\defined('SIGUSR1')) {
-            $this->markTestSkipped('SIGUSR1 not available');
+           self::markTestSkipped('SIGUSR1 not available');
         }
 
         $command = new SignableCommand();
@@ -2008,11 +2008,11 @@ class ApplicationTest extends TestCase
     public function testSignalableRestoresStty()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('stty not available');
+           self::markTestSkipped('stty not available');
         }
 
         if (!SignalRegistry::isSupported()) {
-            $this->markTestSkipped('pcntl signals not available');
+           self::markTestSkipped('pcntl signals not available');
         }
 
         $previousSttyMode = shell_exec('stty -g');

--- a/src/Symfony/Component/Console/Tests/ColorTest.php
+++ b/src/Symfony/Component/Console/Tests/ColorTest.php
@@ -34,7 +34,7 @@ class ColorTest extends TestCase
     public function testTrueColors()
     {
         if ('truecolor' !== getenv('COLORTERM')) {
-            $this->markTestSkipped('True color not supported.');
+           self::markTestSkipped('True color not supported.');
         }
 
         $color = new Color('#fff', '#000');

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -320,7 +320,7 @@ class CommandTest extends TestCase
         $this->assertSame(0, $command->run(new StringInput(''), new NullOutput()));
         if (\function_exists('cli_set_process_title')) {
             if (null === @cli_get_process_title() && 'Darwin' === \PHP_OS) {
-                $this->markTestSkipped('Running "cli_get_process_title" as an unprivileged user is not supported on MacOS.');
+               self::markTestSkipped('Running "cli_get_process_title" as an unprivileged user is not supported on MacOS.');
             }
             $this->assertEquals('foo', cli_get_process_title());
         }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -165,7 +165,7 @@ class OutputFormatterTest extends TestCase
     public function testInlineStyleOptions(string $tag, string $expected = null, string $input = null, bool $truecolor = false)
     {
         if ($truecolor && 'truecolor' !== getenv('COLORTERM')) {
-            $this->markTestSkipped('The terminal does not support true colors.');
+           self::markTestSkipped('The terminal does not support true colors.');
         }
 
         $styleString = substr($tag, 1, -1);

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -189,7 +189,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     public function testAskWithAutocomplete()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         // Acm<NEWLINE>
@@ -224,7 +224,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     public function testAskWithAutocompleteTrimmable()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         // Acm<NEWLINE>
@@ -258,7 +258,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     public function testAskWithAutocompleteCallback()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         // Po<TAB>Cr<TAB>P<DOWN ARROW><DOWN ARROW><NEWLINE>
@@ -301,7 +301,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     public function testAskWithAutocompleteWithNonSequentialKeys()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         // <UP ARROW><UP ARROW><NEWLINE><DOWN ARROW><DOWN ARROW><NEWLINE>
@@ -320,7 +320,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     public function testAskWithAutocompleteWithExactMatch()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         $inputStream = $this->getInputStream("b\n");
@@ -356,7 +356,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     public function testAskWithAutocompleteWithMultiByteCharacter($character)
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         $inputStream = $this->getInputStream("$character\n");
@@ -380,7 +380,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     public function testAutocompleteWithTrailingBackslash()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         $inputStream = $this->getInputStream('E');
@@ -419,7 +419,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     public function testAskHiddenResponse()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test is not supported on Windows');
+           self::markTestSkipped('This test is not supported on Windows');
         }
 
         $dialog = new QuestionHelper();
@@ -433,7 +433,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     public function testAskHiddenResponseTrimmed()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test is not supported on Windows');
+           self::markTestSkipped('This test is not supported on Windows');
         }
 
         $dialog = new QuestionHelper();
@@ -818,7 +818,7 @@ EOD;
     public function testTraversableAutocomplete()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         // Acm<NEWLINE>
@@ -851,7 +851,7 @@ EOD;
     public function testDisableStty()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         $this->expectException(InvalidArgumentException::class);
@@ -880,7 +880,7 @@ EOD;
     public function testTraversableMultiselectAutocomplete()
     {
         if (!Terminal::hasSttyAvailable()) {
-            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+           self::markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
         // <NEWLINE>

--- a/src/Symfony/Component/Console/Tests/TerminalTest.php
+++ b/src/Symfony/Component/Console/Tests/TerminalTest.php
@@ -74,12 +74,12 @@ class TerminalTest extends TestCase
     public function testSttyOnWindows()
     {
         if ('\\' !== \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Must be on windows');
+           self::markTestSkipped('Must be on windows');
         }
 
         $sttyString = exec('(stty -a | grep columns) 2>&1', $output, $exitcode);
         if (0 !== $exitcode) {
-            $this->markTestSkipped('Must have stty support');
+           self::markTestSkipped('Must have stty support');
         }
 
         $matches = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -747,7 +747,7 @@ class AutowirePassTest extends TestCase
     public function testSetterInjectionWithAttribute()
     {
         if (!class_exists(Required::class)) {
-            $this->markTestSkipped('symfony/service-contracts 2.2 required');
+           self::markTestSkipped('symfony/service-contracts 2.2 required');
         }
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredMethodsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredMethodsPassTest.php
@@ -61,7 +61,7 @@ class AutowireRequiredMethodsPassTest extends TestCase
     public function testSetterInjectionWithAttribute()
     {
         if (!class_exists(Required::class)) {
-            $this->markTestSkipped('symfony/service-contracts 2.2 required');
+           self::markTestSkipped('symfony/service-contracts 2.2 required');
         }
 
         $container = new ContainerBuilder();
@@ -155,7 +155,7 @@ class AutowireRequiredMethodsPassTest extends TestCase
     public function testWitherInjectionWithAttribute()
     {
         if (!class_exists(Required::class)) {
-            $this->markTestSkipped('symfony/service-contracts 2.2 required');
+           self::markTestSkipped('symfony/service-contracts 2.2 required');
         }
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredPropertiesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredPropertiesPassTest.php
@@ -51,7 +51,7 @@ class AutowireRequiredPropertiesPassTest extends TestCase
     public function testAttribute()
     {
         if (!class_exists(Required::class)) {
-            $this->markTestSkipped('symfony/service-contracts 2.2 required');
+           self::markTestSkipped('symfony/service-contracts 2.2 required');
         }
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -136,7 +136,7 @@ class MergeExtensionConfigurationPassTest extends TestCase
     public function testReuseEnvPlaceholderGeneratedByPreviousExtension()
     {
         if (!property_exists(BaseNode::class, 'placeholderUniquePrefixes')) {
-            $this->markTestSkipped('This test requires symfony/config ^4.4.11|^5.0.11|^5.1.3');
+           self::markTestSkipped('This test requires symfony/config ^4.4.11|^5.0.11|^5.1.3');
         }
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -286,7 +286,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     public function testServiceSubscriberTraitWithSubscribedServiceAttribute()
     {
         if (!class_exists(SubscribedService::class)) {
-            $this->markTestSkipped('SubscribedService attribute not available.');
+           self::markTestSkipped('SubscribedService attribute not available.');
         }
 
         $container = new ContainerBuilder();
@@ -319,7 +319,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     public function testServiceSubscriberTraitWithSubscribedServiceAttributeOnStaticMethod()
     {
         if (!class_exists(SubscribedService::class)) {
-            $this->markTestSkipped('SubscribedService attribute not available.');
+           self::markTestSkipped('SubscribedService attribute not available.');
         }
 
         $subscriber = new class() implements ServiceSubscriberInterface {
@@ -342,7 +342,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     public function testServiceSubscriberTraitWithSubscribedServiceAttributeOnMethodWithRequiredParameters()
     {
         if (!class_exists(SubscribedService::class)) {
-            $this->markTestSkipped('SubscribedService attribute not available.');
+           self::markTestSkipped('SubscribedService attribute not available.');
         }
 
         $subscriber = new class() implements ServiceSubscriberInterface {
@@ -365,7 +365,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     public function testServiceSubscriberTraitWithSubscribedServiceAttributeOnMethodMissingReturnType()
     {
         if (!class_exists(SubscribedService::class)) {
-            $this->markTestSkipped('SubscribedService attribute not available.');
+           self::markTestSkipped('SubscribedService attribute not available.');
         }
 
         $subscriber = new class() implements ServiceSubscriberInterface {
@@ -388,7 +388,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     public function testServiceSubscriberTraitWithUnionReturnType()
     {
         if (!class_exists(SubscribedService::class)) {
-            $this->markTestSkipped('SubscribedService attribute not available.');
+           self::markTestSkipped('SubscribedService attribute not available.');
         }
 
         $container = new ContainerBuilder();
@@ -418,7 +418,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     public function testServiceSubscriberTraitWithIntersectionReturnType()
     {
         if (!class_exists(SubscribedService::class)) {
-            $this->markTestSkipped('SubscribedService attribute not available.');
+           self::markTestSkipped('SubscribedService attribute not available.');
         }
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
@@ -51,7 +51,7 @@ class IniFileLoaderTest extends TestCase
     public function testTypeConversionsWithNativePhp($key, $value, $supported)
     {
         if (!$supported) {
-            $this->markTestSkipped(sprintf('Converting the value "%s" to "%s" is not supported by the IniFileLoader.', $key, $value));
+           self::markTestSkipped(sprintf('Converting the value "%s" to "%s" is not supported by the IniFileLoader.', $key, $value));
         }
 
         $expected = parse_ini_file(__DIR__.'/../Fixtures/ini/types.ini', true, \INI_SCANNER_TYPED);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -610,7 +610,7 @@ class XmlFileLoaderTest extends TestCase
     public function testExtensionInPhar()
     {
         if (\extension_loaded('suhosin') && !str_contains(\ini_get('suhosin.executor.include.whitelist'), 'phar')) {
-            $this->markTestSkipped('To run this test, add "phar" to the "suhosin.executor.include.whitelist" settings in your php.ini file.');
+           self::markTestSkipped('To run this test, add "phar" to the "suhosin.executor.include.whitelist" settings in your php.ini file.');
         }
 
         require_once self::$fixturesPath.'/includes/ProjectWithXsdExtensionInPhar.phar';

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -88,7 +88,7 @@ class DebugClassLoaderTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Case mismatch between class and real file names');
         if (!file_exists(__DIR__.'/Fixtures/CaseMismatch.php')) {
-            $this->markTestSkipped('Can only be run on case insensitive filesystems');
+           self::markTestSkipped('Can only be run on case insensitive filesystems');
         }
 
         class_exists(Fixtures\CaseMismatch::class, true);

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/ClassNotFoundErrorEnhancerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/ClassNotFoundErrorEnhancerTest.php
@@ -156,7 +156,7 @@ class ClassNotFoundErrorEnhancerTest extends TestCase
     public function testCannotRedeclareClass()
     {
         if (!file_exists(__DIR__.'/../FIXTURES2/REQUIREDTWICE.PHP')) {
-            $this->markTestSkipped('Can only be run on case insensitive filesystems');
+           self::markTestSkipped('Can only be run on case insensitive filesystems');
         }
 
         require_once __DIR__.'/../FIXTURES2/REQUIREDTWICE.PHP';

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -343,7 +343,7 @@ class ErrorHandlerTest extends TestCase
     public function testHandleUserError()
     {
         if (\PHP_VERSION_ID >= 70400) {
-            $this->markTestSkipped('PHP 7.4 allows __toString to throw exceptions');
+           self::markTestSkipped('PHP 7.4 allows __toString to throw exceptions');
         }
 
         try {
@@ -662,7 +662,7 @@ class ErrorHandlerTest extends TestCase
     public function testAssertQuietEval()
     {
         if ('-1' === \ini_get('zend.assertions')) {
-            $this->markTestSkipped('zend.assertions is forcibly disabled');
+           self::markTestSkipped('zend.assertions is forcibly disabled');
         }
 
         $ini = [

--- a/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
@@ -245,7 +245,7 @@ class FlattenExceptionTest extends TestCase
     public function testArguments()
     {
         if (\PHP_VERSION_ID >= 70400) {
-            $this->markTestSkipped('PHP 7.4 removes arguments from exception traces.');
+           self::markTestSkipped('PHP 7.4 removes arguments from exception traces.');
         }
 
         $dh = opendir(__DIR__);
@@ -311,7 +311,7 @@ class FlattenExceptionTest extends TestCase
     public function testRecursionInArguments()
     {
         if (\PHP_VERSION_ID >= 70400) {
-            $this->markTestSkipped('PHP 7.4 removes arguments from exception traces.');
+           self::markTestSkipped('PHP 7.4 removes arguments from exception traces.');
         }
 
         $a = null;
@@ -326,7 +326,7 @@ class FlattenExceptionTest extends TestCase
     public function testTooBigArray()
     {
         if (\PHP_VERSION_ID >= 70400) {
-            $this->markTestSkipped('PHP 7.4 removes arguments from exception traces.');
+           self::markTestSkipped('PHP 7.4 removes arguments from exception traces.');
         }
 
         $a = [];

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -46,11 +46,11 @@ class FilesystemTest extends FilesystemTestCase
         $this->expectException(IOException::class);
         // skip test on Windows; PHP can't easily set file as unreadable on Windows
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test cannot run on Windows.');
+           self::markTestSkipped('This test cannot run on Windows.');
         }
 
         if (!getenv('USER') || 'root' === getenv('USER')) {
-            $this->markTestSkipped('This test will fail if run under superuser');
+           self::markTestSkipped('This test will fail if run under superuser');
         }
 
         $sourceFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_source_file';
@@ -122,11 +122,11 @@ class FilesystemTest extends FilesystemTestCase
         $this->expectException(IOException::class);
         // skip test on Windows; PHP can't easily set file as unwritable on Windows
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test cannot run on Windows.');
+           self::markTestSkipped('This test cannot run on Windows.');
         }
 
         if (!getenv('USER') || 'root' === getenv('USER')) {
-            $this->markTestSkipped('This test will fail if run under superuser');
+           self::markTestSkipped('This test will fail if run under superuser');
         }
 
         $sourceFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_source_file';
@@ -167,7 +167,7 @@ class FilesystemTest extends FilesystemTestCase
     public function testCopyForOriginUrlsAndExistingLocalFileDefaultsToCopy()
     {
         if (!\in_array('https', stream_get_wrappers())) {
-            $this->markTestSkipped('"https" stream wrapper is not enabled.');
+           self::markTestSkipped('"https" stream wrapper is not enabled.');
         }
         $sourceFilePath = 'https://symfony.com/images/common/logo/logo_symfony_header.png';
         $targetFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_target_file';
@@ -399,7 +399,7 @@ class FilesystemTest extends FilesystemTestCase
     {
         $this->expectException(IOException::class);
         if ('\\' !== \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Long file names are an issue on Windows');
+           self::markTestSkipped('Long file names are an issue on Windows');
         }
         $basePath = $this->workspace.'\\directory\\';
         $maxPathLength = \PHP_MAXPATHLEN - 2;
@@ -860,7 +860,7 @@ class FilesystemTest extends FilesystemTestCase
     public function testSymlink()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does not support creating "broken" symlinks');
+           self::markTestSkipped('Windows does not support creating "broken" symlinks');
         }
 
         $file = $this->workspace.\DIRECTORY_SEPARATOR.'file';
@@ -1045,7 +1045,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->markAsSkippedIfSymlinkIsMissing();
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Relative symbolic links are not supported on Windows');
+           self::markTestSkipped('Relative symbolic links are not supported on Windows');
         }
 
         $file = $this->workspace.'/file';
@@ -1092,7 +1092,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->markAsSkippedIfSymlinkIsMissing();
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does not support creating "broken" symlinks');
+           self::markTestSkipped('Windows does not support creating "broken" symlinks');
         }
 
         $file = $this->workspace.'/file';
@@ -1507,7 +1507,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->expectException(IOException::class);
         // Skip test if Phar disabled phar.readonly must be 0 in php.ini
         if (!\Phar::canWrite()) {
-            $this->markTestSkipped('This test cannot run when phar.readonly is 1.');
+           self::markTestSkipped('This test cannot run when phar.readonly is 1.');
         }
 
         $scheme = 'phar://';
@@ -1769,7 +1769,7 @@ class FilesystemTest extends FilesystemTestCase
     public function testDumpToProtectedDirectory()
     {
         if (\DIRECTORY_SEPARATOR !== '\\') {
-            $this->markTestSkipped('This test is specific to Windows.');
+           self::markTestSkipped('This test is specific to Windows.');
         }
 
         if (($userProfilePath = getenv('USERPROFILE')) === false || !is_dir($userProfilePath)) {

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -138,43 +138,43 @@ class FilesystemTestCase extends TestCase
             return $datas['name'];
         }
 
-        $this->markTestSkipped('Unable to retrieve file group name');
+       self::markTestSkipped('Unable to retrieve file group name');
     }
 
     protected function markAsSkippedIfLinkIsMissing()
     {
         if (!\function_exists('link')) {
-            $this->markTestSkipped('link is not supported');
+           self::markTestSkipped('link is not supported');
         }
 
         if ('\\' === \DIRECTORY_SEPARATOR && false === self::$linkOnWindows) {
-            $this->markTestSkipped('link requires "Create hard links" privilege on windows');
+           self::markTestSkipped('link requires "Create hard links" privilege on windows');
         }
     }
 
     protected function markAsSkippedIfSymlinkIsMissing($relative = false)
     {
         if ('\\' === \DIRECTORY_SEPARATOR && false === self::$symlinkOnWindows) {
-            $this->markTestSkipped('symlink requires "Create symbolic links" privilege on Windows');
+           self::markTestSkipped('symlink requires "Create symbolic links" privilege on Windows');
         }
 
         // https://bugs.php.net/69473
         if ($relative && '\\' === \DIRECTORY_SEPARATOR && 1 === \PHP_ZTS) {
-            $this->markTestSkipped('symlink does not support relative paths on thread safe Windows PHP versions');
+           self::markTestSkipped('symlink does not support relative paths on thread safe Windows PHP versions');
         }
     }
 
     protected function markAsSkippedIfChmodIsMissing()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('chmod is not supported on Windows');
+           self::markTestSkipped('chmod is not supported on Windows');
         }
     }
 
     protected function markAsSkippedIfPosixIsMissing()
     {
         if (!\function_exists('posix_isatty')) {
-            $this->markTestSkipped('Function posix_isatty is required.');
+           self::markTestSkipped('Function posix_isatty is required.');
         }
     }
 }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -97,7 +97,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testSymlinksNotResolved()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('symlinks are not supported on Windows');
+           self::markTestSkipped('symlinks are not supported on Windows');
         }
 
         $finder = $this->buildFinder();
@@ -871,7 +871,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testFollowLinks()
     {
         if ('\\' == \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('symlinks are not supported on Windows');
+           self::markTestSkipped('symlinks are not supported on Windows');
         }
 
         $finder = $this->buildFinder();
@@ -948,7 +948,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testInWithGlobBrace()
     {
         if (!\defined('GLOB_BRACE')) {
-            $this->markTestSkipped('Glob brace is not supported on this system.');
+           self::markTestSkipped('Glob brace is not supported on this system.');
         }
 
         $finder = $this->buildFinder();
@@ -1388,7 +1388,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testAccessDeniedException()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('chmod is not supported on Windows');
+           self::markTestSkipped('chmod is not supported on Windows');
         }
 
         $finder = $this->buildFinder();
@@ -1417,14 +1417,14 @@ class FinderTest extends Iterator\RealIteratorTestCase
         clearstatcache(true, $testDir);
 
         if ($couldRead) {
-            $this->markTestSkipped('could read test files while test requires unreadable');
+           self::markTestSkipped('could read test files while test requires unreadable');
         }
     }
 
     public function testIgnoredAccessDeniedException()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('chmod is not supported on Windows');
+           self::markTestSkipped('chmod is not supported on Windows');
         }
 
         $finder = $this->buildFinder();
@@ -1456,7 +1456,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         clearstatcache(true, $testDir);
 
         if ($couldRead) {
-            $this->markTestSkipped('could read test files while test requires unreadable');
+           self::markTestSkipped('could read test files while test requires unreadable');
         }
     }
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
@@ -23,7 +23,7 @@ class RecursiveDirectoryIteratorTest extends IteratorTestCase
         try {
             $i = new RecursiveDirectoryIterator('ftp://speedtest:speedtest@ftp.otenet.gr/', \RecursiveDirectoryIterator::SKIP_DOTS);
         } catch (\UnexpectedValueException $e) {
-            $this->markTestSkipped('Unsupported stream "ftp".');
+           self::markTestSkipped('Unsupported stream "ftp".');
         }
 
         $i->rewind();
@@ -39,7 +39,7 @@ class RecursiveDirectoryIteratorTest extends IteratorTestCase
         try {
             $i = new RecursiveDirectoryIterator('ftp://speedtest:speedtest@ftp.otenet.gr/', \RecursiveDirectoryIterator::SKIP_DOTS);
         } catch (\UnexpectedValueException $e) {
-            $this->markTestSkipped('Unsupported stream "ftp".');
+           self::markTestSkipped('Unsupported stream "ftp".');
         }
 
         $contains = [

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -60,7 +60,7 @@ class SortableIteratorTest extends RealIteratorTestCase
             || SortableIterator::SORT_BY_MODIFIED_TIME === $mode
         ) {
             if ('\\' === \DIRECTORY_SEPARATOR && SortableIterator::SORT_BY_MODIFIED_TIME !== $mode) {
-                $this->markTestSkipped('Sorting by atime or ctime is not supported on Windows');
+               self::markTestSkipped('Sorting by atime or ctime is not supported on Windows');
             }
             $this->assertOrderedIteratorForGroups($expected, $iterator);
         } else {

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -32,7 +32,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     protected function setUp(): void
     {
         if (!\extension_loaded('intl')) {
-            $this->markTestSkipped('Extension intl is required.');
+           self::markTestSkipped('Extension intl is required.');
         }
 
         $this->defaultLocale = \Locale::getDefault();
@@ -125,7 +125,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     protected function renderHelp(FormView $view)
     {
-        $this->markTestSkipped(sprintf('%s::renderHelp() is not implemented.', static::class));
+       self::markTestSkipped(sprintf('%s::renderHelp() is not implemented.', static::class));
     }
 
     abstract protected function renderErrors(FormView $view);

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -195,7 +195,7 @@ TXT
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $formRegistry = new FormRegistry([], new ResolvedFormTypeFactory());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -336,7 +336,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
     public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
     {
         if (!\extension_loaded('intl')) {
-            $this->markTestSkipped('intl extension is not loaded');
+           self::markTestSkipped('intl extension is not loaded');
         }
 
         $this->iniSet('intl.error_level', \E_WARNING);
@@ -349,7 +349,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
     public function testReverseTransformWrapsIntlErrorsWithExceptions()
     {
         if (!\extension_loaded('intl')) {
-            $this->markTestSkipped('intl extension is not loaded');
+           self::markTestSkipped('intl extension is not loaded');
         }
 
         $this->iniSet('intl.use_exceptions', 1);
@@ -362,7 +362,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
     public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
     {
         if (!\extension_loaded('intl')) {
-            $this->markTestSkipped('intl extension is not loaded');
+           self::markTestSkipped('intl extension is not loaded');
         }
 
         $this->iniSet('intl.use_exceptions', 1);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -90,7 +90,7 @@ class IntegerTypeTest extends BaseTypeTest
     public function testSubmittedLargeIntegersAreNotCastToFloat()
     {
         if (4 === \PHP_INT_SIZE) {
-            $this->markTestSkipped('This test requires a 64bit PHP.');
+           self::markTestSkipped('This test requires a 64bit PHP.');
         }
 
         $form = $this->factory->create(static::TESTED_TYPE);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -108,7 +108,7 @@ class TimezoneTypeTest extends BaseTypeTest
         $tzDbVersion = isset($matches[1]) ? (int) trim($matches[1]) : 0;
 
         if (!$tzDbVersion || 2017 <= $tzDbVersion) {
-            $this->markTestSkipped('"Europe/Saratov" is expired until 2017, current version is '.$tzDbVersion);
+           self::markTestSkipped('"Europe/Saratov" is expired until 2017, current version is '.$tzDbVersion);
         }
 
         $form = $this->factory->create(static::TESTED_TYPE, null, ['input' => 'intltimezone']);
@@ -131,7 +131,7 @@ class TimezoneTypeTest extends BaseTypeTest
         $tzDbVersion = isset($matches[1]) ? (int) trim($matches[1]) : 0;
 
         if (!$tzDbVersion || 2017 <= $tzDbVersion) {
-            $this->markTestSkipped('"Europe/Saratov" is expired until 2017, current version is '.$tzDbVersion);
+           self::markTestSkipped('"Europe/Saratov" is expired until 2017, current version is '.$tzDbVersion);
         }
 
         $form = $this->factory->create(static::TESTED_TYPE, null, ['input' => 'intltimezone', 'intl' => true]);

--- a/src/Symfony/Component/Form/Tests/FormErrorIteratorTest.php
+++ b/src/Symfony/Component/Form/Tests/FormErrorIteratorTest.php
@@ -29,7 +29,7 @@ class FormErrorIteratorTest extends TestCase
     public function testFindByCodes($code, $violationsCount)
     {
         if (!class_exists(ConstraintViolation::class)) {
-            $this->markTestSkipped('Validator component required.');
+           self::markTestSkipped('Validator component required.');
         }
 
         $formBuilder = new FormBuilder(

--- a/src/Symfony/Component/Form/Tests/VersionAwareTest.php
+++ b/src/Symfony/Component/Form/Tests/VersionAwareTest.php
@@ -18,7 +18,7 @@ trait VersionAwareTest
     protected function requiresFeatureSet(int $requiredFeatureSetVersion)
     {
         if ($requiredFeatureSetVersion > static::$supportedFeatureSetVersion) {
-            $this->markTestSkipped(sprintf('Test requires features from symfony/form %.2f but only version %.2f is supported.', $requiredFeatureSetVersion / 100, static::$supportedFeatureSetVersion / 100));
+           self::markTestSkipped(sprintf('Test requires features from symfony/form %.2f but only version %.2f is supported.', $requiredFeatureSetVersion / 100, static::$supportedFeatureSetVersion / 100));
         }
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
@@ -23,6 +23,6 @@ class AmpHttpClientTest extends HttpClientTestCase
 
     public function testProxy()
     {
-        $this->markTestSkipped('A real proxy server would be needed.');
+       self::markTestSkipped('A real proxy server would be needed.');
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/AsyncDecoratorTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AsyncDecoratorTraitTest.php
@@ -28,7 +28,7 @@ class AsyncDecoratorTraitTest extends NativeHttpClientTest
     protected function getHttpClient(string $testCase, \Closure $chunkFilter = null, HttpClientInterface $decoratedClient = null): HttpClientInterface
     {
         if ('testHandleIsRemovedOnException' === $testCase) {
-            $this->markTestSkipped("AsyncDecoratorTrait doesn't cache handles");
+           self::markTestSkipped("AsyncDecoratorTrait doesn't cache handles");
         }
 
         if ('testTimeoutOnDestruct' === $testCase) {
@@ -58,7 +58,7 @@ class AsyncDecoratorTraitTest extends NativeHttpClientTest
     public function testTimeoutOnDestruct()
     {
         if (HttpClient::create() instanceof NativeHttpClient) {
-            $this->markTestSkipped('NativeHttpClient doesn\'t support opening concurrent requests.');
+           self::markTestSkipped('NativeHttpClient doesn\'t support opening concurrent requests.');
         }
 
         HttpClientTestCase::testTimeoutOnDestruct();

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -24,11 +24,11 @@ class CurlHttpClientTest extends HttpClientTestCase
     {
         if (false !== strpos($testCase, 'Push')) {
             if (\PHP_VERSION_ID >= 70300 && \PHP_VERSION_ID < 70304) {
-                $this->markTestSkipped('PHP 7.3.0 to 7.3.3 don\'t support HTTP/2 PUSH');
+               self::markTestSkipped('PHP 7.3.0 to 7.3.3 don\'t support HTTP/2 PUSH');
             }
 
             if (!\defined('CURLMOPT_PUSHFUNCTION') || 0x073D00 > ($v = curl_version())['version_number'] || !(\CURL_VERSION_HTTP2 & $v['features'])) {
-                $this->markTestSkipped('curl <7.61 is used or it is not compiled with support for HTTP/2 PUSH');
+               self::markTestSkipped('curl <7.61 is used or it is not compiled with support for HTTP/2 PUSH');
             }
         }
 
@@ -53,7 +53,7 @@ class CurlHttpClientTest extends HttpClientTestCase
     public function testTimeoutIsNotAFatalError()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Too transient on Windows');
+           self::markTestSkipped('Too transient on Windows');
         }
 
         parent::testTimeoutIsNotAFatalError();

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -35,7 +35,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
     public function testTimeoutOnDestruct()
     {
         if (!method_exists(parent::class, 'testTimeoutOnDestruct')) {
-            $this->markTestSkipped('BaseHttpClientTestCase doesn\'t have testTimeoutOnDestruct().');
+           self::markTestSkipped('BaseHttpClientTestCase doesn\'t have testTimeoutOnDestruct().');
         }
 
         parent::testTimeoutOnDestruct();

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -317,42 +317,42 @@ class MockHttpClientTest extends HttpClientTestCase
                 });
 
             case 'testUnsupportedOption':
-                $this->markTestSkipped('MockHttpClient accepts any options by default');
+               self::markTestSkipped('MockHttpClient accepts any options by default');
                 break;
 
             case 'testChunkedEncoding':
-                $this->markTestSkipped("MockHttpClient doesn't dechunk");
+               self::markTestSkipped("MockHttpClient doesn't dechunk");
                 break;
 
             case 'testGzipBroken':
-                $this->markTestSkipped("MockHttpClient doesn't unzip");
+               self::markTestSkipped("MockHttpClient doesn't unzip");
                 break;
 
             case 'testTimeoutWithActiveConcurrentStream':
-                $this->markTestSkipped('Real transport required');
+               self::markTestSkipped('Real transport required');
                 break;
 
             case 'testTimeoutOnInitialize':
             case 'testTimeoutOnDestruct':
-                $this->markTestSkipped('Real transport required');
+               self::markTestSkipped('Real transport required');
                 break;
 
             case 'testDestruct':
-                $this->markTestSkipped("MockHttpClient doesn't timeout on destruct");
+               self::markTestSkipped("MockHttpClient doesn't timeout on destruct");
                 break;
 
             case 'testHandleIsRemovedOnException':
-                $this->markTestSkipped("MockHttpClient doesn't cache handles");
+               self::markTestSkipped("MockHttpClient doesn't cache handles");
                 break;
 
             case 'testPause':
             case 'testPauseReplace':
             case 'testPauseDuringBody':
-                $this->markTestSkipped("MockHttpClient doesn't support pauses by default");
+               self::markTestSkipped("MockHttpClient doesn't support pauses by default");
                 break;
 
             case 'testDnsFailure':
-                $this->markTestSkipped("MockHttpClient doesn't use a DNS");
+               self::markTestSkipped("MockHttpClient doesn't use a DNS");
                 break;
 
             case 'testGetRequest':
@@ -457,12 +457,12 @@ class MockHttpClientTest extends HttpClientTestCase
 
     public function testHttp2PushVulcain()
     {
-        $this->markTestSkipped('MockHttpClient doesn\'t support HTTP/2 PUSH.');
+       self::markTestSkipped('MockHttpClient doesn\'t support HTTP/2 PUSH.');
     }
 
     public function testHttp2PushVulcainWithUnusedResponse()
     {
-        $this->markTestSkipped('MockHttpClient doesn\'t support HTTP/2 PUSH.');
+       self::markTestSkipped('MockHttpClient doesn\'t support HTTP/2 PUSH.');
     }
 
     public function testChangeResponseFactory()

--- a/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
@@ -23,26 +23,26 @@ class NativeHttpClientTest extends HttpClientTestCase
 
     public function testInformationalResponseStream()
     {
-        $this->markTestSkipped('NativeHttpClient doesn\'t support informational status codes.');
+       self::markTestSkipped('NativeHttpClient doesn\'t support informational status codes.');
     }
 
     public function testTimeoutOnInitialize()
     {
-        $this->markTestSkipped('NativeHttpClient doesn\'t support opening concurrent requests.');
+       self::markTestSkipped('NativeHttpClient doesn\'t support opening concurrent requests.');
     }
 
     public function testTimeoutOnDestruct()
     {
-        $this->markTestSkipped('NativeHttpClient doesn\'t support opening concurrent requests.');
+       self::markTestSkipped('NativeHttpClient doesn\'t support opening concurrent requests.');
     }
 
     public function testHttp2PushVulcain()
     {
-        $this->markTestSkipped('NativeHttpClient doesn\'t support HTTP/2.');
+       self::markTestSkipped('NativeHttpClient doesn\'t support HTTP/2.');
     }
 
     public function testHttp2PushVulcainWithUnusedResponse()
     {
-        $this->markTestSkipped('NativeHttpClient doesn\'t support HTTP/2.');
+       self::markTestSkipped('NativeHttpClient doesn\'t support HTTP/2.');
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
@@ -176,7 +176,7 @@ class RetryableHttpClientTest extends TestCase
         $client = HttpClient::create();
 
         if ($client instanceof NativeHttpClient) {
-            $this->markTestSkipped('NativeHttpClient cannot timeout before receiving headers');
+           self::markTestSkipped('NativeHttpClient cannot timeout before receiving headers');
         }
 
         $client = new RetryableHttpClient($client);

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -419,7 +419,7 @@ class BinaryFileResponseTest extends ResponseTestCase
         try {
             $file->getMimeType();
         } catch (\LogicException $e) {
-            $this->markTestSkipped('Guessing the mime type is not possible');
+           self::markTestSkipped('Guessing the mime type is not possible');
         }
 
         $response = new BinaryFileResponse($file);

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -28,7 +28,7 @@ class UploadedFileTest extends TestCase
     protected function setUp(): void
     {
         if (!\ini_get('file_uploads')) {
-            $this->markTestSkipped('file_uploads is disabled in php.ini');
+           self::markTestSkipped('file_uploads is disabled in php.ini');
         }
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -52,7 +52,7 @@ class IpUtilsTest extends TestCase
     public function testIpv6($matches, $remoteAddr, $cidr)
     {
         if (!\defined('AF_INET6')) {
-            $this->markTestSkipped('Only works when PHP is compiled without the option "disable-ipv6".');
+           self::markTestSkipped('Only works when PHP is compiled without the option "disable-ipv6".');
         }
 
         $this->assertSame($matches, IpUtils::checkIp($remoteAddr, $cidr));
@@ -116,7 +116,7 @@ class IpUtilsTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         if (\defined('AF_INET6')) {
-            $this->markTestSkipped('Only works when PHP is compiled with the option "disable-ipv6".');
+           self::markTestSkipped('Only works when PHP is compiled with the option "disable-ipv6".');
         }
 
         IpUtils::checkIp('2a01:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65');

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
@@ -44,7 +44,7 @@ class ResponseFunctionalTest extends TestCase
     public function testCookie($fixture)
     {
         if (\PHP_VERSION_ID >= 80000 && 'cookie_max_age' === $fixture) {
-            $this->markTestSkipped('This fixture produces a fatal error on PHP 8.');
+           self::markTestSkipped('This fixture produces a fatal error on PHP 8.');
         }
 
         $result = file_get_contents(sprintf('http://localhost:8054/%s.php', $fixture));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -36,7 +36,7 @@ class MemcachedSessionHandlerTest extends TestCase
         parent::setUp();
 
         if (version_compare(phpversion('memcached'), '2.2.0', '>=') && version_compare(phpversion('memcached'), '3.0.0b1', '<')) {
-            $this->markTestSkipped('Tests can only be run with memcached extension 2.1.0 or lower, or 3.0.0b1 or higher');
+           self::markTestSkipped('Tests can only be run with memcached extension 2.1.0 or lower, or 3.0.0b1 or higher');
         }
 
         $r = new \ReflectionClass(\Memcached::class);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -35,7 +35,7 @@ class MongoDbSessionHandlerTest extends TestCase
         parent::setUp();
 
         if (!class_exists(Client::class)) {
-            $this->markTestSkipped('The mongodb/mongodb package is required.');
+           self::markTestSkipped('The mongodb/mongodb package is required.');
         }
 
         $this->mongo = $this->getMockBuilder(Client::class)

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -148,7 +148,7 @@ class PdoSessionHandlerTest extends TestCase
     public function testReadLockedConvertsStreamToString()
     {
         if (filter_var(\ini_get('session.use_strict_mode'), \FILTER_VALIDATE_BOOLEAN)) {
-            $this->markTestSkipped('Strict mode needs no locking for new sessions.');
+           self::markTestSkipped('Strict mode needs no locking for new sessions.');
         }
 
         $pdo = new MockPdo('pgsql');

--- a/src/Symfony/Component/HttpFoundation/Tests/UrlHelperTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UrlHelperTest.php
@@ -60,7 +60,7 @@ class UrlHelperTest extends TestCase
     public function testGenerateAbsoluteUrlWithRequestContext($path, $baseUrl, $host, $scheme, $httpPort, $httpsPort, $expected)
     {
         if (!class_exists(RequestContext::class)) {
-            $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
+           self::markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
         }
 
         $requestContext = new RequestContext($baseUrl, 'GET', $host, $scheme, $httpPort, $httpsPort, $path);
@@ -75,7 +75,7 @@ class UrlHelperTest extends TestCase
     public function testGenerateAbsoluteUrlWithoutRequestAndRequestContext($path)
     {
         if (!class_exists(RequestContext::class)) {
-            $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
+           self::markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
         }
 
         $helper = new UrlHelper(new RequestStack());
@@ -118,7 +118,7 @@ class UrlHelperTest extends TestCase
     public function testGenerateRelativePath($expected, $path, $pathinfo)
     {
         if (!method_exists(Request::class, 'getRelativeUriForPath')) {
-            $this->markTestSkipped('Your version of Symfony HttpFoundation is too old.');
+           self::markTestSkipped('Your version of Symfony HttpFoundation is too old.');
         }
 
         $stack = new RequestStack();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
@@ -196,7 +196,7 @@ class DebugHandlersListenerTest extends TestCase
     public function testLevelsAssignedToLoggers(bool $hasLogger, bool $hasDeprecationLogger, $levels, $expectedLoggerLevels, $expectedDeprecationLoggerLevels)
     {
         if (!class_exists(ErrorHandler::class)) {
-            $this->markTestSkipped('ErrorHandler component is required to run this test.');
+           self::markTestSkipped('ErrorHandler component is required to run this test.');
         }
 
         $handler = $this->createMock(ErrorHandler::class);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -585,7 +585,7 @@ class HttpCacheTest extends HttpCacheTestCase
     public function testDegradationWhenCacheLocked()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Skips on windows to avoid permissions issues.');
+           self::markTestSkipped('Skips on windows to avoid permissions issues.');
         }
 
         $this->cacheConfig['stale_while_revalidate'] = 10;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -144,7 +144,7 @@ class HttpKernelBrowserTest extends TestCase
     public function testUploadedFileWhenSizeExceedsUploadMaxFileSize()
     {
         if (UploadedFile::getMaxFilesize() > \PHP_INT_MAX) {
-            $this->markTestSkipped('Requires PHP_INT_MAX to be greater than "upload_max_filesize" and "post_max_size" ini settings');
+           self::markTestSkipped('Requires PHP_INT_MAX to be greater than "upload_max_filesize" and "post_max_size" ini settings');
         }
 
         $source = tempnam(sys_get_temp_dir(), 'source');

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -370,7 +370,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
     public function testFormatTimezone($pattern, $timezone, $expected)
     {
         if ((80114 === \PHP_VERSION_ID || 80201 === \PHP_VERSION_ID) && str_contains($timezone, 'GMT')) {
-            $this->markTestSkipped('Broken version of PHP');
+           self::markTestSkipped('Broken version of PHP');
         }
 
         $formatter = $this->getDefaultDateFormatter($pattern);
@@ -432,7 +432,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
     public function testFormatWithGmtTimezone()
     {
         if (80114 === \PHP_VERSION_ID || 80201 === \PHP_VERSION_ID) {
-            $this->markTestSkipped('Broken version of PHP');
+           self::markTestSkipped('Broken version of PHP');
         }
 
         $formatter = $this->getDefaultDateFormatter('zzzz');
@@ -445,7 +445,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
     public function testFormatWithGmtTimeZoneAndMinutesOffset()
     {
         if (80114 === \PHP_VERSION_ID || 80201 === \PHP_VERSION_ID) {
-            $this->markTestSkipped('Broken version of PHP');
+           self::markTestSkipped('Broken version of PHP');
         }
 
         $formatter = $this->getDefaultDateFormatter('zzzz');
@@ -492,7 +492,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
     public function testFormatWithIntlTimeZone()
     {
         if (!\extension_loaded('intl')) {
-            $this->markTestSkipped('Extension intl is required.');
+           self::markTestSkipped('Extension intl is required.');
         }
 
         $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, \IntlTimeZone::createTimeZone('GMT+03:00'), IntlDateFormatter::GREGORIAN, 'zzzz');
@@ -935,7 +935,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
     public function testSetTimeZoneId($timeZoneId, $expectedTimeZoneId)
     {
         if ((80114 === \PHP_VERSION_ID || 80201 === \PHP_VERSION_ID) && str_contains($timeZoneId ?? '', 'GMT')) {
-            $this->markTestSkipped('Broken version of PHP');
+           self::markTestSkipped('Broken version of PHP');
         }
 
         $formatter = $this->getDefaultDateFormatter();

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -176,7 +176,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
     public function testParseThreeDigitsYears()
     {
         if (\PHP_INT_SIZE < 8) {
-            $this->markTestSkipped('Parsing three digits years requires a 64bit PHP.');
+           self::markTestSkipped('Parsing three digits years requires a 64bit PHP.');
         }
 
         $formatter = $this->getDefaultDateFormatter('yyyy-M-d');
@@ -187,7 +187,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
     protected function getDateFormatter($locale, $datetype, $timetype, $timezone = null, $calendar = IntlDateFormatter::GREGORIAN, $pattern = null)
     {
         if ((80114 === \PHP_VERSION_ID || 80201 === \PHP_VERSION_ID) && \is_string($timezone) && str_contains($timezone, 'GMT')) {
-            $this->markTestSkipped('Broken version of PHP');
+           self::markTestSkipped('Broken version of PHP');
         }
 
         return new class($locale, $datetype, $timetype, $timezone, $calendar, $pattern) extends IntlDateFormatter {

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
@@ -36,7 +36,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
     public function testFormatTimezone($pattern, $timezone, $expected)
     {
         if ((80114 === \PHP_VERSION_ID || 80201 === \PHP_VERSION_ID) && str_contains($timezone, 'GMT')) {
-            $this->markTestSkipped('Broken version of PHP');
+           self::markTestSkipped('Broken version of PHP');
         }
 
         IntlTestHelper::requireFullIntl($this, '59.1');
@@ -64,7 +64,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
     protected function getDateFormatter($locale, $datetype, $timetype, $timezone = null, $calendar = IntlDateFormatter::GREGORIAN, $pattern = null)
     {
         if ((80114 === \PHP_VERSION_ID || 80201 === \PHP_VERSION_ID) && \is_string($timezone) && str_contains($timezone, 'GMT')) {
-            $this->markTestSkipped('Broken version of PHP');
+           self::markTestSkipped('Broken version of PHP');
         }
 
         IntlTestHelper::requireFullIntl($this, '55.1');

--- a/src/Symfony/Component/Intl/Tests/TimezonesTest.php
+++ b/src/Symfony/Component/Intl/Tests/TimezonesTest.php
@@ -632,7 +632,7 @@ class TimezonesTest extends ResourceBundleTestCase
             $this->addToAssertionCount(1);
         } catch (MissingResourceException $e) {
             if (\in_array($timezone, self::ZONES_NO_COUNTRY, true)) {
-                $this->markTestSkipped();
+               self::markTestSkipped();
             } else {
                 $this->fail();
             }

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -160,7 +160,7 @@ class AdapterTest extends LdapTestCase
             $this->assertEquals($final_results->count(), 25);
             $this->assertEquals(\count($final_query->getResources()), 1);
         } catch (LdapException $exc) {
-            $this->markTestSkipped('Test LDAP server does not support pagination');
+           self::markTestSkipped('Test LDAP server does not support pagination');
         }
 
         $this->destroyEntries($ldap, $entries);
@@ -224,7 +224,7 @@ class AdapterTest extends LdapTestCase
             $this->assertEquals(\count($low_max_query->getResources()), 1);
             $this->assertEquals(\count($high_max_query->getResources()), 2);
         } catch (LdapException $exc) {
-            $this->markTestSkipped('Test LDAP server does not support pagination');
+           self::markTestSkipped('Test LDAP server does not support pagination');
         }
 
         $this->destroyEntries($ldap, $entries);

--- a/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
@@ -21,7 +21,7 @@ class LdapTestCase extends TestCase
         @ldap_set_option($h, \LDAP_OPT_PROTOCOL_VERSION, 3);
 
         if (!$h || !@ldap_bind($h)) {
-            $this->markTestSkipped('No server is listening on LDAP_HOST:LDAP_PORT');
+           self::markTestSkipped('No server is listening on LDAP_HOST:LDAP_PORT');
         }
 
         ldap_unbind($h);

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -42,7 +42,7 @@ class CheckLdapCredentialsListenerTest extends TestCase
     protected function setUp(): void
     {
         if (!interface_exists(AuthenticatorInterface::class)) {
-            $this->markTestSkipped('This test requires symfony/security-http:^5.1');
+           self::markTestSkipped('This test requires symfony/security-http:^5.1');
         }
 
         $this->ldap = $this->createMock(LdapInterface::class);
@@ -62,7 +62,7 @@ class CheckLdapCredentialsListenerTest extends TestCase
     public function provideShouldNotCheckPassport()
     {
         if (!interface_exists(AuthenticatorInterface::class)) {
-            $this->markTestSkipped('This test requires symfony/security-http:^5.1');
+           self::markTestSkipped('This test requires symfony/security-http:^5.1');
         }
 
         // no LdapBadge
@@ -111,7 +111,7 @@ class CheckLdapCredentialsListenerTest extends TestCase
     public function provideWrongPassportData()
     {
         if (!interface_exists(AuthenticatorInterface::class)) {
-            $this->markTestSkipped('This test requires symfony/security-http:^5.1');
+           self::markTestSkipped('This test requires symfony/security-http:^5.1');
         }
 
         // no password credentials

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalPostgreSqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalPostgreSqlStoreTest.php
@@ -34,7 +34,7 @@ class DoctrineDbalPostgreSqlStoreTest extends AbstractStoreTest
     public function createPostgreSqlConnection(): Connection
     {
         if (!getenv('POSTGRES_HOST')) {
-            $this->markTestSkipped('Missing POSTGRES_HOST env variable');
+           self::markTestSkipped('Missing POSTGRES_HOST env variable');
         }
 
         return DriverManager::getConnection(['url' => 'pgsql://postgres:password@'.getenv('POSTGRES_HOST')]);

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
@@ -63,7 +63,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTest
 
     public function testAbortAfterExpiration()
     {
-        $this->markTestSkipped('Pdo expects a TTL greater than 1 sec. Simulating a slow network is too hard');
+       self::markTestSkipped('Pdo expects a TTL greater than 1 sec. Simulating a slow network is too hard');
     }
 
     /**

--- a/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
@@ -38,7 +38,7 @@ class FlockStoreTest extends AbstractStoreTest
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The FlockStore directory "/a/b/c/d/e" does not exists and cannot be created.');
         if (!getenv('USER') || 'root' === getenv('USER')) {
-            $this->markTestSkipped('This test will fail if run under superuser');
+           self::markTestSkipped('This test will fail if run under superuser');
         }
 
         new FlockStore('/a/b/c/d/e');
@@ -49,7 +49,7 @@ class FlockStoreTest extends AbstractStoreTest
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The FlockStore directory "/" is not writable.');
         if (!getenv('USER') || 'root' === getenv('USER')) {
-            $this->markTestSkipped('This test will fail if run under superuser');
+           self::markTestSkipped('This test will fail if run under superuser');
         }
 
         new FlockStore('/');

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -64,7 +64,7 @@ class MemcachedStoreTest extends AbstractStoreTest
 
     public function testAbortAfterExpiration()
     {
-        $this->markTestSkipped('Memcached expects a TTL greater than 1 sec. Simulating a slow network is too hard');
+       self::markTestSkipped('Memcached expects a TTL greater than 1 sec. Simulating a slow network is too hard');
     }
 
     public function testInvalidTtl()

--- a/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
@@ -65,7 +65,7 @@ class PdoDbalStoreTest extends AbstractStoreTest
 
     public function testAbortAfterExpiration()
     {
-        $this->markTestSkipped('Pdo expects a TTL greater than 1 sec. Simulating a slow network is too hard');
+       self::markTestSkipped('Pdo expects a TTL greater than 1 sec. Simulating a slow network is too hard');
     }
 
     public function testConfigureSchema()

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -59,7 +59,7 @@ class PdoStoreTest extends AbstractStoreTest
 
     public function testAbortAfterExpiration()
     {
-        $this->markTestSkipped('Pdo expects a TTL greater than 1 sec. Simulating a slow network is too hard');
+       self::markTestSkipped('Pdo expects a TTL greater than 1 sec. Simulating a slow network is too hard');
     }
 
     public function testInvalidTtl()

--- a/src/Symfony/Component/Lock/Tests/Store/PostgreSqlDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PostgreSqlDbalStoreTest.php
@@ -34,7 +34,7 @@ class PostgreSqlDbalStoreTest extends AbstractStoreTest
     public function getStore(): PersistingStoreInterface
     {
         if (!getenv('POSTGRES_HOST')) {
-            $this->markTestSkipped('Missing POSTGRES_HOST env variable');
+           self::markTestSkipped('Missing POSTGRES_HOST env variable');
         }
 
         $this->expectDeprecation('Since symfony/lock 5.4: Usage of a DBAL Connection with "Symfony\Component\Lock\Store\PostgreSqlStore" is deprecated and will be removed in symfony 6.0. Use "Symfony\Component\Lock\Store\DoctrineDbalPostgreSqlStore" instead.');

--- a/src/Symfony/Component/Lock/Tests/Store/PostgreSqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PostgreSqlStoreTest.php
@@ -31,7 +31,7 @@ class PostgreSqlStoreTest extends AbstractStoreTest
     public function getPostgresHost(): string
     {
         if (!$host = getenv('POSTGRES_HOST')) {
-            $this->markTestSkipped('Missing POSTGRES_HOST env variable');
+           self::markTestSkipped('Missing POSTGRES_HOST env variable');
         }
 
         return $host;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -228,7 +228,7 @@ class SendgridApiTransportTest extends TestCase
     public function testTagAndMetadataHeaders()
     {
         if (!class_exists(TagHeader::class)) {
-            $this->markTestSkipped('This test requires symfony/mailer 5.1 or higher.');
+           self::markTestSkipped('This test requires symfony/mailer 5.1 or higher.');
         }
 
         $email = new Email();

--- a/src/Symfony/Component/Mailer/Tests/Transport/NativeTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/NativeTransportFactoryTest.php
@@ -56,7 +56,7 @@ EOT;
     public function testCreateSendmailWithNoSendmailPath()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test cannot run on Windows.');
+           self::markTestSkipped('This test cannot run on Windows.');
         }
 
         $this->expectException(\Exception::class);
@@ -79,7 +79,7 @@ EOT;
     public function testCreateSendmailWithNoHostOrNoPort(string $dsn, string $sendmaiPath, string $smtp, string $smtpPort)
     {
         if ('\\' !== \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test only run on Windows.');
+           self::markTestSkipped('This test only run on Windows.');
         }
 
         $this->expectException(\Exception::class);

--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
@@ -48,7 +48,7 @@ class SendmailTransportTest extends TestCase
     public function testToIsUsedWhenRecipientsAreNotSet()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does not support shebangs nor non-blocking standard streams');
+           self::markTestSkipped('Windows does not support shebangs nor non-blocking standard streams');
         }
 
         $mail = new Email();
@@ -70,7 +70,7 @@ class SendmailTransportTest extends TestCase
     public function testRecipientsAreUsedWhenSet()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does not support shebangs nor non-blocking standard streams');
+           self::markTestSkipped('Windows does not support shebangs nor non-blocking standard streams');
         }
 
         $mail = new Email();

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsIntegrationTest.php
@@ -24,7 +24,7 @@ class AmazonSqsIntegrationTest extends TestCase
     public function testConnectionSendToFifoQueueAndGet()
     {
         if (!getenv('MESSENGER_SQS_FIFO_QUEUE_DSN')) {
-            $this->markTestSkipped('The "MESSENGER_SQS_FIFO_QUEUE_DSN" environment variable is required.');
+           self::markTestSkipped('The "MESSENGER_SQS_FIFO_QUEUE_DSN" environment variable is required.');
         }
 
         $this->execute(getenv('MESSENGER_SQS_FIFO_QUEUE_DSN'));
@@ -33,7 +33,7 @@ class AmazonSqsIntegrationTest extends TestCase
     public function testConnectionSendAndGet()
     {
         if (!getenv('MESSENGER_SQS_DSN')) {
-            $this->markTestSkipped('The "MESSENGER_SQS_DSN" environment variable is required.');
+           self::markTestSkipped('The "MESSENGER_SQS_DSN" environment variable is required.');
         }
 
         $this->execute(getenv('MESSENGER_SQS_DSN'));

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
@@ -42,7 +42,7 @@ class AmqpExtIntegrationTest extends TestCase
         parent::setUp();
 
         if (!getenv('MESSENGER_AMQP_DSN')) {
-            $this->markTestSkipped('The "MESSENGER_AMQP_DSN" environment variable is required.');
+           self::markTestSkipped('The "MESSENGER_AMQP_DSN" environment variable is required.');
         }
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlIntegrationTest.php
@@ -32,7 +32,7 @@ class DoctrinePostgreSqlIntegrationTest extends TestCase
     protected function setUp(): void
     {
         if (!$host = getenv('POSTGRES_HOST')) {
-            $this->markTestSkipped('Missing POSTGRES_HOST env variable');
+           self::markTestSkipped('Missing POSTGRES_HOST env variable');
         }
 
         $this->driverConnection = DriverManager::getConnection(['url' => "pgsql://postgres:password@$host"]);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -29,7 +29,7 @@ class RedisExtIntegrationTest extends TestCase
     protected function setUp(): void
     {
         if (!getenv('MESSENGER_REDIS_DSN')) {
-            $this->markTestSkipped('The "MESSENGER_REDIS_DSN" environment variable is required.');
+           self::markTestSkipped('The "MESSENGER_REDIS_DSN" environment variable is required.');
         }
 
         try {

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -71,33 +71,33 @@ command_bus
 
  The following messages can be dispatched:
 
- ----------------------------------------------------------------------------------------------------------- 
-  Symfony\Component\Messenger\Tests\Fixtures\DummyCommand                                                    
-      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler (when option1=1, option2=2)  
-                                                                                                             
-  Used whenever a test needs to show a message with a class description.                                     
-  Symfony\Component\Messenger\Tests\Fixtures\DummyCommandWithDescription                                     
-      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyCommandWithDescriptionHandler               
-                 Used whenever a test needs to show a message handler with a class description.              
-                                                                                                             
-  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                                            
-      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler                      
-                                                                                                             
- ----------------------------------------------------------------------------------------------------------- 
+ -----------------------------------------------------------------------------------------------------------
+  Symfony\Component\Messenger\Tests\Fixtures\DummyCommand
+      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler (when option1=1, option2=2)
+
+  Used whenever a test needs to show a message with a class description.
+  Symfony\Component\Messenger\Tests\Fixtures\DummyCommandWithDescription
+      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyCommandWithDescriptionHandler
+                 Used whenever a test needs to show a message handler with a class description.
+
+  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage
+      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler
+
+ -----------------------------------------------------------------------------------------------------------
 
 query_bus
 ---------
 
  The following messages can be dispatched:
 
- --------------------------------------------------------------------------------------- 
-  Symfony\Component\Messenger\Tests\Fixtures\DummyQuery                                  
-      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler            
-                                                                                         
-  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                        
-      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler  
-                                                                                         
- --------------------------------------------------------------------------------------- 
+ ---------------------------------------------------------------------------------------
+  Symfony\Component\Messenger\Tests\Fixtures\DummyQuery
+      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler
+
+  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage
+      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler
+
+ ---------------------------------------------------------------------------------------
 
 
 TXT
@@ -116,14 +116,14 @@ query_bus
 
  The following messages can be dispatched:
 
- --------------------------------------------------------------------------------------- 
-  Symfony\Component\Messenger\Tests\Fixtures\DummyQuery                                  
-      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler            
-                                                                                         
-  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                        
-      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler  
-                                                                                         
- --------------------------------------------------------------------------------------- 
+ ---------------------------------------------------------------------------------------
+  Symfony\Component\Messenger\Tests\Fixtures\DummyQuery
+      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler
+
+  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage
+      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler
+
+ ---------------------------------------------------------------------------------------
 
 
 TXT
@@ -146,12 +146,12 @@ Messenger
 command_bus
 -----------
 
- [WARNING] No handled message found in bus "command_bus".                                                               
+ [WARNING] No handled message found in bus "command_bus".
 
 query_bus
 ---------
 
- [WARNING] No handled message found in bus "query_bus".                                                                 
+ [WARNING] No handled message found in bus "query_bus".
 
 
 TXT
@@ -175,7 +175,7 @@ TXT
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $command = new DebugCommand(['command_bus' => [], 'query_bus' => []]);

--- a/src/Symfony/Component/Mime/Tests/AbstractMimeTypeGuesserTest.php
+++ b/src/Symfony/Component/Mime/Tests/AbstractMimeTypeGuesserTest.php
@@ -30,7 +30,7 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
     public function testGuessWithLeadingDash()
     {
         if (!$this->getGuesser()->isGuesserSupported()) {
-            $this->markTestSkipped('Guesser is not supported');
+           self::markTestSkipped('Guesser is not supported');
         }
 
         $cwd = getcwd();
@@ -45,7 +45,7 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
     public function testGuessImageWithoutExtension()
     {
         if (!$this->getGuesser()->isGuesserSupported()) {
-            $this->markTestSkipped('Guesser is not supported');
+           self::markTestSkipped('Guesser is not supported');
         }
 
         $this->assertEquals('image/gif', $this->getGuesser()->guessMimeType(__DIR__.'/Fixtures/mimetypes/test'));
@@ -54,7 +54,7 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
     public function testGuessImageWithDirectory()
     {
         if (!$this->getGuesser()->isGuesserSupported()) {
-            $this->markTestSkipped('Guesser is not supported');
+           self::markTestSkipped('Guesser is not supported');
         }
 
         $this->expectException(\InvalidArgumentException::class);
@@ -64,7 +64,7 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
     public function testGuessImageWithKnownExtension()
     {
         if (!$this->getGuesser()->isGuesserSupported()) {
-            $this->markTestSkipped('Guesser is not supported');
+           self::markTestSkipped('Guesser is not supported');
         }
 
         $this->assertEquals('image/gif', $this->getGuesser()->guessMimeType(__DIR__.'/Fixtures/mimetypes/test.gif'));
@@ -73,7 +73,7 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
     public function testGuessFileWithUnknownExtension()
     {
         if (!$this->getGuesser()->isGuesserSupported()) {
-            $this->markTestSkipped('Guesser is not supported');
+           self::markTestSkipped('Guesser is not supported');
         }
 
         $this->assertEquals('application/octet-stream', $this->getGuesser()->guessMimeType(__DIR__.'/Fixtures/mimetypes/.unknownextension'));
@@ -82,7 +82,7 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
     public function testGuessWithDuplicatedFileType()
     {
         if (!$this->getGuesser()->isGuesserSupported()) {
-            $this->markTestSkipped('Guesser is not supported');
+           self::markTestSkipped('Guesser is not supported');
         }
 
         $this->assertEquals('application/vnd.openxmlformats-officedocument.wordprocessingml.document', $this->getGuesser()->guessMimeType(__DIR__.'/Fixtures/test.docx'));
@@ -91,7 +91,7 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
     public function testGuessWithIncorrectPath()
     {
         if (!$this->getGuesser()->isGuesserSupported()) {
-            $this->markTestSkipped('Guesser is not supported');
+           self::markTestSkipped('Guesser is not supported');
         }
 
         $this->expectException(\InvalidArgumentException::class);
@@ -101,15 +101,15 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
     public function testGuessWithNonReadablePath()
     {
         if (!$this->getGuesser()->isGuesserSupported()) {
-            $this->markTestSkipped('Guesser is not supported');
+           self::markTestSkipped('Guesser is not supported');
         }
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Cannot verify chmod operations on Windows');
+           self::markTestSkipped('Cannot verify chmod operations on Windows');
         }
 
         if (!getenv('USER') || 'root' === getenv('USER')) {
-            $this->markTestSkipped('This test will fail if run under superuser');
+           self::markTestSkipped('This test will fail if run under superuser');
         }
 
         $path = __DIR__.'/Fixtures/mimetypes/to_delete';
@@ -120,7 +120,7 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
             $this->expectException(\InvalidArgumentException::class);
             $this->getGuesser()->guessMimeType($path);
         } else {
-            $this->markTestSkipped('Cannot verify chmod operations, change of file permissions failed');
+           self::markTestSkipped('Cannot verify chmod operations, change of file permissions failed');
         }
     }
 }

--- a/src/Symfony/Component/Mime/Tests/FileBinaryMimeTypeGuesserTest.php
+++ b/src/Symfony/Component/Mime/Tests/FileBinaryMimeTypeGuesserTest.php
@@ -23,6 +23,6 @@ class FileBinaryMimeTypeGuesserTest extends AbstractMimeTypeGuesserTest
 
     public function testGuessWithDuplicatedFileType()
     {
-        $this->markTestSkipped('Result varies depending on the OS');
+       self::markTestSkipped('Result varies depending on the OS');
     }
 }

--- a/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
@@ -140,7 +140,7 @@ class DataPartTest extends TestCase
     public function testFromPathWithUrl()
     {
         if (!\in_array('https', stream_get_wrappers())) {
-            $this->markTestSkipped('"https" stream wrapper is not enabled.');
+           self::markTestSkipped('"https" stream wrapper is not enabled.');
         }
 
         $p = DataPart::fromPath($file = 'https://symfony.com/images/common/logo/logo_symfony_header.png');

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
@@ -62,17 +62,17 @@ final class MercureTransportTest extends TransportTestCase
 
     public function testCanSetCustomPort()
     {
-        $this->markTestSkipped("Mercure transport doesn't use a regular HTTP Dsn");
+       self::markTestSkipped("Mercure transport doesn't use a regular HTTP Dsn");
     }
 
     public function testCanSetCustomHost()
     {
-        $this->markTestSkipped("Mercure transport doesn't use a regular HTTP Dsn");
+       self::markTestSkipped("Mercure transport doesn't use a regular HTTP Dsn");
     }
 
     public function testCanSetCustomHostAndPort()
     {
-        $this->markTestSkipped("Mercure transport doesn't use a regular HTTP Dsn");
+       self::markTestSkipped("Mercure transport doesn't use a regular HTTP Dsn");
     }
 
     public function testConstructWithWrongTopicsThrows()

--- a/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
@@ -68,7 +68,7 @@ class UserPasswordHashCommandTest extends TestCase
     public function testEncodePasswordArgon2i()
     {
         if (!($sodium = SodiumPasswordHasher::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('Argon2i algorithm not available.');
+           self::markTestSkipped('Argon2i algorithm not available.');
         }
         $this->setupArgon2i();
         $this->passwordHasherCommandTester->execute([
@@ -88,7 +88,7 @@ class UserPasswordHashCommandTest extends TestCase
     public function testEncodePasswordArgon2id()
     {
         if (!($sodium = (SodiumPasswordHasher::isSupported() && \defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13'))) && !\defined('PASSWORD_ARGON2ID')) {
-            $this->markTestSkipped('Argon2id algorithm not available.');
+           self::markTestSkipped('Argon2id algorithm not available.');
         }
         $this->setupArgon2id();
         $this->passwordHasherCommandTester->execute([
@@ -124,7 +124,7 @@ class UserPasswordHashCommandTest extends TestCase
     public function testEncodePasswordSodium()
     {
         if (!SodiumPasswordHasher::isSupported()) {
-            $this->markTestSkipped('Libsodium is not available.');
+           self::markTestSkipped('Libsodium is not available.');
         }
         $this->setupSodium();
         $this->passwordHasherCommandTester->execute([
@@ -197,7 +197,7 @@ class UserPasswordHashCommandTest extends TestCase
     public function testEncodePasswordArgon2iOutput()
     {
         if (!(SodiumPasswordHasher::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('Argon2i algorithm not available.');
+           self::markTestSkipped('Argon2i algorithm not available.');
         }
 
         $this->setupArgon2i();
@@ -212,7 +212,7 @@ class UserPasswordHashCommandTest extends TestCase
     public function testEncodePasswordArgon2idOutput()
     {
         if (!(SodiumPasswordHasher::isSupported() && \defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2ID')) {
-            $this->markTestSkipped('Argon2id algorithm not available.');
+           self::markTestSkipped('Argon2id algorithm not available.');
         }
 
         $this->setupArgon2id();
@@ -227,7 +227,7 @@ class UserPasswordHashCommandTest extends TestCase
     public function testEncodePasswordSodiumOutput()
     {
         if (!SodiumPasswordHasher::isSupported()) {
-            $this->markTestSkipped('Libsodium is not available.');
+           self::markTestSkipped('Libsodium is not available.');
         }
 
         $this->setupSodium();
@@ -293,7 +293,7 @@ EOTXT
     public function testCompletionSuggestions(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $command = new UserPasswordHashCommand($this->createMock(PasswordHasherFactoryInterface::class), ['App\Entity\User']);

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
@@ -146,7 +146,7 @@ class PasswordHasherFactoryTest extends TestCase
     public function testMigrateFrom()
     {
         if (!SodiumPasswordHasher::isSupported()) {
-            $this->markTestSkipped('Sodium is not available');
+           self::markTestSkipped('Sodium is not available');
         }
 
         $factory = new PasswordHasherFactory([
@@ -169,7 +169,7 @@ class PasswordHasherFactoryTest extends TestCase
     public function testMigrateFromLegacy()
     {
         if (!SodiumPasswordHasher::isSupported()) {
-            $this->markTestSkipped('Sodium is not available');
+           self::markTestSkipped('Sodium is not available');
         }
 
         $factory = new PasswordHasherFactory([

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
@@ -21,7 +21,7 @@ class SodiumPasswordHasherTest extends TestCase
     protected function setUp(): void
     {
         if (!SodiumPasswordHasher::isSupported()) {
-            $this->markTestSkipped('Libsodium is not available.');
+           self::markTestSkipped('Libsodium is not available.');
         }
     }
 

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -38,7 +38,7 @@ class ExecutableFinderTest extends TestCase
     public function testFind()
     {
         if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
+           self::markTestSkipped('Cannot test when open_basedir is set');
         }
 
         $this->setPath(\dirname(\PHP_BINARY));
@@ -52,7 +52,7 @@ class ExecutableFinderTest extends TestCase
     public function testFindWithDefault()
     {
         if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
+           self::markTestSkipped('Cannot test when open_basedir is set');
         }
 
         $expected = 'defaultValue';
@@ -68,7 +68,7 @@ class ExecutableFinderTest extends TestCase
     public function testFindWithNullAsDefault()
     {
         if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
+           self::markTestSkipped('Cannot test when open_basedir is set');
         }
 
         $this->setPath('');
@@ -83,7 +83,7 @@ class ExecutableFinderTest extends TestCase
     public function testFindWithExtraDirs()
     {
         if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
+           self::markTestSkipped('Cannot test when open_basedir is set');
         }
 
         $this->setPath('');
@@ -102,11 +102,11 @@ class ExecutableFinderTest extends TestCase
     public function testFindWithOpenBaseDir()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Cannot run test on windows');
+           self::markTestSkipped('Cannot run test on windows');
         }
 
         if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
+           self::markTestSkipped('Cannot test when open_basedir is set');
         }
 
         $this->iniSet('open_basedir', \dirname(\PHP_BINARY).\PATH_SEPARATOR.'/');
@@ -123,10 +123,10 @@ class ExecutableFinderTest extends TestCase
     public function testFindProcessInOpenBasedir()
     {
         if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
+           self::markTestSkipped('Cannot test when open_basedir is set');
         }
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Cannot run test on windows');
+           self::markTestSkipped('Cannot run test on windows');
         }
 
         $this->setPath('');
@@ -141,10 +141,10 @@ class ExecutableFinderTest extends TestCase
     public function testFindBatchExecutableOnWindows()
     {
         if (\ini_get('open_basedir')) {
-            $this->markTestSkipped('Cannot test when open_basedir is set');
+           self::markTestSkipped('Cannot test when open_basedir is set');
         }
         if ('\\' !== \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Can be only tested on windows');
+           self::markTestSkipped('Can be only tested on windows');
         }
 
         $target = tempnam(sys_get_temp_dir(), 'example-windows-executable');

--- a/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
@@ -66,7 +66,7 @@ class PhpExecutableFinderTest extends TestCase
     public function testFindWithExecutableDirectory()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Directories are not executable on Windows');
+           self::markTestSkipped('Directories are not executable on Windows');
         }
 
         $originalPhpBinary = getenv('PHP_BINARY');

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -69,7 +69,7 @@ class ProcessTest extends TestCase
     public function testThatProcessDoesNotThrowWarningDuringRun()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test is transient on Windows');
+           self::markTestSkipped('This test is transient on Windows');
         }
         @trigger_error('Test Error', \E_USER_NOTICE);
         $process = $this->getProcessForCode('sleep(3)');
@@ -463,7 +463,7 @@ class ProcessTest extends TestCase
     public function testExitCodeCommandFailed()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does not support POSIX exit code');
+           self::markTestSkipped('Windows does not support POSIX exit code');
         }
 
         // such command run in bash return an exitcode 127
@@ -476,11 +476,11 @@ class ProcessTest extends TestCase
     public function testTTYCommand()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does not have /dev/tty support');
+           self::markTestSkipped('Windows does not have /dev/tty support');
         }
 
         if (!Process::isTtySupported()) {
-            $this->markTestSkipped('There is no TTY support');
+           self::markTestSkipped('There is no TTY support');
         }
 
         $process = $this->getProcess('echo "foo" >> /dev/null && '.$this->getProcessForCode('usleep(100000);')->getCommandLine());
@@ -495,11 +495,11 @@ class ProcessTest extends TestCase
     public function testTTYCommandExitCode()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does have /dev/tty support');
+           self::markTestSkipped('Windows does have /dev/tty support');
         }
 
         if (!Process::isTtySupported()) {
-            $this->markTestSkipped('There is no TTY support');
+           self::markTestSkipped('There is no TTY support');
         }
 
         $process = $this->getProcess('echo "foo" >> /dev/null');
@@ -514,7 +514,7 @@ class ProcessTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('TTY mode is not supported on Windows platform.');
         if ('\\' !== \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test is for Windows platform only');
+           self::markTestSkipped('This test is for Windows platform only');
         }
 
         $process = $this->getProcess('echo "foo" >> /dev/null');
@@ -531,7 +531,7 @@ class ProcessTest extends TestCase
     public function testPTYCommand()
     {
         if (!Process::isPtySupported()) {
-            $this->markTestSkipped('PTY is not supported on this operating system.');
+           self::markTestSkipped('PTY is not supported on this operating system.');
         }
 
         $process = $this->getProcess('echo "foo"');
@@ -676,7 +676,7 @@ class ProcessTest extends TestCase
     public function testProcessIsNotSignaled()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does not support POSIX signals');
+           self::markTestSkipped('Windows does not support POSIX signals');
         }
 
         $process = $this->getProcess('echo foo');
@@ -687,7 +687,7 @@ class ProcessTest extends TestCase
     public function testProcessWithoutTermSignal()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does not support POSIX signals');
+           self::markTestSkipped('Windows does not support POSIX signals');
         }
 
         $process = $this->getProcess('echo foo');
@@ -698,7 +698,7 @@ class ProcessTest extends TestCase
     public function testProcessIsSignaledIfStopped()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows does not support POSIX signals');
+           self::markTestSkipped('Windows does not support POSIX signals');
         }
 
         $process = $this->getProcessForCode('sleep(32);');
@@ -713,11 +713,11 @@ class ProcessTest extends TestCase
         $this->expectException(ProcessSignaledException::class);
         $this->expectExceptionMessage('The process has been signaled with signal "9".');
         if (!\function_exists('posix_kill')) {
-            $this->markTestSkipped('Function posix_kill is required.');
+           self::markTestSkipped('Function posix_kill is required.');
         }
 
         if (self::$sigchild) {
-            $this->markTestSkipped('PHP is compiled with --enable-sigchild.');
+           self::markTestSkipped('PHP is compiled with --enable-sigchild.');
         }
 
         $process = $this->getProcessForCode('sleep(32.1);');
@@ -1001,7 +1001,7 @@ class ProcessTest extends TestCase
     public function testWrongSignal()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('POSIX signals do not work on Windows');
+           self::markTestSkipped('POSIX signals do not work on Windows');
         }
 
         $this->expectException(RuntimeException::class);

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -160,7 +160,7 @@ class PhpDocExtractorTest extends TestCase
     public function testExtractCollection($property, array $type = null, $shortDescription, $longDescription)
     {
         if (!class_exists(Collection::class)) {
-            $this->markTestSkipped('Collections are not implemented in current phpdocumentor/type-resolver version');
+           self::markTestSkipped('Collections are not implemented in current phpdocumentor/type-resolver version');
         }
 
         $this->testExtract($property, $type, $shortDescription, $longDescription);

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -47,7 +47,7 @@ class SerializerExtractorTest extends TestCase
     public function testGetPropertiesWithIgnoredProperties()
     {
         if (!class_exists(Ignore::class)) {
-            $this->markTestSkipped('Ignore annotation is not implemented in current symfony/serializer version');
+           self::markTestSkipped('Ignore annotation is not implemented in current symfony/serializer version');
         }
 
         $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['a']]));

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
@@ -147,7 +147,7 @@ class EncoderFactoryTest extends TestCase
     public function testMigrateFrom()
     {
         if (!SodiumPasswordEncoder::isSupported()) {
-            $this->markTestSkipped('Sodium is not available');
+           self::markTestSkipped('Sodium is not available');
         }
 
         $factory = new EncoderFactory([

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
@@ -23,7 +23,7 @@ class SodiumPasswordEncoderTest extends TestCase
     protected function setUp(): void
     {
         if (!SodiumPasswordEncoder::isSupported()) {
-            $this->markTestSkipped('Libsodium is not available.');
+           self::markTestSkipped('Libsodium is not available.');
         }
     }
 

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/GuardBridgeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/GuardBridgeAuthenticatorTest.php
@@ -38,7 +38,7 @@ class GuardBridgeAuthenticatorTest extends TestCase
     protected function setUp(): void
     {
         if (!interface_exists(\Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface::class)) {
-            $this->markTestSkipped('Authenticator system not installed.');
+           self::markTestSkipped('Authenticator system not installed.');
         }
 
         $this->guardAuthenticator = $this->createMock(AuthenticatorInterface::class);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
@@ -121,7 +121,7 @@ trait CallbacksTestTrait
 
         $obj = new CallbacksObject();
 
-        $this->markTestSkipped('Callback validation for callbacks in the context has been forgotten. See https://github.com/symfony/symfony/pull/30950');
+       self::markTestSkipped('Callback validation for callbacks in the context has been forgotten. See https://github.com/symfony/symfony/pull/30950');
         $this->expectException(InvalidArgumentException::class);
         $normalizer->normalize($obj, null, ['callbacks' => $callbacks]);
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectToPopulateTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectToPopulateTestTrait.php
@@ -54,7 +54,7 @@ trait ObjectToPopulateTestTrait
 
     public function testObjectToPopulateNoMatch()
     {
-        $this->markTestSkipped('something broken here!');
+       self::markTestSkipped('something broken here!');
         $denormalizer = $this->getDenormalizerForObjectToPopulate();
 
         $objectToPopulate = new ObjectInner();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -354,7 +354,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testRejectInvalidKey()
     {
-        $this->markTestSkipped('This test makes no sense with the GetSetMethodNormalizer');
+       self::markTestSkipped('This test makes no sense with the GetSetMethodNormalizer');
     }
 
     protected function getNormalizerForIgnoredAttributes(): GetSetMethodNormalizer

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -732,7 +732,7 @@ class ObjectNormalizerTest extends TestCase
     public function testDoesntHaveIssuesWithUnionConstTypes()
     {
         if (!class_exists(PhpStanExtractor::class) || !class_exists(PhpDocParser::class)) {
-            $this->markTestSkipped('phpstan/phpdoc-parser required for this test');
+           self::markTestSkipped('phpstan/phpdoc-parser required for this test');
         }
 
         $extractor = new PropertyInfoExtractor([], [new PhpStanExtractor(), new PhpDocExtractor(), new ReflectionExtractor()]);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -311,7 +311,7 @@ class PropertyNormalizerTest extends TestCase
 
     public function testIgnoredAttributesContextDenormalizeInherit()
     {
-        $this->markTestSkipped('This has not been tested previously - did not manage to make the test work');
+       self::markTestSkipped('This has not been tested previously - did not manage to make the test work');
     }
 
     protected function getNormalizerForMaxDepth(): PropertyNormalizer

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -49,7 +49,7 @@ abstract class AbstractAsciiTestCase extends TestCase
     public function testBytesAt(array $expected, string $string, int $offset, int $form = null)
     {
         if (2 !== grapheme_strlen('च्छे') && 'नमस्ते' === $string) {
-            $this->markTestSkipped('Skipping due to issue ICU-21661.');
+           self::markTestSkipped('Skipping due to issue ICU-21661.');
         }
 
         $instance = static::createFromString($string);
@@ -174,7 +174,7 @@ abstract class AbstractAsciiTestCase extends TestCase
     public function testLength(int $length, string $string)
     {
         if (2 !== grapheme_strlen('च्छे') && 'अनुच्छेद' === $string) {
-            $this->markTestSkipped('Skipping due to issue ICU-21661.');
+           self::markTestSkipped('Skipping due to issue ICU-21661.');
         }
 
         $instance = static::createFromString($string);

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -83,7 +83,7 @@ END'],
     public function testCodePointsAt(array $expected, string $string, int $offset, int $form = null)
     {
         if (2 !== grapheme_strlen('च्छे') && 'नमस्ते' === $string) {
-            $this->markTestSkipped('Skipping due to issue ICU-21661.');
+           self::markTestSkipped('Skipping due to issue ICU-21661.');
         }
 
         $instance = static::createFromString($string);

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -603,7 +603,7 @@ XLIFF
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $application = new Application();

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -329,7 +329,7 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $application = new Application();

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -21,7 +21,7 @@ class TranslationDataCollectorTest extends TestCase
     protected function setUp(): void
     {
         if (!class_exists(DataCollector::class)) {
-            $this->markTestSkipped('The "DataCollector" is not available');
+           self::markTestSkipped('The "DataCollector" is not available');
         }
     }
 

--- a/src/Symfony/Component/Translation/Tests/Formatter/IntlFormatterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/IntlFormatterTest.php
@@ -37,7 +37,7 @@ class IntlFormatterTest extends \PHPUnit\Framework\TestCase
     public function testFormatWithNamedArguments()
     {
         if (version_compare(\INTL_ICU_VERSION, '4.8', '<')) {
-            $this->markTestSkipped('Format with named arguments can only be run with ICU 4.8 or higher and PHP >= 5.5');
+           self::markTestSkipped('Format with named arguments can only be run with ICU 4.8 or higher and PHP >= 5.5');
         }
 
         $chooseMessage = <<<'_MSG_'

--- a/src/Symfony/Component/Translation/Tests/Loader/LocalizedTestCase.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/LocalizedTestCase.php
@@ -18,7 +18,7 @@ abstract class LocalizedTestCase extends TestCase
     protected function setUp(): void
     {
         if (!\extension_loaded('intl')) {
-            $this->markTestSkipped('Extension intl is required.');
+           self::markTestSkipped('Extension intl is required.');
         }
     }
 }

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -60,7 +60,7 @@ class TranslatorCacheTest extends TestCase
     public function testThatACacheIsUsed($debug)
     {
         if (!class_exists(\MessageFormatter::class)) {
-            $this->markTestSkipped(sprintf('Skipping test as the required "%s" class does not exist. Consider installing the "intl" PHP extension or the "symfony/polyfill-intl-messageformatter" package.', \MessageFormatter::class));
+           self::markTestSkipped(sprintf('Skipping test as the required "%s" class does not exist. Consider installing the "intl" PHP extension or the "symfony/polyfill-intl-messageformatter" package.', \MessageFormatter::class));
         }
 
         $locale = 'any_locale';

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -399,7 +399,7 @@ class TranslatorTest extends TestCase
     public function testTransICU(...$args)
     {
         if (!class_exists(\MessageFormatter::class)) {
-            $this->markTestSkipped(sprintf('Skipping test as the required "%s" class does not exist. Consider installing the "intl" PHP extension or the "symfony/polyfill-intl-messageformatter" package.', \MessageFormatter::class));
+           self::markTestSkipped(sprintf('Skipping test as the required "%s" class does not exist. Consider installing the "intl" PHP extension or the "symfony/polyfill-intl-messageformatter" package.', \MessageFormatter::class));
         }
 
         $this->testTrans(...$args);

--- a/src/Symfony/Component/Uid/Tests/Command/GenerateUlidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/GenerateUlidCommandTest.php
@@ -109,7 +109,7 @@ final class GenerateUlidCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $application = new Application();

--- a/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
@@ -238,7 +238,7 @@ final class GenerateUuidCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $application = new Application();

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
@@ -114,6 +114,6 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
 
     public function provideComparisonsToNullValueAtPropertyPath()
     {
-        $this->markTestSkipped('DivisibleByValidator rejects null values.');
+       self::markTestSkipped('DivisibleByValidator rejects null values.');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -77,19 +77,19 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires either the "value" or "propertyPath" option to be set.');
-        $this->markTestSkipped('Value option always set for PositiveOrZero constraint');
+       self::markTestSkipped('Value option always set for PositiveOrZero constraint');
     }
 
     public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires only one of the "value" or "propertyPath" options to be set, not both.');
-        $this->markTestSkipped('Value option is set for PositiveOrZero constraint automatically');
+       self::markTestSkipped('Value option is set for PositiveOrZero constraint automatically');
     }
 
     public function testInvalidValuePath()
     {
-        $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
+       self::markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 
     /**
@@ -97,7 +97,7 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
      */
     public function testValidComparisonToPropertyPath($comparedValue)
     {
-        $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
+       self::markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 
     /**
@@ -105,11 +105,11 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
      */
     public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
     {
-        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
+       self::markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
     }
 
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
-        $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
+       self::markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -75,24 +75,24 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires either the "value" or "propertyPath" option to be set.');
-        $this->markTestSkipped('Value option always set for Positive constraint.');
+       self::markTestSkipped('Value option always set for Positive constraint.');
     }
 
     public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires only one of the "value" or "propertyPath" options to be set, not both.');
-        $this->markTestSkipped('Value option is set for Positive constraint automatically');
+       self::markTestSkipped('Value option is set for Positive constraint automatically');
     }
 
     public function testNoViolationOnNullObjectWithPropertyPath()
     {
-        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+       self::markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
 
     public function testInvalidValuePath()
     {
-        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+       self::markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
 
     /**
@@ -100,7 +100,7 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
      */
     public function testValidComparisonToPropertyPath($comparedValue)
     {
-        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+       self::markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
 
     /**
@@ -108,11 +108,11 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
      */
     public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
     {
-        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
+       self::markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
     }
 
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
-        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+       self::markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -549,7 +549,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     public function testCorrupted(Image $constraint)
     {
         if (!\function_exists('imagecreatefromstring')) {
-            $this->markTestSkipped('This test require GD extension');
+           self::markTestSkipped('This test require GD extension');
         }
 
         $this->validator->validate($this->image, $constraint);

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -75,24 +75,24 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires either the "value" or "propertyPath" option to be set.');
-        $this->markTestSkipped('Value option always set for NegativeOrZero constraint');
+       self::markTestSkipped('Value option always set for NegativeOrZero constraint');
     }
 
     public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires only one of the "value" or "propertyPath" options to be set, not both.');
-        $this->markTestSkipped('Value option is set for NegativeOrZero constraint automatically');
+       self::markTestSkipped('Value option is set for NegativeOrZero constraint automatically');
     }
 
     public function testNoViolationOnNullObjectWithPropertyPath()
     {
-        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+       self::markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
     public function testInvalidValuePath()
     {
-        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+       self::markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
     /**
@@ -100,7 +100,7 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
      */
     public function testValidComparisonToPropertyPath($comparedValue)
     {
-        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+       self::markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
     /**
@@ -108,7 +108,7 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
      */
     public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
     {
-        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
+       self::markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
     }
 
     /**
@@ -116,11 +116,11 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
      */
     public function testCompareWithNullValueAtPropertyAt($dirtyValue, $dirtyValueAsString, $isValid)
     {
-        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+       self::markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
-        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+       self::markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -75,24 +75,24 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires either the "value" or "propertyPath" option to be set.');
-        $this->markTestSkipped('Value option always set for Negative constraint');
+       self::markTestSkipped('Value option always set for Negative constraint');
     }
 
     public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('requires only one of the "value" or "propertyPath" options to be set, not both.');
-        $this->markTestSkipped('Value option is set for Negative constraint automatically');
+       self::markTestSkipped('Value option is set for Negative constraint automatically');
     }
 
     public function testNoViolationOnNullObjectWithPropertyPath()
     {
-        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+       self::markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 
     public function testInvalidValuePath()
     {
-        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+       self::markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 
     /**
@@ -100,7 +100,7 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
      */
     public function testValidComparisonToPropertyPath($comparedValue)
     {
-        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+       self::markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 
     /**
@@ -108,7 +108,7 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
      */
     public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
     {
-        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
+       self::markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
     }
 
     /**
@@ -116,11 +116,11 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
      */
     public function testCompareWithNullValueAtPropertyAt($dirtyValue, $dirtyValueAsString, $isValid)
     {
-        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+       self::markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
-        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+       self::markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -336,7 +336,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $tzDbVersion = isset($matches[1]) ? (int) trim($matches[1]) : 0;
 
         if (!$tzDbVersion || 2017 <= $tzDbVersion) {
-            $this->markTestSkipped('"Europe/Saratov" is expired until 2017, current version is '.$tzDbVersion);
+           self::markTestSkipped('"Europe/Saratov" is expired until 2017, current version is '.$tzDbVersion);
         }
 
         $constraint = new Timezone([

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -152,7 +152,7 @@ EODUMP;
     public function testHtmlDump()
     {
         if (\ini_get('xdebug.file_link_format') || get_cfg_var('xdebug.file_link_format')) {
-            $this->markTestSkipped('A custom file_link_format is defined.');
+           self::markTestSkipped('A custom file_link_format is defined.');
         }
 
         $e = $this->getTestException(1);

--- a/src/Symfony/Component/VarDumper/Tests/Caster/MemcachedCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/MemcachedCasterTest.php
@@ -24,7 +24,7 @@ class MemcachedCasterTest extends TestCase
     public function testCastMemcachedWithDefaultOptions()
     {
         if (!class_exists(\Memcached::class)) {
-            $this->markTestSkipped('Memcached not available');
+           self::markTestSkipped('Memcached not available');
         }
 
         $var = new \Memcached();
@@ -54,7 +54,7 @@ EOTXT;
     public function testCastMemcachedWithCustomOptions()
     {
         if (!class_exists(\Memcached::class)) {
-            $this->markTestSkipped('Memcached not available');
+           self::markTestSkipped('Memcached not available');
         }
 
         $var = new \Memcached();

--- a/src/Symfony/Component/VarDumper/Tests/Caster/RdKafkaCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/RdKafkaCasterTest.php
@@ -69,7 +69,7 @@ EODUMP;
     public function testDumpProducer()
     {
         if (!$this->hasBroker) {
-            $this->markTestSkipped('Test requires an active broker');
+           self::markTestSkipped('Test requires an active broker');
         }
 
         $producer = new Producer(new Conf());
@@ -132,7 +132,7 @@ EODUMP;
     public function testDumpKafkaConsumer()
     {
         if (!$this->hasBroker) {
-            $this->markTestSkipped('Test requires an active broker');
+           self::markTestSkipped('Test requires an active broker');
         }
 
         $conf = new Conf();

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -503,7 +503,7 @@ EOTXT
     public function testGenerator()
     {
         if (\extension_loaded('xdebug')) {
-            $this->markTestSkipped('xdebug is active');
+           self::markTestSkipped('xdebug is active');
         }
 
         $generator = new GeneratorDemo();
@@ -550,7 +550,7 @@ array:2 [
         Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::foo()
         ›     yield 1;
         › }
-        › 
+        ›
       }
 %A  }
     closed: false

--- a/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
@@ -82,7 +82,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                         (
                             [type] => 4
                             [class] => stdClass
-                            [value] => 
+                            [value] =>
                             [cut] => 0
                             [handle] => %i
                             [refCount] => 0
@@ -101,7 +101,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                         (
                             [type] => 4
                             [class] => stdClass
-                            [value] => 
+                            [value] =>
                             [cut] => 0
                             [handle] => %i
                             [refCount] => 0
@@ -116,7 +116,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                         (
                             [type] => 4
                             [class] => stdClass
-                            [value] => 
+                            [value] =>
                             [cut] => 0
                             [handle] => %i
                             [refCount] => 0
@@ -331,7 +331,7 @@ EOTXT;
     public function testJsonCast()
     {
         if (2 == \ini_get('xdebug.overload_var_dump')) {
-            $this->markTestSkipped('xdebug is active');
+           self::markTestSkipped('xdebug is active');
         }
 
         $data = (array) json_decode('{"1":{}}');
@@ -421,7 +421,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                         (
                             [type] => 4
                             [class] => %s
-                            [value] => 
+                            [value] =>
                             [cut] => 0
                             [handle] => %i
                             [refCount] => 0
@@ -479,7 +479,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                         (
                             [type] => 4
                             [class] => Symfony\Component\VarDumper\Tests\Fixtures\Php74
-                            [value] => 
+                            [value] =>
                             [cut] => 0
                             [handle] => %i
                             [refCount] => 0
@@ -500,12 +500,12 @@ Symfony\Component\VarDumper\Cloner\Data Object
                     [p2] => Symfony\Component\VarDumper\Cloner\Stub Object
                         (
                             [type] => 1
-                            [class] => 
+                            [class] =>
                             [value] => Symfony\Component\VarDumper\Cloner\Stub Object
                                 (
                                     [type] => 4
                                     [class] => stdClass
-                                    [value] => 
+                                    [value] =>
                                     [cut] => 0
                                     [handle] => %i
                                     [refCount] => 1
@@ -529,12 +529,12 @@ Symfony\Component\VarDumper\Cloner\Data Object
                     [p3] => Symfony\Component\VarDumper\Cloner\Stub Object
                         (
                             [type] => 1
-                            [class] => 
+                            [class] =>
                             [value] => Symfony\Component\VarDumper\Cloner\Stub Object
                                 (
                                     [type] => 4
                                     [class] => stdClass
-                                    [value] => 
+                                    [value] =>
                                     [cut] => 0
                                     [handle] => %i
                                     [refCount] => 1
@@ -595,7 +595,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                         (
                             [type] => 4
                             [class] => Symfony\Component\VarDumper\Tests\Fixtures\Php81Enums
-                            [value] => 
+                            [value] =>
                             [cut] => 0
                             [handle] => %i
                             [refCount] => 0
@@ -616,7 +616,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                         (
                             [type] => 4
                             [class] => Symfony\Component\VarDumper\Tests\Fixtures\UnitEnumFixture
-                            [value] => 
+                            [value] =>
                             [cut] => 0
                             [handle] => %i
                             [refCount] => 0
@@ -633,7 +633,7 @@ Symfony\Component\VarDumper\Cloner\Data Object
                         (
                             [type] => 4
                             [class] => Symfony\Component\VarDumper\Tests\Fixtures\BackedEnumFixture
-                            [value] => 
+                            [value] =>
                             [cut] => 0
                             [handle] => %i
                             [refCount] => 0

--- a/src/Symfony/Component/VarDumper/Tests/Command/ServerDumpCommandTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/ServerDumpCommandTest.php
@@ -24,7 +24,7 @@ class ServerDumpCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $tester = new CommandCompletionTester($this->createCommand());

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -145,9 +145,9 @@ RuntimeException {
   trace: {
     %ACliDumperTest.php:%d {
       Symfony\Component\VarDumper\Tests\Dumper\CliDumperTest->testDumpWithCommaFlagsAndExceptionCodeExcerpt()
-      › 
+      ›
       › $ex = new \RuntimeException('foo');
-      › 
+      ›
     }
     %A
   }
@@ -360,7 +360,7 @@ stream resource {@{$ref}
         __TwigTemplate_VarDumperFixture_u75a09->doDisplay(array \$context, array \$blocks = [])
         › foo bar
         ›   twig source
-        › 
+        ›
       }
       %s%eTemplate.php:%d { …}
       %s%eTemplate.php:%d { …}
@@ -527,7 +527,7 @@ EOTXT
     public function testDumpArrayWithColor($value, $flags, $expectedOut)
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('Windows console does not support coloration');
+           self::markTestSkipped('Windows console does not support coloration');
         }
 
         $out = '';

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -24,7 +24,7 @@ class HtmlDumperTest extends TestCase
     public function testGet()
     {
         if (\ini_get('xdebug.file_link_format') || get_cfg_var('xdebug.file_link_format')) {
-            $this->markTestSkipped('A custom file_link_format is defined.');
+           self::markTestSkipped('A custom file_link_format is defined.');
         }
 
         require __DIR__.'/../Fixtures/dumb-var.php';

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
@@ -40,7 +40,7 @@ class ServerDumperTest extends TestCase
     public function testDump()
     {
         if ('True' === getenv('APPVEYOR')) {
-            $this->markTestSkipped('Skip transient test on AppVeyor');
+           self::markTestSkipped('Skip transient test on AppVeyor');
         }
 
         $wrappedDumper = $this->createMock(DataDumperInterface::class);

--- a/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
@@ -25,7 +25,7 @@ class ConnectionTest extends TestCase
     public function testDump()
     {
         if ('True' === getenv('APPVEYOR')) {
-            $this->markTestSkipped('Skip transient test on AppVeyor');
+           self::markTestSkipped('Skip transient test on AppVeyor');
         }
 
         $cloner = new VarCloner();

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -103,7 +103,7 @@ class VarExporterTest extends TestCase
         } elseif (\PHP_VERSION_ID < 70400) {
             $fixtureFile = __DIR__.'/Fixtures/'.$testName.'-legacy.php';
         } else {
-            $this->markTestSkipped('PHP >= 7.4.6 required.');
+           self::markTestSkipped('PHP >= 7.4.6 required.');
         }
         $this->assertStringEqualsFile($fixtureFile, $dump);
 

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -93,7 +93,7 @@ YAML;
     public function testLintAutodetectsGithubActionEnvironment()
     {
         if (!class_exists(GithubActionReporter::class)) {
-            $this->markTestSkipped('The "github" format is only available since "symfony/console" >= 5.3.');
+           self::markTestSkipped('The "github" format is only available since "symfony/console" >= 5.3.');
         }
 
         $prev = getenv('GITHUB_ACTIONS');
@@ -171,7 +171,7 @@ YAML;
     public function testComplete(array $input, array $expectedSuggestions)
     {
         if (!class_exists(CommandCompletionTester::class)) {
-            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+           self::markTestSkipped('Test command completion requires symfony/console 5.4+.');
         }
 
         $tester = new CommandCompletionTester($this->createCommand());

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -96,13 +96,13 @@ class InlineTest extends TestCase
     {
         $locale = setlocale(\LC_NUMERIC, 0);
         if (false === $locale) {
-            $this->markTestSkipped('Your platform does not support locales.');
+           self::markTestSkipped('Your platform does not support locales.');
         }
 
         try {
             $requiredLocales = ['fr_FR.UTF-8', 'fr_FR.UTF8', 'fr_FR.utf-8', 'fr_FR.utf8', 'French_France.1252'];
             if (false === setlocale(\LC_NUMERIC, $requiredLocales)) {
-                $this->markTestSkipped('Could not set any of required locales: '.implode(', ', $requiredLocales));
+               self::markTestSkipped('Could not set any of required locales: '.implode(', ', $requiredLocales));
             }
 
             $this->assertEquals('1.2', Inline::dump(1.2));

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2569,11 +2569,11 @@ YAML;
         $this->expectException(ParseException::class);
         $this->expectExceptionMessageMatches('#^File ".+/Fixtures/not_readable.yml" cannot be read\.$#');
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('chmod is not supported on Windows');
+           self::markTestSkipped('chmod is not supported on Windows');
         }
 
         if (!getenv('USER') || 'root' === getenv('USER')) {
-            $this->markTestSkipped('This test will fail if run under superuser');
+           self::markTestSkipped('This test will fail if run under superuser');
         }
 
         $file = __DIR__.'/Fixtures/not_readable.yml';

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -1123,7 +1123,7 @@ abstract class HttpClientTestCase extends TestCase
     {
         $client = $this->getHttpClient(__FUNCTION__);
         if (!method_exists($client, 'withOptions')) {
-            $this->markTestSkipped(sprintf('Not implementing "%s::withOptions()" is deprecated.', get_debug_type($client)));
+           self::markTestSkipped(sprintf('Not implementing "%s::withOptions()" is deprecated.', get_debug_type($client)));
         }
 
         $client2 = $client->withOptions(['base_uri' => 'http://localhost:8057/']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Refs #48668
| License       | MIT
| Doc PR        | n/a

Spotted while working on
* https://github.com/symfony/symfony/pull/48668

`$this->markTestSkipped()` was defined in a dataProvider (I didn't even know it's possible), so I propose to use the method as static across the whole codebase.

[See reference](https://github.com/symfony/symfony/pull/49242#discussion_r1096640763)

Thoughts @nicolas-grekas ?