### PR TITLE
[MonologBridge] FirePHPHandler::onKernelResponse throws PHP 8.1 deprecation when no user agent is set

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
@@ -41,7 +41,7 @@ class FirePHPHandler extends BaseFirePHPHandler
         }
 
         $request = $event->getRequest();
-        if (!preg_match('{\bFirePHP/\d+\.\d+\b}', $request->headers->get('User-Agent'))
+        if (!preg_match('{\bFirePHP/\d+\.\d+\b}', $request->headers->get('User-Agent', ''))
             && !$request->headers->has('X-FirePHP-Version')) {
             self::$sendHeaders = false;
             $this->headers = [];

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Handler\FirePHPHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class FirePHPHandlerTest extends TestCase
+{
+    public function testOnKernelResponseShouldNotTriggerDeprecation()
+    {
+        $request = Request::create('/');
+        $request->headers->remove('User-Agent');
+
+        $response = new Response('foo');
+        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $error = null;
+        set_error_handler(function ($type, $message) use (&$error) { $error = $message; }, \E_DEPRECATED);
+
+        $listener = new FirePHPHandler();
+        $listener->onKernelResponse($event);
+        restore_error_handler();
+
+        $this->assertNull($error);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes/no
| New feature?  no
| Deprecations? no
| Tickets       | Fix #49392  
| License       | MIT

- Add casting to the second parameter to pass always the right type.

**PHPstan before:**

 ------ -------------------------------------------------------------------------------------------------------- 
  Line   FirePHPHandler.php                                                                                      
 ------ -------------------------------------------------------------------------------------------------------- 
  27     Property Symfony\Bridge\Monolog\Handler\FirePHPHandler::$headers has no type specified.                 
  37     Method Symfony\Bridge\Monolog\Handler\FirePHPHandler::onKernelResponse() has no return type specified.  
  **44     Parameter #2 $subject of function preg_match expects string, string|null given.**                         
  68     If condition is always true.                                                                            
 ------ -------------------------------------------------------------------------------------------------------- 

**PHPstan after:**

 ------ -------------------------------------------------------------------------------------------------------- 
  Line   FirePHPHandler.php                                                                                      
 ------ -------------------------------------------------------------------------------------------------------- 
  27     Property Symfony\Bridge\Monolog\Handler\FirePHPHandler::$headers has no type specified.                 
  37     Method Symfony\Bridge\Monolog\Handler\FirePHPHandler::onKernelResponse() has no return type specified.  
  68     If condition is always true.                                                                            
 ------ -------------------------------------------------------------------------------------------------------- 
