### PR TITLE
Smsapi - Make "from" optional

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Changing the option `from` to optional to enable sending "eco" messages
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/README.md
@@ -12,7 +12,7 @@ SMSAPI_DSN=smsapi://TOKEN@default?from=FROM&fast=FAST&test=TEST
 
 where:
  - `TOKEN` is your API Token (OAuth)
- - `FROM` is the sender name
+ - `FROM` is the sender name (default ""), skip this field to use the cheapest "eco" shipping method.
  - `FAST` setting this parameter to "1" (default "0") will result in sending message with the highest priority which ensures the quickest possible time of delivery. Attention! Fast messages cost more than normal messages.
  - `TEST` setting this parameter to "1" (default "0") will result in sending message in test mode (message is validated, but not sent).
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
@@ -29,7 +29,7 @@ final class SmsapiTransportFactory extends AbstractTransportFactory
         }
 
         $authToken = $this->getUser($dsn);
-        $from = $dsn->getRequiredOption('from');
+        $from = $dsn->getOption('from', '');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $fast = filter_var($dsn->getOption('fast', false), \FILTER_VALIDATE_BOOL);
         $test = filter_var($dsn->getOption('test', false), \FILTER_VALIDATE_BOOL);

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
@@ -24,6 +24,11 @@ final class SmsapiTransportFactoryTest extends TransportFactoryTestCase
     public function createProvider(): iterable
     {
         yield [
+            'smsapi://host.test',
+            'smsapi://token@host.test',
+        ];
+
+        yield [
             'smsapi://host.test?from=testFrom',
             'smsapi://token@host.test?from=testFrom',
         ];
@@ -71,6 +76,9 @@ final class SmsapiTransportFactoryTest extends TransportFactoryTestCase
 
     public function supportsProvider(): iterable
     {
+        yield [true, 'smsapi://host'];
+        yield [true, 'smsapi://host?fast=1'];
+        yield [true, 'smsapi://host?test=1'];
         yield [true, 'smsapi://host?from=testFrom'];
         yield [true, 'smsapi://host?from=testFrom&fast=1'];
         yield [true, 'smsapi://host?from=testFrom&test=1'];
@@ -82,14 +90,8 @@ final class SmsapiTransportFactoryTest extends TransportFactoryTestCase
         yield 'missing token' => ['smsapi://host.test?from=testFrom'];
     }
 
-    public function missingRequiredOptionProvider(): iterable
-    {
-        yield 'missing option: from' => ['smsapi://token@host'];
-    }
-
     public function unsupportedSchemeProvider(): iterable
     {
         yield ['somethingElse://token@host?from=testFrom'];
-        yield ['somethingElse://token@host']; // missing "from" option
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
@@ -23,17 +23,21 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class SmsapiTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, bool $fast = false, bool $test = false): SmsapiTransport
+    public function createTransport(HttpClientInterface $client = null, string $from = '', bool $fast = false, bool $test = false): SmsapiTransport
     {
-        return (new SmsapiTransport('testToken', 'testFrom', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('test.host')->setFast($fast)->setTest($test);
+        return (new SmsapiTransport('testToken', $from, $client ?? $this->createMock(HttpClientInterface::class)))->setHost('test.host')->setFast($fast)->setTest($test);
     }
 
     public function toStringProvider(): iterable
     {
-        yield ['smsapi://test.host?from=testFrom', $this->createTransport()];
-        yield ['smsapi://test.host?from=testFrom&fast=1', $this->createTransport(null, true)];
-        yield ['smsapi://test.host?from=testFrom&test=1', $this->createTransport(null, false, true)];
-        yield ['smsapi://test.host?from=testFrom&fast=1&test=1', $this->createTransport(null, true, true)];
+        yield ['smsapi://test.host', $this->createTransport()];
+        yield ['smsapi://test.host?fast=1', $this->createTransport(null, '', true)];
+        yield ['smsapi://test.host?test=1', $this->createTransport(null, '', false, true)];
+        yield ['smsapi://test.host?fast=1&test=1', $this->createTransport(null, '', true, true)];
+        yield ['smsapi://test.host?from=testFrom', $this->createTransport(null, 'testFrom')];
+        yield ['smsapi://test.host?from=testFrom&fast=1', $this->createTransport(null, 'testFrom', true)];
+        yield ['smsapi://test.host?from=testFrom&test=1', $this->createTransport(null, 'testFrom', false, true)];
+        yield ['smsapi://test.host?from=testFrom&fast=1&test=1', $this->createTransport(null, 'testFrom', true, true)];
     }
 
     public function supportedMessagesProvider(): iterable


### PR DESCRIPTION
Smsapi.com API have option to send "eco" messages, default with drawn phone number instead of "from" name defined in Smsapi.com User Panel.

So, when from is not set in body of request, in default message is send as "eco". My changes make it possible.

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
