### PR TITLE
[PropertyAccess] Allow escaping in PropertyPath

### DIFF
--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Allow escaping `.` and `[` with `\` in `PropertyPath`
+
 6.2
 ---
 

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -95,7 +95,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         $remaining = $propertyPath;
 
         // first element is evaluated differently - no leading dot for properties
-        $pattern = '/^(([^\.\[]++)|\[([^\]]++)\])(.*)/';
+        $pattern = '/^(((?:[^\\\\.\[]|\\\\.)++)|\[([^\]]++)\])(.*)/';
 
         while (preg_match($pattern, $remaining, $matches)) {
             if ('' !== $matches[2]) {
@@ -114,11 +114,15 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 $this->isNullSafe[] = false;
             }
 
+            $element = preg_replace('/\\\([.[])/', '$1', $element);
+            if (str_ends_with($element, '\\\\')) {
+                $element = substr($element, 0, -1);
+            }
             $this->elements[] = $element;
 
             $position += \strlen($matches[1]);
             $remaining = $matches[4];
-            $pattern = '/^(\.([^\.|\[]++)|\[([^\]]++)\])(.*)/';
+            $pattern = '/^(\.((?:[^\\\\.\[]|\\\\.)++)|\[([^\]]++)\])(.*)/';
         }
 
         if ('' !== $remaining) {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
@@ -78,6 +78,34 @@ class PropertyPathTest extends TestCase
         $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
     }
 
+    public function testGetElementsWithEscapedDot()
+    {
+        $propertyPath = new PropertyPath('grandpa\.parent.child');
+
+        $this->assertEquals(['grandpa.parent', 'child'], $propertyPath->getElements());
+    }
+
+    public function testGetElementsWithEscapedArray()
+    {
+        $propertyPath = new PropertyPath('grandpa\[parent][child]');
+
+        $this->assertEquals(['grandpa[parent]', 'child'], $propertyPath->getElements());
+    }
+
+    public function testGetElementsWithDoubleEscapedDot()
+    {
+        $propertyPath = new PropertyPath('grandpa\\\.par\ent.\\\child');
+
+        $this->assertEquals(['grandpa\\', 'par\ent', '\\\child'], $propertyPath->getElements());
+    }
+
+    public function testGetElementsWithDoubleEscapedArray()
+    {
+        $propertyPath = new PropertyPath('grandpa\\\[par\ent][\\\child]');
+
+        $this->assertEquals(['grandpa\\', 'par\ent', '\\\child'], $propertyPath->getElements());
+    }
+
     public function testGetParentWithIndex()
     {
         $propertyPath = new PropertyPath('grandpa.parent[child]');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #41845
| License       | MIT
| Doc PR        | TODO symfony/symfony-docs#...

I'm not sure if it can be considered a feature or a fix.

Currently there is no way to escape `.` and `[` when using `PropertyPath`.
It can cause issue when we want to access a "property" containing a dot (for instance a key in an array).

I tried to modify the regexp as little as possible and to handle (really) edge cases such as double escaping.

Initially I had the issue in some Behat tests where I needed to evaluate some paths in a big JSON file (OpenAPI documentation).
Some keys contain dots and I cannot test the JSON node when it's the case.