### PR TITLE
[HtmlSanitizer] Remove experimental status

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizer.php
@@ -19,8 +19,6 @@ use Symfony\Component\HtmlSanitizer\Visitor\DomVisitor;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 final class HtmlSanitizer implements HtmlSanitizerInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
@@ -16,8 +16,6 @@ use Symfony\Component\HtmlSanitizer\Visitor\AttributeSanitizer\AttributeSanitize
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 class HtmlSanitizerConfig
 {

--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerInterface.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerInterface.php
@@ -18,8 +18,6 @@ namespace Symfony\Component\HtmlSanitizer;
  * ({@see https://wicg.github.io/sanitizer-api/}).
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 interface HtmlSanitizerInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/Parser/MastermindsParser.php
+++ b/src/Symfony/Component/HtmlSanitizer/Parser/MastermindsParser.php
@@ -15,8 +15,6 @@ use Masterminds\HTML5;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 final class MastermindsParser implements ParserInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/Parser/ParserInterface.php
+++ b/src/Symfony/Component/HtmlSanitizer/Parser/ParserInterface.php
@@ -15,8 +15,6 @@ namespace Symfony\Component\HtmlSanitizer\Parser;
  * Transforms an untrusted HTML input string into a DOM tree.
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 interface ParserInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/AttributeSanitizer/AttributeSanitizerInterface.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/AttributeSanitizer/AttributeSanitizerInterface.php
@@ -17,8 +17,6 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
  * Implements attribute-specific sanitization logic.
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 interface AttributeSanitizerInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/AttributeSanitizer/UrlAttributeSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/AttributeSanitizer/UrlAttributeSanitizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Symfony\Component\HtmlSanitizer\TextSanitizer\UrlSanitizer;
 
 /**
- * @experimental
+ * @author Titouan Galopin <galopintitouan@gmail.com>
  */
 final class UrlAttributeSanitizer implements AttributeSanitizerInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/BlockedNode.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/BlockedNode.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\HtmlSanitizer\Visitor\Node;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 final class BlockedNode implements NodeInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/DocumentNode.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/DocumentNode.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\HtmlSanitizer\Visitor\Node;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 final class DocumentNode implements NodeInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
@@ -15,8 +15,6 @@ use Symfony\Component\HtmlSanitizer\TextSanitizer\StringSanitizer;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 final class Node implements NodeInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/NodeInterface.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/NodeInterface.php
@@ -17,8 +17,6 @@ namespace Symfony\Component\HtmlSanitizer\Visitor\Node;
  * Once the sanitization is done, nodes are rendered into the final output string.
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 interface NodeInterface
 {

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/TextNode.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/TextNode.php
@@ -15,8 +15,6 @@ use Symfony\Component\HtmlSanitizer\TextSanitizer\StringSanitizer;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 final class TextNode implements NodeInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The HtmlSanitizer component was introduced in May 2022 and the overall API seems stable (I don't anticipate any BC break needed any time soon).

I suggest we remove its experimental status for 6.3. I removed it in the code, I didn't find other places where it could be referenced as experimental but if I forgot some, please let me know :) !