### PR TITLE
[HttpKernel] Add `skip_response_headers` to the `HttpCache` options

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG
  * Add `#[WithHttpStatus]` for defining status codes for exceptions
  * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
  * Add `#[WithLogLevel]` for defining log levels for exceptions
- * Allow extending the `Autowire` attribute
+ * Add `skip_response_headers` to the `HttpCache` options
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -1740,6 +1740,43 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals(500, $this->response->getStatusCode());
     }
 
+    public function testSkipsConfiguredResponseHeadersForStore()
+    {
+        $storeMock = $this->createMock(StoreInterface::class);
+        $storeMock
+            ->expects($this->once())
+            ->method('write')
+            ->with(
+                $this->isInstanceOf(Request::class),
+                $this->callback(function (Response $response) {
+                    $this->assertFalse($response->headers->has('Set-Cookie'));
+                    $this->assertFalse($response->headers->has('Another-One-To-Skip'));
+                    $this->assertTrue($response->headers->has('Cache-Control'));
+                    $this->assertTrue($response->headers->has('Another-One-To-Keep'));
+
+                    return true;
+                })
+            );
+
+        $this->setNextResponse(200, [
+            'Cache-Control' => 'public, s-maxage=20',
+            'Set-Cookie' => 'foobar=value; path=/',
+            'Another-One-To-Skip' => 'foobar',
+            'Another-One-To-Keep' => 'foobar',
+        ]);
+
+        $httpCache = new HttpCache($this->kernel, $storeMock, null, [
+            'skip_response_headers' => ['Set-Cookie', 'Another-One-To-Skip', 'I-do-Not-Exist'],
+        ]);
+
+        $response = $httpCache->handle(Request::create('/'));
+
+        $this->assertSame('foobar=value; path=/', $response->headers->get('Set-Cookie'));
+        $this->assertSame('foobar', $response->headers->get('Another-One-To-Skip'));
+        $this->assertSame('foobar', $response->headers->get('Another-One-To-Keep'));
+        $this->assertFalse($response->headers->has('I-do-Not-Exist'));
+    }
+
     public static function getResponseDataThatMustNotBeServedStaleIfError()
     {
         // All data sets assume that a 10s stale-if-error grace period has been configured


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/49257
| License       | MIT
| Doc PR        | 

