### PR TITLE
[HttpFoundation] Deprecate passing invalid URI to Request::create

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -342,6 +342,10 @@ class Request
         $server['REQUEST_METHOD'] = strtoupper($method);
 
         $components = parse_url($uri);
+        if (false === $components) {
+            trigger_deprecation('symfony/http-foundation', '6.3', 'Calling "%s()" with an invalid URI is deprecated.', __METHOD__);
+            $components = [];
+        }
         if (isset($components['host'])) {
             $server['SERVER_NAME'] = $components['host'];
             $server['HTTP_HOST'] = $components['host'];

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2554,6 +2554,15 @@ class RequestTest extends TestCase
             $this->assertNotSame(0b10000000, $value, sprintf('The constant "%s" should not use the reserved value "0b10000000".', $constant));
         }
     }
+
+    /**
+     * @group legacy
+     */
+    public function testInvalidUriCreationDeprecated()
+    {
+        $this->expectDeprecation('Since symfony/http-foundation 6.3: Calling "Symfony\Component\HttpFoundation\Request::create()" with an invalid URI is deprecated.');
+        Request::create('/invalid-path:123');
+    }
 }
 
 class RequestContentProxy extends Request


### PR DESCRIPTION
Fixes: #47084

Passing an invalid URI to Request::create triggers an undefined code path. In PHP7 the false value returned by parse_url would quietly be treated as a an array through type coercion leading to unexpected results. In PHP8 this triggers a deprecation exposing the bug.

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #47084
| License       | MIT
