### PR TITLE
[TwigBridge] Fix raw content rendering in HTML notification emails

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Email/zurb_2/notification/body.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Email/zurb_2/notification/body.html.twig
@@ -26,7 +26,7 @@
                     {% if markdown %}
                         {{ include('@email/zurb_2/notification/content_markdown.html.twig') }}
                     {% else %}
-                        {{ (raw ? content|raw : content)|nl2br }}
+                        {{ raw ? content|raw : content|nl2br }}
                     {% endif %}
                 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        |

Applying nl2br on raw HTML seems wrong to me and it also makes raw ineffective.
