### PR TITLE
[VarDumper] Fix error when reflected class has default Enum parameter in constructor

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -292,7 +292,7 @@ class ReflectionCaster
         if ($c->isOptional()) {
             try {
                 $a[$prefix.'default'] = $v = $c->getDefaultValue();
-                if ($c->isDefaultValueConstant()) {
+                if ($c->isDefaultValueConstant() && !\is_object($v)) {
                     $a[$prefix.'default'] = new ConstStub($c->getDefaultValueConstantName(), $v);
                 }
                 if (null === $v) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Have classes:

```
enum GeometryType: string
{
    case Geometry = 'GEOMETRY';
}
```

```
final class Geometry
{
    public function __construct(GeometryType $type = GeometryType::Geometry)
    {
    }
}
```

Try to dump reflection of class Geometry:

```
$reflection = new \ReflectionClass(Geometry::class);
dump($reflection);
```

Have error:
`Symfony\Component\VarDumper\Caster\ConstStub::__construct(): Argument #2 ($value) must be of type string|int|float|null, App\Infrastructure\Geometry\GeometryType given, called in [...]/vendor/symfony/var-dumper/Caster/ReflectionCaster.php on line 296`