### PR TITLE
[HttpClient] Fix data collector

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -43,8 +43,8 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
 
     public function lateCollect()
     {
-        $this->data['request_count'] = 0;
-        $this->data['error_count'] = 0;
+        $this->data['request_count'] = $this->data['request_count'] ?? 0;
+        $this->data['error_count'] = $this->data['error_count'] ?? 0;
         $this->data += ['clients' => []];
 
         foreach ($this->clients as $name => $client) {
@@ -59,7 +59,8 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
 
             $this->data['clients'][$name]['traces'] = array_merge($this->data['clients'][$name]['traces'], $traces);
             $this->data['request_count'] += \count($traces);
-            $this->data['error_count'] += $this->data['clients'][$name]['error_count'] += $errorCount;
+            $this->data['error_count'] += $errorCount;
+            $this->data['clients'][$name]['error_count'] += $errorCount;
 
             $client->reset();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | -
| Tickets       | https://github.com/symfony/symfony/issues/49219
| License       | MIT
| Doc PR        | -

It fixes HTTP requests not showing anymore in the profiler panel because `lateCollect()` overrides `request_count` to 0.

It also fixes the wrong error count. 