### PR TITLE
[ErrorHandler] Do not patch return statements in closures

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -1090,7 +1090,20 @@ EOTXT;
         }
 
         $end = $method->isGenerator() ? $i : $method->getEndLine();
+        $inClosure = false;
+        $braces = 0;
         for (; $i < $end; ++$i) {
+            if (!$inClosure) {
+                $inClosure = str_contains($code[$i], 'function (');
+            }
+
+            if ($inClosure) {
+                $braces += substr_count($code[$i], '{') - substr_count($code[$i], '}');
+                $inClosure = $braces > 0;
+
+                continue;
+            }
+
             if ('void' === $returnType) {
                 $fixedCode[$i] = str_replace('    return null;', '    return;', $code[$i]);
             } elseif ('mixed' === $returnType || '?' === $returnType[0]) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The type patcher script also fixes some return statements automatically to deal with void/null differences. However, the script is a bit too eager and also patches return statements of closures inside methods:

```php
public function something(): void
{
    $someHandler = function (): ?string {
        if (...) {
            return null;
        }
    };
}
```

Statements like this were patched to `return;`, causing a PHP fatal error.

Note: I didn't find any test for the return statement patching, so I also didn't write one for this bug. However, this bug is discovered by our own CI in #49342, so I would say we've covered the fix :)