### PR TITLE
[DoctrineBridge] Allow to ignore specific nullable fields in UniqueEntity

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -251,8 +251,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider provideConstraintsWithIgnoreNullDisabled
+     * @dataProvider provideConstraintsWithIgnoreNullEnabledOnFirstField
      */
-    public function testValidateUniquenessWithIgnoreNullDisabled(UniqueEntity $constraint)
+    public function testValidateUniquenessWithIgnoreNullDisableOnSecondField(UniqueEntity $constraint)
     {
         $entity1 = new DoubleNameEntity(1, 'Foo', null);
         $entity2 = new DoubleNameEntity(2, 'Foo', null);
@@ -304,6 +305,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider provideConstraintsWithIgnoreNullEnabled
+     * @dataProvider provideConstraintsWithIgnoreNullEnabledOnFirstField
      */
     public function testNoValidationIfFirstFieldIsNullAndNullValuesAreIgnored(UniqueEntity $constraint)
     {
@@ -336,6 +338,18 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         ])];
 
         yield 'Named arguments' => [new UniqueEntity(message: 'myMessage', fields: ['name', 'name2'], em: 'foo', ignoreNull: true)];
+    }
+
+    public static function provideConstraintsWithIgnoreNullEnabledOnFirstField(): iterable
+    {
+        yield 'Doctrine style (name field)' => [new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['name', 'name2'],
+            'em' => self::EM_NAME,
+            'ignoreNull' => 'name',
+        ])];
+
+        yield 'Named arguments (name field)' => [new UniqueEntity(message: 'myMessage', fields: ['name', 'name2'], em: 'foo', ignoreNull: 'name')];
     }
 
     public function testValidateUniquenessWithValidCustomErrorPath()

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -45,7 +45,8 @@ class UniqueEntity extends Constraint
     protected static $errorNames = self::ERROR_NAMES;
 
     /**
-     * @param array|string $fields the combination of fields that must contain unique values or a set of options
+     * @param array|string      $fields     The combination of fields that must contain unique values or a set of options
+     * @param bool|array|string $ignoreNull The combination of fields that ignore null values
      */
     public function __construct(
         $fields,
@@ -55,7 +56,7 @@ class UniqueEntity extends Constraint
         string $entityClass = null,
         string $repositoryMethod = null,
         string $errorPath = null,
-        bool $ignoreNull = null,
+        bool|string|array $ignoreNull = null,
         array $groups = null,
         $payload = null,
         array $options = []


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#...  TODO

When the UniqueEntity is applied on multiple things the only option was 
- ignore all nullable values
- do not ignore any nullable values

With this feature, it would be possible to ignore nullable values for specific field only and do not ignore nullable values for others.