### PR TITLE
[Notifier] Make `TransportTestCase` data providers static

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -75,6 +75,12 @@ Monolog
  * Deprecate `ResetLoggersWorkerSubscriber` to reset buffered logs in messenger
    workers, use `framework.messenger.reset_on_message` option in FrameworkBundle messenger configuration instead.
 
+Notifier
+--------
+
+ * [BC BREAK] The following data providers for `TransportTestCase` are now static: `toStringProvider()`, `supportedMessagesProvider()` and `unsupportedMessagesProvider()`
+ * [BC BREAK] The `TransportTestCase::createTransport()` method is now static
+
 SecurityBundle
 --------------
 

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/Tests/AllMySmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/Tests/AllMySmsTransportTest.php
@@ -13,9 +13,10 @@ namespace Symfony\Component\Notifier\Bridge\AllMySms\Tests;
 
 use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,25 +25,25 @@ final class AllMySmsTransportTest extends TransportTestCase
     /**
      * @return AllMySmsTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
     {
-        return new AllMySmsTransport('login', 'apiKey', $from, $client ?? $this->createMock(HttpClientInterface::class));
+        return new AllMySmsTransport('login', 'apiKey', $from, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['allmysms://api.allmysms.com', $this->createTransport()];
-        yield ['allmysms://api.allmysms.com?from=TEST', $this->createTransport(null, 'TEST')];
+        yield ['allmysms://api.allmysms.com', self::createTransport()];
+        yield ['allmysms://api.allmysms.com?from=TEST', self::createTransport(null, 'TEST')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\AllMySms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportTest.php
@@ -16,35 +16,36 @@ use AsyncAws\Sns\SnsClient;
 use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsOptions;
 use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
-use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Tests\Fixtures\TestOptions;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class AmazonSnsTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new AmazonSnsTransport(new SnsClient(['region' => 'eu-west-3']), $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new AmazonSnsTransport(new SnsClient(['region' => 'eu-west-3']), $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sns://host.test?region=eu-west-3', $this->createTransport()];
+        yield ['sns://host.test?region=eu-west-3', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0601020304', 'Hello!')];
         yield [new ChatMessage('Hello', new AmazonSnsOptions('my-topic'))];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
-        yield [$this->createMock(MessageInterface::class)];
-        yield [new ChatMessage('hello', $this->createMock(MessageOptionsInterface::class))];
+        yield [new DummyMessage()];
+        yield [new ChatMessage('hello', new TestOptions())];
     }
 
     public function testSmsMessageOptions()

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.4|^6.0",
+        "symfony/notifier": "^5.4.21|^6.2.7",
         "async-aws/sns": "^1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/Tests/ClickatellTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/Tests/ClickatellTransportTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -28,31 +30,31 @@ final class ClickatellTransportTest extends TransportTestCase
     /**
      * @return ClickatellTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
     {
-        return new ClickatellTransport('authToken', $from, $client ?? $this->createMock(HttpClientInterface::class));
+        return new ClickatellTransport('authToken', $from, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['clickatell://api.clickatell.com', $this->createTransport()];
-        yield ['clickatell://api.clickatell.com?from=TEST', $this->createTransport(null, 'TEST')];
+        yield ['clickatell://api.clickatell.com', self::createTransport()];
+        yield ['clickatell://api.clickatell.com?from=TEST', self::createTransport(null, 'TEST')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+33612345678', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testExceptionIsThrownWhenNonMessageIsSend()
     {
-        $transport = $this->createTransport();
+        $transport = self::createTransport();
 
         $this->expectException(LogicException::class);
 
@@ -77,7 +79,7 @@ final class ClickatellTransportTest extends TransportTestCase
 
         $client = new MockHttpClient($response);
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send SMS with Clickatell: Error code 105 with message "Invalid Account Reference EX0000000" (https://documentation-page).');

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Clickatell\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0",
+        "symfony/notifier": "^5.4.21|^6.2.7",
         "symfony/polyfill-mbstring": "^1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
@@ -15,9 +15,10 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -28,25 +29,25 @@ final class EsendexTransportTest extends TransportTestCase
     /**
      * @return EsendexTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new EsendexTransport('email', 'password', 'testAccountReference', 'testFrom', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new EsendexTransport('email', 'password', 'testAccountReference', 'testFrom', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['esendex://host.test?accountreference=testAccountReference&from=testFrom', $this->createTransport()];
+        yield ['esendex://host.test?accountreference=testAccountReference&from=testFrom', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithErrorResponseThrowsTransportException()
@@ -60,7 +61,7 @@ final class EsendexTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send the SMS: error 500.');
@@ -82,7 +83,7 @@ final class EsendexTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send the SMS: error 500. Details from Esendex: accountreference_invalid: "Invalid Account Reference EX0000000".');
@@ -105,7 +106,7 @@ final class EsendexTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send(new SmsMessage('phone', 'testMessage'));
 

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "require-dev": {
         "symfony/uid": "^5.4|^6.0"

--- a/src/Symfony/Component/Notifier/Bridge/Expo/Tests/ExpoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/Tests/ExpoTransportTest.php
@@ -12,10 +12,11 @@
 namespace Symfony\Component\Notifier\Bridge\Expo\Tests;
 
 use Symfony\Component\Notifier\Bridge\Expo\ExpoTransport;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\PushMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -27,24 +28,24 @@ final class ExpoTransportTest extends TransportTestCase
     /**
      * @return ExpoTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new ExpoTransport('token', $client ?? $this->createMock(HttpClientInterface::class));
+        return new ExpoTransport('token', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['expo://exp.host/--/api/v2/push/send', $this->createTransport()];
+        yield ['expo://exp.host/--/api/v2/push/send', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new PushMessage('Hello!', 'Symfony Notifier')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0670802161', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.4|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Expo\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatEmailTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatEmailTransportTest.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\Notifier\Bridge\FakeChat\Tests;
 
-use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Notifier\Bridge\FakeChat\FakeChatEmailTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Tests\Fixtures\TestOptions;
 use Symfony\Component\Notifier\Tests\Mailer\DummyMailer;
 use Symfony\Component\Notifier\Transport\TransportInterface;
@@ -25,9 +25,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FakeChatEmailTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $transportName = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $transportName = null): TransportInterface
     {
-        $transport = (new FakeChatEmailTransport($this->createMock(MailerInterface::class), 'recipient@email.net', 'sender@email.net', $client ?? $this->createMock(HttpClientInterface::class)));
+        $transport = (new FakeChatEmailTransport(new DummyMailer(), 'recipient@email.net', 'sender@email.net', $client ?? new DummyHttpClient()));
 
         if (null !== $transportName) {
             $transport->setHost($transportName);
@@ -36,21 +36,21 @@ final class FakeChatEmailTransportTest extends TransportTestCase
         return $transport;
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['fakechat+email://default?to=recipient@email.net&from=sender@email.net', $this->createTransport()];
-        yield ['fakechat+email://mailchimp?to=recipient@email.net&from=sender@email.net', $this->createTransport(null, 'mailchimp')];
+        yield ['fakechat+email://default?to=recipient@email.net&from=sender@email.net', self::createTransport()];
+        yield ['fakechat+email://mailchimp?to=recipient@email.net&from=sender@email.net', self::createTransport(null, 'mailchimp')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithDefaultTransportAndWithRecipient()

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatLoggerTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatLoggerTransportTest.php
@@ -14,34 +14,36 @@ namespace Symfony\Component\Notifier\Bridge\FakeChat\Tests;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Notifier\Bridge\FakeChat\FakeChatLoggerTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyLogger;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Tests\Fixtures\TestOptions;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FakeChatLoggerTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
     {
-        return new FakeChatLoggerTransport($logger ?? $this->createMock(LoggerInterface::class), $client ?? $this->createMock(HttpClientInterface::class));
+        return new FakeChatLoggerTransport($logger ?? new DummyLogger(), $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['fakechat+logger://default', $this->createTransport()];
+        yield ['fakechat+logger://default', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithDefaultTransport()
@@ -51,7 +53,7 @@ final class FakeChatLoggerTransportTest extends TransportTestCase
 
         $logger = new TestLogger();
 
-        $transport = $this->createTransport(null, $logger);
+        $transport = self::createTransport(null, $logger);
 
         $transport->send($message1);
         $transport->send($message2);

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0",
+        "symfony/notifier": "^5.4.21|^6.2.7",
         "symfony/mailer": "^5.2|^6.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsEmailTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsEmailTransportTest.php
@@ -11,22 +11,22 @@
 
 namespace Symfony\Component\Notifier\Bridge\FakeSms\Tests;
 
-use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsEmailTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Tests\Mailer\DummyMailer;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FakeSmsEmailTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $transportName = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $transportName = null): TransportInterface
     {
-        $transport = (new FakeSmsEmailTransport($this->createMock(MailerInterface::class), 'recipient@email.net', 'sender@email.net', $client ?? $this->createMock(HttpClientInterface::class)));
+        $transport = (new FakeSmsEmailTransport(new DummyMailer(), 'recipient@email.net', 'sender@email.net', $client ?? new DummyHttpClient()));
 
         if (null !== $transportName) {
             $transport->setHost($transportName);
@@ -35,22 +35,22 @@ final class FakeSmsEmailTransportTest extends TransportTestCase
         return $transport;
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['fakesms+email://default?to=recipient@email.net&from=sender@email.net', $this->createTransport()];
-        yield ['fakesms+email://mailchimp?to=recipient@email.net&from=sender@email.net', $this->createTransport(null, 'mailchimp')];
+        yield ['fakesms+email://default?to=recipient@email.net&from=sender@email.net', self::createTransport()];
+        yield ['fakesms+email://mailchimp?to=recipient@email.net&from=sender@email.net', self::createTransport(null, 'mailchimp')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new SmsMessage('+33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithDefaultTransport()

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsLoggerTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsLoggerTransportTest.php
@@ -14,36 +14,38 @@ namespace Symfony\Component\Notifier\Bridge\FakeSms\Tests;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsLoggerTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyLogger;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FakeSmsLoggerTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
     {
-        $transport = (new FakeSmsLoggerTransport($logger ?? $this->createMock(LoggerInterface::class), $client ?? $this->createMock(HttpClientInterface::class)));
+        $transport = (new FakeSmsLoggerTransport($logger ?? new DummyLogger(), $client ?? new DummyHttpClient()));
 
         return $transport;
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['fakesms+logger://default', $this->createTransport()];
+        yield ['fakesms+logger://default', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new SmsMessage('+33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithDefaultTransport()
@@ -52,7 +54,7 @@ final class FakeSmsLoggerTransportTest extends TransportTestCase
 
         $logger = new TestLogger();
 
-        $transport = $this->createTransport(null, $logger);
+        $transport = self::createTransport(null, $logger);
 
         $transport->send($message);
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0",
+        "symfony/notifier": "^5.4.21|^6.2.7",
         "symfony/mailer": "^5.2|^6.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
@@ -17,9 +17,10 @@ use Symfony\Component\Notifier\Bridge\Firebase\FirebaseOptions;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -32,25 +33,25 @@ final class FirebaseTransportTest extends TransportTestCase
     /**
      * @return FirebaseTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new FirebaseTransport('username:password', $client ?? $this->createMock(HttpClientInterface::class));
+        return new FirebaseTransport('username:password', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['firebase://fcm.googleapis.com/fcm/send', $this->createTransport()];
+        yield ['firebase://fcm.googleapis.com/fcm/send', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     /**
@@ -65,7 +66,7 @@ final class FirebaseTransportTest extends TransportTestCase
         });
         $options = new class('recipient-id', []) extends FirebaseOptions {};
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('Hello!', $options));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Firebase\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
@@ -13,9 +13,10 @@ namespace Symfony\Component\Notifier\Bridge\FreeMobile\Tests;
 
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,26 +25,26 @@ final class FreeMobileTransportTest extends TransportTestCase
     /**
      * @return FreeMobileTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new FreeMobileTransport('login', 'pass', '0611223344', $client ?? $this->createMock(HttpClientInterface::class));
+        return new FreeMobileTransport('login', 'pass', '0611223344', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['freemobile://smsapi.free-mobile.fr/sendmsg?phone=0611223344', $this->createTransport()];
+        yield ['freemobile://smsapi.free-mobile.fr/sendmsg?phone=0611223344', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new SmsMessage('+33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0699887766', 'Hello!')]; // because this phone number is not configured on the transport!
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.1|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FreeMobile\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportTest.php
@@ -14,10 +14,11 @@ namespace Symfony\Component\Notifier\Bridge\GatewayApi\Tests;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\GatewayApi\GatewayApiTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -31,25 +32,25 @@ final class GatewayApiTransportTest extends TransportTestCase
     /**
      * @return GatewayApiTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new GatewayApiTransport('authtoken', 'Symfony', $client ?? $this->createMock(HttpClientInterface::class));
+        return new GatewayApiTransport('authtoken', 'Symfony', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['gatewayapi://gatewayapi.com?from=Symfony', $this->createTransport()];
+        yield ['gatewayapi://gatewayapi.com?from=Symfony', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSend()
@@ -68,7 +69,7 @@ final class GatewayApiTransportTest extends TransportTestCase
 
         $message = new SmsMessage('3333333333', 'Hello!');
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
         $sentMessage = $transport->send($message);
 
         $this->assertInstanceOf(SentMessage::class, $sentMessage);

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\GatewayApi\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/Tests/GitterTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/Tests/GitterTransportTest.php
@@ -13,9 +13,10 @@ namespace Symfony\Component\Notifier\Bridge\Gitter\Tests;
 
 use Symfony\Component\Notifier\Bridge\Gitter\GitterTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +25,24 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class GitterTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new GitterTransport('token', '5539a3ee5etest0d3255bfef', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('api.gitter.im');
+        return (new GitterTransport('token', '5539a3ee5etest0d3255bfef', $client ?? new DummyHttpClient()))->setHost('api.gitter.im');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['gitter://api.gitter.im?room_id=5539a3ee5etest0d3255bfef', $this->createTransport()];
+        yield ['gitter://api.gitter.im?room_id=5539a3ee5etest0d3255bfef', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Gitter\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
@@ -17,11 +17,12 @@ use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -31,26 +32,26 @@ final class GoogleChatTransportTest extends TransportTestCase
     /**
      * @return GoogleChatTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $threadKey = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $threadKey = null): TransportInterface
     {
-        return new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $threadKey, $client ?? $this->createMock(HttpClientInterface::class));
+        return new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $threadKey, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['googlechat://chat.googleapis.com/My-Space', $this->createTransport()];
-        yield ['googlechat://chat.googleapis.com/My-Space?thread_key=abcdefg', $this->createTransport(null, 'abcdefg')];
+        yield ['googlechat://chat.googleapis.com/My-Space', self::createTransport()];
+        yield ['googlechat://chat.googleapis.com/My-Space?thread_key=abcdefg', self::createTransport(null, 'abcdefg')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithEmptyArrayResponseThrowsTransportException()
@@ -71,7 +72,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -95,7 +96,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -126,7 +127,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'My-Thread');
+        $transport = self::createTransport($client, 'My-Thread');
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -158,7 +159,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send($chatMessage);
 
@@ -174,7 +175,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $this->createMock(ResponseInterface::class);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }
@@ -203,7 +204,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\GoogleChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportTest.php
@@ -13,9 +13,10 @@ namespace Symfony\Component\Notifier\Bridge\Infobip\Tests;
 
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +25,24 @@ final class InfobipTransportTest extends TransportTestCase
     /**
      * @return InfobipTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new InfobipTransport('authtoken', '0611223344', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new InfobipTransport('authtoken', '0611223344', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['infobip://host.test?from=0611223344', $this->createTransport()];
+        yield ['infobip://host.test?from=0611223344', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Infobip\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class IqsmsTransportTest extends TransportTestCase
     /**
      * @return IqsmsTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new IqsmsTransport('login', 'password', 'sender', $client ?? $this->createMock(HttpClientInterface::class));
+        return new IqsmsTransport('login', 'password', 'sender', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['iqsms://api.iqsms.ru?from=sender', $this->createTransport()];
+        yield ['iqsms://api.iqsms.ru?from=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Iqsms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/Tests/LightSmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/Tests/LightSmsTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class LightSmsTransportTest extends TransportTestCase
     /**
      * @return LightSmsTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new LightSmsTransport('accountSid', 'authToken', 'from', $client ?? $this->createMock(HttpClientInterface::class));
+        return new LightSmsTransport('accountSid', 'authToken', 'from', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['lightsms://www.lightsms.com?from=from', $this->createTransport()];
+        yield ['lightsms://www.lightsms.com?from=from', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\LightSms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -30,25 +32,25 @@ final class LinkedInTransportTest extends TransportTestCase
     /**
      * @return LinkedInTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new LinkedInTransport('AuthToken', 'AccountId', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new LinkedInTransport('AuthToken', 'AccountId', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['linkedin://host.test', $this->createTransport()];
+        yield ['linkedin://host.test', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithEmptyArrayResponseThrowsTransportException()
@@ -65,7 +67,7 @@ final class LinkedInTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
 
@@ -90,7 +92,7 @@ final class LinkedInTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -134,7 +136,7 @@ final class LinkedInTransportTest extends TransportTestCase
 
             return $response;
         });
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage($message));
     }
@@ -182,7 +184,7 @@ final class LinkedInTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send($chatMessage);
     }
@@ -195,7 +197,7 @@ final class LinkedInTransportTest extends TransportTestCase
             return $this->createMock(ResponseInterface::class);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\LinkedIn\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/Tests/MailjetTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/Tests/MailjetTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class MailjetTransportTest extends TransportTestCase
     /**
      * @return MailjetTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new MailjetTransport('authtoken', 'Mailjet', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new MailjetTransport('authtoken', 'Mailjet', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['mailjet://Mailjet@host.test', $this->createTransport()];
+        yield ['mailjet://Mailjet@host.test', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3.4|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mailjet\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -27,24 +29,24 @@ final class MattermostTransportTest extends TransportTestCase
     /**
      * @return MattermostTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new MattermostTransport('testAccessToken', 'testChannel', null, $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new MattermostTransport('testAccessToken', 'testChannel', null, $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['mattermost://host.test?channel=testChannel', $this->createTransport()];
+        yield ['mattermost://host.test?channel=testChannel', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mattermost\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
@@ -26,6 +26,8 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHub;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use TypeError;
@@ -35,29 +37,29 @@ use TypeError;
  */
 final class MercureTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, HubInterface $hub = null, string $hubId = 'hubId', $topics = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, HubInterface $hub = null, string $hubId = 'hubId', $topics = null): TransportInterface
     {
-        $hub = $hub ?? $this->createMock(HubInterface::class);
+        $hub = $hub ?? new DummyHub();
 
         return new MercureTransport($hub, $hubId, $topics);
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['mercure://hubId?topic=https%3A%2F%2Fsymfony.com%2Fnotifier', $this->createTransport()];
-        yield ['mercure://customHubId?topic=%2Ftopic', $this->createTransport(null, null, 'customHubId', '/topic')];
-        yield ['mercure://customHubId?topic%5B0%5D=%2Ftopic%2F1&topic%5B1%5D%5B0%5D=%2Ftopic%2F2', $this->createTransport(null, null, 'customHubId', ['/topic/1', ['/topic/2']])];
+        yield ['mercure://hubId?topic=https%3A%2F%2Fsymfony.com%2Fnotifier', self::createTransport()];
+        yield ['mercure://customHubId?topic=%2Ftopic', self::createTransport(null, null, 'customHubId', '/topic')];
+        yield ['mercure://customHubId?topic%5B0%5D=%2Ftopic%2F1&topic%5B1%5D%5B0%5D=%2Ftopic%2F2', self::createTransport(null, null, 'customHubId', ['/topic/1', ['/topic/2']])];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testCanSetCustomPort()
@@ -78,13 +80,13 @@ final class MercureTransportTest extends TransportTestCase
     public function testConstructWithWrongTopicsThrows()
     {
         $this->expectException(TypeError::class);
-        $this->createTransport(null, null, 'publisherId', new \stdClass());
+        self::createTransport(null, null, 'publisherId', new \stdClass());
     }
 
     public function testSendWithNonMercureOptionsThrows()
     {
         $this->expectException(LogicException::class);
-        $this->createTransport()->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
+        self::createTransport()->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }
 
     public function testSendWithTransportFailureThrows()
@@ -96,7 +98,7 @@ final class MercureTransportTest extends TransportTestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to post the Mercure message: Cannot connect to mercure');
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject'));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject'));
     }
 
     public function testSendWithWrongTokenThrows()
@@ -108,7 +110,7 @@ final class MercureTransportTest extends TransportTestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to post the Mercure message: The provided JWT is not valid');
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject'));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject'));
     }
 
     public function testSendWithMercureOptions()
@@ -124,7 +126,7 @@ final class MercureTransportTest extends TransportTestCase
             return 'id';
         });
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject', new MercureOptions(['/topic/1', '/topic/2'], true, 'id', 'type', 1)));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject', new MercureOptions(['/topic/1', '/topic/2'], true, 'id', 'type', 1)));
     }
 
     public function testSendWithMercureOptionsButWithoutOptionTopic()
@@ -140,7 +142,7 @@ final class MercureTransportTest extends TransportTestCase
             return 'id';
         });
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject', new MercureOptions(null, true, 'id', 'type', 1)));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject', new MercureOptions(null, true, 'id', 'type', 1)));
     }
 
     public function testSendWithoutMercureOptions()
@@ -153,7 +155,7 @@ final class MercureTransportTest extends TransportTestCase
             return 'id';
         });
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject'));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject'));
     }
 
     public function testSendSuccessfully()
@@ -164,7 +166,7 @@ final class MercureTransportTest extends TransportTestCase
             return $messageId;
         });
 
-        $sentMessage = $this->createTransport(null, $hub)->send(new ChatMessage('subject'));
+        $sentMessage = self::createTransport(null, $hub)->send(new ChatMessage('subject'));
         $this->assertSame($messageId, $sentMessage->getMessageId());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "symfony/mercure": "^0.5.2|^0.6",
-        "symfony/notifier": "^5.3|^6.0",
+        "symfony/notifier": "^5.4.21|^6.2.7",
         "symfony/service-contracts": "^1.10|^2|^3"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/Tests/MessageBirdTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/Tests/MessageBirdTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class MessageBirdTransportTest extends TransportTestCase
     /**
      * @return MessageBirdTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new MessageBirdTransport('token', 'from', $client ?? $this->createMock(HttpClientInterface::class));
+        return new MessageBirdTransport('token', 'from', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['messagebird://rest.messagebird.com?from=from', $this->createTransport()];
+        yield ['messagebird://rest.messagebird.com?from=from', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MessageBird\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/Tests/MessageMediaTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/Tests/MessageMediaTransportTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -28,26 +30,26 @@ final class MessageMediaTransportTest extends TransportTestCase
     /**
      * @return MessageMediaTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
     {
-        return new MessageMediaTransport('apiKey', 'apiSecret', $from, $client ?? $this->createMock(HttpClientInterface::class));
+        return new MessageMediaTransport('apiKey', 'apiSecret', $from, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['messagemedia://api.messagemedia.com', $this->createTransport()];
-        yield ['messagemedia://api.messagemedia.com?from=TEST', $this->createTransport(null, 'TEST')];
+        yield ['messagemedia://api.messagemedia.com', self::createTransport()];
+        yield ['messagemedia://api.messagemedia.com?from=TEST', self::createTransport(null, 'TEST')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0491570156', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MessageMedia\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Tests/MicrosoftTeamsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Tests/MicrosoftTeamsTransportTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -30,25 +32,25 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
     /**
      * @return MicrosoftTeamsTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new MicrosoftTeamsTransport('/testPath', $client ?: $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new MicrosoftTeamsTransport('/testPath', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['microsoftteams://host.test/testPath', $this->createTransport()];
+        yield ['microsoftteams://host.test/testPath', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithErrorResponseThrows()
@@ -57,7 +59,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('testErrorMessage', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 400]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/testErrorMessage/');
@@ -69,7 +71,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
     {
         $client = new MockHttpClient(new MockResponse());
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/request-id not found/');
@@ -91,7 +93,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('1', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 200]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage($message));
     }
@@ -113,7 +115,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('1', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 200]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage($message, $options));
     }
@@ -140,7 +142,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('1', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 200]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage($message, $options));
     }
@@ -160,7 +162,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('1', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 200]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send($chatMessage);
     }

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MicrosoftTeams\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytTransportTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -28,25 +30,25 @@ final class MobytTransportTest extends TransportTestCase
     /**
      * @return MobytTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $messageType = MobytOptions::MESSAGE_TYPE_QUALITY_LOW): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $messageType = MobytOptions::MESSAGE_TYPE_QUALITY_LOW): TransportInterface
     {
-        return (new MobytTransport('accountSid', 'authToken', 'from', $messageType, $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new MobytTransport('accountSid', 'authToken', 'from', $messageType, $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['mobyt://host.test?from=from&type_quality=LL', $this->createTransport()];
-        yield ['mobyt://host.test?from=from&type_quality=N', $this->createTransport(null, MobytOptions::MESSAGE_TYPE_QUALITY_HIGH)];
+        yield ['mobyt://host.test?from=from&type_quality=LL', self::createTransport()];
+        yield ['mobyt://host.test?from=from&type_quality=N', self::createTransport(null, MobytOptions::MESSAGE_TYPE_QUALITY_HIGH)];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mobyt\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -27,24 +29,24 @@ final class NexmoTransportTest extends TransportTestCase
     /**
      * @return NexmoTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new NexmoTransport('apiKey', 'apiSecret', 'sender', $client ?? $this->createMock(HttpClientInterface::class));
+        return new NexmoTransport('apiKey', 'apiSecret', 'sender', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['nexmo://rest.nexmo.com?from=sender', $this->createTransport()];
+        yield ['nexmo://rest.nexmo.com?from=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Nexmo\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/Tests/OctopushTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/Tests/OctopushTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class OctopushTransportTest extends TransportTestCase
     /**
      * @return OctopushTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new OctopushTransport('userLogin', 'apiKey', 'from', 'type', $client ?? $this->createMock(HttpClientInterface::class));
+        return new OctopushTransport('userLogin', 'apiKey', 'from', 'type', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['octopush://www.octopush-dm.com?from=from&type=type', $this->createTransport()];
+        yield ['octopush://www.octopush-dm.com?from=from&type=type', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Octopush\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/Tests/OneSignalTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/Tests/OneSignalTransportTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\PushMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -33,14 +35,14 @@ final class OneSignalTransportTest extends TransportTestCase
     /**
      * @return OneSignalTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $recipientId = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $recipientId = null): TransportInterface
     {
-        return new OneSignalTransport('9fb175f0-0b32-4e99-ae97-bd228b9eb246', 'api_key', $recipientId, $client ?? $this->createMock(HttpClientInterface::class));
+        return new OneSignalTransport('9fb175f0-0b32-4e99-ae97-bd228b9eb246', 'api_key', $recipientId, $client ?? new DummyHttpClient());
     }
 
     public function testCanSetCustomHost()
     {
-        $transport = $this->createTransport();
+        $transport = self::createTransport();
 
         $transport->setHost($customHost = self::CUSTOM_HOST);
 
@@ -49,7 +51,7 @@ final class OneSignalTransportTest extends TransportTestCase
 
     public function testCanSetCustomHostAndPort()
     {
-        $transport = $this->createTransport();
+        $transport = self::createTransport();
 
         $transport->setHost($customHost = self::CUSTOM_HOST);
         $transport->setPort($customPort = self::CUSTOM_PORT);
@@ -57,33 +59,33 @@ final class OneSignalTransportTest extends TransportTestCase
         $this->assertSame(sprintf('onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@%s:%d', $customHost, $customPort), (string) $transport);
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@onesignal.com', $this->createTransport()];
-        yield ['onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@onesignal.com?recipientId=ea345989-d273-4f21-a33b-0c006efc5edb', $this->createTransport(null, 'ea345989-d273-4f21-a33b-0c006efc5edb')];
+        yield ['onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@onesignal.com', self::createTransport()];
+        yield ['onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@onesignal.com?recipientId=ea345989-d273-4f21-a33b-0c006efc5edb', self::createTransport(null, 'ea345989-d273-4f21-a33b-0c006efc5edb')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
-        yield [new PushMessage('Hello', 'World'), $this->createTransport(null, 'ea345989-d273-4f21-a33b-0c006efc5edb')];
+        yield [new PushMessage('Hello', 'World'), self::createTransport(null, 'ea345989-d273-4f21-a33b-0c006efc5edb')];
         yield [new PushMessage('Hello', 'World', (new OneSignalOptions())->recipient('ea345989-d273-4f21-a33b-0c006efc5edb'))];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testUnsupportedWithoutRecipientId()
     {
-        $this->assertFalse($this->createTransport()->supports(new PushMessage('Hello', 'World')));
+        $this->assertFalse(self::createTransport()->supports(new PushMessage('Hello', 'World')));
     }
 
     public function testSendThrowsWithoutRecipient()
     {
-        $transport = $this->createTransport();
+        $transport = self::createTransport();
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The "Symfony\Component\Notifier\Bridge\OneSignal\OneSignalTransport" transport should have configured `defaultRecipientId` via DSN or provided with message options.');
@@ -105,7 +107,7 @@ final class OneSignalTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
+        $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/Message Notifications must have English language content/');
@@ -127,7 +129,7 @@ final class OneSignalTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
+        $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/All included players are not subscribed/');
@@ -153,7 +155,7 @@ final class OneSignalTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
+        $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
 
         $sentMessage = $transport->send(new PushMessage('Hello', 'World'));
 

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.4|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OneSignal\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -27,26 +29,26 @@ final class OvhCloudTransportTest extends TransportTestCase
     /**
      * @return OvhCloudTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $sender = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $sender = null): TransportInterface
     {
-        return (new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $client ?? $this->createMock(HttpClientInterface::class)))->setSender($sender);
+        return (new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $client ?? new DummyHttpClient()))->setSender($sender);
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName', $this->createTransport()];
-        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&sender=sender', $this->createTransport(null, 'sender')];
+        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName', self::createTransport()];
+        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&sender=sender', self::createTransport(null, 'sender')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function validMessagesProvider(): iterable
@@ -82,7 +84,7 @@ final class OvhCloudTransportTest extends TransportTestCase
             $lastResponse,
         ];
 
-        $transport = $this->createTransport(new MockHttpClient($responses));
+        $transport = self::createTransport(new MockHttpClient($responses));
         $transport->send($smsMessage);
 
         $body = $lastResponse->getRequestOptions()['body'];
@@ -109,7 +111,7 @@ final class OvhCloudTransportTest extends TransportTestCase
             new MockResponse($data),
         ];
 
-        $transport = $this->createTransport(new MockHttpClient($responses));
+        $transport = self::createTransport(new MockHttpClient($responses));
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Attempt to send the SMS to invalid receivers: "invalid_receiver"');

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OvhCloud\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -27,25 +29,25 @@ final class RocketChatTransportTest extends TransportTestCase
     /**
      * @return RocketChatTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $channel = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $channel = null): TransportInterface
     {
-        return new RocketChatTransport('testAccessToken', $channel, $client ?? $this->createMock(HttpClientInterface::class));
+        return new RocketChatTransport('testAccessToken', $channel, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['rocketchat://rocketchat.com', $this->createTransport()];
-        yield ['rocketchat://rocketchat.com?channel=testChannel', $this->createTransport(null, 'testChannel')];
+        yield ['rocketchat://rocketchat.com', self::createTransport()];
+        yield ['rocketchat://rocketchat.com?channel=testChannel', self::createTransport(null, 'testChannel')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\RocketChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -27,25 +29,25 @@ final class SendinblueTransportTest extends TransportTestCase
     /**
      * @return SendinblueTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new SendinblueTransport('api-key', '0611223344', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new SendinblueTransport('api-key', '0611223344', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sendinblue://host.test?sender=0611223344', $this->createTransport()];
+        yield ['sendinblue://host.test?sender=0611223344', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithErrorResponseThrowsTransportException()
@@ -62,7 +64,7 @@ final class SendinblueTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send the SMS: bad request');

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sendinblue\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class SinchTransportTest extends TransportTestCase
     /**
      * @return SinchTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new SinchTransport('accountSid', 'authToken', 'sender', $client ?? $this->createMock(HttpClientInterface::class));
+        return new SinchTransport('accountSid', 'authToken', 'sender', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sinch://sms.api.sinch.com?from=sender', $this->createTransport()];
+        yield ['sinch://sms.api.sinch.com?from=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sinch\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -23,6 +23,8 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -32,26 +34,26 @@ final class SlackTransportTest extends TransportTestCase
     /**
      * @return SlackTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $channel = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $channel = null): TransportInterface
     {
-        return new SlackTransport('xoxb-TestToken', $channel, $client ?? $this->createMock(HttpClientInterface::class));
+        return new SlackTransport('xoxb-TestToken', $channel, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['slack://slack.com', $this->createTransport()];
-        yield ['slack://slack.com?channel=test+Channel', $this->createTransport(null, 'test Channel')];
+        yield ['slack://slack.com', self::createTransport()];
+        yield ['slack://slack.com?channel=test+Channel', self::createTransport(null, 'test Channel')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testInstatiatingWithAnInvalidSlackTokenThrowsInvalidArgumentException()
@@ -78,7 +80,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -101,7 +103,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -129,7 +131,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, $channel);
+        $transport = self::createTransport($client, $channel);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -167,7 +169,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, $channel);
+        $transport = self::createTransport($client, $channel);
 
         $sentMessage = $transport->send($chatMessage);
 
@@ -182,7 +184,7 @@ final class SlackTransportTest extends TransportTestCase
             return $this->createMock(ResponseInterface::class);
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }
@@ -212,7 +214,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, $channel);
+        $transport = self::createTransport($client, $channel);
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -235,7 +237,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -260,7 +262,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to post the Slack message: "invalid_blocks" (no more than 50 items allowed [json-pointer:/blocks]).');

--- a/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Slack\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,25 +26,25 @@ final class Sms77TransportTest extends TransportTestCase
     /**
      * @return Sms77Transport
      */
-    public function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
     {
-        return new Sms77Transport('apiKey', $from, $client ?? $this->createMock(HttpClientInterface::class));
+        return new Sms77Transport('apiKey', $from, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sms77://gateway.sms77.io', $this->createTransport()];
-        yield ['sms77://gateway.sms77.io?from=TEST', $this->createTransport(null, 'TEST')];
+        yield ['sms77://gateway.sms77.io', self::createTransport()];
+        yield ['sms77://gateway.sms77.io?from=TEST', self::createTransport(null, 'TEST')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sms77\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/Tests/SmsBiurasTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/Tests/SmsBiurasTransportTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -26,25 +28,25 @@ final class SmsBiurasTransportTest extends TransportTestCase
     /**
      * @return SmsBiurasTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new SmsBiurasTransport('uid', 'api_key', 'from', true, $client ?? $this->createMock(HttpClientInterface::class));
+        return new SmsBiurasTransport('uid', 'api_key', 'from', true, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['smsbiuras://savitarna.smsbiuras.lt?from=from&test_mode=1', $this->createTransport()];
+        yield ['smsbiuras://savitarna.smsbiuras.lt?from=from&test_mode=1', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SmsBiuras\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -27,25 +29,25 @@ final class SmsapiTransportTest extends TransportTestCase
     /**
      * @return SmsapiTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new SmsapiTransport('testToken', 'testFrom', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('test.host');
+        return (new SmsapiTransport('testToken', 'testFrom', $client ?? new DummyHttpClient()))->setHost('test.host');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['smsapi://test.host?from=testFrom', $this->createTransport()];
+        yield ['smsapi://test.host?from=testFrom', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function createClient(int $statusCode, string $content): HttpClientInterface
@@ -75,7 +77,7 @@ final class SmsapiTransportTest extends TransportTestCase
     public function testThrowExceptionWhenMessageWasNotSent(int $statusCode, string $content, string $errorMessage)
     {
         $client = $this->createClient($statusCode, $content);
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
         $message = new SmsMessage('0611223344', 'Hello!');
 
         $this->expectException(TransportException::class);

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsapi\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/Tests/SmscTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/Tests/SmscTransportTest.php
@@ -16,29 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class SmscTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new SmscTransport('login', 'password', 'MyApp', $client ?? $this->createMock(HttpClientInterface::class));
+        return new SmscTransport('login', 'password', 'MyApp', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['smsc://smsc.ru?from=MyApp', $this->createTransport()];
+        yield ['smsc://smsc.ru?from=MyApp', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsc\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,25 +26,25 @@ final class SpotHitTransportTest extends TransportTestCase
     /**
      * @return SpotHitTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new SpotHitTransport('api_token', 'MyCompany', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new SpotHitTransport('api_token', 'MyCompany', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['spothit://host.test?from=MyCompany', $this->createTransport()];
+        yield ['spothit://host.test?from=MyCompany', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new SmsMessage('+33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.1|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SpotHit\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -28,26 +30,26 @@ final class TelegramTransportTest extends TransportTestCase
     /**
      * @return TelegramTransport
      */
-    public function createTransport(HttpClientInterface $client = null, string $channel = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null, string $channel = null): TransportInterface
     {
-        return new TelegramTransport('token', $channel, $client ?? $this->createMock(HttpClientInterface::class));
+        return new TelegramTransport('token', $channel, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['telegram://api.telegram.org', $this->createTransport()];
-        yield ['telegram://api.telegram.org?channel=testChannel', $this->createTransport(null, 'testChannel')];
+        yield ['telegram://api.telegram.org', self::createTransport()];
+        yield ['telegram://api.telegram.org?channel=testChannel', self::createTransport(null, 'testChannel')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithErrorResponseThrowsTransportException()
@@ -67,7 +69,7 @@ final class TelegramTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -119,7 +121,7 @@ JSON;
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -175,7 +177,7 @@ JSON;
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'defaultChannel');
+        $transport = self::createTransport($client, 'defaultChannel');
 
         $messageOptions = new TelegramOptions();
         $messageOptions->chatId($channelOverride);
@@ -233,7 +235,7 @@ JSON;
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('I contain special characters _ * [ ] ( ) ~ ` > # + - = | { } . ! to send.'));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Telegram\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/Tests/TelnyxTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/Tests/TelnyxTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class TelnyxTransportTest extends TransportTestCase
     /**
      * @return TelnyxTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new TelnyxTransport('api_key', 'from', 'messaging_profile_id', $client ?? $this->createMock(HttpClientInterface::class));
+        return new TelnyxTransport('api_key', 'from', 'messaging_profile_id', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['telnyx://api.telnyx.com?from=from&messaging_profile_id=messaging_profile_id', $this->createTransport()];
+        yield ['telnyx://api.telnyx.com?from=from&messaging_profile_id=messaging_profile_id', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Telnyx\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -29,25 +31,25 @@ final class TurboSmsTransportTest extends TransportTestCase
     /**
      * @return TurboSmsTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new TurboSmsTransport('authToken', 'sender', $client ?? $this->createMock(HttpClientInterface::class));
+        return new TurboSmsTransport('authToken', 'sender', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['turbosms://api.turbosms.ua?from=sender', $this->createTransport()];
+        yield ['turbosms://api.turbosms.ua?from=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('380931234567', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSuccessfulSend()
@@ -81,7 +83,7 @@ final class TurboSmsTransportTest extends TransportTestCase
 
         $message = new SmsMessage('380931234567', 'Тест/Test');
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
         $sentMessage = $transport->send($message);
 
         self::assertInstanceOf(SentMessage::class, $sentMessage);
@@ -112,7 +114,7 @@ final class TurboSmsTransportTest extends TransportTestCase
 
         $message = new SmsMessage('380931234567', 'Тест/Test');
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send SMS with TurboSMS: Error code 103 with message "REQUIRED_TOKEN".');

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "symfony/http-client": "^5.3|^6.0",
-        "symfony/notifier": "^5.3|^6.0",
+        "symfony/notifier": "^5.4.21|^6.2.7",
         "symfony/polyfill-mbstring": "^1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Twilio\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/Tests/VonageTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/Tests/VonageTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class VonageTransportTest extends TransportTestCase
     /**
      * @return VonageTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new VonageTransport('apiKey', 'apiSecret', 'sender', $client ?? $this->createMock(HttpClientInterface::class));
+        return new VonageTransport('apiKey', 'apiSecret', 'sender', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['vonage://rest.nexmo.com?from=sender', $this->createTransport()];
+        yield ['vonage://rest.nexmo.com?from=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Vonage\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class YunpianTransportTest extends TransportTestCase
     /**
      * @return YunpianTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return new YunpianTransport('api_key', $client ?? $this->createMock(HttpClientInterface::class));
+        return new YunpianTransport('api_key', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['yunpian://sms.yunpian.com', $this->createTransport()];
+        yield ['yunpian://sms.yunpian.com', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.2|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Yunpian\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,24 +26,24 @@ final class ZulipTransportTest extends TransportTestCase
     /**
      * @return ZulipTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new ZulipTransport('testEmail', 'testToken', 'testChannel', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('test.host');
+        return (new ZulipTransport('testEmail', 'testToken', 'testChannel', $client ?? new DummyHttpClient()))->setHost('test.host');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['zulip://test.host?channel=testChannel', $this->createTransport()];
+        yield ['zulip://test.host?channel=testChannel', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4.21|^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Zulip\\": "" },

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.4.21
+------
+
+ * [BC BREAK] The following data providers for `TransportTestCase` are now static: `toStringProvider()`, `supportedMessagesProvider()` and `unsupportedMessagesProvider()`
+ * [BC BREAK] `TransportTestCase::createTransport()` is now static
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Test/TransportTestCase.php
+++ b/src/Symfony/Component/Notifier/Test/TransportTestCase.php
@@ -27,22 +27,22 @@ abstract class TransportTestCase extends TestCase
     protected const CUSTOM_HOST = 'host.test';
     protected const CUSTOM_PORT = 42;
 
-    abstract public function createTransport(HttpClientInterface $client = null): TransportInterface;
+    abstract static public function createTransport(HttpClientInterface $client = null): TransportInterface;
 
     /**
      * @return iterable<array{0: string, 1: TransportInterface}>
      */
-    abstract public function toStringProvider(): iterable;
+    abstract public static function toStringProvider(): iterable;
 
     /**
      * @return iterable<array{0: MessageInterface, 1: TransportInterface}>
      */
-    abstract public function supportedMessagesProvider(): iterable;
+    abstract public static function supportedMessagesProvider(): iterable;
 
     /**
      * @return iterable<array{0: MessageInterface, 1: TransportInterface}>
      */
-    abstract public function unsupportedMessagesProvider(): iterable;
+    abstract public static function unsupportedMessagesProvider(): iterable;
 
     /**
      * @dataProvider toStringProvider

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyHttpClient.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyHttpClient.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+class DummyHttpClient implements HttpClientInterface
+{
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+    }
+
+    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    {
+    }
+
+    public function withOptions(array $options): HttpClientInterface
+    {
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyHub.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyHub.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
+use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
+use Symfony\Component\Mercure\Update;
+
+class DummyHub implements HubInterface
+{
+    public function getUrl(): string
+    {
+    }
+
+    public function getPublicUrl(): string
+    {
+    }
+
+    public function getProvider(): TokenProviderInterface
+    {
+    }
+
+    public function getFactory(): ?TokenFactoryInterface
+    {
+        return null;
+    }
+
+    public function publish(Update $update): string
+    {
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyLogger.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyLogger.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Psr\Log\LoggerInterface;
+
+class DummyLogger implements LoggerInterface
+{
+    public function emergency($message, array $context = []): void
+    {
+    }
+
+    public function alert($message, array $context = []): void
+    {
+    }
+
+    public function critical($message, array $context = []): void
+    {
+    }
+
+    public function error($message, array $context = []): void
+    {
+    }
+
+    public function warning($message, array $context = []): void
+    {
+    }
+
+    public function notice($message, array $context = []): void
+    {
+    }
+
+    public function info($message, array $context = []): void
+    {
+    }
+
+    public function debug($message, array $context = []): void
+    {
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyMailer.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyMailer.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\RawMessage;
+
+class DummyMailer implements MailerInterface
+{
+    public function send(RawMessage $message, Envelope $envelope = null): void
+    {
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyMessage.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyMessage.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+class DummyMessage implements MessageInterface
+{
+    public function getRecipientId(): ?string
+    {
+        return null;
+    }
+
+    public function getSubject(): string
+    {
+        return '';
+    }
+
+    public function getOptions(): ?MessageOptionsInterface
+    {
+        return null;
+    }
+
+    public function getTransport(): ?string
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of https://github.com/symfony/symfony/pull/49368
| License       | MIT
| Doc PR        | -

:information_source: Note: the `TransportTestCase::createTransport()` method also had to be passed to static.

cc @OskarStark 