### PR TITLE
[Notifier][WebProfilerBundle] Ignore messages whose `getNotification` returns `null`

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
@@ -114,24 +114,24 @@
                                     <span class="label">Subject</span>
                                     <h2 class="m-t-10">{{ message.getSubject() ?? '(empty)' }}</h2>
                                 </div>
-                                {% if message.getNotification is defined %}
+                                {% set notification = message.notification ?? null %}
+                                {% if notification %}
                                     <div class="card-block">
                                         <div class="row">
                                             <div class="col">
                                                 <span class="label">Content</span>
-                                                <pre class="prewrap">{{ message.getNotification().getContent() ?? '(empty)' }}</pre>
+                                                <pre class="prewrap">{{ notification.getContent() ?? '(empty)' }}</pre>
                                                 <span class="label">Importance</span>
-                                                <pre class="prewrap">{{ message.getNotification().getImportance() }}</pre>
+                                                <pre class="prewrap">{{ notification.getImportance() }}</pre>
                                             </div>
                                         </div>
                                     </div>
                                 {% endif %}
                                     <div class="card-block">
                                         <div class="sf-tabs sf-tabs-sm">
-                                            {% if message.getNotification is defined %}
+                                            {% if notification %}
                                                 <div class="tab">
                                                     <h3 class="tab-title">Notification</h3>
-                                                    {% set notification = event.message.getNotification() %}
                                                     <div class="tab-content">
                                                         <pre class="prewrap" style="max-height: 600px">
                                                             {{- 'Subject: ' ~ notification.getSubject() }}<br/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49305
| License       | MIT
| Doc PR        | N/A

Make use of Twig’s null-coalescing operator because `MessageInterface::getNotification` can return `null` when it exists.