### PR TITLE
[DependencyInjection] Add AsAlias attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to tell under which alias a service should be registered or to use the implemented interface if no parameter is given.
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class AsAlias
+{
+    public function __construct(
+        public ?string $id = null,
+        public bool $public = false,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Deprecate undefined and numeric keys with `service_locator` config
  * Fail if Target attribute does not exist during compilation
  * Enable deprecating parameters with `ContainerBuilder::deprecateParameter()`
+ * Add `#[AsAlias]` attribute to tell under which alias a service should be registered or to use the implemented interface if no parameter is given
 
 6.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/AliasBarInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/AliasBarInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+interface AliasBarInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/AliasFooInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/AliasFooInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+interface AliasFooInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAlias.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAlias.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(id: AliasFooInterface::class)]
+class WithAsAlias
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasDuplicate.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasDuplicate.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(id: AliasFooInterface::class)]
+class WithAsAliasDuplicate
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasIdMultipleInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasIdMultipleInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(id: AliasBarInterface::class)]
+class WithAsAliasIdMultipleInterface implements AliasFooInterface, AliasBarInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias]
+class WithAsAliasInterface implements AliasFooInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasMultiple.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasMultiple.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(id: AliasFooInterface::class, public: true)]
+#[AsAlias(id: 'some-alias')]
+class WithAsAliasMultiple
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasMultipleInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasMultipleInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias]
+class WithAsAliasMultipleInterface implements AliasFooInterface, AliasBarInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49361
| License       | MIT
| Doc PR        | TODO symfony/symfony-docs#...

Add the `AsAlias` attribute for defining an alias on a service:
```php
use Symfony\Component\DependencyInjection\Attribute\AsAlias;
use App\MyInterface;

#[AsAlias(id: 'my-alias', public: true)]
#[AsAlias(id: MyInterface::class)]
class MyService
{}
```
If no parameter is used in the attribute and if there is only one implemented interface, it takes this interface for the alias:
```php
use Symfony\Component\DependencyInjection\Attribute\AsAlias;
use App\MyInterface;

#[AsAlias]
class MyService implements MyInterface
{}
```
is equivalent to:
```php
$services->alias(MyInterface::class, MyService::class);
```

This implementation follows @nicolas-grekas suggestion in #49361: doing it in `FileLoader::registerClasses()` allows to check if there is no collision.