### PR TITLE
[DependencyInjection] Fix dumping closure of service closure

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1132,6 +1132,10 @@ EOTXT
 
             if (['Closure', 'fromCallable'] === $callable && [0] === array_keys($definition->getArguments())) {
                 $callable = $definition->getArgument(0);
+                if ($callable instanceof ServiceClosureArgument) {
+                    return $return.sprintf('static fn(): \Closure => %s', $this->dumpLiteralClass($this->dumpValue($callable))).$tail;
+                }
+
                 $arguments = ['...'];
 
                 if ($callable instanceof Reference || $callable instanceof Definition) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1569,6 +1569,11 @@ PHP
             ->setFactory(['Closure', 'fromCallable'])
             ->setArguments([new Reference('bar')]);
         $container->register('bar', 'stdClass');
+        $container->register('closure_of_service_closure', 'Closure')
+            ->setPublic('true')
+            ->setFactory(['Closure', 'fromCallable'])
+            ->setArguments([new ServiceClosureArgument(new Reference('bar2'))]);
+        $container->register('bar2', 'stdClass');
         $container->compile();
         $dumper = new PhpDumper($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/closure.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/closure.expected.yml
@@ -8,3 +8,9 @@ services:
         class: stdClass
         public: true
         properties: { foo: !service { class: Closure, arguments: [!service { class: stdClass }], factory: [Closure, fromCallable] } }
+    closure_of_service_closure:
+        class: stdClass
+        public: true
+        arguments: [!service { class: Closure, arguments: [!service_closure '@bar2'], factory: [Closure, fromCallable] }]
+    bar2:
+        class: stdClass

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/closure.php
@@ -9,6 +9,10 @@ return new class() {
             ->set('closure_property', 'stdClass')
                 ->public()
                 ->property('foo', closure(service('bar')))
-            ->set('bar', 'stdClass');
+            ->set('bar', 'stdClass')
+            ->set('closure_of_service_closure', 'stdClass')
+                ->public()
+                ->args([closure(service_closure('bar2'))])
+            ->set('bar2', 'stdClass');
     }
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure.php
@@ -21,6 +21,7 @@ class ProjectServiceContainer extends Container
         $this->services = $this->privates = [];
         $this->methodMap = [
             'closure' => 'getClosureService',
+            'closure_of_service_closure' => 'getClosureOfServiceClosureService',
         ];
 
         $this->aliases = [];
@@ -40,6 +41,7 @@ class ProjectServiceContainer extends Container
     {
         return [
             'bar' => true,
+            'bar2' => true,
         ];
     }
 
@@ -51,5 +53,17 @@ class ProjectServiceContainer extends Container
     protected function getClosureService()
     {
         return $this->services['closure'] = (new \stdClass())->__invoke(...);
+    }
+
+    /**
+     * Gets the public 'closure_of_service_closure' shared service.
+     *
+     * @return \Closure
+     */
+    protected function getClosureOfServiceClosureService()
+    {
+        return $this->services['closure_of_service_closure'] = static fn(): \Closure => ${($_ = #[\Closure(name: 'bar2', class: 'stdClass')] function () {
+            return ($this->privates['bar2'] ??= new \stdClass());
+        }) && false ?: "_"};
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | -
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

Using `closure(service_closure(MyService::class))`, I'm expecting to get a wrapping closure of the service closure, not directly the service closure.
If it's not a valid use case at all, then we have to deprecate it because it's really misleading :sweat: 