### PR TITLE
[VarExporter] Fix lazy-proxying readonly classes on PHP 8.3

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Traits/RedisProxiesTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisProxiesTest.php
@@ -27,7 +27,7 @@ class RedisProxiesTest extends TestCase
     public function testRedis5Proxy($class)
     {
         $proxy = file_get_contents(\dirname(__DIR__, 2)."/Traits/{$class}5Proxy.php");
-        $proxy = substr($proxy, 0, 8 + strpos($proxy, "\n    ];"));
+        $proxy = substr($proxy, 0, 4 + strpos($proxy, '[];'));
         $methods = [];
 
         foreach ((new \ReflectionClass($class))->getMethods() as $method) {
@@ -42,7 +42,7 @@ class RedisProxiesTest extends TestCase
             $return = $method->getReturnType() instanceof \ReflectionNamedType && 'void' === (string) $method->getReturnType() ? '' : 'return ';
             $methods[] = "\n    ".ProxyHelper::exportSignature($method, false)."\n".<<<EOPHP
                 {
-                    {$return}\$this->lazyObjectReal->{$method->name}({$args});
+                    {$return}(\$this->lazyObjectState->realInstance ??= (\$this->lazyObjectState->initializer)())->{$method->name}({$args});
                 }
 
             EOPHP;
@@ -69,7 +69,7 @@ class RedisProxiesTest extends TestCase
         eval(substr($stub, 5));
 
         $proxy = file_get_contents(\dirname(__DIR__, 2)."/Traits/{$class}6Proxy.php");
-        $proxy = substr($proxy, 0, 8 + strpos($proxy, "\n    ];"));
+        $proxy = substr($proxy, 0, 4 + strpos($proxy, '[];'));
         $methods = [];
 
         foreach ((new \ReflectionClass($class.'StubInterface'))->getMethods() as $method) {
@@ -84,7 +84,7 @@ class RedisProxiesTest extends TestCase
             $return = $method->getReturnType() instanceof \ReflectionNamedType && 'void' === (string) $method->getReturnType() ? '' : 'return ';
             $methods[] = "\n    ".ProxyHelper::exportSignature($method, false)."\n".<<<EOPHP
                 {
-                    {$return}\$this->lazyObjectReal->{$method->name}({$args});
+                    {$return}(\$this->lazyObjectState->realInstance ??= (\$this->lazyObjectState->initializer)())->{$method->name}({$args});
                 }
 
             EOPHP;

--- a/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
@@ -29,1203 +29,1200 @@ class Redis5Proxy extends \Redis implements ResetInterface, LazyObjectInterface
         resetLazyObject as reset;
     }
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [
-        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
-        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
-    ];
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 
     public function __construct()
     {
-        return $this->lazyObjectReal->__construct();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct();
     }
 
     public function _prefix($key)
     {
-        return $this->lazyObjectReal->_prefix($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_prefix($key);
     }
 
     public function _serialize($value)
     {
-        return $this->lazyObjectReal->_serialize($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_serialize($value);
     }
 
     public function _unserialize($value)
     {
-        return $this->lazyObjectReal->_unserialize($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unserialize($value);
     }
 
     public function _pack($value)
     {
-        return $this->lazyObjectReal->_pack($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_pack($value);
     }
 
     public function _unpack($value)
     {
-        return $this->lazyObjectReal->_unpack($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unpack($value);
     }
 
     public function _compress($value)
     {
-        return $this->lazyObjectReal->_compress($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_compress($value);
     }
 
     public function _uncompress($value)
     {
-        return $this->lazyObjectReal->_uncompress($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_uncompress($value);
     }
 
     public function acl($subcmd, ...$args)
     {
-        return $this->lazyObjectReal->acl($subcmd, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->acl($subcmd, ...$args);
     }
 
     public function append($key, $value)
     {
-        return $this->lazyObjectReal->append($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->append($key, $value);
     }
 
     public function auth($auth)
     {
-        return $this->lazyObjectReal->auth($auth);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->auth($auth);
     }
 
     public function bgSave()
     {
-        return $this->lazyObjectReal->bgSave();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgSave();
     }
 
     public function bgrewriteaof()
     {
-        return $this->lazyObjectReal->bgrewriteaof();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgrewriteaof();
     }
 
     public function bitcount($key)
     {
-        return $this->lazyObjectReal->bitcount($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitcount($key);
     }
 
     public function bitop($operation, $ret_key, $key, ...$other_keys)
     {
-        return $this->lazyObjectReal->bitop($operation, $ret_key, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitop($operation, $ret_key, $key, ...$other_keys);
     }
 
     public function bitpos($key, $bit, $start = null, $end = null)
     {
-        return $this->lazyObjectReal->bitpos($key, $bit, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitpos($key, $bit, $start, $end);
     }
 
     public function blPop($key, $timeout_or_key, ...$extra_args)
     {
-        return $this->lazyObjectReal->blPop($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blPop($key, $timeout_or_key, ...$extra_args);
     }
 
     public function brPop($key, $timeout_or_key, ...$extra_args)
     {
-        return $this->lazyObjectReal->brPop($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brPop($key, $timeout_or_key, ...$extra_args);
     }
 
     public function brpoplpush($src, $dst, $timeout)
     {
-        return $this->lazyObjectReal->brpoplpush($src, $dst, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpoplpush($src, $dst, $timeout);
     }
 
     public function bzPopMax($key, $timeout_or_key, ...$extra_args)
     {
-        return $this->lazyObjectReal->bzPopMax($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzPopMax($key, $timeout_or_key, ...$extra_args);
     }
 
     public function bzPopMin($key, $timeout_or_key, ...$extra_args)
     {
-        return $this->lazyObjectReal->bzPopMin($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzPopMin($key, $timeout_or_key, ...$extra_args);
     }
 
     public function clearLastError()
     {
-        return $this->lazyObjectReal->clearLastError();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearLastError();
     }
 
     public function client($cmd, ...$args)
     {
-        return $this->lazyObjectReal->client($cmd, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->client($cmd, ...$args);
     }
 
     public function close()
     {
-        return $this->lazyObjectReal->close();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->close();
     }
 
     public function command(...$args)
     {
-        return $this->lazyObjectReal->command(...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->command(...$args);
     }
 
     public function config($cmd, $key, $value = null)
     {
-        return $this->lazyObjectReal->config($cmd, $key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->config($cmd, $key, $value);
     }
 
     public function connect($host, $port = null, $timeout = null, $retry_interval = null)
     {
-        return $this->lazyObjectReal->connect($host, $port, $timeout, $retry_interval);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->connect($host, $port, $timeout, $retry_interval);
     }
 
     public function dbSize()
     {
-        return $this->lazyObjectReal->dbSize();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dbSize();
     }
 
     public function debug($key)
     {
-        return $this->lazyObjectReal->debug($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->debug($key);
     }
 
     public function decr($key)
     {
-        return $this->lazyObjectReal->decr($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decr($key);
     }
 
     public function decrBy($key, $value)
     {
-        return $this->lazyObjectReal->decrBy($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrBy($key, $value);
     }
 
     public function del($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->del($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->del($key, ...$other_keys);
     }
 
     public function discard()
     {
-        return $this->lazyObjectReal->discard();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->discard();
     }
 
     public function dump($key)
     {
-        return $this->lazyObjectReal->dump($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dump($key);
     }
 
     public function echo($msg)
     {
-        return $this->lazyObjectReal->echo($msg);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->echo($msg);
     }
 
     public function eval($script, $args = null, $num_keys = null)
     {
-        return $this->lazyObjectReal->eval($script, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval($script, $args, $num_keys);
     }
 
     public function evalsha($script_sha, $args = null, $num_keys = null)
     {
-        return $this->lazyObjectReal->evalsha($script_sha, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha($script_sha, $args, $num_keys);
     }
 
     public function exec()
     {
-        return $this->lazyObjectReal->exec();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exec();
     }
 
     public function exists($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->exists($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exists($key, ...$other_keys);
     }
 
     public function expire($key, $timeout)
     {
-        return $this->lazyObjectReal->expire($key, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expire($key, $timeout);
     }
 
     public function expireAt($key, $timestamp)
     {
-        return $this->lazyObjectReal->expireAt($key, $timestamp);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expireAt($key, $timestamp);
     }
 
     public function flushAll($async = null)
     {
-        return $this->lazyObjectReal->flushAll($async);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushAll($async);
     }
 
     public function flushDB($async = null)
     {
-        return $this->lazyObjectReal->flushDB($async);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushDB($async);
     }
 
     public function geoadd($key, $lng, $lat, $member, ...$other_triples)
     {
-        return $this->lazyObjectReal->geoadd($key, $lng, $lat, $member, ...$other_triples);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geoadd($key, $lng, $lat, $member, ...$other_triples);
     }
 
     public function geodist($key, $src, $dst, $unit = null)
     {
-        return $this->lazyObjectReal->geodist($key, $src, $dst, $unit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geodist($key, $src, $dst, $unit);
     }
 
     public function geohash($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->geohash($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geohash($key, $member, ...$other_members);
     }
 
     public function geopos($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->geopos($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geopos($key, $member, ...$other_members);
     }
 
     public function georadius($key, $lng, $lan, $radius, $unit, $opts = null)
     {
-        return $this->lazyObjectReal->georadius($key, $lng, $lan, $radius, $unit, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius($key, $lng, $lan, $radius, $unit, $opts);
     }
 
     public function georadius_ro($key, $lng, $lan, $radius, $unit, $opts = null)
     {
-        return $this->lazyObjectReal->georadius_ro($key, $lng, $lan, $radius, $unit, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius_ro($key, $lng, $lan, $radius, $unit, $opts);
     }
 
     public function georadiusbymember($key, $member, $radius, $unit, $opts = null)
     {
-        return $this->lazyObjectReal->georadiusbymember($key, $member, $radius, $unit, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember($key, $member, $radius, $unit, $opts);
     }
 
     public function georadiusbymember_ro($key, $member, $radius, $unit, $opts = null)
     {
-        return $this->lazyObjectReal->georadiusbymember_ro($key, $member, $radius, $unit, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember_ro($key, $member, $radius, $unit, $opts);
     }
 
     public function get($key)
     {
-        return $this->lazyObjectReal->get($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->get($key);
     }
 
     public function getAuth()
     {
-        return $this->lazyObjectReal->getAuth();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getAuth();
     }
 
     public function getBit($key, $offset)
     {
-        return $this->lazyObjectReal->getBit($key, $offset);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getBit($key, $offset);
     }
 
     public function getDBNum()
     {
-        return $this->lazyObjectReal->getDBNum();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getDBNum();
     }
 
     public function getHost()
     {
-        return $this->lazyObjectReal->getHost();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getHost();
     }
 
     public function getLastError()
     {
-        return $this->lazyObjectReal->getLastError();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getLastError();
     }
 
     public function getMode()
     {
-        return $this->lazyObjectReal->getMode();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getMode();
     }
 
     public function getOption($option)
     {
-        return $this->lazyObjectReal->getOption($option);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getOption($option);
     }
 
     public function getPersistentID()
     {
-        return $this->lazyObjectReal->getPersistentID();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPersistentID();
     }
 
     public function getPort()
     {
-        return $this->lazyObjectReal->getPort();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPort();
     }
 
     public function getRange($key, $start, $end)
     {
-        return $this->lazyObjectReal->getRange($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getRange($key, $start, $end);
     }
 
     public function getReadTimeout()
     {
-        return $this->lazyObjectReal->getReadTimeout();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getReadTimeout();
     }
 
     public function getSet($key, $value)
     {
-        return $this->lazyObjectReal->getSet($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getSet($key, $value);
     }
 
     public function getTimeout()
     {
-        return $this->lazyObjectReal->getTimeout();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getTimeout();
     }
 
     public function hDel($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->hDel($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hDel($key, $member, ...$other_members);
     }
 
     public function hExists($key, $member)
     {
-        return $this->lazyObjectReal->hExists($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hExists($key, $member);
     }
 
     public function hGet($key, $member)
     {
-        return $this->lazyObjectReal->hGet($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hGet($key, $member);
     }
 
     public function hGetAll($key)
     {
-        return $this->lazyObjectReal->hGetAll($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hGetAll($key);
     }
 
     public function hIncrBy($key, $member, $value)
     {
-        return $this->lazyObjectReal->hIncrBy($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hIncrBy($key, $member, $value);
     }
 
     public function hIncrByFloat($key, $member, $value)
     {
-        return $this->lazyObjectReal->hIncrByFloat($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hIncrByFloat($key, $member, $value);
     }
 
     public function hKeys($key)
     {
-        return $this->lazyObjectReal->hKeys($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hKeys($key);
     }
 
     public function hLen($key)
     {
-        return $this->lazyObjectReal->hLen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hLen($key);
     }
 
     public function hMget($key, $keys)
     {
-        return $this->lazyObjectReal->hMget($key, $keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hMget($key, $keys);
     }
 
     public function hMset($key, $pairs)
     {
-        return $this->lazyObjectReal->hMset($key, $pairs);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hMset($key, $pairs);
     }
 
     public function hSet($key, $member, $value)
     {
-        return $this->lazyObjectReal->hSet($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hSet($key, $member, $value);
     }
 
     public function hSetNx($key, $member, $value)
     {
-        return $this->lazyObjectReal->hSetNx($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hSetNx($key, $member, $value);
     }
 
     public function hStrLen($key, $member)
     {
-        return $this->lazyObjectReal->hStrLen($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hStrLen($key, $member);
     }
 
     public function hVals($key)
     {
-        return $this->lazyObjectReal->hVals($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hVals($key);
     }
 
     public function hscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return $this->lazyObjectReal->hscan($str_key, $i_iterator, $str_pattern, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($str_key, $i_iterator, $str_pattern, $i_count);
     }
 
     public function incr($key)
     {
-        return $this->lazyObjectReal->incr($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incr($key);
     }
 
     public function incrBy($key, $value)
     {
-        return $this->lazyObjectReal->incrBy($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrBy($key, $value);
     }
 
     public function incrByFloat($key, $value)
     {
-        return $this->lazyObjectReal->incrByFloat($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrByFloat($key, $value);
     }
 
     public function info($option = null)
     {
-        return $this->lazyObjectReal->info($option);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->info($option);
     }
 
     public function isConnected()
     {
-        return $this->lazyObjectReal->isConnected();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->isConnected();
     }
 
     public function keys($pattern)
     {
-        return $this->lazyObjectReal->keys($pattern);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->keys($pattern);
     }
 
     public function lInsert($key, $position, $pivot, $value)
     {
-        return $this->lazyObjectReal->lInsert($key, $position, $pivot, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lInsert($key, $position, $pivot, $value);
     }
 
     public function lLen($key)
     {
-        return $this->lazyObjectReal->lLen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lLen($key);
     }
 
     public function lPop($key)
     {
-        return $this->lazyObjectReal->lPop($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPop($key);
     }
 
     public function lPush($key, $value)
     {
-        return $this->lazyObjectReal->lPush($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPush($key, $value);
     }
 
     public function lPushx($key, $value)
     {
-        return $this->lazyObjectReal->lPushx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPushx($key, $value);
     }
 
     public function lSet($key, $index, $value)
     {
-        return $this->lazyObjectReal->lSet($key, $index, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lSet($key, $index, $value);
     }
 
     public function lastSave()
     {
-        return $this->lazyObjectReal->lastSave();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lastSave();
     }
 
     public function lindex($key, $index)
     {
-        return $this->lazyObjectReal->lindex($key, $index);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lindex($key, $index);
     }
 
     public function lrange($key, $start, $end)
     {
-        return $this->lazyObjectReal->lrange($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrange($key, $start, $end);
     }
 
     public function lrem($key, $value, $count)
     {
-        return $this->lazyObjectReal->lrem($key, $value, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrem($key, $value, $count);
     }
 
     public function ltrim($key, $start, $stop)
     {
-        return $this->lazyObjectReal->ltrim($key, $start, $stop);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim($key, $start, $stop);
     }
 
     public function mget($keys)
     {
-        return $this->lazyObjectReal->mget($keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget($keys);
     }
 
     public function migrate($host, $port, $key, $db, $timeout, $copy = null, $replace = null)
     {
-        return $this->lazyObjectReal->migrate($host, $port, $key, $db, $timeout, $copy, $replace);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->migrate($host, $port, $key, $db, $timeout, $copy, $replace);
     }
 
     public function move($key, $dbindex)
     {
-        return $this->lazyObjectReal->move($key, $dbindex);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->move($key, $dbindex);
     }
 
     public function mset($pairs)
     {
-        return $this->lazyObjectReal->mset($pairs);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mset($pairs);
     }
 
     public function msetnx($pairs)
     {
-        return $this->lazyObjectReal->msetnx($pairs);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->msetnx($pairs);
     }
 
     public function multi($mode = null)
     {
-        return $this->lazyObjectReal->multi($mode);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->multi($mode);
     }
 
     public function object($field, $key)
     {
-        return $this->lazyObjectReal->object($field, $key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->object($field, $key);
     }
 
     public function pconnect($host, $port = null, $timeout = null)
     {
-        return $this->lazyObjectReal->pconnect($host, $port, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pconnect($host, $port, $timeout);
     }
 
     public function persist($key)
     {
-        return $this->lazyObjectReal->persist($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->persist($key);
     }
 
     public function pexpire($key, $timestamp)
     {
-        return $this->lazyObjectReal->pexpire($key, $timestamp);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpire($key, $timestamp);
     }
 
     public function pexpireAt($key, $timestamp)
     {
-        return $this->lazyObjectReal->pexpireAt($key, $timestamp);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpireAt($key, $timestamp);
     }
 
     public function pfadd($key, $elements)
     {
-        return $this->lazyObjectReal->pfadd($key, $elements);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfadd($key, $elements);
     }
 
     public function pfcount($key)
     {
-        return $this->lazyObjectReal->pfcount($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfcount($key);
     }
 
     public function pfmerge($dstkey, $keys)
     {
-        return $this->lazyObjectReal->pfmerge($dstkey, $keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfmerge($dstkey, $keys);
     }
 
     public function ping()
     {
-        return $this->lazyObjectReal->ping();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ping();
     }
 
     public function pipeline()
     {
-        return $this->lazyObjectReal->pipeline();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pipeline();
     }
 
     public function psetex($key, $expire, $value)
     {
-        return $this->lazyObjectReal->psetex($key, $expire, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psetex($key, $expire, $value);
     }
 
     public function psubscribe($patterns, $callback)
     {
-        return $this->lazyObjectReal->psubscribe($patterns, $callback);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psubscribe($patterns, $callback);
     }
 
     public function pttl($key)
     {
-        return $this->lazyObjectReal->pttl($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pttl($key);
     }
 
     public function publish($channel, $message)
     {
-        return $this->lazyObjectReal->publish($channel, $message);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->publish($channel, $message);
     }
 
     public function pubsub($cmd, ...$args)
     {
-        return $this->lazyObjectReal->pubsub($cmd, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pubsub($cmd, ...$args);
     }
 
     public function punsubscribe($pattern, ...$other_patterns)
     {
-        return $this->lazyObjectReal->punsubscribe($pattern, ...$other_patterns);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->punsubscribe($pattern, ...$other_patterns);
     }
 
     public function rPop($key)
     {
-        return $this->lazyObjectReal->rPop($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPop($key);
     }
 
     public function rPush($key, $value)
     {
-        return $this->lazyObjectReal->rPush($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPush($key, $value);
     }
 
     public function rPushx($key, $value)
     {
-        return $this->lazyObjectReal->rPushx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPushx($key, $value);
     }
 
     public function randomKey()
     {
-        return $this->lazyObjectReal->randomKey();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->randomKey();
     }
 
     public function rawcommand($cmd, ...$args)
     {
-        return $this->lazyObjectReal->rawcommand($cmd, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rawcommand($cmd, ...$args);
     }
 
     public function rename($key, $newkey)
     {
-        return $this->lazyObjectReal->rename($key, $newkey);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rename($key, $newkey);
     }
 
     public function renameNx($key, $newkey)
     {
-        return $this->lazyObjectReal->renameNx($key, $newkey);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renameNx($key, $newkey);
     }
 
     public function restore($ttl, $key, $value)
     {
-        return $this->lazyObjectReal->restore($ttl, $key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->restore($ttl, $key, $value);
     }
 
     public function role()
     {
-        return $this->lazyObjectReal->role();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->role();
     }
 
     public function rpoplpush($src, $dst)
     {
-        return $this->lazyObjectReal->rpoplpush($src, $dst);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpoplpush($src, $dst);
     }
 
     public function sAdd($key, $value)
     {
-        return $this->lazyObjectReal->sAdd($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sAdd($key, $value);
     }
 
     public function sAddArray($key, $options)
     {
-        return $this->lazyObjectReal->sAddArray($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sAddArray($key, $options);
     }
 
     public function sDiff($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sDiff($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sDiff($key, ...$other_keys);
     }
 
     public function sDiffStore($dst, $key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sDiffStore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sDiffStore($dst, $key, ...$other_keys);
     }
 
     public function sInter($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sInter($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sInter($key, ...$other_keys);
     }
 
     public function sInterStore($dst, $key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sInterStore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sInterStore($dst, $key, ...$other_keys);
     }
 
     public function sMembers($key)
     {
-        return $this->lazyObjectReal->sMembers($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMembers($key);
     }
 
     public function sMisMember($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->sMisMember($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMisMember($key, $member, ...$other_members);
     }
 
     public function sMove($src, $dst, $value)
     {
-        return $this->lazyObjectReal->sMove($src, $dst, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMove($src, $dst, $value);
     }
 
     public function sPop($key)
     {
-        return $this->lazyObjectReal->sPop($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sPop($key);
     }
 
     public function sRandMember($key, $count = null)
     {
-        return $this->lazyObjectReal->sRandMember($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sRandMember($key, $count);
     }
 
     public function sUnion($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sUnion($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sUnion($key, ...$other_keys);
     }
 
     public function sUnionStore($dst, $key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sUnionStore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sUnionStore($dst, $key, ...$other_keys);
     }
 
     public function save()
     {
-        return $this->lazyObjectReal->save();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->save();
     }
 
     public function scan(&$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return $this->lazyObjectReal->scan($i_iterator, $str_pattern, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($i_iterator, $str_pattern, $i_count);
     }
 
     public function scard($key)
     {
-        return $this->lazyObjectReal->scard($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scard($key);
     }
 
     public function script($cmd, ...$args)
     {
-        return $this->lazyObjectReal->script($cmd, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->script($cmd, ...$args);
     }
 
     public function select($dbindex)
     {
-        return $this->lazyObjectReal->select($dbindex);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->select($dbindex);
     }
 
     public function set($key, $value, $opts = null)
     {
-        return $this->lazyObjectReal->set($key, $value, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->set($key, $value, $opts);
     }
 
     public function setBit($key, $offset, $value)
     {
-        return $this->lazyObjectReal->setBit($key, $offset, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setBit($key, $offset, $value);
     }
 
     public function setOption($option, $value)
     {
-        return $this->lazyObjectReal->setOption($option, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setOption($option, $value);
     }
 
     public function setRange($key, $offset, $value)
     {
-        return $this->lazyObjectReal->setRange($key, $offset, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setRange($key, $offset, $value);
     }
 
     public function setex($key, $expire, $value)
     {
-        return $this->lazyObjectReal->setex($key, $expire, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setex($key, $expire, $value);
     }
 
     public function setnx($key, $value)
     {
-        return $this->lazyObjectReal->setnx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setnx($key, $value);
     }
 
     public function sismember($key, $value)
     {
-        return $this->lazyObjectReal->sismember($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sismember($key, $value);
     }
 
     public function slaveof($host = null, $port = null)
     {
-        return $this->lazyObjectReal->slaveof($host, $port);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slaveof($host, $port);
     }
 
     public function slowlog($arg, $option = null)
     {
-        return $this->lazyObjectReal->slowlog($arg, $option);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slowlog($arg, $option);
     }
 
     public function sort($key, $options = null)
     {
-        return $this->lazyObjectReal->sort($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort($key, $options);
     }
 
     public function sortAsc($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
     {
-        return $this->lazyObjectReal->sortAsc($key, $pattern, $get, $start, $end, $getList);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortAsc($key, $pattern, $get, $start, $end, $getList);
     }
 
     public function sortAscAlpha($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
     {
-        return $this->lazyObjectReal->sortAscAlpha($key, $pattern, $get, $start, $end, $getList);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortAscAlpha($key, $pattern, $get, $start, $end, $getList);
     }
 
     public function sortDesc($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
     {
-        return $this->lazyObjectReal->sortDesc($key, $pattern, $get, $start, $end, $getList);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortDesc($key, $pattern, $get, $start, $end, $getList);
     }
 
     public function sortDescAlpha($key, $pattern = null, $get = null, $start = null, $end = null, $getList = null)
     {
-        return $this->lazyObjectReal->sortDescAlpha($key, $pattern, $get, $start, $end, $getList);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortDescAlpha($key, $pattern, $get, $start, $end, $getList);
     }
 
     public function srem($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->srem($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srem($key, $member, ...$other_members);
     }
 
     public function sscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return $this->lazyObjectReal->sscan($str_key, $i_iterator, $str_pattern, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($str_key, $i_iterator, $str_pattern, $i_count);
     }
 
     public function strlen($key)
     {
-        return $this->lazyObjectReal->strlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->strlen($key);
     }
 
     public function subscribe($channels, $callback)
     {
-        return $this->lazyObjectReal->subscribe($channels, $callback);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->subscribe($channels, $callback);
     }
 
     public function swapdb($srcdb, $dstdb)
     {
-        return $this->lazyObjectReal->swapdb($srcdb, $dstdb);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->swapdb($srcdb, $dstdb);
     }
 
     public function time()
     {
-        return $this->lazyObjectReal->time();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->time();
     }
 
     public function ttl($key)
     {
-        return $this->lazyObjectReal->ttl($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ttl($key);
     }
 
     public function type($key)
     {
-        return $this->lazyObjectReal->type($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->type($key);
     }
 
     public function unlink($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->unlink($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unlink($key, ...$other_keys);
     }
 
     public function unsubscribe($channel, ...$other_channels)
     {
-        return $this->lazyObjectReal->unsubscribe($channel, ...$other_channels);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unsubscribe($channel, ...$other_channels);
     }
 
     public function unwatch()
     {
-        return $this->lazyObjectReal->unwatch();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch();
     }
 
     public function wait($numslaves, $timeout)
     {
-        return $this->lazyObjectReal->wait($numslaves, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->wait($numslaves, $timeout);
     }
 
     public function watch($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->watch($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->watch($key, ...$other_keys);
     }
 
     public function xack($str_key, $str_group, $arr_ids)
     {
-        return $this->lazyObjectReal->xack($str_key, $str_group, $arr_ids);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xack($str_key, $str_group, $arr_ids);
     }
 
     public function xadd($str_key, $str_id, $arr_fields, $i_maxlen = null, $boo_approximate = null)
     {
-        return $this->lazyObjectReal->xadd($str_key, $str_id, $arr_fields, $i_maxlen, $boo_approximate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xadd($str_key, $str_id, $arr_fields, $i_maxlen, $boo_approximate);
     }
 
     public function xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts = null)
     {
-        return $this->lazyObjectReal->xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts);
     }
 
     public function xdel($str_key, $arr_ids)
     {
-        return $this->lazyObjectReal->xdel($str_key, $arr_ids);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xdel($str_key, $arr_ids);
     }
 
     public function xgroup($str_operation, $str_key = null, $str_arg1 = null, $str_arg2 = null, $str_arg3 = null)
     {
-        return $this->lazyObjectReal->xgroup($str_operation, $str_key, $str_arg1, $str_arg2, $str_arg3);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xgroup($str_operation, $str_key, $str_arg1, $str_arg2, $str_arg3);
     }
 
     public function xinfo($str_cmd, $str_key = null, $str_group = null)
     {
-        return $this->lazyObjectReal->xinfo($str_cmd, $str_key, $str_group);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xinfo($str_cmd, $str_key, $str_group);
     }
 
     public function xlen($key)
     {
-        return $this->lazyObjectReal->xlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xlen($key);
     }
 
     public function xpending($str_key, $str_group, $str_start = null, $str_end = null, $i_count = null, $str_consumer = null)
     {
-        return $this->lazyObjectReal->xpending($str_key, $str_group, $str_start, $str_end, $i_count, $str_consumer);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xpending($str_key, $str_group, $str_start, $str_end, $i_count, $str_consumer);
     }
 
     public function xrange($str_key, $str_start, $str_end, $i_count = null)
     {
-        return $this->lazyObjectReal->xrange($str_key, $str_start, $str_end, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrange($str_key, $str_start, $str_end, $i_count);
     }
 
     public function xread($arr_streams, $i_count = null, $i_block = null)
     {
-        return $this->lazyObjectReal->xread($arr_streams, $i_count, $i_block);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xread($arr_streams, $i_count, $i_block);
     }
 
     public function xreadgroup($str_group, $str_consumer, $arr_streams, $i_count = null, $i_block = null)
     {
-        return $this->lazyObjectReal->xreadgroup($str_group, $str_consumer, $arr_streams, $i_count, $i_block);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xreadgroup($str_group, $str_consumer, $arr_streams, $i_count, $i_block);
     }
 
     public function xrevrange($str_key, $str_start, $str_end, $i_count = null)
     {
-        return $this->lazyObjectReal->xrevrange($str_key, $str_start, $str_end, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrevrange($str_key, $str_start, $str_end, $i_count);
     }
 
     public function xtrim($str_key, $i_maxlen, $boo_approximate = null)
     {
-        return $this->lazyObjectReal->xtrim($str_key, $i_maxlen, $boo_approximate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xtrim($str_key, $i_maxlen, $boo_approximate);
     }
 
     public function zAdd($key, $score, $value, ...$extra_args)
     {
-        return $this->lazyObjectReal->zAdd($key, $score, $value, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zAdd($key, $score, $value, ...$extra_args);
     }
 
     public function zCard($key)
     {
-        return $this->lazyObjectReal->zCard($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zCard($key);
     }
 
     public function zCount($key, $min, $max)
     {
-        return $this->lazyObjectReal->zCount($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zCount($key, $min, $max);
     }
 
     public function zIncrBy($key, $value, $member)
     {
-        return $this->lazyObjectReal->zIncrBy($key, $value, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zIncrBy($key, $value, $member);
     }
 
     public function zLexCount($key, $min, $max)
     {
-        return $this->lazyObjectReal->zLexCount($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zLexCount($key, $min, $max);
     }
 
     public function zPopMax($key)
     {
-        return $this->lazyObjectReal->zPopMax($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zPopMax($key);
     }
 
     public function zPopMin($key)
     {
-        return $this->lazyObjectReal->zPopMin($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zPopMin($key);
     }
 
     public function zRange($key, $start, $end, $scores = null)
     {
-        return $this->lazyObjectReal->zRange($key, $start, $end, $scores);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRange($key, $start, $end, $scores);
     }
 
     public function zRangeByLex($key, $min, $max, $offset = null, $limit = null)
     {
-        return $this->lazyObjectReal->zRangeByLex($key, $min, $max, $offset, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRangeByLex($key, $min, $max, $offset, $limit);
     }
 
     public function zRangeByScore($key, $start, $end, $options = null)
     {
-        return $this->lazyObjectReal->zRangeByScore($key, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRangeByScore($key, $start, $end, $options);
     }
 
     public function zRank($key, $member)
     {
-        return $this->lazyObjectReal->zRank($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRank($key, $member);
     }
 
     public function zRem($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->zRem($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRem($key, $member, ...$other_members);
     }
 
     public function zRemRangeByLex($key, $min, $max)
     {
-        return $this->lazyObjectReal->zRemRangeByLex($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByLex($key, $min, $max);
     }
 
     public function zRemRangeByRank($key, $start, $end)
     {
-        return $this->lazyObjectReal->zRemRangeByRank($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByRank($key, $start, $end);
     }
 
     public function zRemRangeByScore($key, $min, $max)
     {
-        return $this->lazyObjectReal->zRemRangeByScore($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByScore($key, $min, $max);
     }
 
     public function zRevRange($key, $start, $end, $scores = null)
     {
-        return $this->lazyObjectReal->zRevRange($key, $start, $end, $scores);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRange($key, $start, $end, $scores);
     }
 
     public function zRevRangeByLex($key, $min, $max, $offset = null, $limit = null)
     {
-        return $this->lazyObjectReal->zRevRangeByLex($key, $min, $max, $offset, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRangeByLex($key, $min, $max, $offset, $limit);
     }
 
     public function zRevRangeByScore($key, $start, $end, $options = null)
     {
-        return $this->lazyObjectReal->zRevRangeByScore($key, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRangeByScore($key, $start, $end, $options);
     }
 
     public function zRevRank($key, $member)
     {
-        return $this->lazyObjectReal->zRevRank($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRank($key, $member);
     }
 
     public function zScore($key, $member)
     {
-        return $this->lazyObjectReal->zScore($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zScore($key, $member);
     }
 
     public function zinterstore($key, $keys, $weights = null, $aggregate = null)
     {
-        return $this->lazyObjectReal->zinterstore($key, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinterstore($key, $keys, $weights, $aggregate);
     }
 
     public function zscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return $this->lazyObjectReal->zscan($str_key, $i_iterator, $str_pattern, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($str_key, $i_iterator, $str_pattern, $i_count);
     }
 
     public function zunionstore($key, $keys, $weights = null, $aggregate = null)
     {
-        return $this->lazyObjectReal->zunionstore($key, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunionstore($key, $keys, $weights, $aggregate);
     }
 
     public function delete($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->delete($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->delete($key, ...$other_keys);
     }
 
     public function evaluate($script, $args = null, $num_keys = null)
     {
-        return $this->lazyObjectReal->evaluate($script, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evaluate($script, $args, $num_keys);
     }
 
     public function evaluateSha($script_sha, $args = null, $num_keys = null)
     {
-        return $this->lazyObjectReal->evaluateSha($script_sha, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evaluateSha($script_sha, $args, $num_keys);
     }
 
     public function getKeys($pattern)
     {
-        return $this->lazyObjectReal->getKeys($pattern);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getKeys($pattern);
     }
 
     public function getMultiple($keys)
     {
-        return $this->lazyObjectReal->getMultiple($keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getMultiple($keys);
     }
 
     public function lGet($key, $index)
     {
-        return $this->lazyObjectReal->lGet($key, $index);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lGet($key, $index);
     }
 
     public function lGetRange($key, $start, $end)
     {
-        return $this->lazyObjectReal->lGetRange($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lGetRange($key, $start, $end);
     }
 
     public function lRemove($key, $value, $count)
     {
-        return $this->lazyObjectReal->lRemove($key, $value, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lRemove($key, $value, $count);
     }
 
     public function lSize($key)
     {
-        return $this->lazyObjectReal->lSize($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lSize($key);
     }
 
     public function listTrim($key, $start, $stop)
     {
-        return $this->lazyObjectReal->listTrim($key, $start, $stop);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->listTrim($key, $start, $stop);
     }
 
     public function open($host, $port = null, $timeout = null, $retry_interval = null)
     {
-        return $this->lazyObjectReal->open($host, $port, $timeout, $retry_interval);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->open($host, $port, $timeout, $retry_interval);
     }
 
     public function popen($host, $port = null, $timeout = null)
     {
-        return $this->lazyObjectReal->popen($host, $port, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->popen($host, $port, $timeout);
     }
 
     public function renameKey($key, $newkey)
     {
-        return $this->lazyObjectReal->renameKey($key, $newkey);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renameKey($key, $newkey);
     }
 
     public function sContains($key, $value)
     {
-        return $this->lazyObjectReal->sContains($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sContains($key, $value);
     }
 
     public function sGetMembers($key)
     {
-        return $this->lazyObjectReal->sGetMembers($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sGetMembers($key);
     }
 
     public function sRemove($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->sRemove($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sRemove($key, $member, ...$other_members);
     }
 
     public function sSize($key)
     {
-        return $this->lazyObjectReal->sSize($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sSize($key);
     }
 
     public function sendEcho($msg)
     {
-        return $this->lazyObjectReal->sendEcho($msg);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sendEcho($msg);
     }
 
     public function setTimeout($key, $timeout)
     {
-        return $this->lazyObjectReal->setTimeout($key, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setTimeout($key, $timeout);
     }
 
     public function substr($key, $start, $end)
     {
-        return $this->lazyObjectReal->substr($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->substr($key, $start, $end);
     }
 
     public function zDelete($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->zDelete($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zDelete($key, $member, ...$other_members);
     }
 
     public function zDeleteRangeByRank($key, $min, $max)
     {
-        return $this->lazyObjectReal->zDeleteRangeByRank($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zDeleteRangeByRank($key, $min, $max);
     }
 
     public function zDeleteRangeByScore($key, $min, $max)
     {
-        return $this->lazyObjectReal->zDeleteRangeByScore($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zDeleteRangeByScore($key, $min, $max);
     }
 
     public function zInter($key, $keys, $weights = null, $aggregate = null)
     {
-        return $this->lazyObjectReal->zInter($key, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zInter($key, $keys, $weights, $aggregate);
     }
 
     public function zRemove($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->zRemove($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemove($key, $member, ...$other_members);
     }
 
     public function zRemoveRangeByScore($key, $min, $max)
     {
-        return $this->lazyObjectReal->zRemoveRangeByScore($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemoveRangeByScore($key, $min, $max);
     }
 
     public function zReverseRange($key, $start, $end, $scores = null)
     {
-        return $this->lazyObjectReal->zReverseRange($key, $start, $end, $scores);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zReverseRange($key, $start, $end, $scores);
     }
 
     public function zSize($key)
     {
-        return $this->lazyObjectReal->zSize($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zSize($key);
     }
 
     public function zUnion($key, $keys, $weights = null, $aggregate = null)
     {
-        return $this->lazyObjectReal->zUnion($key, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zUnion($key, $keys, $weights, $aggregate);
     }
 }

--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -29,1268 +29,1265 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
         resetLazyObject as reset;
     }
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [
-        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
-        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
-    ];
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 
     public function __construct($options = null)
     {
-        return $this->lazyObjectReal->__construct($options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct($options);
     }
 
     public function _compress($value): string
     {
-        return $this->lazyObjectReal->_compress($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_compress($value);
     }
 
     public function _uncompress($value): string
     {
-        return $this->lazyObjectReal->_uncompress($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_uncompress($value);
     }
 
     public function _prefix($key): string
     {
-        return $this->lazyObjectReal->_prefix($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_prefix($key);
     }
 
     public function _serialize($value): string
     {
-        return $this->lazyObjectReal->_serialize($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_serialize($value);
     }
 
     public function _unserialize($value): mixed
     {
-        return $this->lazyObjectReal->_unserialize($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unserialize($value);
     }
 
     public function _pack($value): string
     {
-        return $this->lazyObjectReal->_pack($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_pack($value);
     }
 
     public function _unpack($value): mixed
     {
-        return $this->lazyObjectReal->_unpack($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unpack($value);
     }
 
     public function acl($subcmd, ...$args): mixed
     {
-        return $this->lazyObjectReal->acl($subcmd, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->acl($subcmd, ...$args);
     }
 
     public function append($key, $value): \Redis|false|int
     {
-        return $this->lazyObjectReal->append($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->append($key, $value);
     }
 
     public function auth(#[\SensitiveParameter] $credentials): \Redis|bool
     {
-        return $this->lazyObjectReal->auth($credentials);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->auth($credentials);
     }
 
     public function bgSave(): \Redis|bool
     {
-        return $this->lazyObjectReal->bgSave();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgSave();
     }
 
     public function bgrewriteaof(): \Redis|bool
     {
-        return $this->lazyObjectReal->bgrewriteaof();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgrewriteaof();
     }
 
     public function bitcount($key, $start = 0, $end = -1, $bybit = false): \Redis|false|int
     {
-        return $this->lazyObjectReal->bitcount($key, $start, $end, $bybit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitcount($key, $start, $end, $bybit);
     }
 
     public function bitop($operation, $deskey, $srckey, ...$other_keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->bitop($operation, $deskey, $srckey, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitop($operation, $deskey, $srckey, ...$other_keys);
     }
 
     public function bitpos($key, $bit, $start = 0, $end = -1, $bybit = false): \Redis|false|int
     {
-        return $this->lazyObjectReal->bitpos($key, $bit, $start, $end, $bybit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitpos($key, $bit, $start, $end, $bybit);
     }
 
     public function blPop($key_or_keys, $timeout_or_key, ...$extra_args): \Redis|array|false|null
     {
-        return $this->lazyObjectReal->blPop($key_or_keys, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blPop($key_or_keys, $timeout_or_key, ...$extra_args);
     }
 
     public function brPop($key_or_keys, $timeout_or_key, ...$extra_args): \Redis|array|false|null
     {
-        return $this->lazyObjectReal->brPop($key_or_keys, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brPop($key_or_keys, $timeout_or_key, ...$extra_args);
     }
 
     public function brpoplpush($src, $dst, $timeout): \Redis|false|string
     {
-        return $this->lazyObjectReal->brpoplpush($src, $dst, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpoplpush($src, $dst, $timeout);
     }
 
     public function bzPopMax($key, $timeout_or_key, ...$extra_args): \Redis|array|false
     {
-        return $this->lazyObjectReal->bzPopMax($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzPopMax($key, $timeout_or_key, ...$extra_args);
     }
 
     public function bzPopMin($key, $timeout_or_key, ...$extra_args): \Redis|array|false
     {
-        return $this->lazyObjectReal->bzPopMin($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzPopMin($key, $timeout_or_key, ...$extra_args);
     }
 
     public function bzmpop($timeout, $keys, $from, $count = 1): \Redis|array|false|null
     {
-        return $this->lazyObjectReal->bzmpop($timeout, $keys, $from, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzmpop($timeout, $keys, $from, $count);
     }
 
     public function zmpop($keys, $from, $count = 1): \Redis|array|false|null
     {
-        return $this->lazyObjectReal->zmpop($keys, $from, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zmpop($keys, $from, $count);
     }
 
     public function blmpop($timeout, $keys, $from, $count = 1): \Redis|array|false|null
     {
-        return $this->lazyObjectReal->blmpop($timeout, $keys, $from, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmpop($timeout, $keys, $from, $count);
     }
 
     public function lmpop($keys, $from, $count = 1): \Redis|array|false|null
     {
-        return $this->lazyObjectReal->lmpop($keys, $from, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmpop($keys, $from, $count);
     }
 
     public function clearLastError(): bool
     {
-        return $this->lazyObjectReal->clearLastError();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearLastError();
     }
 
     public function client($opt, ...$args): mixed
     {
-        return $this->lazyObjectReal->client($opt, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->client($opt, ...$args);
     }
 
     public function close(): bool
     {
-        return $this->lazyObjectReal->close();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->close();
     }
 
     public function command($opt = null, ...$args): mixed
     {
-        return $this->lazyObjectReal->command($opt, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->command($opt, ...$args);
     }
 
     public function config($operation, $key_or_settings = null, $value = null): mixed
     {
-        return $this->lazyObjectReal->config($operation, $key_or_settings, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->config($operation, $key_or_settings, $value);
     }
 
     public function connect($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, $context = null): bool
     {
-        return $this->lazyObjectReal->connect($host, $port, $timeout, $persistent_id, $retry_interval, $read_timeout, $context);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->connect($host, $port, $timeout, $persistent_id, $retry_interval, $read_timeout, $context);
     }
 
     public function copy($src, $dst, $options = null): \Redis|bool
     {
-        return $this->lazyObjectReal->copy($src, $dst, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->copy($src, $dst, $options);
     }
 
     public function dbSize(): \Redis|false|int
     {
-        return $this->lazyObjectReal->dbSize();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dbSize();
     }
 
     public function debug($key): \Redis|string
     {
-        return $this->lazyObjectReal->debug($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->debug($key);
     }
 
     public function decr($key, $by = 1): \Redis|false|int
     {
-        return $this->lazyObjectReal->decr($key, $by);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decr($key, $by);
     }
 
     public function decrBy($key, $value): \Redis|false|int
     {
-        return $this->lazyObjectReal->decrBy($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrBy($key, $value);
     }
 
     public function del($key, ...$other_keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->del($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->del($key, ...$other_keys);
     }
 
     public function delete($key, ...$other_keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->delete($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->delete($key, ...$other_keys);
     }
 
     public function discard(): \Redis|bool
     {
-        return $this->lazyObjectReal->discard();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->discard();
     }
 
     public function dump($key): \Redis|string
     {
-        return $this->lazyObjectReal->dump($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dump($key);
     }
 
     public function echo($str): \Redis|false|string
     {
-        return $this->lazyObjectReal->echo($str);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->echo($str);
     }
 
     public function eval($script, $args = [], $num_keys = 0): mixed
     {
-        return $this->lazyObjectReal->eval($script, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval($script, $args, $num_keys);
     }
 
     public function eval_ro($script_sha, $args = [], $num_keys = 0): mixed
     {
-        return $this->lazyObjectReal->eval_ro($script_sha, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval_ro($script_sha, $args, $num_keys);
     }
 
     public function evalsha($sha1, $args = [], $num_keys = 0): mixed
     {
-        return $this->lazyObjectReal->evalsha($sha1, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha($sha1, $args, $num_keys);
     }
 
     public function evalsha_ro($sha1, $args = [], $num_keys = 0): mixed
     {
-        return $this->lazyObjectReal->evalsha_ro($sha1, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha_ro($sha1, $args, $num_keys);
     }
 
     public function exec(): \Redis|array|false
     {
-        return $this->lazyObjectReal->exec();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exec();
     }
 
     public function exists($key, ...$other_keys): \Redis|bool|int
     {
-        return $this->lazyObjectReal->exists($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exists($key, ...$other_keys);
     }
 
     public function expire($key, $timeout, $mode = null): \Redis|bool
     {
-        return $this->lazyObjectReal->expire($key, $timeout, $mode);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expire($key, $timeout, $mode);
     }
 
     public function expireAt($key, $timestamp, $mode = null): \Redis|bool
     {
-        return $this->lazyObjectReal->expireAt($key, $timestamp, $mode);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expireAt($key, $timestamp, $mode);
     }
 
     public function failover($to = null, $abort = false, $timeout = 0): \Redis|bool
     {
-        return $this->lazyObjectReal->failover($to, $abort, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->failover($to, $abort, $timeout);
     }
 
     public function expiretime($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->expiretime($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expiretime($key);
     }
 
     public function pexpiretime($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->pexpiretime($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpiretime($key);
     }
 
     public function fcall($fn, $keys = [], $args = []): mixed
     {
-        return $this->lazyObjectReal->fcall($fn, $keys, $args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->fcall($fn, $keys, $args);
     }
 
     public function fcall_ro($fn, $keys = [], $args = []): mixed
     {
-        return $this->lazyObjectReal->fcall_ro($fn, $keys, $args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->fcall_ro($fn, $keys, $args);
     }
 
     public function flushAll($sync = null): \Redis|bool
     {
-        return $this->lazyObjectReal->flushAll($sync);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushAll($sync);
     }
 
     public function flushDB($sync = null): \Redis|bool
     {
-        return $this->lazyObjectReal->flushDB($sync);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushDB($sync);
     }
 
     public function function($operation, ...$args): \Redis|array|bool|string
     {
-        return $this->lazyObjectReal->function($operation, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->function($operation, ...$args);
     }
 
     public function geoadd($key, $lng, $lat, $member, ...$other_triples_and_options): \Redis|false|int
     {
-        return $this->lazyObjectReal->geoadd($key, $lng, $lat, $member, ...$other_triples_and_options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geoadd($key, $lng, $lat, $member, ...$other_triples_and_options);
     }
 
     public function geodist($key, $src, $dst, $unit = null): \Redis|false|float
     {
-        return $this->lazyObjectReal->geodist($key, $src, $dst, $unit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geodist($key, $src, $dst, $unit);
     }
 
     public function geohash($key, $member, ...$other_members): \Redis|array|false
     {
-        return $this->lazyObjectReal->geohash($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geohash($key, $member, ...$other_members);
     }
 
     public function geopos($key, $member, ...$other_members): \Redis|array|false
     {
-        return $this->lazyObjectReal->geopos($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geopos($key, $member, ...$other_members);
     }
 
     public function georadius($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return $this->lazyObjectReal->georadius($key, $lng, $lat, $radius, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius($key, $lng, $lat, $radius, $unit, $options);
     }
 
     public function georadius_ro($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return $this->lazyObjectReal->georadius_ro($key, $lng, $lat, $radius, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius_ro($key, $lng, $lat, $radius, $unit, $options);
     }
 
     public function georadiusbymember($key, $member, $radius, $unit, $options = []): mixed
     {
-        return $this->lazyObjectReal->georadiusbymember($key, $member, $radius, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember($key, $member, $radius, $unit, $options);
     }
 
     public function georadiusbymember_ro($key, $member, $radius, $unit, $options = []): mixed
     {
-        return $this->lazyObjectReal->georadiusbymember_ro($key, $member, $radius, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember_ro($key, $member, $radius, $unit, $options);
     }
 
     public function geosearch($key, $position, $shape, $unit, $options = []): array
     {
-        return $this->lazyObjectReal->geosearch($key, $position, $shape, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearch($key, $position, $shape, $unit, $options);
     }
 
     public function geosearchstore($dst, $src, $position, $shape, $unit, $options = []): \Redis|array|false|int
     {
-        return $this->lazyObjectReal->geosearchstore($dst, $src, $position, $shape, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearchstore($dst, $src, $position, $shape, $unit, $options);
     }
 
     public function get($key): mixed
     {
-        return $this->lazyObjectReal->get($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->get($key);
     }
 
     public function getAuth(): mixed
     {
-        return $this->lazyObjectReal->getAuth();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getAuth();
     }
 
     public function getBit($key, $idx): \Redis|false|int
     {
-        return $this->lazyObjectReal->getBit($key, $idx);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getBit($key, $idx);
     }
 
     public function getEx($key, $options = []): \Redis|bool|string
     {
-        return $this->lazyObjectReal->getEx($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getEx($key, $options);
     }
 
     public function getDBNum(): int
     {
-        return $this->lazyObjectReal->getDBNum();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getDBNum();
     }
 
     public function getDel($key): \Redis|bool|string
     {
-        return $this->lazyObjectReal->getDel($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getDel($key);
     }
 
     public function getHost(): string
     {
-        return $this->lazyObjectReal->getHost();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getHost();
     }
 
     public function getLastError(): ?string
     {
-        return $this->lazyObjectReal->getLastError();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getLastError();
     }
 
     public function getMode(): int
     {
-        return $this->lazyObjectReal->getMode();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getMode();
     }
 
     public function getOption($option): mixed
     {
-        return $this->lazyObjectReal->getOption($option);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getOption($option);
     }
 
     public function getPersistentID(): ?string
     {
-        return $this->lazyObjectReal->getPersistentID();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPersistentID();
     }
 
     public function getPort(): int
     {
-        return $this->lazyObjectReal->getPort();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getPort();
     }
 
     public function getRange($key, $start, $end): \Redis|false|string
     {
-        return $this->lazyObjectReal->getRange($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getRange($key, $start, $end);
     }
 
     public function lcs($key1, $key2, $options = null): \Redis|array|false|int|string
     {
-        return $this->lazyObjectReal->lcs($key1, $key2, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lcs($key1, $key2, $options);
     }
 
     public function getReadTimeout(): float
     {
-        return $this->lazyObjectReal->getReadTimeout();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getReadTimeout();
     }
 
     public function getset($key, $value): \Redis|false|string
     {
-        return $this->lazyObjectReal->getset($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getset($key, $value);
     }
 
     public function getTimeout(): false|float
     {
-        return $this->lazyObjectReal->getTimeout();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getTimeout();
     }
 
     public function getTransferredBytes(): array
     {
-        return $this->lazyObjectReal->getTransferredBytes();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getTransferredBytes();
     }
 
     public function clearTransferredBytes(): void
     {
-        $this->lazyObjectReal->clearTransferredBytes();
+        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearTransferredBytes();
     }
 
     public function hDel($key, $field, ...$other_fields): \Redis|false|int
     {
-        return $this->lazyObjectReal->hDel($key, $field, ...$other_fields);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hDel($key, $field, ...$other_fields);
     }
 
     public function hExists($key, $field): \Redis|bool
     {
-        return $this->lazyObjectReal->hExists($key, $field);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hExists($key, $field);
     }
 
     public function hGet($key, $member): mixed
     {
-        return $this->lazyObjectReal->hGet($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hGet($key, $member);
     }
 
     public function hGetAll($key): \Redis|array|false
     {
-        return $this->lazyObjectReal->hGetAll($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hGetAll($key);
     }
 
     public function hIncrBy($key, $field, $value): \Redis|false|int
     {
-        return $this->lazyObjectReal->hIncrBy($key, $field, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hIncrBy($key, $field, $value);
     }
 
     public function hIncrByFloat($key, $field, $value): \Redis|false|float
     {
-        return $this->lazyObjectReal->hIncrByFloat($key, $field, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hIncrByFloat($key, $field, $value);
     }
 
     public function hKeys($key): \Redis|array|false
     {
-        return $this->lazyObjectReal->hKeys($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hKeys($key);
     }
 
     public function hLen($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->hLen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hLen($key);
     }
 
     public function hMget($key, $fields): \Redis|array|false
     {
-        return $this->lazyObjectReal->hMget($key, $fields);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hMget($key, $fields);
     }
 
     public function hMset($key, $fieldvals): \Redis|bool
     {
-        return $this->lazyObjectReal->hMset($key, $fieldvals);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hMset($key, $fieldvals);
     }
 
     public function hRandField($key, $options = null): \Redis|array|string
     {
-        return $this->lazyObjectReal->hRandField($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hRandField($key, $options);
     }
 
     public function hSet($key, $member, $value): \Redis|false|int
     {
-        return $this->lazyObjectReal->hSet($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hSet($key, $member, $value);
     }
 
     public function hSetNx($key, $field, $value): \Redis|bool
     {
-        return $this->lazyObjectReal->hSetNx($key, $field, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hSetNx($key, $field, $value);
     }
 
     public function hStrLen($key, $field): \Redis|false|int
     {
-        return $this->lazyObjectReal->hStrLen($key, $field);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hStrLen($key, $field);
     }
 
     public function hVals($key): \Redis|array|false
     {
-        return $this->lazyObjectReal->hVals($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hVals($key);
     }
 
     public function hscan($key, &$iterator, $pattern = null, $count = 0): \Redis|array|bool
     {
-        return $this->lazyObjectReal->hscan($key, $iterator, $pattern, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, $pattern, $count);
     }
 
     public function incr($key, $by = 1): \Redis|false|int
     {
-        return $this->lazyObjectReal->incr($key, $by);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incr($key, $by);
     }
 
     public function incrBy($key, $value): \Redis|false|int
     {
-        return $this->lazyObjectReal->incrBy($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrBy($key, $value);
     }
 
     public function incrByFloat($key, $value): \Redis|false|float
     {
-        return $this->lazyObjectReal->incrByFloat($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrByFloat($key, $value);
     }
 
     public function info(...$sections): \Redis|array|false
     {
-        return $this->lazyObjectReal->info(...$sections);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->info(...$sections);
     }
 
     public function isConnected(): bool
     {
-        return $this->lazyObjectReal->isConnected();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->isConnected();
     }
 
     public function keys($pattern)
     {
-        return $this->lazyObjectReal->keys($pattern);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->keys($pattern);
     }
 
     public function lInsert($key, $pos, $pivot, $value)
     {
-        return $this->lazyObjectReal->lInsert($key, $pos, $pivot, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lInsert($key, $pos, $pivot, $value);
     }
 
     public function lLen($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->lLen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lLen($key);
     }
 
     public function lMove($src, $dst, $wherefrom, $whereto): \Redis|false|string
     {
-        return $this->lazyObjectReal->lMove($src, $dst, $wherefrom, $whereto);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lMove($src, $dst, $wherefrom, $whereto);
     }
 
     public function blmove($src, $dst, $wherefrom, $whereto, $timeout): \Redis|false|string
     {
-        return $this->lazyObjectReal->blmove($src, $dst, $wherefrom, $whereto, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmove($src, $dst, $wherefrom, $whereto, $timeout);
     }
 
     public function lPop($key, $count = 0): \Redis|array|bool|string
     {
-        return $this->lazyObjectReal->lPop($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPop($key, $count);
     }
 
     public function lPos($key, $value, $options = null): \Redis|array|bool|int|null
     {
-        return $this->lazyObjectReal->lPos($key, $value, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPos($key, $value, $options);
     }
 
     public function lPush($key, ...$elements): \Redis|false|int
     {
-        return $this->lazyObjectReal->lPush($key, ...$elements);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPush($key, ...$elements);
     }
 
     public function rPush($key, ...$elements): \Redis|false|int
     {
-        return $this->lazyObjectReal->rPush($key, ...$elements);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPush($key, ...$elements);
     }
 
     public function lPushx($key, $value): \Redis|false|int
     {
-        return $this->lazyObjectReal->lPushx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lPushx($key, $value);
     }
 
     public function rPushx($key, $value): \Redis|false|int
     {
-        return $this->lazyObjectReal->rPushx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPushx($key, $value);
     }
 
     public function lSet($key, $index, $value): \Redis|bool
     {
-        return $this->lazyObjectReal->lSet($key, $index, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lSet($key, $index, $value);
     }
 
     public function lastSave(): int
     {
-        return $this->lazyObjectReal->lastSave();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lastSave();
     }
 
     public function lindex($key, $index): mixed
     {
-        return $this->lazyObjectReal->lindex($key, $index);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lindex($key, $index);
     }
 
     public function lrange($key, $start, $end): \Redis|array|false
     {
-        return $this->lazyObjectReal->lrange($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrange($key, $start, $end);
     }
 
     public function lrem($key, $value, $count = 0): \Redis|false|int
     {
-        return $this->lazyObjectReal->lrem($key, $value, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrem($key, $value, $count);
     }
 
     public function ltrim($key, $start, $end): \Redis|bool
     {
-        return $this->lazyObjectReal->ltrim($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim($key, $start, $end);
     }
 
     public function mget($keys): \Redis|array
     {
-        return $this->lazyObjectReal->mget($keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget($keys);
     }
 
     public function migrate($host, $port, $key, $dstdb, $timeout, $copy = false, $replace = false, #[\SensitiveParameter] $credentials = null): \Redis|bool
     {
-        return $this->lazyObjectReal->migrate($host, $port, $key, $dstdb, $timeout, $copy, $replace, $credentials);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->migrate($host, $port, $key, $dstdb, $timeout, $copy, $replace, $credentials);
     }
 
     public function move($key, $index): \Redis|bool
     {
-        return $this->lazyObjectReal->move($key, $index);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->move($key, $index);
     }
 
     public function mset($key_values): \Redis|bool
     {
-        return $this->lazyObjectReal->mset($key_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mset($key_values);
     }
 
     public function msetnx($key_values): \Redis|bool
     {
-        return $this->lazyObjectReal->msetnx($key_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->msetnx($key_values);
     }
 
     public function multi($value = \Redis::MULTI): \Redis|bool
     {
-        return $this->lazyObjectReal->multi($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->multi($value);
     }
 
     public function object($subcommand, $key): \Redis|false|int|string
     {
-        return $this->lazyObjectReal->object($subcommand, $key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->object($subcommand, $key);
     }
 
     public function open($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, $context = null): bool
     {
-        return $this->lazyObjectReal->open($host, $port, $timeout, $persistent_id, $retry_interval, $read_timeout, $context);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->open($host, $port, $timeout, $persistent_id, $retry_interval, $read_timeout, $context);
     }
 
     public function pconnect($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, $context = null): bool
     {
-        return $this->lazyObjectReal->pconnect($host, $port, $timeout, $persistent_id, $retry_interval, $read_timeout, $context);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pconnect($host, $port, $timeout, $persistent_id, $retry_interval, $read_timeout, $context);
     }
 
     public function persist($key): \Redis|bool
     {
-        return $this->lazyObjectReal->persist($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->persist($key);
     }
 
     public function pexpire($key, $timeout, $mode = null): bool
     {
-        return $this->lazyObjectReal->pexpire($key, $timeout, $mode);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpire($key, $timeout, $mode);
     }
 
     public function pexpireAt($key, $timestamp, $mode = null): \Redis|bool
     {
-        return $this->lazyObjectReal->pexpireAt($key, $timestamp, $mode);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpireAt($key, $timestamp, $mode);
     }
 
     public function pfadd($key, $elements): \Redis|int
     {
-        return $this->lazyObjectReal->pfadd($key, $elements);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfadd($key, $elements);
     }
 
     public function pfcount($key_or_keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->pfcount($key_or_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfcount($key_or_keys);
     }
 
     public function pfmerge($dst, $srckeys): \Redis|bool
     {
-        return $this->lazyObjectReal->pfmerge($dst, $srckeys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfmerge($dst, $srckeys);
     }
 
     public function ping($message = null): \Redis|bool|string
     {
-        return $this->lazyObjectReal->ping($message);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ping($message);
     }
 
     public function pipeline(): \Redis|bool
     {
-        return $this->lazyObjectReal->pipeline();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pipeline();
     }
 
     public function popen($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, $context = null): bool
     {
-        return $this->lazyObjectReal->popen($host, $port, $timeout, $persistent_id, $retry_interval, $read_timeout, $context);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->popen($host, $port, $timeout, $persistent_id, $retry_interval, $read_timeout, $context);
     }
 
     public function psetex($key, $expire, $value): \Redis|bool
     {
-        return $this->lazyObjectReal->psetex($key, $expire, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psetex($key, $expire, $value);
     }
 
     public function psubscribe($patterns, $cb): bool
     {
-        return $this->lazyObjectReal->psubscribe($patterns, $cb);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psubscribe($patterns, $cb);
     }
 
     public function pttl($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->pttl($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pttl($key);
     }
 
     public function publish($channel, $message): \Redis|false|int
     {
-        return $this->lazyObjectReal->publish($channel, $message);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->publish($channel, $message);
     }
 
     public function pubsub($command, $arg = null): mixed
     {
-        return $this->lazyObjectReal->pubsub($command, $arg);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pubsub($command, $arg);
     }
 
     public function punsubscribe($patterns): \Redis|array|bool
     {
-        return $this->lazyObjectReal->punsubscribe($patterns);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->punsubscribe($patterns);
     }
 
     public function rPop($key, $count = 0): \Redis|array|bool|string
     {
-        return $this->lazyObjectReal->rPop($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rPop($key, $count);
     }
 
     public function randomKey(): \Redis|false|string
     {
-        return $this->lazyObjectReal->randomKey();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->randomKey();
     }
 
     public function rawcommand($command, ...$args): mixed
     {
-        return $this->lazyObjectReal->rawcommand($command, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rawcommand($command, ...$args);
     }
 
     public function rename($old_name, $new_name): \Redis|bool
     {
-        return $this->lazyObjectReal->rename($old_name, $new_name);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rename($old_name, $new_name);
     }
 
     public function renameNx($key_src, $key_dst): \Redis|bool
     {
-        return $this->lazyObjectReal->renameNx($key_src, $key_dst);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renameNx($key_src, $key_dst);
     }
 
     public function restore($key, $ttl, $value, $options = null): \Redis|bool
     {
-        return $this->lazyObjectReal->restore($key, $ttl, $value, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->restore($key, $ttl, $value, $options);
     }
 
     public function role(): mixed
     {
-        return $this->lazyObjectReal->role();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->role();
     }
 
     public function rpoplpush($srckey, $dstkey): \Redis|false|string
     {
-        return $this->lazyObjectReal->rpoplpush($srckey, $dstkey);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpoplpush($srckey, $dstkey);
     }
 
     public function sAdd($key, $value, ...$other_values): \Redis|false|int
     {
-        return $this->lazyObjectReal->sAdd($key, $value, ...$other_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sAdd($key, $value, ...$other_values);
     }
 
     public function sAddArray($key, $values): int
     {
-        return $this->lazyObjectReal->sAddArray($key, $values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sAddArray($key, $values);
     }
 
     public function sDiff($key, ...$other_keys): \Redis|array|false
     {
-        return $this->lazyObjectReal->sDiff($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sDiff($key, ...$other_keys);
     }
 
     public function sDiffStore($dst, $key, ...$other_keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->sDiffStore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sDiffStore($dst, $key, ...$other_keys);
     }
 
     public function sInter($key, ...$other_keys): \Redis|array|false
     {
-        return $this->lazyObjectReal->sInter($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sInter($key, ...$other_keys);
     }
 
     public function sintercard($keys, $limit = -1): \Redis|false|int
     {
-        return $this->lazyObjectReal->sintercard($keys, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sintercard($keys, $limit);
     }
 
     public function sInterStore($key, ...$other_keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->sInterStore($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sInterStore($key, ...$other_keys);
     }
 
     public function sMembers($key): \Redis|array|false
     {
-        return $this->lazyObjectReal->sMembers($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMembers($key);
     }
 
     public function sMisMember($key, $member, ...$other_members): \Redis|array|false
     {
-        return $this->lazyObjectReal->sMisMember($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMisMember($key, $member, ...$other_members);
     }
 
     public function sMove($src, $dst, $value): \Redis|bool
     {
-        return $this->lazyObjectReal->sMove($src, $dst, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sMove($src, $dst, $value);
     }
 
     public function sPop($key, $count = 0): \Redis|array|false|string
     {
-        return $this->lazyObjectReal->sPop($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sPop($key, $count);
     }
 
     public function sRandMember($key, $count = 0): \Redis|array|false|string
     {
-        return $this->lazyObjectReal->sRandMember($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sRandMember($key, $count);
     }
 
     public function sUnion($key, ...$other_keys): \Redis|array|false
     {
-        return $this->lazyObjectReal->sUnion($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sUnion($key, ...$other_keys);
     }
 
     public function sUnionStore($dst, $key, ...$other_keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->sUnionStore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sUnionStore($dst, $key, ...$other_keys);
     }
 
     public function save(): \Redis|bool
     {
-        return $this->lazyObjectReal->save();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->save();
     }
 
     public function scan(&$iterator, $pattern = null, $count = 0, $type = null): array|false
     {
-        return $this->lazyObjectReal->scan($iterator, $pattern, $count, $type);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, $pattern, $count, $type);
     }
 
     public function scard($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->scard($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scard($key);
     }
 
     public function script($command, ...$args): mixed
     {
-        return $this->lazyObjectReal->script($command, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->script($command, ...$args);
     }
 
     public function select($db): \Redis|bool
     {
-        return $this->lazyObjectReal->select($db);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->select($db);
     }
 
     public function set($key, $value, $options = null): \Redis|bool|string
     {
-        return $this->lazyObjectReal->set($key, $value, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->set($key, $value, $options);
     }
 
     public function setBit($key, $idx, $value): \Redis|false|int
     {
-        return $this->lazyObjectReal->setBit($key, $idx, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setBit($key, $idx, $value);
     }
 
     public function setRange($key, $index, $value): \Redis|false|int
     {
-        return $this->lazyObjectReal->setRange($key, $index, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setRange($key, $index, $value);
     }
 
     public function setOption($option, $value): bool
     {
-        return $this->lazyObjectReal->setOption($option, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setOption($option, $value);
     }
 
     public function setex($key, $expire, $value)
     {
-        return $this->lazyObjectReal->setex($key, $expire, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setex($key, $expire, $value);
     }
 
     public function setnx($key, $value): \Redis|bool
     {
-        return $this->lazyObjectReal->setnx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setnx($key, $value);
     }
 
     public function sismember($key, $value): \Redis|bool
     {
-        return $this->lazyObjectReal->sismember($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sismember($key, $value);
     }
 
     public function slaveof($host = null, $port = 6379): \Redis|bool
     {
-        return $this->lazyObjectReal->slaveof($host, $port);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slaveof($host, $port);
     }
 
     public function replicaof($host = null, $port = 6379): \Redis|bool
     {
-        return $this->lazyObjectReal->replicaof($host, $port);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->replicaof($host, $port);
     }
 
     public function touch($key_or_array, ...$more_keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->touch($key_or_array, ...$more_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->touch($key_or_array, ...$more_keys);
     }
 
     public function slowlog($operation, $length = 0): mixed
     {
-        return $this->lazyObjectReal->slowlog($operation, $length);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slowlog($operation, $length);
     }
 
     public function sort($key, $options = null): mixed
     {
-        return $this->lazyObjectReal->sort($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort($key, $options);
     }
 
     public function sort_ro($key, $options = null): mixed
     {
-        return $this->lazyObjectReal->sort_ro($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort_ro($key, $options);
     }
 
     public function sortAsc($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
     {
-        return $this->lazyObjectReal->sortAsc($key, $pattern, $get, $offset, $count, $store);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortAsc($key, $pattern, $get, $offset, $count, $store);
     }
 
     public function sortAscAlpha($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
     {
-        return $this->lazyObjectReal->sortAscAlpha($key, $pattern, $get, $offset, $count, $store);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortAscAlpha($key, $pattern, $get, $offset, $count, $store);
     }
 
     public function sortDesc($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
     {
-        return $this->lazyObjectReal->sortDesc($key, $pattern, $get, $offset, $count, $store);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortDesc($key, $pattern, $get, $offset, $count, $store);
     }
 
     public function sortDescAlpha($key, $pattern = null, $get = null, $offset = -1, $count = -1, $store = null): array
     {
-        return $this->lazyObjectReal->sortDescAlpha($key, $pattern, $get, $offset, $count, $store);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sortDescAlpha($key, $pattern, $get, $offset, $count, $store);
     }
 
     public function srem($key, $value, ...$other_values): \Redis|false|int
     {
-        return $this->lazyObjectReal->srem($key, $value, ...$other_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srem($key, $value, ...$other_values);
     }
 
     public function sscan($key, &$iterator, $pattern = null, $count = 0): array|false
     {
-        return $this->lazyObjectReal->sscan($key, $iterator, $pattern, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, $pattern, $count);
     }
 
     public function ssubscribe($channels, $cb): bool
     {
-        return $this->lazyObjectReal->ssubscribe($channels, $cb);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ssubscribe($channels, $cb);
     }
 
     public function strlen($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->strlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->strlen($key);
     }
 
     public function subscribe($channels, $cb): bool
     {
-        return $this->lazyObjectReal->subscribe($channels, $cb);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->subscribe($channels, $cb);
     }
 
     public function sunsubscribe($channels): \Redis|array|bool
     {
-        return $this->lazyObjectReal->sunsubscribe($channels);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunsubscribe($channels);
     }
 
     public function swapdb($src, $dst): \Redis|bool
     {
-        return $this->lazyObjectReal->swapdb($src, $dst);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->swapdb($src, $dst);
     }
 
     public function time(): \Redis|array
     {
-        return $this->lazyObjectReal->time();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->time();
     }
 
     public function ttl($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->ttl($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ttl($key);
     }
 
     public function type($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->type($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->type($key);
     }
 
     public function unlink($key, ...$other_keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->unlink($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unlink($key, ...$other_keys);
     }
 
     public function unsubscribe($channels): \Redis|array|bool
     {
-        return $this->lazyObjectReal->unsubscribe($channels);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unsubscribe($channels);
     }
 
     public function unwatch(): \Redis|bool
     {
-        return $this->lazyObjectReal->unwatch();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch();
     }
 
     public function watch($key, ...$other_keys): \Redis|bool
     {
-        return $this->lazyObjectReal->watch($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->watch($key, ...$other_keys);
     }
 
     public function wait($numreplicas, $timeout): false|int
     {
-        return $this->lazyObjectReal->wait($numreplicas, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->wait($numreplicas, $timeout);
     }
 
     public function xack($key, $group, $ids): false|int
     {
-        return $this->lazyObjectReal->xack($key, $group, $ids);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xack($key, $group, $ids);
     }
 
     public function xadd($key, $id, $values, $maxlen = 0, $approx = false, $nomkstream = false): \Redis|false|string
     {
-        return $this->lazyObjectReal->xadd($key, $id, $values, $maxlen, $approx, $nomkstream);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xadd($key, $id, $values, $maxlen, $approx, $nomkstream);
     }
 
     public function xautoclaim($key, $group, $consumer, $min_idle, $start, $count = -1, $justid = false): \Redis|array|bool
     {
-        return $this->lazyObjectReal->xautoclaim($key, $group, $consumer, $min_idle, $start, $count, $justid);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xautoclaim($key, $group, $consumer, $min_idle, $start, $count, $justid);
     }
 
     public function xclaim($key, $group, $consumer, $min_idle, $ids, $options): \Redis|array|bool
     {
-        return $this->lazyObjectReal->xclaim($key, $group, $consumer, $min_idle, $ids, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xclaim($key, $group, $consumer, $min_idle, $ids, $options);
     }
 
     public function xdel($key, $ids): \Redis|false|int
     {
-        return $this->lazyObjectReal->xdel($key, $ids);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xdel($key, $ids);
     }
 
     public function xgroup($operation, $key = null, $group = null, $id_or_consumer = null, $mkstream = false, $entries_read = -2): mixed
     {
-        return $this->lazyObjectReal->xgroup($operation, $key, $group, $id_or_consumer, $mkstream, $entries_read);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xgroup($operation, $key, $group, $id_or_consumer, $mkstream, $entries_read);
     }
 
     public function xinfo($operation, $arg1 = null, $arg2 = null, $count = -1): mixed
     {
-        return $this->lazyObjectReal->xinfo($operation, $arg1, $arg2, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xinfo($operation, $arg1, $arg2, $count);
     }
 
     public function xlen($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->xlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xlen($key);
     }
 
     public function xpending($key, $group, $start = null, $end = null, $count = -1, $consumer = null): \Redis|array|false
     {
-        return $this->lazyObjectReal->xpending($key, $group, $start, $end, $count, $consumer);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xpending($key, $group, $start, $end, $count, $consumer);
     }
 
     public function xrange($key, $start, $end, $count = -1): \Redis|array|bool
     {
-        return $this->lazyObjectReal->xrange($key, $start, $end, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrange($key, $start, $end, $count);
     }
 
     public function xread($streams, $count = -1, $block = -1): \Redis|array|bool
     {
-        return $this->lazyObjectReal->xread($streams, $count, $block);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xread($streams, $count, $block);
     }
 
     public function xreadgroup($group, $consumer, $streams, $count = 1, $block = 1): \Redis|array|bool
     {
-        return $this->lazyObjectReal->xreadgroup($group, $consumer, $streams, $count, $block);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xreadgroup($group, $consumer, $streams, $count, $block);
     }
 
     public function xrevrange($key, $end, $start, $count = -1): \Redis|array|bool
     {
-        return $this->lazyObjectReal->xrevrange($key, $end, $start, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrevrange($key, $end, $start, $count);
     }
 
     public function xtrim($key, $threshold, $approx = false, $minid = false, $limit = -1): \Redis|false|int
     {
-        return $this->lazyObjectReal->xtrim($key, $threshold, $approx, $minid, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xtrim($key, $threshold, $approx, $minid, $limit);
     }
 
     public function zAdd($key, $score_or_options, ...$more_scores_and_mems): \Redis|false|int
     {
-        return $this->lazyObjectReal->zAdd($key, $score_or_options, ...$more_scores_and_mems);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zAdd($key, $score_or_options, ...$more_scores_and_mems);
     }
 
     public function zCard($key): \Redis|false|int
     {
-        return $this->lazyObjectReal->zCard($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zCard($key);
     }
 
     public function zCount($key, $start, $end): \Redis|false|int
     {
-        return $this->lazyObjectReal->zCount($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zCount($key, $start, $end);
     }
 
     public function zIncrBy($key, $value, $member): \Redis|false|float
     {
-        return $this->lazyObjectReal->zIncrBy($key, $value, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zIncrBy($key, $value, $member);
     }
 
     public function zLexCount($key, $min, $max): \Redis|false|int
     {
-        return $this->lazyObjectReal->zLexCount($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zLexCount($key, $min, $max);
     }
 
     public function zMscore($key, $member, ...$other_members): \Redis|array|false
     {
-        return $this->lazyObjectReal->zMscore($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zMscore($key, $member, ...$other_members);
     }
 
     public function zPopMax($key, $count = null): \Redis|array|false
     {
-        return $this->lazyObjectReal->zPopMax($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zPopMax($key, $count);
     }
 
     public function zPopMin($key, $count = null): \Redis|array|false
     {
-        return $this->lazyObjectReal->zPopMin($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zPopMin($key, $count);
     }
 
     public function zRange($key, $start, $end, $options = null): \Redis|array|false
     {
-        return $this->lazyObjectReal->zRange($key, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRange($key, $start, $end, $options);
     }
 
     public function zRangeByLex($key, $min, $max, $offset = -1, $count = -1): \Redis|array|false
     {
-        return $this->lazyObjectReal->zRangeByLex($key, $min, $max, $offset, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRangeByLex($key, $min, $max, $offset, $count);
     }
 
     public function zRangeByScore($key, $start, $end, $options = []): \Redis|array|false
     {
-        return $this->lazyObjectReal->zRangeByScore($key, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRangeByScore($key, $start, $end, $options);
     }
 
     public function zrangestore($dstkey, $srckey, $start, $end, $options = null): \Redis|false|int
     {
-        return $this->lazyObjectReal->zrangestore($dstkey, $srckey, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangestore($dstkey, $srckey, $start, $end, $options);
     }
 
     public function zRandMember($key, $options = null): \Redis|array|string
     {
-        return $this->lazyObjectReal->zRandMember($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRandMember($key, $options);
     }
 
     public function zRank($key, $member): \Redis|false|int
     {
-        return $this->lazyObjectReal->zRank($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRank($key, $member);
     }
 
     public function zRem($key, $member, ...$other_members): \Redis|false|int
     {
-        return $this->lazyObjectReal->zRem($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRem($key, $member, ...$other_members);
     }
 
     public function zRemRangeByLex($key, $min, $max): \Redis|false|int
     {
-        return $this->lazyObjectReal->zRemRangeByLex($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByLex($key, $min, $max);
     }
 
     public function zRemRangeByRank($key, $start, $end): \Redis|false|int
     {
-        return $this->lazyObjectReal->zRemRangeByRank($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByRank($key, $start, $end);
     }
 
     public function zRemRangeByScore($key, $start, $end): \Redis|false|int
     {
-        return $this->lazyObjectReal->zRemRangeByScore($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRemRangeByScore($key, $start, $end);
     }
 
     public function zRevRange($key, $start, $end, $scores = null): \Redis|array|false
     {
-        return $this->lazyObjectReal->zRevRange($key, $start, $end, $scores);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRange($key, $start, $end, $scores);
     }
 
     public function zRevRangeByLex($key, $max, $min, $offset = -1, $count = -1): \Redis|array|false
     {
-        return $this->lazyObjectReal->zRevRangeByLex($key, $max, $min, $offset, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRangeByLex($key, $max, $min, $offset, $count);
     }
 
     public function zRevRangeByScore($key, $max, $min, $options = []): \Redis|array|false
     {
-        return $this->lazyObjectReal->zRevRangeByScore($key, $max, $min, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRangeByScore($key, $max, $min, $options);
     }
 
     public function zRevRank($key, $member): \Redis|false|int
     {
-        return $this->lazyObjectReal->zRevRank($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zRevRank($key, $member);
     }
 
     public function zScore($key, $member): \Redis|false|float
     {
-        return $this->lazyObjectReal->zScore($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zScore($key, $member);
     }
 
     public function zdiff($keys, $options = null): \Redis|array|false
     {
-        return $this->lazyObjectReal->zdiff($keys, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiff($keys, $options);
     }
 
     public function zdiffstore($dst, $keys): \Redis|false|int
     {
-        return $this->lazyObjectReal->zdiffstore($dst, $keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiffstore($dst, $keys);
     }
 
     public function zinter($keys, $weights = null, $options = null): \Redis|array|false
     {
-        return $this->lazyObjectReal->zinter($keys, $weights, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinter($keys, $weights, $options);
     }
 
     public function zintercard($keys, $limit = -1): \Redis|false|int
     {
-        return $this->lazyObjectReal->zintercard($keys, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zintercard($keys, $limit);
     }
 
     public function zinterstore($dst, $keys, $weights = null, $aggregate = null): \Redis|false|int
     {
-        return $this->lazyObjectReal->zinterstore($dst, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinterstore($dst, $keys, $weights, $aggregate);
     }
 
     public function zscan($key, &$iterator, $pattern = null, $count = 0): \Redis|array|false
     {
-        return $this->lazyObjectReal->zscan($key, $iterator, $pattern, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, $pattern, $count);
     }
 
     public function zunion($keys, $weights = null, $options = null): \Redis|array|false
     {
-        return $this->lazyObjectReal->zunion($keys, $weights, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunion($keys, $weights, $options);
     }
 
     public function zunionstore($dst, $keys, $weights = null, $aggregate = null): \Redis|false|int
     {
-        return $this->lazyObjectReal->zunionstore($dst, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunionstore($dst, $keys, $weights, $aggregate);
     }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
@@ -29,958 +29,955 @@ class RedisCluster5Proxy extends \RedisCluster implements ResetInterface, LazyOb
         resetLazyObject as reset;
     }
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [
-        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
-        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
-    ];
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 
     public function __construct($name, $seeds = null, $timeout = null, $read_timeout = null, $persistent = null, $auth = null)
     {
-        return $this->lazyObjectReal->__construct($name, $seeds, $timeout, $read_timeout, $persistent, $auth);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct($name, $seeds, $timeout, $read_timeout, $persistent, $auth);
     }
 
     public function _masters()
     {
-        return $this->lazyObjectReal->_masters();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_masters();
     }
 
     public function _prefix($key)
     {
-        return $this->lazyObjectReal->_prefix($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_prefix($key);
     }
 
     public function _redir()
     {
-        return $this->lazyObjectReal->_redir();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_redir();
     }
 
     public function _serialize($value)
     {
-        return $this->lazyObjectReal->_serialize($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_serialize($value);
     }
 
     public function _unserialize($value)
     {
-        return $this->lazyObjectReal->_unserialize($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unserialize($value);
     }
 
     public function _compress($value)
     {
-        return $this->lazyObjectReal->_compress($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_compress($value);
     }
 
     public function _uncompress($value)
     {
-        return $this->lazyObjectReal->_uncompress($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_uncompress($value);
     }
 
     public function _pack($value)
     {
-        return $this->lazyObjectReal->_pack($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_pack($value);
     }
 
     public function _unpack($value)
     {
-        return $this->lazyObjectReal->_unpack($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unpack($value);
     }
 
     public function acl($key_or_address, $subcmd, ...$args)
     {
-        return $this->lazyObjectReal->acl($key_or_address, $subcmd, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->acl($key_or_address, $subcmd, ...$args);
     }
 
     public function append($key, $value)
     {
-        return $this->lazyObjectReal->append($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->append($key, $value);
     }
 
     public function bgrewriteaof($key_or_address)
     {
-        return $this->lazyObjectReal->bgrewriteaof($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgrewriteaof($key_or_address);
     }
 
     public function bgsave($key_or_address)
     {
-        return $this->lazyObjectReal->bgsave($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgsave($key_or_address);
     }
 
     public function bitcount($key)
     {
-        return $this->lazyObjectReal->bitcount($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitcount($key);
     }
 
     public function bitop($operation, $ret_key, $key, ...$other_keys)
     {
-        return $this->lazyObjectReal->bitop($operation, $ret_key, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitop($operation, $ret_key, $key, ...$other_keys);
     }
 
     public function bitpos($key, $bit, $start = null, $end = null)
     {
-        return $this->lazyObjectReal->bitpos($key, $bit, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitpos($key, $bit, $start, $end);
     }
 
     public function blpop($key, $timeout_or_key, ...$extra_args)
     {
-        return $this->lazyObjectReal->blpop($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blpop($key, $timeout_or_key, ...$extra_args);
     }
 
     public function brpop($key, $timeout_or_key, ...$extra_args)
     {
-        return $this->lazyObjectReal->brpop($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpop($key, $timeout_or_key, ...$extra_args);
     }
 
     public function brpoplpush($src, $dst, $timeout)
     {
-        return $this->lazyObjectReal->brpoplpush($src, $dst, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpoplpush($src, $dst, $timeout);
     }
 
     public function clearlasterror()
     {
-        return $this->lazyObjectReal->clearlasterror();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearlasterror();
     }
 
     public function bzpopmax($key, $timeout_or_key, ...$extra_args)
     {
-        return $this->lazyObjectReal->bzpopmax($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmax($key, $timeout_or_key, ...$extra_args);
     }
 
     public function bzpopmin($key, $timeout_or_key, ...$extra_args)
     {
-        return $this->lazyObjectReal->bzpopmin($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmin($key, $timeout_or_key, ...$extra_args);
     }
 
     public function client($key_or_address, $arg = null, ...$other_args)
     {
-        return $this->lazyObjectReal->client($key_or_address, $arg, ...$other_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->client($key_or_address, $arg, ...$other_args);
     }
 
     public function close()
     {
-        return $this->lazyObjectReal->close();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->close();
     }
 
     public function cluster($key_or_address, $arg = null, ...$other_args)
     {
-        return $this->lazyObjectReal->cluster($key_or_address, $arg, ...$other_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->cluster($key_or_address, $arg, ...$other_args);
     }
 
     public function command(...$args)
     {
-        return $this->lazyObjectReal->command(...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->command(...$args);
     }
 
     public function config($key_or_address, $arg = null, ...$other_args)
     {
-        return $this->lazyObjectReal->config($key_or_address, $arg, ...$other_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->config($key_or_address, $arg, ...$other_args);
     }
 
     public function dbsize($key_or_address)
     {
-        return $this->lazyObjectReal->dbsize($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dbsize($key_or_address);
     }
 
     public function decr($key)
     {
-        return $this->lazyObjectReal->decr($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decr($key);
     }
 
     public function decrby($key, $value)
     {
-        return $this->lazyObjectReal->decrby($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrby($key, $value);
     }
 
     public function del($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->del($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->del($key, ...$other_keys);
     }
 
     public function discard()
     {
-        return $this->lazyObjectReal->discard();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->discard();
     }
 
     public function dump($key)
     {
-        return $this->lazyObjectReal->dump($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dump($key);
     }
 
     public function echo($msg)
     {
-        return $this->lazyObjectReal->echo($msg);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->echo($msg);
     }
 
     public function eval($script, $args = null, $num_keys = null)
     {
-        return $this->lazyObjectReal->eval($script, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval($script, $args, $num_keys);
     }
 
     public function evalsha($script_sha, $args = null, $num_keys = null)
     {
-        return $this->lazyObjectReal->evalsha($script_sha, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha($script_sha, $args, $num_keys);
     }
 
     public function exec()
     {
-        return $this->lazyObjectReal->exec();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exec();
     }
 
     public function exists($key)
     {
-        return $this->lazyObjectReal->exists($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exists($key);
     }
 
     public function expire($key, $timeout)
     {
-        return $this->lazyObjectReal->expire($key, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expire($key, $timeout);
     }
 
     public function expireat($key, $timestamp)
     {
-        return $this->lazyObjectReal->expireat($key, $timestamp);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expireat($key, $timestamp);
     }
 
     public function flushall($key_or_address, $async = null)
     {
-        return $this->lazyObjectReal->flushall($key_or_address, $async);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushall($key_or_address, $async);
     }
 
     public function flushdb($key_or_address, $async = null)
     {
-        return $this->lazyObjectReal->flushdb($key_or_address, $async);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushdb($key_or_address, $async);
     }
 
     public function geoadd($key, $lng, $lat, $member, ...$other_triples)
     {
-        return $this->lazyObjectReal->geoadd($key, $lng, $lat, $member, ...$other_triples);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geoadd($key, $lng, $lat, $member, ...$other_triples);
     }
 
     public function geodist($key, $src, $dst, $unit = null)
     {
-        return $this->lazyObjectReal->geodist($key, $src, $dst, $unit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geodist($key, $src, $dst, $unit);
     }
 
     public function geohash($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->geohash($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geohash($key, $member, ...$other_members);
     }
 
     public function geopos($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->geopos($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geopos($key, $member, ...$other_members);
     }
 
     public function georadius($key, $lng, $lan, $radius, $unit, $opts = null)
     {
-        return $this->lazyObjectReal->georadius($key, $lng, $lan, $radius, $unit, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius($key, $lng, $lan, $radius, $unit, $opts);
     }
 
     public function georadius_ro($key, $lng, $lan, $radius, $unit, $opts = null)
     {
-        return $this->lazyObjectReal->georadius_ro($key, $lng, $lan, $radius, $unit, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius_ro($key, $lng, $lan, $radius, $unit, $opts);
     }
 
     public function georadiusbymember($key, $member, $radius, $unit, $opts = null)
     {
-        return $this->lazyObjectReal->georadiusbymember($key, $member, $radius, $unit, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember($key, $member, $radius, $unit, $opts);
     }
 
     public function georadiusbymember_ro($key, $member, $radius, $unit, $opts = null)
     {
-        return $this->lazyObjectReal->georadiusbymember_ro($key, $member, $radius, $unit, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember_ro($key, $member, $radius, $unit, $opts);
     }
 
     public function get($key)
     {
-        return $this->lazyObjectReal->get($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->get($key);
     }
 
     public function getbit($key, $offset)
     {
-        return $this->lazyObjectReal->getbit($key, $offset);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getbit($key, $offset);
     }
 
     public function getlasterror()
     {
-        return $this->lazyObjectReal->getlasterror();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getlasterror();
     }
 
     public function getmode()
     {
-        return $this->lazyObjectReal->getmode();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getmode();
     }
 
     public function getoption($option)
     {
-        return $this->lazyObjectReal->getoption($option);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getoption($option);
     }
 
     public function getrange($key, $start, $end)
     {
-        return $this->lazyObjectReal->getrange($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getrange($key, $start, $end);
     }
 
     public function getset($key, $value)
     {
-        return $this->lazyObjectReal->getset($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getset($key, $value);
     }
 
     public function hdel($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->hdel($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hdel($key, $member, ...$other_members);
     }
 
     public function hexists($key, $member)
     {
-        return $this->lazyObjectReal->hexists($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hexists($key, $member);
     }
 
     public function hget($key, $member)
     {
-        return $this->lazyObjectReal->hget($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hget($key, $member);
     }
 
     public function hgetall($key)
     {
-        return $this->lazyObjectReal->hgetall($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hgetall($key);
     }
 
     public function hincrby($key, $member, $value)
     {
-        return $this->lazyObjectReal->hincrby($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrby($key, $member, $value);
     }
 
     public function hincrbyfloat($key, $member, $value)
     {
-        return $this->lazyObjectReal->hincrbyfloat($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrbyfloat($key, $member, $value);
     }
 
     public function hkeys($key)
     {
-        return $this->lazyObjectReal->hkeys($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hkeys($key);
     }
 
     public function hlen($key)
     {
-        return $this->lazyObjectReal->hlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hlen($key);
     }
 
     public function hmget($key, $keys)
     {
-        return $this->lazyObjectReal->hmget($key, $keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmget($key, $keys);
     }
 
     public function hmset($key, $pairs)
     {
-        return $this->lazyObjectReal->hmset($key, $pairs);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmset($key, $pairs);
     }
 
     public function hscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return $this->lazyObjectReal->hscan($str_key, $i_iterator, $str_pattern, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($str_key, $i_iterator, $str_pattern, $i_count);
     }
 
     public function hset($key, $member, $value)
     {
-        return $this->lazyObjectReal->hset($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hset($key, $member, $value);
     }
 
     public function hsetnx($key, $member, $value)
     {
-        return $this->lazyObjectReal->hsetnx($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hsetnx($key, $member, $value);
     }
 
     public function hstrlen($key, $member)
     {
-        return $this->lazyObjectReal->hstrlen($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hstrlen($key, $member);
     }
 
     public function hvals($key)
     {
-        return $this->lazyObjectReal->hvals($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hvals($key);
     }
 
     public function incr($key)
     {
-        return $this->lazyObjectReal->incr($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incr($key);
     }
 
     public function incrby($key, $value)
     {
-        return $this->lazyObjectReal->incrby($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrby($key, $value);
     }
 
     public function incrbyfloat($key, $value)
     {
-        return $this->lazyObjectReal->incrbyfloat($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrbyfloat($key, $value);
     }
 
     public function info($key_or_address, $option = null)
     {
-        return $this->lazyObjectReal->info($key_or_address, $option);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->info($key_or_address, $option);
     }
 
     public function keys($pattern)
     {
-        return $this->lazyObjectReal->keys($pattern);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->keys($pattern);
     }
 
     public function lastsave($key_or_address)
     {
-        return $this->lazyObjectReal->lastsave($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lastsave($key_or_address);
     }
 
     public function lget($key, $index)
     {
-        return $this->lazyObjectReal->lget($key, $index);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lget($key, $index);
     }
 
     public function lindex($key, $index)
     {
-        return $this->lazyObjectReal->lindex($key, $index);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lindex($key, $index);
     }
 
     public function linsert($key, $position, $pivot, $value)
     {
-        return $this->lazyObjectReal->linsert($key, $position, $pivot, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->linsert($key, $position, $pivot, $value);
     }
 
     public function llen($key)
     {
-        return $this->lazyObjectReal->llen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->llen($key);
     }
 
     public function lpop($key)
     {
-        return $this->lazyObjectReal->lpop($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpop($key);
     }
 
     public function lpush($key, $value)
     {
-        return $this->lazyObjectReal->lpush($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpush($key, $value);
     }
 
     public function lpushx($key, $value)
     {
-        return $this->lazyObjectReal->lpushx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpushx($key, $value);
     }
 
     public function lrange($key, $start, $end)
     {
-        return $this->lazyObjectReal->lrange($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrange($key, $start, $end);
     }
 
     public function lrem($key, $value)
     {
-        return $this->lazyObjectReal->lrem($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrem($key, $value);
     }
 
     public function lset($key, $index, $value)
     {
-        return $this->lazyObjectReal->lset($key, $index, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lset($key, $index, $value);
     }
 
     public function ltrim($key, $start, $stop)
     {
-        return $this->lazyObjectReal->ltrim($key, $start, $stop);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim($key, $start, $stop);
     }
 
     public function mget($keys)
     {
-        return $this->lazyObjectReal->mget($keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget($keys);
     }
 
     public function mset($pairs)
     {
-        return $this->lazyObjectReal->mset($pairs);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mset($pairs);
     }
 
     public function msetnx($pairs)
     {
-        return $this->lazyObjectReal->msetnx($pairs);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->msetnx($pairs);
     }
 
     public function multi()
     {
-        return $this->lazyObjectReal->multi();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->multi();
     }
 
     public function object($field, $key)
     {
-        return $this->lazyObjectReal->object($field, $key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->object($field, $key);
     }
 
     public function persist($key)
     {
-        return $this->lazyObjectReal->persist($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->persist($key);
     }
 
     public function pexpire($key, $timestamp)
     {
-        return $this->lazyObjectReal->pexpire($key, $timestamp);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpire($key, $timestamp);
     }
 
     public function pexpireat($key, $timestamp)
     {
-        return $this->lazyObjectReal->pexpireat($key, $timestamp);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpireat($key, $timestamp);
     }
 
     public function pfadd($key, $elements)
     {
-        return $this->lazyObjectReal->pfadd($key, $elements);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfadd($key, $elements);
     }
 
     public function pfcount($key)
     {
-        return $this->lazyObjectReal->pfcount($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfcount($key);
     }
 
     public function pfmerge($dstkey, $keys)
     {
-        return $this->lazyObjectReal->pfmerge($dstkey, $keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfmerge($dstkey, $keys);
     }
 
     public function ping($key_or_address)
     {
-        return $this->lazyObjectReal->ping($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ping($key_or_address);
     }
 
     public function psetex($key, $expire, $value)
     {
-        return $this->lazyObjectReal->psetex($key, $expire, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psetex($key, $expire, $value);
     }
 
     public function psubscribe($patterns, $callback)
     {
-        return $this->lazyObjectReal->psubscribe($patterns, $callback);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psubscribe($patterns, $callback);
     }
 
     public function pttl($key)
     {
-        return $this->lazyObjectReal->pttl($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pttl($key);
     }
 
     public function publish($channel, $message)
     {
-        return $this->lazyObjectReal->publish($channel, $message);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->publish($channel, $message);
     }
 
     public function pubsub($key_or_address, $arg = null, ...$other_args)
     {
-        return $this->lazyObjectReal->pubsub($key_or_address, $arg, ...$other_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pubsub($key_or_address, $arg, ...$other_args);
     }
 
     public function punsubscribe($pattern, ...$other_patterns)
     {
-        return $this->lazyObjectReal->punsubscribe($pattern, ...$other_patterns);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->punsubscribe($pattern, ...$other_patterns);
     }
 
     public function randomkey($key_or_address)
     {
-        return $this->lazyObjectReal->randomkey($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->randomkey($key_or_address);
     }
 
     public function rawcommand($cmd, ...$args)
     {
-        return $this->lazyObjectReal->rawcommand($cmd, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rawcommand($cmd, ...$args);
     }
 
     public function rename($key, $newkey)
     {
-        return $this->lazyObjectReal->rename($key, $newkey);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rename($key, $newkey);
     }
 
     public function renamenx($key, $newkey)
     {
-        return $this->lazyObjectReal->renamenx($key, $newkey);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renamenx($key, $newkey);
     }
 
     public function restore($ttl, $key, $value)
     {
-        return $this->lazyObjectReal->restore($ttl, $key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->restore($ttl, $key, $value);
     }
 
     public function role()
     {
-        return $this->lazyObjectReal->role();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->role();
     }
 
     public function rpop($key)
     {
-        return $this->lazyObjectReal->rpop($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpop($key);
     }
 
     public function rpoplpush($src, $dst)
     {
-        return $this->lazyObjectReal->rpoplpush($src, $dst);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpoplpush($src, $dst);
     }
 
     public function rpush($key, $value)
     {
-        return $this->lazyObjectReal->rpush($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpush($key, $value);
     }
 
     public function rpushx($key, $value)
     {
-        return $this->lazyObjectReal->rpushx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpushx($key, $value);
     }
 
     public function sadd($key, $value)
     {
-        return $this->lazyObjectReal->sadd($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sadd($key, $value);
     }
 
     public function saddarray($key, $options)
     {
-        return $this->lazyObjectReal->saddarray($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->saddarray($key, $options);
     }
 
     public function save($key_or_address)
     {
-        return $this->lazyObjectReal->save($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->save($key_or_address);
     }
 
     public function scan(&$i_iterator, $str_node, $str_pattern = null, $i_count = null)
     {
-        return $this->lazyObjectReal->scan($i_iterator, $str_node, $str_pattern, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($i_iterator, $str_node, $str_pattern, $i_count);
     }
 
     public function scard($key)
     {
-        return $this->lazyObjectReal->scard($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scard($key);
     }
 
     public function script($key_or_address, $arg = null, ...$other_args)
     {
-        return $this->lazyObjectReal->script($key_or_address, $arg, ...$other_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->script($key_or_address, $arg, ...$other_args);
     }
 
     public function sdiff($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sdiff($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiff($key, ...$other_keys);
     }
 
     public function sdiffstore($dst, $key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sdiffstore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiffstore($dst, $key, ...$other_keys);
     }
 
     public function set($key, $value, $opts = null)
     {
-        return $this->lazyObjectReal->set($key, $value, $opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->set($key, $value, $opts);
     }
 
     public function setbit($key, $offset, $value)
     {
-        return $this->lazyObjectReal->setbit($key, $offset, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setbit($key, $offset, $value);
     }
 
     public function setex($key, $expire, $value)
     {
-        return $this->lazyObjectReal->setex($key, $expire, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setex($key, $expire, $value);
     }
 
     public function setnx($key, $value)
     {
-        return $this->lazyObjectReal->setnx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setnx($key, $value);
     }
 
     public function setoption($option, $value)
     {
-        return $this->lazyObjectReal->setoption($option, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setoption($option, $value);
     }
 
     public function setrange($key, $offset, $value)
     {
-        return $this->lazyObjectReal->setrange($key, $offset, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setrange($key, $offset, $value);
     }
 
     public function sinter($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sinter($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinter($key, ...$other_keys);
     }
 
     public function sinterstore($dst, $key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sinterstore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinterstore($dst, $key, ...$other_keys);
     }
 
     public function sismember($key, $value)
     {
-        return $this->lazyObjectReal->sismember($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sismember($key, $value);
     }
 
     public function slowlog($key_or_address, $arg = null, ...$other_args)
     {
-        return $this->lazyObjectReal->slowlog($key_or_address, $arg, ...$other_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slowlog($key_or_address, $arg, ...$other_args);
     }
 
     public function smembers($key)
     {
-        return $this->lazyObjectReal->smembers($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smembers($key);
     }
 
     public function smove($src, $dst, $value)
     {
-        return $this->lazyObjectReal->smove($src, $dst, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smove($src, $dst, $value);
     }
 
     public function sort($key, $options = null)
     {
-        return $this->lazyObjectReal->sort($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort($key, $options);
     }
 
     public function spop($key)
     {
-        return $this->lazyObjectReal->spop($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->spop($key);
     }
 
     public function srandmember($key, $count = null)
     {
-        return $this->lazyObjectReal->srandmember($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srandmember($key, $count);
     }
 
     public function srem($key, $value)
     {
-        return $this->lazyObjectReal->srem($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srem($key, $value);
     }
 
     public function sscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return $this->lazyObjectReal->sscan($str_key, $i_iterator, $str_pattern, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($str_key, $i_iterator, $str_pattern, $i_count);
     }
 
     public function strlen($key)
     {
-        return $this->lazyObjectReal->strlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->strlen($key);
     }
 
     public function subscribe($channels, $callback)
     {
-        return $this->lazyObjectReal->subscribe($channels, $callback);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->subscribe($channels, $callback);
     }
 
     public function sunion($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sunion($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunion($key, ...$other_keys);
     }
 
     public function sunionstore($dst, $key, ...$other_keys)
     {
-        return $this->lazyObjectReal->sunionstore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunionstore($dst, $key, ...$other_keys);
     }
 
     public function time()
     {
-        return $this->lazyObjectReal->time();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->time();
     }
 
     public function ttl($key)
     {
-        return $this->lazyObjectReal->ttl($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ttl($key);
     }
 
     public function type($key)
     {
-        return $this->lazyObjectReal->type($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->type($key);
     }
 
     public function unsubscribe($channel, ...$other_channels)
     {
-        return $this->lazyObjectReal->unsubscribe($channel, ...$other_channels);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unsubscribe($channel, ...$other_channels);
     }
 
     public function unlink($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->unlink($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unlink($key, ...$other_keys);
     }
 
     public function unwatch()
     {
-        return $this->lazyObjectReal->unwatch();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch();
     }
 
     public function watch($key, ...$other_keys)
     {
-        return $this->lazyObjectReal->watch($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->watch($key, ...$other_keys);
     }
 
     public function xack($str_key, $str_group, $arr_ids)
     {
-        return $this->lazyObjectReal->xack($str_key, $str_group, $arr_ids);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xack($str_key, $str_group, $arr_ids);
     }
 
     public function xadd($str_key, $str_id, $arr_fields, $i_maxlen = null, $boo_approximate = null)
     {
-        return $this->lazyObjectReal->xadd($str_key, $str_id, $arr_fields, $i_maxlen, $boo_approximate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xadd($str_key, $str_id, $arr_fields, $i_maxlen, $boo_approximate);
     }
 
     public function xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts = null)
     {
-        return $this->lazyObjectReal->xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xclaim($str_key, $str_group, $str_consumer, $i_min_idle, $arr_ids, $arr_opts);
     }
 
     public function xdel($str_key, $arr_ids)
     {
-        return $this->lazyObjectReal->xdel($str_key, $arr_ids);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xdel($str_key, $arr_ids);
     }
 
     public function xgroup($str_operation, $str_key = null, $str_arg1 = null, $str_arg2 = null, $str_arg3 = null)
     {
-        return $this->lazyObjectReal->xgroup($str_operation, $str_key, $str_arg1, $str_arg2, $str_arg3);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xgroup($str_operation, $str_key, $str_arg1, $str_arg2, $str_arg3);
     }
 
     public function xinfo($str_cmd, $str_key = null, $str_group = null)
     {
-        return $this->lazyObjectReal->xinfo($str_cmd, $str_key, $str_group);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xinfo($str_cmd, $str_key, $str_group);
     }
 
     public function xlen($key)
     {
-        return $this->lazyObjectReal->xlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xlen($key);
     }
 
     public function xpending($str_key, $str_group, $str_start = null, $str_end = null, $i_count = null, $str_consumer = null)
     {
-        return $this->lazyObjectReal->xpending($str_key, $str_group, $str_start, $str_end, $i_count, $str_consumer);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xpending($str_key, $str_group, $str_start, $str_end, $i_count, $str_consumer);
     }
 
     public function xrange($str_key, $str_start, $str_end, $i_count = null)
     {
-        return $this->lazyObjectReal->xrange($str_key, $str_start, $str_end, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrange($str_key, $str_start, $str_end, $i_count);
     }
 
     public function xread($arr_streams, $i_count = null, $i_block = null)
     {
-        return $this->lazyObjectReal->xread($arr_streams, $i_count, $i_block);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xread($arr_streams, $i_count, $i_block);
     }
 
     public function xreadgroup($str_group, $str_consumer, $arr_streams, $i_count = null, $i_block = null)
     {
-        return $this->lazyObjectReal->xreadgroup($str_group, $str_consumer, $arr_streams, $i_count, $i_block);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xreadgroup($str_group, $str_consumer, $arr_streams, $i_count, $i_block);
     }
 
     public function xrevrange($str_key, $str_start, $str_end, $i_count = null)
     {
-        return $this->lazyObjectReal->xrevrange($str_key, $str_start, $str_end, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrevrange($str_key, $str_start, $str_end, $i_count);
     }
 
     public function xtrim($str_key, $i_maxlen, $boo_approximate = null)
     {
-        return $this->lazyObjectReal->xtrim($str_key, $i_maxlen, $boo_approximate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xtrim($str_key, $i_maxlen, $boo_approximate);
     }
 
     public function zadd($key, $score, $value, ...$extra_args)
     {
-        return $this->lazyObjectReal->zadd($key, $score, $value, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zadd($key, $score, $value, ...$extra_args);
     }
 
     public function zcard($key)
     {
-        return $this->lazyObjectReal->zcard($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcard($key);
     }
 
     public function zcount($key, $min, $max)
     {
-        return $this->lazyObjectReal->zcount($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcount($key, $min, $max);
     }
 
     public function zincrby($key, $value, $member)
     {
-        return $this->lazyObjectReal->zincrby($key, $value, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zincrby($key, $value, $member);
     }
 
     public function zinterstore($key, $keys, $weights = null, $aggregate = null)
     {
-        return $this->lazyObjectReal->zinterstore($key, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinterstore($key, $keys, $weights, $aggregate);
     }
 
     public function zlexcount($key, $min, $max)
     {
-        return $this->lazyObjectReal->zlexcount($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zlexcount($key, $min, $max);
     }
 
     public function zpopmax($key)
     {
-        return $this->lazyObjectReal->zpopmax($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmax($key);
     }
 
     public function zpopmin($key)
     {
-        return $this->lazyObjectReal->zpopmin($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmin($key);
     }
 
     public function zrange($key, $start, $end, $scores = null)
     {
-        return $this->lazyObjectReal->zrange($key, $start, $end, $scores);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrange($key, $start, $end, $scores);
     }
 
     public function zrangebylex($key, $min, $max, $offset = null, $limit = null)
     {
-        return $this->lazyObjectReal->zrangebylex($key, $min, $max, $offset, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebylex($key, $min, $max, $offset, $limit);
     }
 
     public function zrangebyscore($key, $start, $end, $options = null)
     {
-        return $this->lazyObjectReal->zrangebyscore($key, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebyscore($key, $start, $end, $options);
     }
 
     public function zrank($key, $member)
     {
-        return $this->lazyObjectReal->zrank($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrank($key, $member);
     }
 
     public function zrem($key, $member, ...$other_members)
     {
-        return $this->lazyObjectReal->zrem($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrem($key, $member, ...$other_members);
     }
 
     public function zremrangebylex($key, $min, $max)
     {
-        return $this->lazyObjectReal->zremrangebylex($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebylex($key, $min, $max);
     }
 
     public function zremrangebyrank($key, $min, $max)
     {
-        return $this->lazyObjectReal->zremrangebyrank($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyrank($key, $min, $max);
     }
 
     public function zremrangebyscore($key, $min, $max)
     {
-        return $this->lazyObjectReal->zremrangebyscore($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyscore($key, $min, $max);
     }
 
     public function zrevrange($key, $start, $end, $scores = null)
     {
-        return $this->lazyObjectReal->zrevrange($key, $start, $end, $scores);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrange($key, $start, $end, $scores);
     }
 
     public function zrevrangebylex($key, $min, $max, $offset = null, $limit = null)
     {
-        return $this->lazyObjectReal->zrevrangebylex($key, $min, $max, $offset, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebylex($key, $min, $max, $offset, $limit);
     }
 
     public function zrevrangebyscore($key, $start, $end, $options = null)
     {
-        return $this->lazyObjectReal->zrevrangebyscore($key, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebyscore($key, $start, $end, $options);
     }
 
     public function zrevrank($key, $member)
     {
-        return $this->lazyObjectReal->zrevrank($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrank($key, $member);
     }
 
     public function zscan($str_key, &$i_iterator, $str_pattern = null, $i_count = null)
     {
-        return $this->lazyObjectReal->zscan($str_key, $i_iterator, $str_pattern, $i_count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($str_key, $i_iterator, $str_pattern, $i_count);
     }
 
     public function zscore($key, $member)
     {
-        return $this->lazyObjectReal->zscore($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscore($key, $member);
     }
 
     public function zunionstore($key, $keys, $weights = null, $aggregate = null)
     {
-        return $this->lazyObjectReal->zunionstore($key, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunionstore($key, $keys, $weights, $aggregate);
     }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
@@ -29,1118 +29,1115 @@ class RedisCluster6Proxy extends \RedisCluster implements ResetInterface, LazyOb
         resetLazyObject as reset;
     }
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [
-        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
-        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
-    ];
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 
     public function __construct($name, $seeds = null, $timeout = 0, $read_timeout = 0, $persistent = false, #[\SensitiveParameter] $auth = null, $context = null)
     {
-        return $this->lazyObjectReal->__construct($name, $seeds, $timeout, $read_timeout, $persistent, $auth, $context);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct($name, $seeds, $timeout, $read_timeout, $persistent, $auth, $context);
     }
 
     public function _compress($value): string
     {
-        return $this->lazyObjectReal->_compress($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_compress($value);
     }
 
     public function _uncompress($value): string
     {
-        return $this->lazyObjectReal->_uncompress($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_uncompress($value);
     }
 
     public function _serialize($value): bool|string
     {
-        return $this->lazyObjectReal->_serialize($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_serialize($value);
     }
 
     public function _unserialize($value): mixed
     {
-        return $this->lazyObjectReal->_unserialize($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unserialize($value);
     }
 
     public function _pack($value): string
     {
-        return $this->lazyObjectReal->_pack($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_pack($value);
     }
 
     public function _unpack($value): mixed
     {
-        return $this->lazyObjectReal->_unpack($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_unpack($value);
     }
 
     public function _prefix($key): bool|string
     {
-        return $this->lazyObjectReal->_prefix($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_prefix($key);
     }
 
     public function _masters(): array
     {
-        return $this->lazyObjectReal->_masters();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_masters();
     }
 
     public function _redir(): ?string
     {
-        return $this->lazyObjectReal->_redir();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->_redir();
     }
 
     public function acl($key_or_address, $subcmd, ...$args): mixed
     {
-        return $this->lazyObjectReal->acl($key_or_address, $subcmd, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->acl($key_or_address, $subcmd, ...$args);
     }
 
     public function append($key, $value): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->append($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->append($key, $value);
     }
 
     public function bgrewriteaof($key_or_address): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->bgrewriteaof($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgrewriteaof($key_or_address);
     }
 
     public function bgsave($key_or_address): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->bgsave($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bgsave($key_or_address);
     }
 
     public function bitcount($key, $start = 0, $end = -1, $bybit = false): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->bitcount($key, $start, $end, $bybit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitcount($key, $start, $end, $bybit);
     }
 
     public function bitop($operation, $deskey, $srckey, ...$otherkeys): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->bitop($operation, $deskey, $srckey, ...$otherkeys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitop($operation, $deskey, $srckey, ...$otherkeys);
     }
 
     public function bitpos($key, $bit, $start = 0, $end = -1, $bybit = false): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->bitpos($key, $bit, $start, $end, $bybit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bitpos($key, $bit, $start, $end, $bybit);
     }
 
     public function blpop($key, $timeout_or_key, ...$extra_args): \RedisCluster|array|false|null
     {
-        return $this->lazyObjectReal->blpop($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blpop($key, $timeout_or_key, ...$extra_args);
     }
 
     public function brpop($key, $timeout_or_key, ...$extra_args): \RedisCluster|array|false|null
     {
-        return $this->lazyObjectReal->brpop($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpop($key, $timeout_or_key, ...$extra_args);
     }
 
     public function brpoplpush($srckey, $deskey, $timeout): mixed
     {
-        return $this->lazyObjectReal->brpoplpush($srckey, $deskey, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->brpoplpush($srckey, $deskey, $timeout);
     }
 
     public function lmove($src, $dst, $wherefrom, $whereto): \Redis|false|string
     {
-        return $this->lazyObjectReal->lmove($src, $dst, $wherefrom, $whereto);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmove($src, $dst, $wherefrom, $whereto);
     }
 
     public function blmove($src, $dst, $wherefrom, $whereto, $timeout): \Redis|false|string
     {
-        return $this->lazyObjectReal->blmove($src, $dst, $wherefrom, $whereto, $timeout);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmove($src, $dst, $wherefrom, $whereto, $timeout);
     }
 
     public function bzpopmax($key, $timeout_or_key, ...$extra_args): array
     {
-        return $this->lazyObjectReal->bzpopmax($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmax($key, $timeout_or_key, ...$extra_args);
     }
 
     public function bzpopmin($key, $timeout_or_key, ...$extra_args): array
     {
-        return $this->lazyObjectReal->bzpopmin($key, $timeout_or_key, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzpopmin($key, $timeout_or_key, ...$extra_args);
     }
 
     public function bzmpop($timeout, $keys, $from, $count = 1): \RedisCluster|array|false|null
     {
-        return $this->lazyObjectReal->bzmpop($timeout, $keys, $from, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->bzmpop($timeout, $keys, $from, $count);
     }
 
     public function zmpop($keys, $from, $count = 1): \RedisCluster|array|false|null
     {
-        return $this->lazyObjectReal->zmpop($keys, $from, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zmpop($keys, $from, $count);
     }
 
     public function blmpop($timeout, $keys, $from, $count = 1): \RedisCluster|array|false|null
     {
-        return $this->lazyObjectReal->blmpop($timeout, $keys, $from, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmpop($timeout, $keys, $from, $count);
     }
 
     public function lmpop($keys, $from, $count = 1): \RedisCluster|array|false|null
     {
-        return $this->lazyObjectReal->lmpop($keys, $from, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmpop($keys, $from, $count);
     }
 
     public function clearlasterror(): bool
     {
-        return $this->lazyObjectReal->clearlasterror();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->clearlasterror();
     }
 
     public function client($key_or_address, $subcommand, $arg = null): array|bool|string
     {
-        return $this->lazyObjectReal->client($key_or_address, $subcommand, $arg);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->client($key_or_address, $subcommand, $arg);
     }
 
     public function close(): bool
     {
-        return $this->lazyObjectReal->close();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->close();
     }
 
     public function cluster($key_or_address, $command, ...$extra_args): mixed
     {
-        return $this->lazyObjectReal->cluster($key_or_address, $command, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->cluster($key_or_address, $command, ...$extra_args);
     }
 
     public function command(...$extra_args): mixed
     {
-        return $this->lazyObjectReal->command(...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->command(...$extra_args);
     }
 
     public function config($key_or_address, $subcommand, ...$extra_args): mixed
     {
-        return $this->lazyObjectReal->config($key_or_address, $subcommand, ...$extra_args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->config($key_or_address, $subcommand, ...$extra_args);
     }
 
     public function dbsize($key_or_address): \RedisCluster|int
     {
-        return $this->lazyObjectReal->dbsize($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dbsize($key_or_address);
     }
 
     public function copy($src, $dst, $options = null): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->copy($src, $dst, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->copy($src, $dst, $options);
     }
 
     public function decr($key, $by = 1): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->decr($key, $by);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decr($key, $by);
     }
 
     public function decrby($key, $value): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->decrby($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrby($key, $value);
     }
 
     public function decrbyfloat($key, $value): float
     {
-        return $this->lazyObjectReal->decrbyfloat($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->decrbyfloat($key, $value);
     }
 
     public function del($key, ...$other_keys): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->del($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->del($key, ...$other_keys);
     }
 
     public function discard(): bool
     {
-        return $this->lazyObjectReal->discard();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->discard();
     }
 
     public function dump($key): \RedisCluster|false|string
     {
-        return $this->lazyObjectReal->dump($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->dump($key);
     }
 
     public function echo($key_or_address, $msg): \RedisCluster|false|string
     {
-        return $this->lazyObjectReal->echo($key_or_address, $msg);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->echo($key_or_address, $msg);
     }
 
     public function eval($script, $args = [], $num_keys = 0): mixed
     {
-        return $this->lazyObjectReal->eval($script, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval($script, $args, $num_keys);
     }
 
     public function eval_ro($script, $args = [], $num_keys = 0): mixed
     {
-        return $this->lazyObjectReal->eval_ro($script, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->eval_ro($script, $args, $num_keys);
     }
 
     public function evalsha($script_sha, $args = [], $num_keys = 0): mixed
     {
-        return $this->lazyObjectReal->evalsha($script_sha, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha($script_sha, $args, $num_keys);
     }
 
     public function evalsha_ro($script_sha, $args = [], $num_keys = 0): mixed
     {
-        return $this->lazyObjectReal->evalsha_ro($script_sha, $args, $num_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->evalsha_ro($script_sha, $args, $num_keys);
     }
 
     public function exec(): array|false
     {
-        return $this->lazyObjectReal->exec();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exec();
     }
 
     public function exists($key, ...$other_keys): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->exists($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->exists($key, ...$other_keys);
     }
 
     public function touch($key, ...$other_keys): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->touch($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->touch($key, ...$other_keys);
     }
 
     public function expire($key, $timeout, $mode = null): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->expire($key, $timeout, $mode);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expire($key, $timeout, $mode);
     }
 
     public function expireat($key, $timestamp, $mode = null): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->expireat($key, $timestamp, $mode);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expireat($key, $timestamp, $mode);
     }
 
     public function expiretime($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->expiretime($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->expiretime($key);
     }
 
     public function pexpiretime($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->pexpiretime($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpiretime($key);
     }
 
     public function flushall($key_or_address, $async = false): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->flushall($key_or_address, $async);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushall($key_or_address, $async);
     }
 
     public function flushdb($key_or_address, $async = false): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->flushdb($key_or_address, $async);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->flushdb($key_or_address, $async);
     }
 
     public function geoadd($key, $lng, $lat, $member, ...$other_triples_and_options): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->geoadd($key, $lng, $lat, $member, ...$other_triples_and_options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geoadd($key, $lng, $lat, $member, ...$other_triples_and_options);
     }
 
     public function geodist($key, $src, $dest, $unit = null): \RedisCluster|false|float
     {
-        return $this->lazyObjectReal->geodist($key, $src, $dest, $unit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geodist($key, $src, $dest, $unit);
     }
 
     public function geohash($key, $member, ...$other_members): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->geohash($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geohash($key, $member, ...$other_members);
     }
 
     public function geopos($key, $member, ...$other_members): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->geopos($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geopos($key, $member, ...$other_members);
     }
 
     public function georadius($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return $this->lazyObjectReal->georadius($key, $lng, $lat, $radius, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius($key, $lng, $lat, $radius, $unit, $options);
     }
 
     public function georadius_ro($key, $lng, $lat, $radius, $unit, $options = []): mixed
     {
-        return $this->lazyObjectReal->georadius_ro($key, $lng, $lat, $radius, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadius_ro($key, $lng, $lat, $radius, $unit, $options);
     }
 
     public function georadiusbymember($key, $member, $radius, $unit, $options = []): mixed
     {
-        return $this->lazyObjectReal->georadiusbymember($key, $member, $radius, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember($key, $member, $radius, $unit, $options);
     }
 
     public function georadiusbymember_ro($key, $member, $radius, $unit, $options = []): mixed
     {
-        return $this->lazyObjectReal->georadiusbymember_ro($key, $member, $radius, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->georadiusbymember_ro($key, $member, $radius, $unit, $options);
     }
 
     public function geosearch($key, $position, $shape, $unit, $options = []): \RedisCluster|array
     {
-        return $this->lazyObjectReal->geosearch($key, $position, $shape, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearch($key, $position, $shape, $unit, $options);
     }
 
     public function geosearchstore($dst, $src, $position, $shape, $unit, $options = []): \RedisCluster|array|false|int
     {
-        return $this->lazyObjectReal->geosearchstore($dst, $src, $position, $shape, $unit, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->geosearchstore($dst, $src, $position, $shape, $unit, $options);
     }
 
     public function get($key): mixed
     {
-        return $this->lazyObjectReal->get($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->get($key);
     }
 
     public function getbit($key, $value): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->getbit($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getbit($key, $value);
     }
 
     public function getlasterror(): ?string
     {
-        return $this->lazyObjectReal->getlasterror();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getlasterror();
     }
 
     public function getmode(): int
     {
-        return $this->lazyObjectReal->getmode();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getmode();
     }
 
     public function getoption($option): mixed
     {
-        return $this->lazyObjectReal->getoption($option);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getoption($option);
     }
 
     public function getrange($key, $start, $end): \RedisCluster|false|string
     {
-        return $this->lazyObjectReal->getrange($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getrange($key, $start, $end);
     }
 
     public function lcs($key1, $key2, $options = null): \RedisCluster|array|false|int|string
     {
-        return $this->lazyObjectReal->lcs($key1, $key2, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lcs($key1, $key2, $options);
     }
 
     public function getset($key, $value): \RedisCluster|bool|string
     {
-        return $this->lazyObjectReal->getset($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getset($key, $value);
     }
 
     public function gettransferredbytes(): array|false
     {
-        return $this->lazyObjectReal->gettransferredbytes();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->gettransferredbytes();
     }
 
     public function cleartransferredbytes(): void
     {
-        $this->lazyObjectReal->cleartransferredbytes();
+        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->cleartransferredbytes();
     }
 
     public function hdel($key, $member, ...$other_members): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->hdel($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hdel($key, $member, ...$other_members);
     }
 
     public function hexists($key, $member): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->hexists($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hexists($key, $member);
     }
 
     public function hget($key, $member): mixed
     {
-        return $this->lazyObjectReal->hget($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hget($key, $member);
     }
 
     public function hgetall($key): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->hgetall($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hgetall($key);
     }
 
     public function hincrby($key, $member, $value): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->hincrby($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrby($key, $member, $value);
     }
 
     public function hincrbyfloat($key, $member, $value): \RedisCluster|false|float
     {
-        return $this->lazyObjectReal->hincrbyfloat($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hincrbyfloat($key, $member, $value);
     }
 
     public function hkeys($key): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->hkeys($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hkeys($key);
     }
 
     public function hlen($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->hlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hlen($key);
     }
 
     public function hmget($key, $keys): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->hmget($key, $keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmget($key, $keys);
     }
 
     public function hmset($key, $key_values): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->hmset($key, $key_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hmset($key, $key_values);
     }
 
     public function hscan($key, &$iterator, $pattern = null, $count = 0): array|bool
     {
-        return $this->lazyObjectReal->hscan($key, $iterator, $pattern, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hscan($key, $iterator, $pattern, $count);
     }
 
     public function hrandfield($key, $options = null): \RedisCluster|array|string
     {
-        return $this->lazyObjectReal->hrandfield($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hrandfield($key, $options);
     }
 
     public function hset($key, $member, $value): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->hset($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hset($key, $member, $value);
     }
 
     public function hsetnx($key, $member, $value): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->hsetnx($key, $member, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hsetnx($key, $member, $value);
     }
 
     public function hstrlen($key, $field): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->hstrlen($key, $field);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hstrlen($key, $field);
     }
 
     public function hvals($key): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->hvals($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->hvals($key);
     }
 
     public function incr($key, $by = 1): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->incr($key, $by);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incr($key, $by);
     }
 
     public function incrby($key, $value): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->incrby($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrby($key, $value);
     }
 
     public function incrbyfloat($key, $value): \RedisCluster|false|float
     {
-        return $this->lazyObjectReal->incrbyfloat($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->incrbyfloat($key, $value);
     }
 
     public function info($key_or_address, ...$sections): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->info($key_or_address, ...$sections);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->info($key_or_address, ...$sections);
     }
 
     public function keys($pattern): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->keys($pattern);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->keys($pattern);
     }
 
     public function lastsave($key_or_address): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->lastsave($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lastsave($key_or_address);
     }
 
     public function lget($key, $index): \RedisCluster|bool|string
     {
-        return $this->lazyObjectReal->lget($key, $index);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lget($key, $index);
     }
 
     public function lindex($key, $index): mixed
     {
-        return $this->lazyObjectReal->lindex($key, $index);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lindex($key, $index);
     }
 
     public function linsert($key, $pos, $pivot, $value): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->linsert($key, $pos, $pivot, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->linsert($key, $pos, $pivot, $value);
     }
 
     public function llen($key): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->llen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->llen($key);
     }
 
     public function lpop($key, $count = 0): \RedisCluster|array|bool|string
     {
-        return $this->lazyObjectReal->lpop($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpop($key, $count);
     }
 
     public function lpos($key, $value, $options = null): \Redis|array|bool|int|null
     {
-        return $this->lazyObjectReal->lpos($key, $value, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpos($key, $value, $options);
     }
 
     public function lpush($key, $value, ...$other_values): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->lpush($key, $value, ...$other_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpush($key, $value, ...$other_values);
     }
 
     public function lpushx($key, $value): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->lpushx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lpushx($key, $value);
     }
 
     public function lrange($key, $start, $end): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->lrange($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrange($key, $start, $end);
     }
 
     public function lrem($key, $value, $count = 0): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->lrem($key, $value, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lrem($key, $value, $count);
     }
 
     public function lset($key, $index, $value): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->lset($key, $index, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lset($key, $index, $value);
     }
 
     public function ltrim($key, $start, $end): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->ltrim($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ltrim($key, $start, $end);
     }
 
     public function mget($keys): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->mget($keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mget($keys);
     }
 
     public function mset($key_values): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->mset($key_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->mset($key_values);
     }
 
     public function msetnx($key_values): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->msetnx($key_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->msetnx($key_values);
     }
 
     public function multi($value = \Redis::MULTI): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->multi($value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->multi($value);
     }
 
     public function object($subcommand, $key): \RedisCluster|false|int|string
     {
-        return $this->lazyObjectReal->object($subcommand, $key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->object($subcommand, $key);
     }
 
     public function persist($key): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->persist($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->persist($key);
     }
 
     public function pexpire($key, $timeout, $mode = null): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->pexpire($key, $timeout, $mode);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpire($key, $timeout, $mode);
     }
 
     public function pexpireat($key, $timestamp, $mode = null): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->pexpireat($key, $timestamp, $mode);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pexpireat($key, $timestamp, $mode);
     }
 
     public function pfadd($key, $elements): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->pfadd($key, $elements);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfadd($key, $elements);
     }
 
     public function pfcount($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->pfcount($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfcount($key);
     }
 
     public function pfmerge($key, $keys): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->pfmerge($key, $keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pfmerge($key, $keys);
     }
 
     public function ping($key_or_address, $message = null): mixed
     {
-        return $this->lazyObjectReal->ping($key_or_address, $message);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ping($key_or_address, $message);
     }
 
     public function psetex($key, $timeout, $value): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->psetex($key, $timeout, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psetex($key, $timeout, $value);
     }
 
     public function psubscribe($patterns, $callback): void
     {
-        $this->lazyObjectReal->psubscribe($patterns, $callback);
+        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->psubscribe($patterns, $callback);
     }
 
     public function pttl($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->pttl($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pttl($key);
     }
 
     public function publish($channel, $message): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->publish($channel, $message);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->publish($channel, $message);
     }
 
     public function pubsub($key_or_address, ...$values): mixed
     {
-        return $this->lazyObjectReal->pubsub($key_or_address, ...$values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->pubsub($key_or_address, ...$values);
     }
 
     public function punsubscribe($pattern, ...$other_patterns): array|bool
     {
-        return $this->lazyObjectReal->punsubscribe($pattern, ...$other_patterns);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->punsubscribe($pattern, ...$other_patterns);
     }
 
     public function randomkey($key_or_address): \RedisCluster|bool|string
     {
-        return $this->lazyObjectReal->randomkey($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->randomkey($key_or_address);
     }
 
     public function rawcommand($key_or_address, $command, ...$args): mixed
     {
-        return $this->lazyObjectReal->rawcommand($key_or_address, $command, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rawcommand($key_or_address, $command, ...$args);
     }
 
     public function rename($key_src, $key_dst): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->rename($key_src, $key_dst);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rename($key_src, $key_dst);
     }
 
     public function renamenx($key, $newkey): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->renamenx($key, $newkey);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->renamenx($key, $newkey);
     }
 
     public function restore($key, $timeout, $value, $options = null): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->restore($key, $timeout, $value, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->restore($key, $timeout, $value, $options);
     }
 
     public function role($key_or_address): mixed
     {
-        return $this->lazyObjectReal->role($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->role($key_or_address);
     }
 
     public function rpop($key, $count = 0): \RedisCluster|array|bool|string
     {
-        return $this->lazyObjectReal->rpop($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpop($key, $count);
     }
 
     public function rpoplpush($src, $dst): \RedisCluster|bool|string
     {
-        return $this->lazyObjectReal->rpoplpush($src, $dst);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpoplpush($src, $dst);
     }
 
     public function rpush($key, ...$elements): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->rpush($key, ...$elements);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpush($key, ...$elements);
     }
 
     public function rpushx($key, $value): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->rpushx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->rpushx($key, $value);
     }
 
     public function sadd($key, $value, ...$other_values): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->sadd($key, $value, ...$other_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sadd($key, $value, ...$other_values);
     }
 
     public function saddarray($key, $values): \RedisCluster|bool|int
     {
-        return $this->lazyObjectReal->saddarray($key, $values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->saddarray($key, $values);
     }
 
     public function save($key_or_address): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->save($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->save($key_or_address);
     }
 
     public function scan(&$iterator, $key_or_address, $pattern = null, $count = 0): array|bool
     {
-        return $this->lazyObjectReal->scan($iterator, $key_or_address, $pattern, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scan($iterator, $key_or_address, $pattern, $count);
     }
 
     public function scard($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->scard($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->scard($key);
     }
 
     public function script($key_or_address, ...$args): mixed
     {
-        return $this->lazyObjectReal->script($key_or_address, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->script($key_or_address, ...$args);
     }
 
     public function sdiff($key, ...$other_keys): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->sdiff($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiff($key, ...$other_keys);
     }
 
     public function sdiffstore($dst, $key, ...$other_keys): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->sdiffstore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiffstore($dst, $key, ...$other_keys);
     }
 
     public function set($key, $value, $options = null): \RedisCluster|bool|string
     {
-        return $this->lazyObjectReal->set($key, $value, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->set($key, $value, $options);
     }
 
     public function setbit($key, $offset, $onoff): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->setbit($key, $offset, $onoff);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setbit($key, $offset, $onoff);
     }
 
     public function setex($key, $expire, $value): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->setex($key, $expire, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setex($key, $expire, $value);
     }
 
     public function setnx($key, $value): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->setnx($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setnx($key, $value);
     }
 
     public function setoption($option, $value): bool
     {
-        return $this->lazyObjectReal->setoption($option, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setoption($option, $value);
     }
 
     public function setrange($key, $offset, $value): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->setrange($key, $offset, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setrange($key, $offset, $value);
     }
 
     public function sinter($key, ...$other_keys): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->sinter($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinter($key, ...$other_keys);
     }
 
     public function sintercard($keys, $limit = -1): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->sintercard($keys, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sintercard($keys, $limit);
     }
 
     public function sinterstore($key, ...$other_keys): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->sinterstore($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sinterstore($key, ...$other_keys);
     }
 
     public function sismember($key, $value): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->sismember($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sismember($key, $value);
     }
 
     public function smismember($key, $member, ...$other_members): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->smismember($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smismember($key, $member, ...$other_members);
     }
 
     public function slowlog($key_or_address, ...$args): mixed
     {
-        return $this->lazyObjectReal->slowlog($key_or_address, ...$args);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->slowlog($key_or_address, ...$args);
     }
 
     public function smembers($key): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->smembers($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smembers($key);
     }
 
     public function smove($src, $dst, $member): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->smove($src, $dst, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->smove($src, $dst, $member);
     }
 
     public function sort($key, $options = null): \RedisCluster|array|bool|int|string
     {
-        return $this->lazyObjectReal->sort($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort($key, $options);
     }
 
     public function sort_ro($key, $options = null): \RedisCluster|array|bool|int|string
     {
-        return $this->lazyObjectReal->sort_ro($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sort_ro($key, $options);
     }
 
     public function spop($key, $count = 0): \RedisCluster|array|false|string
     {
-        return $this->lazyObjectReal->spop($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->spop($key, $count);
     }
 
     public function srandmember($key, $count = 0): \RedisCluster|array|false|string
     {
-        return $this->lazyObjectReal->srandmember($key, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srandmember($key, $count);
     }
 
     public function srem($key, $value, ...$other_values): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->srem($key, $value, ...$other_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->srem($key, $value, ...$other_values);
     }
 
     public function sscan($key, &$iterator, $pattern = null, $count = 0): array|false
     {
-        return $this->lazyObjectReal->sscan($key, $iterator, $pattern, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sscan($key, $iterator, $pattern, $count);
     }
 
     public function strlen($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->strlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->strlen($key);
     }
 
     public function subscribe($channels, $cb): void
     {
-        $this->lazyObjectReal->subscribe($channels, $cb);
+        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->subscribe($channels, $cb);
     }
 
     public function sunion($key, ...$other_keys): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->sunion($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunion($key, ...$other_keys);
     }
 
     public function sunionstore($dst, $key, ...$other_keys): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->sunionstore($dst, $key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunionstore($dst, $key, ...$other_keys);
     }
 
     public function time($key_or_address): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->time($key_or_address);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->time($key_or_address);
     }
 
     public function ttl($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->ttl($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->ttl($key);
     }
 
     public function type($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->type($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->type($key);
     }
 
     public function unsubscribe($channels): array|bool
     {
-        return $this->lazyObjectReal->unsubscribe($channels);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unsubscribe($channels);
     }
 
     public function unlink($key, ...$other_keys): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->unlink($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unlink($key, ...$other_keys);
     }
 
     public function unwatch(): bool
     {
-        return $this->lazyObjectReal->unwatch();
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch();
     }
 
     public function watch($key, ...$other_keys): \RedisCluster|bool
     {
-        return $this->lazyObjectReal->watch($key, ...$other_keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->watch($key, ...$other_keys);
     }
 
     public function xack($key, $group, $ids): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->xack($key, $group, $ids);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xack($key, $group, $ids);
     }
 
     public function xadd($key, $id, $values, $maxlen = 0, $approx = false): \RedisCluster|false|string
     {
-        return $this->lazyObjectReal->xadd($key, $id, $values, $maxlen, $approx);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xadd($key, $id, $values, $maxlen, $approx);
     }
 
     public function xclaim($key, $group, $consumer, $min_iddle, $ids, $options): \RedisCluster|array|false|string
     {
-        return $this->lazyObjectReal->xclaim($key, $group, $consumer, $min_iddle, $ids, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xclaim($key, $group, $consumer, $min_iddle, $ids, $options);
     }
 
     public function xdel($key, $ids): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->xdel($key, $ids);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xdel($key, $ids);
     }
 
     public function xgroup($operation, $key = null, $group = null, $id_or_consumer = null, $mkstream = false, $entries_read = -2): mixed
     {
-        return $this->lazyObjectReal->xgroup($operation, $key, $group, $id_or_consumer, $mkstream, $entries_read);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xgroup($operation, $key, $group, $id_or_consumer, $mkstream, $entries_read);
     }
 
     public function xautoclaim($key, $group, $consumer, $min_idle, $start, $count = -1, $justid = false): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->xautoclaim($key, $group, $consumer, $min_idle, $start, $count, $justid);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xautoclaim($key, $group, $consumer, $min_idle, $start, $count, $justid);
     }
 
     public function xinfo($operation, $arg1 = null, $arg2 = null, $count = -1): mixed
     {
-        return $this->lazyObjectReal->xinfo($operation, $arg1, $arg2, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xinfo($operation, $arg1, $arg2, $count);
     }
 
     public function xlen($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->xlen($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xlen($key);
     }
 
     public function xpending($key, $group, $start = null, $end = null, $count = -1, $consumer = null): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->xpending($key, $group, $start, $end, $count, $consumer);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xpending($key, $group, $start, $end, $count, $consumer);
     }
 
     public function xrange($key, $start, $end, $count = -1): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->xrange($key, $start, $end, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrange($key, $start, $end, $count);
     }
 
     public function xread($streams, $count = -1, $block = -1): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->xread($streams, $count, $block);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xread($streams, $count, $block);
     }
 
     public function xreadgroup($group, $consumer, $streams, $count = 1, $block = 1): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->xreadgroup($group, $consumer, $streams, $count, $block);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xreadgroup($group, $consumer, $streams, $count, $block);
     }
 
     public function xrevrange($key, $start, $end, $count = -1): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->xrevrange($key, $start, $end, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xrevrange($key, $start, $end, $count);
     }
 
     public function xtrim($key, $maxlen, $approx = false, $minid = false, $limit = -1): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->xtrim($key, $maxlen, $approx, $minid, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xtrim($key, $maxlen, $approx, $minid, $limit);
     }
 
     public function zadd($key, $score_or_options, ...$more_scores_and_mems): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zadd($key, $score_or_options, ...$more_scores_and_mems);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zadd($key, $score_or_options, ...$more_scores_and_mems);
     }
 
     public function zcard($key): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zcard($key);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcard($key);
     }
 
     public function zcount($key, $start, $end): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zcount($key, $start, $end);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zcount($key, $start, $end);
     }
 
     public function zincrby($key, $value, $member): \RedisCluster|false|float
     {
-        return $this->lazyObjectReal->zincrby($key, $value, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zincrby($key, $value, $member);
     }
 
     public function zinterstore($dst, $keys, $weights = null, $aggregate = null): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zinterstore($dst, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinterstore($dst, $keys, $weights, $aggregate);
     }
 
     public function zintercard($keys, $limit = -1): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zintercard($keys, $limit);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zintercard($keys, $limit);
     }
 
     public function zlexcount($key, $min, $max): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zlexcount($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zlexcount($key, $min, $max);
     }
 
     public function zpopmax($key, $value = null): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->zpopmax($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmax($key, $value);
     }
 
     public function zpopmin($key, $value = null): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->zpopmin($key, $value);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zpopmin($key, $value);
     }
 
     public function zrange($key, $start, $end, $options = null): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->zrange($key, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrange($key, $start, $end, $options);
     }
 
     public function zrangestore($dstkey, $srckey, $start, $end, $options = null): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zrangestore($dstkey, $srckey, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangestore($dstkey, $srckey, $start, $end, $options);
     }
 
     public function zrandmember($key, $options = null): \RedisCluster|array|string
     {
-        return $this->lazyObjectReal->zrandmember($key, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrandmember($key, $options);
     }
 
     public function zrangebylex($key, $min, $max, $offset = -1, $count = -1): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->zrangebylex($key, $min, $max, $offset, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebylex($key, $min, $max, $offset, $count);
     }
 
     public function zrangebyscore($key, $start, $end, $options = []): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->zrangebyscore($key, $start, $end, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrangebyscore($key, $start, $end, $options);
     }
 
     public function zrank($key, $member): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zrank($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrank($key, $member);
     }
 
     public function zrem($key, $value, ...$other_values): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zrem($key, $value, ...$other_values);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrem($key, $value, ...$other_values);
     }
 
     public function zremrangebylex($key, $min, $max): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zremrangebylex($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebylex($key, $min, $max);
     }
 
     public function zremrangebyrank($key, $min, $max): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zremrangebyrank($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyrank($key, $min, $max);
     }
 
     public function zremrangebyscore($key, $min, $max): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zremrangebyscore($key, $min, $max);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zremrangebyscore($key, $min, $max);
     }
 
     public function zrevrange($key, $min, $max, $options = null): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->zrevrange($key, $min, $max, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrange($key, $min, $max, $options);
     }
 
     public function zrevrangebylex($key, $min, $max, $options = null): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->zrevrangebylex($key, $min, $max, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebylex($key, $min, $max, $options);
     }
 
     public function zrevrangebyscore($key, $min, $max, $options = null): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->zrevrangebyscore($key, $min, $max, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrangebyscore($key, $min, $max, $options);
     }
 
     public function zrevrank($key, $member): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zrevrank($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zrevrank($key, $member);
     }
 
     public function zscan($key, &$iterator, $pattern = null, $count = 0): \RedisCluster|array|bool
     {
-        return $this->lazyObjectReal->zscan($key, $iterator, $pattern, $count);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscan($key, $iterator, $pattern, $count);
     }
 
     public function zscore($key, $member): \RedisCluster|false|float
     {
-        return $this->lazyObjectReal->zscore($key, $member);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zscore($key, $member);
     }
 
     public function zmscore($key, $member, ...$other_members): \Redis|array|false
     {
-        return $this->lazyObjectReal->zmscore($key, $member, ...$other_members);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zmscore($key, $member, ...$other_members);
     }
 
     public function zunionstore($dst, $keys, $weights = null, $aggregate = null): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zunionstore($dst, $keys, $weights, $aggregate);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunionstore($dst, $keys, $weights, $aggregate);
     }
 
     public function zinter($keys, $weights = null, $options = null): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->zinter($keys, $weights, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zinter($keys, $weights, $options);
     }
 
     public function zdiffstore($dst, $keys): \RedisCluster|false|int
     {
-        return $this->lazyObjectReal->zdiffstore($dst, $keys);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiffstore($dst, $keys);
     }
 
     public function zunion($keys, $weights = null, $options = null): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->zunion($keys, $weights, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zunion($keys, $weights, $options);
     }
 
     public function zdiff($keys, $options = null): \RedisCluster|array|false
     {
-        return $this->lazyObjectReal->zdiff($keys, $options);
+        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->zdiff($keys, $options);
     }
 }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -26,7 +26,7 @@
         "psr/log": "^1.1|^2|^3",
         "symfony/cache-contracts": "^1.1.7|^2|^3",
         "symfony/service-contracts": "^1.1|^2|^3",
-        "symfony/var-exporter": "^6.2"
+        "symfony/var-exporter": "^6.2.7"
     },
     "require-dev": {
         "cache/integration-tests": "dev-master",

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
@@ -117,10 +117,7 @@ class stdClassProxy5a8a5eb extends \stdClass implements \Symfony\Component\VarEx
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 
-    private const LAZY_OBJECT_PROPERTY_SCOPES = [
-        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
-        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
-    ];
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 }
 
 // Help opcache.preload discover always-needed symbols

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
@@ -76,8 +76,6 @@ class WitherProxy94fa281 extends \Symfony\Component\DependencyInjection\Tests\Co
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 
     private const LAZY_OBJECT_PROPERTY_SCOPES = [
-        'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
-        "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
         'foo' => [parent::class, 'foo', null],
     ];
 }

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -20,7 +20,7 @@
         "psr/container": "^1.1|^2.0",
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/service-contracts": "^1.1.6|^2.0|^3.0",
-        "symfony/var-exporter": "^6.2"
+        "symfony/var-exporter": "^6.2.7"
     },
     "require-dev": {
         "symfony/yaml": "^5.4|^6.0",

--- a/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
@@ -76,12 +76,21 @@ class SymfonyCaster
 
         $stub->cut += \count($a) - 1;
 
-        return ['status' => new ConstStub(match ($a['status']) {
+        $instance = $a['realInstance'] ?? null;
+
+        $a = ['status' => new ConstStub(match ($a['status']) {
             LazyObjectState::STATUS_INITIALIZED_FULL => 'INITIALIZED_FULL',
             LazyObjectState::STATUS_INITIALIZED_PARTIAL => 'INITIALIZED_PARTIAL',
             LazyObjectState::STATUS_UNINITIALIZED_FULL => 'UNINITIALIZED_FULL',
             LazyObjectState::STATUS_UNINITIALIZED_PARTIAL => 'UNINITIALIZED_PARTIAL',
         }, $a['status'])];
+
+        if ($instance) {
+            $a['realInstance'] = $instance;
+            --$stub->cut;
+        }
+
+        return $a;
     }
 
     public static function castUuid(Uuid $uuid, array $a, Stub $stub, bool $isNested)

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
@@ -45,10 +45,7 @@ class LazyObjectRegistry
      */
     public static $parentMethods = [];
 
-    /**
-     * @var LazyObjectState
-     */
-    public static $noInitializerState;
+    public static ?\Closure $noInitializerState = null;
 
     public static function getClassResetters($class)
     {

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectState.php
@@ -37,6 +37,8 @@ class LazyObjectState
      */
     public int $status = 0;
 
+    public object $realInstance;
+
     public function __construct(public readonly \Closure|array $initializer, $skippedProperties = [])
     {
         $this->skippedProperties = $skippedProperties;

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectTrait.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Internal;
+
+if (\PHP_VERSION_ID >= 80300) {
+    /**
+     * @internal
+     */
+    trait LazyObjectTrait
+    {
+        private readonly LazyObjectState $lazyObjectState;
+    }
+} else {
+    /**
+     * @internal
+     */
+    trait LazyObjectTrait
+    {
+        private LazyObjectState $lazyObjectState;
+    }
+}

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -14,10 +14,11 @@ namespace Symfony\Component\VarExporter;
 use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
+use Symfony\Component\VarExporter\Internal\LazyObjectTrait;
 
 trait LazyGhostTrait
 {
-    private LazyObjectState $lazyObjectState;
+    use LazyObjectTrait;
 
     /**
      * Creates a lazy-loading ghost instance.

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -15,17 +15,17 @@ use Symfony\Component\VarExporter\Hydrator as PublicHydrator;
 use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
+use Symfony\Component\VarExporter\Internal\LazyObjectTrait;
 
 trait LazyProxyTrait
 {
-    private LazyObjectState $lazyObjectState;
-    private object $lazyObjectReal;
+    use LazyObjectTrait;
 
     /**
      * Creates a lazy-loading virtual proxy.
      *
      * @param \Closure():object $initializer Returns the proxied object
-     * @param static|null $instance
+     * @param static|null       $instance
      */
     public static function createLazyProxy(\Closure $initializer, object $instance = null): static
     {
@@ -52,11 +52,7 @@ trait LazyProxyTrait
      */
     public function isLazyObjectInitialized(bool $partial = false): bool
     {
-        if (!isset($this->lazyObjectState) || Registry::$noInitializerState === $this->lazyObjectState) {
-            return true;
-        }
-
-        return \array_key_exists("\0".self::class."\0lazyObjectReal", (array) $this);
+        return !isset($this->lazyObjectState) || isset($this->lazyObjectState->realInstance) || Registry::$noInitializerState === $this->lazyObjectState->initializer;
     }
 
     /**
@@ -64,8 +60,8 @@ trait LazyProxyTrait
      */
     public function initializeLazyObject(): parent
     {
-        if (isset($this->lazyObjectReal)) {
-            return $this->lazyObjectReal;
+        if ($state = $this->lazyObjectState ?? null) {
+            return $state->realInstance ??= ($state->initializer)();
         }
 
         return $this;
@@ -76,13 +72,11 @@ trait LazyProxyTrait
      */
     public function resetLazyObject(): bool
     {
-        if (!isset($this->lazyObjectState) || Registry::$noInitializerState === $this->lazyObjectState) {
+        if (!isset($this->lazyObjectState) || Registry::$noInitializerState === $this->lazyObjectState->initializer) {
             return false;
         }
 
-        if (\array_key_exists("\0".self::class."\0lazyObjectReal", (array) $this)) {
-            unset($this->lazyObjectReal);
-        }
+        unset($this->lazyObjectState->realInstance);
 
         return true;
     }
@@ -98,14 +92,7 @@ trait LazyProxyTrait
 
             if (null === $scope || isset($propertyScopes["\0$scope\0$name"])) {
                 if ($state = $this->lazyObjectState ?? null) {
-                    if ('lazyObjectReal' === $name && self::class === $scope) {
-                        $this->lazyObjectReal = ($state->initializer)();
-
-                        return $this->lazyObjectReal;
-                    }
-                    if (isset($this->lazyObjectReal)) {
-                        $instance = $this->lazyObjectReal;
-                    }
+                    $instance = $state->realInstance ??= ($state->initializer)();
                 }
                 $parent = 2;
                 goto get_in_scope;
@@ -113,8 +100,8 @@ trait LazyProxyTrait
         }
         $parent = (Registry::$parentMethods[self::class] ??= Registry::getParentMethods(self::class))['get'];
 
-        if (isset($this->lazyObjectReal)) {
-            $instance = $this->lazyObjectReal;
+        if ($state = $this->lazyObjectState ?? null) {
+            $instance = $state->realInstance ??= ($state->initializer)();
         } else {
             if (2 === $parent) {
                 return parent::__get($name);
@@ -174,22 +161,15 @@ trait LazyProxyTrait
             $scope = Registry::getScope($propertyScopes, $class, $name, $readonlyScope);
 
             if ($readonlyScope === $scope || isset($propertyScopes["\0$scope\0$name"])) {
-                if (isset($this->lazyObjectState)) {
-                    if ('lazyObjectReal' === $name && self::class === $scope) {
-                        $this->lazyObjectReal = $value;
-
-                        return;
-                    }
-                    if (isset($this->lazyObjectReal)) {
-                        $instance = $this->lazyObjectReal;
-                    }
+                if ($state = $this->lazyObjectState ?? null) {
+                    $instance = $state->realInstance ??= ($state->initializer)();
                 }
                 goto set_in_scope;
             }
         }
 
-        if (isset($this->lazyObjectReal)) {
-            $instance = $this->lazyObjectReal;
+        if ($state = $this->lazyObjectState ?? null) {
+            $instance = $state->realInstance ??= ($state->initializer)();
         } elseif ((Registry::$parentMethods[self::class] ??= Registry::getParentMethods(self::class))['set']) {
             parent::__set($name, $value);
 
@@ -216,22 +196,15 @@ trait LazyProxyTrait
             $scope = Registry::getScope($propertyScopes, $class, $name);
 
             if (null === $scope || isset($propertyScopes["\0$scope\0$name"])) {
-                if (isset($this->lazyObjectState)) {
-                    if ('lazyObjectReal' === $name && self::class === $scope) {
-                        $state = $this->lazyObjectState ?? null;
-
-                        return null !== $this->lazyObjectReal = $state ? ($state->initializer)() : null;
-                    }
-                    if (isset($this->lazyObjectReal)) {
-                        $instance = $this->lazyObjectReal;
-                    }
+                if ($state = $this->lazyObjectState ?? null) {
+                    $instance = $state->realInstance ??= ($state->initializer)();
                 }
                 goto isset_in_scope;
             }
         }
 
-        if (isset($this->lazyObjectReal)) {
-            $instance = $this->lazyObjectReal;
+        if ($state = $this->lazyObjectState ?? null) {
+            $instance = $state->realInstance ??= ($state->initializer)();
         } elseif ((Registry::$parentMethods[self::class] ??= Registry::getParentMethods(self::class))['isset']) {
             return parent::__isset($name);
         }
@@ -256,22 +229,15 @@ trait LazyProxyTrait
             $scope = Registry::getScope($propertyScopes, $class, $name, $readonlyScope);
 
             if ($readonlyScope === $scope || isset($propertyScopes["\0$scope\0$name"])) {
-                if (isset($this->lazyObjectState)) {
-                    if ('lazyObjectReal' === $name && self::class === $scope) {
-                        unset($this->lazyObjectReal);
-
-                        return;
-                    }
-                    if (isset($this->lazyObjectReal)) {
-                        $instance = $this->lazyObjectReal;
-                    }
+                if ($state = $this->lazyObjectState ?? null) {
+                    $instance = $state->realInstance ??= ($state->initializer)();
                 }
                 goto unset_in_scope;
             }
         }
 
-        if (isset($this->lazyObjectReal)) {
-            $instance = $this->lazyObjectReal;
+        if ($state = $this->lazyObjectState ?? null) {
+            $instance = $state->realInstance ??= ($state->initializer)();
         } elseif ((Registry::$parentMethods[self::class] ??= Registry::getParentMethods(self::class))['unset']) {
             parent::__unset($name);
 
@@ -298,26 +264,30 @@ trait LazyProxyTrait
             return;
         }
 
-        if (\array_key_exists("\0".self::class."\0lazyObjectReal", (array) $this)) {
-            $this->lazyObjectReal = clone $this->lazyObjectReal;
-        }
-        if ($state = $this->lazyObjectState ?? null) {
-            $this->lazyObjectState = clone $state;
+        $this->lazyObjectState = clone $this->lazyObjectState;
+
+        if (isset($this->lazyObjectState->realInstance)) {
+            $this->lazyObjectState->realInstance = clone $this->lazyObjectState->realInstance;
         }
     }
 
     public function __serialize(): array
     {
         $class = self::class;
+        $state = $this->lazyObjectState ?? null;
 
-        if (!isset($this->lazyObjectReal) && (Registry::$parentMethods[$class] ??= Registry::getParentMethods($class))['serialize']) {
+        if (!$state && (Registry::$parentMethods[$class] ??= Registry::getParentMethods($class))['serialize']) {
             $properties = parent::__serialize();
         } else {
             $properties = (array) $this;
-        }
-        unset($properties["\0$class\0lazyObjectState"]);
 
-        if (isset($this->lazyObjectReal) || Registry::$parentMethods[$class]['serialize'] || !Registry::$parentMethods[$class]['sleep']) {
+            if ($state) {
+                unset($properties["\0$class\0lazyObjectState"]);
+                $properties["\0$class\0lazyObjectReal"] = $state->realInstance ??= ($state->initializer)();
+            }
+        }
+
+        if ($state || Registry::$parentMethods[$class]['serialize'] || !Registry::$parentMethods[$class]['sleep']) {
             return $properties;
         }
 
@@ -341,17 +311,18 @@ trait LazyProxyTrait
     {
         $class = self::class;
 
-        if (isset($data["\0$class\0lazyObjectReal"])) {
+        if ($instance = $data["\0$class\0lazyObjectReal"] ?? null) {
+            unset($data["\0$class\0lazyObjectReal"]);
+
             foreach (Registry::$classResetters[$class] ??= Registry::getClassResetters($class) as $reset) {
                 $reset($this, $data);
             }
 
-            if (1 < \count($data)) {
+            if ($data) {
                 PublicHydrator::hydrate($this, $data);
-            } else {
-                $this->lazyObjectReal = $data["\0$class\0lazyObjectReal"];
             }
-            $this->lazyObjectState = Registry::$noInitializerState ??= new LazyObjectState(static fn () => throw new \LogicException('Lazy proxy has no initializer.'));
+            $this->lazyObjectState = new LazyObjectState(Registry::$noInitializerState ??= static fn () => throw new \LogicException('Lazy proxy has no initializer.'));
+            $this->lazyObjectState->realInstance = $instance;
         } elseif ((Registry::$parentMethods[$class] ??= Registry::getParentMethods($class))['unserialize']) {
             parent::__unserialize($data);
         } else {

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ReadOnlyClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/ReadOnlyClass.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
+
+readonly class ReadOnlyClass
+{
+    public function __construct(
+        public int $foo
+    ) {
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildStdClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildTestClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\LazyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\MagicClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ReadOnlyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\TestClass;
 
 class LazyGhostTraitTest extends TestCase
@@ -405,6 +406,16 @@ class LazyGhostTraitTest extends TestCase
         $proxy->foo[] = 123;
 
         $this->assertSame([123], $proxy->foo);
+    }
+
+    /**
+     * @requires PHP 8.3
+     */
+    public function testReadOnlyClass()
+    {
+        $proxy = $this->createLazyGhost(ReadOnlyClass::class, fn ($proxy) => $proxy->__construct(123));
+
+        $this->assertSame(123, $proxy->foo);
     }
 
     /**

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -168,10 +168,10 @@ class LazyProxyTraitTest extends TestCase
         $this->assertSame(1, $initCounter);
         $this->assertSame(123, $proxy->dynProp);
         $this->assertTrue(isset($proxy->dynProp));
-        $this->assertCount(2, (array) $proxy);
+        $this->assertCount(1, (array) $proxy);
         unset($proxy->dynProp);
         $this->assertFalse(isset($proxy->dynProp));
-        $this->assertCount(2, (array) $proxy);
+        $this->assertCount(1, (array) $proxy);
     }
 
     public function testStringMagicGet()
@@ -250,9 +250,14 @@ class LazyProxyTraitTest extends TestCase
      */
     public function testReadOnlyClass()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Cannot generate lazy proxy: class "Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\ReadOnlyClass" is read-only.');
-        $this->createLazyProxy(ReadOnlyClass::class, fn () => new ReadOnlyClass(123));
+        if (\PHP_VERSION_ID < 80300) {
+            $this->expectException(LogicException::class);
+            $this->expectExceptionMessage('Cannot generate lazy proxy: class "Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\ReadOnlyClass" is readonly.');
+        }
+
+        $proxy = $this->createLazyProxy(ReadOnlyClass::class, fn () => new ReadOnlyClass(123));
+
+        $this->assertSame(123, $proxy->foo);
     }
 
     public function testLazyDecoratorClass()

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -66,15 +66,12 @@ class ProxyHelperTest extends TestCase
         {
             use \Symfony\Component\VarExporter\LazyProxyTrait;
 
-            private const LAZY_OBJECT_PROPERTY_SCOPES = [
-                'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
-                "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
-            ];
+            private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 
             public function foo1(): ?\Symfony\Component\VarExporter\Tests\Bar
             {
-                if (isset($this->lazyObjectReal)) {
-                    return $this->lazyObjectReal->foo1(...\func_get_args());
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo1(...\func_get_args());
                 }
 
                 return parent::foo1(...\func_get_args());
@@ -82,8 +79,8 @@ class ProxyHelperTest extends TestCase
 
             public function foo4(\Symfony\Component\VarExporter\Tests\Bar|string $b): void
             {
-                if (isset($this->lazyObjectReal)) {
-                    $this->lazyObjectReal->foo4(...\func_get_args());
+                if (isset($this->lazyObjectState)) {
+                    ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo4(...\func_get_args());
                 } else {
                     parent::foo4(...\func_get_args());
                 }
@@ -91,8 +88,8 @@ class ProxyHelperTest extends TestCase
 
             protected function foo7()
             {
-                if (isset($this->lazyObjectReal)) {
-                    return $this->lazyObjectReal->foo7(...\func_get_args());
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo7(...\func_get_args());
                 }
 
                 return throw new \BadMethodCallException('Cannot forward abstract method "Symfony\Component\VarExporter\Tests\TestForProxyHelper::foo7()".');
@@ -116,15 +113,12 @@ class ProxyHelperTest extends TestCase
         {
             use \Symfony\Component\VarExporter\LazyProxyTrait;
 
-            private const LAZY_OBJECT_PROPERTY_SCOPES = [
-                'lazyObjectReal' => [self::class, 'lazyObjectReal', null],
-                "\0".self::class."\0lazyObjectReal" => [self::class, 'lazyObjectReal', null],
-            ];
+            private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 
             public function initializeLazyObject(): \Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface1&\Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2
             {
-                if (isset($this->lazyObjectReal)) {
-                    return $this->lazyObjectReal;
+                if ($state = $this->lazyObjectState ?? null) {
+                    return $state->realInstance ??= ($state->initializer)();
                 }
 
                 return $this;
@@ -132,8 +126,8 @@ class ProxyHelperTest extends TestCase
 
             public function foo1(): ?\Symfony\Component\VarExporter\Tests\Bar
             {
-                if (isset($this->lazyObjectReal)) {
-                    return $this->lazyObjectReal->foo1(...\func_get_args());
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo1(...\func_get_args());
                 }
 
                 return throw new \BadMethodCallException('Cannot forward abstract method "Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface1::foo1()".');
@@ -141,8 +135,8 @@ class ProxyHelperTest extends TestCase
 
             public function foo2(?\Symfony\Component\VarExporter\Tests\Bar $b): \Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2
             {
-                if (isset($this->lazyObjectReal)) {
-                    return $this->lazyObjectReal->foo2(...\func_get_args());
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo2(...\func_get_args());
                 }
 
                 return throw new \BadMethodCallException('Cannot forward abstract method "Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2::foo2()".');
@@ -170,8 +164,8 @@ class ProxyHelperTest extends TestCase
 
             public function foo(#[\SensitiveParameter] $a): int
             {
-                if (isset($this->lazyObjectReal)) {
-                    return $this->lazyObjectReal->foo(...\func_get_args());
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo(...\func_get_args());
                 }
 
                 return parent::foo(...\func_get_args());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | n
| Tickets       | -
| License       | MIT
| Doc PR        | -

Now that https://wiki.php.net/rfc/readonly_amendments has been accepted, I figured out the design of `LazyProxyTrait` needs some tweaks to support readonly classes.

This basically move the `LazyProxyTrait::$lazyObjectReal` property to `LazyObjectState::$realInstance`.