### PR TITLE
[FrameworkBundle][HttpKernel] Configure `ErrorHandler` on boot

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Deprecate the `notifier.logger_notification_listener` service, use the `notifier.notification_logger_listener` service instead
  * Allow setting private services with the test container
  * Register alias for argument for workflow services with workflow name only
+ * Configure the `ErrorHandler` on `FrameworkBundle::boot()`
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1095,12 +1095,12 @@ class FrameworkExtension extends Extension
             $loader->load('debug.php');
         }
 
-        $definition = $container->findDefinition('debug.debug_handlers_listener');
+        $definition = $container->findDefinition('debug.error_handler_configurator');
 
         if (false === $config['log']) {
-            $definition->replaceArgument(1, null);
+            $definition->replaceArgument(0, null);
         } elseif (true !== $config['log']) {
-            $definition->replaceArgument(2, $config['log']);
+            $definition->replaceArgument(1, $config['log']);
         }
 
         if (!$config['throw']) {

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -94,7 +94,8 @@ class FrameworkBundle extends Bundle
      */
     public function boot()
     {
-        ErrorHandler::register(null, false)->throwAt($this->container->getParameter('debug.error_handler.throw_at'), true);
+        $handler = ErrorHandler::register(null, false);
+        $this->container->get('debug.error_handler_configurator')->configure($handler);
 
         if ($this->container->getParameter('kernel.http_method_override')) {
             Request::enableHttpMethodParameterOverride();

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\HttpKernel\Debug\ErrorHandlerConfigurator;
 use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 use Symfony\Component\HttpKernel\EventListener\DebugHandlersListener;
 
@@ -18,9 +19,9 @@ return static function (ContainerConfigurator $container) {
     $container->parameters()->set('debug.error_handler.throw_at', -1);
 
     $container->services()
-        ->set('debug.debug_handlers_listener', DebugHandlersListener::class)
+        ->set('debug.error_handler_configurator', ErrorHandlerConfigurator::class)
+            ->public()
             ->args([
-                null, // Exception handler
                 service('monolog.logger.php')->nullOnInvalid(),
                 null, // Log levels map for enabled error levels
                 param('debug.error_handler.throw_at'),
@@ -28,8 +29,10 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.debug'),
                 service('monolog.logger.deprecation')->nullOnInvalid(),
             ])
-            ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'php'])
+
+        ->set('debug.debug_handlers_listener', DebugHandlersListener::class)
+            ->tag('kernel.event_subscriber')
 
         ->set('debug.file_link_formatter', FileLinkFormatter::class)
             ->args([param('debug.file_link_format')])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -541,9 +541,9 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         $container = $this->createContainerFromFile('php_errors_enabled');
 
-        $definition = $container->getDefinition('debug.debug_handlers_listener');
-        $this->assertEquals(new Reference('monolog.logger.php', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(1));
-        $this->assertNull($definition->getArgument(2));
+        $definition = $container->getDefinition('debug.error_handler_configurator');
+        $this->assertEquals(new Reference('monolog.logger.php', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(0));
+        $this->assertNull($definition->getArgument(1));
         $this->assertSame(-1, $container->getParameter('debug.error_handler.throw_at'));
     }
 
@@ -551,9 +551,9 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         $container = $this->createContainerFromFile('php_errors_disabled');
 
-        $definition = $container->getDefinition('debug.debug_handlers_listener');
+        $definition = $container->getDefinition('debug.error_handler_configurator');
+        $this->assertNull($definition->getArgument(0));
         $this->assertNull($definition->getArgument(1));
-        $this->assertNull($definition->getArgument(2));
         $this->assertSame(0, $container->getParameter('debug.error_handler.throw_at'));
     }
 
@@ -561,21 +561,21 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         $container = $this->createContainerFromFile('php_errors_log_level');
 
-        $definition = $container->getDefinition('debug.debug_handlers_listener');
-        $this->assertEquals(new Reference('monolog.logger.php', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(1));
-        $this->assertSame(8, $definition->getArgument(2));
+        $definition = $container->getDefinition('debug.error_handler_configurator');
+        $this->assertEquals(new Reference('monolog.logger.php', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(0));
+        $this->assertSame(8, $definition->getArgument(1));
     }
 
     public function testPhpErrorsWithLogLevels()
     {
         $container = $this->createContainerFromFile('php_errors_log_levels');
 
-        $definition = $container->getDefinition('debug.debug_handlers_listener');
-        $this->assertEquals(new Reference('monolog.logger.php', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(1));
+        $definition = $container->getDefinition('debug.error_handler_configurator');
+        $this->assertEquals(new Reference('monolog.logger.php', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(0));
         $this->assertSame([
             \E_NOTICE => \Psr\Log\LogLevel::ERROR,
             \E_WARNING => \Psr\Log\LogLevel::ERROR,
-        ], $definition->getArgument(2));
+        ], $definition->getArgument(1));
     }
 
     public function testExceptionsConfig()

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/error-handler": "^6.1",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/http-foundation": "^6.2",
-        "symfony/http-kernel": "^6.2.1",
+        "symfony/http-kernel": "^6.3",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "^5.4|^6.0",
         "symfony/finder": "^5.4|^6.0",

--- a/src/Symfony/Component/HttpKernel/Debug/ErrorHandlerConfigurator.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ErrorHandlerConfigurator.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Debug;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\ErrorHandler\ErrorHandler;
+
+/**
+ * Configures the error handler.
+ *
+ * @final
+ *
+ * @internal
+ */
+class ErrorHandlerConfigurator
+{
+    private ?LoggerInterface $logger;
+    private ?LoggerInterface $deprecationLogger;
+    private array|int|null $levels;
+    private ?int $throwAt;
+    private bool $scream;
+    private bool $scope;
+
+    /**
+     * @param array|int|null $levels  An array map of E_* to LogLevel::* or an integer bit field of E_* constants
+     * @param int|null       $throwAt Thrown errors in a bit field of E_* constants, or null to keep the current value
+     * @param bool           $scream  Enables/disables screaming mode, where even silenced errors are logged
+     * @param bool           $scope   Enables/disables scoping mode
+     */
+    public function __construct(LoggerInterface $logger = null, array|int|null $levels = \E_ALL, ?int $throwAt = \E_ALL, bool $scream = true, bool $scope = true, LoggerInterface $deprecationLogger = null)
+    {
+        $this->logger = $logger;
+        $this->levels = $levels ?? \E_ALL;
+        $this->throwAt = \is_int($throwAt) ? $throwAt : (null === $throwAt ? null : ($throwAt ? \E_ALL : null));
+        $this->scream = $scream;
+        $this->scope = $scope;
+        $this->deprecationLogger = $deprecationLogger;
+    }
+
+    /**
+     * Configures the error handler.
+     */
+    public function configure(ErrorHandler $handler): void
+    {
+        if ($this->logger || $this->deprecationLogger) {
+            $this->setDefaultLoggers($handler);
+            if (\is_array($this->levels)) {
+                $levels = 0;
+                foreach ($this->levels as $type => $log) {
+                    $levels |= $type;
+                }
+            } else {
+                $levels = $this->levels;
+            }
+
+            if ($this->scream) {
+                $handler->screamAt($levels);
+            }
+            if ($this->scope) {
+                $handler->scopeAt($levels & ~\E_USER_DEPRECATED & ~\E_DEPRECATED);
+            } else {
+                $handler->scopeAt(0, true);
+            }
+            $this->logger = $this->deprecationLogger = $this->levels = null;
+        }
+        if (null !== $this->throwAt) {
+            $handler->throwAt($this->throwAt, true);
+        }
+    }
+
+    private function setDefaultLoggers(ErrorHandler $handler): void
+    {
+        if (\is_array($this->levels)) {
+            $levelsDeprecatedOnly = [];
+            $levelsWithoutDeprecated = [];
+            foreach ($this->levels as $type => $log) {
+                if (\E_DEPRECATED == $type || \E_USER_DEPRECATED == $type) {
+                    $levelsDeprecatedOnly[$type] = $log;
+                } else {
+                    $levelsWithoutDeprecated[$type] = $log;
+                }
+            }
+        } else {
+            $levelsDeprecatedOnly = $this->levels & (\E_DEPRECATED | \E_USER_DEPRECATED);
+            $levelsWithoutDeprecated = $this->levels & ~\E_DEPRECATED & ~\E_USER_DEPRECATED;
+        }
+
+        $defaultLoggerLevels = $this->levels;
+        if ($this->deprecationLogger && $levelsDeprecatedOnly) {
+            $handler->setDefaultLogger($this->deprecationLogger, $levelsDeprecatedOnly);
+            $defaultLoggerLevels = $levelsWithoutDeprecated;
+        }
+
+        if ($this->logger && $defaultLoggerLevels) {
+            $handler->setDefaultLogger($this->logger, $defaultLoggerLevels);
+        }
+    }
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -21,7 +20,7 @@ use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * Configures errors and exceptions handlers.
+ * Sets an exception handler.
  *
  * @author Nicolas Grekas <p@tchwork.com>
  *
@@ -33,35 +32,19 @@ class DebugHandlersListener implements EventSubscriberInterface
 {
     private string|object|null $earlyHandler;
     private ?\Closure $exceptionHandler;
-    private ?LoggerInterface $logger;
-    private ?LoggerInterface $deprecationLogger;
-    private array|int|null $levels;
-    private ?int $throwAt;
-    private bool $scream;
-    private bool $scope;
     private bool $firstCall = true;
     private bool $hasTerminatedWithException = false;
 
     /**
-     * @param callable|null  $exceptionHandler A handler that must support \Throwable instances that will be called on Exception
-     * @param array|int|null $levels           An array map of E_* to LogLevel::* or an integer bit field of E_* constants
-     * @param int|null       $throwAt          Thrown errors in a bit field of E_* constants, or null to keep the current value
-     * @param bool           $scream           Enables/disables screaming mode, where even silenced errors are logged
-     * @param bool           $scope            Enables/disables scoping mode
+     * @param callable|null $exceptionHandler A handler that must support \Throwable instances that will be called on Exception
      */
-    public function __construct(callable $exceptionHandler = null, LoggerInterface $logger = null, array|int|null $levels = \E_ALL, ?int $throwAt = \E_ALL, bool $scream = true, bool $scope = true, LoggerInterface $deprecationLogger = null)
+    public function __construct(callable $exceptionHandler = null)
     {
         $handler = set_exception_handler('is_int');
         $this->earlyHandler = \is_array($handler) ? $handler[0] : null;
         restore_exception_handler();
 
         $this->exceptionHandler = null === $exceptionHandler ? null : $exceptionHandler(...);
-        $this->logger = $logger;
-        $this->levels = $levels ?? \E_ALL;
-        $this->throwAt = \is_int($throwAt) ? $throwAt : (null === $throwAt ? null : ($throwAt ? \E_ALL : null));
-        $this->scream = $scream;
-        $this->scope = $scope;
-        $this->deprecationLogger = $deprecationLogger;
     }
 
     /**
@@ -77,40 +60,6 @@ class DebugHandlersListener implements EventSubscriberInterface
         }
         $this->firstCall = $this->hasTerminatedWithException = false;
 
-        $handler = set_exception_handler('is_int');
-        $handler = \is_array($handler) ? $handler[0] : null;
-        restore_exception_handler();
-
-        if (!$handler instanceof ErrorHandler) {
-            $handler = $this->earlyHandler;
-        }
-
-        if ($handler instanceof ErrorHandler) {
-            if ($this->logger || $this->deprecationLogger) {
-                $this->setDefaultLoggers($handler);
-                if (\is_array($this->levels)) {
-                    $levels = 0;
-                    foreach ($this->levels as $type => $log) {
-                        $levels |= $type;
-                    }
-                } else {
-                    $levels = $this->levels;
-                }
-
-                if ($this->scream) {
-                    $handler->screamAt($levels);
-                }
-                if ($this->scope) {
-                    $handler->scopeAt($levels & ~\E_USER_DEPRECATED & ~\E_DEPRECATED);
-                } else {
-                    $handler->scopeAt(0, true);
-                }
-                $this->logger = $this->deprecationLogger = $this->levels = null;
-            }
-            if (null !== $this->throwAt) {
-                $handler->throwAt($this->throwAt, true);
-            }
-        }
         if (!$this->exceptionHandler) {
             if ($event instanceof KernelEvent) {
                 if (method_exists($kernel = $event->getKernel(), 'terminateWithException')) {
@@ -136,38 +85,18 @@ class DebugHandlersListener implements EventSubscriberInterface
             }
         }
         if ($this->exceptionHandler) {
+            $handler = set_exception_handler('is_int');
+            $handler = \is_array($handler) ? $handler[0] : null;
+            restore_exception_handler();
+
+            if (!$handler instanceof ErrorHandler) {
+                $handler = $this->earlyHandler;
+            }
+
             if ($handler instanceof ErrorHandler) {
                 $handler->setExceptionHandler($this->exceptionHandler);
             }
             $this->exceptionHandler = null;
-        }
-    }
-
-    private function setDefaultLoggers(ErrorHandler $handler): void
-    {
-        if (\is_array($this->levels)) {
-            $levelsDeprecatedOnly = [];
-            $levelsWithoutDeprecated = [];
-            foreach ($this->levels as $type => $log) {
-                if (\E_DEPRECATED == $type || \E_USER_DEPRECATED == $type) {
-                    $levelsDeprecatedOnly[$type] = $log;
-                } else {
-                    $levelsWithoutDeprecated[$type] = $log;
-                }
-            }
-        } else {
-            $levelsDeprecatedOnly = $this->levels & (\E_DEPRECATED | \E_USER_DEPRECATED);
-            $levelsWithoutDeprecated = $this->levels & ~\E_DEPRECATED & ~\E_USER_DEPRECATED;
-        }
-
-        $defaultLoggerLevels = $this->levels;
-        if ($this->deprecationLogger && $levelsDeprecatedOnly) {
-            $handler->setDefaultLogger($this->deprecationLogger, $levelsDeprecatedOnly);
-            $defaultLoggerLevels = $levelsWithoutDeprecated;
-        }
-
-        if ($this->logger && $defaultLoggerLevels) {
-            $handler->setDefaultLogger($this->logger, $defaultLoggerLevels);
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerConfiguratorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerConfiguratorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\ErrorHandler\ErrorHandler;
+use Symfony\Component\HttpKernel\Debug\ErrorHandlerConfigurator;
+
+class ErrorHandlerConfiguratorTest extends TestCase
+{
+    public function testConfigure()
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $configurator = new ErrorHandlerConfigurator($logger);
+        $handler = new ErrorHandler();
+
+        $configurator->configure($handler);
+
+        $loggers = $handler->setLoggers([]);
+
+        $this->assertArrayHasKey(\E_DEPRECATED, $loggers);
+        $this->assertSame([$logger, LogLevel::INFO], $loggers[\E_DEPRECATED]);
+    }
+
+    /**
+     * @dataProvider provideLevelsAssignedToLoggers
+     */
+    public function testLevelsAssignedToLoggers(bool $hasLogger, bool $hasDeprecationLogger, array|int $levels, array|int|null $expectedLoggerLevels, array|int|null $expectedDeprecationLoggerLevels)
+    {
+        $handler = $this->createMock(ErrorHandler::class);
+
+        $expectedCalls = [];
+        $logger = null;
+        $deprecationLogger = null;
+
+        if ($hasDeprecationLogger) {
+            $deprecationLogger = $this->createMock(LoggerInterface::class);
+            if (null !== $expectedDeprecationLoggerLevels) {
+                $expectedCalls[] = [$deprecationLogger, $expectedDeprecationLoggerLevels];
+            }
+        }
+
+        if ($hasLogger) {
+            $logger = $this->createMock(LoggerInterface::class);
+            if (null !== $expectedLoggerLevels) {
+                $expectedCalls[] = [$logger, $expectedLoggerLevels];
+            }
+        }
+
+        $handler
+            ->expects($this->exactly(\count($expectedCalls)))
+            ->method('setDefaultLogger')
+            ->withConsecutive(...$expectedCalls);
+
+        $configurator = new ErrorHandlerConfigurator($logger, $levels, null, true, true, $deprecationLogger);
+
+        $configurator->configure($handler);
+    }
+
+    public static function provideLevelsAssignedToLoggers(): iterable
+    {
+        yield [false, false, 0, null, null];
+        yield [false, false, \E_ALL, null, null];
+        yield [false, false, [], null, null];
+        yield [false, false, [\E_WARNING => LogLevel::WARNING, \E_USER_DEPRECATED => LogLevel::NOTICE], null, null];
+
+        yield [true, false, \E_ALL, \E_ALL, null];
+        yield [true, false, \E_DEPRECATED, \E_DEPRECATED, null];
+        yield [true, false, [], null, null];
+        yield [true, false, [\E_WARNING => LogLevel::WARNING, \E_DEPRECATED => LogLevel::NOTICE], [\E_WARNING => LogLevel::WARNING, \E_DEPRECATED => LogLevel::NOTICE], null];
+
+        yield [false, true, 0, null, null];
+        yield [false, true, \E_ALL, null, \E_DEPRECATED | \E_USER_DEPRECATED];
+        yield [false, true, \E_ERROR, null, null];
+        yield [false, true, [], null, null];
+        yield [false, true, [\E_ERROR => LogLevel::ERROR, \E_DEPRECATED => LogLevel::DEBUG], null, [\E_DEPRECATED => LogLevel::DEBUG]];
+
+        yield [true, true, 0, null, null];
+        yield [true, true, \E_ALL, \E_ALL & ~(\E_DEPRECATED | \E_USER_DEPRECATED), \E_DEPRECATED | \E_USER_DEPRECATED];
+        yield [true, true, \E_ERROR, \E_ERROR, null];
+        yield [true, true, \E_USER_DEPRECATED, null, \E_USER_DEPRECATED];
+        yield [true, true, [\E_ERROR => LogLevel::ERROR, \E_DEPRECATED => LogLevel::DEBUG], [\E_ERROR => LogLevel::ERROR], [\E_DEPRECATED => LogLevel::DEBUG]];
+        yield [true, true, [\E_ERROR => LogLevel::ALERT], [\E_ERROR => LogLevel::ALERT], null];
+        yield [true, true, [\E_USER_DEPRECATED => LogLevel::NOTICE], null, [\E_USER_DEPRECATED => LogLevel::NOTICE]];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\ConsoleEvents;
@@ -36,9 +34,8 @@ class DebugHandlersListenerTest extends TestCase
 {
     public function testConfigure()
     {
-        $logger = $this->createMock(LoggerInterface::class);
         $userHandler = function () {};
-        $listener = new DebugHandlersListener($userHandler, $logger);
+        $listener = new DebugHandlersListener($userHandler);
         $eHandler = new ErrorHandler();
 
         $exception = null;
@@ -57,11 +54,6 @@ class DebugHandlersListenerTest extends TestCase
         }
 
         $this->assertSame($userHandler, $eHandler->setExceptionHandler('var_dump'));
-
-        $loggers = $eHandler->setLoggers([]);
-
-        $this->assertArrayHasKey(\E_DEPRECATED, $loggers);
-        $this->assertSame([$logger, LogLevel::INFO], $loggers[\E_DEPRECATED]);
     }
 
     public function testConfigureForHttpKernelWithNoTerminateWithException()
@@ -152,86 +144,5 @@ class DebugHandlersListenerTest extends TestCase
         }
 
         $this->assertSame($userHandler, $eHandler->setExceptionHandler('var_dump'));
-    }
-
-    public static function provideLevelsAssignedToLoggers(): array
-    {
-        return [
-            [false, false, '0', null, null],
-            [false, false, \E_ALL, null, null],
-            [false, false, [], null, null],
-            [false, false, [\E_WARNING => LogLevel::WARNING, \E_USER_DEPRECATED => LogLevel::NOTICE], null, null],
-
-            [true, false, \E_ALL, \E_ALL, null],
-            [true, false, \E_DEPRECATED, \E_DEPRECATED, null],
-            [true, false, [], null, null],
-            [true, false, [\E_WARNING => LogLevel::WARNING, \E_DEPRECATED => LogLevel::NOTICE], [\E_WARNING => LogLevel::WARNING, \E_DEPRECATED => LogLevel::NOTICE], null],
-
-            [false, true, '0', null, null],
-            [false, true, \E_ALL, null, \E_DEPRECATED | \E_USER_DEPRECATED],
-            [false, true, \E_ERROR, null, null],
-            [false, true, [], null, null],
-            [false, true, [\E_ERROR => LogLevel::ERROR, \E_DEPRECATED => LogLevel::DEBUG], null, [\E_DEPRECATED => LogLevel::DEBUG]],
-
-            [true, true, '0', null, null],
-            [true, true, \E_ALL, \E_ALL & ~(\E_DEPRECATED | \E_USER_DEPRECATED), \E_DEPRECATED | \E_USER_DEPRECATED],
-            [true, true, \E_ERROR, \E_ERROR, null],
-            [true, true, \E_USER_DEPRECATED, null, \E_USER_DEPRECATED],
-            [true, true, [\E_ERROR => LogLevel::ERROR, \E_DEPRECATED => LogLevel::DEBUG], [\E_ERROR => LogLevel::ERROR], [\E_DEPRECATED => LogLevel::DEBUG]],
-            [true, true, [\E_ERROR => LogLevel::ALERT], [\E_ERROR => LogLevel::ALERT], null],
-            [true, true, [\E_USER_DEPRECATED => LogLevel::NOTICE], null, [\E_USER_DEPRECATED => LogLevel::NOTICE]],
-        ];
-    }
-
-    /**
-     * @dataProvider provideLevelsAssignedToLoggers
-     *
-     * @param array|string      $levels
-     * @param array|string|null $expectedLoggerLevels
-     * @param array|string|null $expectedDeprecationLoggerLevels
-     */
-    public function testLevelsAssignedToLoggers(bool $hasLogger, bool $hasDeprecationLogger, $levels, $expectedLoggerLevels, $expectedDeprecationLoggerLevels)
-    {
-        $handler = $this->createMock(ErrorHandler::class);
-
-        $expectedCalls = [];
-        $logger = null;
-
-        $deprecationLogger = null;
-        if ($hasDeprecationLogger) {
-            $deprecationLogger = $this->createMock(LoggerInterface::class);
-            if (null !== $expectedDeprecationLoggerLevels) {
-                $expectedCalls[] = [$deprecationLogger, $expectedDeprecationLoggerLevels];
-            }
-        }
-
-        if ($hasLogger) {
-            $logger = $this->createMock(LoggerInterface::class);
-            if (null !== $expectedLoggerLevels) {
-                $expectedCalls[] = [$logger, $expectedLoggerLevels];
-            }
-        }
-
-        $handler
-            ->expects($this->exactly(\count($expectedCalls)))
-            ->method('setDefaultLogger')
-            ->withConsecutive(...$expectedCalls);
-
-        $sut = new DebugHandlersListener(null, $logger, $levels, null, true, true, $deprecationLogger);
-        $prevHander = set_exception_handler([$handler, 'handleError']);
-
-        try {
-            $handler
-                ->method('handleError')
-                ->willReturnCallback(function () use ($prevHander) {
-                    $prevHander(...\func_get_args());
-                });
-
-            $sut->configure();
-            set_exception_handler($prevHander);
-        } catch (\Exception $e) {
-            set_exception_handler($prevHander);
-            throw $e;
-        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the `ErrorHandler` is somewhat configured in `FrameworkBundle::boot()` and then later fully in `DebugHandlersListener::configure()`.

https://github.com/symfony/symfony/blob/3e79a276ecdad009bd36b85c7c8745f5bc2b525a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php#L92-L96
https://github.com/symfony/symfony/blob/3e79a276ecdad009bd36b85c7c8745f5bc2b525a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php#L70-L144

However, I've noticed that there are some edge case when the handler doesn't get configured in time/at all.

One such example is when using the Sentry bundle. The bundle has its own error handler which gets registered when the [Sentry client is instantiated](https://github.com/getsentry/sentry-php/blob/6402930e7fde5198a07fb126786d1ed6c3fbe281/src/Client.php#L105). If you're using [Sentry with Monolog](https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration) the client gets instantiated when a Monolog logger is used. Since the `http_kernel` service requires a logger, the client gets instantiated before the `kernel.request` event and, as a result, when the `DebugHandlersListener` is trigger both `$handler` and `$this->earlyHandler` are `null` and the error handler is never configured properly.

Another example when the handler is not configured in time is when an error occurs in a `kernel.request` listener that has a higher priority then the `DebugHandlersListener`. In such cases the error handler's loggers are not yet configured and the errors are not logged properly.

These cases were tested with `APP_DEBUG=0` since the error handler is registered [earlier when debug is enabled](https://github.com/symfony/symfony/blob/3e79a276ecdad009bd36b85c7c8745f5bc2b525a/src/Symfony/Component/Runtime/GenericRuntime.php#L71-L81).

The idea of this PR is to configure the error handler as early as possible to prevent such edge cases from ever being able to happen. The error handler is now fully configured in `FrameworkBundle::boot()`.