### PR TITLE
[VarDumper] Disable links for IntelliJ platform

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -96,7 +96,8 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     {
         if (null === $this->handlesHrefGracefully) {
             $this->handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR')
-                && (!getenv('KONSOLE_VERSION') || (int) getenv('KONSOLE_VERSION') > 201100);
+                && (!getenv('KONSOLE_VERSION') || (int) getenv('KONSOLE_VERSION') > 201100)
+                && !isset($_SERVER['IDEA_INITIAL_DIRECTORY']);
         }
 
         if (null !== $this->href && $this->handlesHrefGracefully) {

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -448,7 +448,8 @@ class CliDumper extends AbstractDumper
 
         if (null === $this->handlesHrefGracefully) {
             $this->handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR')
-                && (!getenv('KONSOLE_VERSION') || (int) getenv('KONSOLE_VERSION') > 201100);
+                && (!getenv('KONSOLE_VERSION') || (int) getenv('KONSOLE_VERSION') > 201100)
+                && !isset($_SERVER['IDEA_INITIAL_DIRECTORY']);
         }
 
         if (isset($attr['ellipsis'], $attr['ellipsis-type'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

IntelliJ IDEA / PHP Storm does not support hrefs (TBD: Perhaps only on Windows OS?)

This fix detects that the console was launched from an IDEA environment by `IDEA_INITIAL_DIRECTORY` env variable and disables href rendering.

~Unit tests are missing, because it cannot be tested in simple ways.~

UPD: Added tests by analogy with the proposal in https://github.com/symfony/symfony/pull/49274#issuecomment-1421644128

### Before

![image](https://user-images.githubusercontent.com/2461257/217154408-cf243b32-3ae2-4104-9612-cce2a317f594.png)

### After

![image](https://user-images.githubusercontent.com/2461257/217154446-667a9329-4f1a-4e9c-8876-aedd3dcb1ec3.png)
