### PR TITLE
[Notifier] Make `TransportTestCase` data providers static (6.2)

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/Tests/AllMySmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/Tests/AllMySmsTransportTest.php
@@ -13,32 +13,33 @@ namespace Symfony\Component\Notifier\Bridge\AllMySms\Tests;
 
 use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class AllMySmsTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $from = null): AllMySmsTransport
+    public static function createTransport(HttpClientInterface $client = null, string $from = null): AllMySmsTransport
     {
-        return new AllMySmsTransport('login', 'apiKey', $from, $client ?? $this->createMock(HttpClientInterface::class));
+        return new AllMySmsTransport('login', 'apiKey', $from, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['allmysms://api.allmysms.com', $this->createTransport()];
-        yield ['allmysms://api.allmysms.com?from=TEST', $this->createTransport(null, 'TEST')];
+        yield ['allmysms://api.allmysms.com', self::createTransport()];
+        yield ['allmysms://api.allmysms.com?from=TEST', self::createTransport(null, 'TEST')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\AllMySms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportTest.php
@@ -17,34 +17,35 @@ use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsOptions;
 use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
-use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Tests\Fixtures\TestOptions;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class AmazonSnsTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): AmazonSnsTransport
+    public static function createTransport(HttpClientInterface $client = null): AmazonSnsTransport
     {
-        return (new AmazonSnsTransport(new SnsClient(['region' => 'eu-west-3']), $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new AmazonSnsTransport(new SnsClient(['region' => 'eu-west-3']), $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sns://host.test?region=eu-west-3', $this->createTransport()];
+        yield ['sns://host.test?region=eu-west-3', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0601020304', 'Hello!')];
         yield [new ChatMessage('Hello', new AmazonSnsOptions('my-topic'))];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
-        yield [$this->createMock(MessageInterface::class)];
-        yield [new ChatMessage('hello', $this->createMock(MessageOptionsInterface::class))];
+        yield [new DummyMessage()];
+        yield [new ChatMessage('hello', new TestOptions())];
     }
 
     public function testSmsMessageWithFrom()

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2",
+        "symfony/notifier": "^6.2.7",
         "async-aws/sns": "^1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Chatwork/Tests/ChatworkTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Chatwork/Tests/ChatworkTransportTest.php
@@ -15,34 +15,35 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Chatwork\ChatworkTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class ChatworkTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new ChatworkTransport('testToken', 'testRoomId', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new ChatworkTransport('testToken', 'testRoomId', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['chatwork://host.test?room_id=testRoomId', $this->createTransport()];
+        yield ['chatwork://host.test?room_id=testRoomId', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testWithErrorResponseThrows()

--- a/src/Symfony/Component/Notifier/Bridge/Chatwork/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Chatwork/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Chatwork\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/Tests/ClickatellTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/Tests/ClickatellTransportTest.php
@@ -19,36 +19,38 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class ClickatellTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $from = null): ClickatellTransport
+    public static function createTransport(HttpClientInterface $client = null, string $from = null): ClickatellTransport
     {
-        return new ClickatellTransport('authToken', $from, $client ?? $this->createMock(HttpClientInterface::class));
+        return new ClickatellTransport('authToken', $from, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['clickatell://api.clickatell.com', $this->createTransport()];
-        yield ['clickatell://api.clickatell.com?from=TEST', $this->createTransport(null, 'TEST')];
+        yield ['clickatell://api.clickatell.com', self::createTransport()];
+        yield ['clickatell://api.clickatell.com?from=TEST', self::createTransport(null, 'TEST')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+33612345678', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testExceptionIsThrownWhenNonMessageIsSend()
     {
-        $transport = $this->createTransport();
+        $transport = self::createTransport();
 
         $this->expectException(LogicException::class);
 
@@ -73,7 +75,7 @@ final class ClickatellTransportTest extends TransportTestCase
 
         $client = new MockHttpClient($response);
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send SMS with Clickatell: Error code 105 with message "Invalid Account Reference EX0000000" (https://documentation-page).');

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Clickatell\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneTransportTest.php
@@ -15,34 +15,35 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\ContactEveryone\ContactEveryoneTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class ContactEveryoneTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): ContactEveryoneTransport
+    public static function createTransport(HttpClientInterface $client = null): ContactEveryoneTransport
     {
-        return new ContactEveryoneTransport('API_TOKEN', 'Symfony', 'Foo', $client ?? $this->createMock(HttpClientInterface::class));
+        return new ContactEveryoneTransport('API_TOKEN', 'Symfony', 'Foo', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['contact-everyone://contact-everyone.orange-business.com?diffusionname=Symfony&category=Foo', $this->createTransport()];
+        yield ['contact-everyone://contact-everyone.orange-business.com?diffusionname=Symfony&category=Foo', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendSuccessfully()

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "require-dev": {
         "symfony/uid": "^5.4|^6.0"

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
@@ -16,38 +16,39 @@ use Symfony\Component\Notifier\Bridge\Discord\DiscordTransport;
 use Symfony\Component\Notifier\Exception\LengthException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class DiscordTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): DiscordTransport
+    public static function createTransport(HttpClientInterface $client = null): DiscordTransport
     {
-        return (new DiscordTransport('testToken', 'testWebhookId', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new DiscordTransport('testToken', 'testWebhookId', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['discord://host.test?webhook_id=testWebhookId', $this->createTransport()];
+        yield ['discord://host.test?webhook_id=testWebhookId', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendChatMessageWithMoreThan2000CharsThrowsLogicException()
     {
-        $transport = $this->createTransport();
+        $transport = self::createTransport();
 
         $this->expectException(LengthException::class);
         $this->expectExceptionMessage('The subject length of a Discord message must not exceed 2000 characters.');
@@ -69,7 +70,7 @@ final class DiscordTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/testDescription.+testErrorCode/');

--- a/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2",
+        "symfony/notifier": "^6.2.7",
         "symfony/polyfill-mbstring": "^1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/Tests/EngagespotTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/Tests/EngagespotTransportTest.php
@@ -12,10 +12,11 @@
 namespace Symfony\Component\Notifier\Bridge\Engagespot\Tests;
 
 use Symfony\Component\Notifier\Bridge\Engagespot\EngagespotTransport;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\PushMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -23,24 +24,24 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class EngagespotTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): EngagespotTransport
+    public static function createTransport(HttpClientInterface $client = null): EngagespotTransport
     {
-        return new EngagespotTransport('apiKey', 'TEST', $client ?? $this->createMock(HttpClientInterface::class));
+        return new EngagespotTransport('apiKey', 'TEST', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['engagespot://api.engagespot.co/2/campaigns?campaign_name=TEST', $this->createTransport()];
+        yield ['engagespot://api.engagespot.co/2/campaigns?campaign_name=TEST', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new PushMessage('Hello!', 'Symfony Notifier')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0123456789', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Engagespot\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
@@ -15,34 +15,35 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class EsendexTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): EsendexTransport
+    public static function createTransport(HttpClientInterface $client = null): EsendexTransport
     {
-        return (new EsendexTransport('email', 'password', 'testAccountReference', 'testFrom', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new EsendexTransport('email', 'password', 'testAccountReference', 'testFrom', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['esendex://host.test?accountreference=testAccountReference&from=testFrom', $this->createTransport()];
+        yield ['esendex://host.test?accountreference=testAccountReference&from=testFrom', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithErrorResponseThrowsTransportException()
@@ -56,7 +57,7 @@ final class EsendexTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send the SMS: error 500.');
@@ -78,7 +79,7 @@ final class EsendexTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send the SMS: error 500. Details from Esendex: accountreference_invalid: "Invalid Account Reference EX0000000".');
@@ -101,7 +102,7 @@ final class EsendexTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send(new SmsMessage('phone', 'testMessage'));
 

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "require-dev": {
         "symfony/uid": "^5.4|^6.0"

--- a/src/Symfony/Component/Notifier/Bridge/Expo/Tests/ExpoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/Tests/ExpoTransportTest.php
@@ -12,10 +12,11 @@
 namespace Symfony\Component\Notifier\Bridge\Expo\Tests;
 
 use Symfony\Component\Notifier\Bridge\Expo\ExpoTransport;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\PushMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -23,24 +24,24 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ExpoTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): ExpoTransport
+    public static function createTransport(HttpClientInterface $client = null): ExpoTransport
     {
-        return new ExpoTransport('token', $client ?? $this->createMock(HttpClientInterface::class));
+        return new ExpoTransport('token', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['expo://exp.host/--/api/v2/push/send', $this->createTransport()];
+        yield ['expo://exp.host/--/api/v2/push/send', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new PushMessage('Hello!', 'Symfony Notifier')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0670802161', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Expo\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatEmailTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatEmailTransportTest.php
@@ -11,22 +11,22 @@
 
 namespace Symfony\Component\Notifier\Bridge\FakeChat\Tests;
 
-use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Notifier\Bridge\FakeChat\FakeChatEmailTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Tests\Fixtures\TestOptions;
 use Symfony\Component\Notifier\Tests\Mailer\DummyMailer;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FakeChatEmailTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $transportName = null): FakeChatEmailTransport
+    public static function createTransport(HttpClientInterface $client = null, string $transportName = null): FakeChatEmailTransport
     {
-        $transport = (new FakeChatEmailTransport($this->createMock(MailerInterface::class), 'recipient@email.net', 'sender@email.net', $client ?? $this->createMock(HttpClientInterface::class)));
+        $transport = (new FakeChatEmailTransport(new DummyMailer(), 'recipient@email.net', 'sender@email.net', $client ?? new DummyHttpClient()));
 
         if (null !== $transportName) {
             $transport->setHost($transportName);
@@ -35,21 +35,21 @@ final class FakeChatEmailTransportTest extends TransportTestCase
         return $transport;
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['fakechat+email://default?to=recipient@email.net&from=sender@email.net', $this->createTransport()];
-        yield ['fakechat+email://mailchimp?to=recipient@email.net&from=sender@email.net', $this->createTransport(null, 'mailchimp')];
+        yield ['fakechat+email://default?to=recipient@email.net&from=sender@email.net', self::createTransport()];
+        yield ['fakechat+email://mailchimp?to=recipient@email.net&from=sender@email.net', self::createTransport(null, 'mailchimp')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithDefaultTransportAndWithRecipient()

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatLoggerTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatLoggerTransportTest.php
@@ -14,33 +14,35 @@ namespace Symfony\Component\Notifier\Bridge\FakeChat\Tests;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Notifier\Bridge\FakeChat\FakeChatLoggerTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyLogger;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Tests\Fixtures\TestOptions;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FakeChatLoggerTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, LoggerInterface $logger = null): FakeChatLoggerTransport
+    public static function createTransport(HttpClientInterface $client = null, LoggerInterface $logger = null): FakeChatLoggerTransport
     {
-        return new FakeChatLoggerTransport($logger ?? $this->createMock(LoggerInterface::class), $client ?? $this->createMock(HttpClientInterface::class));
+        return new FakeChatLoggerTransport($logger ?? new DummyLogger(), $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['fakechat+logger://default', $this->createTransport()];
+        yield ['fakechat+logger://default', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithDefaultTransport()
@@ -50,7 +52,7 @@ final class FakeChatLoggerTransportTest extends TransportTestCase
 
         $logger = new TestLogger();
 
-        $transport = $this->createTransport(null, $logger);
+        $transport = self::createTransport(null, $logger);
 
         $transport->send($message1);
         $transport->send($message2);

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2",
+        "symfony/notifier": "^6.2.7",
         "symfony/mailer": "^5.4|^6.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsEmailTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsEmailTransportTest.php
@@ -11,21 +11,21 @@
 
 namespace Symfony\Component\Notifier\Bridge\FakeSms\Tests;
 
-use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsEmailTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Tests\Mailer\DummyMailer;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FakeSmsEmailTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $transportName = null): FakeSmsEmailTransport
+    public static function createTransport(HttpClientInterface $client = null, string $transportName = null): FakeSmsEmailTransport
     {
-        $transport = (new FakeSmsEmailTransport($this->createMock(MailerInterface::class), 'recipient@email.net', 'sender@email.net', $client ?? $this->createMock(HttpClientInterface::class)));
+        $transport = (new FakeSmsEmailTransport(new DummyMailer(), 'recipient@email.net', 'sender@email.net', $client ?? new DummyHttpClient()));
 
         if (null !== $transportName) {
             $transport->setHost($transportName);
@@ -34,22 +34,22 @@ final class FakeSmsEmailTransportTest extends TransportTestCase
         return $transport;
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['fakesms+email://default?to=recipient@email.net&from=sender@email.net', $this->createTransport()];
-        yield ['fakesms+email://mailchimp?to=recipient@email.net&from=sender@email.net', $this->createTransport(null, 'mailchimp')];
+        yield ['fakesms+email://default?to=recipient@email.net&from=sender@email.net', self::createTransport()];
+        yield ['fakesms+email://mailchimp?to=recipient@email.net&from=sender@email.net', self::createTransport(null, 'mailchimp')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new SmsMessage('+33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithDefaultTransport()

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsLoggerTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsLoggerTransportTest.php
@@ -14,35 +14,37 @@ namespace Symfony\Component\Notifier\Bridge\FakeSms\Tests;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsLoggerTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyLogger;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FakeSmsLoggerTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, LoggerInterface $logger = null): FakeSmsLoggerTransport
+    public static function createTransport(HttpClientInterface $client = null, LoggerInterface $logger = null): FakeSmsLoggerTransport
     {
-        $transport = (new FakeSmsLoggerTransport($logger ?? $this->createMock(LoggerInterface::class), $client ?? $this->createMock(HttpClientInterface::class)));
+        $transport = (new FakeSmsLoggerTransport($logger ?? new DummyLogger(), $client ?? new DummyHttpClient()));
 
         return $transport;
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['fakesms+logger://default', $this->createTransport()];
+        yield ['fakesms+logger://default', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new SmsMessage('+33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithDefaultTransport()
@@ -51,7 +53,7 @@ final class FakeSmsLoggerTransportTest extends TransportTestCase
 
         $logger = new TestLogger();
 
-        $transport = $this->createTransport(null, $logger);
+        $transport = self::createTransport(null, $logger);
 
         $transport->send($message);
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2",
+        "symfony/notifier": "^6.2.7",
         "symfony/mailer": "^5.4|^6.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
@@ -17,9 +17,10 @@ use Symfony\Component\Notifier\Bridge\Firebase\FirebaseOptions;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -28,25 +29,25 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class FirebaseTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): FirebaseTransport
+    public static function createTransport(HttpClientInterface $client = null): FirebaseTransport
     {
-        return new FirebaseTransport('username:password', $client ?? $this->createMock(HttpClientInterface::class));
+        return new FirebaseTransport('username:password', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['firebase://fcm.googleapis.com/fcm/send', $this->createTransport()];
+        yield ['firebase://fcm.googleapis.com/fcm/send', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     /**
@@ -61,7 +62,7 @@ final class FirebaseTransportTest extends TransportTestCase
         });
         $options = new class('recipient-id', []) extends FirebaseOptions {};
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('Hello!', $options));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Firebase\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/Tests/FortySixElksTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/Tests/FortySixElksTransportTest.php
@@ -15,34 +15,35 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\FortySixElks\FortySixElksTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class FortySixElksTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): FortySixElksTransport
+    public static function createTransport(HttpClientInterface $client = null): FortySixElksTransport
     {
-        return new FortySixElksTransport('api_username', 'api_password', 'Symfony', $client ?? $this->createMock(HttpClientInterface::class));
+        return new FortySixElksTransport('api_username', 'api_password', 'Symfony', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['forty-six-elks://api.46elks.com?from=Symfony', $this->createTransport()];
+        yield ['forty-six-elks://api.46elks.com?from=Symfony', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+46701111111', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendSuccessfully()

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FortySixElks\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
@@ -14,34 +14,35 @@ namespace Symfony\Component\Notifier\Bridge\FreeMobile\Tests;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FreeMobileTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): FreeMobileTransport
+    public static function createTransport(HttpClientInterface $client = null): FreeMobileTransport
     {
-        return new FreeMobileTransport('login', 'pass', '0611223344', $client ?? $this->createMock(HttpClientInterface::class));
+        return new FreeMobileTransport('login', 'pass', '0611223344', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['freemobile://smsapi.free-mobile.fr/sendmsg?phone=0611223344', $this->createTransport()];
+        yield ['freemobile://smsapi.free-mobile.fr/sendmsg?phone=0611223344', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new SmsMessage('+33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0699887766', 'Hello!')]; // because this phone number is not configured on the transport!
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSmsMessageWithFrom()

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FreeMobile\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportTest.php
@@ -14,10 +14,12 @@ namespace Symfony\Component\Notifier\Bridge\GatewayApi\Tests;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\GatewayApi\GatewayApiTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -27,25 +29,25 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class GatewayApiTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): GatewayApiTransport
+    public static function createTransport(HttpClientInterface $client = null): GatewayApiTransport
     {
-        return new GatewayApiTransport('authtoken', 'Symfony', $client ?? $this->createMock(HttpClientInterface::class));
+        return new GatewayApiTransport('authtoken', 'Symfony', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['gatewayapi://gatewayapi.com?from=Symfony', $this->createTransport()];
+        yield ['gatewayapi://gatewayapi.com?from=Symfony', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSend()
@@ -64,7 +66,7 @@ final class GatewayApiTransportTest extends TransportTestCase
 
         $message = new SmsMessage('3333333333', 'Hello!');
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
         $sentMessage = $transport->send($message);
 
         $this->assertInstanceOf(SentMessage::class, $sentMessage);

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\GatewayApi\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/Tests/GitterTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/Tests/GitterTransportTest.php
@@ -13,9 +13,11 @@ namespace Symfony\Component\Notifier\Bridge\Gitter\Tests;
 
 use Symfony\Component\Notifier\Bridge\Gitter\GitterTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -23,24 +25,24 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class GitterTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): GitterTransport
+    public static function createTransport(HttpClientInterface $client = null): GitterTransport
     {
-        return (new GitterTransport('token', '5539a3ee5etest0d3255bfef', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('api.gitter.im');
+        return (new GitterTransport('token', '5539a3ee5etest0d3255bfef', $client ?? new DummyHttpClient()))->setHost('api.gitter.im');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['gitter://api.gitter.im?room_id=5539a3ee5etest0d3255bfef', $this->createTransport()];
+        yield ['gitter://api.gitter.im?room_id=5539a3ee5etest0d3255bfef', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Gitter\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
@@ -17,36 +17,38 @@ use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class GoogleChatTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $threadKey = null): GoogleChatTransport
+    public static function createTransport(HttpClientInterface $client = null, string $threadKey = null): GoogleChatTransport
     {
-        return new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $threadKey, $client ?? $this->createMock(HttpClientInterface::class));
+        return new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $threadKey, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['googlechat://chat.googleapis.com/My-Space', $this->createTransport()];
-        yield ['googlechat://chat.googleapis.com/My-Space?thread_key=abcdefg', $this->createTransport(null, 'abcdefg')];
+        yield ['googlechat://chat.googleapis.com/My-Space', self::createTransport()];
+        yield ['googlechat://chat.googleapis.com/My-Space?thread_key=abcdefg', self::createTransport(null, 'abcdefg')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithEmptyArrayResponseThrowsTransportException()
@@ -67,7 +69,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -91,7 +93,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -122,7 +124,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'My-Thread');
+        $transport = self::createTransport($client, 'My-Thread');
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -154,7 +156,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send($chatMessage);
 
@@ -170,7 +172,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $this->createMock(ResponseInterface::class);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }
@@ -199,7 +201,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\GoogleChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportTest.php
@@ -13,31 +13,33 @@ namespace Symfony\Component\Notifier\Bridge\Infobip\Tests;
 
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class InfobipTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): InfobipTransport
+    public static function createTransport(HttpClientInterface $client = null): InfobipTransport
     {
-        return (new InfobipTransport('authtoken', '0611223344', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new InfobipTransport('authtoken', '0611223344', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['infobip://host.test?from=0611223344', $this->createTransport()];
+        yield ['infobip://host.test?from=0611223344', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Infobip\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class IqsmsTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): IqsmsTransport
+    public static function createTransport(HttpClientInterface $client = null): IqsmsTransport
     {
-        return new IqsmsTransport('login', 'password', 'sender', $client ?? $this->createMock(HttpClientInterface::class));
+        return new IqsmsTransport('login', 'password', 'sender', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['iqsms://api.iqsms.ru?from=sender', $this->createTransport()];
+        yield ['iqsms://api.iqsms.ru?from=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Iqsms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/Tests/KazInfoTehTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/Tests/KazInfoTehTransportTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -26,26 +28,26 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class KazInfoTehTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public static function createTransport(HttpClientInterface $client = null): TransportInterface
     {
-        return (new KazInfoTehTransport('username', 'password', 'sender', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('test.host');
+        return (new KazInfoTehTransport('username', 'password', 'sender', $client ?? new DummyHttpClient()))->setHost('test.host');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['kaz-info-teh://test.host?sender=sender', $this->createTransport()];
+        yield ['kaz-info-teh://test.host?sender=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('77000000000', 'KazInfoTeh!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('420000000000', 'KazInfoTeh!')];
 
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function createClient(int $statusCode, string $content): HttpClientInterface

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.1",
         "ext-simplexml": "*",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\KazInfoTeh\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/Tests/LightSmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/Tests/LightSmsTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class LightSmsTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): LightSmsTransport
+    public static function createTransport(HttpClientInterface $client = null): LightSmsTransport
     {
-        return new LightSmsTransport('accountSid', 'authToken', 'from', $client ?? $this->createMock(HttpClientInterface::class));
+        return new LightSmsTransport('accountSid', 'authToken', 'from', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['lightsms://www.lightsms.com?from=from', $this->createTransport()];
+        yield ['lightsms://www.lightsms.com?from=from', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\LightSms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
@@ -21,30 +21,33 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class LinkedInTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): LinkedInTransport
+    public static function createTransport(HttpClientInterface $client = null): LinkedInTransport
     {
-        return (new LinkedInTransport('AuthToken', 'AccountId', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new LinkedInTransport('AuthToken', 'AccountId', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['linkedin://host.test', $this->createTransport()];
+        yield ['linkedin://host.test', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithEmptyArrayResponseThrowsTransportException()
@@ -61,7 +64,7 @@ final class LinkedInTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
 
@@ -86,7 +89,7 @@ final class LinkedInTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -130,7 +133,7 @@ final class LinkedInTransportTest extends TransportTestCase
 
             return $response;
         });
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage($message));
     }
@@ -178,7 +181,7 @@ final class LinkedInTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send($chatMessage);
     }
@@ -191,7 +194,7 @@ final class LinkedInTransportTest extends TransportTestCase
             return $this->createMock(ResponseInterface::class);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\LinkedIn\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/Tests/MailjetTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/Tests/MailjetTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class MailjetTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): MailjetTransport
+    public static function createTransport(HttpClientInterface $client = null): MailjetTransport
     {
-        return (new MailjetTransport('authtoken', 'Mailjet', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new MailjetTransport('authtoken', 'Mailjet', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['mailjet://Mailjet@host.test', $this->createTransport()];
+        yield ['mailjet://Mailjet@host.test', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mailjet\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -23,24 +26,24 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class MattermostTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): MattermostTransport
+    public static function createTransport(HttpClientInterface $client = null): MattermostTransport
     {
-        return (new MattermostTransport('testAccessToken', 'testChannel', null, $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new MattermostTransport('testAccessToken', 'testChannel', null, $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['mattermost://host.test?channel=testChannel', $this->createTransport()];
+        yield ['mattermost://host.test?channel=testChannel', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mattermost\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
@@ -26,6 +26,9 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHub;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use TypeError;
 
@@ -34,29 +37,29 @@ use TypeError;
  */
 final class MercureTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, HubInterface $hub = null, string $hubId = 'hubId', $topics = null): MercureTransport
+    public static function createTransport(HttpClientInterface $client = null, HubInterface $hub = null, string $hubId = 'hubId', $topics = null): MercureTransport
     {
-        $hub ??= $this->createMock(HubInterface::class);
+        $hub ??= new DummyHub();
 
         return new MercureTransport($hub, $hubId, $topics);
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['mercure://hubId?topic=https%3A%2F%2Fsymfony.com%2Fnotifier', $this->createTransport()];
-        yield ['mercure://customHubId?topic=%2Ftopic', $this->createTransport(null, null, 'customHubId', '/topic')];
-        yield ['mercure://customHubId?topic%5B0%5D=%2Ftopic%2F1&topic%5B1%5D%5B0%5D=%2Ftopic%2F2', $this->createTransport(null, null, 'customHubId', ['/topic/1', ['/topic/2']])];
+        yield ['mercure://hubId?topic=https%3A%2F%2Fsymfony.com%2Fnotifier', self::createTransport()];
+        yield ['mercure://customHubId?topic=%2Ftopic', self::createTransport(null, null, 'customHubId', '/topic')];
+        yield ['mercure://customHubId?topic%5B0%5D=%2Ftopic%2F1&topic%5B1%5D%5B0%5D=%2Ftopic%2F2', self::createTransport(null, null, 'customHubId', ['/topic/1', ['/topic/2']])];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testCanSetCustomPort()
@@ -77,13 +80,13 @@ final class MercureTransportTest extends TransportTestCase
     public function testConstructWithWrongTopicsThrows()
     {
         $this->expectException(TypeError::class);
-        $this->createTransport(null, null, 'publisherId', new \stdClass());
+        self::createTransport(null, null, 'publisherId', new \stdClass());
     }
 
     public function testSendWithNonMercureOptionsThrows()
     {
         $this->expectException(LogicException::class);
-        $this->createTransport()->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
+        self::createTransport()->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }
 
     public function testSendWithTransportFailureThrows()
@@ -95,7 +98,7 @@ final class MercureTransportTest extends TransportTestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to post the Mercure message: Cannot connect to mercure');
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject'));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject'));
     }
 
     public function testSendWithWrongTokenThrows()
@@ -107,7 +110,7 @@ final class MercureTransportTest extends TransportTestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to post the Mercure message: The provided JWT is not valid');
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject'));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject'));
     }
 
     public function testSendWithMercureOptions()
@@ -123,7 +126,7 @@ final class MercureTransportTest extends TransportTestCase
             return 'id';
         });
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject', new MercureOptions(['/topic/1', '/topic/2'], true, 'id', 'type', 1)));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject', new MercureOptions(['/topic/1', '/topic/2'], true, 'id', 'type', 1)));
     }
 
     public function testSendWithMercureOptionsButWithoutOptionTopic()
@@ -139,7 +142,7 @@ final class MercureTransportTest extends TransportTestCase
             return 'id';
         });
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject', new MercureOptions(null, true, 'id', 'type', 1)));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject', new MercureOptions(null, true, 'id', 'type', 1)));
     }
 
     public function testSendWithoutMercureOptions()
@@ -152,7 +155,7 @@ final class MercureTransportTest extends TransportTestCase
             return 'id';
         });
 
-        $this->createTransport(null, $hub)->send(new ChatMessage('subject'));
+        self::createTransport(null, $hub)->send(new ChatMessage('subject'));
     }
 
     public function testSendSuccessfully()
@@ -163,7 +166,7 @@ final class MercureTransportTest extends TransportTestCase
             return $messageId;
         });
 
-        $sentMessage = $this->createTransport(null, $hub)->send(new ChatMessage('subject'));
+        $sentMessage = self::createTransport(null, $hub)->send(new ChatMessage('subject'));
         $this->assertSame($messageId, $sentMessage->getMessageId());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "symfony/mercure": "^0.5.2|^0.6",
-        "symfony/notifier": "^6.2",
+        "symfony/notifier": "^6.2.7",
         "symfony/service-contracts": "^1.10|^2|^3"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/Tests/MessageBirdTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/Tests/MessageBirdTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class MessageBirdTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): MessageBirdTransport
+    public static function createTransport(HttpClientInterface $client = null): MessageBirdTransport
     {
-        return new MessageBirdTransport('token', 'from', $client ?? $this->createMock(HttpClientInterface::class));
+        return new MessageBirdTransport('token', 'from', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['messagebird://rest.messagebird.com?from=from', $this->createTransport()];
+        yield ['messagebird://rest.messagebird.com?from=from', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MessageBird\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/Tests/MessageMediaTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/Tests/MessageMediaTransportTest.php
@@ -19,31 +19,34 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class MessageMediaTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $from = null): MessageMediaTransport
+    public static function createTransport(HttpClientInterface $client = null, string $from = null): MessageMediaTransport
     {
-        return new MessageMediaTransport('apiKey', 'apiSecret', $from, $client ?? $this->createMock(HttpClientInterface::class));
+        return new MessageMediaTransport('apiKey', 'apiSecret', $from, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['messagemedia://api.messagemedia.com', $this->createTransport()];
-        yield ['messagemedia://api.messagemedia.com?from=TEST', $this->createTransport(null, 'TEST')];
+        yield ['messagemedia://api.messagemedia.com', self::createTransport()];
+        yield ['messagemedia://api.messagemedia.com?from=TEST', self::createTransport(null, 'TEST')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0491570156', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MessageMedia\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Tests/MicrosoftTeamsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Tests/MicrosoftTeamsTransportTest.php
@@ -21,30 +21,33 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class MicrosoftTeamsTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): MicrosoftTeamsTransport
+    public static function createTransport(HttpClientInterface $client = null): MicrosoftTeamsTransport
     {
-        return (new MicrosoftTeamsTransport('/testPath', $client ?: $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new MicrosoftTeamsTransport('/testPath', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['microsoftteams://host.test/testPath', $this->createTransport()];
+        yield ['microsoftteams://host.test/testPath', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithErrorResponseThrows()
@@ -53,7 +56,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('testErrorMessage', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 400]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/testErrorMessage/');
@@ -65,7 +68,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
     {
         $client = new MockHttpClient(new MockResponse());
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/request-id not found/');
@@ -87,7 +90,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('1', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 200]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage($message));
     }
@@ -109,7 +112,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('1', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 200]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage($message, $options));
     }
@@ -136,7 +139,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('1', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 200]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage($message, $options));
     }
@@ -156,7 +159,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
             return new MockResponse('1', ['response_headers' => ['request-id' => ['testRequestId']], 'http_code' => 200]);
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send($chatMessage);
     }

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MicrosoftTeams\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytTransportTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -24,25 +27,25 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class MobytTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $messageType = MobytOptions::MESSAGE_TYPE_QUALITY_LOW): MobytTransport
+    public static function createTransport(HttpClientInterface $client = null, string $messageType = MobytOptions::MESSAGE_TYPE_QUALITY_LOW): MobytTransport
     {
-        return (new MobytTransport('accountSid', 'authToken', 'from', $messageType, $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new MobytTransport('accountSid', 'authToken', 'from', $messageType, $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['mobyt://host.test?from=from&type_quality=LL', $this->createTransport()];
-        yield ['mobyt://host.test?from=from&type_quality=N', $this->createTransport(null, MobytOptions::MESSAGE_TYPE_QUALITY_HIGH)];
+        yield ['mobyt://host.test?from=from&type_quality=LL', self::createTransport()];
+        yield ['mobyt://host.test?from=from&type_quality=N', self::createTransport(null, MobytOptions::MESSAGE_TYPE_QUALITY_HIGH)];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mobyt\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/Tests/OctopushTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/Tests/OctopushTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class OctopushTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): OctopushTransport
+    public static function createTransport(HttpClientInterface $client = null): OctopushTransport
     {
-        return new OctopushTransport('userLogin', 'apiKey', 'from', 'type', $client ?? $this->createMock(HttpClientInterface::class));
+        return new OctopushTransport('userLogin', 'apiKey', 'from', 'type', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['octopush://www.octopush-dm.com?from=from&type=type', $this->createTransport()];
+        yield ['octopush://www.octopush-dm.com?from=from&type=type', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Octopush\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/Tests/OneSignalTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/Tests/OneSignalTransportTest.php
@@ -21,6 +21,9 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\PushMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -29,14 +32,14 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class OneSignalTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $recipientId = null): OneSignalTransport
+    public static function createTransport(HttpClientInterface $client = null, string $recipientId = null): OneSignalTransport
     {
-        return new OneSignalTransport('9fb175f0-0b32-4e99-ae97-bd228b9eb246', 'api_key', $recipientId, $client ?? $this->createMock(HttpClientInterface::class));
+        return new OneSignalTransport('9fb175f0-0b32-4e99-ae97-bd228b9eb246', 'api_key', $recipientId, $client ?? new DummyHttpClient());
     }
 
     public function testCanSetCustomHost()
     {
-        $transport = $this->createTransport();
+        $transport = self::createTransport();
 
         $transport->setHost($customHost = self::CUSTOM_HOST);
 
@@ -45,7 +48,7 @@ final class OneSignalTransportTest extends TransportTestCase
 
     public function testCanSetCustomHostAndPort()
     {
-        $transport = $this->createTransport();
+        $transport = self::createTransport();
 
         $transport->setHost($customHost = self::CUSTOM_HOST);
         $transport->setPort($customPort = self::CUSTOM_PORT);
@@ -53,33 +56,33 @@ final class OneSignalTransportTest extends TransportTestCase
         $this->assertSame(sprintf('onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@%s:%d', $customHost, $customPort), (string) $transport);
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@onesignal.com', $this->createTransport()];
-        yield ['onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@onesignal.com?recipientId=ea345989-d273-4f21-a33b-0c006efc5edb', $this->createTransport(null, 'ea345989-d273-4f21-a33b-0c006efc5edb')];
+        yield ['onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@onesignal.com', self::createTransport()];
+        yield ['onesignal://9fb175f0-0b32-4e99-ae97-bd228b9eb246@onesignal.com?recipientId=ea345989-d273-4f21-a33b-0c006efc5edb', self::createTransport(null, 'ea345989-d273-4f21-a33b-0c006efc5edb')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
-        yield [new PushMessage('Hello', 'World'), $this->createTransport(null, 'ea345989-d273-4f21-a33b-0c006efc5edb')];
+        yield [new PushMessage('Hello', 'World'), self::createTransport(null, 'ea345989-d273-4f21-a33b-0c006efc5edb')];
         yield [new PushMessage('Hello', 'World', (new OneSignalOptions())->recipient('ea345989-d273-4f21-a33b-0c006efc5edb'))];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testUnsupportedWithoutRecipientId()
     {
-        $this->assertFalse($this->createTransport()->supports(new PushMessage('Hello', 'World')));
+        $this->assertFalse(self::createTransport()->supports(new PushMessage('Hello', 'World')));
     }
 
     public function testSendThrowsWithoutRecipient()
     {
-        $transport = $this->createTransport();
+        $transport = self::createTransport();
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The "Symfony\Component\Notifier\Bridge\OneSignal\OneSignalTransport" transport should have configured `defaultRecipientId` via DSN or provided with message options.');
@@ -101,7 +104,7 @@ final class OneSignalTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
+        $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/Message Notifications must have English language content/');
@@ -123,7 +126,7 @@ final class OneSignalTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
+        $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/All included players are not subscribed/');
@@ -149,7 +152,7 @@ final class OneSignalTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
+        $transport = self::createTransport($client, 'ea345989-d273-4f21-a33b-0c006efc5edb');
 
         $sentMessage = $transport->send(new PushMessage('Hello', 'World'));
 

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OneSignal\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/Tests/OrangeSmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/Tests/OrangeSmsTransportTest.php
@@ -16,28 +16,30 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class OrangeSmsTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): OrangeSmsTransport
+    public static function createTransport(HttpClientInterface $client = null): OrangeSmsTransport
     {
-        return (new OrangeSmsTransport('CLIENT_ID', 'CLIENT_SECRET', 'FROM', 'SENDER_NAME', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new OrangeSmsTransport('CLIENT_ID', 'CLIENT_SECRET', 'FROM', 'SENDER_NAME', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['orange-sms://host.test?from=FROM&sender_name=SENDER_NAME', $this->createTransport()];
+        yield ['orange-sms://host.test?from=FROM&sender_name=SENDER_NAME', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+243899999999', 'Hello World!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello World!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "require-dev": {
         "symfony/uid": "^5.4|^6.0"

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OvhCloud\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -23,25 +26,25 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class RocketChatTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $channel = null): RocketChatTransport
+    public static function createTransport(HttpClientInterface $client = null, string $channel = null): RocketChatTransport
     {
-        return new RocketChatTransport('testAccessToken', $channel, $client ?? $this->createMock(HttpClientInterface::class));
+        return new RocketChatTransport('testAccessToken', $channel, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['rocketchat://rocketchat.com', $this->createTransport()];
-        yield ['rocketchat://rocketchat.com?channel=testChannel', $this->createTransport(null, 'testChannel')];
+        yield ['rocketchat://rocketchat.com', self::createTransport()];
+        yield ['rocketchat://rocketchat.com?channel=testChannel', self::createTransport(null, 'testChannel')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\RocketChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/Tests/SendberryTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/Tests/SendberryTransportTest.php
@@ -16,28 +16,30 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class SendberryTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): SendberryTransport
+    public static function createTransport(HttpClientInterface $client = null): SendberryTransport
     {
-        return new SendberryTransport('username', 'password', 'auth_key', 'from', $client ?? $this->createMock(HttpClientInterface::class));
+        return new SendberryTransport('username', 'password', 'auth_key', 'from', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sendberry://username:password@api.sendberry.com?auth_key=auth_key&from=from', $this->createTransport()];
+        yield ['sendberry://username:password@api.sendberry.com?auth_key=auth_key&from=from', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sendberry\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
@@ -18,30 +18,33 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class SendinblueTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): SendinblueTransport
+    public static function createTransport(HttpClientInterface $client = null): SendinblueTransport
     {
-        return (new SendinblueTransport('api-key', '0611223344', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new SendinblueTransport('api-key', '0611223344', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sendinblue://host.test?sender=0611223344', $this->createTransport()];
+        yield ['sendinblue://host.test?sender=0611223344', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithErrorResponseThrowsTransportException()
@@ -58,7 +61,7 @@ final class SendinblueTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send the SMS: bad request');

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sendinblue\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class SinchTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): SinchTransport
+    public static function createTransport(HttpClientInterface $client = null): SinchTransport
     {
-        return new SinchTransport('accountSid', 'authToken', 'sender', $client ?? $this->createMock(HttpClientInterface::class));
+        return new SinchTransport('accountSid', 'authToken', 'sender', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sinch://sms.api.sinch.com?from=sender', $this->createTransport()];
+        yield ['sinch://sms.api.sinch.com?from=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sinch\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -23,31 +23,34 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class SlackTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $channel = null): SlackTransport
+    public static function createTransport(HttpClientInterface $client = null, string $channel = null): SlackTransport
     {
-        return new SlackTransport('xoxb-TestToken', $channel, $client ?? $this->createMock(HttpClientInterface::class));
+        return new SlackTransport('xoxb-TestToken', $channel, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['slack://slack.com', $this->createTransport()];
-        yield ['slack://slack.com?channel=test+Channel', $this->createTransport(null, 'test Channel')];
+        yield ['slack://slack.com', self::createTransport()];
+        yield ['slack://slack.com?channel=test+Channel', self::createTransport(null, 'test Channel')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testInstatiatingWithAnInvalidSlackTokenThrowsInvalidArgumentException()
@@ -74,7 +77,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -97,7 +100,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -125,7 +128,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, $channel);
+        $transport = self::createTransport($client, $channel);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -163,7 +166,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, $channel);
+        $transport = self::createTransport($client, $channel);
 
         $sentMessage = $transport->send($chatMessage);
 
@@ -178,7 +181,7 @@ final class SlackTransportTest extends TransportTestCase
             return $this->createMock(ResponseInterface::class);
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }
@@ -208,7 +211,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, $channel);
+        $transport = self::createTransport($client, $channel);
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -231,7 +234,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -256,7 +259,7 @@ final class SlackTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to post the Slack message: "invalid_blocks" (no more than 50 items allowed [json-pointer:/blocks]).');

--- a/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Slack\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
@@ -16,29 +16,32 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class Sms77TransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $from = null): Sms77Transport
+    public static function createTransport(HttpClientInterface $client = null, string $from = null): Sms77Transport
     {
-        return new Sms77Transport('apiKey', $from, $client ?? $this->createMock(HttpClientInterface::class));
+        return new Sms77Transport('apiKey', $from, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sms77://gateway.sms77.io', $this->createTransport()];
-        yield ['sms77://gateway.sms77.io?from=TEST', $this->createTransport(null, 'TEST')];
+        yield ['sms77://gateway.sms77.io', self::createTransport()];
+        yield ['sms77://gateway.sms77.io?from=TEST', self::createTransport(null, 'TEST')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sms77\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/Tests/SmsBiurasTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/Tests/SmsBiurasTransportTest.php
@@ -17,30 +17,33 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class SmsBiurasTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): SmsBiurasTransport
+    public static function createTransport(HttpClientInterface $client = null): SmsBiurasTransport
     {
-        return new SmsBiurasTransport('uid', 'api_key', 'from', true, $client ?? $this->createMock(HttpClientInterface::class));
+        return new SmsBiurasTransport('uid', 'api_key', 'from', true, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['smsbiuras://savitarna.smsbiuras.lt?from=from&test_mode=1', $this->createTransport()];
+        yield ['smsbiuras://savitarna.smsbiuras.lt?from=from&test_mode=1', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SmsBiuras\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/Tests/SmsFactorTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/Tests/SmsFactorTransportTest.php
@@ -17,28 +17,30 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class SmsFactorTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): SmsFactorTransport
+    public static function createTransport(HttpClientInterface $client = null): SmsFactorTransport
     {
-        return (new SmsFactorTransport('TOKEN', 'MY_COMPANY', SmsFactorPushType::Alert, $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new SmsFactorTransport('TOKEN', 'MY_COMPANY', SmsFactorPushType::Alert, $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['sms-factor://host.test?sender=MY_COMPANY&push_type=alert', $this->createTransport()];
+        yield ['sms-factor://host.test?sender=MY_COMPANY&push_type=alert', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+33611223344', 'Hello World!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello World!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2",
+        "symfony/notifier": "^6.2.7",
         "symfony/uid": "^5.4|^6.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
@@ -19,32 +19,35 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class SmsapiTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, bool $fast = false, bool $test = false): SmsapiTransport
+    public static function createTransport(HttpClientInterface $client = null, bool $fast = false, bool $test = false): SmsapiTransport
     {
-        return (new SmsapiTransport('testToken', 'testFrom', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('test.host')->setFast($fast)->setTest($test);
+        return (new SmsapiTransport('testToken', 'testFrom', $client ?? new DummyHttpClient()))->setHost('test.host')->setFast($fast)->setTest($test);
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['smsapi://test.host?from=testFrom', $this->createTransport()];
-        yield ['smsapi://test.host?from=testFrom&fast=1', $this->createTransport(null, true)];
-        yield ['smsapi://test.host?from=testFrom&test=1', $this->createTransport(null, false, true)];
-        yield ['smsapi://test.host?from=testFrom&fast=1&test=1', $this->createTransport(null, true, true)];
+        yield ['smsapi://test.host?from=testFrom', self::createTransport()];
+        yield ['smsapi://test.host?from=testFrom&fast=1', self::createTransport(null, true)];
+        yield ['smsapi://test.host?from=testFrom&test=1', self::createTransport(null, false, true)];
+        yield ['smsapi://test.host?from=testFrom&fast=1&test=1', self::createTransport(null, true, true)];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function createClient(int $statusCode, string $content): HttpClientInterface
@@ -74,7 +77,7 @@ final class SmsapiTransportTest extends TransportTestCase
     public function testThrowExceptionWhenMessageWasNotSent(int $statusCode, string $content, string $errorMessage)
     {
         $client = $this->createClient($statusCode, $content);
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
         $message = new SmsMessage('0611223344', 'Hello!');
 
         $this->expectException(TransportException::class);

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsapi\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/Tests/SmscTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/Tests/SmscTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class SmscTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): SmscTransport
+    public static function createTransport(HttpClientInterface $client = null): SmscTransport
     {
-        return new SmscTransport('login', 'password', 'MyApp', $client ?? $this->createMock(HttpClientInterface::class));
+        return new SmscTransport('login', 'password', 'MyApp', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['smsc://smsc.ru?from=MyApp', $this->createTransport()];
+        yield ['smsc://smsc.ru?from=MyApp', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsc\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportTest.php
@@ -16,29 +16,32 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class SpotHitTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): SpotHitTransport
+    public static function createTransport(HttpClientInterface $client = null): SpotHitTransport
     {
-        return (new SpotHitTransport('api_token', 'MyCompany', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new SpotHitTransport('api_token', 'MyCompany', $client ?? new DummyHttpClient()))->setHost('host.test');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['spothit://host.test?from=MyCompany', $this->createTransport()];
+        yield ['spothit://host.test?from=MyCompany', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [new SmsMessage('+33611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SpotHit\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -19,31 +19,34 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class TelegramTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $channel = null): TelegramTransport
+    public static function createTransport(HttpClientInterface $client = null, string $channel = null): TelegramTransport
     {
-        return new TelegramTransport('token', $channel, $client ?? $this->createMock(HttpClientInterface::class));
+        return new TelegramTransport('token', $channel, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['telegram://api.telegram.org', $this->createTransport()];
-        yield ['telegram://api.telegram.org?channel=testChannel', $this->createTransport(null, 'testChannel')];
+        yield ['telegram://api.telegram.org', self::createTransport()];
+        yield ['telegram://api.telegram.org?channel=testChannel', self::createTransport(null, 'testChannel')];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSendWithErrorResponseThrowsTransportException()
@@ -63,7 +66,7 @@ final class TelegramTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -138,7 +141,7 @@ JSON;
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -241,7 +244,7 @@ JSON;
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'defaultChannel');
+        $transport = self::createTransport($client, 'defaultChannel');
 
         $messageOptions = new TelegramOptions();
         $messageOptions->chatId($channelOverride);
@@ -299,7 +302,7 @@ JSON;
             return $response;
         });
 
-        $transport = $this->createTransport($client, 'testChannel');
+        $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('I contain special characters _ * [ ] ( ) ~ ` > # + - = | { } . ! to send.'));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Telegram\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/Tests/TelnyxTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/Tests/TelnyxTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class TelnyxTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): TelnyxTransport
+    public static function createTransport(HttpClientInterface $client = null): TelnyxTransport
     {
-        return new TelnyxTransport('api_key', 'from', 'messaging_profile_id', $client ?? $this->createMock(HttpClientInterface::class));
+        return new TelnyxTransport('api_key', 'from', 'messaging_profile_id', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['telnyx://api.telnyx.com?from=from&messaging_profile_id=messaging_profile_id', $this->createTransport()];
+        yield ['telnyx://api.telnyx.com?from=from&messaging_profile_id=messaging_profile_id', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Telnyx\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
@@ -20,30 +20,33 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class TurboSmsTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): TurboSmsTransport
+    public static function createTransport(HttpClientInterface $client = null): TurboSmsTransport
     {
-        return new TurboSmsTransport('authToken', 'sender', $client ?? $this->createMock(HttpClientInterface::class));
+        return new TurboSmsTransport('authToken', 'sender', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['turbosms://api.turbosms.ua?from=sender', $this->createTransport()];
+        yield ['turbosms://api.turbosms.ua?from=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('380931234567', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSuccessfulSend()
@@ -77,7 +80,7 @@ final class TurboSmsTransportTest extends TransportTestCase
 
         $message = new SmsMessage('380931234567', 'Тест/Test');
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
         $sentMessage = $transport->send($message);
 
         self::assertInstanceOf(SentMessage::class, $sentMessage);
@@ -108,7 +111,7 @@ final class TurboSmsTransportTest extends TransportTestCase
 
         $message = new SmsMessage('380931234567', 'Тест/Test');
 
-        $transport = $this->createTransport($client);
+        $transport = self::createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send SMS with TurboSMS: Error code 103 with message "REQUIRED_TOKEN".');

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2",
+        "symfony/notifier": "^6.2.7",
         "symfony/polyfill-mbstring": "^1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
@@ -18,30 +18,33 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class TwilioTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null, string $from = 'from'): TwilioTransport
+    public static function createTransport(HttpClientInterface $client = null, string $from = 'from'): TwilioTransport
     {
-        return new TwilioTransport('accountSid', 'authToken', $from, $client ?? $this->createMock(HttpClientInterface::class));
+        return new TwilioTransport('accountSid', 'authToken', $from, $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['twilio://api.twilio.com?from=from', $this->createTransport()];
+        yield ['twilio://api.twilio.com?from=from', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     /**
@@ -49,7 +52,7 @@ final class TwilioTransportTest extends TransportTestCase
      */
     public function testInvalidArgumentExceptionIsThrownIfFromIsInvalid(string $from)
     {
-        $transport = $this->createTransport(null, $from);
+        $transport = self::createTransport(null, $from);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $from));
@@ -107,7 +110,7 @@ final class TwilioTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client, $from);
+        $transport = self::createTransport($client, $from);
 
         $sentMessage = $transport->send($message);
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Twilio\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/Tests/VonageTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/Tests/VonageTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class VonageTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): VonageTransport
+    public static function createTransport(HttpClientInterface $client = null): VonageTransport
     {
-        return new VonageTransport('apiKey', 'apiSecret', 'sender', $client ?? $this->createMock(HttpClientInterface::class));
+        return new VonageTransport('apiKey', 'apiSecret', 'sender', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['vonage://rest.nexmo.com?from=sender', $this->createTransport()];
+        yield ['vonage://rest.nexmo.com?from=sender', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Vonage\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportTest.php
@@ -17,29 +17,32 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class YunpianTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): YunpianTransport
+    public static function createTransport(HttpClientInterface $client = null): YunpianTransport
     {
-        return new YunpianTransport('api_key', $client ?? $this->createMock(HttpClientInterface::class));
+        return new YunpianTransport('api_key', $client ?? new DummyHttpClient());
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['yunpian://sms.yunpian.com', $this->createTransport()];
+        yield ['yunpian://sms.yunpian.com', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('+0611223344', 'Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 
     public function testSmsMessageWithFrom()

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Yunpian\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Zendesk/Tests/ZendeskTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zendesk/Tests/ZendeskTransportTest.php
@@ -17,29 +17,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class ZendeskTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): ZendeskTransport
+    public static function createTransport(HttpClientInterface $client = null): ZendeskTransport
     {
-        return (new ZendeskTransport('testEmail', 'testToken', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('test.zendesk.com');
+        return (new ZendeskTransport('testEmail', 'testToken', $client ?? new DummyHttpClient()))->setHost('test.zendesk.com');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['zendesk://test.zendesk.com', $this->createTransport()];
+        yield ['zendesk://test.zendesk.com', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
         yield [new ChatMessage('Hello!', new ZendeskOptions('urgent'))];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Zendesk/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Zendesk/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Zendesk\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportTest.php
@@ -16,28 +16,31 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyHttpClient;
+use Symfony\Component\Notifier\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class ZulipTransportTest extends TransportTestCase
 {
-    public function createTransport(HttpClientInterface $client = null): ZulipTransport
+    public static function createTransport(HttpClientInterface $client = null): ZulipTransport
     {
-        return (new ZulipTransport('testEmail', 'testToken', 'testChannel', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('test.host');
+        return (new ZulipTransport('testEmail', 'testToken', 'testChannel', $client ?? new DummyHttpClient()))->setHost('test.host');
     }
 
-    public function toStringProvider(): iterable
+    public static function toStringProvider(): iterable
     {
-        yield ['zulip://test.host?channel=testChannel', $this->createTransport()];
+        yield ['zulip://test.host?channel=testChannel', self::createTransport()];
     }
 
-    public function supportedMessagesProvider(): iterable
+    public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
     }
 
-    public function unsupportedMessagesProvider(): iterable
+    public static function unsupportedMessagesProvider(): iterable
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
-        yield [$this->createMock(MessageInterface::class)];
+        yield [new DummyMessage()];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0",
-        "symfony/notifier": "^6.2"
+        "symfony/notifier": "^6.2.7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Zulip\\": "" },

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -12,6 +12,12 @@ CHANGELOG
 
  * Use importance level to set flash message type
 
+5.4.21
+------
+
+ * [BC BREAK] The following data providers for `TransportTestCase` are now static: `toStringProvider()`, `supportedMessagesProvider()` and `unsupportedMessagesProvider()`
+ * [BC BREAK] `TransportTestCase::createTransport()` is now static
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Notifier/Test/TransportFactoryTestCase.php
@@ -17,6 +17,7 @@ use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 
 /**
  * A test case to ease testing a notifier transport factory.

--- a/src/Symfony/Component/Notifier/Test/TransportTestCase.php
+++ b/src/Symfony/Component/Notifier/Test/TransportTestCase.php
@@ -27,22 +27,22 @@ abstract class TransportTestCase extends TestCase
     protected const CUSTOM_HOST = 'host.test';
     protected const CUSTOM_PORT = 42;
 
-    abstract public function createTransport(HttpClientInterface $client = null): TransportInterface;
+    abstract static public function createTransport(HttpClientInterface $client = null): TransportInterface;
 
     /**
      * @return iterable<array{0: string, 1: TransportInterface}>
      */
-    abstract public function toStringProvider(): iterable;
+    abstract public static function toStringProvider(): iterable;
 
     /**
      * @return iterable<array{0: MessageInterface, 1: TransportInterface}>
      */
-    abstract public function supportedMessagesProvider(): iterable;
+    abstract public static function supportedMessagesProvider(): iterable;
 
     /**
      * @return iterable<array{0: MessageInterface, 1: TransportInterface}>
      */
-    abstract public function unsupportedMessagesProvider(): iterable;
+    abstract public static function unsupportedMessagesProvider(): iterable;
 
     /**
      * @dataProvider toStringProvider

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyHttpClient.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyHttpClient.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+class DummyHttpClient implements HttpClientInterface
+{
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+    }
+
+    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    {
+    }
+
+    public function withOptions(array $options): static
+    {
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyHub.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyHub.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
+use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
+use Symfony\Component\Mercure\Update;
+
+class DummyHub implements HubInterface
+{
+    public function getUrl(): string
+    {
+    }
+
+    public function getPublicUrl(): string
+    {
+    }
+
+    public function getProvider(): TokenProviderInterface
+    {
+    }
+
+    public function getFactory(): ?TokenFactoryInterface
+    {
+        return null;
+    }
+
+    public function publish(Update $update): string
+    {
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyLogger.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyLogger.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Psr\Log\LoggerInterface;
+
+class DummyLogger implements LoggerInterface
+{
+    public function emergency($message, array $context = []): void
+    {
+    }
+
+    public function alert($message, array $context = []): void
+    {
+    }
+
+    public function critical($message, array $context = []): void
+    {
+    }
+
+    public function error($message, array $context = []): void
+    {
+    }
+
+    public function warning($message, array $context = []): void
+    {
+    }
+
+    public function notice($message, array $context = []): void
+    {
+    }
+
+    public function info($message, array $context = []): void
+    {
+    }
+
+    public function debug($message, array $context = []): void
+    {
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyMailer.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyMailer.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\RawMessage;
+
+class DummyMailer implements MailerInterface
+{
+    public function send(RawMessage $message, Envelope $envelope = null): void
+    {
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Fixtures/DummyMessage.php
+++ b/src/Symfony/Component/Notifier/Tests/Fixtures/DummyMessage.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Fixtures;
+
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+class DummyMessage implements MessageInterface
+{
+    public function getRecipientId(): ?string
+    {
+        return null;
+    }
+
+    public function getSubject(): string
+    {
+        return '';
+    }
+
+    public function getOptions(): ?MessageOptionsInterface
+    {
+        return null;
+    }
+
+    public function getTransport(): ?string
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Follow-up of https://github.com/symfony/symfony/pull/49385#pullrequestreview-1299110460
| License       | MIT
| Doc PR        | _NA_

cc @OskarStark 