### PR TITLE
[Notifier] Fix notifier profiler when transport name is null

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
@@ -17,7 +17,7 @@
 
             {% for transport in events.transports %}
                 <div class="sf-toolbar-info-piece">
-                    <b>{{ transport }}</b>
+                    <b>{{ transport ?: '<em>Empty Transport Name</em>' }}</b>
                     <span class="sf-toolbar-status">{{ events.messages(transport)|length }}</span>
                 </div>
             {% endfor %}
@@ -100,7 +100,7 @@
     </div>
 
     {% for transport in events.transports %}
-        <h3>{{ transport }}</h3>
+        <h3>{{ transport ?: '<em>Empty Transport Name</em>' }}</h3>
 
         <div class="card-block">
             <div class="sf-tabs sf-tabs-sm">

--- a/src/Symfony/Component/Notifier/Event/NotificationEvents.php
+++ b/src/Symfony/Component/Notifier/Event/NotificationEvents.php
@@ -24,7 +24,7 @@ class NotificationEvents
     public function add(MessageEvent $event): void
     {
         $this->events[] = $event;
-        $this->transports[$event->getMessage()->getTransport()] = true;
+        $this->transports[(string) $event->getMessage()->getTransport()] = true;
     }
 
     public function getTransports(): array
@@ -43,7 +43,7 @@ class NotificationEvents
 
         $events = [];
         foreach ($this->events as $event) {
-            if ($name === $event->getMessage()->getTransport()) {
+            if ($name === (string) $event->getMessage()->getTransport()) {
                 $events[] = $event;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a

When the transport name is `null`, the profiler is currently broken (JS error).
