### PR TITLE
[Security] Defer clearing CSRF tokens on login after the controller is called

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -105,7 +105,6 @@ return static function (ContainerConfigurator $container) {
         ->set('security.authentication.session_strategy', SessionAuthenticationStrategy::class)
             ->args([
                 param('security.authentication.session_strategy.strategy'),
-                service('security.csrf.token_storage')->ignoreOnInvalid(),
             ])
         ->alias(SessionAuthenticationStrategyInterface::class, 'security.authentication.session_strategy')
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfHttpBasicLoginBundle/Controller/IndexController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfHttpBasicLoginBundle/Controller/IndexController.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfHttpBasicLoginBundle\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\HttpFoundation\Response;
+
+class IndexController implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function __invoke()
+    {
+        $form = $this->container->get('form.factory')
+            ->createNamedBuilder(
+                '',
+                'Symfony\Component\Form\Extension\Core\Type\FormType',
+                null,
+                ['csrf_token_id' => 'foo']
+            )
+            ->add('submit', 'Symfony\Component\Form\Extension\Core\Type\SubmitType')
+            ->getForm()
+            ->handleRequest($this->container->get('request_stack')->getCurrentRequest())
+        ;
+
+        if (!$form->isSubmitted()) {
+            return new Response($this->container->get('twig')->render('@CsrfHttpBasicLogin/form.html.twig', [
+                'form' => $form->createView(),
+            ]));
+        }
+
+        return new Response('', $form->isValid() ? 200 : 400);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfHttpBasicLoginBundle/CsrfHttpBasicLoginBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfHttpBasicLoginBundle/CsrfHttpBasicLoginBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfHttpBasicLoginBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class CsrfHttpBasicLoginBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfHttpBasicLoginBundle/Resources/views/form.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfHttpBasicLoginBundle/Resources/views/form.html.twig
@@ -1,0 +1,3 @@
+{% extends "base.html.twig" %}
+
+{% block body form(form) %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfHttpBasicLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfHttpBasicLoginTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+class CsrfHttpBasicLoginTest extends AbstractWebTestCase
+{
+    public function testFormSubmitAfterLogin()
+    {
+        $client = $this->createClient(
+            [
+                'test_case' => 'CsrfHttpBasicLogin',
+                'root_config' => 'config.yml',
+            ],
+            [
+                'PHP_AUTH_USER' => 'johannes',
+                'PHP_AUTH_PW' => 'test',
+            ]
+        );
+
+        $client->request('GET', '/');
+        $client->submitForm('submit');
+
+        $this->assertResponseIsSuccessful();
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfHttpBasicLogin/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfHttpBasicLogin/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+    new Symfony\Bundle\TwigBundle\TwigBundle(),
+    new Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfHttpBasicLoginBundle\CsrfHttpBasicLoginBundle(),
+    new Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle(),
+];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfHttpBasicLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfHttpBasicLogin/config.yml
@@ -1,0 +1,18 @@
+imports:
+    - { resource: ./../config/default.yml }
+
+security:
+    enable_authenticator_manager: true
+
+    password_hashers:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    johannes: { password: test, roles: [ROLE_USER] }
+
+    firewalls:
+        default:
+            http_basic: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfHttpBasicLogin/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfHttpBasicLogin/routing.yml
@@ -1,0 +1,3 @@
+form_login_homepage:
+    path:     /
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfHttpBasicLoginBundle\Controller\IndexController::__invoke }

--- a/src/Symfony/Component/Security/Http/EventListener/CsrfTokenClearingLoginListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CsrfTokenClearingLoginListener.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
+
+/**
+ * Clears the CSRF token storage after a successful login has migrated the session.
+ * We wait for the kernel.response event because CSRF tokens could need to be checked after authentication.
+ *
+ * @author Mathieu Lechat <mathieu.lechat@les-tilleuls.com>
+ */
+final class CsrfTokenClearingLoginListener implements EventSubscriberInterface
+{
+    /** @var ClearableTokenStorageInterface */
+    private $csrfTokenStorage;
+
+    public function __construct(ClearableTokenStorageInterface $csrfTokenStorage)
+    {
+        $this->csrfTokenStorage = $csrfTokenStorage;
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        if ($event->getRequest()->attributes->get(SessionAuthenticationStrategyInterface::CLEAR_CSRF_STORAGE_ATTR_NAME, false)) {
+            $this->csrfTokenStorage->clear();
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::RESPONSE => 'onKernelResponse'];
+    }
+}

--- a/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Http\Session;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
 
 /**
  * The default session strategy implementation.
@@ -32,15 +31,10 @@ class SessionAuthenticationStrategy implements SessionAuthenticationStrategyInte
     public const INVALIDATE = 'invalidate';
 
     private $strategy;
-    private $csrfTokenStorage = null;
 
-    public function __construct(string $strategy, ClearableTokenStorageInterface $csrfTokenStorage = null)
+    public function __construct(string $strategy)
     {
         $this->strategy = $strategy;
-
-        if (self::MIGRATE === $strategy) {
-            $this->csrfTokenStorage = $csrfTokenStorage;
-        }
     }
 
     /**
@@ -54,10 +48,7 @@ class SessionAuthenticationStrategy implements SessionAuthenticationStrategyInte
 
             case self::MIGRATE:
                 $request->getSession()->migrate(true);
-
-                if ($this->csrfTokenStorage) {
-                    $this->csrfTokenStorage->clear();
-                }
+                $request->attributes->set(self::CLEAR_CSRF_STORAGE_ATTR_NAME, true);
 
                 return;
 

--- a/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategyInterface.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategyInterface.php
@@ -25,6 +25,12 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 interface SessionAuthenticationStrategyInterface
 {
     /**
+     * This attribute name can be used by the implementation if it needs to
+     * clear the CSRF token storage when there is no actual Response, yet.
+     */
+    public const CLEAR_CSRF_STORAGE_ATTR_NAME = '_security_clear_csrf_storage';
+
+    /**
      * This performs any necessary changes to the session.
      *
      * This method should be called before the TokenStorage is populated with a


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49194 
| License       | MIT
| Doc PR        | N/A

[The fix for CVE-2022-24895 ](https://github.com/symfony/symfony/commit/5909d74ecee359ea4982fcf4331aaf2e489a1fd4) has introduced a new issue: when clearing the CSRF token storage on login, the controller can no longer checks any.
That means e.g. you’ll never be able to submit a CSRF-protected form using a stateless authentication.

This PR tries to fix this by deferring the clearing once the controller has been called.

4.4 branch is not impacted because listeners will skip authentication if a token is found in the session.