### PR TITLE
[DependencyInjection] Fix autowire attribute with nullable parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -276,23 +276,17 @@ class AutowirePass extends AbstractRecursivePass
                 continue;
             }
 
-            $type = ProxyHelper::exportType($parameter, true);
-
             if ($checkAttributes) {
                 foreach ($parameter->getAttributes() as $attribute) {
                     if (\in_array($attribute->getName(), [TaggedIterator::class, TaggedLocator::class, Autowire::class, MapDecorated::class], true)) {
                         $arguments[$index] = $this->processAttribute($attribute->newInstance(), $parameter->allowsNull());
 
-                        break;
+                        continue 2;
                     }
-                }
-
-                if ('' !== ($arguments[$index] ?? '')) {
-                    continue;
                 }
             }
 
-            if (!$type) {
+            if (!$type = ProxyHelper::exportType($parameter, true)) {
                 if (isset($arguments[$index])) {
                     continue;
                 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1185,21 +1185,23 @@ class AutowirePassTest extends TestCase
 
         $container->register('some.id', \stdClass::class);
         $container->setParameter('some.parameter', 'foo');
+        $container->setParameter('null.parameter', null);
 
         (new ResolveClassPass())->process($container);
         (new AutowirePass())->process($container);
 
         $definition = $container->getDefinition(AutowireAttribute::class);
 
-        $this->assertCount(8, $definition->getArguments());
+        $this->assertCount(9, $definition->getArguments());
         $this->assertEquals(new Reference('some.id'), $definition->getArgument(0));
         $this->assertEquals(new Expression("parameter('some.parameter')"), $definition->getArgument(1));
         $this->assertSame('foo/bar', $definition->getArgument(2));
-        $this->assertEquals(new Reference('some.id'), $definition->getArgument(3));
-        $this->assertEquals(new Expression("parameter('some.parameter')"), $definition->getArgument(4));
-        $this->assertSame('bar', $definition->getArgument(5));
-        $this->assertSame('@bar', $definition->getArgument(6));
-        $this->assertEquals(new Reference('invalid.id', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(7));
+        $this->assertNull($definition->getArgument(3));
+        $this->assertEquals(new Reference('some.id'), $definition->getArgument(4));
+        $this->assertEquals(new Expression("parameter('some.parameter')"), $definition->getArgument(5));
+        $this->assertSame('bar', $definition->getArgument(6));
+        $this->assertSame('@bar', $definition->getArgument(7));
+        $this->assertEquals(new Reference('invalid.id', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(8));
 
         $container->compile();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -40,6 +40,8 @@ class AutowireAttribute
         public string $expression,
         #[Autowire(value: '%some.parameter%/bar')]
         public string $value,
+        #[Autowire(value: '%null.parameter%')]
+        public ?string $nullableValue,
         #[Autowire('@some.id')]
         public \stdClass $serviceAsValue,
         #[Autowire("@=parameter('some.parameter')")]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49370
| License       | MIT
| Doc PR        | N/A

This PR fix throwing exception `Cannot autowire service "%s": argument "$%s" of method "%s()" %s, you should configure its value explicitly.` when parameter is nullable with null value. 

(sorry for pinging reviewers, switching branch trigger that)