### PR TITLE
[Serializer] Add methods `getSupportedTypes` to allow better performance

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -8130,6 +8130,7 @@ index 1924b1ddb0..62c58c8e8b 100644
          $annotatedClasses = [];
 diff --git a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php b/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
 index dff3e248ae..381db9aa8f 100644
+index 6e00840c7e..8e69c81c23 100644
 --- a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
 +++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
 @@ -34,5 +34,5 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
@@ -11254,24 +11255,24 @@ index fc6336ebdb..e13a834930 100644
      {
          if (1 > \func_num_args()) {
 diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
-index 52e985815b..e7d0493152 100644
+index 7d138b0b26..03e28f9d20 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
-@@ -210,5 +210,5 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
+@@ -215,5 +215,5 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
       * @throws LogicException if the 'allow_extra_attributes' context variable is false and no class metadata factory is provided
       */
 -    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false)
 +    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false): array|bool
      {
          $allowExtraAttributes = $context[self::ALLOW_EXTRA_ATTRIBUTES] ?? $this->defaultContext[self::ALLOW_EXTRA_ATTRIBUTES];
-@@ -260,5 +260,5 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
+@@ -265,5 +265,5 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
       * @return bool
       */
 -    protected function isAllowedAttribute(object|string $classOrObject, string $attribute, string $format = null, array $context = [])
 +    protected function isAllowedAttribute(object|string $classOrObject, string $attribute, string $format = null, array $context = []): bool
      {
          $ignoredAttributes = $context[self::IGNORED_ATTRIBUTES] ?? $this->defaultContext[self::IGNORED_ATTRIBUTES];
-@@ -311,5 +311,5 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
+@@ -316,5 +316,5 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
       * @throws MissingConstructorArgumentException
       */
 -    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, string $format = null)
@@ -11279,7 +11280,7 @@ index 52e985815b..e7d0493152 100644
      {
          if (null !== $object = $this->extractObjectToPopulate($class, $context, self::OBJECT_TO_POPULATE)) {
 diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
-index a02a46b941..aedfd67c2e 100644
+index 75fe3a5cb1..a28dd40568 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
 @@ -139,10 +139,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
@@ -11321,46 +11322,36 @@ index a02a46b941..aedfd67c2e 100644
 -    public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */)
 +    public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */): bool
      {
-         return class_exists($type) || (interface_exists($type, false) && $this->classDiscriminatorResolver && null !== $this->classDiscriminatorResolver->getMappingForClass($type));
+         return class_exists($type) || (interface_exists($type, false) && null !== $this->classDiscriminatorResolver?->getMappingForClass($type));
      }
  
 -    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
 +    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
      {
          if (!isset($context['cache_key'])) {
-diff --git a/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareTrait.php b/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareTrait.php
-index c5cc86ecf6..c65534fafb 100644
---- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareTrait.php
-+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareTrait.php
-@@ -25,5 +25,5 @@ trait DenormalizerAwareTrait
-      * @return void
-      */
--    public function setDenormalizer(DenormalizerInterface $denormalizer)
-+    public function setDenormalizer(DenormalizerInterface $denormalizer): void
-     {
-         $this->denormalizer = $denormalizer;
 diff --git a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
-index 1786d6fff1..04a2e62ed2 100644
+index 1d83b2da11..1c632f42bf 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
-@@ -45,5 +45,5 @@ interface DenormalizerInterface
+@@ -47,5 +47,5 @@ interface DenormalizerInterface
       * @throws ExceptionInterface       Occurs for all the other cases of errors
       */
 -    public function denormalize(mixed $data, string $type, string $format = null, array $context = []);
 +    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed;
  
      /**
-@@ -57,4 +57,4 @@ interface DenormalizerInterface
+@@ -64,5 +64,5 @@ interface DenormalizerInterface
       * @return bool
       */
 -    public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */);
 +    public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */): bool;
- }
+ 
+     /**
 diff --git a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
-index e08dd5d9ec..cc282ae4bb 100644
+index 2719c8b52c..1112f7f3cc 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
-@@ -138,5 +138,5 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
+@@ -148,5 +148,5 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
       * @return void
       */
 -    protected function setAttributeValue(object $object, string $attribute, mixed $value, string $format = null, array $context = [])
@@ -11379,27 +11370,28 @@ index 40a4fa0e8c..a1e2749aae 100644
      {
          $this->normalizer = $normalizer;
 diff --git a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
-index cb43d78cc7..d215ffe997 100644
+index d6d0707ff5..9953ad3005 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
-@@ -37,5 +37,5 @@ interface NormalizerInterface
+@@ -39,5 +39,5 @@ interface NormalizerInterface
       * @throws ExceptionInterface         Occurs for all the other cases of errors
       */
 -    public function normalize(mixed $object, string $format = null, array $context = []);
 +    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null;
  
      /**
-@@ -48,4 +48,4 @@ interface NormalizerInterface
+@@ -55,5 +55,5 @@ interface NormalizerInterface
       * @return bool
       */
 -    public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */);
 +    public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */): bool;
- }
+ 
+     /**
 diff --git a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
-index 8018cb7a49..aa06b9c50b 100644
+index 140e89c6a1..f77348252b 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
-@@ -133,5 +133,5 @@ class ObjectNormalizer extends AbstractObjectNormalizer
+@@ -143,5 +143,5 @@ class ObjectNormalizer extends AbstractObjectNormalizer
       * @return void
       */
 -    protected function setAttributeValue(object $object, string $attribute, mixed $value, string $format = null, array $context = [])
@@ -11407,10 +11399,10 @@ index 8018cb7a49..aa06b9c50b 100644
      {
          try {
 diff --git a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
-index 3dd734055d..cbc0e86d27 100644
+index 645ba74290..d960bf4b20 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
-@@ -175,5 +175,5 @@ class PropertyNormalizer extends AbstractObjectNormalizer
+@@ -185,5 +185,5 @@ class PropertyNormalizer extends AbstractObjectNormalizer
       * @return void
       */
 -    protected function setAttributeValue(object $object, string $attribute, mixed $value, string $format = null, array $context = [])

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/FlattenExceptionNormalizer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/FlattenExceptionNormalizer.php
@@ -45,6 +45,13 @@ final class FlattenExceptionNormalizer implements DenormalizerInterface, Context
         return $normalized;
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            FlattenException::class => false,
+        ];
+    }
+
     public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof FlattenException && ($context[Serializer::MESSENGER_SERIALIZATION_CONTEXT] ?? false);

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,7 +6,9 @@ CHANGELOG
 
  * Add `XmlEncoder::SAVE_OPTIONS` context option
  * Add `BackedEnumNormalizer::ALLOW_INVALID_VALUES` context option
+ * Add method `getSupportedTypes(?string $format)` to `NormalizerInterface` and `DenormalizerInterface`
  * Deprecate `MissingConstructorArgumentsException` in favor of `MissingConstructorArgumentException`
+ * Deprecate `CacheableSupportsMethodInterface` in favor of the new `getSupportedTypes(?string $format)` methods
 
 6.2
 ---

--- a/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
@@ -33,13 +33,16 @@ class TraceableNormalizer implements NormalizerInterface, DenormalizerInterface,
         private NormalizerInterface|DenormalizerInterface $normalizer,
         private SerializerDataCollector $dataCollector,
     ) {
+        if (!method_exists($normalizer, 'getSupportedTypes')) {
+            trigger_deprecation('symfony/serializer', '6.3', 'Not implementing the "NormalizerInterface::getSupportedTypes()" in "%s" is deprecated.', get_debug_type($normalizer));
+        }
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
         // @deprecated remove condition in 7.0
         if (!method_exists($this->normalizer, 'getSupportedTypes')) {
-            return null;
+            return ['*' => $this->normalizer instanceof CacheableSupportsMethodInterface && $this->normalizer->hasCacheableSupportsMethod()];
         }
 
         return $this->normalizer->getSupportedTypes($format);

--- a/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
@@ -35,6 +35,16 @@ class TraceableNormalizer implements NormalizerInterface, DenormalizerInterface,
     ) {
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        // @deprecated remove condition in 7.0
+        if (!method_exists($this->normalizer, 'getSupportedTypes')) {
+            return null;
+        }
+
+        return $this->normalizer->getSupportedTypes($format);
+    }
+
     public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         if (!$this->normalizer instanceof NormalizerInterface) {
@@ -114,8 +124,13 @@ class TraceableNormalizer implements NormalizerInterface, DenormalizerInterface,
         $this->normalizer->setDenormalizer($denormalizer);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return $this->normalizer instanceof CacheableSupportsMethodInterface && $this->normalizer->hasCacheableSupportsMethod();
     }
 

--- a/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Serializer\Debug;
 use Symfony\Component\Serializer\DataCollector\SerializerDataCollector;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -29,13 +30,13 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
 {
     public const DEBUG_TRACE_ID = 'debug_trace_id';
 
-    /**
-     * @param SerializerInterface&NormalizerInterface&DenormalizerInterface&EncoderInterface&DecoderInterface $serializer
-     */
     public function __construct(
-        private SerializerInterface $serializer,
+        private SerializerInterface&NormalizerInterface&DenormalizerInterface&EncoderInterface&DecoderInterface $serializer,
         private SerializerDataCollector $dataCollector,
     ) {
+        if (!method_exists($serializer, 'getSupportedTypes')) {
+            trigger_deprecation('symfony/serializer', '6.3', 'Not implementing the "NormalizerInterface::getSupportedTypes()" in "%s" is deprecated.', get_debug_type($serializer));
+        }
     }
 
     public function serialize(mixed $data, string $format, array $context = []): string
@@ -128,11 +129,11 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
         return $result;
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
         // @deprecated remove condition in 7.0
         if (!method_exists($this->serializer, 'getSupportedTypes')) {
-            return null;
+            return ['*' => $this->serializer instanceof CacheableSupportsMethodInterface && $this->serializer->hasCacheableSupportsMethod()];
         }
 
         return $this->serializer->getSupportedTypes($format);

--- a/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
@@ -128,6 +128,16 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
         return $result;
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        // @deprecated remove condition in 7.0
+        if (!method_exists($this->serializer, 'getSupportedTypes')) {
+            return null;
+        }
+
+        return $this->serializer->getSupportedTypes($format);
+    }
+
     public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $this->serializer->supportsNormalization($data, $format, $context);

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -150,8 +150,13 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         }
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return false;
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -300,7 +300,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      */
     public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */)
     {
-        return class_exists($type) || (interface_exists($type, false) && $this->classDiscriminatorResolver && null !== $this->classDiscriminatorResolver->getMappingForClass($type));
+        return class_exists($type) || (interface_exists($type, false) && null !== $this->classDiscriminatorResolver?->getMappingForClass($type));
     }
 
     public function denormalize(mixed $data, string $type, string $format = null, array $context = [])

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -27,11 +27,20 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
 {
     use DenormalizerAwareTrait;
 
-    public function getSupportedTypes(?string $format): ?array
+    public function setDenormalizer(DenormalizerInterface $denormalizer): void
+    {
+        if (!method_exists($denormalizer, 'getSupportedTypes')) {
+            trigger_deprecation('symfony/serializer', '6.3', 'Not implementing the "DenormalizerInterface::getSupportedTypes()" in "%s" is deprecated.', get_debug_type($denormalizer));
+        }
+
+        $this->denormalizer = $denormalizer;
+    }
+
+    public function getSupportedTypes(?string $format): array
     {
         // @deprecated remove condition in 7.0
         if (!method_exists($this->denormalizer, 'getSupportedTypes')) {
-            return null;
+            return ['*' => $this->denormalizer instanceof CacheableSupportsMethodInterface && $this->denormalizer->hasCacheableSupportsMethod()];
         }
 
         return $this->denormalizer->getSupportedTypes($format);

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -27,6 +27,16 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
 {
     use DenormalizerAwareTrait;
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        // @deprecated remove condition in 7.0
+        if (!method_exists($this->denormalizer, 'getSupportedTypes')) {
+            return null;
+        }
+
+        return $this->denormalizer->getSupportedTypes($format);
+    }
+
     /**
      * @throws NotNormalizableValueException
      */
@@ -69,8 +79,13 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
             && $this->denormalizer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return $this->denormalizer instanceof CacheableSupportsMethodInterface && $this->denormalizer->hasCacheableSupportsMethod();
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -27,6 +27,13 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
      */
     public const ALLOW_INVALID_VALUES = 'allow_invalid_values';
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+           \BackedEnum::class => true,
+        ];
+    }
+
     public function normalize(mixed $object, string $format = null, array $context = []): int|string
     {
         if (!$object instanceof \BackedEnum) {
@@ -78,8 +85,13 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
         return is_subclass_of($type, \BackedEnum::class);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return true;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/CacheableSupportsMethodInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CacheableSupportsMethodInterface.php
@@ -19,6 +19,8 @@ namespace Symfony\Component\Serializer\Normalizer;
  * supports*() methods will be cached by type and format.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated since Symfony 6.3, implement "getSupportedTypes(?string $format)" instead
  */
 interface CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -39,6 +39,13 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
         $this->nameConverter = $nameConverter;
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return [
+            ConstraintViolationListInterface::class => __CLASS__ === static::class,
+        ];
+    }
+
     public function normalize(mixed $object, string $format = null, array $context = []): array
     {
         if (\array_key_exists(self::PAYLOAD_FIELDS, $context)) {
@@ -109,8 +116,13 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
         return $data instanceof ConstraintViolationListInterface;
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -39,10 +39,10 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
         $this->nameConverter = $nameConverter;
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
         return [
-            ConstraintViolationListInterface::class => __CLASS__ === static::class,
+            ConstraintViolationListInterface::class => __CLASS__ === static::class || $this->hasCacheableSupportsMethod(),
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -25,7 +25,7 @@ class CustomNormalizer implements NormalizerInterface, DenormalizerInterface, Se
     public function getSupportedTypes(?string $format): array
     {
         return [
-            NormalizableInterface::class => __CLASS__ === static::class,
+            NormalizableInterface::class => __CLASS__ === static::class || $this->hasCacheableSupportsMethod(),
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -22,6 +22,13 @@ class CustomNormalizer implements NormalizerInterface, DenormalizerInterface, Se
     use ObjectToPopulateTrait;
     use SerializerAwareTrait;
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            NormalizableInterface::class => __CLASS__ === static::class,
+        ];
+    }
+
     public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return $object->normalize($this->serializer, $format, $context);
@@ -60,8 +67,13 @@ class CustomNormalizer implements NormalizerInterface, DenormalizerInterface, Se
         return is_subclass_of($type, DenormalizableInterface::class);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -45,6 +45,15 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
         $this->mimeTypeGuesser = $mimeTypeGuesser;
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            \SplFileInfo::class => __CLASS__ === static::class,
+            \SplFileObject::class => __CLASS__ === static::class,
+            File::class => __CLASS__ === static::class,
+        ];
+    }
+
     public function normalize(mixed $object, string $format = null, array $context = []): string
     {
         if (!$object instanceof \SplFileInfo) {
@@ -118,8 +127,13 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
         return isset(self::SUPPORTED_TYPES[$type]);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -47,10 +47,12 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
 
     public function getSupportedTypes(?string $format): array
     {
+        $isCacheable = __CLASS__ === static::class || $this->hasCacheableSupportsMethod();
+
         return [
-            \SplFileInfo::class => __CLASS__ === static::class,
-            \SplFileObject::class => __CLASS__ === static::class,
-            File::class => __CLASS__ === static::class,
+            \SplFileInfo::class => $isCacheable,
+            \SplFileObject::class => $isCacheable,
+            File::class => $isCacheable,
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -33,6 +33,13 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            \DateInterval::class => __CLASS__ === static::class,
+        ];
+    }
+
     /**
      * @throws InvalidArgumentException
      */
@@ -53,8 +60,13 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
         return $data instanceof \DateInterval;
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -36,7 +36,7 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
     public function getSupportedTypes(?string $format): array
     {
         return [
-            \DateInterval::class => __CLASS__ === static::class,
+            \DateInterval::class => __CLASS__ === static::class || $this->hasCacheableSupportsMethod(),
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -47,6 +47,15 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            \DateTimeInterface::class => __CLASS__ === static::class,
+            \DateTimeImmutable::class => __CLASS__ === static::class,
+            \DateTime::class => __CLASS__ === static::class,
+        ];
+    }
+
     /**
      * @throws InvalidArgumentException
      */
@@ -124,8 +133,13 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         return isset(self::SUPPORTED_TYPES[$type]);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -49,10 +49,12 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
 
     public function getSupportedTypes(?string $format): array
     {
+        $isCacheable = __CLASS__ === static::class || $this->hasCacheableSupportsMethod();
+
         return [
-            \DateTimeInterface::class => __CLASS__ === static::class,
-            \DateTimeImmutable::class => __CLASS__ === static::class,
-            \DateTime::class => __CLASS__ === static::class,
+            \DateTimeInterface::class => $isCacheable,
+            \DateTimeImmutable::class => $isCacheable,
+            \DateTime::class => $isCacheable,
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
@@ -22,6 +22,13 @@ use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
  */
 class DateTimeZoneNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            \DateTimeZone::class => __CLASS__ === static::class,
+        ];
+    }
+
     /**
      * @throws InvalidArgumentException
      */
@@ -66,8 +73,13 @@ class DateTimeZoneNormalizer implements NormalizerInterface, DenormalizerInterfa
         return \DateTimeZone::class === $type;
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
@@ -25,7 +25,7 @@ class DateTimeZoneNormalizer implements NormalizerInterface, DenormalizerInterfa
     public function getSupportedTypes(?string $format): array
     {
         return [
-            \DateTimeZone::class => __CLASS__ === static::class,
+            \DateTimeZone::class => __CLASS__ === static::class || $this->hasCacheableSupportsMethod(),
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -21,6 +21,8 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @method getSupportedTypes(?string $format): ?array
  */
 interface DenormalizerInterface
 {
@@ -49,12 +51,32 @@ interface DenormalizerInterface
     /**
      * Checks whether the given class is supported for denormalization by this normalizer.
      *
-     * @param mixed       $data   Data to denormalize from
-     * @param string      $type   The class to which the data should be denormalized
-     * @param string|null $format The format being deserialized from
+     * Since Symfony 6.3, this method will only be called if the type is
+     * included in the supported types returned by getSupportedTypes().
+     *
+     * @see getSupportedTypes()
+     *
+     * @param mixed       $data    Data to denormalize from
+     * @param string      $type    The class to which the data should be denormalized
+     * @param string|null $format  The format being deserialized from
      * @param array       $context Options available to the denormalizer
      *
      * @return bool
      */
     public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */);
+
+    /*
+     * Return the types supported for normalization by this denormalizer for
+     * this format associated to a boolean value indicating if the result of
+     * supports*() methods can be cached or if the result can not be cached
+     * because it depends on the context.
+     * Returning null means this denormalizer will be considered for
+     * every format/class.
+     * Return an empty array if no type is supported for this format.
+     *
+     * @param string $format The format being (de-)serialized from or into
+     *
+     * @return array<class-string|string, bool>|null
+     */
+    /* public function getSupportedTypes(?string $format): ?array; */
 }

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -22,7 +22,7 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  *
- * @method getSupportedTypes(?string $format): ?array
+ * @method getSupportedTypes(?string $format): array
  */
 interface DenormalizerInterface
 {
@@ -65,18 +65,19 @@ interface DenormalizerInterface
      */
     public function supportsDenormalization(mixed $data, string $type, string $format = null /* , array $context = [] */);
 
-    /*
-     * Return the types supported for normalization by this denormalizer for
-     * this format associated to a boolean value indicating if the result of
-     * supports*() methods can be cached or if the result can not be cached
-     * because it depends on the context.
-     * Returning null means this denormalizer will be considered for
-     * every format/class.
-     * Return an empty array if no type is supported for this format.
+    /**
+     * Returns the types potentially supported by this denormalizer.
      *
-     * @param string $format The format being (de-)serialized from or into
+     * For each supported formats (if applicable), the supported types should be
+     * returned as keys, and each type should be mapped to a boolean indicating
+     * if the result of supportsDenormalization() can be cached or not
+     * (a result cannot be cached when it depends on the context or on the data.)
      *
-     * @return array<class-string|string, bool>|null
+     * The special type '*' can be used to indicate that the denormalizer might
+     * support any types. A null value means that the denormalizer does not support
+     * the corresponding type.
+     *
+     * @return array<class-string|'*'|string, bool|null>
      */
-    /* public function getSupportedTypes(?string $format): ?array; */
+    /* public function getSupportedTypes(?string $format): array; */
 }

--- a/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
@@ -38,6 +38,13 @@ final class FormErrorNormalizer implements NormalizerInterface, CacheableSupport
         return $data;
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            FormInterface::class => false,
+        ];
+    }
+
     public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof FormInterface && $data->isSubmitted() && !$data->isValid();
@@ -76,8 +83,13 @@ final class FormErrorNormalizer implements NormalizerInterface, CacheableSupport
         return $children;
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -36,9 +36,9 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 {
     private static $setterAccessibleCache = [];
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => __CLASS__ === static::class || $this->hasCacheableSupportsMethod()];
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -36,6 +36,11 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 {
     private static $setterAccessibleCache = [];
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     /**
      * @param array $context
      */
@@ -52,8 +57,13 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         return parent::supportsDenormalization($data, $type, $format) && $this->supports($type);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
@@ -38,6 +38,13 @@ class JsonSerializableNormalizer extends AbstractNormalizer
         return $this->serializer->normalize($object->jsonSerialize(), $format, $context);
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            \JsonSerializable::class => __CLASS__ === static::class,
+        ];
+    }
+
     /**
      * @param array $context
      */
@@ -59,8 +66,13 @@ class JsonSerializableNormalizer extends AbstractNormalizer
         throw new LogicException(sprintf('Cannot denormalize with "%s".', \JsonSerializable::class));
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
@@ -41,7 +41,7 @@ class JsonSerializableNormalizer extends AbstractNormalizer
     public function getSupportedTypes(?string $format): array
     {
         return [
-            \JsonSerializable::class => __CLASS__ === static::class,
+            \JsonSerializable::class => __CLASS__ === static::class || $this->hasCacheableSupportsMethod(),
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -42,6 +42,17 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         $this->headersProperty = new \ReflectionProperty(Headers::class, 'headers');
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            Message::class => true,
+            Headers::class => true,
+            HeaderInterface::class => true,
+            Address::class => true,
+            AbstractPart::class => true,
+        ];
+    }
+
     public function setSerializer(SerializerInterface $serializer): void
     {
         $this->serializer = $serializer;
@@ -101,8 +112,13 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         return is_a($type, Message::class, true) || Headers::class === $type || AbstractPart::class === $type;
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -44,12 +44,14 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
 
     public function getSupportedTypes(?string $format): array
     {
+        $isCacheable = __CLASS__ === static::class || $this->hasCacheableSupportsMethod();
+
         return [
-            Message::class => true,
-            Headers::class => true,
-            HeaderInterface::class => true,
-            Address::class => true,
-            AbstractPart::class => true,
+            Message::class => $isCacheable,
+            Headers::class => $isCacheable,
+            HeaderInterface::class => $isCacheable,
+            Address::class => $isCacheable,
+            AbstractPart::class => $isCacheable,
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Exception\LogicException;
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  *
- * @method getSupportedTypes(?string $format): ?array
+ * @method getSupportedTypes(?string $format): array
  */
 interface NormalizerInterface
 {
@@ -56,18 +56,19 @@ interface NormalizerInterface
      */
     public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */);
 
-    /*
-     * Return the types supported for normalization by this normalizer for this
-     * format associated to a boolean value indicating if the result of
-     * supports*() methods can be cached or if the result can not be cached
-     * because it depends on the context.
-     * Returning null means this normalizer will be considered for
-     * every format/class.
-     * Return an empty array if no type is supported for this format.
+    /**
+     * Returns the types potentially supported by this normalizer.
      *
-     * @param string $format The format being (de-)serialized from or into
+     * For each supported formats (if applicable), the supported types should be
+     * returned as keys, and each type should be mapped to a boolean indicating
+     * if the result of supportsNormalization() can be cached or not
+     * (a result cannot be cached when it depends on the context or on the data.)
      *
-     * @return array<class-string|string, bool>|null
+     * The special type '*' can be used to indicate that the normalizer might
+     * support any types. A null value means that the normalizer does not support
+     * the corresponding type.
+     *
+     * @return array<class-string|'*'|string, bool|null>
      */
-    /* public function getSupportedTypes(?string $format): ?array; */
+    /* public function getSupportedTypes(?string $format): array; */
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\Serializer\Exception\LogicException;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @method getSupportedTypes(?string $format): ?array
  */
 interface NormalizerInterface
 {
@@ -41,11 +43,31 @@ interface NormalizerInterface
     /**
      * Checks whether the given class is supported for normalization by this normalizer.
      *
+     * Since Symfony 6.3, this method will only be called if the $data type is
+     * included in the supported types returned by getSupportedTypes().
+     *
+     * @see getSupportedTypes()
+     *
      * @param mixed       $data    Data to normalize
-     * @param string|null $format The format being (de-)serialized from or into
+     * @param string|null $format  The format being (de-)serialized from or into
      * @param array       $context Context options for the normalizer
      *
      * @return bool
      */
     public function supportsNormalization(mixed $data, string $format = null /* , array $context = [] */);
+
+    /*
+     * Return the types supported for normalization by this normalizer for this
+     * format associated to a boolean value indicating if the result of
+     * supports*() methods can be cached or if the result can not be cached
+     * because it depends on the context.
+     * Returning null means this normalizer will be considered for
+     * every format/class.
+     * Return an empty array if no type is supported for this format.
+     *
+     * @param string $format The format being (de-)serialized from or into
+     *
+     * @return array<class-string|string, bool>|null
+     */
+    /* public function getSupportedTypes(?string $format): ?array; */
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -47,9 +47,9 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         $this->objectClassResolver = $objectClassResolver ?? fn ($class) => \is_object($class) ? $class::class : $class;
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => __CLASS__ === static::class || $this->hasCacheableSupportsMethod()];
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -47,8 +47,18 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         $this->objectClassResolver = $objectClassResolver ?? fn ($class) => \is_object($class) ? $class::class : $class;
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -40,6 +40,13 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
         $this->defaultContext = $defaultContext + $this->defaultContext;
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            FlattenException::class => __CLASS__ === self::class,
+        ];
+    }
+
     public function normalize(mixed $object, string $format = null, array $context = []): array
     {
         if (!$object instanceof FlattenException) {
@@ -71,8 +78,13 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
         return $data instanceof FlattenException;
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return true;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -43,7 +43,7 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     public function getSupportedTypes(?string $format): array
     {
         return [
-            FlattenException::class => __CLASS__ === self::class,
+            FlattenException::class => __CLASS__ === self::class || $this->hasCacheableSupportsMethod(),
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -54,9 +54,9 @@ class PropertyNormalizer extends AbstractObjectNormalizer
         }
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => __CLASS__ === static::class || $this->hasCacheableSupportsMethod()];
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -54,6 +54,11 @@ class PropertyNormalizer extends AbstractObjectNormalizer
         }
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     /**
      * @param array $context
      */
@@ -70,8 +75,13 @@ class PropertyNormalizer extends AbstractObjectNormalizer
         return parent::supportsDenormalization($data, $type, $format) && $this->supports($type);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
@@ -41,6 +41,13 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            AbstractUid::class => true,
+        ];
+    }
+
     /**
      * @param AbstractUid $object
      */
@@ -92,8 +99,13 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
         return is_subclass_of($type, AbstractUid::class, true);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return __CLASS__ === static::class;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
@@ -32,9 +32,9 @@ final class UnwrappingDenormalizer implements DenormalizerInterface, SerializerA
         $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => false];
     }
 
     public function denormalize(mixed $data, string $class, string $format = null, array $context = []): mixed

--- a/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UnwrappingDenormalizer.php
@@ -32,6 +32,11 @@ final class UnwrappingDenormalizer implements DenormalizerInterface, SerializerA
         $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     public function denormalize(mixed $data, string $class, string $format = null, array $context = []): mixed
     {
         $propertyPath = $context[self::UNWRAP_PATH];
@@ -53,8 +58,13 @@ final class UnwrappingDenormalizer implements DenormalizerInterface, SerializerA
         return \array_key_exists(self::UNWRAP_PATH, $context) && !isset($context['unwrapped']);
     }
 
+    /**
+     * @deprecated since Symfony 6.3, use "getSupportedTypes()" instead
+     */
     public function hasCacheableSupportsMethod(): bool
     {
+        trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
+
         return $this->serializer instanceof CacheableSupportsMethodInterface && $this->serializer->hasCacheableSupportsMethod();
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableNormalizerTest.php
@@ -15,14 +15,15 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\DataCollector\SerializerDataCollector;
 use Symfony\Component\Serializer\Debug\TraceableNormalizer;
 use Symfony\Component\Serializer\Debug\TraceableSerializer;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\UpcomingDenormalizerInterface as DenormalizerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\UpcomingNormalizerInterface as NormalizerInterface;
 
 class TraceableNormalizerTest extends TestCase
 {
     public function testForwardsToNormalizer()
     {
         $normalizer = $this->createMock(NormalizerInterface::class);
+        $normalizer->method('getSupportedTypes')->willReturn(['*' => false]);
         $normalizer
             ->expects($this->once())
             ->method('normalize')
@@ -30,6 +31,7 @@ class TraceableNormalizerTest extends TestCase
             ->willReturn('normalized');
 
         $denormalizer = $this->createMock(DenormalizerInterface::class);
+        $denormalizer->method('getSupportedTypes')->willReturn(['*' => false]);
         $denormalizer
             ->expects($this->once())
             ->method('denormalize')
@@ -43,7 +45,9 @@ class TraceableNormalizerTest extends TestCase
     public function testCollectNormalizationData()
     {
         $normalizer = $this->createMock(NormalizerInterface::class);
+        $normalizer->method('getSupportedTypes')->willReturn(['*' => false]);
         $denormalizer = $this->createMock(DenormalizerInterface::class);
+        $denormalizer->method('getSupportedTypes')->willReturn(['*' => false]);
 
         $dataCollector = $this->createMock(SerializerDataCollector::class);
         $dataCollector
@@ -62,7 +66,9 @@ class TraceableNormalizerTest extends TestCase
     public function testNotCollectNormalizationDataIfNoDebugTraceId()
     {
         $normalizer = $this->createMock(NormalizerInterface::class);
+        $normalizer->method('getSupportedTypes')->willReturn(['*' => false]);
         $denormalizer = $this->createMock(DenormalizerInterface::class);
+        $denormalizer->method('getSupportedTypes')->willReturn(['*' => false]);
 
         $dataCollector = $this->createMock(SerializerDataCollector::class);
         $dataCollector->expects($this->never())->method('collectNormalization');
@@ -89,9 +95,11 @@ class TraceableNormalizerTest extends TestCase
     public function testSupports()
     {
         $normalizer = $this->createMock(NormalizerInterface::class);
+        $normalizer->method('getSupportedTypes')->willReturn(['*' => false]);
         $normalizer->method('supportsNormalization')->willReturn(true);
 
         $denormalizer = $this->createMock(DenormalizerInterface::class);
+        $denormalizer->method('getSupportedTypes')->willReturn(['*' => false]);
         $denormalizer->method('supportsDenormalization')->willReturn(true);
 
         $traceableNormalizer = new TraceableNormalizer($normalizer, new SerializerDataCollector());

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
@@ -145,6 +145,11 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         return 'normalized';
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return true;

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
@@ -145,9 +145,9 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         return 'normalized';
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => false];
     }
 
     public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -944,6 +944,11 @@ XML;
 
         $mock
             ->expects($this->once())
+            ->method('getSupportedTypes')
+            ->willReturn([\DateTime::class => true]);
+
+        $mock
+            ->expects($this->once())
             ->method('supportsNormalization')
             ->with(new \DateTime($this->exampleDateTimeString), 'xml')
             ->willReturn(true);

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
@@ -20,6 +20,11 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
  */
 class AbstractNormalizerDummy extends AbstractNormalizer
 {
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     public function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false): array|bool
     {
         return parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
@@ -20,9 +20,9 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
  */
 class AbstractNormalizerDummy extends AbstractNormalizer
 {
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => false];
     }
 
     public function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false): array|bool

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
@@ -31,7 +31,7 @@ class EnvelopeNormalizer implements NormalizerInterface
         ];
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
         return [
             EnvelopeObject::class => true,

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
@@ -31,6 +31,13 @@ class EnvelopeNormalizer implements NormalizerInterface
         ];
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return [
+            EnvelopeObject::class => true,
+        ];
+    }
+
     public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return $data instanceof EnvelopeObject;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
@@ -25,7 +25,7 @@ class EnvelopedMessageNormalizer implements NormalizerInterface
         ];
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
         return [
             EnvelopedMessage::class => true,

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
@@ -25,6 +25,13 @@ class EnvelopedMessageNormalizer implements NormalizerInterface
         ];
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return [
+            EnvelopedMessage::class => true,
+        ];
+    }
+
     public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return $data instanceof EnvelopedMessage;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/UpcomingDenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/UpcomingDenormalizerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+// @deprecated remove in 7.0 in favor of direct use of the DenormalizerInterface
+interface UpcomingDenormalizerInterface extends DenormalizerInterface
+{
+    public function getSupportedTypes(?string $format): array;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/UpcomingNormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/UpcomingNormalizerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+// @deprecated remove in 7.0 in favor of direct use of the NormalizerInterface
+interface UpcomingNormalizerInterface extends NormalizerInterface
+{
+    public function getSupportedTypes(?string $format): array;
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -546,9 +546,9 @@ class AbstractObjectNormalizerTest extends TestCase
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
 {
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => false];
     }
 
     protected function extractAttributes(object $object, string $format = null, array $context = []): array
@@ -656,9 +656,9 @@ class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
         parent::__construct($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => false];
     }
 
     protected function extractAttributes(object $object, string $format = null, array $context = []): array
@@ -762,9 +762,9 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
         return null;
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => false];
     }
 
     public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
@@ -775,9 +775,9 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
 
 class AbstractObjectNormalizerCollectionDummy extends AbstractObjectNormalizer
 {
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => false];
     }
 
     protected function extractAttributes(object $object, string $format = null, array $context = []): array
@@ -834,7 +834,7 @@ class ArrayDenormalizerDummy implements DenormalizerInterface, SerializerAwareIn
         return $data;
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
         return $this->serializer->getSupportedTypes($format);
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -546,6 +546,11 @@ class AbstractObjectNormalizerTest extends TestCase
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
 {
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     protected function extractAttributes(object $object, string $format = null, array $context = []): array
     {
         return [];
@@ -651,6 +656,11 @@ class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
         parent::__construct($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     protected function extractAttributes(object $object, string $format = null, array $context = []): array
     {
     }
@@ -752,6 +762,11 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
         return null;
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
         return true;
@@ -760,6 +775,11 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
 
 class AbstractObjectNormalizerCollectionDummy extends AbstractObjectNormalizer
 {
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     protected function extractAttributes(object $object, string $format = null, array $context = []): array
     {
     }
@@ -812,6 +832,11 @@ class ArrayDenormalizerDummy implements DenormalizerInterface, SerializerAwareIn
         }
 
         return $data;
+    }
+
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return $this->serializer->getSupportedTypes($format);
     }
 
     public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -14,23 +14,16 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
-use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\UpcomingDenormalizerInterface as DenormalizerInterface;
 
 class ArrayDenormalizerTest extends TestCase
 {
-    /**
-     * @var ArrayDenormalizer
-     */
-    private $denormalizer;
-
-    /**
-     * @var MockObject&ContextAwareDenormalizerInterface
-     */
-    private $serializer;
+    private ArrayDenormalizer $denormalizer;
+    private MockObject&DenormalizerInterface $serializer;
 
     protected function setUp(): void
     {
-        $this->serializer = $this->createMock(ContextAwareDenormalizerInterface::class);
+        $this->serializer = $this->createMock(DenormalizerInterface::class);
         $this->denormalizer = new ArrayDenormalizer();
         $this->denormalizer->setDenormalizer($this->serializer);
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
@@ -24,9 +24,9 @@ class TestDenormalizer implements DenormalizerInterface
     {
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => false];
     }
 
     public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
@@ -24,6 +24,11 @@ class TestDenormalizer implements DenormalizerInterface
     {
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
         return true;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
@@ -25,6 +25,11 @@ class TestNormalizer implements NormalizerInterface
         return null;
     }
 
+    public function getSupportedTypes(?string $format): ?array
+    {
+        return null;
+    }
+
     public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return true;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
@@ -25,9 +25,9 @@ class TestNormalizer implements NormalizerInterface
         return null;
     }
 
-    public function getSupportedTypes(?string $format): ?array
+    public function getSupportedTypes(?string $format): array
     {
-        return null;
+        return ['*' => false];
     }
 
     public function supportsNormalization($data, string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -42,10 +42,8 @@ use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeZoneNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Normalizer\UidNormalizer;
@@ -66,22 +64,13 @@ use Symfony\Component\Serializer\Tests\Fixtures\Php74Full;
 use Symfony\Component\Serializer\Tests\Fixtures\Php80WithPromotedTypedConstructor;
 use Symfony\Component\Serializer\Tests\Fixtures\TraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\TrueBuiltInDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\UpcomingDenormalizerInterface as DenormalizerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\UpcomingNormalizerInterface as NormalizerInterface;
 use Symfony\Component\Serializer\Tests\Normalizer\TestDenormalizer;
 use Symfony\Component\Serializer\Tests\Normalizer\TestNormalizer;
 
 class SerializerTest extends TestCase
 {
-    public function testInterface()
-    {
-        $serializer = new Serializer();
-
-        $this->assertInstanceOf(SerializerInterface::class, $serializer);
-        $this->assertInstanceOf(NormalizerInterface::class, $serializer);
-        $this->assertInstanceOf(DenormalizerInterface::class, $serializer);
-        $this->assertInstanceOf(EncoderInterface::class, $serializer);
-        $this->assertInstanceOf(DecoderInterface::class, $serializer);
-    }
-
     public function testItThrowsExceptionOnInvalidNormalizer()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -153,11 +142,13 @@ class SerializerTest extends TestCase
     public function testNormalizeWithSupportOnData()
     {
         $normalizer1 = $this->createMock(NormalizerInterface::class);
+        $normalizer1->method('getSupportedTypes')->willReturn(['*' => false]);
         $normalizer1->method('supportsNormalization')
             ->willReturnCallback(fn ($data, $format) => isset($data->test));
         $normalizer1->method('normalize')->willReturn('test1');
 
         $normalizer2 = $this->createMock(NormalizerInterface::class);
+        $normalizer2->method('getSupportedTypes')->willReturn(['*' => false]);
         $normalizer2->method('supportsNormalization')
             ->willReturn(true);
         $normalizer2->method('normalize')->willReturn('test2');
@@ -174,11 +165,13 @@ class SerializerTest extends TestCase
     public function testDenormalizeWithSupportOnData()
     {
         $denormalizer1 = $this->createMock(DenormalizerInterface::class);
+        $denormalizer1->method('getSupportedTypes')->willReturn(['*' => false]);
         $denormalizer1->method('supportsDenormalization')
             ->willReturnCallback(fn ($data, $type, $format) => isset($data['test1']));
         $denormalizer1->method('denormalize')->willReturn('test1');
 
         $denormalizer2 = $this->createMock(DenormalizerInterface::class);
+        $denormalizer2->method('getSupportedTypes')->willReturn(['*' => false]);
         $denormalizer2->method('supportsDenormalization')
             ->willReturn(true);
         $denormalizer2->method('denormalize')->willReturn('test2');
@@ -370,8 +363,7 @@ class SerializerTest extends TestCase
     {
         $normalizerAware = $this->createMock(NormalizerAwareNormalizer::class);
         $normalizerAware->expects($this->once())
-            ->method('setNormalizer')
-            ->with($this->isInstanceOf(NormalizerInterface::class));
+            ->method('setNormalizer');
 
         new Serializer([$normalizerAware]);
     }
@@ -380,8 +372,7 @@ class SerializerTest extends TestCase
     {
         $denormalizerAware = $this->createMock(DenormalizerAwareDenormalizer::class);
         $denormalizerAware->expects($this->once())
-            ->method('setDenormalizer')
-            ->with($this->isInstanceOf(DenormalizerInterface::class));
+            ->method('setDenormalizer');
 
         new Serializer([$denormalizerAware]);
     }
@@ -1235,6 +1226,76 @@ class SerializerTest extends TestCase
             [new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()))],
         ];
     }
+
+    public function testSerializerUsesSupportedTypesMethod()
+    {
+        $neverCalledNormalizer = $this->createMock(DummyNormalizer::class);
+        $neverCalledNormalizer
+            // once for normalization, once for denormalization
+            ->expects($this->exactly(2))
+            ->method('getSupportedTypes')
+            ->willReturn([
+                Foo::class => true,
+                Bar::class => false,
+            ]);
+
+        $supportedAndCachedNormalizer = $this->createMock(DummyNormalizer::class);
+        $supportedAndCachedNormalizer
+            // once for normalization, once for denormalization
+            ->expects($this->exactly(2))
+            ->method('getSupportedTypes')
+            ->willReturn([
+                Model::class => true,
+            ]);
+
+        $serializer = new Serializer(
+            [
+                $neverCalledNormalizer,
+                $supportedAndCachedNormalizer,
+                new ObjectNormalizer(),
+            ],
+            ['json' => new JsonEncoder()]
+        );
+
+        // Normalization process
+        $neverCalledNormalizer
+            ->expects($this->never())
+            ->method('supportsNormalization');
+        $neverCalledNormalizer
+            ->expects($this->never())
+            ->method('normalize');
+
+        $supportedAndCachedNormalizer
+            ->expects($this->once())
+            ->method('supportsNormalization')
+            ->willReturn(true);
+        $supportedAndCachedNormalizer
+            ->expects($this->exactly(2))
+            ->method('normalize')
+            ->willReturn(['foo' => 'bar']);
+
+        $serializer->normalize(new Model(), 'json');
+        $serializer->normalize(new Model(), 'json');
+
+        // Denormalization pass
+        $neverCalledNormalizer
+            ->expects($this->never())
+            ->method('supportsDenormalization');
+        $neverCalledNormalizer
+            ->expects($this->never())
+            ->method('denormalize');
+        $supportedAndCachedNormalizer
+            ->expects($this->once())
+            ->method('supportsDenormalization')
+            ->willReturn(true);
+        $supportedAndCachedNormalizer
+            ->expects($this->exactly(2))
+            ->method('denormalize')
+            ->willReturn(new Model());
+
+        $serializer->denormalize('foo', Model::class, 'json');
+        $serializer->denormalize('foo', Model::class, 'json');
+    }
 }
 
 class Model
@@ -1387,6 +1448,11 @@ class DummyList extends \ArrayObject
     {
         return new \ArrayIterator($this->list);
     }
+}
+
+abstract class DummyNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    abstract public function getSupportedTypes(?string $format): array;
 }
 
 interface NormalizerAwareNormalizer extends NormalizerInterface, NormalizerAwareInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes (new method in the interfaces, one interface deprecated)
| License       | MIT
| Doc PR        | to be written

The PRs allows normalizers or denormalizers to expose their supported types and the associated cacheability to the Serializer.
With this info,  even if the `supports*` call is not cacheable, the Serializer can skip a ton of method calls to `supports*` improving performance substaintially in some cases:
![Screenshot 2023-02-02 at 15 46 49](https://user-images.githubusercontent.com/870118/217378926-03aa77e8-d80e-4bdd-b5dc-acc3602b70b3.png)

<details>
 <summary>I found this design while working on a customer project performance (a big app built around API Platform): we reached the point where the slowest part of main application endpoint was `Symfony\Component\Serializer\Serializer::getNormalizer`.</summary>

After some digging, we found out we were experiencing the conjunction of two phenomenons:
- the application is quite complex and returns deep nested and repeating structures, exposing the underlying bottleneck;
- and a lot of custom non-cacheable normalizers.
Because most of the normalizers are not cacheable, the Serializer has to call every normalizer over and over again leading `getNormalizer` to account for 20% of the total wall time:
![Screenshot 2023-02-07 at 16 56 02](https://user-images.githubusercontent.com/870118/217375680-e7d33db2-fd6a-4ef0-b8d0-34d0eac8cf09.png)

We first tried to improve cacheability based on context without much success, then an approach similar to #45779 with some success but still feeling this could be faster.
We then thought that even if the `supportsNormalization` could not be cached (because of the context), maybe we could avoid the calls at the origin by letting the `Normalizers` expose the types they support and came to this PR with pretty good results.
</details>

The perfornance improvement was only measured by adapting Symfony's normalizers as well as the project ones, proper third party normalizers updates should improve performance even more.

This should effectively replaces the `CacheableSupportsMethodInterface` as the cacheability can now be returned by `getSupportedTypes`.