### PR TITLE
[HttpClient] Revert support for "friendsofphp/well-known-implementations"

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -7,7 +7,6 @@ CHANGELOG
  * Make `HttplugClient` implement `Psr\Http\Message\RequestFactoryInterface`, `StreamFactoryInterface` and `UriFactoryInterface`
  * Deprecate implementing `Http\Message\RequestFactory`, `StreamFactory` and `UriFactory` on `HttplugClient`
  * Add `withOptions()` to `HttplugClient` and `Psr18Client`
- * Add support for "friendsofphp/well-known-implementations"
 
 6.1
 ---

--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Component\HttpClient;
 
-use FriendsOfPHP\WellKnownImplementations\WellKnownPsr17Factory;
-use FriendsOfPHP\WellKnownImplementations\WellKnownPsr7Request;
-use FriendsOfPHP\WellKnownImplementations\WellKnownPsr7Uri;
 use GuzzleHttp\Promise\Promise as GuzzlePromise;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Promise\Utils;
@@ -84,12 +81,12 @@ final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestF
         $this->promisePool = class_exists(Utils::class) ? new \SplObjectStorage() : null;
 
         if (null === $responseFactory || null === $streamFactory) {
-            if (!class_exists(Psr17Factory::class) && !class_exists(WellKnownPsr17Factory::class) && !class_exists(Psr17FactoryDiscovery::class)) {
+            if (!class_exists(Psr17Factory::class) && !class_exists(Psr17FactoryDiscovery::class)) {
                 throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\HttplugClient" as no PSR-17 factories have been provided. Try running "composer require nyholm/psr7".');
             }
 
             try {
-                $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : (class_exists(WellKnownPsr17Factory::class, false) ? new WellKnownPsr17Factory() : null);
+                $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : null;
                 $responseFactory ??= $psr17Factory ?? Psr17FactoryDiscovery::findResponseFactory();
                 $streamFactory ??= $psr17Factory ?? Psr17FactoryDiscovery::findStreamFactory();
             } catch (NotFoundException $e) {
@@ -170,8 +167,6 @@ final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestF
             $request = $this->responseFactory->createRequest($method, $uri);
         } elseif (class_exists(Request::class)) {
             $request = new Request($method, $uri);
-        } elseif (class_exists(WellKnownPsr7Request::class)) {
-            $request = new WellKnownPsr7Request($method, $uri);
         } elseif (class_exists(Psr17FactoryDiscovery::class)) {
             $request = Psr17FactoryDiscovery::findRequestFactory()->createRequest($method, $uri);
         } else {
@@ -247,10 +242,6 @@ final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestF
 
         if (class_exists(Uri::class)) {
             return new Uri($uri);
-        }
-
-        if (class_exists(WellKnownPsr7Uri::class)) {
-            return new WellKnownPsr7Uri($uri);
         }
 
         if (class_exists(Psr17FactoryDiscovery::class)) {

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Component\HttpClient;
 
-use FriendsOfPHP\WellKnownImplementations\WellKnownPsr17Factory;
-use FriendsOfPHP\WellKnownImplementations\WellKnownPsr7Request;
-use FriendsOfPHP\WellKnownImplementations\WellKnownPsr7Uri;
 use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -65,12 +62,12 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
         $streamFactory ??= $responseFactory instanceof StreamFactoryInterface ? $responseFactory : null;
 
         if (null === $responseFactory || null === $streamFactory) {
-            if (!class_exists(Psr17Factory::class) && !class_exists(WellKnownPsr17Factory::class) && !class_exists(Psr17FactoryDiscovery::class)) {
+            if (!class_exists(Psr17Factory::class) && !class_exists(Psr17FactoryDiscovery::class)) {
                 throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\Psr18Client" as no PSR-17 factories have been provided. Try running "composer require nyholm/psr7".');
             }
 
             try {
-                $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : (class_exists(WellKnownPsr17Factory::class, false) ? new WellKnownPsr17Factory() : null);
+                $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : null;
                 $responseFactory ??= $psr17Factory ?? Psr17FactoryDiscovery::findResponseFactory();
                 $streamFactory ??= $psr17Factory ?? Psr17FactoryDiscovery::findStreamFactory();
             } catch (NotFoundException $e) {
@@ -149,10 +146,6 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
             return new Request($method, $uri);
         }
 
-        if (class_exists(WellKnownPsr7Request::class)) {
-            return new WellKnownPsr7Request($method, $uri);
-        }
-
         if (class_exists(Psr17FactoryDiscovery::class)) {
             return Psr17FactoryDiscovery::findRequestFactory()->createRequest($method, $uri);
         }
@@ -189,10 +182,6 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
 
         if (class_exists(Uri::class)) {
             return new Uri($uri);
-        }
-
-        if (class_exists(WellKnownPsr7Uri::class)) {
-            return new WellKnownPsr7Uri($uri);
         }
 
         if (class_exists(Psr17FactoryDiscovery::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This reverts PR #47950

The major features of "friendsofphp/well-known-implementations" are now available in "php-http/discovery"  [v1.15.0](https://github.com/php-http/discovery/releases/tag/1.15.0), see:
- https://github.com/php-http/discovery/pull/209
- https://github.com/php-http/discovery/pull/208

Given the extremely low download stats of "friendsofphp/well-known-implementations", I propose to just remove support for it as a bugfix:
https://packagist.org/packages/friendsofphp/well-known-implementations

This will save us from maintaining this integration, which is unused code in practice anyway.