### PR TITLE
[HttpFoundation] Add `Cookie::createStringFromPairs()`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `ParameterBag::getEnum()`
  * Create migration for session table when pdo handler is used
  * Add support for Relay PHP extension for Redis
+ * Add `Cookie::createStringFromPairs()`
 
 6.2
 ---

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -79,6 +79,21 @@ class Cookie
         return new self($name, $value, $expire, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
     }
 
+    public static function createStringFromPairs(array $pairs, int|string|\DateTimeInterface $expire = 0, ?string $path = '/', string $domain = null, bool $secure = null, bool $httpOnly = true, bool $raw = false, ?string $sameSite = self::SAMESITE_LAX): string
+    {
+        if (empty($pairs)) {
+            throw new \InvalidArgumentException('At least one pair must be provided.');
+        }
+
+        $cookie = (string) new self('__base', 'null', $expire, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
+        $concatPairs = [];
+        foreach ($pairs as $k => $v) {
+            $concatPairs[] = $k.'='.$v;
+        }
+
+        return strtr($cookie, ['__base=null' => implode('; ', $concatPairs)]);
+    }
+
     /**
      * @param string                        $name     The name of the cookie
      * @param string|null                   $value    The value of the cookie

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -387,4 +387,33 @@ class CookieTest extends TestCase
         $this->assertEquals(time(), $cookie->getExpiresTime());
         $this->assertEquals('foo=bar; expires='.gmdate('D, d M Y H:i:s T', $cookie->getExpiresTime()).'; Max-Age=0; path=/', $cookie->__toString());
     }
+
+    public function testStringFromPairsEmptyIterable()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one pair must be provided.');
+
+        Cookie::createStringFromPairs([]);
+    }
+
+    public function testStringFromPairs()
+    {
+        $this->assertSame('flavor=chocolate; size=medium; path=/; httponly; samesite=lax', Cookie::createStringFromPairs(['flavor' => 'chocolate', 'size' => 'medium']));
+    }
+
+    public function testStringFromPairsWithOptions()
+    {
+        $cookie = Cookie::createStringFromPairs(
+            ['flavor' => 'chocolate', 'size' => 'medium'],
+            strtotime('+1 day'),
+            '/custom-path',
+            'cookie.example.com',
+            true,
+            false,
+            false,
+            Cookie::SAMESITE_STRICT
+        );
+
+        $this->assertStringMatchesFormat('flavor=chocolate; size=medium; expires=%s; Max-Age=86400; path=/custom-path; domain=cookie.example.com; secure; samesite=strict', $cookie);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Kinda from here: https://github.com/symfony/symfony-docs/issues/17875#issuecomment-1427227023
| License       | MIT
| Doc PR        | Todo

When using HttpClient to send request with the `Cookie` header set, we are not able to pass "multiple" cookies at once, other than creating the cookie string by hand. This new factory would allow to create such string in a more convenient way.

I thought of another solution of refactoring a bit the class, but it seems it would bring to many breaking changes because of `$value` and `$name` being declared as `protected` in the class. This is why I went for the factory way.