### PR TITLE
[HttpKernel] Fix setting the session on the main request when it's started by a subrequest

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -72,6 +72,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
             $request->setSessionFactory(function () use (&$sess, $request) {
                 if (!$sess) {
                     $sess = $this->getSession();
+                    $request->setSession($sess);
 
                     /*
                      * For supporting sessions in php runtime with runners like roadrunner or swoole, the session

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -691,6 +691,27 @@ class SessionListenerTest extends TestCase
         $subRequest->getSession();
     }
 
+    public function testGetSessionSetsSessionOnMainRequest()
+    {
+        $mainRequest = new Request();
+        $listener = $this->createListener($mainRequest, new NativeSessionStorageFactory());
+
+        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $mainRequest, HttpKernelInterface::MAIN_REQUEST);
+        $listener->onKernelRequest($event);
+
+        $this->assertFalse($mainRequest->hasSession(true));
+
+        $subRequest = $mainRequest->duplicate();
+
+        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $subRequest, HttpKernelInterface::SUB_REQUEST);
+        $listener->onKernelRequest($event);
+
+        $session = $subRequest->getSession();
+
+        $this->assertTrue($mainRequest->hasSession(true));
+        $this->assertSame($session, $mainRequest->getSession());
+    }
+
     public function testSessionUsageExceptionIfStatelessAndSessionUsed()
     {
         $session = $this->createMock(Session::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When a sub-request starts the session (eg when app.flashes is used in a template), the main request remains unaware of it and so does `SessionListener` as a consequence. This prevents it from running its `onKernelResponse` logic, leading to e.g. a `Set-Cookie` being sent on such pages even when a session is already active.