### PR TITLE
Fix PHPUnit 9.6 deprecations

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -311,12 +311,25 @@ class ExpressionLanguageTest extends TestCase
     /**
      * @dataProvider provideInvalidNullSafe
      */
-    public function testNullSafeCompileFails($expression, $foo)
+    public function testNullSafeCompileFails($expression)
     {
         $expressionLanguage = new ExpressionLanguage();
 
-        $this->expectWarning();
-        eval(sprintf('return %s;', $expressionLanguage->compile($expression, ['foo' => 'foo'])));
+        $this->expectException(\ErrorException::class);
+
+        set_error_handler(static function (int $errno, string $errstr, string $errfile = null, int $errline = null): bool {
+            if ($errno & (\E_WARNING | \E_USER_WARNING)) {
+                throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+            }
+
+            return false;
+        });
+
+        try {
+            eval(sprintf('return %s;', $expressionLanguage->compile($expression, ['foo' => 'foo'])));
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public static function provideInvalidNullSafe()

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
@@ -373,7 +373,7 @@ class InfobipApiTransportTest extends TestCase
         $email = $this->basicValidEmail();
 
         $this->expectException(HttpTransportException::class);
-        $this->expectDeprecationMessage('Unable to send an email: ""');
+        $this->expectExceptionMessage('Unable to send an email: ""');
 
         $this->transport->send($email);
     }
@@ -384,7 +384,7 @@ class InfobipApiTransportTest extends TestCase
         $email = $this->basicValidEmail();
 
         $this->expectException(HttpTransportException::class);
-        $this->expectDeprecationMessage('Unable to send an email: "{"requestError": {"serviceException": {"messageId": "string","text": "string"}}}" (code 400)');
+        $this->expectExceptionMessage('Unable to send an email: "{"requestError": {"serviceException": {"messageId": "string","text": "string"}}}" (code 400)');
 
         $this->transport->send($email);
     }
@@ -395,7 +395,7 @@ class InfobipApiTransportTest extends TestCase
         $email = $this->basicValidEmail();
 
         $this->expectException(HttpTransportException::class);
-        $this->expectDeprecationMessage('Could not reach the remote Infobip server.');
+        $this->expectExceptionMessage('Could not reach the remote Infobip server.');
         $this->transport->send($email);
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunHttpTransportTest.php
@@ -132,8 +132,8 @@ class MailgunHttpTransportTest extends TestCase
 
         $this->assertCount(4, $email->getHeaders()->toArray());
         $this->assertSame('foo: bar', $email->getHeaders()->get('foo')->toString());
-        $this->assertCount(2, $email->getHeaders()->all('X-Mailgun-Tag'));
         $tagHeaders = iterator_to_array($email->getHeaders()->all('X-Mailgun-Tag'));
+        $this->assertCount(2, $tagHeaders);
         $this->assertSame('X-Mailgun-Tag: password-reset', $tagHeaders[0]->toString());
         $this->assertSame('X-Mailgun-Tag: product-name', $tagHeaders[1]->toString());
         $this->assertSame('X-Mailgun-Variables: '.json_encode(['Color' => 'blue', 'Client-ID' => '12345']), $email->getHeaders()->get('X-Mailgun-Variables')->toString());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Related to #49233
| License       | MIT
| Doc PR        | N/A

This PR fixes deprecations introduced by PHPUnit 9.6. We should merge this PR before merging up #49233.