### PR TITLE
Use xxh128 instead of md5

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -309,7 +309,7 @@ EOF;
                 $value = str_replace("\n", "\n    ", $value);
                 $value = "static function () {\n    return {$value};\n}";
             }
-            $hash = hash('md5', $value);
+            $hash = hash('xxh128', $value);
 
             if (null === $id = $dumpedMap[$hash] ?? null) {
                 $id = $dumpedMap[$hash] = \count($dumpedMap);

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -27,7 +27,7 @@ class MaxIdLengthAdapterTest extends TestCase
         $cache->expects($this->exactly(2))
             ->method('doHave')
             ->withConsecutive(
-                [$this->equalTo('----------:nWfzGiCgLczv3SSUzXL3kg:')],
+                [$this->equalTo('----------:z5XrNUPebf0nPxQwjc6C1A:')],
                 [$this->equalTo('----------:---------------------------------------')]
             )->willReturn(false);
 

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -353,8 +353,8 @@ trait AbstractAdapterTrait
             return $this->namespace.$this->namespaceVersion.$key;
         }
         if (\strlen($id = $this->namespace.$this->namespaceVersion.$key) > $this->maxIdLength) {
-            // Use MD5 to favor speed over security, which is not an issue here
-            $this->ids[$key] = $id = substr_replace(base64_encode(hash('md5', $key, true)), static::NS_SEPARATOR, -(\strlen($this->namespaceVersion) + 2));
+            // Use xxh128 to favor speed over security, which is not an issue here
+            $this->ids[$key] = $id = substr_replace(base64_encode(hash('xxh128', $key, true)), static::NS_SEPARATOR, -(\strlen($this->namespaceVersion) + 2));
             $id = $this->namespace.$this->namespaceVersion.$id;
         }
 

--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -112,8 +112,8 @@ trait FilesystemCommonTrait
 
     private function getFile(string $id, bool $mkdir = false, string $directory = null)
     {
-        // Use MD5 to favor speed over security, which is not an issue here
-        $hash = str_replace('/', '-', base64_encode(hash('md5', static::class.$id, true)));
+        // Use xxh128 to favor speed over security, which is not an issue here
+        $hash = str_replace('/', '-', base64_encode(hash('xxh128', static::class.$id, true)));
         $dir = ($directory ?? $this->directory).strtoupper($hash[0].\DIRECTORY_SEPARATOR.$hash[1].\DIRECTORY_SEPARATOR);
 
         if ($mkdir && !is_dir($dir)) {

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -43,7 +43,7 @@ class DirectoryResource implements SelfCheckingResourceInterface
 
     public function __toString(): string
     {
-        return md5(serialize([$this->resource, $this->pattern]));
+        return hash('xxh128', serialize([$this->resource, $this->pattern]));
     }
 
     public function getResource(): string

--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -200,7 +200,7 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
 
     private function computeHash(): string
     {
-        $hash = hash_init('md5');
+        $hash = hash_init('xxh128');
 
         foreach ($this->getIterator() as $path => $info) {
             hash_update($hash, $path."\n");

--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -105,7 +105,7 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
             // the class does not exist anymore
             return false;
         }
-        $hash = hash_init('md5');
+        $hash = hash_init('xxh128');
 
         foreach ($this->generateSignature($this->classReflector) as $info) {
             hash_update($hash, $info);

--- a/src/Symfony/Component/DependencyInjection/Config/ContainerParametersResource.php
+++ b/src/Symfony/Component/DependencyInjection/Config/ContainerParametersResource.php
@@ -34,7 +34,7 @@ class ContainerParametersResource implements ResourceInterface
 
     public function __toString(): string
     {
-        return 'container_parameters_'.md5(serialize($this->parameters));
+        return 'container_parameters_'.hash('xxh128', serialize($this->parameters));
     }
 
     public function getParameters(): array

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -48,7 +48,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
                 throw new RuntimeException(sprintf('The default value of an env() parameter must be a string or null, but "%s" given to "%s".', get_debug_type($defaultValue), $name));
             }
 
-            $uniqueName = md5($name.'_'.self::$counter++);
+            $uniqueName = hash('xxh128', $name.'_'.self::$counter++);
             $placeholder = sprintf('%s_%s_%s', $this->getEnvPlaceholderUniquePrefix(), strtr($env, ':-.\\', '____'), $uniqueName);
             $this->envPlaceholders[$env][$placeholder] = $placeholder;
 
@@ -66,7 +66,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
         if (!isset($this->envPlaceholderUniquePrefix)) {
             $reproducibleEntropy = unserialize(serialize($this->parameters));
             array_walk_recursive($reproducibleEntropy, function (&$v) { $v = null; });
-            $this->envPlaceholderUniquePrefix = 'env_'.substr(md5(serialize($reproducibleEntropy)), -16);
+            $this->envPlaceholderUniquePrefix = 'env_'.substr(hash('xxh128', serialize($reproducibleEntropy)), -16);
         }
 
         return $this->envPlaceholderUniquePrefix;

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceTest.php
@@ -26,7 +26,7 @@ class ContainerParametersResourceTest extends TestCase
 
     public function testToString()
     {
-        $this->assertSame('container_parameters_9893d3133814ab03cac3490f36dece77', (string) $this->resource);
+        $this->assertSame('container_parameters_f2f012423c221eddf6c9a6305f965327', (string) $this->resource);
     }
 
     public function testSerializeUnserialize()

--- a/src/Symfony/Component/HttpClient/Internal/AmpClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpClientState.php
@@ -128,7 +128,7 @@ final class AmpClientState extends ClientState
             'proxy' => $options['proxy'],
         ];
 
-        $key = md5(serialize($options));
+        $key = hash('xxh128', serialize($options));
 
         if (isset($this->clients[$key])) {
             return $this->clients[$key];

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -259,7 +259,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
                 continue;
             }
 
-            $errorId = md5("{$exception->getSeverity()}/{$exception->getLine()}/{$exception->getFile()}\0{$message}", true);
+            $errorId = hash('xxh128', "{$exception->getSeverity()}/{$exception->getLine()}/{$exception->getFile()}\0{$message}", true);
 
             if (isset($sanitizedLogs[$errorId])) {
                 ++$sanitizedLogs[$errorId]['errorCount'];

--- a/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
+++ b/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
@@ -110,7 +110,7 @@ if (!class_exists(\Transliterator::class)) {
             static $cookie;
             static $transliterator;
 
-            $cookie ??= md5(random_bytes(8));
+            $cookie ??= hash('xxh128', random_bytes(8));
             $this->transliterator ??= clone $transliterator ??= \Transliterator::createFromRules('[:any:]* > '.$cookie);
 
             if (false === $result = $this->transliterator->transliterate($string, $start, $end)) {

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -56,7 +56,7 @@ class SemaphoreStore implements BlockingStoreInterface
             return;
         }
 
-        $keyId = unpack('i', md5($key, true))[1];
+        $keyId = unpack('i', hash('xxh128', $key, true))[1];
         $resource = @sem_get($keyId);
         $acquired = $resource && @sem_acquire($resource, !$blocking);
 

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
@@ -83,7 +83,7 @@ final class TwitterTransport extends AbstractTransport
 
         $oauth = [
             'oauth_consumer_key' => $this->apiKey,
-            'oauth_nonce' => self::$nonce = md5(self::$nonce ??= random_bytes(16)),
+            'oauth_nonce' => self::$nonce = hash('xxh128', self::$nonce ??= random_bytes(16)),
             'oauth_signature_method' => 'HMAC-SHA1',
             'oauth_timestamp' => time(),
             'oauth_token' => $this->accessToken,

--- a/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
@@ -112,7 +112,7 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
         $key = random_bytes(32);
         $value = $this->xor($value, $key);
 
-        return sprintf('%s.%s.%s', substr(md5($key), 0, 1 + (\ord($key[0]) % 32)), rtrim(strtr(base64_encode($key), '+/', '-_'), '='), rtrim(strtr(base64_encode($value), '+/', '-_'), '='));
+        return sprintf('%s.%s.%s', substr(hash('xxh128', $key), 0, 1 + (\ord($key[0]) % 32)), rtrim(strtr(base64_encode($key), '+/', '-_'), '='), rtrim(strtr(base64_encode($value), '+/', '-_'), '='));
     }
 
     private function derandomize(string $value): string

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -151,7 +151,7 @@ class SwitchUserListener extends AbstractListener
         }
 
         $currentUsername = $token->getUserIdentifier();
-        $nonExistentUsername = '_'.md5(random_bytes(8).$username);
+        $nonExistentUsername = '_'.hash('xxh128', random_bytes(8).$username);
 
         // To protect against user enumeration via timing measurements
         // we always load both successfully and unsuccessfully

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -142,6 +142,6 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return $class.'-'.$context['cache_key'];
         }
 
-        return $class.md5(serialize($context[AbstractNormalizer::GROUPS] ?? []));
+        return $class.hash('xxh128', serialize($context[AbstractNormalizer::GROUPS] ?? []));
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -730,7 +730,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         unset($context['cache_key']); // avoid artificially different keys
 
         try {
-            return md5($format.serialize([
+            return hash('xxh128', $format.serialize([
                 'context' => $context,
                 'ignored' => $context[self::IGNORED_ATTRIBUTES] ?? $this->defaultContext[self::IGNORED_ATTRIBUTES],
             ]));

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -41,7 +41,7 @@ class VarCloner extends AbstractCloner
         $stub = null;                   // Stub capturing the main properties of an original item value
                                         // or null if the original value is used directly
 
-        $gid = self::$gid ??= md5(random_bytes(6)); // Unique string used to detect the special $GLOBALS variable
+        $gid = self::$gid ??= hash('xxh128', random_bytes(6)); // Unique string used to detect the special $GLOBALS variable
         $arrayStub = new Stub();
         $arrayStub->type = Stub::TYPE_ARRAY;
         $fromObjCast = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

`xxh128` is a hash algorithm available in PHP 8.1 that is ~15 times faster than `md5`.

Let's use it where it doesn't change anything functionally to improve the performance.