### PR TITLE
[Serializer] Fix CsvEncoder decode on empty data

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -167,7 +167,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
                     $headerCount = array_fill(0, $nbCols, 1);
                 } else {
                     foreach ($cols as $col) {
-                        $header = explode($keySeparator, $col);
+                        $header = explode($keySeparator, $col ?? '');
                         $headers[] = $header;
                         $headerCount[] = \count($header);
                     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -211,6 +211,14 @@ CSV
     {
         $this->assertEquals("\n\n", $this->encoder->encode([], 'csv'));
         $this->assertEquals("\n\n", $this->encoder->encode([[]], 'csv'));
+        $this->assertEquals("\n\n", $this->encoder->encode([['' => null]], 'csv'));
+    }
+
+    public function testDecodeEmptyData()
+    {
+        $data = $this->encoder->decode("\n\n", 'csv');
+
+        $this->assertSame([['' => null]], $data);
     }
 
     public function testEncodeVariableStructure()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | - 
| License       | MIT
| Doc PR        | -

Test that reproduces the error: https://gist.github.com/cazak/954d8bfe53d5b9139667eae8fe53957f
The message i get after running the test:
  1x: explode(): Passing null to parameter #2 ($string) of type string is deprecated
    1x in CsvEncoderTest::testSuccess from App\Tests\Functional\Task

