### PR TITLE
[Cache] Only validate dbindex parameter when applicable

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -66,6 +66,9 @@ class RedisAdapterTest extends AbstractRedisAdapterTestCase
         $this->assertTrue($redis->isConnected());
         $this->assertSame(0, $redis->getDbNum());
 
+        $redis = RedisAdapter::createConnection('redis://'.$uri.'/');
+        $this->assertSame(0, $redis->getDbNum());
+
         $redis = RedisAdapter::createConnection('redis://'.$uri.'/2');
         $this->assertSame(2, $redis->getDbNum());
 

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -148,7 +148,7 @@ trait RedisTrait
         }
 
         if (isset($params['host']) || isset($params['path'])) {
-            if (!isset($params['dbindex']) && isset($params['path'])) {
+            if (!isset($params['dbindex']) && isset($params['path']) && '/' !== $params['path']) {
                 if (preg_match('#/(\d+)$#', $params['path'], $m)) {
                     $params['dbindex'] = $m[1];
                     $params['path'] = substr($params['path'], 0, -\strlen($m[0]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/44215
| License       | MIT

It does not make sense to validate the path parameter when we _know_ that there can't be a dbindex. The problem with this validation is that it actually triggers when DSN looks something like: `redis://127.0.0.1:51148/` which happened to me in rare cases.
