### PR TITLE
[Messenger] Allow passing a string instead of an array in `TransportNamesStamp`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
    `Symfony\Component\Messenger\Transport\InMemoryTransportFactory` in favor of
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport` and
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransportFactory`
+ * Allow passing a string instead of an array in `TransportNamesStamp`
 
 6.2
 ---

--- a/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
@@ -16,11 +16,14 @@ namespace Symfony\Component\Messenger\Stamp;
  */
 final class TransportNamesStamp implements StampInterface
 {
+    private array $transports;
+
     /**
-     * @param string[] $transports Transport names to be used for the message
+     * @param string[]|string $transports Transport names to be used for the message
      */
-    public function __construct(private array $transports)
+    public function __construct(array|string $transports)
     {
+        $this->transports = (array) $transports;
     }
 
     public function getTransportNames(): array

--- a/src/Symfony/Component/Messenger/Tests/Stamp/TransportNamesStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/TransportNamesStampTest.php
@@ -27,4 +27,13 @@ class TransportNamesStampTest extends TestCase
             $this->assertSame($sender, $stampSenders[$key]);
         }
     }
+
+    public function testGetIndividualSender()
+    {
+        $stamp = new TransportNamesStamp('first_transport');
+        $stampSenders = $stamp->getTransportNames();
+
+        $this->assertCount(1, $stampSenders);
+        $this->assertSame('first_transport', $stampSenders[0]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

This PR aims to improve a bit the DX when using `TransportNamesStamp` by allowing passing a string as the only argument of the stamp when only one transport is provided by the developer.

Also, I fixed the property name to match getter's name. I did not changed constructor argument's name as I'm afraid it would be a BC if it is used with named arguments 🤔 