### PR TITLE
[TwigBridge] Improve form_errors of bootstrap5 form theme

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -353,7 +353,7 @@
 {%- block form_errors -%}
     {%- if errors|length > 0 -%}
         {%- for error in errors -%}
-            <div class="invalid-feedback d-block">{{ error.message }}</div>
+            <div class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block">{{ error.message }}</div>
         {%- endfor -%}
     {%- endif %}
 {%- endblock form_errors %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5HorizontalLayoutTest.php
@@ -28,9 +28,9 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
-        $form->addError(new FormError('[trans]Error![/trans]'));
-        $html = $this->renderRow($form->createView());
+        $form = $this->factory->createNamed('')->add('name', TextType::class);
+        $form->get('name')->addError(new FormError('[trans]Error![/trans]'));
+        $html = $this->renderRow($form->get('name')->createView());
 
         $this->assertMatchesXpath($html,
             '/div
@@ -55,9 +55,9 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
 
     public function testRowWithCustomClass()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
-        $form->addError(new FormError('[trans]Error![/trans]'));
-        $html = $this->renderRow($form->createView(), [
+        $form = $this->factory->createNamed('')->add('name', TextType::class);
+        $form->get('name')->addError(new FormError('[trans]Error![/trans]'));
+        $html = $this->renderRow($form->get('name')->createView(), [
             'row_attr' => [
                 'class' => 'mb-5',
             ],

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
@@ -40,9 +40,9 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
-        $form->addError(new FormError('[trans]Error![/trans]'));
-        $html = $this->renderRow($form->createView());
+        $form = $this->factory->createNamed('')->add('name', TextType::class);
+        $form->get('name')->addError(new FormError('[trans]Error![/trans]'));
+        $html = $this->renderRow($form->get('name')->createView());
 
         $this->assertMatchesXpath($html,
             '/div
@@ -61,9 +61,9 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testRowWithCustomClass()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
-        $form->addError(new FormError('[trans]Error![/trans]'));
-        $html = $this->renderRow($form->createView(), [
+        $form = $this->factory->createNamed('')->add('name', TextType::class);
+        $form->get('name')->addError(new FormError('[trans]Error![/trans]'));
+        $html = $this->renderRow($form->get('name')->createView(), [
             'row_attr' => [
                 'class' => 'mb-5',
             ],
@@ -309,10 +309,33 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testErrors()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        self::markTestSkipped('This method has been split into testRootErrors() and testRowErrors().');
+    }
+
+    public function testRootErrors()
+    {
+        $form = $this->factory->createNamed('');
         $form->addError(new FormError('[trans]Error 1[/trans]'));
         $form->addError(new FormError('[trans]Error 2[/trans]'));
         $html = $this->renderErrors($form->createView());
+
+        $this->assertMatchesXpath($html,
+            '/div
+    [@class="alert alert-danger d-block"]
+    [.="[trans]Error 1[/trans]"]
+    /following-sibling::div
+    [@class="alert alert-danger d-block"]
+    [.="[trans]Error 2[/trans]"]
+'
+        );
+    }
+
+    public function testRowErrors()
+    {
+        $form = $this->factory->createNamed('')->add('name', TextType::class);
+        $form->get('name')->addError(new FormError('[trans]Error 1[/trans]'));
+        $form->get('name')->addError(new FormError('[trans]Error 2[/trans]'));
+        $html = $this->renderErrors($form->get('name')->createView());
 
         $this->assertMatchesXpath($html,
             '/div


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR improves output of `form_errors()` for the root form with Bootstrap 5 form theme.

### Example

<details>
<summary>Usage code</summary>

```php
public function buildForm(FormBuilderInterface $builder, array $options): void
{
    $builder
        ->add('text', TextType::class, [
            'constraints' => new Assert\NotBlank(),
        ])
        ->add('textarea', TextareaType::class, [
            'attr' => [
                'rows' => 3,
            ],
            'constraints' => new Assert\NotBlank(),
        ])
        ->add('select', ChoiceType::class, [
            'choices' => [
                'Alice' => 'Alice',
                'Bob' => 'Bob',
                'Charlie' => 'Charlie',
            ],
            'constraints' => new Assert\Choice(choices: ['Dave']),
        ])
        ->add('selectMultiple', ChoiceType::class, [
            'multiple' => true,
            'choices' => [
                'Alice' => 'Alice',
                'Bob' => 'Bob',
                'Charlie' => 'Charlie',
            ],
            'constraints' => new Assert\Choice(choices: ['Dave']),
        ])
        ->add('radio', ChoiceType::class, [
            'expanded' => true,
            'choices' => [
                'Alice' => 'Alice',
                'Bob' => 'Bob',
                'Charlie' => 'Charlie',
            ],
            'constraints' => new Assert\Choice(choices: ['Dave']),
        ])
        ->add('checkbox', ChoiceType::class, [
            'expanded' => true,
            'multiple' => true,
            'choices' => [
                'Alice' => 'Alice',
                'Bob' => 'Bob',
                'Charlie' => 'Charlie',
            ],
            'constraints' => new Assert\Choice(choices: ['Dave']),
        ])
        ->add('singleCheckbox', CheckboxType::class, [
            'constraints' => new Assert\NotBlank(),
        ])
    ;
}
```

</details>

#### Before

<img width="1343" alt="image" src="https://user-images.githubusercontent.com/4360663/216811963-ea66cdfa-2080-4ee0-aaef-433f3276843b.png">

#### After

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/4360663/216811972-54b0666b-ccf6-4ecd-9435-f24dfed96447.png">

