### PR TITLE
[Tests] Migrate tests to static data providers

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
@@ -49,66 +49,63 @@ class DoctrineOrmTypeGuesserTest extends TestCase
         yield [Types::DATETIMETZ_MUTABLE, new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateTimeType', [], Guess::HIGH_CONFIDENCE)];
     }
 
-    /**
-     * @dataProvider requiredProvider
-     */
-    public function testRequiredGuesser($classMetadata, $expected)
+    public function testRequiredGuesserSimpleFieldNotNullable()
     {
-        $this->assertEquals($expected, $this->getGuesser($classMetadata)->guessRequired('TestEntity', 'field'));
-    }
-
-    public function requiredProvider()
-    {
-        $return = [];
-
-        // Simple field, not nullable
         $classMetadata = $this->createMock(ClassMetadata::class);
         $classMetadata->fieldMappings['field'] = true;
         $classMetadata->expects($this->once())->method('isNullable')->with('field')->willReturn(false);
 
-        $return[] = [$classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE)];
+        $this->assertEquals(new ValueGuess(true, Guess::HIGH_CONFIDENCE), $this->getGuesser($classMetadata)->guessRequired('TestEntity', 'field'));
+    }
 
-        // Simple field, nullable
+    public function testRequiredGuesserSimpleFieldNullable()
+    {
         $classMetadata = $this->createMock(ClassMetadata::class);
         $classMetadata->fieldMappings['field'] = true;
         $classMetadata->expects($this->once())->method('isNullable')->with('field')->willReturn(true);
 
-        $return[] = [$classMetadata, new ValueGuess(false, Guess::MEDIUM_CONFIDENCE)];
+        $this->assertEquals(new ValueGuess(false, Guess::MEDIUM_CONFIDENCE), $this->getGuesser($classMetadata)->guessRequired('TestEntity', 'field'));
+    }
 
-        // One-to-one, nullable (by default)
+    public function testRequiredGuesserOneToOneNullable()
+    {
         $classMetadata = $this->createMock(ClassMetadata::class);
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = ['joinColumns' => [[]]];
         $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
-        $return[] = [$classMetadata, new ValueGuess(false, Guess::HIGH_CONFIDENCE)];
+        $this->assertEquals(new ValueGuess(false, Guess::HIGH_CONFIDENCE), $this->getGuesser($classMetadata)->guessRequired('TestEntity', 'field'));
+    }
 
-        // One-to-one, nullable (explicit)
+    public function testRequiredGuesserOneToOneExplicitNullable()
+    {
         $classMetadata = $this->createMock(ClassMetadata::class);
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = ['joinColumns' => [['nullable' => true]]];
         $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
-        $return[] = [$classMetadata, new ValueGuess(false, Guess::HIGH_CONFIDENCE)];
+        $this->assertEquals(new ValueGuess(false, Guess::HIGH_CONFIDENCE), $this->getGuesser($classMetadata)->guessRequired('TestEntity', 'field'));
+    }
 
-        // One-to-one, not nullable
+    public function testRequiredGuesserOneToOneNotNullable()
+    {
         $classMetadata = $this->createMock(ClassMetadata::class);
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = ['joinColumns' => [['nullable' => false]]];
         $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
-        $return[] = [$classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE)];
+        $this->assertEquals(new ValueGuess(true, Guess::HIGH_CONFIDENCE), $this->getGuesser($classMetadata)->guessRequired('TestEntity', 'field'));
+    }
 
-        // One-to-many, no clue
+    public function testRequiredGuesserOneToMany()
+    {
         $classMetadata = $this->createMock(ClassMetadata::class);
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(false);
 
-        $return[] = [$classMetadata, null];
-
-        return $return;
+        $this->assertNull($this->getGuesser($classMetadata)->guessRequired('TestEntity', 'field'));
     }
 
     private function getGuesser(ClassMetadata $classMetadata)

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\Tests\Controller;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController;
@@ -367,6 +368,99 @@ class ProfilerControllerTest extends WebTestCase
      */
     public function testDefaultPanel(string $expectedPanel, Profile $profile)
     {
+        $this->assertDefaultPanel($expectedPanel, $profile);
+    }
+
+    public static function defaultPanelProvider(): \Generator
+    {
+        // Test default behavior
+        $profile = new Profile('xxxxxx');
+        $profile->addCollector($requestDataCollector = new RequestDataCollector());
+        yield [$requestDataCollector->getName(), $profile];
+
+        // Test exception
+        $profile = new Profile('xxxxxx');
+        $profile->addCollector($exceptionDataCollector = new ExceptionDataCollector());
+        $exceptionDataCollector->collect(new Request(), new Response(), new \DomainException());
+        yield [$exceptionDataCollector->getName(), $profile];
+    }
+
+    private function createController($profiler, $twig, $withCSP, array $templates = []): ProfilerController
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+
+        if ($withCSP) {
+            $nonceGenerator = $this->createMock(NonceGenerator::class);
+            $nonceGenerator->method('generate')->willReturn('dummy_nonce');
+
+            return new ProfilerController($urlGenerator, $profiler, $twig, $templates, new ContentSecurityPolicyHandler($nonceGenerator));
+        }
+
+        return new ProfilerController($urlGenerator, $profiler, $twig, $templates);
+    }
+
+    public function testDumpPanelExceptionPriority()
+    {
+        $exceptionDataCollector = new ExceptionDataCollector();
+        $exceptionDataCollector->collect(new Request(), new Response(), new \DomainException());
+
+        $dumpDataCollector = $this->createDumpDataCollector();
+
+        $profile = new Profile('xxxxxx');
+        $profile->setCollectors([$exceptionDataCollector, $dumpDataCollector]);
+
+        $this->assertDefaultPanel($exceptionDataCollector->getName(), $profile);
+    }
+
+    public function testDumpPanelWhenDefinedAfterwards()
+    {
+        $exceptionDataCollector = new ExceptionDataCollector();
+        $exceptionDataCollector->collect(new Request(), new Response(), new \DomainException());
+
+        $dumpDataCollector = $this->createDumpDataCollector();
+        $dumpDataCollector
+            ->expects($this->atLeastOnce())
+            ->method('getDumpsCount')
+            ->willReturn(1)
+        ;
+
+        $profile = new Profile('xxxxxx');
+        $profile->setCollectors([$dumpDataCollector, $exceptionDataCollector]);
+
+        $this->assertDefaultPanel($exceptionDataCollector->getName(), $profile);
+    }
+
+    public function testDumpPanel()
+    {
+        $dumpDataCollector = $this->createDumpDataCollector();
+        $dumpDataCollector
+            ->expects($this->atLeastOnce())
+            ->method('getDumpsCount')
+            ->willReturn(1)
+        ;
+
+        $profile = new Profile('xxxxxx');
+        $profile->addCollector($dumpDataCollector);
+
+        $this->assertDefaultPanel($dumpDataCollector->getName(), $profile);
+    }
+
+    /**
+     * @return MockObject<DumpDataCollector>
+     */
+    private function createDumpDataCollector(): MockObject
+    {
+        $dumpDataCollector = $this->createMock(DumpDataCollector::class);
+        $dumpDataCollector
+            ->expects($this->atLeastOnce())
+            ->method('getName')
+            ->willReturn('dump');
+
+        return $dumpDataCollector;
+    }
+
+    private function assertDefaultPanel(string $expectedPanel, Profile $profile)
+    {
         $profiler = $this->createMock(Profiler::class);
         $profiler
             ->expects($this->atLeastOnce())
@@ -414,57 +508,5 @@ class ProfilerControllerTest extends WebTestCase
                 return [$collectorName, 'other_template.html.twig'];
             }, $collectorsNames))
             ->panelAction(new Request(), $profile->getToken());
-    }
-
-    public function defaultPanelProvider(): \Generator
-    {
-        // Test default behavior
-        $profile = new Profile('xxxxxx');
-        $profile->addCollector($requestDataCollector = new RequestDataCollector());
-        yield [$requestDataCollector->getName(), $profile];
-
-        // Test exception
-        $profile = new Profile('xxxxxx');
-        $profile->addCollector($exceptionDataCollector = new ExceptionDataCollector());
-        $exceptionDataCollector->collect(new Request(), new Response(), new \DomainException());
-        yield [$exceptionDataCollector->getName(), $profile];
-
-        // Test exception priority
-        $dumpDataCollector = $this->createMock(DumpDataCollector::class);
-        $dumpDataCollector
-            ->expects($this->atLeastOnce())
-            ->method('getName')
-            ->willReturn('dump');
-        $dumpDataCollector
-            ->expects($this->atLeastOnce())
-            ->method('getDumpsCount')
-            ->willReturn(1);
-        $profile = new Profile('xxxxxx');
-        $profile->setCollectors([$exceptionDataCollector, $dumpDataCollector]);
-        yield [$exceptionDataCollector->getName(), $profile];
-
-        // Test exception priority when defined afterwards
-        $profile = new Profile('xxxxxx');
-        $profile->setCollectors([$dumpDataCollector, $exceptionDataCollector]);
-        yield [$exceptionDataCollector->getName(), $profile];
-
-        // Test dump
-        $profile = new Profile('xxxxxx');
-        $profile->addCollector($dumpDataCollector);
-        yield [$dumpDataCollector->getName(), $profile];
-    }
-
-    private function createController($profiler, $twig, $withCSP, array $templates = []): ProfilerController
-    {
-        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-
-        if ($withCSP) {
-            $nonceGenerator = $this->createMock(NonceGenerator::class);
-            $nonceGenerator->method('generate')->willReturn('dummy_nonce');
-
-            return new ProfilerController($urlGenerator, $profiler, $twig, $templates, new ContentSecurityPolicyHandler($nonceGenerator));
-        }
-
-        return new ProfilerController($urlGenerator, $profiler, $twig, $templates);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTestCase.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTestCase.php
@@ -53,27 +53,27 @@ abstract class AbstractDescriptorTestCase extends TestCase
 
     public static function getDescribeInputArgumentTestData()
     {
-        return static::getDescriptionTestData(ObjectsProvider::getInputArguments());
+        return self::getDescriptionTestData(ObjectsProvider::getInputArguments());
     }
 
     public static function getDescribeInputOptionTestData()
     {
-        return static::getDescriptionTestData(ObjectsProvider::getInputOptions());
+        return self::getDescriptionTestData(ObjectsProvider::getInputOptions());
     }
 
     public static function getDescribeInputDefinitionTestData()
     {
-        return static::getDescriptionTestData(ObjectsProvider::getInputDefinitions());
+        return self::getDescriptionTestData(ObjectsProvider::getInputDefinitions());
     }
 
     public static function getDescribeCommandTestData()
     {
-        return static::getDescriptionTestData(ObjectsProvider::getCommands());
+        return self::getDescriptionTestData(ObjectsProvider::getCommands());
     }
 
     public static function getDescribeApplicationTestData()
     {
-        return static::getDescriptionTestData(ObjectsProvider::getApplications());
+        return self::getDescriptionTestData(ObjectsProvider::getApplications());
     }
 
     abstract protected function getDescriptor();

--- a/src/Symfony/Component/DomCrawler/Tests/Html5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Html5ParserCrawlerTest.php
@@ -52,7 +52,7 @@ class Html5ParserCrawlerTest extends AbstractCrawlerTestCase
 
     public function validHtml5Provider(): iterable
     {
-        $html = static::getDoctype().'<html><body><h1><p>Foo</p></h1></body></html>';
+        $html = self::getDoctype().'<html><body><h1><p>Foo</p></h1></body></html>';
         $BOM = \chr(0xEF).\chr(0xBB).\chr(0xBF);
 
         yield 'BOM first' => [$BOM.$html];
@@ -65,7 +65,7 @@ class Html5ParserCrawlerTest extends AbstractCrawlerTestCase
 
     public function invalidHtml5Provider(): iterable
     {
-        $html = static::getDoctype().'<html><body><h1><p>Foo</p></h1></body></html>';
+        $html = self::getDoctype().'<html><body><h1><p>Foo</p></h1></body></html>';
 
         yield 'Text' => ['hello world'.$html];
         yield 'Text between comments' => ['<!--c--> test <!--cc-->'.$html];

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -21,39 +21,39 @@ class GetAttrNodeTest extends AbstractNodeTestCase
     public static function getEvaluateData(): array
     {
         return [
-            ['b', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), static::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b']]],
-            ['a', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), static::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b']]],
+            ['b', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), self::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b']]],
+            ['a', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), self::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b']]],
 
-            ['bar', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            ['bar', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), self::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
 
-            ['baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
-            ['a', new GetAttrNode(new NameNode('foo'), new NameNode('index'), static::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b'], 'index' => 'b']],
+            ['baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), self::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
+            ['a', new GetAttrNode(new NameNode('foo'), new NameNode('index'), self::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b'], 'index' => 'b']],
         ];
     }
 
     public static function getCompileData(): array
     {
         return [
-            ['$foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
-            ['$foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['$foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['$foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
 
-            ['$foo->foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            ['$foo->foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), self::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
 
-            ['$foo->foo(["b" => "a", 0 => "b"])', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), static::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
-            ['$foo[$index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['$foo->foo(["b" => "a", 0 => "b"])', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), self::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
+            ['$foo[$index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
         ];
     }
 
     public static function getDumpData(): array
     {
         return [
-            ['foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
-            ['foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
 
-            ['foo.foo', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), static::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            ['foo.foo', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), self::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
 
-            ['foo.foo({"b": "a", 0: "b"})', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), static::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
-            ['foo[index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), static::getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['foo.foo({"b": "a", 0: "b"})', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), self::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
+            ['foo[index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
         ];
     }
 

--- a/src/Symfony/Component/Filesystem/Tests/PathTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/PathTest.php
@@ -462,7 +462,7 @@ class PathTest extends TestCase
 
     public function provideMakeAbsoluteTests(): \Generator
     {
-        yield from static::getPathTests();
+        yield from self::getPathTests();
 
         // collapse dots
         yield ['css/./style.css', '/webmozart/symfony', '/webmozart/symfony/css/style.css'];
@@ -589,7 +589,7 @@ class PathTest extends TestCase
 
     public function provideMakeRelativeTests(): \Generator
     {
-        foreach (static::getPathTests() as $set) {
+        foreach (self::getPathTests() as $set) {
             yield [$set[2], $set[1], $set[0]];
         }
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/DepthRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/DepthRangeFilterIteratorTest.php
@@ -93,11 +93,11 @@ class DepthRangeFilterIteratorTest extends RealIteratorTestCase
         ];
 
         return [
-            [0, 0, static::toAbsolute($lessThan1)],
-            [0, 1, static::toAbsolute($lessThanOrEqualTo1)],
+            [0, 0, self::toAbsolute($lessThan1)],
+            [0, 1, self::toAbsolute($lessThanOrEqualTo1)],
             [2, \PHP_INT_MAX, []],
-            [1, \PHP_INT_MAX, static::toAbsolute($graterThanOrEqualTo1)],
-            [1, 1, static::toAbsolute($equalTo1)],
+            [1, \PHP_INT_MAX, self::toAbsolute($graterThanOrEqualTo1)],
+            [1, 1, self::toAbsolute($equalTo1)],
         ];
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/ExcludeDirectoryFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/ExcludeDirectoryFilterIteratorTest.php
@@ -99,9 +99,9 @@ class ExcludeDirectoryFilterIteratorTest extends RealIteratorTestCase
         ];
 
         return [
-            [['foo'], static::toAbsolute($foo)],
-            [['fo'], static::toAbsolute($fo)],
-            [['toto/'], static::toAbsolute($toto)],
+            [['foo'], self::toAbsolute($foo)],
+            [['fo'], self::toAbsolute($fo)],
+            [['toto/'], self::toAbsolute($toto)],
         ];
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/FileTypeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FileTypeFilterIteratorTest.php
@@ -57,8 +57,8 @@ class FileTypeFilterIteratorTest extends RealIteratorTestCase
         ];
 
         return [
-            [FileTypeFilterIterator::ONLY_FILES, static::toAbsolute($onlyFiles)],
-            [FileTypeFilterIterator::ONLY_DIRECTORIES, static::toAbsolute($onlyDirectories)],
+            [FileTypeFilterIterator::ONLY_FILES, self::toAbsolute($onlyFiles)],
+            [FileTypeFilterIterator::ONLY_DIRECTORIES, self::toAbsolute($onlyDirectories)],
         ];
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -247,13 +247,13 @@ class SortableIteratorTest extends RealIteratorTestCase
         ];
 
         return [
-            [SortableIterator::SORT_BY_NAME, static::toAbsolute($sortByName)],
-            [SortableIterator::SORT_BY_TYPE, static::toAbsolute($sortByType)],
-            [SortableIterator::SORT_BY_ACCESSED_TIME, static::toAbsolute($sortByAccessedTime)],
-            [SortableIterator::SORT_BY_CHANGED_TIME, static::toAbsolute($sortByChangedTime)],
-            [SortableIterator::SORT_BY_MODIFIED_TIME, static::toAbsolute($sortByModifiedTime)],
-            [SortableIterator::SORT_BY_NAME_NATURAL, static::toAbsolute($sortByNameNatural)],
-            [function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealPath(), $b->getRealPath()); }, static::toAbsolute($customComparison)],
+            [SortableIterator::SORT_BY_NAME, self::toAbsolute($sortByName)],
+            [SortableIterator::SORT_BY_TYPE, self::toAbsolute($sortByType)],
+            [SortableIterator::SORT_BY_ACCESSED_TIME, self::toAbsolute($sortByAccessedTime)],
+            [SortableIterator::SORT_BY_CHANGED_TIME, self::toAbsolute($sortByChangedTime)],
+            [SortableIterator::SORT_BY_MODIFIED_TIME, self::toAbsolute($sortByModifiedTime)],
+            [SortableIterator::SORT_BY_NAME_NATURAL, self::toAbsolute($sortByNameNatural)],
+            [function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealPath(), $b->getRealPath()); }, self::toAbsolute($customComparison)],
         ];
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\Store\MongoDbStore;
+use Symfony\Component\Lock\Store\StoreFactory;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @requires extension mongo
+ */
+class MongoDbStoreFactoryTest extends TestCase
+{
+    public function testCreateMongoDbCollectionStore()
+    {
+        $store = StoreFactory::createStore($this->createMock(\MongoDB\Collection::class));
+
+        $this->assertInstanceOf(MongoDbStore::class, $store);
+    }
+
+    public function testCreateMongoDbCollectionStoreAsDsn()
+    {
+        $store = StoreFactory::createStore('mongodb://localhost/test?collection=lock');
+
+        $this->assertInstanceOf(MongoDbStore::class, $store);
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/RedisProxyStoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisProxyStoreFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Traits\RedisProxy;
+use Symfony\Component\Lock\Store\RedisStore;
+use Symfony\Component\Lock\Store\StoreFactory;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class RedisProxyStoreFactoryTest extends TestCase
+{
+    public function testCreateStore()
+    {
+        if (!class_exists(RedisProxy::class)) {
+            $this->markTestSkipped();
+        }
+
+        $store = StoreFactory::createStore($this->createMock(RedisProxy::class));
+
+        $this->assertInstanceOf(RedisStore::class, $store);
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -15,19 +15,16 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Lock\Store\DoctrineDbalPostgreSqlStore;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
 use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Lock\Store\MemcachedStore;
-use Symfony\Component\Lock\Store\MongoDbStore;
 use Symfony\Component\Lock\Store\PdoStore;
 use Symfony\Component\Lock\Store\PostgreSqlStore;
 use Symfony\Component\Lock\Store\RedisStore;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Lock\Store\StoreFactory;
-use Symfony\Component\Lock\Store\ZookeeperStore;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
@@ -44,25 +41,14 @@ class StoreFactoryTest extends TestCase
         $this->assertInstanceOf($expectedStoreClass, $store);
     }
 
-    public function validConnections()
+    public static function validConnections(): \Generator
     {
         if (class_exists(\Redis::class)) {
             yield [new \Redis(), RedisStore::class];
         }
-        if (class_exists(RedisProxy::class)) {
-            yield [$this->createMock(RedisProxy::class), RedisStore::class];
-        }
         yield [new \Predis\Client(), RedisStore::class];
         if (class_exists(\Memcached::class)) {
             yield [new \Memcached(), MemcachedStore::class];
-        }
-        if (class_exists(\MongoDB\Collection::class)) {
-            yield [$this->createMock(\MongoDB\Collection::class), MongoDbStore::class];
-            yield ['mongodb://localhost/test?collection=lock', MongoDbStore::class];
-        }
-        if (class_exists(\Zookeeper::class)) {
-            yield [$this->createMock(\Zookeeper::class), ZookeeperStore::class];
-            yield ['zookeeper://localhost:2181', ZookeeperStore::class];
         }
         if (\extension_loaded('sysvsem')) {
             yield ['semaphore', SemaphoreStore::class];

--- a/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\Store\StoreFactory;
+use Symfony\Component\Lock\Store\ZookeeperStore;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @requires extension zookeeper
+ */
+class ZookeeperStoreFactoryTest extends TestCase
+{
+    public function testCreateZooKeeperStore()
+    {
+        $store = StoreFactory::createStore($this->createMock(\Zookeeper::class));
+
+        $this->assertInstanceOf(ZookeeperStore::class, $store);
+    }
+
+    public function testCreateZooKeeperStoreAsDsn()
+    {
+        $store = StoreFactory::createStore('zookeeper://localhost:2181');
+
+        $this->assertInstanceOf(ZookeeperStore::class, $store);
+    }
+
+    public function testCreateZooKeeperStoreWithMultipleHosts()
+    {
+        $store = StoreFactory::createStore('zookeeper://localhost01,localhost02:2181');
+
+        $this->assertInstanceOf(ZookeeperStore::class, $store);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/AffirmativeStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/AffirmativeStrategyTest.php
@@ -20,13 +20,13 @@ class AffirmativeStrategyTest extends AccessDecisionStrategyTestCase
     {
         $strategy = new AffirmativeStrategy();
 
-        yield [$strategy, static::getVoters(1, 0, 0), true];
-        yield [$strategy, static::getVoters(1, 2, 0), true];
-        yield [$strategy, static::getVoters(0, 1, 0), false];
-        yield [$strategy, static::getVoters(0, 0, 1), false];
+        yield [$strategy, self::getVoters(1, 0, 0), true];
+        yield [$strategy, self::getVoters(1, 2, 0), true];
+        yield [$strategy, self::getVoters(0, 1, 0), false];
+        yield [$strategy, self::getVoters(0, 0, 1), false];
 
         $strategy = new AffirmativeStrategy(true);
 
-        yield [$strategy, static::getVoters(0, 0, 1), true];
+        yield [$strategy, self::getVoters(0, 0, 1), true];
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/ConsensusStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/ConsensusStrategyTest.php
@@ -20,21 +20,21 @@ class ConsensusStrategyTest extends AccessDecisionStrategyTestCase
     {
         $strategy = new ConsensusStrategy();
 
-        yield [$strategy, static::getVoters(1, 0, 0), true];
-        yield [$strategy, static::getVoters(1, 2, 0), false];
-        yield [$strategy, static::getVoters(2, 1, 0), true];
-        yield [$strategy, static::getVoters(0, 0, 1), false];
+        yield [$strategy, self::getVoters(1, 0, 0), true];
+        yield [$strategy, self::getVoters(1, 2, 0), false];
+        yield [$strategy, self::getVoters(2, 1, 0), true];
+        yield [$strategy, self::getVoters(0, 0, 1), false];
 
-        yield [$strategy, static::getVoters(2, 2, 0), true];
-        yield [$strategy, static::getVoters(2, 2, 1), true];
+        yield [$strategy, self::getVoters(2, 2, 0), true];
+        yield [$strategy, self::getVoters(2, 2, 1), true];
 
         $strategy = new ConsensusStrategy(true);
 
-        yield [$strategy, static::getVoters(0, 0, 1), true];
+        yield [$strategy, self::getVoters(0, 0, 1), true];
 
         $strategy = new ConsensusStrategy(false, false);
 
-        yield [$strategy, static::getVoters(2, 2, 0), false];
-        yield [$strategy, static::getVoters(2, 2, 1), false];
+        yield [$strategy, self::getVoters(2, 2, 0), false];
+        yield [$strategy, self::getVoters(2, 2, 1), false];
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/PriorityStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/PriorityStrategyTest.php
@@ -22,23 +22,23 @@ class PriorityStrategyTest extends AccessDecisionStrategyTestCase
         $strategy = new PriorityStrategy();
 
         yield [$strategy, [
-            static::getVoter(VoterInterface::ACCESS_ABSTAIN),
-            static::getVoter(VoterInterface::ACCESS_GRANTED),
-            static::getVoter(VoterInterface::ACCESS_DENIED),
-            static::getVoter(VoterInterface::ACCESS_DENIED),
+            self::getVoter(VoterInterface::ACCESS_ABSTAIN),
+            self::getVoter(VoterInterface::ACCESS_GRANTED),
+            self::getVoter(VoterInterface::ACCESS_DENIED),
+            self::getVoter(VoterInterface::ACCESS_DENIED),
         ], true];
 
         yield [$strategy, [
-            static::getVoter(VoterInterface::ACCESS_ABSTAIN),
-            static::getVoter(VoterInterface::ACCESS_DENIED),
-            static::getVoter(VoterInterface::ACCESS_GRANTED),
-            static::getVoter(VoterInterface::ACCESS_GRANTED),
+            self::getVoter(VoterInterface::ACCESS_ABSTAIN),
+            self::getVoter(VoterInterface::ACCESS_DENIED),
+            self::getVoter(VoterInterface::ACCESS_GRANTED),
+            self::getVoter(VoterInterface::ACCESS_GRANTED),
         ], false];
 
-        yield [$strategy, static::getVoters(0, 0, 2), false];
+        yield [$strategy, self::getVoters(0, 0, 2), false];
 
         $strategy = new PriorityStrategy(true);
 
-        yield [$strategy, static::getVoters(0, 0, 2), true];
+        yield [$strategy, self::getVoters(0, 0, 2), true];
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/UnanimousStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/UnanimousStrategyTest.php
@@ -20,14 +20,14 @@ class UnanimousStrategyTest extends AccessDecisionStrategyTestCase
     {
         $strategy = new UnanimousStrategy();
 
-        yield [$strategy, static::getVoters(1, 0, 0), true];
-        yield [$strategy, static::getVoters(1, 0, 1), true];
-        yield [$strategy, static::getVoters(1, 1, 0), false];
+        yield [$strategy, self::getVoters(1, 0, 0), true];
+        yield [$strategy, self::getVoters(1, 0, 1), true];
+        yield [$strategy, self::getVoters(1, 1, 0), false];
 
-        yield [$strategy, static::getVoters(0, 0, 2), false];
+        yield [$strategy, self::getVoters(0, 0, 2), false];
 
         $strategy = new UnanimousStrategy(true);
 
-        yield [$strategy, static::getVoters(0, 0, 2), true];
+        yield [$strategy, self::getVoters(0, 0, 2), true];
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -15,13 +15,11 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PasswordUpgradeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
@@ -29,6 +27,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 use Symfony\Component\Security\Http\Authenticator\Passport\UserPassportInterface;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\EventListener\PasswordMigratingListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyAuthenticator;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyToken;
 
 class PasswordMigratingListenerTest extends TestCase
 {
@@ -58,13 +58,13 @@ class PasswordMigratingListenerTest extends TestCase
         $this->listener->onLoginSuccess($event);
     }
 
-    public function provideUnsupportedEvents()
+    public static function provideUnsupportedEvents()
     {
         // no password upgrade badge
-        yield [$this->createEvent(new SelfValidatingPassport(new UserBadge('test', function () { return $this->createMock(UserInterface::class); })))];
+        yield [self::createEvent(new SelfValidatingPassport(new UserBadge('test', function () { return $this->createMock(UserInterface::class); })))];
 
         // blank password
-        yield [$this->createEvent(new SelfValidatingPassport(new UserBadge('test', function () { return $this->createMock(TestPasswordAuthenticatedUser::class); }), [new PasswordUpgradeBadge('', $this->createPasswordUpgrader())]))];
+        yield [self::createEvent(new SelfValidatingPassport(new UserBadge('test', function () { return new DummyTestPasswordAuthenticatedUser(); }), [new PasswordUpgradeBadge('', self::createPasswordUpgrader())]))];
     }
 
     /**
@@ -96,7 +96,7 @@ class PasswordMigratingListenerTest extends TestCase
 
     public function testUpgradeWithUpgrader()
     {
-        $passwordUpgrader = $this->createPasswordUpgrader();
+        $passwordUpgrader = $this->getMockForAbstractClass(TestMigratingUserProvider::class);
         $passwordUpgrader->expects($this->once())
             ->method('upgradePassword')
             ->with($this->user, 'new-hash')
@@ -133,14 +133,14 @@ class PasswordMigratingListenerTest extends TestCase
         $this->listener->onLoginSuccess($event);
     }
 
-    private function createPasswordUpgrader()
+    private static function createPasswordUpgrader()
     {
-        return $this->getMockForAbstractClass(TestMigratingUserProvider::class);
+        return new DummyTestMigratingUserProvider();
     }
 
-    private function createEvent(PassportInterface $passport)
+    private static function createEvent(PassportInterface $passport)
     {
-        return new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), $passport, $this->createMock(TokenInterface::class), new Request(), null, 'main');
+        return new LoginSuccessEvent(new DummyAuthenticator(), $passport, new DummyToken(), new Request(), null, 'main');
     }
 }
 
@@ -151,9 +151,62 @@ abstract class TestMigratingUserProvider implements UserProviderInterface, Passw
     abstract public function loadUserByIdentifier(string $identifier): UserInterface;
 }
 
+class DummyTestMigratingUserProvider extends TestMigratingUserProvider
+{
+    public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
+    {
+    }
+
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+    }
+
+    public function refreshUser(UserInterface $user)
+    {
+    }
+
+    public function supportsClass(string $class)
+    {
+    }
+
+    public function loadUserByUsername(string $username)
+    {
+    }
+}
+
 abstract class TestPasswordAuthenticatedUser implements UserInterface, PasswordAuthenticatedUserInterface
 {
     abstract public function getPassword(): ?string;
 
     abstract public function getSalt(): ?string;
+}
+
+class DummyTestPasswordAuthenticatedUser extends TestPasswordAuthenticatedUser
+{
+    public function getPassword(): ?string
+    {
+        return null;
+    }
+
+    public function getSalt(): ?string
+    {
+        return null;
+    }
+
+    public function getRoles(): array
+    {
+        return [];
+    }
+
+    public function eraseCredentials()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function getUserIdentifier(): string
+    {
+    }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyAuthenticator.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class DummyAuthenticator implements AuthenticatorInterface
+{
+    public function supports(Request $request): ?bool
+    {
+        return null;
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return null;
+    }
+
+    public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyToken.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyToken.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class DummyToken implements TokenInterface
+{
+    public function serialize()
+    {
+    }
+
+    public function unserialize($data)
+    {
+    }
+
+    public function __toString(): string
+    {
+    }
+
+    public function getRoleNames(): array
+    {
+    }
+
+    public function getCredentials(): mixed
+    {
+    }
+
+    public function getUser(): ?UserInterface
+    {
+    }
+
+    public function setUser($user)
+    {
+    }
+
+    public function isAuthenticated(): bool
+    {
+    }
+
+    public function setAuthenticated(bool $isAuthenticated)
+    {
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+
+    public function getAttributes(): array
+    {
+    }
+
+    public function setAttributes(array $attributes): void
+    {
+    }
+
+    public function hasAttribute(string $name): bool
+    {
+    }
+
+    public function getAttribute(string $name): mixed
+    {
+    }
+
+    public function setAttribute(string $name, $value): void
+    {
+    }
+
+    public function getUsername(): string
+    {
+    }
+
+    public function getUserIdentifier(): string
+    {
+    }
+
+    public function __serialize(): array
+    {
+    }
+
+    public function __unserialize(array $data): void
+    {
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -69,7 +69,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         return $result;
     }
 
-    public function provideInvalidConstraintOptions()
+    public static function provideInvalidConstraintOptions()
     {
         return [
             [null],
@@ -112,15 +112,16 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         $this->assertNoViolation();
     }
 
-    public function provideAllValidComparisons(): array
+    public static function provideAllValidComparisons(): array
     {
         // The provider runs before setUp(), so we need to manually fix
         // the default timezone
-        $this->setDefaultTimezone('UTC');
+        $timezone = date_default_timezone_get();
+        date_default_timezone_set('UTC');
 
-        $comparisons = self::addPhp5Dot5Comparisons($this->provideValidComparisons());
+        $comparisons = self::addPhp5Dot5Comparisons(static::provideValidComparisons());
 
-        $this->restoreDefaultTimezone();
+        date_default_timezone_set($timezone);
 
         return $comparisons;
     }
@@ -166,9 +167,9 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         $this->validator->validate(5, $constraint);
     }
 
-    abstract public function provideValidComparisons(): array;
+    abstract public static function provideValidComparisons(): array;
 
-    abstract public function provideValidComparisonsToPropertyPath(): array;
+    abstract public static function provideValidComparisonsToPropertyPath(): array;
 
     /**
      * @dataProvider provideAllInvalidComparisons
@@ -233,9 +234,9 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         $this->validator->validate($value, $constraint);
     }
 
-    public function throwsOnInvalidStringDatesProvider(): array
+    public static function throwsOnInvalidStringDatesProvider(): array
     {
-        $constraint = $this->createConstraint([
+        $constraint = static::createConstraint([
             'value' => 'foo',
         ]);
 
@@ -273,27 +274,28 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         }
     }
 
-    public function provideAllInvalidComparisons(): array
+    public static function provideAllInvalidComparisons(): array
     {
         // The provider runs before setUp(), so we need to manually fix
         // the default timezone
-        $this->setDefaultTimezone('UTC');
+        $timezone = date_default_timezone_get();
+        date_default_timezone_set('UTC');
 
-        $comparisons = self::addPhp5Dot5Comparisons($this->provideInvalidComparisons());
+        $comparisons = self::addPhp5Dot5Comparisons(static::provideInvalidComparisons());
 
-        $this->restoreDefaultTimezone();
+        date_default_timezone_set($timezone);
 
         return $comparisons;
     }
 
-    abstract public function provideInvalidComparisons(): array;
+    abstract public static function provideInvalidComparisons(): array;
 
-    abstract public function provideComparisonsToNullValueAtPropertyPath();
+    abstract public static function provideComparisonsToNullValueAtPropertyPath();
 
     /**
      * @param array|null $options Options for the constraint
      */
-    abstract protected function createConstraint(array $options = null): Constraint;
+    abstract protected static function createConstraint(array $options = null): Constraint;
 
     protected function getErrorCode(): ?string
     {

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
@@ -26,7 +26,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
         return new DivisibleByValidator();
     }
 
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new DivisibleBy($options);
     }
@@ -39,7 +39,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [-7, 1],
@@ -68,7 +68,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath(): array
+    public static function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [25],
@@ -78,7 +78,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'int'],
@@ -112,8 +112,8 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
         ];
     }
 
-    public function provideComparisonsToNullValueAtPropertyPath()
+    public static function provideComparisonsToNullValueAtPropertyPath()
     {
-        $this->markTestSkipped('DivisibleByValidator rejects null values.');
+        self::markTestSkipped('DivisibleByValidator rejects null values.');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -25,7 +25,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
         return new EqualToValidator();
     }
 
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new EqualTo($options);
     }
@@ -38,7 +38,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [3, 3],
@@ -55,7 +55,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath(): array
+    public static function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [5],
@@ -65,7 +65,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'int'],
@@ -77,7 +77,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
         ];
     }
 
-    public function provideComparisonsToNullValueAtPropertyPath()
+    public static function provideComparisonsToNullValueAtPropertyPath()
     {
         return [
             [5, '5', false],

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -25,7 +25,7 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
         return new GreaterThanOrEqualValidator();
     }
 
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new GreaterThanOrEqual($options);
     }
@@ -38,7 +38,7 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [3, 2],
@@ -58,7 +58,7 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath(): array
+    public static function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [5],
@@ -69,7 +69,7 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'int'],
@@ -80,7 +80,7 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
         ];
     }
 
-    public function provideComparisonsToNullValueAtPropertyPath()
+    public static function provideComparisonsToNullValueAtPropertyPath()
     {
         return [
             [5, '5', true],

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends GreaterThanOrEqualValidatorTest
 {
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new PositiveOrZero();
     }
@@ -29,7 +29,7 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [0, 0],
@@ -45,7 +45,7 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [-1, '-1', 0, '0', 'int'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -25,7 +25,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
         return new GreaterThanValidator();
     }
 
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new GreaterThan($options);
     }
@@ -38,7 +38,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [2, 1],
@@ -54,7 +54,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath(): array
+    public static function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [6],
@@ -64,7 +64,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'int'],
@@ -82,7 +82,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
         ];
     }
 
-    public function provideComparisonsToNullValueAtPropertyPath()
+    public static function provideComparisonsToNullValueAtPropertyPath()
     {
         return [
             [5, '5', true],

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidatorTest
 {
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new Positive();
     }
@@ -29,7 +29,7 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [2, 0],
@@ -42,7 +42,7 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [0, '0', 0, '0', 'int'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -25,7 +25,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         return new IdenticalToValidator();
     }
 
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new IdenticalTo($options);
     }
@@ -35,15 +35,16 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         return IdenticalTo::NOT_IDENTICAL_ERROR;
     }
 
-    public function provideAllValidComparisons(): array
+    public static function provideAllValidComparisons(): array
     {
-        $this->setDefaultTimezone('UTC');
+        $timezone = date_default_timezone_get();
+        date_default_timezone_set('UTC');
 
         // Don't call addPhp5Dot5Comparisons() automatically, as it does
         // not take care of identical objects
-        $comparisons = $this->provideValidComparisons();
+        $comparisons = self::provideValidComparisons();
 
-        $this->restoreDefaultTimezone();
+        date_default_timezone_set($timezone);
 
         return $comparisons;
     }
@@ -51,7 +52,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         $date = new \DateTime('2000-01-01');
         $object = new ComparisonTest_Class(2);
@@ -73,7 +74,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath(): array
+    public static function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [5],
@@ -83,7 +84,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'int'],
@@ -95,7 +96,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         ];
     }
 
-    public function provideComparisonsToNullValueAtPropertyPath()
+    public static function provideComparisonsToNullValueAtPropertyPath()
     {
         return [
             [5, '5', false],

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -25,7 +25,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
         return new LessThanOrEqualValidator();
     }
 
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new LessThanOrEqual($options);
     }
@@ -38,7 +38,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [1, 2],
@@ -60,7 +60,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath(): array
+    public static function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [4],
@@ -71,7 +71,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [2, '2', 1, '1', 'int'],
@@ -83,7 +83,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
         ];
     }
 
-    public function provideComparisonsToNullValueAtPropertyPath()
+    public static function provideComparisonsToNullValueAtPropertyPath()
     {
         return [
             [5, '5', true],

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanOrEqualValidatorTest
 {
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new NegativeOrZero();
     }
@@ -29,7 +29,7 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [0, 0],
@@ -43,7 +43,7 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [2, '2', 0, '0', 'int'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -25,7 +25,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
         return new LessThanValidator();
     }
 
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new LessThan($options);
     }
@@ -38,7 +38,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [1, 2],
@@ -54,7 +54,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath(): array
+    public static function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [4],
@@ -64,7 +64,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [3, '3', 2, '2', 'int'],
@@ -81,7 +81,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
         ];
     }
 
-    public function provideComparisonsToNullValueAtPropertyPath()
+    public static function provideComparisonsToNullValueAtPropertyPath()
     {
         return [
             [5, '5', true],

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
 {
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new Negative();
     }
@@ -29,7 +29,7 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [-1, 0],
@@ -42,7 +42,7 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [0, '0', 0, '0', 'int'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -25,7 +25,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
         return new NotEqualToValidator();
     }
 
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new NotEqualTo($options);
     }
@@ -38,7 +38,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [1, 2],
@@ -54,7 +54,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath(): array
+    public static function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [0],
@@ -64,7 +64,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         return [
             [3, '3', 3, '3', 'int'],
@@ -77,7 +77,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
         ];
     }
 
-    public function provideComparisonsToNullValueAtPropertyPath()
+    public static function provideComparisonsToNullValueAtPropertyPath()
     {
         return [
             [5, '5', true],

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -25,7 +25,7 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         return new NotIdenticalToValidator();
     }
 
-    protected function createConstraint(array $options = null): Constraint
+    protected static function createConstraint(array $options = null): Constraint
     {
         return new NotIdenticalTo($options);
     }
@@ -38,7 +38,7 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons(): array
+    public static function provideValidComparisons(): array
     {
         return [
             [1, 2],
@@ -57,22 +57,23 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath(): array
+    public static function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [0],
         ];
     }
 
-    public function provideAllInvalidComparisons(): array
+    public static function provideAllInvalidComparisons(): array
     {
-        $this->setDefaultTimezone('UTC');
+        $timezone = date_default_timezone_get();
+        date_default_timezone_set('UTC');
 
         // Don't call addPhp5Dot5Comparisons() automatically, as it does
         // not take care of identical objects
-        $comparisons = $this->provideInvalidComparisons();
+        $comparisons = self::provideInvalidComparisons();
 
-        $this->restoreDefaultTimezone();
+        date_default_timezone_set($timezone);
 
         return $comparisons;
     }
@@ -80,7 +81,7 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons(): array
+    public static function provideInvalidComparisons(): array
     {
         $date = new \DateTime('2000-01-01');
         $object = new ComparisonTest_Class(2);
@@ -95,7 +96,7 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         return $comparisons;
     }
 
-    public function provideComparisonsToNullValueAtPropertyPath()
+    public static function provideComparisonsToNullValueAtPropertyPath()
     {
         return [
             [5, '5', true],

--- a/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
@@ -47,28 +47,28 @@ class GraphvizDumperTest extends TestCase
         $this->assertEquals($expected, $dump);
     }
 
-    public function provideWorkflowDefinitionWithMarking()
+    public static function provideWorkflowDefinitionWithMarking()
     {
         yield [
-            $this->createComplexWorkflowDefinition(),
+            self::createComplexWorkflowDefinition(),
             new Marking(['b' => 1]),
-            $this->createComplexWorkflowDefinitionDumpWithMarking(),
+            self::createComplexWorkflowDefinitionDumpWithMarking(),
         ];
 
         yield [
-            $this->createSimpleWorkflowDefinition(),
+            self::createSimpleWorkflowDefinition(),
             new Marking(['c' => 1, 'd' => 1]),
-            $this->createSimpleWorkflowDumpWithMarking(),
+            self::createSimpleWorkflowDumpWithMarking(),
         ];
     }
 
-    public function provideWorkflowDefinitionWithoutMarking()
+    public static function provideWorkflowDefinitionWithoutMarking()
     {
-        yield [$this->createComplexWorkflowDefinition(), $this->provideComplexWorkflowDumpWithoutMarking()];
-        yield [$this->createSimpleWorkflowDefinition(), $this->provideSimpleWorkflowDumpWithoutMarking()];
+        yield [self::createComplexWorkflowDefinition(), self::provideComplexWorkflowDumpWithoutMarking()];
+        yield [self::createSimpleWorkflowDefinition(), self::provideSimpleWorkflowDumpWithoutMarking()];
     }
 
-    public function createComplexWorkflowDefinitionDumpWithMarking()
+    public static function createComplexWorkflowDefinitionDumpWithMarking()
     {
         return 'digraph workflow {
   ratio="compress" rankdir="LR"
@@ -106,7 +106,7 @@ class GraphvizDumperTest extends TestCase
 ';
     }
 
-    public function createSimpleWorkflowDumpWithMarking()
+    public static function createSimpleWorkflowDumpWithMarking()
     {
         return 'digraph workflow {
   ratio="compress" rankdir="LR"
@@ -126,7 +126,7 @@ class GraphvizDumperTest extends TestCase
 ';
     }
 
-    public function provideComplexWorkflowDumpWithoutMarking()
+    public static function provideComplexWorkflowDumpWithoutMarking()
     {
         return 'digraph workflow {
   ratio="compress" rankdir="LR"
@@ -164,7 +164,7 @@ class GraphvizDumperTest extends TestCase
 ';
     }
 
-    public function provideSimpleWorkflowDumpWithoutMarking()
+    public static function provideSimpleWorkflowDumpWithoutMarking()
     {
         return 'digraph workflow {
   ratio="compress" rankdir="LR"

--- a/src/Symfony/Component/Workflow/Tests/Dumper/MermaidDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/MermaidDumperTest.php
@@ -71,11 +71,11 @@ class MermaidDumperTest extends TestCase
         $this->assertEquals($expected, $dump);
     }
 
-    public function provideWorkflowDefinitionWithoutMarking(): array
+    public static function provideWorkflowDefinitionWithoutMarking(): array
     {
         return [
             [
-                $this->createComplexWorkflowDefinition(),
+                self::createComplexWorkflowDefinition(),
                 "graph LR\n"
                ."a0([\"a\"])\n"
                ."b1((\"b\"))\n"
@@ -108,7 +108,7 @@ class MermaidDumperTest extends TestCase
                .'transition5-->g6',
             ],
             [
-                $this->createWorkflowWithSameNameTransition(),
+                self::createWorkflowWithSameNameTransition(),
                 "graph LR\n"
                ."a0([\"a\"])\n"
                ."b1((\"b\"))\n"
@@ -128,7 +128,7 @@ class MermaidDumperTest extends TestCase
                .'transition3-->a0',
             ],
             [
-                $this->createSimpleWorkflowDefinition(),
+                self::createSimpleWorkflowDefinition(),
                 "graph LR\n"
                ."a0([\"a\"])\n"
                ."b1((\"b\"))\n"
@@ -146,7 +146,7 @@ class MermaidDumperTest extends TestCase
         ];
     }
 
-    public function provideWorkflowWithReservedWords()
+    public static function provideWorkflowWithReservedWords()
     {
         $builder = new DefinitionBuilder();
 
@@ -177,11 +177,11 @@ class MermaidDumperTest extends TestCase
         ];
     }
 
-    public function provideStatemachine(): array
+    public static function provideStatemachine(): array
     {
         return [
             [
-                $this->createComplexStateMachineDefinition(),
+                self::createComplexStateMachineDefinition(),
                 "graph LR\n"
                ."a0([\"a\"])\n"
                ."b1((\"b\"))\n"
@@ -196,7 +196,7 @@ class MermaidDumperTest extends TestCase
         ];
     }
 
-    public function provideWorkflowWithMarking(): array
+    public static function provideWorkflowWithMarking(): array
     {
         $marking = new Marking();
         $marking->mark('b');
@@ -204,7 +204,7 @@ class MermaidDumperTest extends TestCase
 
         return [
             [
-                $this->createSimpleWorkflowDefinition(),
+                self::createSimpleWorkflowDefinition(),
                 $marking,
                 "graph LR\n"
                 ."a0([\"a\"])\n"

--- a/src/Symfony/Component/Workflow/Tests/Dumper/PlantUmlDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/PlantUmlDumperTest.php
@@ -36,14 +36,14 @@ class PlantUmlDumperTest extends TestCase
         $this->assertStringEqualsFile($file, $dump);
     }
 
-    public function provideWorkflowDefinitionWithoutMarking()
+    public static function provideWorkflowDefinitionWithoutMarking()
     {
-        yield [$this->createSimpleWorkflowDefinition(), null, 'simple-workflow-nomarking', 'SimpleDiagram'];
-        yield [$this->createComplexWorkflowDefinition(), null, 'complex-workflow-nomarking', 'ComplexDiagram'];
+        yield [self::createSimpleWorkflowDefinition(), null, 'simple-workflow-nomarking', 'SimpleDiagram'];
+        yield [self::createComplexWorkflowDefinition(), null, 'complex-workflow-nomarking', 'ComplexDiagram'];
         $marking = new Marking(['b' => 1]);
-        yield [$this->createSimpleWorkflowDefinition(), $marking, 'simple-workflow-marking', 'SimpleDiagram'];
+        yield [self::createSimpleWorkflowDefinition(), $marking, 'simple-workflow-marking', 'SimpleDiagram'];
         $marking = new Marking(['c' => 1, 'e' => 1]);
-        yield [$this->createComplexWorkflowDefinition(), $marking, 'complex-workflow-marking', 'ComplexDiagram'];
+        yield [self::createComplexWorkflowDefinition(), $marking, 'complex-workflow-marking', 'ComplexDiagram'];
     }
 
     /**
@@ -59,11 +59,11 @@ class PlantUmlDumperTest extends TestCase
         $this->assertStringEqualsFile($file, $dump);
     }
 
-    public function provideStateMachineDefinitionWithoutMarking()
+    public static function provideStateMachineDefinitionWithoutMarking()
     {
-        yield [$this->createComplexStateMachineDefinition(), null, 'complex-state-machine-nomarking', 'SimpleDiagram'];
+        yield [static::createComplexStateMachineDefinition(), null, 'complex-state-machine-nomarking', 'SimpleDiagram'];
         $marking = new Marking(['c' => 1, 'e' => 1]);
-        yield [$this->createComplexStateMachineDefinition(), $marking, 'complex-state-machine-marking', 'SimpleDiagram'];
+        yield [static::createComplexStateMachineDefinition(), $marking, 'complex-state-machine-marking', 'SimpleDiagram'];
     }
 
     public function testDumpWorkflowWithSpacesInTheStateNamesAndDescription()

--- a/src/Symfony/Component/Workflow/Tests/WorkflowBuilderTrait.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowBuilderTrait.php
@@ -17,7 +17,7 @@ use Symfony\Component\Workflow\Transition;
 
 trait WorkflowBuilderTrait
 {
-    private function createComplexWorkflowDefinition()
+    private static function createComplexWorkflowDefinition()
     {
         $places = range('a', 'g');
 
@@ -52,7 +52,7 @@ trait WorkflowBuilderTrait
         //           +----+                          +----+     +----+     +----+
     }
 
-    private function createSimpleWorkflowDefinition()
+    private static function createSimpleWorkflowDefinition()
     {
         $places = range('a', 'c');
 
@@ -87,7 +87,7 @@ trait WorkflowBuilderTrait
         // +---+     +----+     +---+     +----+     +---+
     }
 
-    private function createWorkflowWithSameNameTransition()
+    private static function createWorkflowWithSameNameTransition()
     {
         $places = range('a', 'c');
 
@@ -115,7 +115,7 @@ trait WorkflowBuilderTrait
         //   +--------------------------------------------------------------------+
     }
 
-    private function createComplexStateMachineDefinition()
+    private static function createComplexStateMachineDefinition()
     {
         $places = ['a', 'b', 'c', 'd'];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes-ish
| New feature?  | no
| Deprecations? | no
| Tickets       | Continuing https://github.com/symfony/symfony/pull/48668#issuecomment-1421103922
| License       | MIT
| Doc PR        | _NA_

This is yet another PR to continue the manual work needed for the  migration of data providers to static ones.
I also took the opportunity to pass a few `static::` to `self::` calls, as pointed out by Nicolas in this comment: https://github.com/symfony/symfony/pull/49244#discussion_r1097075773

cc @OskarStark 👋 