### PR TITLE
Add warning about Symfony 5.2 changing pcntl_async_signals

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 5.1 to 5.2
 =======================
 
+Console
+-------
+
+ * `Application` now runs `pcntl_async_signals(true)` when constucted; if the code of your CLI application depends on pcntl signals being synchronous, you should either call `pcntl_async_signals(false)` or implement `SignalableCommandInterface::handleSignal()`
+
 DependencyInjection
 -------------------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no (and yes in a sense)
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

https://symfony.com/blog/new-in-symfony-5-2-console-signals

There should be a warning regarding this in the upgrade guide. 

To illustrate the problem:

* you have a command that should finish when sent SIG_WINCH
* you have a code there that is something like this:
```
 pcntl_signal(SIGWINCH, function ($signo) use ($worker) {
     print "Stopped by signal $signo";
     exit(0);
});

while($hasNextMessage) {
     pcntl_signal_dispatch();
     $this->stuffNeedsToBeFinishedAtAllCases($message);
}
```
pre 5.2 this would wait for the work to finish and then stop. With 5.2 it exits unexpectedly in the middle of work. 
