### PR TITLE
[Messenger] Add `Envelope::getResult()`

### DIFF
--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger;
 
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
@@ -126,5 +127,10 @@ final class Envelope
     public function getMessage(): object
     {
         return $this->message;
+    }
+
+    public function getResult(): mixed
+    {
+        return $this->last(HandledStamp::class)?->getResult();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |
| Tickets       |
| License       | MIT
| Doc PR        |

we were reading https://thomas.jarrand.fr/blog/cache-query-avec-symfony-messenger/ and a line triggered @damienalexandre:
```php
$envelope->last(HandledStamp::class)->getResult()
```

I agree this line is not very optimal:
* it's long
* you need to know internals to write it

That's why I propose a shortcut

---

If this feature is accepted, I'll write

* [ ] A test
* [ ] CHANGELOG.md
