### PR TITLE
[CssSelector] Add `:has()` support

### DIFF
--- a/src/Symfony/Component/CssSelector/CHANGELOG.md
+++ b/src/Symfony/Component/CssSelector/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for `:has()`
+
 7.1
 ---
 

--- a/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
+++ b/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
@@ -17,7 +17,7 @@ use Symfony\Component\CssSelector\Parser\Token;
  * ParseException is thrown when a CSS selector syntax is not valid.
  *
  * This component is a port of the Python cssselect library,
- * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
+ * which is copyright Ian Bicking, @see https://github.com/scrapy/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
  */

--- a/src/Symfony/Component/CssSelector/Node/RelationNode.php
+++ b/src/Symfony/Component/CssSelector/Node/RelationNode.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\CssSelector\Node;
+
+/**
+ * Represents a "<selector>:has(<subselector>)" node.
+ *
+ * This component is a port of the Python cssselect library,
+ * which is copyright Ian Bicking, @see https://github.com/scrapy/cssselect.
+ *
+ * @author Franck Ranaivo-Harisoa <franckranaivo@gmail.com>
+ *
+ * @internal
+ */
+class RelationNode extends AbstractNode
+{
+    public function __construct(
+        private NodeInterface $selector,
+        private string $combinator,
+        private NodeInterface $subSelector,
+    ) {
+    }
+
+    public function getSelector(): NodeInterface
+    {
+        return $this->selector;
+    }
+
+    public function getCombinator(): string
+    {
+        return $this->combinator;
+    }
+
+    public function getSubSelector(): NodeInterface
+    {
+        return $this->subSelector;
+    }
+
+    public function getSpecificity(): Specificity
+    {
+        return $this->selector->getSpecificity()->plus($this->subSelector->getSpecificity());
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('%s[%s:has(%s)]', $this->getNodeName(), $this->selector, $this->subSelector);
+    }
+}

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\CssSelector\Parser;
 
+use Symfony\Component\CssSelector\Exception\InternalErrorException;
 use Symfony\Component\CssSelector\Exception\SyntaxErrorException;
 use Symfony\Component\CssSelector\Node;
 use Symfony\Component\CssSelector\Parser\Tokenizer\Tokenizer;
@@ -145,9 +146,45 @@ class Parser implements ParserInterface
     }
 
     /**
+     * @throws SyntaxErrorException
+     * @throws InternalErrorException
+     */
+    private function parseRelativeSelector(TokenStream $stream): array
+    {
+        $stream->skipWhitespace();
+        $subSelector = '';
+        $next = $stream->getNext();
+
+        if ($next->isDelimiter(['+', '>', '~'])) {
+            $combinator = $next->getValue();
+            $stream->skipWhitespace();
+            $next = $stream->getNext();
+        } else {
+            $combinator = ' ';
+        }
+
+        while (true) {
+            if ($next->isString() || $next->isIdentifier() || $next->isNumber() || $next->isDelimiter(['.', '*'])) {
+                $subSelector .= $next->getValue();
+            } elseif ($next->isHash()) {
+                $subSelector .= '#'.$next->getValue();
+            } elseif ($next->isDelimiter([')'])) {
+                $result = $this->parse($subSelector);
+
+                return [$combinator, $result[0]];
+            } else {
+                throw SyntaxErrorException::unexpectedToken('an argument', $next);
+            }
+
+            $next = $stream->getNext();
+        }
+    }
+
+    /**
      * Parses next simple node (hash, class, pseudo, negation).
      *
      * @throws SyntaxErrorException
+     * @throws InternalErrorException
      */
     private function parseSimpleSelector(TokenStream $stream, bool $insideNegation = false, bool $isArgument = false): array
     {
@@ -253,6 +290,9 @@ class Parser implements ParserInterface
                     }
 
                     $result = new Node\SpecificityAdjustmentNode($result, $selectors);
+                } elseif ('has' === strtolower($identifier)) {
+                    [$combinator, $arguments] = $this->parseRelativeSelector($stream);
+                    $result = new Node\RelationNode($result, $combinator, $arguments);
                 } else {
                     $arguments = [];
                     $next = null;

--- a/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
@@ -135,6 +135,7 @@ class ParserTest extends TestCase
             ['div:contains("foo")', ["Function[Element[div]:contains(['foo'])]"]],
             ['div#foobar', ['Hash[Element[div]#foobar]']],
             ['div:not(div.foo)', ['Negation[Element[div]:not(Class[Element[div].foo])]']],
+            ['div:has(div.foo)', ['Relation[Element[div]:has(Selector[Class[Element[div].foo]])]']],
             ['td ~ th', ['CombinedSelector[Element[td] ~ Element[th]]']],
             ['.foo[data-bar][data-baz=0]', ["Attribute[Attribute[Class[Element[*].foo][data-bar]][data-baz = '0']]"]],
             ['div#foo\.bar', ['Hash[Element[div]#foo.bar]']],

--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -236,6 +236,11 @@ class TranslatorTest extends TestCase
             [':scope', '*[1]'],
             ['e:is(section, article) h1', "e[(name() = 'section') or (name() = 'article')]/descendant-or-self::*/h1"],
             ['e:where(section, article) h1', "e[(name() = 'section') or (name() = 'article')]/descendant-or-self::*/h1"],
+            ['div:has(> .foo)', "div[./*[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]]"],
+            ['div:has(~ .foo)', "div[following-sibling::*[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]]"],
+            ['div:has(+ .foo)', "div[following-sibling::*[(@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')) and (position() = 1)]]"],
+            ['div:has(.foo)', "div[descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]]"],
+            ['div:has(#bar)', "div[descendant-or-self::*[@id = 'bar']]"],
         ];
     }
 

--- a/src/Symfony/Component/CssSelector/XPath/Extension/AbstractExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/AbstractExtension.php
@@ -15,7 +15,7 @@ namespace Symfony\Component\CssSelector\XPath\Extension;
  * XPath expression translator abstract extension.
  *
  * This component is a port of the Python cssselect library,
- * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
+ * which is copyright Ian Bicking, @see https://github.com/scrapy/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
  *
@@ -44,6 +44,11 @@ abstract class AbstractExtension implements ExtensionInterface
     }
 
     public function getAttributeMatchingTranslators(): array
+    {
+        return [];
+    }
+
+    public function getRelativeCombinationTranslators(): array
     {
         return [];
     }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/ExtensionInterface.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Component\CssSelector\XPath\Extension;
 
+use Symfony\Component\CssSelector\XPath\XPathExpr;
+
 /**
  * XPath expression translator extension interface.
  *
  * This component is a port of the Python cssselect library,
- * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
+ * which is copyright Ian Bicking, @see https://github.com/scrapy/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
  *
@@ -59,6 +61,13 @@ interface ExtensionInterface
      * @return callable[]
      */
     public function getAttributeMatchingTranslators(): array;
+
+    /**
+     * Returns combination translators found inside ":has()" relation.
+     *
+     * @return array<string, callable(XPathExpr, XPathExpr): XPathExpr>
+     */
+    public function getRelativeCombinationTranslators(): array;
 
     /**
      * Returns extension name.

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  * XPath expression translator node extension.
  *
  * This component is a port of the Python cssselect library,
- * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
+ * which is copyright Ian Bicking, @see https://github.com/scrapy/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
  *
@@ -71,6 +71,7 @@ class NodeExtension extends AbstractExtension
             'Class' => $this->translateClass(...),
             'Hash' => $this->translateHash(...),
             'Element' => $this->translateElement(...),
+            'Relation' => $this->translateRelation(...),
         ];
     }
 
@@ -207,6 +208,13 @@ class NodeExtension extends AbstractExtension
         }
 
         return $xpath;
+    }
+
+    public function translateRelation(Node\RelationNode $node, Translator $translator): XPathExpr
+    {
+        $combinator = $node->getCombinator();
+
+        return $translator->addRelativeCombination($combinator, $node->getSelector(), $node->getSubSelector());
     }
 
     public function getName(): string

--- a/src/Symfony/Component/CssSelector/XPath/Extension/RelationExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/RelationExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\CssSelector\XPath\Extension;
+
+use Symfony\Component\CssSelector\XPath\XPathExpr;
+
+/**
+ * XPath expression translator combination extension.
+ *
+ * This component is a port of the Python cssselect library,
+ * which is copyright Ian Bicking, @see https://github.com/scrapy/cssselect.
+ *
+ * @author Franck Ranaivo-Harisoa <franckranaivo@gmail.com>
+ *
+ * @internal
+ */
+class RelationExtension extends AbstractExtension
+{
+    public function getRelativeCombinationTranslators(): array
+    {
+        return [
+            ' ' => $this->translateRelationDescendant(...),
+            '>' => $this->translateRelationChild(...),
+            '+' => $this->translateRelationDirectAdjacent(...),
+            '~' => $this->translateRelationIndirectAdjacent(...),
+        ];
+    }
+
+    public function translateRelationDescendant(XPathExpr $xpath, XPathExpr $combinedXpath): XPathExpr
+    {
+        return $xpath->join('[descendant-or-self::', $combinedXpath, ']', true);
+    }
+
+    public function translateRelationChild(XPathExpr $xpath, XPathExpr $combinedXpath): XPathExpr
+    {
+        return $xpath->join('[./', $combinedXpath, ']', true);
+    }
+
+    public function translateRelationDirectAdjacent(XPathExpr $xpath, XPathExpr $combinedXpath): XPathExpr
+    {
+        $combinedXpath
+            ->addNameTest()
+            ->addCondition('position() = 1');
+
+        return $xpath
+            ->join('[following-sibling::', $combinedXpath, ']', true);
+    }
+
+    public function translateRelationIndirectAdjacent(XPathExpr $xpath, XPathExpr $combinedXpath): XPathExpr
+    {
+        return $xpath->join('[following-sibling::', $combinedXpath, ']', true);
+    }
+
+    public function getName(): string
+    {
+        return 'relation';
+    }
+}

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -44,6 +44,7 @@ class Translator implements TranslatorInterface
 
     private array $nodeTranslators = [];
     private array $combinationTranslators = [];
+    private array $relativeCombinationTranslators = [];
     private array $functionTranslators = [];
     private array $pseudoClassTranslators = [];
     private array $attributeMatchingTranslators = [];
@@ -58,6 +59,7 @@ class Translator implements TranslatorInterface
             ->registerExtension(new Extension\FunctionExtension())
             ->registerExtension(new Extension\PseudoClassExtension())
             ->registerExtension(new Extension\AttributeMatchingExtension())
+            ->registerExtension(new Extension\RelationExtension())
         ;
     }
 
@@ -119,6 +121,7 @@ class Translator implements TranslatorInterface
         $this->functionTranslators = array_merge($this->functionTranslators, $extension->getFunctionTranslators());
         $this->pseudoClassTranslators = array_merge($this->pseudoClassTranslators, $extension->getPseudoClassTranslators());
         $this->attributeMatchingTranslators = array_merge($this->attributeMatchingTranslators, $extension->getAttributeMatchingTranslators());
+        $this->relativeCombinationTranslators = array_merge($this->relativeCombinationTranslators, $extension->getRelativeCombinationTranslators());
 
         return $this;
     }
@@ -167,6 +170,18 @@ class Translator implements TranslatorInterface
         }
 
         return $this->combinationTranslators[$combiner]($this->nodeToXPath($xpath), $this->nodeToXPath($combinedXpath));
+    }
+
+    /**
+     * @throws ExpressionErrorException
+     */
+    public function addRelativeCombination(string $combiner, NodeInterface $xpath, NodeInterface $combinedXpath): XPathExpr
+    {
+        if (!isset($this->relativeCombinationTranslators[$combiner])) {
+            throw new ExpressionErrorException(\sprintf('Combiner "%s" not supported.', $combiner));
+        }
+
+        return $this->relativeCombinationTranslators[$combiner]($this->nodeToXPath($xpath), $this->nodeToXPath($combinedXpath));
     }
 
     /**

--- a/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
@@ -82,7 +82,7 @@ class XPathExpr
      *
      * @return $this
      */
-    public function join(string $combiner, self $expr): static
+    public function join(string $combiner, self $expr, ?string $closingCombiner = null, bool $hasInnerConditions = false): static
     {
         $path = $this->__toString().$combiner;
 
@@ -91,8 +91,19 @@ class XPathExpr
         }
 
         $this->path = $path;
-        $this->element = $expr->element;
-        $this->condition = $expr->condition;
+
+        if (!$hasInnerConditions) {
+            $this->element = $expr->element.($closingCombiner ?? '');
+            $this->condition = $expr->condition;
+        } else {
+            $this->element = $expr->element;
+            if ($expr->condition) {
+                $this->element .= '['.$expr->condition.']';
+            }
+            if ($closingCombiner) {
+                $this->element .= $closingCombiner;
+            }
+        }
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 8.1
| Bug fix       | no
| New feature  | yes
| Tickets          | Fix https://github.com/symfony/symfony/issues/40179
| Deprecations | no
| License       | MIT
| Doc PR        |  https://github.com/symfony/symfony-docs/pull/17994

Add support for :has() function.
