### PR TITLE
Add PHP types to private methods and functions

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -252,6 +252,17 @@ index 18f7ba0fb0..7f37cb6d9b 100644
 +    protected function start(string $name): TraceableAdapterEvent
      {
          $this->calls[] = $event = new TraceableAdapterEvent();
+diff --git a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+index 2ee96e9b37..f49ed24f68 100644
+--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
++++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+@@ -81,5 +81,5 @@ trait FilesystemCommonTrait
+      * @return bool
+      */
+-    protected function doUnlink(string $file)
++    protected function doUnlink(string $file): bool
+     {
+         return @unlink($file);
 diff --git a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
 index 7cda0bc7d8..b2311826f4 100644
 --- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -350,7 +361,7 @@ index e3ca1d49c4..526d350484 100644
 +    public function locate(string $name, string $currentPath = null, bool $first = true): string|array;
  }
 diff --git a/src/Symfony/Component/Config/Loader/FileLoader.php b/src/Symfony/Component/Config/Loader/FileLoader.php
-index 30034e55a5..d6a57be190 100644
+index 3f06f0c38c..ce0fd1d76d 100644
 --- a/src/Symfony/Component/Config/Loader/FileLoader.php
 +++ b/src/Symfony/Component/Config/Loader/FileLoader.php
 @@ -67,5 +67,5 @@ abstract class FileLoader extends Loader
@@ -552,7 +563,7 @@ index 2762cdf05c..737334268a 100644
 +    public function getName(): string;
  }
 diff --git a/src/Symfony/Component/Console/Helper/Table.php b/src/Symfony/Component/Console/Helper/Table.php
-index 893b3192e9..94822ed191 100644
+index 7d31794be3..1c311aded2 100644
 --- a/src/Symfony/Component/Console/Helper/Table.php
 +++ b/src/Symfony/Component/Console/Helper/Table.php
 @@ -193,5 +193,5 @@ class Table
@@ -609,6 +620,17 @@ index 74d885d131..3de806a60e 100644
 +    protected function getErrorOutput(): OutputInterface
      {
          if (!$this->output instanceof ConsoleOutputInterface) {
+diff --git a/src/Symfony/Component/CssSelector/Parser/Reader.php b/src/Symfony/Component/CssSelector/Parser/Reader.php
+index 7f6ae7a600..d79db02567 100644
+--- a/src/Symfony/Component/CssSelector/Parser/Reader.php
++++ b/src/Symfony/Component/CssSelector/Parser/Reader.php
+@@ -57,5 +57,5 @@ class Reader
+      * @return int|false
+      */
+-    public function getOffset(string $string): int|bool
++    public function getOffset(string $string): int|false
+     {
+         $position = strpos($this->source, $string, $this->position);
 diff --git a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
 index b4e982c457..521a9531f8 100644
 --- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -853,30 +875,8 @@ index 479aeef880..272954c082 100644
 -    public function getFunctions();
 +    public function getFunctions(): array;
  }
-diff --git a/src/Symfony/Component/ExpressionLanguage/Node/ArrayNode.php b/src/Symfony/Component/ExpressionLanguage/Node/ArrayNode.php
-index e1a3169b00..e5dc5bfe21 100644
---- a/src/Symfony/Component/ExpressionLanguage/Node/ArrayNode.php
-+++ b/src/Symfony/Component/ExpressionLanguage/Node/ArrayNode.php
-@@ -45,5 +45,5 @@ class ArrayNode extends Node
-     }
- 
--    public function evaluate(array $functions, array $values)
-+    public function evaluate(array $functions, array $values): mixed
-     {
-         $result = [];
-diff --git a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
-index 0b31c66ded..e798ef8f2f 100644
---- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
-+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
-@@ -93,5 +93,5 @@ class BinaryNode extends Node
-     }
- 
--    public function evaluate(array $functions, array $values)
-+    public function evaluate(array $functions, array $values): mixed
-     {
-         $operator = $this->attributes['operator'];
 diff --git a/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php b/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
-index ba78a2848e..f805b5655e 100644
+index fec02abaae..7d02544275 100644
 --- a/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
 +++ b/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
 @@ -41,5 +41,5 @@ class ConditionalNode extends Node
@@ -886,17 +886,6 @@ index ba78a2848e..f805b5655e 100644
 +    public function evaluate(array $functions, array $values): mixed
      {
          if ($this->nodes['expr1']->evaluate($functions, $values)) {
-diff --git a/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php b/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
-index 869e350dc9..f1c1ad5bd3 100644
---- a/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
-+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
-@@ -39,5 +39,5 @@ class ConstantNode extends Node
-     }
- 
--    public function evaluate(array $functions, array $values)
-+    public function evaluate(array $functions, array $values): mixed
-     {
-         return $this->attributes['value'];
 diff --git a/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php b/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
 index 06078da305..cc11697293 100644
 --- a/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
@@ -915,28 +904,6 @@ index 06078da305..cc11697293 100644
 +    public function toArray(): array
      {
          $array = [];
-diff --git a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
-index e9b10c3295..7aefd9bb84 100644
---- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
-+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
-@@ -66,5 +66,5 @@ class GetAttrNode extends Node
-     }
- 
--    public function evaluate(array $functions, array $values)
-+    public function evaluate(array $functions, array $values): mixed
-     {
-         switch ($this->attributes['type']) {
-diff --git a/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php b/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php
-index e017e967a1..8ea5bcf28c 100644
---- a/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php
-+++ b/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php
-@@ -34,5 +34,5 @@ class NameNode extends Node
-     }
- 
--    public function evaluate(array $functions, array $values)
-+    public function evaluate(array $functions, array $values): mixed
-     {
-         return $values[$this->attributes['name']];
 diff --git a/src/Symfony/Component/ExpressionLanguage/Node/Node.php b/src/Symfony/Component/ExpressionLanguage/Node/Node.php
 index eb5046c9bf..ef142d3787 100644
 --- a/src/Symfony/Component/ExpressionLanguage/Node/Node.php
@@ -969,17 +936,6 @@ index eb5046c9bf..ef142d3787 100644
 +    protected function isHash(array $value): bool
      {
          $expectedKey = 0;
-diff --git a/src/Symfony/Component/ExpressionLanguage/Node/NullCoalesceNode.php b/src/Symfony/Component/ExpressionLanguage/Node/NullCoalesceNode.php
-index 3e59ef8676..b6371df241 100644
---- a/src/Symfony/Component/ExpressionLanguage/Node/NullCoalesceNode.php
-+++ b/src/Symfony/Component/ExpressionLanguage/Node/NullCoalesceNode.php
-@@ -37,5 +37,5 @@ class NullCoalesceNode extends Node
-     }
- 
--    public function evaluate(array $functions, array $values)
-+    public function evaluate(array $functions, array $values): mixed
-     {
-         if ($this->nodes['expr1'] instanceof GetAttrNode) {
 diff --git a/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php b/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
 index 9e30d848eb..ee82938d8a 100644
 --- a/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
@@ -1392,6 +1348,17 @@ index d894b7e74c..f0d6d32f0a 100644
 +    protected function guessRoute(Request $request, string|object|array $controller): string
      {
          return 'n/a';
+diff --git a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+index fcb100859f..8bf3ef09d5 100644
+--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
++++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+@@ -53,5 +53,5 @@ class FileLinkFormatter
+      * @return string|false
+      */
+-    public function format(string $file, int $line): string|bool
++    public function format(string $file, int $line): string|false
+     {
+         if ($fmt = $this->getFileLinkFormat()) {
 diff --git a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
 index 3650d1700d..055b57fc77 100644
 --- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -1978,6 +1945,17 @@ index 69ac3d6ec4..d96c7d038d 100644
 +    public function getMessageKey(): string
      {
          return 'An authentication exception occurred.';
+diff --git a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+index b4ffa1dcd4..dd3c58a6d0 100644
+--- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
++++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+@@ -98,5 +98,5 @@ class InMemoryUserProvider implements UserProviderInterface
+      * @return InMemoryUser change return type on 7.0
+      */
+-    private function getUser(string $username): UserInterface
++    private function getUser(string $username): InMemoryUser
+     {
+         if (!isset($this->users[strtolower($username)])) {
 diff --git a/src/Symfony/Component/Security/Core/User/UserProviderInterface.php b/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
 index ec90d413fa..9f1401aa91 100644
 --- a/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
@@ -2286,7 +2264,7 @@ index 1749dd78d2..250b46bdd3 100644
      {
          return $this->class;
 diff --git a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
-index edac8395df..f3998dc4dd 100644
+index 1b2457707f..5811aa8106 100644
 --- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
 +++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
 @@ -295,5 +295,5 @@ abstract class ConstraintValidatorTestCase extends TestCase
@@ -3192,7 +3170,7 @@ index dba7c3dcfb..dce66ea6b9 100644
      {
          return $this->places;
 diff --git a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
-index cfe1c09b6e..de62f635f9 100644
+index 06340a61bb..2654d15b9a 100644
 --- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
 +++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
 @@ -80,5 +80,5 @@ class ParentTestService

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -124,7 +124,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
         return $listenerRefs;
     }
 
-    private function getEventManagerDef(ContainerBuilder $container, string $name)
+    private function getEventManagerDef(ContainerBuilder $container, string $name): Definition
     {
         if (!isset($this->eventManagers[$name])) {
             $this->eventManagers[$name] = $container->getDefinition(sprintf($this->managerTemplate, $name));

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -193,7 +193,7 @@ class UniqueEntityValidator extends ConstraintValidator
             ->addViolation();
     }
 
-    private function formatWithIdentifiers(ObjectManager $em, ClassMetadata $class, mixed $value)
+    private function formatWithIdentifiers(ObjectManager $em, ClassMetadata $class, mixed $value): string
     {
         if (!\is_object($value) || $value instanceof \DateTimeInterface) {
             return $this->formatValue($value, self::PRETTY_DATE);

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -354,7 +354,7 @@ class DeprecationErrorHandler
         }
     }
 
-    private static function getPhpUnitErrorHandler()
+    private static function getPhpUnitErrorHandler(): callable
     {
         if (!$eh = self::$errorHandler) {
             if (class_exists(Handler::class)) {

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -154,20 +154,15 @@ class Configuration
         $this->logFile = $logFile;
     }
 
-    /**
-     * @return bool
-     */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return $this->enabled;
     }
 
     /**
      * @param DeprecationGroup[] $deprecationGroups
-     *
-     * @return bool
      */
-    public function tolerates(array $deprecationGroups)
+    public function tolerates(array $deprecationGroups): bool
     {
         $grandTotal = 0;
 
@@ -229,10 +224,7 @@ class Configuration
         return true;
     }
 
-    /**
-     * @return bool
-     */
-    public function isBaselineDeprecation(Deprecation $deprecation)
+    public function isBaselineDeprecation(Deprecation $deprecation): bool
     {
         if ($deprecation->isLegacy()) {
             return false;
@@ -260,20 +252,17 @@ class Configuration
         return $result;
     }
 
-    /**
-     * @return bool
-     */
-    public function isGeneratingBaseline()
+    public function isGeneratingBaseline(): bool
     {
         return $this->generateBaseline;
     }
 
-    public function getBaselineFile()
+    public function getBaselineFile(): string
     {
         return $this->baselineFile;
     }
 
-    public function writeBaseline()
+    public function writeBaseline(): void
     {
         $map = [];
         foreach ($this->baselineDeprecations as $location => $messages) {
@@ -290,36 +279,28 @@ class Configuration
 
     /**
      * @param string $message
-     *
-     * @return bool
      */
-    public function shouldDisplayStackTrace($message)
+    public function shouldDisplayStackTrace($message): bool
     {
         return '' !== $this->regex && preg_match($this->regex, $message);
     }
 
-    /**
-     * @return bool
-     */
-    public function isInRegexMode()
+    public function isInRegexMode(): bool
     {
         return '' !== $this->regex;
     }
 
-    /**
-     * @return bool
-     */
-    public function verboseOutput($group)
+    public function verboseOutput($group): bool
     {
         return $this->verboseOutput[$group];
     }
 
-    public function shouldWriteToLogFile()
+    public function shouldWriteToLogFile(): bool
     {
         return null !== $this->logFile;
     }
 
-    public function getLogFile()
+    public function getLogFile(): ?string
     {
         return $this->logFile;
     }
@@ -327,10 +308,8 @@ class Configuration
     /**
      * @param string $serializedConfiguration an encoded string, for instance
      *                                        max[total]=1234&max[indirect]=42
-     *
-     * @return self
      */
-    public static function fromUrlEncodedString($serializedConfiguration)
+    public static function fromUrlEncodedString($serializedConfiguration): self
     {
         parse_str($serializedConfiguration, $normalizedConfiguration);
         foreach (array_keys($normalizedConfiguration) as $key) {
@@ -376,10 +355,7 @@ class Configuration
         );
     }
 
-    /**
-     * @return self
-     */
-    public static function inDisabledMode()
+    public static function inDisabledMode(): self
     {
         $configuration = new self();
         $configuration->enabled = false;
@@ -387,18 +363,12 @@ class Configuration
         return $configuration;
     }
 
-    /**
-     * @return self
-     */
-    public static function inStrictMode()
+    public static function inStrictMode(): self
     {
         return new self(['total' => 0]);
     }
 
-    /**
-     * @return self
-     */
-    public static function inWeakMode()
+    public static function inWeakMode(): self
     {
         $verboseOutput = [];
         foreach (['unsilenced', 'direct', 'indirect', 'self', 'other'] as $group) {
@@ -408,18 +378,12 @@ class Configuration
         return new self([], '', $verboseOutput);
     }
 
-    /**
-     * @return self
-     */
-    public static function fromNumber($upperBound)
+    public static function fromNumber($upperBound): self
     {
         return new self(['total' => $upperBound]);
     }
 
-    /**
-     * @return self
-     */
-    public static function fromRegex($regex)
+    public static function fromRegex($regex): self
     {
         return new self([], $regex);
     }

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -356,7 +356,7 @@ class Deprecation
         return self::$vendors;
     }
 
-    private static function addSourcePathsFromPrefixes(array $prefixesByNamespace, array $paths)
+    private static function addSourcePathsFromPrefixes(array $prefixesByNamespace, array $paths): array
     {
         foreach ($prefixesByNamespace as $prefixes) {
             foreach ($prefixes as $prefix) {

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationGroup.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationGroup.php
@@ -50,20 +50,18 @@ final class DeprecationGroup
 
     /**
      * @param string $message
-     *
-     * @return DeprecationNotice
      */
-    private function deprecationNotice($message)
+    private function deprecationNotice($message): DeprecationNotice
     {
         return $this->deprecationNotices[$message] ?? $this->deprecationNotices[$message] = new DeprecationNotice();
     }
 
-    public function count()
+    public function count(): int
     {
         return $this->count;
     }
 
-    public function notices()
+    public function notices(): array
     {
         return $this->deprecationNotices;
     }

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationNotice.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationNotice.php
@@ -37,12 +37,12 @@ final class DeprecationNotice
         ++$this->count;
     }
 
-    public function getCountsByCaller()
+    public function getCountsByCaller(): array
     {
         return $this->countsByCaller;
     }
 
-    public function count()
+    public function count(): int
     {
         return $this->count;
     }

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -179,7 +179,7 @@ EOF
         };
     }
 
-    private function displayTxt(OutputInterface $output, SymfonyStyle $io, array $filesInfo, bool $errorAsGithubAnnotations = false)
+    private function displayTxt(OutputInterface $output, SymfonyStyle $io, array $filesInfo, bool $errorAsGithubAnnotations = false): int
     {
         $errors = 0;
         $githubReporter = $errorAsGithubAnnotations ? new GithubActionReporter($output) : null;
@@ -254,7 +254,7 @@ EOF
         }
     }
 
-    private function getContext(string $template, int $line, int $context = 3)
+    private function getContext(string $template, int $line, int $context = 3): array
     {
         $lines = explode("\n", $template);
 

--- a/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
+++ b/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
@@ -78,37 +78,37 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
         $templateFinder($this->profile);
     }
 
-    public function getTime()
+    public function getTime(): int
     {
         return $this->getProfile()->getDuration() * 1000;
     }
 
-    public function getTemplateCount()
+    public function getTemplateCount(): int
     {
         return $this->getComputedData('template_count');
     }
 
-    public function getTemplatePaths()
+    public function getTemplatePaths(): array
     {
         return $this->data['template_paths'];
     }
 
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return $this->getComputedData('templates');
     }
 
-    public function getBlockCount()
+    public function getBlockCount(): int
     {
         return $this->getComputedData('block_count');
     }
 
-    public function getMacroCount()
+    public function getMacroCount(): int
     {
         return $this->getComputedData('macro_count');
     }
 
-    public function getHtmlCallGraph()
+    public function getHtmlCallGraph(): Markup
     {
         $dumper = new HtmlDumper();
         $dump = $dumper->dump($this->getProfile());
@@ -129,7 +129,7 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
         return new Markup($dump, 'UTF-8');
     }
 
-    public function getProfile()
+    public function getProfile(): Profile
     {
         return $this->profile ??= unserialize($this->data['profile'], ['allowed_classes' => ['Twig_Profiler_Profile', Profile::class]]);
     }
@@ -141,7 +141,7 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
         return $this->computed[$index];
     }
 
-    private function computeData(Profile $profile)
+    private function computeData(Profile $profile): array
     {
         $data = [
             'template_count' => 0,

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -129,7 +129,7 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         }
     }
 
-    private function initializeBundles()
+    private function initializeBundles(): array
     {
         // Re-build bundle manually to initialize DI extensions that can be extended by other bundles in their build() method
         // as this method is not called when the container is loaded from the cache.

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -38,7 +38,7 @@ abstract class Descriptor implements DescriptorInterface
      */
     protected $output;
 
-    public function describe(OutputInterface $output, mixed $object, array $options = [])
+    public function describe(OutputInterface $output, mixed $object, array $options = []): void
     {
         $this->output = $output;
 
@@ -73,18 +73,18 @@ abstract class Descriptor implements DescriptorInterface
         return $this->output;
     }
 
-    protected function write(string $content, bool $decorated = false)
+    protected function write(string $content, bool $decorated = false): void
     {
         $this->output->write($content, false, $decorated ? OutputInterface::OUTPUT_NORMAL : OutputInterface::OUTPUT_RAW);
     }
 
-    abstract protected function describeRouteCollection(RouteCollection $routes, array $options = []);
+    abstract protected function describeRouteCollection(RouteCollection $routes, array $options = []): void;
 
-    abstract protected function describeRoute(Route $route, array $options = []);
+    abstract protected function describeRoute(Route $route, array $options = []): void;
 
-    abstract protected function describeContainerParameters(ParameterBag $parameters, array $options = []);
+    abstract protected function describeContainerParameters(ParameterBag $parameters, array $options = []): void;
 
-    abstract protected function describeContainerTags(ContainerBuilder $builder, array $options = []);
+    abstract protected function describeContainerTags(ContainerBuilder $builder, array $options = []): void;
 
     /**
      * Describes a container service by its name.
@@ -94,7 +94,7 @@ abstract class Descriptor implements DescriptorInterface
      *
      * @param Definition|Alias|object $service
      */
-    abstract protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null);
+    abstract protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null): void;
 
     /**
      * Describes container services.
@@ -102,17 +102,17 @@ abstract class Descriptor implements DescriptorInterface
      * Common options are:
      * * tag: filters described services by given tag
      */
-    abstract protected function describeContainerServices(ContainerBuilder $builder, array $options = []);
+    abstract protected function describeContainerServices(ContainerBuilder $builder, array $options = []): void;
 
     abstract protected function describeContainerDeprecations(ContainerBuilder $builder, array $options = []): void;
 
-    abstract protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null);
+    abstract protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null): void;
 
-    abstract protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null);
+    abstract protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null): void;
 
-    abstract protected function describeContainerParameter(mixed $parameter, array $options = []);
+    abstract protected function describeContainerParameter(mixed $parameter, array $options = []): void;
 
-    abstract protected function describeContainerEnvVars(array $envs, array $options = []);
+    abstract protected function describeContainerEnvVars(array $envs, array $options = []): void;
 
     /**
      * Describes event dispatcher listeners.
@@ -214,7 +214,7 @@ abstract class Descriptor implements DescriptorInterface
         return $definitions;
     }
 
-    protected function sortParameters(ParameterBag $parameters)
+    protected function sortParameters(ParameterBag $parameters): array
     {
         $parameters = $parameters->all();
         ksort($parameters);
@@ -222,7 +222,7 @@ abstract class Descriptor implements DescriptorInterface
         return $parameters;
     }
 
-    protected function sortServiceIds(array $serviceIds)
+    protected function sortServiceIds(array $serviceIds): array
     {
         asort($serviceIds);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -32,7 +32,7 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class JsonDescriptor extends Descriptor
 {
-    protected function describeRouteCollection(RouteCollection $routes, array $options = [])
+    protected function describeRouteCollection(RouteCollection $routes, array $options = []): void
     {
         $data = [];
         foreach ($routes->all() as $name => $route) {
@@ -42,17 +42,17 @@ class JsonDescriptor extends Descriptor
         $this->writeData($data, $options);
     }
 
-    protected function describeRoute(Route $route, array $options = [])
+    protected function describeRoute(Route $route, array $options = []): void
     {
         $this->writeData($this->getRouteData($route), $options);
     }
 
-    protected function describeContainerParameters(ParameterBag $parameters, array $options = [])
+    protected function describeContainerParameters(ParameterBag $parameters, array $options = []): void
     {
         $this->writeData($this->sortParameters($parameters), $options);
     }
 
-    protected function describeContainerTags(ContainerBuilder $builder, array $options = [])
+    protected function describeContainerTags(ContainerBuilder $builder, array $options = []): void
     {
         $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $data = [];
@@ -67,7 +67,7 @@ class JsonDescriptor extends Descriptor
         $this->writeData($data, $options);
     }
 
-    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null): void
     {
         if (!isset($options['id'])) {
             throw new \InvalidArgumentException('An "id" option must be provided.');
@@ -82,7 +82,7 @@ class JsonDescriptor extends Descriptor
         }
     }
 
-    protected function describeContainerServices(ContainerBuilder $builder, array $options = [])
+    protected function describeContainerServices(ContainerBuilder $builder, array $options = []): void
     {
         $serviceIds = isset($options['tag']) && $options['tag']
             ? $this->sortTaggedServicesByPriority($builder->findTaggedServiceIds($options['tag']))
@@ -115,12 +115,12 @@ class JsonDescriptor extends Descriptor
         $this->writeData($data, $options);
     }
 
-    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null): void
     {
         $this->writeData($this->getContainerDefinitionData($definition, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $builder, $options['id'] ?? null), $options);
     }
 
-    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null): void
     {
         if (!$builder) {
             $this->writeData($this->getContainerAliasData($alias), $options);
@@ -134,24 +134,24 @@ class JsonDescriptor extends Descriptor
         );
     }
 
-    protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = [])
+    protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = []): void
     {
         $this->writeData($this->getEventDispatcherListenersData($eventDispatcher, $options), $options);
     }
 
-    protected function describeCallable(mixed $callable, array $options = [])
+    protected function describeCallable(mixed $callable, array $options = []): void
     {
         $this->writeData($this->getCallableData($callable), $options);
     }
 
-    protected function describeContainerParameter(mixed $parameter, array $options = [])
+    protected function describeContainerParameter(mixed $parameter, array $options = []): void
     {
         $key = $options['parameter'] ?? '';
 
         $this->writeData([$key => $parameter], $options);
     }
 
-    protected function describeContainerEnvVars(array $envs, array $options = [])
+    protected function describeContainerEnvVars(array $envs, array $options = []): void
     {
         throw new LogicException('Using the JSON format to debug environment variables is not supported.');
     }
@@ -180,7 +180,7 @@ class JsonDescriptor extends Descriptor
         $this->writeData(['remainingCount' => $remainingCount, 'deprecations' => $formattedLogs], $options);
     }
 
-    private function writeData(array $data, array $options)
+    private function writeData(array $data, array $options): void
     {
         $flags = $options['json_encoding'] ?? 0;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -29,7 +29,7 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class MarkdownDescriptor extends Descriptor
 {
-    protected function describeRouteCollection(RouteCollection $routes, array $options = [])
+    protected function describeRouteCollection(RouteCollection $routes, array $options = []): void
     {
         $first = true;
         foreach ($routes->all() as $name => $route) {
@@ -43,7 +43,7 @@ class MarkdownDescriptor extends Descriptor
         $this->write("\n");
     }
 
-    protected function describeRoute(Route $route, array $options = [])
+    protected function describeRoute(Route $route, array $options = []): void
     {
         $output = '- Path: '.$route->getPath()
             ."\n".'- Path Regex: '.$route->compile()->getRegex()
@@ -66,7 +66,7 @@ class MarkdownDescriptor extends Descriptor
         $this->write("\n");
     }
 
-    protected function describeContainerParameters(ParameterBag $parameters, array $options = [])
+    protected function describeContainerParameters(ParameterBag $parameters, array $options = []): void
     {
         $this->write("Container parameters\n====================\n");
         foreach ($this->sortParameters($parameters) as $key => $value) {
@@ -74,7 +74,7 @@ class MarkdownDescriptor extends Descriptor
         }
     }
 
-    protected function describeContainerTags(ContainerBuilder $builder, array $options = [])
+    protected function describeContainerTags(ContainerBuilder $builder, array $options = []): void
     {
         $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $this->write("Container tags\n==============");
@@ -88,7 +88,7 @@ class MarkdownDescriptor extends Descriptor
         }
     }
 
-    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null): void
     {
         if (!isset($options['id'])) {
             throw new \InvalidArgumentException('An "id" option must be provided.');
@@ -132,7 +132,7 @@ class MarkdownDescriptor extends Descriptor
         }
     }
 
-    protected function describeContainerServices(ContainerBuilder $builder, array $options = [])
+    protected function describeContainerServices(ContainerBuilder $builder, array $options = []): void
     {
         $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
 
@@ -193,7 +193,7 @@ class MarkdownDescriptor extends Descriptor
         }
     }
 
-    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null): void
     {
         $output = '';
 
@@ -263,7 +263,7 @@ class MarkdownDescriptor extends Descriptor
         $this->write(isset($options['id']) ? sprintf("### %s\n\n%s\n", $options['id'], $output) : $output);
     }
 
-    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null): void
     {
         $output = '- Service: `'.$alias.'`'
             ."\n".'- Public: '.($alias->isPublic() && !$alias->isPrivate() ? 'yes' : 'no');
@@ -284,17 +284,17 @@ class MarkdownDescriptor extends Descriptor
         $this->describeContainerDefinition($builder->getDefinition((string) $alias), array_merge($options, ['id' => (string) $alias]), $builder);
     }
 
-    protected function describeContainerParameter(mixed $parameter, array $options = [])
+    protected function describeContainerParameter(mixed $parameter, array $options = []): void
     {
         $this->write(isset($options['parameter']) ? sprintf("%s\n%s\n\n%s", $options['parameter'], str_repeat('=', \strlen($options['parameter'])), $this->formatParameter($parameter)) : $parameter);
     }
 
-    protected function describeContainerEnvVars(array $envs, array $options = [])
+    protected function describeContainerEnvVars(array $envs, array $options = []): void
     {
         throw new LogicException('Using the markdown format to debug environment variables is not supported.');
     }
 
-    protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = [])
+    protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = []): void
     {
         $event = $options['event'] ?? null;
         $dispatcherServiceName = $options['dispatcher_service_name'] ?? null;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -44,7 +44,7 @@ class TextDescriptor extends Descriptor
         $this->fileLinkFormatter = $fileLinkFormatter;
     }
 
-    protected function describeRouteCollection(RouteCollection $routes, array $options = [])
+    protected function describeRouteCollection(RouteCollection $routes, array $options = []): void
     {
         $showControllers = isset($options['show_controllers']) && $options['show_controllers'];
 
@@ -81,7 +81,7 @@ class TextDescriptor extends Descriptor
         }
     }
 
-    protected function describeRoute(Route $route, array $options = [])
+    protected function describeRoute(Route $route, array $options = []): void
     {
         $defaults = $route->getDefaults();
         if (isset($defaults['_controller'])) {
@@ -112,7 +112,7 @@ class TextDescriptor extends Descriptor
         $table->render();
     }
 
-    protected function describeContainerParameters(ParameterBag $parameters, array $options = [])
+    protected function describeContainerParameters(ParameterBag $parameters, array $options = []): void
     {
         $tableHeaders = ['Parameter', 'Value'];
 
@@ -125,7 +125,7 @@ class TextDescriptor extends Descriptor
         $options['output']->table($tableHeaders, $tableRows);
     }
 
-    protected function describeContainerTags(ContainerBuilder $builder, array $options = [])
+    protected function describeContainerTags(ContainerBuilder $builder, array $options = []): void
     {
         $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
 
@@ -141,7 +141,7 @@ class TextDescriptor extends Descriptor
         }
     }
 
-    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null): void
     {
         if (!isset($options['id'])) {
             throw new \InvalidArgumentException('An "id" option must be provided.');
@@ -162,7 +162,7 @@ class TextDescriptor extends Descriptor
         }
     }
 
-    protected function describeContainerServices(ContainerBuilder $builder, array $options = [])
+    protected function describeContainerServices(ContainerBuilder $builder, array $options = []): void
     {
         $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $showTag = $options['tag'] ?? null;
@@ -251,7 +251,7 @@ class TextDescriptor extends Descriptor
         $options['output']->table($tableHeaders, $tableRows);
     }
 
-    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null): void
     {
         if (isset($options['id'])) {
             $options['output']->title(sprintf('Information for Service "<info>%s</info>"', $options['id']));
@@ -390,7 +390,7 @@ class TextDescriptor extends Descriptor
         $options['output']->listing($formattedLogs);
     }
 
-    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null): void
     {
         if ($alias->isPublic() && !$alias->isPrivate()) {
             $options['output']->comment(sprintf('This service is a <info>public</info> alias for the service <info>%s</info>', (string) $alias));
@@ -405,7 +405,7 @@ class TextDescriptor extends Descriptor
         $this->describeContainerDefinition($builder->getDefinition((string) $alias), array_merge($options, ['id' => (string) $alias]), $builder);
     }
 
-    protected function describeContainerParameter(mixed $parameter, array $options = [])
+    protected function describeContainerParameter(mixed $parameter, array $options = []): void
     {
         $options['output']->table(
             ['Parameter', 'Value'],
@@ -415,7 +415,7 @@ class TextDescriptor extends Descriptor
         ]);
     }
 
-    protected function describeContainerEnvVars(array $envs, array $options = [])
+    protected function describeContainerEnvVars(array $envs, array $options = []): void
     {
         $dump = new Dumper($this->output);
         $options['output']->title('Symfony Container Environment Variables');
@@ -477,7 +477,7 @@ class TextDescriptor extends Descriptor
         }
     }
 
-    protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = [])
+    protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = []): void
     {
         $event = $options['event'] ?? null;
         $dispatcherServiceName = $options['dispatcher_service_name'] ?? null;
@@ -509,12 +509,12 @@ class TextDescriptor extends Descriptor
         }
     }
 
-    protected function describeCallable(mixed $callable, array $options = [])
+    protected function describeCallable(mixed $callable, array $options = []): void
     {
         $this->writeText($this->formatCallable($callable), $options);
     }
 
-    private function renderEventListenerTable(EventDispatcherInterface $eventDispatcher, string $event, array $eventListeners, SymfonyStyle $io)
+    private function renderEventListenerTable(EventDispatcherInterface $eventDispatcher, string $event, array $eventListeners, SymfonyStyle $io): void
     {
         $tableHeaders = ['Order', 'Callable', 'Priority'];
         $tableRows = [];
@@ -629,7 +629,7 @@ class TextDescriptor extends Descriptor
         throw new \InvalidArgumentException('Callable is not describable.');
     }
 
-    private function writeText(string $content, array $options = [])
+    private function writeText(string $content, array $options = []): void
     {
         $this->write(
             isset($options['raw_text']) && $options['raw_text'] ? strip_tags($content) : $content,

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -33,27 +33,27 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class XmlDescriptor extends Descriptor
 {
-    protected function describeRouteCollection(RouteCollection $routes, array $options = [])
+    protected function describeRouteCollection(RouteCollection $routes, array $options = []): void
     {
         $this->writeDocument($this->getRouteCollectionDocument($routes));
     }
 
-    protected function describeRoute(Route $route, array $options = [])
+    protected function describeRoute(Route $route, array $options = []): void
     {
         $this->writeDocument($this->getRouteDocument($route, $options['name'] ?? null));
     }
 
-    protected function describeContainerParameters(ParameterBag $parameters, array $options = [])
+    protected function describeContainerParameters(ParameterBag $parameters, array $options = []): void
     {
         $this->writeDocument($this->getContainerParametersDocument($parameters));
     }
 
-    protected function describeContainerTags(ContainerBuilder $builder, array $options = [])
+    protected function describeContainerTags(ContainerBuilder $builder, array $options = []): void
     {
         $this->writeDocument($this->getContainerTagsDocument($builder, isset($options['show_hidden']) && $options['show_hidden']));
     }
 
-    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerService(object $service, array $options = [], ContainerBuilder $builder = null): void
     {
         if (!isset($options['id'])) {
             throw new \InvalidArgumentException('An "id" option must be provided.');
@@ -62,17 +62,17 @@ class XmlDescriptor extends Descriptor
         $this->writeDocument($this->getContainerServiceDocument($service, $options['id'], $builder, isset($options['show_arguments']) && $options['show_arguments']));
     }
 
-    protected function describeContainerServices(ContainerBuilder $builder, array $options = [])
+    protected function describeContainerServices(ContainerBuilder $builder, array $options = []): void
     {
         $this->writeDocument($this->getContainerServicesDocument($builder, $options['tag'] ?? null, isset($options['show_hidden']) && $options['show_hidden'], isset($options['show_arguments']) && $options['show_arguments'], $options['filter'] ?? null, $options['id'] ?? null));
     }
 
-    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerDefinition(Definition $definition, array $options = [], ContainerBuilder $builder = null): void
     {
         $this->writeDocument($this->getContainerDefinitionDocument($definition, $options['id'] ?? null, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'], $builder));
     }
 
-    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null)
+    protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null): void
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($dom->importNode($this->getContainerAliasDocument($alias, $options['id'] ?? null)->childNodes->item(0), true));
@@ -88,22 +88,22 @@ class XmlDescriptor extends Descriptor
         $this->writeDocument($dom);
     }
 
-    protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = [])
+    protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = []): void
     {
         $this->writeDocument($this->getEventDispatcherListenersDocument($eventDispatcher, $options));
     }
 
-    protected function describeCallable(mixed $callable, array $options = [])
+    protected function describeCallable(mixed $callable, array $options = []): void
     {
         $this->writeDocument($this->getCallableDocument($callable));
     }
 
-    protected function describeContainerParameter(mixed $parameter, array $options = [])
+    protected function describeContainerParameter(mixed $parameter, array $options = []): void
     {
         $this->writeDocument($this->getContainerParameterDocument($parameter, $options));
     }
 
-    protected function describeContainerEnvVars(array $envs, array $options = [])
+    protected function describeContainerEnvVars(array $envs, array $options = []): void
     {
         throw new LogicException('Using the XML format to debug environment variables is not supported.');
     }
@@ -136,7 +136,7 @@ class XmlDescriptor extends Descriptor
         $this->writeDocument($dom);
     }
 
-    private function writeDocument(\DOMDocument $dom)
+    private function writeDocument(\DOMDocument $dom): void
     {
         $dom->formatOutput = true;
         $this->write($dom->saveXML());
@@ -503,7 +503,7 @@ class XmlDescriptor extends Descriptor
         return $dom;
     }
 
-    private function appendEventListenerDocument(EventDispatcherInterface $eventDispatcher, string $event, \DOMElement $element, array $eventListeners)
+    private function appendEventListenerDocument(EventDispatcherInterface $eventDispatcher, string $event, \DOMElement $element, array $eventListeners): void
     {
         foreach ($eventListeners as $listener) {
             $callableXML = $this->getCallableDocument($listener);

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -353,7 +353,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    private function createFirewall(ContainerBuilder $container, string $id, array $firewall, array &$authenticationProviders, array $providerIds, string $configId)
+    private function createFirewall(ContainerBuilder $container, string $id, array $firewall, array &$authenticationProviders, array $providerIds, string $configId): array
     {
         $config = $container->setDefinition($configId, new ChildDefinition('security.firewall.config'));
         $config->replaceArgument(0, $id);
@@ -599,7 +599,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         return $this->contextListeners[$contextKey] = $listenerId;
     }
 
-    private function createAuthenticationListeners(ContainerBuilder $container, string $id, array $firewall, array &$authenticationProviders, ?string $defaultProvider, array $providerIds, ?string $defaultEntryPoint, string $contextListenerId = null)
+    private function createAuthenticationListeners(ContainerBuilder $container, string $id, array $firewall, array &$authenticationProviders, ?string $defaultProvider, array $providerIds, ?string $defaultEntryPoint, string $contextListenerId = null): array
     {
         $listeners = [];
         $entryPoints = [];

--- a/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
@@ -68,7 +68,7 @@ class WebProfilerExtension extends ProfilerExtension
         ];
     }
 
-    public function dumpData(Environment $env, Data $data, int $maxDepth = 0)
+    public function dumpData(Environment $env, Data $data, int $maxDepth = 0): string
     {
         $this->dumper->setCharset($env->getCharset());
         $this->dumper->dump($data, null, [
@@ -82,7 +82,7 @@ class WebProfilerExtension extends ProfilerExtension
         return str_replace("\n</pre", '</pre', rtrim($dump));
     }
 
-    public function dumpLog(Environment $env, string $message, Data $context = null)
+    public function dumpLog(Environment $env, string $message, Data $context = null): string
     {
         $message = twig_escape_filter($env, $message);
         $message = preg_replace('/&quot;(.*?)&quot;/', '&quot;<b>$1</b>&quot;', $message);
@@ -106,7 +106,7 @@ class WebProfilerExtension extends ProfilerExtension
         return '<span class="dump-inline">'.strtr($message, $replacements).'</span>';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'profiler';
     }

--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -110,7 +110,7 @@ class UrlPackage extends Package
         return abs(crc32($path)) % \count($this->baseUrls);
     }
 
-    private function getSslUrls(array $urls)
+    private function getSslUrls(array $urls): array
     {
         $sslUrls = [];
         foreach ($urls as $url) {

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -215,7 +215,7 @@ class CachePoolPass implements CompilerPassInterface
         }
     }
 
-    private function getNamespace(string $seed, string $id)
+    private function getNamespace(string $seed, string $id): string
     {
         return substr(str_replace('/', '-', base64_encode(hash('sha256', $id.$seed, true))), 0, 10);
     }
@@ -223,7 +223,7 @@ class CachePoolPass implements CompilerPassInterface
     /**
      * @internal
      */
-    public static function getServiceProvider(ContainerBuilder $container, string $name)
+    public static function getServiceProvider(ContainerBuilder $container, string $name): string
     {
         $container->resolveEnvPlaceholders($name, null, $usedEnvs);
 

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -317,7 +317,7 @@ trait AbstractAdapterTrait
         }
     }
 
-    private function getId(mixed $key)
+    private function getId(mixed $key): string
     {
         if ($this->versioningIsEnabled && '' === $this->namespaceVersion) {
             $this->ids = [];

--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -77,12 +77,15 @@ trait FilesystemCommonTrait
         return $ok;
     }
 
+    /**
+     * @return bool
+     */
     protected function doUnlink(string $file)
     {
         return @unlink($file);
     }
 
-    private function write(string $file, string $data, int $expiresAt = null)
+    private function write(string $file, string $data, int $expiresAt = null): bool
     {
         set_error_handler(__CLASS__.'::throwError');
         try {
@@ -110,7 +113,7 @@ trait FilesystemCommonTrait
         }
     }
 
-    private function getFile(string $id, bool $mkdir = false, string $directory = null)
+    private function getFile(string $id, bool $mkdir = false, string $directory = null): string
     {
         // Use xxh128 to favor speed over security, which is not an issue here
         $hash = str_replace('/', '-', base64_encode(hash('xxh128', static::class.$id, true)));

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -97,7 +97,7 @@ abstract class FileLoader extends Loader
     /**
      * @internal
      */
-    protected function glob(string $pattern, bool $recursive, array|GlobResource &$resource = null, bool $ignoreErrors = false, bool $forExclusion = false, array $excluded = [])
+    protected function glob(string $pattern, bool $recursive, array|GlobResource &$resource = null, bool $ignoreErrors = false, bool $forExclusion = false, array $excluded = []): iterable
     {
         if (\strlen($pattern) === $i = strcspn($pattern, '*?{[')) {
             $prefix = $pattern;

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -727,7 +727,7 @@ class Table
     /**
      * fill cells for a row that contains colspan > 1.
      */
-    private function fillCells(iterable $row)
+    private function fillCells(iterable $row): iterable
     {
         $newRow = [];
 

--- a/src/Symfony/Component/CssSelector/Parser/Reader.php
+++ b/src/Symfony/Component/CssSelector/Parser/Reader.php
@@ -53,7 +53,10 @@ class Reader
         return substr($this->source, $this->position + $offset, $length);
     }
 
-    public function getOffset(string $string)
+    /**
+     * @return int|false
+     */
+    public function getOffset(string $string): int|bool
     {
         $position = strpos($this->source, $string, $this->position);
 
@@ -71,12 +74,12 @@ class Reader
         return false;
     }
 
-    public function moveForward(int $length)
+    public function moveForward(int $length): void
     {
         $this->position += $length;
     }
 
-    public function moveToEnd()
+    public function moveToEnd(): void
     {
         $this->position = $this->length;
     }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -171,7 +171,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
         return implode(', ', $result);
     }
 
-    private function formatArgsAsText(array $args)
+    private function formatArgsAsText(array $args): string
     {
         return strip_tags($this->formatArgs($args));
     }
@@ -273,7 +273,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
         return '';
     }
 
-    private function fixCodeMarkup(string $line)
+    private function fixCodeMarkup(string $line): string
     {
         // </span> ending tag from previous line
         $opening = strpos($line, '<span');
@@ -292,12 +292,12 @@ class HtmlErrorRenderer implements ErrorRendererInterface
         return trim($line);
     }
 
-    private function formatFileFromText(string $text)
+    private function formatFileFromText(string $text): string
     {
         return preg_replace_callback('/in ("|&quot;)?(.+?)\1(?: +(?:on|at))? +line (\d+)/s', fn ($match) => 'in '.$this->formatFile($match[2], $match[3]), $text);
     }
 
-    private function formatLogMessage(string $message, array $context)
+    private function formatLogMessage(string $message, array $context): string
     {
         if ($context && str_contains($message, '{')) {
             $replacements = [];

--- a/src/Symfony/Component/ExpressionLanguage/Node/ArgumentsNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ArgumentsNode.php
@@ -20,12 +20,12 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  */
 class ArgumentsNode extends ArrayNode
 {
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $this->compileArguments($compiler, false);
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         $array = [];
 

--- a/src/Symfony/Component/ExpressionLanguage/Node/ArrayNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ArrayNode.php
@@ -27,7 +27,7 @@ class ArrayNode extends Node
         $this->index = -1;
     }
 
-    public function addElement(Node $value, Node $key = null)
+    public function addElement(Node $value, Node $key = null): void
     {
         $key ??= new ConstantNode(++$this->index);
 
@@ -37,14 +37,14 @@ class ArrayNode extends Node
     /**
      * Compiles the node to PHP.
      */
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $compiler->raw('[');
         $this->compileArguments($compiler);
         $compiler->raw(']');
     }
 
-    public function evaluate(array $functions, array $values)
+    public function evaluate(array $functions, array $values): array
     {
         $result = [];
         foreach ($this->getKeyValuePairs() as $pair) {
@@ -54,7 +54,7 @@ class ArrayNode extends Node
         return $result;
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         $value = [];
         foreach ($this->getKeyValuePairs() as $pair) {
@@ -84,7 +84,7 @@ class ArrayNode extends Node
         return $array;
     }
 
-    protected function getKeyValuePairs()
+    protected function getKeyValuePairs(): array
     {
         $pairs = [];
         foreach (array_chunk($this->nodes, 2) as $pair) {
@@ -94,7 +94,7 @@ class ArrayNode extends Node
         return $pairs;
     }
 
-    protected function compileArguments(Compiler $compiler, bool $withKeys = true)
+    protected function compileArguments(Compiler $compiler, bool $withKeys = true): void
     {
         $first = true;
         foreach ($this->getKeyValuePairs() as $pair) {

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -45,7 +45,7 @@ class BinaryNode extends Node
         );
     }
 
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $operator = $this->attributes['operator'];
 
@@ -92,7 +92,7 @@ class BinaryNode extends Node
         ;
     }
 
-    public function evaluate(array $functions, array $values)
+    public function evaluate(array $functions, array $values): mixed
     {
         $operator = $this->attributes['operator'];
         $left = $this->nodes['left']->evaluate($functions, $values);
@@ -171,7 +171,7 @@ class BinaryNode extends Node
         }
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return ['(', $this->nodes['left'], ' '.$this->attributes['operator'].' ', $this->nodes['right'], ')'];
     }

--- a/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
@@ -27,7 +27,7 @@ class ConditionalNode extends Node
         );
     }
 
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $compiler
             ->raw('((')
@@ -49,7 +49,7 @@ class ConditionalNode extends Node
         return $this->nodes['expr3']->evaluate($functions, $values);
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return ['(', $this->nodes['expr1'], ' ? ', $this->nodes['expr2'], ' : ', $this->nodes['expr3'], ')'];
     }

--- a/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
@@ -33,17 +33,17 @@ class ConstantNode extends Node
         );
     }
 
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $compiler->repr($this->attributes['value']);
     }
 
-    public function evaluate(array $functions, array $values)
+    public function evaluate(array $functions, array $values): mixed
     {
         return $this->attributes['value'];
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         $array = [];
         $value = $this->attributes['value'];

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -24,6 +24,9 @@ class GetAttrNode extends Node
     public const METHOD_CALL = 2;
     public const ARRAY_CALL = 3;
 
+    /**
+     * @param self::* $type
+     */
     public function __construct(Node $node, Node $attribute, ArrayNode $arguments, int $type)
     {
         parent::__construct(
@@ -32,7 +35,7 @@ class GetAttrNode extends Node
         );
     }
 
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $nullSafe = $this->nodes['attribute'] instanceof ConstantNode && $this->nodes['attribute']->isNullSafe;
         switch ($this->attributes['type']) {
@@ -65,7 +68,7 @@ class GetAttrNode extends Node
         }
     }
 
-    public function evaluate(array $functions, array $values)
+    public function evaluate(array $functions, array $values): mixed
     {
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
@@ -136,7 +139,7 @@ class GetAttrNode extends Node
         return $this->attributes['is_short_circuited'] || ($this->nodes['node'] instanceof self && $this->nodes['node']->isShortCircuited());
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:

--- a/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php
@@ -28,17 +28,17 @@ class NameNode extends Node
         );
     }
 
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $compiler->raw('$'.$this->attributes['name']);
     }
 
-    public function evaluate(array $functions, array $values)
+    public function evaluate(array $functions, array $values): mixed
     {
         return $values[$this->attributes['name']];
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return [$this->attributes['name']];
     }

--- a/src/Symfony/Component/ExpressionLanguage/Node/NullCoalesceNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/NullCoalesceNode.php
@@ -25,7 +25,7 @@ class NullCoalesceNode extends Node
         parent::__construct(['expr1' => $expr1, 'expr2' => $expr2]);
     }
 
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $compiler
             ->raw('((')
@@ -36,7 +36,7 @@ class NullCoalesceNode extends Node
         ;
     }
 
-    public function evaluate(array $functions, array $values)
+    public function evaluate(array $functions, array $values): mixed
     {
         if ($this->nodes['expr1'] instanceof GetAttrNode) {
             $this->nodes['expr1']->attributes['is_null_coalesce'] = true;
@@ -45,7 +45,7 @@ class NullCoalesceNode extends Node
         return $this->nodes['expr1']->evaluate($functions, $values) ?? $this->nodes['expr2']->evaluate($functions, $values);
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return ['(', $this->nodes['expr1'], ') ?? (', $this->nodes['expr2'], ')'];
     }

--- a/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
@@ -40,7 +40,7 @@ abstract class Descriptor implements DescriptorInterface
     protected $parents = [];
     protected $extensions = [];
 
-    public function describe(OutputInterface $output, ?object $object, array $options = [])
+    public function describe(OutputInterface $output, ?object $object, array $options = []): void
     {
         $this->output = $output instanceof OutputStyle ? $output : new SymfonyStyle(new ArrayInput([]), $output);
 
@@ -52,13 +52,13 @@ abstract class Descriptor implements DescriptorInterface
         };
     }
 
-    abstract protected function describeDefaults(array $options);
+    abstract protected function describeDefaults(array $options): void;
 
-    abstract protected function describeResolvedFormType(ResolvedFormTypeInterface $resolvedFormType, array $options = []);
+    abstract protected function describeResolvedFormType(ResolvedFormTypeInterface $resolvedFormType, array $options = []): void;
 
-    abstract protected function describeOption(OptionsResolver $optionsResolver, array $options);
+    abstract protected function describeOption(OptionsResolver $optionsResolver, array $options): void;
 
-    protected function collectOptions(ResolvedFormTypeInterface $type)
+    protected function collectOptions(ResolvedFormTypeInterface $type): void
     {
         $this->parents = [];
         $this->extensions = [];
@@ -96,7 +96,7 @@ abstract class Descriptor implements DescriptorInterface
         $this->extensions = array_keys($this->extensions);
     }
 
-    protected function getOptionDefinition(OptionsResolver $optionsResolver, string $option)
+    protected function getOptionDefinition(OptionsResolver $optionsResolver, string $option): array
     {
         $definition = [];
 
@@ -139,7 +139,7 @@ abstract class Descriptor implements DescriptorInterface
         return $definition;
     }
 
-    protected function filterOptionsByDeprecated(ResolvedFormTypeInterface $type)
+    protected function filterOptionsByDeprecated(ResolvedFormTypeInterface $type): void
     {
         $deprecatedOptions = [];
         $resolver = $type->getOptionsResolver();
@@ -186,7 +186,7 @@ abstract class Descriptor implements DescriptorInterface
         return $optionsResolver;
     }
 
-    private function collectTypeExtensionsOptions(ResolvedFormTypeInterface $type, OptionsResolver $optionsResolver)
+    private function collectTypeExtensionsOptions(ResolvedFormTypeInterface $type, OptionsResolver $optionsResolver): void
     {
         foreach ($type->getTypeExtensions() as $extension) {
             $inheritedOptions = $optionsResolver->getDefinedOptions();

--- a/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class JsonDescriptor extends Descriptor
 {
-    protected function describeDefaults(array $options)
+    protected function describeDefaults(array $options): void
     {
         $data['builtin_form_types'] = $options['core_types'];
         $data['service_form_types'] = $options['service_types'];
@@ -33,7 +33,7 @@ class JsonDescriptor extends Descriptor
         $this->writeData($data, $options);
     }
 
-    protected function describeResolvedFormType(ResolvedFormTypeInterface $resolvedFormType, array $options = [])
+    protected function describeResolvedFormType(ResolvedFormTypeInterface $resolvedFormType, array $options = []): void
     {
         $this->collectOptions($resolvedFormType);
 
@@ -61,7 +61,7 @@ class JsonDescriptor extends Descriptor
         $this->writeData($data, $options);
     }
 
-    protected function describeOption(OptionsResolver $optionsResolver, array $options)
+    protected function describeOption(OptionsResolver $optionsResolver, array $options): void
     {
         $definition = $this->getOptionDefinition($optionsResolver, $options['option']);
 
@@ -93,14 +93,14 @@ class JsonDescriptor extends Descriptor
         $this->writeData($data, $options);
     }
 
-    private function writeData(array $data, array $options)
+    private function writeData(array $data, array $options): void
     {
         $flags = $options['json_encoding'] ?? 0;
 
         $this->output->write(json_encode($data, $flags | \JSON_PRETTY_PRINT)."\n");
     }
 
-    private function sortOptions(array &$options)
+    private function sortOptions(array &$options): void
     {
         foreach ($options as &$opts) {
             $sorted = false;

--- a/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
@@ -31,7 +31,7 @@ class TextDescriptor extends Descriptor
         $this->fileLinkFormatter = $fileLinkFormatter;
     }
 
-    protected function describeDefaults(array $options)
+    protected function describeDefaults(array $options): void
     {
         if ($options['core_types']) {
             $this->output->section('Built-in form types (Symfony\Component\Form\Extension\Core\Type)');
@@ -59,7 +59,7 @@ class TextDescriptor extends Descriptor
         }
     }
 
-    protected function describeResolvedFormType(ResolvedFormTypeInterface $resolvedFormType, array $options = [])
+    protected function describeResolvedFormType(ResolvedFormTypeInterface $resolvedFormType, array $options = []): void
     {
         $this->collectOptions($resolvedFormType);
 
@@ -99,7 +99,7 @@ class TextDescriptor extends Descriptor
         }
     }
 
-    protected function describeOption(OptionsResolver $optionsResolver, array $options)
+    protected function describeOption(OptionsResolver $optionsResolver, array $options): void
     {
         $definition = $this->getOptionDefinition($optionsResolver, $options['option']);
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -420,7 +420,7 @@ class ChoiceType extends AbstractType
         $builder->add($name, $choiceType, $choiceOpts);
     }
 
-    private function createChoiceList(array $options)
+    private function createChoiceList(array $options): ChoiceListInterface
     {
         if (null !== $options['choice_loader']) {
             return $this->choiceListFactory->createListFromLoader(
@@ -440,7 +440,7 @@ class ChoiceType extends AbstractType
         );
     }
 
-    private function createChoiceListView(ChoiceListInterface $choiceList, array $options)
+    private function createChoiceListView(ChoiceListInterface $choiceList, array $options): ChoiceListView
     {
         return $this->choiceListFactory->createView(
             $choiceList,

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -319,7 +319,7 @@ class DateType extends AbstractType
         return 'date';
     }
 
-    private function formatTimestamps(\IntlDateFormatter $formatter, string $regex, array $timestamps)
+    private function formatTimestamps(\IntlDateFormatter $formatter, string $regex, array $timestamps): array
     {
         $pattern = $formatter->getPattern();
         $timezone = $formatter->getTimeZoneId();
@@ -344,7 +344,7 @@ class DateType extends AbstractType
         return $formattedTimestamps;
     }
 
-    private function listYears(array $years)
+    private function listYears(array $years): array
     {
         $result = [];
 
@@ -355,7 +355,7 @@ class DateType extends AbstractType
         return $result;
     }
 
-    private function listMonths(array $months)
+    private function listMonths(array $months): array
     {
         $result = [];
 
@@ -366,7 +366,7 @@ class DateType extends AbstractType
         return $result;
     }
 
-    private function listDays(array $days)
+    private function listDays(array $days): array
     {
         $result = [];
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -124,7 +124,7 @@ class FileType extends AbstractType
         return 'file';
     }
 
-    private function getFileUploadError(int $errorCode)
+    private function getFileUploadError(int $errorCode): FileUploadError
     {
         $messageParameters = [];
 
@@ -191,7 +191,7 @@ class FileType extends AbstractType
      *
      * This method should be kept in sync with Symfony\Component\Validator\Constraints\FileValidator::factorizeSizes().
      */
-    private function factorizeSizes(int $size, int|float $limit)
+    private function factorizeSizes(int $size, int|float $limit): array
     {
         $coef = self::MIB_BYTES;
         $coefFactor = self::KIB_BYTES;

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -227,7 +227,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         return $logs;
     }
 
-    private function sanitizeLogs(array $logs)
+    private function sanitizeLogs(array $logs): array
     {
         $sanitizedLogs = [];
         $silencedLogs = [];

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -49,7 +49,10 @@ class FileLinkFormatter
         $this->urlFormat = $urlFormat;
     }
 
-    public function format(string $file, int $line)
+    /**
+     * @return string|false
+     */
+    public function format(string $file, int $line): string|bool
     {
         if ($fmt = $this->getFileLinkFormat()) {
             for ($i = 1; isset($fmt[$i]); ++$i) {

--- a/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
@@ -36,7 +36,7 @@ abstract class AbstractDataGenerator
         $this->dirName = $dirName;
     }
 
-    public function generateData(GeneratorConfig $config)
+    public function generateData(GeneratorConfig $config): void
     {
         $filesystem = new Filesystem();
         $localeScanner = new LocaleScanner();

--- a/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
@@ -53,13 +53,13 @@ class CurrencyDataGenerator extends AbstractDataGenerator
         return $scanner->scanLocales($sourceDir.'/curr');
     }
 
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir): void
     {
         $compiler->compile($sourceDir.'/curr', $tempDir);
         $compiler->compile($sourceDir.'/misc/currencyNumericCodes.txt', $tempDir);
     }
 
-    protected function preGenerate()
+    protected function preGenerate(): void
     {
         $this->currencyCodes = [];
     }

--- a/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
@@ -103,13 +103,13 @@ class LanguageDataGenerator extends AbstractDataGenerator
         return $scanner->scanLocales($sourceDir.'/lang');
     }
 
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir): void
     {
         $compiler->compile($sourceDir.'/lang', $tempDir);
         $compiler->compile($sourceDir.'/misc/metadata.txt', $tempDir);
     }
 
-    protected function preGenerate()
+    protected function preGenerate(): void
     {
         $this->languageCodes = [];
     }

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -67,7 +67,7 @@ class RegionDataGenerator extends AbstractDataGenerator
      */
     private array $regionCodes = [];
 
-    public static function isValidCountryCode(int|string|null $region)
+    public static function isValidCountryCode(int|string|null $region): bool
     {
         if (isset(self::DENYLIST[$region])) {
             return false;
@@ -86,13 +86,13 @@ class RegionDataGenerator extends AbstractDataGenerator
         return $scanner->scanLocales($sourceDir.'/region');
     }
 
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir): void
     {
         $compiler->compile($sourceDir.'/region', $tempDir);
         $compiler->compile($sourceDir.'/misc/metadata.txt', $tempDir);
     }
 
-    protected function preGenerate()
+    protected function preGenerate(): void
     {
         $this->regionCodes = [];
     }

--- a/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
@@ -40,12 +40,12 @@ class ScriptDataGenerator extends AbstractDataGenerator
         return $scanner->scanLocales($sourceDir.'/lang');
     }
 
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir): void
     {
         $compiler->compile($sourceDir.'/lang', $tempDir);
     }
 
-    protected function preGenerate()
+    protected function preGenerate(): void
     {
         $this->scriptCodes = [];
     }

--- a/src/Symfony/Component/Intl/Data/Generator/TimezoneDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/TimezoneDataGenerator.php
@@ -46,7 +46,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
         return $scanner->scanLocales($sourceDir.'/zone');
     }
 
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir): void
     {
         $filesystem = new Filesystem();
         $filesystem->mkdir($tempDir.'/region');
@@ -57,7 +57,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
         $compiler->compile($sourceDir.'/misc/windowsZones.txt', $tempDir);
     }
 
-    protected function preGenerate()
+    protected function preGenerate(): void
     {
         $this->zoneIds = [];
         $this->zoneToCountryMapping = [];

--- a/src/Symfony/Component/Intl/Data/Util/ArrayAccessibleResourceBundle.php
+++ b/src/Symfony/Component/Intl/Data/Util/ArrayAccessibleResourceBundle.php
@@ -69,12 +69,12 @@ class ArrayAccessibleResourceBundle implements \ArrayAccess, \IteratorAggregate,
         return $this->bundleImpl->count();
     }
 
-    public function getErrorCode()
+    public function getErrorCode(): int
     {
         return $this->bundleImpl->getErrorCode();
     }
 
-    public function getErrorMessage()
+    public function getErrorMessage(): string
     {
         return $this->bundleImpl->getErrorMessage();
     }

--- a/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
@@ -79,7 +79,7 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
         return $casters;
     }
 
-    private function collectMessage(string $busName, array $tracedMessage)
+    private function collectMessage(string $busName, array $tracedMessage): array
     {
         $message = $tracedMessage['message'];
 

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -527,7 +527,10 @@ class Email extends Message
         return $this;
     }
 
-    private function addListAddressHeaderBody(string $name, array $addresses)
+    /**
+     * @return $this
+     */
+    private function addListAddressHeaderBody(string $name, array $addresses): static
     {
         if (!$header = $this->getHeaders()->get($name)) {
             return $this->setListAddressHeaderBody($name, $addresses);

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1567,7 +1567,7 @@ class Process implements \IteratorAggregate
         return '"'.str_replace(['"', '^', '%', '!', "\n"], ['""', '"^^"', '"^%"', '"^!"', '!LF!'], $argument).'"';
     }
 
-    private function replacePlaceholders(string $commandline, array $env)
+    private function replacePlaceholders(string $commandline, array $env): string
     {
         return preg_replace_callback('/"\$\{:([_a-zA-Z]++[_a-zA-Z0-9]*+)\}"/', function ($matches) use ($commandline, $env) {
             if (!isset($env[$matches[1]]) || false === $env[$matches[1]]) {

--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -61,7 +61,7 @@ final class Window implements LimiterStateInterface
         return $this->hitCount;
     }
 
-    public function getAvailableTokens(float $now)
+    public function getAvailableTokens(float $now): int
     {
         // if now is more than the window interval in the past, all tokens are available
         if (($now - $this->timer) > $this->intervalInSeconds) {

--- a/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
@@ -61,7 +61,7 @@ class StaticPrefixCollection
     /**
      * Adds a route to a group.
      */
-    public function addRoute(string $prefix, array|StaticPrefixCollection $route)
+    public function addRoute(string $prefix, array|StaticPrefixCollection $route): void
     {
         [$prefix, $staticPrefix] = $this->getCommonPrefix($prefix, $prefix);
 
@@ -196,7 +196,7 @@ class StaticPrefixCollection
         return [substr($prefix, 0, $i), substr($prefix, 0, $staticLength ?? $i)];
     }
 
-    public static function handleError(int $type, string $msg)
+    public static function handleError(int $type, string $msg): bool
     {
         return str_contains($msg, 'Compilation failed: lookbehind assertion is not fixed length');
     }

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -428,7 +428,7 @@ class Route implements \Serializable
         }, $pattern);
     }
 
-    private function sanitizeRequirement(string $key, string $regex)
+    private function sanitizeRequirement(string $key, string $regex): string
     {
         if ('' !== $regex) {
             if ('^' === $regex[0]) {

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
@@ -54,6 +54,10 @@ class InMemoryUserProvider implements UserProviderInterface
      */
     public function createUser(UserInterface $user)
     {
+        if (!$user instanceof InMemoryUser) {
+            trigger_deprecation('symfony/security-core', '6.3', 'Passing users that are not instance of "%s" to "%s" is deprecated, "%s" given.', InMemoryUser::class, __METHOD__, get_debug_type($user));
+        }
+
         $userIdentifier = strtolower($user->getUserIdentifier());
         if (isset($this->users[$userIdentifier])) {
             throw new \LogicException('Another user with the same username already exists.');
@@ -90,8 +94,10 @@ class InMemoryUserProvider implements UserProviderInterface
      * Returns the user by given username.
      *
      * @throws UserNotFoundException if user whose given username does not exist
+     *
+     * @return InMemoryUser change return type on 7.0
      */
-    private function getUser(string $username)/* : InMemoryUser */
+    private function getUser(string $username): UserInterface
     {
         if (!isset($this->users[strtolower($username)])) {
             $ex = new UserNotFoundException(sprintf('Username "%s" does not exist.', $username));

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -136,7 +136,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         $this->translator = $translator;
     }
 
-    private function getCredentials(Request $request)
+    private function getCredentials(Request $request): array
     {
         $data = json_decode($request->getContent());
         if (!$data instanceof \stdClass) {

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -86,7 +86,7 @@ class AccessListener extends AbstractListener
         }
     }
 
-    private function createAccessDeniedException(Request $request, array $attributes)
+    private function createAccessDeniedException(Request $request, array $attributes): AccessDeniedException
     {
         $exception = new AccessDeniedException();
         $exception->setAttributes($attributes);

--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
@@ -65,7 +65,7 @@ class ClassDiscriminatorFromClassMetadata implements ClassDiscriminatorResolverI
         return $mapping->getMappedObjectType($object);
     }
 
-    private function resolveMappingForMappedObject(object|string $object)
+    private function resolveMappingForMappedObject(object|string $object): ?ClassDiscriminatorMapping
     {
         $reflectionClass = new \ReflectionClass($object);
         if ($parentClass = $reflectionClass->getParentClass()) {

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -161,7 +161,7 @@ EOF
         };
     }
 
-    private function displayTxt(SymfonyStyle $io, array $filesInfo, bool $errorAsGithubAnnotations = false)
+    private function displayTxt(SymfonyStyle $io, array $filesInfo, bool $errorAsGithubAnnotations = false): int
     {
         $countFiles = \count($filesInfo);
         $erroredFiles = 0;
@@ -209,7 +209,7 @@ EOF
         return min($errors, 1);
     }
 
-    private function getFiles(string $fileOrDirectory)
+    private function getFiles(string $fileOrDirectory): iterable
     {
         if (is_file($fileOrDirectory)) {
             yield new \SplFileInfo($fileOrDirectory);

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -91,7 +91,7 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
         return 'translation';
     }
 
-    private function sanitizeCollectedMessages(array $messages)
+    private function sanitizeCollectedMessages(array $messages): array
     {
         $result = [];
         foreach ($messages as $key => $message) {
@@ -116,7 +116,7 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
         return $result;
     }
 
-    private function computeCount(array $messages)
+    private function computeCount(array $messages): array
     {
         $count = [
             DataCollectorTranslator::MESSAGE_DEFINED => 0,
@@ -131,7 +131,7 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
         return $count;
     }
 
-    private function sanitizeString(string $string, int $length = 80)
+    private function sanitizeString(string $string, int $length = 80): string
     {
         $string = trim(preg_replace('/\s+/', ' ', $string));
 

--- a/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
@@ -83,7 +83,7 @@ class IcuResFileDumper extends FileDumper
         return $padding ? str_repeat("\xAA", 4 - $padding) : null;
     }
 
-    private function getPosition(string $data)
+    private function getPosition(string $data): float|int
     {
         return (\strlen($data) + 28) / 4;
     }

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -65,7 +65,7 @@ class PoFileDumper extends FileDumper
         return $output;
     }
 
-    private function getStandardRules(string $id)
+    private function getStandardRules(string $id): array
     {
         // Partly copied from TranslatorTrait::trans.
         $parts = [];

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -54,7 +54,7 @@ class XliffFileDumper extends FileDumper
         return $this->extension;
     }
 
-    private function dumpXliff1(string $defaultLocale, MessageCatalogue $messages, ?string $domain, array $options = [])
+    private function dumpXliff1(string $defaultLocale, MessageCatalogue $messages, ?string $domain, array $options = []): string
     {
         $toolInfo = ['tool-id' => 'symfony', 'tool-name' => 'Symfony'];
         if (\array_key_exists('tool_info', $options)) {
@@ -137,7 +137,7 @@ class XliffFileDumper extends FileDumper
         return $dom->saveXML();
     }
 
-    private function dumpXliff2(string $defaultLocale, MessageCatalogue $messages, ?string $domain)
+    private function dumpXliff2(string $defaultLocale, MessageCatalogue $messages, ?string $domain): string
     {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = true;

--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -197,7 +197,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
      * Extracts the message from the iterator while the tokens
      * match allowed message tokens.
      */
-    private function getValue(\Iterator $tokenIterator)
+    private function getValue(\Iterator $tokenIterator): string
     {
         $message = '';
         $docToken = '';

--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -95,7 +95,7 @@ foreach ($config['original_files'] as $originalFilePath) {
 
 exit($totalTranslationMismatches > 0 ? 1 : 0);
 
-function findTranslationFiles($originalFilePath, $localeToAnalyze)
+function findTranslationFiles($originalFilePath, $localeToAnalyze): array
 {
     $translations = [];
 
@@ -118,7 +118,7 @@ function findTranslationFiles($originalFilePath, $localeToAnalyze)
     return $translations;
 }
 
-function calculateTranslationStatus($originalFilePath, $translationFilePaths)
+function calculateTranslationStatus($originalFilePath, $translationFilePaths): array
 {
     $translationStatus = [];
     $allTranslationKeys = extractTranslationKeys($originalFilePath);
@@ -159,7 +159,7 @@ function extractLocaleFromFilePath($filePath)
     return $parts[count($parts) - 2];
 }
 
-function extractTranslationKeys($filePath)
+function extractTranslationKeys($filePath): array
 {
     $translationKeys = [];
     $contents = new \SimpleXMLElement(file_get_contents($filePath));

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -414,7 +414,7 @@ final class ConstraintViolationAssertion
         return new self($this->context, $message, $this->constraint, $assertions);
     }
 
-    public function assertRaised()
+    public function assertRaised(): void
     {
         $expected = [];
         foreach ($this->assertions as $assertion) {
@@ -564,17 +564,17 @@ class AssertingContextualValidator implements ContextualValidatorInterface
         throw new \BadMethodCallException();
     }
 
-    public function doGetViolations()
+    public function doGetViolations(): ConstraintViolationListInterface
     {
         return $this->context->getViolations();
     }
 
-    public function expectNoValidate()
+    public function expectNoValidate(): void
     {
         $this->expectNoValidate = true;
     }
 
-    public function expectValidation(string $call, ?string $propertyPath, mixed $value, string|GroupSequence|array|null $group, callable $constraints, ConstraintViolationInterface $violation = null)
+    public function expectValidation(string $call, ?string $propertyPath, mixed $value, string|GroupSequence|array|null $group, callable $constraints, ConstraintViolationInterface $violation = null): void
     {
         if (null !== $propertyPath) {
             $this->expectedAtPath[$call] = $propertyPath;

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -962,7 +962,7 @@ EOHTML
     }
 }
 
-function esc(string $str)
+function esc(string $str): string
 {
     return htmlspecialchars($str, \ENT_QUOTES, 'UTF-8');
 }

--- a/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
@@ -186,7 +186,7 @@ class MermaidDumper implements DumperInterface
      * Replace double quotes with the mermaid escape syntax and
      * ensure all other characters are properly escaped.
      */
-    private function escape(string $label)
+    private function escape(string $label): string
     {
         $label = str_replace('"', '#quot;', $label);
 
@@ -207,12 +207,8 @@ class MermaidDumper implements DumperInterface
         }
     }
 
-    private function styleStatemachineTransition(
-        string $from,
-        string $to,
-        string $transitionLabel,
-        array $transitionMeta
-    ): array {
+    private function styleStatemachineTransition(string $from, string $to, string $transitionLabel, array $transitionMeta): array
+    {
         $transitionOutput = [sprintf('%s-->|%s|%s', $from, $this->escape($transitionLabel), $to)];
 
         $linkStyle = $this->styleLink($transitionMeta);
@@ -225,13 +221,8 @@ class MermaidDumper implements DumperInterface
         return $transitionOutput;
     }
 
-    private function styleWorkflowTransition(
-        string $from,
-        string $to,
-        int $transitionId,
-        string $transitionLabel,
-        array $transitionMeta
-    ) {
+    private function styleWorkflowTransition(string $from, string $to, int $transitionId, string $transitionLabel, array $transitionMeta): array
+    {
         $transitionOutput = [];
 
         $transitionLabel = $this->escape($transitionLabel);

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -124,7 +124,7 @@ EOF
         return $this->display($io, $filesInfo);
     }
 
-    private function validate(string $content, int $flags, string $file = null)
+    private function validate(string $content, int $flags, string $file = null): array
     {
         $prevErrorHandler = set_error_handler(function ($level, $message, $file, $line) use (&$prevErrorHandler) {
             if (\E_USER_DEPRECATED === $level) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Ref #47551, continues #49342
| License       | MIT
| Doc PR        | -

This PR adds real PHP types to private, internal or final (excluding `@final`) methods based on Psalm's type inference. Many more return types are missing still, but let's do them in other contributions.

This change can result in BC breaks in multiple ways, so we should carefully review the changes:

* A method may wrongly be considered "safe" by Psalter. If the method is unsafe (e.g. `@final`, but not yet real `final`), we should instead add a PHPdoc return type (see #49349)
* Psalm may not infer the correct set of return types. If an unexpected type is returned, this will result in a PHP error.