### PR TITLE
[FrameworkBundle] Improve error message in MicroKernelTrait when using deprecated configureRoutes(RouteCollectionBuilder) with symfony/routing >= 6.0

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -213,6 +213,10 @@ trait MicroKernelTrait
         if ($configuratorClass && !is_a(RoutingConfigurator::class, $configuratorClass, true)) {
             trigger_deprecation('symfony/framework-bundle', '5.1', 'Using type "%s" for argument 1 of method "%s:configureRoutes()" is deprecated, use "%s" instead.', RouteCollectionBuilder::class, self::class, RoutingConfigurator::class);
 
+            if (!class_exists(RouteCollectionBuilder::class)) {
+                throw new \InvalidArgumentException(sprintf('Using type "%s" for argument 1 of method "%s:configureRoutes()" is not compatible with the installed "symfony/routing" version. Use "%s" instead, or run "composer require symfony/routing:^5.4".', RouteCollectionBuilder::class, self::class, RoutingConfigurator::class));
+            }
+
             $routes = new RouteCollectionBuilder($loader);
             $this->configureRoutes($routes);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/49264
| License       | MIT
| Doc PR        | -

`RouteCollectionBuilder` doesn't exist on 6.0. I guess we don't want to change `symfony/routing` requirement to `^5.4`.
So the only thing we can do is to improve the error a bit?