### PR TITLE
[Tests] Migrate data providers to static ones

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
@@ -35,7 +35,7 @@ class DoctrineOrmTypeGuesserTest extends TestCase
         $this->assertEquals($expected, $this->getGuesser($classMetadata)->guessType('TestEntity', 'field'));
     }
 
-    public function requiredType()
+    public static function requiredType()
     {
         yield [Types::DATE_IMMUTABLE, new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateType', ['input' => 'datetime_immutable'], Guess::HIGH_CONFIDENCE)];
         yield [Types::DATE_MUTABLE, new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateType', [], Guess::HIGH_CONFIDENCE)];

--- a/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTest.php
@@ -51,40 +51,40 @@ abstract class AbstractDescriptorTest extends TestCase
         $this->assertDescription($expectedDescription, $application);
     }
 
-    public function getDescribeInputArgumentTestData()
+    public static function getDescribeInputArgumentTestData()
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getInputArguments());
+        return static::getDescriptionTestData(ObjectsProvider::getInputArguments());
     }
 
-    public function getDescribeInputOptionTestData()
+    public static function getDescribeInputOptionTestData()
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getInputOptions());
+        return static::getDescriptionTestData(ObjectsProvider::getInputOptions());
     }
 
-    public function getDescribeInputDefinitionTestData()
+    public static function getDescribeInputDefinitionTestData()
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getInputDefinitions());
+        return static::getDescriptionTestData(ObjectsProvider::getInputDefinitions());
     }
 
-    public function getDescribeCommandTestData()
+    public static function getDescribeCommandTestData()
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getCommands());
+        return static::getDescriptionTestData(ObjectsProvider::getCommands());
     }
 
-    public function getDescribeApplicationTestData()
+    public static function getDescribeApplicationTestData()
     {
-        return $this->getDescriptionTestData(ObjectsProvider::getApplications());
+        return static::getDescriptionTestData(ObjectsProvider::getApplications());
     }
 
     abstract protected function getDescriptor();
 
-    abstract protected function getFormat();
+    abstract protected static function getFormat();
 
-    protected function getDescriptionTestData(array $objects)
+    protected static function getDescriptionTestData(array $objects)
     {
         $data = [];
         foreach ($objects as $name => $object) {
-            $description = file_get_contents(sprintf('%s/../Fixtures/%s.%s', __DIR__, $name, $this->getFormat()));
+            $description = file_get_contents(sprintf('%s/../Fixtures/%s.%s', __DIR__, $name, static::getFormat()));
             $data[] = [$object, $description];
         }
 

--- a/src/Symfony/Component/Console/Tests/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/JsonDescriptorTest.php
@@ -20,7 +20,7 @@ class JsonDescriptorTest extends AbstractDescriptorTest
         return new JsonDescriptor();
     }
 
-    protected function getFormat()
+    protected static function getFormat()
     {
         return 'json';
     }

--- a/src/Symfony/Component/Console/Tests/Descriptor/MarkdownDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/MarkdownDescriptorTest.php
@@ -17,17 +17,17 @@ use Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString;
 
 class MarkdownDescriptorTest extends AbstractDescriptorTest
 {
-    public function getDescribeCommandTestData()
+    public static function getDescribeCommandTestData()
     {
-        return $this->getDescriptionTestData(array_merge(
+        return self::getDescriptionTestData(array_merge(
             ObjectsProvider::getCommands(),
             ['command_mbstring' => new DescriptorCommandMbString()]
         ));
     }
 
-    public function getDescribeApplicationTestData()
+    public static function getDescribeApplicationTestData()
     {
-        return $this->getDescriptionTestData(array_merge(
+        return self::getDescriptionTestData(array_merge(
             ObjectsProvider::getApplications(),
             ['application_mbstring' => new DescriptorApplicationMbString()]
         ));
@@ -38,7 +38,7 @@ class MarkdownDescriptorTest extends AbstractDescriptorTest
         return new MarkdownDescriptor();
     }
 
-    protected function getFormat()
+    protected static function getFormat()
     {
         return 'md';
     }

--- a/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
@@ -18,17 +18,17 @@ use Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString;
 
 class TextDescriptorTest extends AbstractDescriptorTest
 {
-    public function getDescribeCommandTestData()
+    public static function getDescribeCommandTestData()
     {
-        return $this->getDescriptionTestData(array_merge(
+        return self::getDescriptionTestData(array_merge(
             ObjectsProvider::getCommands(),
             ['command_mbstring' => new DescriptorCommandMbString()]
         ));
     }
 
-    public function getDescribeApplicationTestData()
+    public static function getDescribeApplicationTestData()
     {
-        return $this->getDescriptionTestData(array_merge(
+        return self::getDescriptionTestData(array_merge(
             ObjectsProvider::getApplications(),
             ['application_mbstring' => new DescriptorApplicationMbString()]
         ));
@@ -46,7 +46,7 @@ class TextDescriptorTest extends AbstractDescriptorTest
         return new TextDescriptor();
     }
 
-    protected function getFormat()
+    protected static function getFormat()
     {
         return 'txt';
     }

--- a/src/Symfony/Component/Console/Tests/Descriptor/XmlDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/XmlDescriptorTest.php
@@ -20,7 +20,7 @@ class XmlDescriptorTest extends AbstractDescriptorTest
         return new XmlDescriptor();
     }
 
-    protected function getFormat()
+    protected static function getFormat()
     {
         return 'xml';
     }

--- a/src/Symfony/Component/CssSelector/Tests/Node/AbstractNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/AbstractNodeTest.php
@@ -28,7 +28,7 @@ abstract class AbstractNodeTest extends TestCase
         $this->assertEquals($value, $node->getSpecificity()->getValue());
     }
 
-    abstract public function getToStringConversionTestData();
+    abstract public static function getToStringConversionTestData();
 
-    abstract public function getSpecificityValueTestData();
+    abstract public static function getSpecificityValueTestData();
 }

--- a/src/Symfony/Component/CssSelector/Tests/Node/AttributeNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/AttributeNodeTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\CssSelector\Node\ElementNode;
 
 class AttributeNodeTest extends AbstractNodeTest
 {
-    public function getToStringConversionTestData()
+    public static function getToStringConversionTestData()
     {
         return [
             [new AttributeNode(new ElementNode(), null, 'attribute', 'exists', null), 'Attribute[Element[*][attribute]]'],
@@ -25,7 +25,7 @@ class AttributeNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getSpecificityValueTestData()
+    public static function getSpecificityValueTestData()
     {
         return [
             [new AttributeNode(new ElementNode(), null, 'attribute', 'exists', null), 10],

--- a/src/Symfony/Component/CssSelector/Tests/Node/ClassNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/ClassNodeTest.php
@@ -16,14 +16,14 @@ use Symfony\Component\CssSelector\Node\ElementNode;
 
 class ClassNodeTest extends AbstractNodeTest
 {
-    public function getToStringConversionTestData()
+    public static function getToStringConversionTestData()
     {
         return [
             [new ClassNode(new ElementNode(), 'class'), 'Class[Element[*].class]'],
         ];
     }
 
-    public function getSpecificityValueTestData()
+    public static function getSpecificityValueTestData()
     {
         return [
             [new ClassNode(new ElementNode(), 'class'), 10],

--- a/src/Symfony/Component/CssSelector/Tests/Node/CombinedSelectorNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/CombinedSelectorNodeTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\CssSelector\Node\ElementNode;
 
 class CombinedSelectorNodeTest extends AbstractNodeTest
 {
-    public function getToStringConversionTestData()
+    public static function getToStringConversionTestData()
     {
         return [
             [new CombinedSelectorNode(new ElementNode(), '>', new ElementNode()), 'CombinedSelector[Element[*] > Element[*]]'],
@@ -24,7 +24,7 @@ class CombinedSelectorNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getSpecificityValueTestData()
+    public static function getSpecificityValueTestData()
     {
         return [
             [new CombinedSelectorNode(new ElementNode(), '>', new ElementNode()), 0],

--- a/src/Symfony/Component/CssSelector/Tests/Node/ElementNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/ElementNodeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\CssSelector\Node\ElementNode;
 
 class ElementNodeTest extends AbstractNodeTest
 {
-    public function getToStringConversionTestData()
+    public static function getToStringConversionTestData()
     {
         return [
             [new ElementNode(), 'Element[*]'],
@@ -24,7 +24,7 @@ class ElementNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getSpecificityValueTestData()
+    public static function getSpecificityValueTestData()
     {
         return [
             [new ElementNode(), 0],

--- a/src/Symfony/Component/CssSelector/Tests/Node/FunctionNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/FunctionNodeTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\CssSelector\Parser\Token;
 
 class FunctionNodeTest extends AbstractNodeTest
 {
-    public function getToStringConversionTestData()
+    public static function getToStringConversionTestData()
     {
         return [
             [new FunctionNode(new ElementNode(), 'function'), 'Function[Element[*]:function()]'],
@@ -31,7 +31,7 @@ class FunctionNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getSpecificityValueTestData()
+    public static function getSpecificityValueTestData()
     {
         return [
             [new FunctionNode(new ElementNode(), 'function'), 10],

--- a/src/Symfony/Component/CssSelector/Tests/Node/HashNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/HashNodeTest.php
@@ -16,14 +16,14 @@ use Symfony\Component\CssSelector\Node\HashNode;
 
 class HashNodeTest extends AbstractNodeTest
 {
-    public function getToStringConversionTestData()
+    public static function getToStringConversionTestData()
     {
         return [
             [new HashNode(new ElementNode(), 'id'), 'Hash[Element[*]#id]'],
         ];
     }
 
-    public function getSpecificityValueTestData()
+    public static function getSpecificityValueTestData()
     {
         return [
             [new HashNode(new ElementNode(), 'id'), 100],

--- a/src/Symfony/Component/CssSelector/Tests/Node/NegationNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/NegationNodeTest.php
@@ -17,14 +17,14 @@ use Symfony\Component\CssSelector\Node\NegationNode;
 
 class NegationNodeTest extends AbstractNodeTest
 {
-    public function getToStringConversionTestData()
+    public static function getToStringConversionTestData()
     {
         return [
             [new NegationNode(new ElementNode(), new ClassNode(new ElementNode(), 'class')), 'Negation[Element[*]:not(Class[Element[*].class])]'],
         ];
     }
 
-    public function getSpecificityValueTestData()
+    public static function getSpecificityValueTestData()
     {
         return [
             [new NegationNode(new ElementNode(), new ClassNode(new ElementNode(), 'class')), 10],

--- a/src/Symfony/Component/CssSelector/Tests/Node/PseudoNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/PseudoNodeTest.php
@@ -16,14 +16,14 @@ use Symfony\Component\CssSelector\Node\PseudoNode;
 
 class PseudoNodeTest extends AbstractNodeTest
 {
-    public function getToStringConversionTestData()
+    public static function getToStringConversionTestData()
     {
         return [
             [new PseudoNode(new ElementNode(), 'pseudo'), 'Pseudo[Element[*]:pseudo]'],
         ];
     }
 
-    public function getSpecificityValueTestData()
+    public static function getSpecificityValueTestData()
     {
         return [
             [new PseudoNode(new ElementNode(), 'pseudo'), 10],

--- a/src/Symfony/Component/CssSelector/Tests/Node/SelectorNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/SelectorNodeTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\CssSelector\Node\SelectorNode;
 
 class SelectorNodeTest extends AbstractNodeTest
 {
-    public function getToStringConversionTestData()
+    public static function getToStringConversionTestData()
     {
         return [
             [new SelectorNode(new ElementNode()), 'Selector[Element[*]]'],
@@ -24,7 +24,7 @@ class SelectorNodeTest extends AbstractNodeTest
         ];
     }
 
-    public function getSpecificityValueTestData()
+    public static function getSpecificityValueTestData()
     {
         return [
             [new SelectorNode(new ElementNode()), 0],

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -47,7 +47,7 @@ class ParserTest extends TestCase
         $this->assertEquals($node, $parser->parse($lexer->tokenize($expression), $names));
     }
 
-    public function getParseData()
+    public static function getParseData()
     {
         $arguments = new Node\ArgumentsNode();
         $arguments->addElement(new Node\ConstantNode('arg1'));
@@ -139,10 +139,10 @@ class ParserTest extends TestCase
 
             // chained calls
             [
-                $this->createGetAttrNode(
-                    $this->createGetAttrNode(
-                        $this->createGetAttrNode(
-                            $this->createGetAttrNode(new Node\NameNode('foo'), 'bar', Node\GetAttrNode::METHOD_CALL),
+                self::createGetAttrNode(
+                    self::createGetAttrNode(
+                        self::createGetAttrNode(
+                            self::createGetAttrNode(new Node\NameNode('foo'), 'bar', Node\GetAttrNode::METHOD_CALL),
                             'foo', Node\GetAttrNode::METHOD_CALL),
                         'baz', Node\GetAttrNode::PROPERTY_CALL),
                     '3', Node\GetAttrNode::ARRAY_CALL),
@@ -192,7 +192,7 @@ class ParserTest extends TestCase
         ];
     }
 
-    private function createGetAttrNode($node, $item, $type)
+    private static function createGetAttrNode($node, $item, $type)
     {
         return new Node\GetAttrNode($node, new Node\ConstantNode($item, Node\GetAttrNode::ARRAY_CALL !== $type), new Node\ArgumentsNode(), $type);
     }
@@ -208,7 +208,7 @@ class ParserTest extends TestCase
         $parser->parse($lexer->tokenize($expr), $names);
     }
 
-    public function getInvalidPostfixData()
+    public static function getInvalidPostfixData()
     {
         return [
             [
@@ -258,7 +258,7 @@ class ParserTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
-    public function getLintData(): array
+    public static function getLintData(): array
     {
         return [
             'valid expression' => [

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
@@ -204,7 +204,7 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $resolver->getController($request);
     }
 
-    public function getUndefinedControllers()
+    public static function getUndefinedControllers(): array
     {
         $tests = parent::getUndefinedControllers();
         $tests[0] = ['foo', \InvalidArgumentException::class, 'Controller "foo" does neither exist as service nor as class'];

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -165,7 +165,7 @@ class ControllerResolverTest extends TestCase
         $resolver->getController($request);
     }
 
-    public function getUndefinedControllers()
+    public static function getUndefinedControllers()
     {
         $controller = new ControllerTest();
 

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -91,7 +91,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $this->assertIsIntlSuccess($formatter, $errorMessage, $errorCode);
     }
 
-    public function formatProvider()
+    public static function formatProvider()
     {
         $dateTime = new \DateTime('@0');
         $dateTimeImmutable = new \DateTimeImmutable('@0');
@@ -316,7 +316,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $this->assertIsIntlFailure($formatter, $errorMessage, $errorCode);
     }
 
-    public function formatErrorProvider()
+    public static function formatErrorProvider()
     {
         return [
             ['y-M-d', 'foobar', 'datefmt_format: string \'foobar\' is not numeric, which would be required for it to be a valid date: U_ILLEGAL_ARGUMENT_ERROR'],
@@ -333,7 +333,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $this->assertSame($expected, $formatter->format($timestamp));
     }
 
-    public function formatWithTimezoneProvider()
+    public static function formatWithTimezoneProvider()
     {
         $data = [
             [0, 'UTC', '1970-01-01 00:00:00'],
@@ -379,7 +379,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $this->assertEquals($expected, $formatter->format(0));
     }
 
-    public function formatTimezoneProvider()
+    public static function formatTimezoneProvider()
     {
         return [
             ['z', 'GMT', 'GMT'],
@@ -528,7 +528,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $this->assertSame($expected, $formatter->format($timestamp));
     }
 
-    public function dateAndTimeTypeProvider()
+    public static function dateAndTimeTypeProvider()
     {
         return [
             [0, IntlDateFormatter::FULL, IntlDateFormatter::NONE, 'Thursday, January 1, 1970'],
@@ -585,7 +585,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $this->assertIsIntlSuccess($formatter, $errorMessage, $errorCode);
     }
 
-    public function parseProvider()
+    public static function parseProvider()
     {
         return array_merge(
             static::parseYearProvider(),
@@ -610,7 +610,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         );
     }
 
-    public function parseYearProvider()
+    public static function parseYearProvider()
     {
         return [
             ['y-M-d', '1970-1-1', 0],
@@ -618,7 +618,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseQuarterProvider()
+    public static function parseQuarterProvider()
     {
         return [
             ['Q', '1', 0],
@@ -641,7 +641,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseMonthProvider()
+    public static function parseMonthProvider()
     {
         return [
             ['y-M-d', '1970-1-1', 0],
@@ -651,7 +651,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseStandaloneMonthProvider()
+    public static function parseStandaloneMonthProvider()
     {
         return [
             ['y-L-d', '1970-1-1', 0],
@@ -660,7 +660,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseDayProvider()
+    public static function parseDayProvider()
     {
         return [
             ['y-M-d', '1970-1-1', 0],
@@ -670,7 +670,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseDayOfWeekProvider()
+    public static function parseDayOfWeekProvider()
     {
         return [
             ['E', 'Thu', 0],
@@ -682,7 +682,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseDayOfYearProvider()
+    public static function parseDayOfYearProvider()
     {
         return [
             ['D', '1', 0],
@@ -690,7 +690,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseHour12ClockOneBasedProvider()
+    public static function parseHour12ClockOneBasedProvider()
     {
         return [
             // 12 hours (1-12)
@@ -715,7 +715,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseHour12ClockZeroBasedProvider()
+    public static function parseHour12ClockZeroBasedProvider()
     {
         return [
             // 12 hours (0-11)
@@ -740,7 +740,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseHour24ClockOneBasedProvider()
+    public static function parseHour24ClockOneBasedProvider()
     {
         return [
             // 24 hours (1-24)
@@ -767,7 +767,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseHour24ClockZeroBasedProvider()
+    public static function parseHour24ClockZeroBasedProvider()
     {
         return [
             // 24 hours (0-23)
@@ -794,7 +794,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseMinuteProvider()
+    public static function parseMinuteProvider()
     {
         return [
             ['y-M-d HH:m', '1970-1-1 0:1', 60],
@@ -802,7 +802,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseSecondProvider()
+    public static function parseSecondProvider()
     {
         return [
             ['y-M-d HH:mm:s', '1970-1-1 00:01:1', 61],
@@ -810,7 +810,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseTimezoneProvider()
+    public static function parseTimezoneProvider()
     {
         if (80114 === \PHP_VERSION_ID || 80201 === \PHP_VERSION_ID) {
             return [['y-M-d HH:mm:ss', '1970-1-1 00:00:00', 0]];
@@ -830,7 +830,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseAmPmProvider()
+    public static function parseAmPmProvider()
     {
         return [
             // AM/PM (already covered by hours tests)
@@ -839,7 +839,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseStandaloneAmPmProvider()
+    public static function parseStandaloneAmPmProvider()
     {
         return [
             ['a', 'AM', 0],
@@ -847,7 +847,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseRegexMetaCharsProvider()
+    public static function parseRegexMetaCharsProvider()
     {
         return [
             // regexp meta chars in the pattern string
@@ -856,7 +856,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseQuoteCharsProvider()
+    public static function parseQuoteCharsProvider()
     {
         return [
             ["'M'", 'M', 0],
@@ -867,7 +867,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         ];
     }
 
-    public function parseDashSlashProvider()
+    public static function parseDashSlashProvider()
     {
         return [
             ['y-M-d', '1970/1/1', 0],
@@ -890,7 +890,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $this->assertIsIntlFailure($formatter, $errorMessage, $errorCode);
     }
 
-    public function parseErrorProvider()
+    public static function parseErrorProvider()
     {
         return [
             // 1 char month
@@ -945,7 +945,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $this->assertEquals($expectedTimeZoneId, $formatter->getTimeZoneId());
     }
 
-    public function setTimeZoneIdProvider()
+    public static function setTimeZoneIdProvider()
     {
         return [
             ['UTC', 'UTC'],

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -153,24 +153,24 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         parent::testFormatWithNonStandardTimezone();
     }
 
-    public function parseStandaloneAmPmProvider()
+    public static function parseStandaloneAmPmProvider()
     {
-        return $this->notImplemented(parent::parseStandaloneAmPmProvider());
+        return self::notImplemented(parent::parseStandaloneAmPmProvider());
     }
 
-    public function parseDayOfWeekProvider()
+    public static function parseDayOfWeekProvider()
     {
-        return $this->notImplemented(parent::parseDayOfWeekProvider());
+        return self::notImplemented(parent::parseDayOfWeekProvider());
     }
 
-    public function parseDayOfYearProvider()
+    public static function parseDayOfYearProvider()
     {
-        return $this->notImplemented(parent::parseDayOfYearProvider());
+        return self::notImplemented(parent::parseDayOfYearProvider());
     }
 
-    public function parseQuarterProvider()
+    public static function parseQuarterProvider()
     {
-        return $this->notImplemented(parent::parseQuarterProvider());
+        return self::notImplemented(parent::parseQuarterProvider());
     }
 
     public function testParseThreeDigitsYears()
@@ -221,7 +221,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
      * + 10 seconds) are added, then we have 86,400 seconds (24h * 60min * 60s)
      * + 10 seconds
      */
-    private function notImplemented(array $dataSets): array
+    private static function notImplemented(array $dataSets): array
     {
         return array_map(function (array $row) {
             return [$row[0], $row[1], 0];

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -34,7 +34,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals($expected, $formatter->formatCurrency($value, $currency));
     }
 
-    public function formatCurrencyWithDecimalStyleProvider()
+    public static function formatCurrencyWithDecimalStyleProvider()
     {
         return [
             [100, 'ALL', '100'],
@@ -66,7 +66,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals($expected, $formatter->formatCurrency($value, $currency));
     }
 
-    public function formatCurrencyWithCurrencyStyleProvider()
+    public static function formatCurrencyWithCurrencyStyleProvider()
     {
         return [
             [100, 'ALL', "ALL\xc2\xa0100"],
@@ -94,7 +94,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals(sprintf($expected, $symbol), $formatter->formatCurrency($value, $currency));
     }
 
-    public function formatCurrencyWithCurrencyStyleCostaRicanColonsRoundingProvider()
+    public static function formatCurrencyWithCurrencyStyleCostaRicanColonsRoundingProvider()
     {
         return [
             [100, 'CRC', 'CRC', "%s\xc2\xa0100.00"],
@@ -112,7 +112,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals(sprintf($expected, $symbol), $formatter->formatCurrency($value, $currency));
     }
 
-    public function formatCurrencyWithCurrencyStyleBrazilianRealRoundingProvider()
+    public static function formatCurrencyWithCurrencyStyleBrazilianRealRoundingProvider()
     {
         return [
             [100, 'BRL', 'R', '%s$100.00'],
@@ -141,7 +141,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals(sprintf($expected, $symbol), $formatter->formatCurrency($value, $currency));
     }
 
-    public function formatCurrencyWithCurrencyStyleSwissRoundingProvider()
+    public static function formatCurrencyWithCurrencyStyleSwissRoundingProvider()
     {
         return [
             [100, 'CHF', 'CHF', "%s\xc2\xa0100.00"],
@@ -196,7 +196,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals($expected, $formattedValue, $message);
     }
 
-    public function formatTypeInt32Provider()
+    public static function formatTypeInt32Provider()
     {
         $formatter = static::getNumberFormatter('en', NumberFormatter::DECIMAL);
 
@@ -221,7 +221,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals($expected, $formattedValue, $message);
     }
 
-    public function formatTypeInt32WithCurrencyStyleProvider()
+    public static function formatTypeInt32WithCurrencyStyleProvider()
     {
         $formatter = static::getNumberFormatter('en', NumberFormatter::CURRENCY);
 
@@ -246,7 +246,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals($expected, $formattedValue);
     }
 
-    public function formatTypeInt64Provider()
+    public static function formatTypeInt64Provider()
     {
         $formatter = static::getNumberFormatter('en', NumberFormatter::DECIMAL);
 
@@ -269,7 +269,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals($expected, $formattedValue);
     }
 
-    public function formatTypeInt64WithCurrencyStyleProvider()
+    public static function formatTypeInt64WithCurrencyStyleProvider()
     {
         $formatter = static::getNumberFormatter('en', NumberFormatter::CURRENCY);
 
@@ -290,7 +290,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals($expected, $formattedValue);
     }
 
-    public function formatTypeDoubleProvider()
+    public static function formatTypeDoubleProvider()
     {
         $formatter = static::getNumberFormatter('en', NumberFormatter::DECIMAL);
 
@@ -311,7 +311,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEquals($expected, $formattedValue);
     }
 
-    public function formatTypeDoubleWithCurrencyStyleProvider()
+    public static function formatTypeDoubleWithCurrencyStyleProvider()
     {
         $formatter = static::getNumberFormatter('en', NumberFormatter::CURRENCY);
 
@@ -349,7 +349,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertFalse(@$formatter->format($value, NumberFormatter::TYPE_CURRENCY));
     }
 
-    public function formatTypeCurrencyProvider()
+    public static function formatTypeCurrencyProvider()
     {
         $df = static::getNumberFormatter('en', NumberFormatter::DECIMAL);
         $cf = static::getNumberFormatter('en', NumberFormatter::CURRENCY);
@@ -383,7 +383,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         }
     }
 
-    public function formatFractionDigitsProvider()
+    public static function formatFractionDigitsProvider()
     {
         yield [1.123, '1.123', null, 0];
         yield [1.123, '1', 0, 0];
@@ -413,7 +413,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         }
     }
 
-    public function formatGroupingUsedProvider()
+    public static function formatGroupingUsedProvider()
     {
         yield [1000, '1,000', null, 1];
         yield [1000, '1000', 0, 0];
@@ -434,7 +434,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_HALFUP rounding mode.');
     }
 
-    public function formatRoundingModeRoundHalfUpProvider()
+    public static function formatRoundingModeRoundHalfUpProvider()
     {
         // The commented value is differently rounded by intl's NumberFormatter in 32 and 64 bit architectures
         return [
@@ -459,7 +459,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_HALFDOWN rounding mode.');
     }
 
-    public function formatRoundingModeRoundHalfDownProvider()
+    public static function formatRoundingModeRoundHalfDownProvider()
     {
         return [
             [1.121, '1.12'],
@@ -483,7 +483,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_HALFEVEN rounding mode.');
     }
 
-    public function formatRoundingModeRoundHalfEvenProvider()
+    public static function formatRoundingModeRoundHalfEvenProvider()
     {
         return [
             [1.121, '1.12'],
@@ -507,7 +507,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_CEILING rounding mode.');
     }
 
-    public function formatRoundingModeRoundCeilingProvider()
+    public static function formatRoundingModeRoundCeilingProvider()
     {
         return [
             [1.123, '1.13'],
@@ -532,7 +532,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_FLOOR rounding mode.');
     }
 
-    public function formatRoundingModeRoundFloorProvider()
+    public static function formatRoundingModeRoundFloorProvider()
     {
         return [
             [1.123, '1.12'],
@@ -557,7 +557,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_DOWN rounding mode.');
     }
 
-    public function formatRoundingModeRoundDownProvider()
+    public static function formatRoundingModeRoundDownProvider()
     {
         return [
             [1.123, '1.12'],
@@ -582,7 +582,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_UP rounding mode.');
     }
 
-    public function formatRoundingModeRoundUpProvider()
+    public static function formatRoundingModeRoundUpProvider()
     {
         return [
             [1.123, '1.13'],
@@ -661,7 +661,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertSame(0 !== $errorCode, $this->isIntlFailure($formatter->getErrorCode()));
     }
 
-    public function parseProvider()
+    public static function parseProvider()
     {
         return [
             ['prefix1', false, '->parse() does not parse a number with a string prefix.', 0],
@@ -727,7 +727,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertSame($expected, $parsedValue, $message);
     }
 
-    public function parseTypeInt32Provider()
+    public static function parseTypeInt32Provider()
     {
         return [
             ['1', 1],
@@ -819,7 +819,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $this->assertEqualsWithDelta($expectedValue, $parsedValue, 0.001);
     }
 
-    public function parseTypeDoubleProvider()
+    public static function parseTypeDoubleProvider()
     {
         return [
             ['1', (float) 1],
@@ -854,7 +854,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
     /**
      * @return NumberFormatter|\NumberFormatter
      */
-    abstract protected function getNumberFormatter(string $locale = 'en', string $style = null, string $pattern = null);
+    abstract protected static function getNumberFormatter(string $locale = 'en', string $style = null, string $pattern = null);
 
     abstract protected function getIntlErrorMessage(): string;
 

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
@@ -171,7 +171,7 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         $formatter->setTextAttribute(NumberFormatter::NEGATIVE_PREFIX, '-');
     }
 
-    protected function getNumberFormatter(?string $locale = 'en', string $style = null, string $pattern = null): NumberFormatter
+    protected static function getNumberFormatter(?string $locale = 'en', string $style = null, string $pattern = null): NumberFormatter
     {
         return new class($locale, $style, $pattern) extends NumberFormatter {
         };

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
@@ -39,7 +39,7 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         parent::testGetTextAttribute();
     }
 
-    protected function getNumberFormatter(?string $locale = 'en', string $style = null, string $pattern = null): \NumberFormatter
+    protected static function getNumberFormatter(?string $locale = 'en', string $style = null, string $pattern = null): \NumberFormatter
     {
         return new \NumberFormatter($locale, $style, $pattern);
     }

--- a/src/Symfony/Component/Translation/Tests/PseudoLocalizationTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/PseudoLocalizationTranslatorTest.php
@@ -26,24 +26,24 @@ final class PseudoLocalizationTranslatorTest extends TestCase
         $this->assertSame($expected, (new PseudoLocalizationTranslator(new IdentityTranslator(), $options))->trans($input));
     }
 
-    public function provideTrans(): array
+    public static function provideTrans(): array
     {
         return [
             ['[ƒöö⭐ ≤þ≥ƁÅŔ≤⁄þ≥]', 'foo⭐ <p>BAR</p>'], // Test defaults
-            ['before <div data-label="fcy"><a href="#" title="bar" data-content="ccc">foo</a></div> after', 'before <div data-label="fcy"><a href="#" title="bar" data-content="ccc">foo</a></div> after', $this->getIsolatedOptions(['parse_html' => true])],
-            ['ƀéƒöŕé <div data-label="fcyéé"><a href="#" title="bar" data-content="ccc">ƒöö éé</a></div> åƒţéŕ', 'before <div data-label="fcyéé"><a href="#" title="bar" data-content="ccc">foo éé</a></div> after', $this->getIsolatedOptions(['parse_html' => true, 'accents' => true])],
-            ['ƀéƒöŕé <div data-label="ƒçý"><a href="#" title="ƀåŕ" data-content="ccc">ƒöö</a></div> åƒţéŕ', 'before <div data-label="fcy"><a href="#" title="bar" data-content="ccc">foo</a></div> after', $this->getIsolatedOptions(['parse_html' => true, 'localizable_html_attributes' => ['data-label', 'title'], 'accents' => true])],
-            [' ¡″♯€‰⅋´{}⁎⁺،‐·⁄⓪①②③④⑤⑥⑦⑧⑨∶⁏≤≂≥¿՞ÅƁÇÐÉƑĜĤÎĴĶĻṀÑÖÞǪŔŠŢÛṼŴẊÝŽ⁅∖⁆˄‿‵åƀçðéƒĝĥîĵķļɱñöþǫŕšţûṽŵẋýž(¦)˞', ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~', $this->getIsolatedOptions(['accents' => true])],
-            ['foo <p>bar</p> ~~~~~~~~~~ ~~', 'foo <p>bar</p>', $this->getIsolatedOptions(['expansion_factor' => 2.0])],
-            ['foo <p>bar</p> ~~~ ~~', 'foo <p>bar</p>', $this->getIsolatedOptions(['parse_html' => true, 'expansion_factor' => 2.0])], // Only the visible text length is expanded
-            ['foobar ~~', 'foobar', $this->getIsolatedOptions(['expansion_factor' => 1.35])], // 6*1.35 = 8.1 but we round up to 9
-            ['[foobar]', 'foobar', $this->getIsolatedOptions(['brackets' => true])],
-            ['[foobar ~~~]', 'foobar', $this->getIsolatedOptions(['expansion_factor' => 2.0, 'brackets' => true])], // The added brackets are taken into account in the expansion
-            ['<p data-foo="&quot;ççç&lt;å">ƀåŕ</p>', '<p data-foo="&quot;ccc&lt;a">bar</p>', $this->getIsolatedOptions(['parse_html' => true, 'localizable_html_attributes' => ['data-foo'], 'accents' => true])],
-            ['<p data-foo="ççéç&quot;&quot;">ƀåéŕ</p>', '<p data-foo="ccéc&quot;&quot;">baér</p>', $this->getIsolatedOptions(['parse_html' => true, 'localizable_html_attributes' => ['data-foo'], 'accents' => true])],
-            ['<p data-foo="ccc&quot;&quot;">ƀåŕ</p>', '<p data-foo="ccc&quot;&quot;">bar</p>', $this->getIsolatedOptions(['parse_html' => true, 'accents' => true])],
-            ['<p>″≤″</p>', '<p>&quot;&lt;&quot;</p>', $this->getIsolatedOptions(['parse_html' => true, 'accents' => true])],
-            ['Symfony is an Open Source, community-driven project with thousands of contributors. ~~~~~~~ ~~ ~~~~ ~~~~~~~ ~~~~~~~ ~~ ~~~~ ~~~~~~~~~~~~~ ~~~~~~~~~~~~~ ~~~~~~~ ~~ ~~~', 'Symfony is an Open Source, community-driven project with thousands of contributors.', $this->getIsolatedOptions(['expansion_factor' => 2.0])],
+            ['before <div data-label="fcy"><a href="#" title="bar" data-content="ccc">foo</a></div> after', 'before <div data-label="fcy"><a href="#" title="bar" data-content="ccc">foo</a></div> after', self::getIsolatedOptions(['parse_html' => true])],
+            ['ƀéƒöŕé <div data-label="fcyéé"><a href="#" title="bar" data-content="ccc">ƒöö éé</a></div> åƒţéŕ', 'before <div data-label="fcyéé"><a href="#" title="bar" data-content="ccc">foo éé</a></div> after', self::getIsolatedOptions(['parse_html' => true, 'accents' => true])],
+            ['ƀéƒöŕé <div data-label="ƒçý"><a href="#" title="ƀåŕ" data-content="ccc">ƒöö</a></div> åƒţéŕ', 'before <div data-label="fcy"><a href="#" title="bar" data-content="ccc">foo</a></div> after', self::getIsolatedOptions(['parse_html' => true, 'localizable_html_attributes' => ['data-label', 'title'], 'accents' => true])],
+            [' ¡″♯€‰⅋´{}⁎⁺،‐·⁄⓪①②③④⑤⑥⑦⑧⑨∶⁏≤≂≥¿՞ÅƁÇÐÉƑĜĤÎĴĶĻṀÑÖÞǪŔŠŢÛṼŴẊÝŽ⁅∖⁆˄‿‵åƀçðéƒĝĥîĵķļɱñöþǫŕšţûṽŵẋýž(¦)˞', ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~', self::getIsolatedOptions(['accents' => true])],
+            ['foo <p>bar</p> ~~~~~~~~~~ ~~', 'foo <p>bar</p>', self::getIsolatedOptions(['expansion_factor' => 2.0])],
+            ['foo <p>bar</p> ~~~ ~~', 'foo <p>bar</p>', self::getIsolatedOptions(['parse_html' => true, 'expansion_factor' => 2.0])], // Only the visible text length is expanded
+            ['foobar ~~', 'foobar', self::getIsolatedOptions(['expansion_factor' => 1.35])], // 6*1.35 = 8.1 but we round up to 9
+            ['[foobar]', 'foobar', self::getIsolatedOptions(['brackets' => true])],
+            ['[foobar ~~~]', 'foobar', self::getIsolatedOptions(['expansion_factor' => 2.0, 'brackets' => true])], // The added brackets are taken into account in the expansion
+            ['<p data-foo="&quot;ççç&lt;å">ƀåŕ</p>', '<p data-foo="&quot;ccc&lt;a">bar</p>', self::getIsolatedOptions(['parse_html' => true, 'localizable_html_attributes' => ['data-foo'], 'accents' => true])],
+            ['<p data-foo="ççéç&quot;&quot;">ƀåéŕ</p>', '<p data-foo="ccéc&quot;&quot;">baér</p>', self::getIsolatedOptions(['parse_html' => true, 'localizable_html_attributes' => ['data-foo'], 'accents' => true])],
+            ['<p data-foo="ccc&quot;&quot;">ƀåŕ</p>', '<p data-foo="ccc&quot;&quot;">bar</p>', self::getIsolatedOptions(['parse_html' => true, 'accents' => true])],
+            ['<p>″≤″</p>', '<p>&quot;&lt;&quot;</p>', self::getIsolatedOptions(['parse_html' => true, 'accents' => true])],
+            ['Symfony is an Open Source, community-driven project with thousands of contributors. ~~~~~~~ ~~ ~~~~ ~~~~~~~ ~~~~~~~ ~~ ~~~~ ~~~~~~~~~~~~~ ~~~~~~~~~~~~~ ~~~~~~~ ~~ ~~~', 'Symfony is an Open Source, community-driven project with thousands of contributors.', self::getIsolatedOptions(['expansion_factor' => 2.0])],
         ];
     }
 
@@ -60,7 +60,7 @@ final class PseudoLocalizationTranslatorTest extends TestCase
         ]);
     }
 
-    public function provideInvalidExpansionFactor(): array
+    public static function provideInvalidExpansionFactor(): array
     {
         return [
             [0],
@@ -69,7 +69,7 @@ final class PseudoLocalizationTranslatorTest extends TestCase
         ];
     }
 
-    private function getIsolatedOptions(array $options): array
+    private static function getIsolatedOptions(array $options): array
     {
         return array_replace([
             'parse_html' => false,

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -124,14 +124,14 @@ YAML;
         $this->assertEquals($expected, var_export($this->parser->parse($yaml), true), $comment);
     }
 
-    public function getDataFormSpecifications()
+    public static function getDataFormSpecifications()
     {
-        return $this->loadTestsFromFixtureFiles('index.yml');
+        return self::loadTestsFromFixtureFiles('index.yml');
     }
 
-    public function getNonStringMappingKeysData()
+    public static function getNonStringMappingKeysData()
     {
-        return $this->loadTestsFromFixtureFiles('nonStringKeys.yml');
+        return self::loadTestsFromFixtureFiles('nonStringKeys.yml');
     }
 
     /**
@@ -2390,7 +2390,7 @@ INI;
         $this->parser->parse($ini);
     }
 
-    private function loadTestsFromFixtureFiles($testsFile)
+    private static function loadTestsFromFixtureFiles($testsFile)
     {
         $parser = new Parser();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes-ish
| New feature?  | no
| Deprecations? | no
| Tickets       | Related to #48668
| License       | MIT
| Doc PR        | _NA_

Migrating data providers to static ones, based on the failing CI of https://github.com/symfony/symfony/pull/48668

cc @OskarStark 👋 