### PR TITLE
[FrameworkBundle] Add inlined env vars into debug:container output

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -308,6 +308,21 @@ abstract class Descriptor implements DescriptorInterface
 
         $envs = [];
 
+        if ($container->hasParameter('.debug.container.build_time_env_vars')) {
+            foreach ($container->getParameter('.debug.container.build_time_env_vars') as $name => $value) {
+                $envs["{$name}inline"] = [
+                    'name' => $name,
+                    'inlined' => true,
+                    'processor' => 'string',
+                    'default_available' => false,
+                    'default_value' => null,
+                    'runtime_available' => true,
+                    'runtime_value' => $value,
+                    'processed_value' => $value, // Env var processors are not supported at the moment
+                ];
+            }
+        }
+
         foreach ($envVars as $env) {
             $processor = 'string';
             if (false !== $i = strrpos($name = $env, ':')) {
@@ -321,6 +336,7 @@ abstract class Descriptor implements DescriptorInterface
             $processedValue = ($hasRuntime = null !== $runtimeValue) || $hasDefault ? $getEnvReflection->invoke($container, $env) : null;
             $envs["$name$processor"] = [
                 'name' => $name,
+                'inlined' => false,
                 'processor' => $processor,
                 'default_available' => $hasDefault,
                 'default_value' => $defaultValue,

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -428,11 +428,17 @@ class TextDescriptor extends Descriptor
                 if ($name === $env['name'] || false !== stripos($env['name'], $name)) {
                     $matches = true;
                     $options['output']->section('%env('.$env['processor'].':'.$env['name'].')%');
-                    $options['output']->table([], [
-                        ['<info>Default value</>', $env['default_available'] ? $dump($env['default_value']) : 'n/a'],
-                        ['<info>Real value</>', $env['runtime_available'] ? $dump($env['runtime_value']) : 'n/a'],
-                        ['<info>Processed value</>', $env['default_available'] || $env['runtime_available'] ? $dump($env['processed_value']) : 'n/a'],
-                    ]);
+                    if (!$env['inlined']) {
+                        $options['output']->table([], [
+                            ['<info>Default value</>', $env['default_available'] ? $dump($env['default_value']) : 'n/a'],
+                            ['<info>Real value</>', $env['runtime_available'] ? $dump($env['runtime_value']) : 'n/a'],
+                            ['<info>Processed value</>', $env['default_available'] || $env['runtime_available'] ? $dump($env['processed_value']) : 'n/a'],
+                        ]);
+                    } else {
+                        $options['output']->table([], [
+                            ['<info>Inlined value</>', $dump($env['processed_value'])],
+                        ]);
+                    }
                 }
             }
 
@@ -454,12 +460,13 @@ class TextDescriptor extends Descriptor
         $rows = [];
         $missing = [];
         foreach ($envs as $env) {
-            if (isset($rows[$env['name']])) {
+            $name = !$env['inlined'] ? $env['name'] : "{$env['name']} (inlined)";
+            if (isset($rows[$name])) {
                 continue;
             }
 
-            $rows[$env['name']] = [
-                $env['name'],
+            $rows[$name] = [
+                $name,
                 $env['default_available'] ? $dump($env['default_value']) : 'n/a',
                 $env['runtime_available'] ? $dump($env['runtime_value']) : 'n/a',
             ];

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/StoreInlinedEnvVarsCompilerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/StoreInlinedEnvVarsCompilerPass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Stores environment variables used during build, for debugging purposes
+ *
+ * @author Valtteri Rauhala <valtzu@gmail.com>
+ */
+class StoreInlinedEnvVarsCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $buildTimeEnvVars = [];
+        foreach ($container->getEnvCounters() as $env => $count) {
+            if ($count > 0) {
+                $buildTimeEnvVars[$env] = $container->resolveEnvPlaceholders("%env($env)%", true);
+            }
+        }
+
+        $container->setParameter('.debug.container.build_time_env_vars', $buildTimeEnvVars);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSessionMarshallingHandlerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerRealRefPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerWeakRefPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\StoreInlinedEnvVarsCompilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\UnusedTagsPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\WorkflowGuardListenerPass;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
@@ -175,6 +176,7 @@ class FrameworkBundle extends Bundle
             $container->addCompilerPass(new EnableLoggerDebugModePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -33);
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);
+            $container->addCompilerPass(new StoreInlinedEnvVarsCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING, -254);
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_BEFORE_REMOVING, -255);
             $container->addCompilerPass(new CacheCollectorPass(), PassConfig::TYPE_BEFORE_REMOVING);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->



<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Currently environment variables that are consumed during build process are not visible to `debug:container` command. It took a long time to realize changes to runtime environment variables wont have any effect because those vars are inlined during build process of the DI container.

This MR shows all env vars that any extension resolved during compilation of the container.


### Example:

Given the following config:

```yaml
parameters:
    env(LOG_LEVEL): info

services:
    _defaults:
        bind:
            $logLevel: '%env(string:LOG_LEVEL)%'

monolog:
    handlers:
        main:
            type: stream
            path: "%kernel.logs_dir%/%kernel.environment%.log"
            level: '%env(LOG_LEVEL)%'
```

With empty cache directory, 1st time we run the cli command, it'll build the container:

```bash
$ LOG_LEVEL=notice bin/console debug:container --env-vars

Symfony Container Environment Variables
=======================================

 --------------------- --------------- ------------------------------------ 
  Name                  Default value   Real value                          
 --------------------- --------------- ------------------------------------ 
  LOG_LEVEL (inlined)   n/a             "notice"                            
  LOG_LEVEL             "info"          "notice"     
```


Now, if we run the command with different `LOG_LEVEL` value, we see that the inlined value stays the same.

```bash
$ LOG_LEVEL=debug bin/console debug:container --env-vars

Symfony Container Environment Variables
=======================================

 --------------------- --------------- ------------------------------------ 
  Name                  Default value   Real value                          
 --------------------- --------------- ------------------------------------ 
  LOG_LEVEL (inlined)   n/a             "notice"                            
  LOG_LEVEL             "info"          "debug"                             
```

This would mean that Monolog uses `LOG_LEVEL=notice` while the services where `$logLevel` is injected would receive `debug` value.


And with more verbose `--env-var` flag

```bash
$ LOG_LEVEL=debug bin/console debug:container --env-var LOG_LEVEL

Symfony Container Environment Variables
=======================================

 // Displaying detailed environment variable usage matching LOG_LEVEL                                                   

%env(string:LOG_LEVEL)%
-----------------------

 --------------- ---------- 
  Inlined value   "notice"  
 --------------- ---------- 

%env(string:LOG_LEVEL)%
-----------------------

 ----------------- --------- 
  Default value     "info"   
  Real value        "debug"  
  Processed value   "debug"  
 ----------------- --------- 
```

---

In my opinion better solution would be to deny the usage of `resolveEnvPlaceholders` before container is built but that would of course break backwards compatibility.
