### PR TITLE
[Twig] Remove Twig templates from preloading

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
@@ -42,15 +42,9 @@ class TemplateCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInte
     {
         $this->twig ??= $this->container->get('twig');
 
-        $files = [];
-
         foreach ($this->iterator as $template) {
             try {
-                $template = $this->twig->load($template);
-
-                if (\is_callable([$template, 'unwrap'])) {
-                    $files[] = (new \ReflectionClass($template->unwrap()))->getFileName();
-                }
+                $this->twig->load($template);
             } catch (Error) {
                 /*
                  * Problem during compilation, give up for this template (e.g. syntax errors).
@@ -63,7 +57,7 @@ class TemplateCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInte
             }
         }
 
-        return $files;
+        return [];
     }
 
     public function isOptional(): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49360
| License       | MIT

Twig templates loaded with TemplateCacheWarmer are no longer returned to avoid them being preloaded in OPCache as it may load a lot of files in memory without improving than much performance.

I've mostly cleanup code, as Reflection is not longer necessary since we just want to warmup Twig cache files and no longer returning them.
