### PR TITLE
[Security] Deprecate using string as attributes in Authorization

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -66,3 +66,8 @@ Validator
 ---------
 
  * Implementing the `ConstraintViolationInterface` without implementing the `getConstraint()` method is deprecated
+
+Security
+----------
+
+ * Using `string` as type for `$attribute` in `Voter::supports()` and `Voter::voteOnAttribute()` is deprecated, use `mixed` instead

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Using `string` as type for `$attribute` in `Voter::supports()` and `Voter::voteOnAttribute()` is deprecated, use `mixed` instead
+
 6.2
 ---
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -12,12 +12,14 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class VoterTest extends TestCase
 {
+    use ExpectDeprecationTrait;
     protected $token;
 
     protected function setUp(): void
@@ -70,16 +72,60 @@ class VoterTest extends TestCase
         $voter = new TypeErrorVoterTest_Voter();
         $voter->vote($this->token, new \stdClass(), ['EDIT']);
     }
+
+    /**
+     * @group legacy
+     */
+    public function testSupportsAttrStringDeprecation()
+    {
+        $this->expectDeprecation('Since symfony/security-core 6.3: Using string as first parameter type in "Symfony\Component\Security\Core\Tests\Authorization\Voter\VoterTestSupportsString_Voter::supports()" class is deprecated, use "mixed" instead.');
+        new VoterTestSupportsString_Voter();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testVoteOnAttributeAttrStringDeprecation()
+    {
+        $this->expectDeprecation('Since symfony/security-core 6.3: Using string as first parameter type in "Symfony\Component\Security\Core\Tests\Authorization\Voter\VoterTestVoteOnAttributeString_Voter::voteOnAttribute()" class is deprecated, use "mixed" instead.');
+        new VoterTestVoteOnAttributeString_Voter();
+    }
+}
+
+class VoterTestSupportsString_Voter extends Voter
+{
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return false;
+    }
+
+    protected function voteOnAttribute(mixed $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        return false;
+    }
+}
+
+class VoterTestVoteOnAttributeString_Voter extends Voter
+{
+    protected function supports(mixed $attribute, mixed $subject): bool
+    {
+        return false;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        return false;
+    }
 }
 
 class VoterTest_Voter extends Voter
 {
-    protected function voteOnAttribute(string $attribute, $object, TokenInterface $token): bool
+    protected function voteOnAttribute(mixed $attribute, mixed $object, TokenInterface $token): bool
     {
-        return 'EDIT' === $attribute;
+        return 'EDIT' == $attribute;
     }
 
-    protected function supports(string $attribute, $object): bool
+    protected function supports(mixed $attribute, mixed $object): bool
     {
         return $object instanceof \stdClass && \in_array($attribute, ['EDIT', 'CREATE']);
     }
@@ -87,12 +133,12 @@ class VoterTest_Voter extends Voter
 
 class IntegerVoterTest_Voter extends Voter
 {
-    protected function voteOnAttribute($attribute, $object, TokenInterface $token): bool
+    protected function voteOnAttribute(mixed $attribute, mixed $object, TokenInterface $token): bool
     {
         return 42 === $attribute;
     }
 
-    protected function supports($attribute, $object): bool
+    protected function supports(mixed $attribute, mixed $object): bool
     {
         return $object instanceof \stdClass && \is_int($attribute);
     }
@@ -100,12 +146,12 @@ class IntegerVoterTest_Voter extends Voter
 
 class TypeErrorVoterTest_Voter extends Voter
 {
-    protected function voteOnAttribute($attribute, $object, TokenInterface $token): bool
+    protected function voteOnAttribute(mixed $attribute, mixed $object, TokenInterface $token): bool
     {
         return false;
     }
 
-    protected function supports($attribute, $object): bool
+    protected function supports(mixed $attribute, mixed $object): bool
     {
         throw new \TypeError('Should error');
     }

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/password-hasher": "^5.4|^6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #49201
| License       | MIT
| Doc PR        | N/A
