### PR TITLE
[FrameworkBundle] Remove duplicated using of default paths

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -168,6 +168,9 @@ EOF
             return self::EXIT_CODE_GENERAL_ERROR;
         }
 
+        $onlyMissing = $input->getOption('only-missing');
+        $onlyUnused = $input->getOption('only-unused');
+
         // Load the fallback catalogues
         $fallbackCatalogues = $this->loadFallbackCatalogues($locale, $transPaths);
 
@@ -187,20 +190,20 @@ EOF
                     if (!$currentCatalogue->defines($messageId, $domain)) {
                         $states[] = self::MESSAGE_MISSING;
 
-                        if (!$input->getOption('only-unused')) {
+                        if (!$onlyUnused) {
                             $exitCode = $exitCode | self::EXIT_CODE_MISSING;
                         }
                     }
                 } elseif ($currentCatalogue->defines($messageId, $domain)) {
                     $states[] = self::MESSAGE_UNUSED;
 
-                    if (!$input->getOption('only-missing')) {
+                    if (!$onlyMissing) {
                         $exitCode = $exitCode | self::EXIT_CODE_UNUSED;
                     }
                 }
 
-                if (!\in_array(self::MESSAGE_UNUSED, $states) && $input->getOption('only-unused')
-                    || !\in_array(self::MESSAGE_MISSING, $states) && $input->getOption('only-missing')
+                if (($onlyUnused && !\in_array(self::MESSAGE_UNUSED, $states, true))
+                    || ($onlyMissing && !\in_array(self::MESSAGE_MISSING, $states, true))
                 ) {
                     continue;
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Translation\Catalogue\MergeOperation;
 use Symfony\Component\Translation\DataCollectorTranslator;
@@ -139,34 +140,7 @@ EOF
         $kernel = $this->getApplication()->getKernel();
 
         // Define Root Paths
-        $transPaths = $this->getRootTransPaths();
-        $codePaths = $this->getRootCodePaths($kernel);
-
-        // Override with provided Bundle info
-        if (null !== $input->getArgument('bundle')) {
-            try {
-                $bundle = $kernel->getBundle($input->getArgument('bundle'));
-                $bundleDir = $bundle->getPath();
-                $transPaths = [is_dir($bundleDir.'/Resources/translations') ? $bundleDir.'/Resources/translations' : $bundleDir.'/translations'];
-                $codePaths = [is_dir($bundleDir.'/Resources/views') ? $bundleDir.'/Resources/views' : $bundleDir.'/templates'];
-            } catch (\InvalidArgumentException $e) {
-                // such a bundle does not exist, so treat the argument as path
-                $path = $input->getArgument('bundle');
-
-                $transPaths = [$path.'/translations'];
-                $codePaths = [$path.'/templates'];
-
-                if (!is_dir($transPaths[0])) {
-                    throw new InvalidArgumentException(sprintf('"%s" is neither an enabled bundle nor a directory.', $transPaths[0]));
-                }
-            }
-        } elseif ($input->getOption('all')) {
-            foreach ($kernel->getBundles() as $bundle) {
-                $bundleDir = $bundle->getPath();
-                $transPaths[] = is_dir($bundleDir.'/Resources/translations') ? $bundleDir.'/Resources/translations' : $bundle->getPath().'/translations';
-                $codePaths[] = is_dir($bundleDir.'/Resources/views') ? $bundleDir.'/Resources/views' : $bundle->getPath().'/templates';
-            }
-        }
+        [$transPaths, $codePaths] = $this->defineRootPaths($kernel, $input);
 
         // Extract used messages
         $extractedCatalogue = $this->extractMessages($locale, $codePaths);
@@ -408,5 +382,46 @@ EOF
         }
 
         return $codePaths;
+    }
+
+    /**
+     * @return array<int,array<int,string>>
+     */
+    private function defineRootPaths(KernelInterface $kernel, InputInterface $input): array
+    {
+        $transPaths = $this->getRootTransPaths();
+        $codePaths = $this->getRootCodePaths($kernel);
+
+        try {
+            foreach ($this->iterateBundles($kernel, $input) as $bundle) {
+                $bundleDir = $bundle->getPath();
+                $transPaths[] = is_dir($bundleDir . '/Resources/translations') ? $bundleDir . '/Resources/translations' : $bundleDir . '/translations';
+                $codePaths[] = is_dir($bundleDir . '/Resources/views') ? $bundleDir . '/Resources/views' : $bundleDir . '/templates';
+            }
+        } catch (\InvalidArgumentException $e) {
+            // such a bundle does not exist, so treat the argument as path
+            $path = $input->getArgument('bundle');
+
+            $transPaths = [$path . '/translations'];
+            $codePaths = [$path . '/templates'];
+
+            if (!is_dir($transPaths[0])) {
+                throw new InvalidArgumentException(sprintf('"%s" is neither an enabled bundle nor a directory.', $transPaths[0]));
+            }
+        }
+
+        return [$transPaths, $codePaths];
+    }
+
+    /**
+     * @return iterable<BundleInterface>
+     */
+    private function iterateBundles(KernelInterface $kernel, InputInterface $input): iterable
+    {
+        if (null !== ($bundle = $input->getArgument('bundle'))) {
+            yield $kernel->getBundle($bundle);
+        } elseif ($input->getOption('all')) {
+            yield from $kernel->getBundles();
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -149,12 +149,6 @@ EOF
                 $bundleDir = $bundle->getPath();
                 $transPaths = [is_dir($bundleDir.'/Resources/translations') ? $bundleDir.'/Resources/translations' : $bundleDir.'/translations'];
                 $codePaths = [is_dir($bundleDir.'/Resources/views') ? $bundleDir.'/Resources/views' : $bundleDir.'/templates'];
-                if ($this->defaultTransPath) {
-                    $transPaths[] = $this->defaultTransPath;
-                }
-                if ($this->defaultViewsPath) {
-                    $codePaths[] = $this->defaultViewsPath;
-                }
             } catch (\InvalidArgumentException $e) {
                 // such a bundle does not exist, so treat the argument as path
                 $path = $input->getArgument('bundle');

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -78,7 +78,7 @@ class TranslationDebugCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([
@@ -120,8 +120,7 @@ You can display information about translations in all registered bundles in a sp
   <info>php %command.full_name% --all en</info>
 
 EOF
-            )
-        ;
+            );
     }
 
     /**
@@ -191,14 +190,14 @@ EOF
                         $states[] = self::MESSAGE_MISSING;
 
                         if (!$onlyUnused) {
-                            $exitCode = $exitCode | self::EXIT_CODE_MISSING;
+                            $exitCode |= self::EXIT_CODE_MISSING;
                         }
                     }
                 } elseif ($currentCatalogue->defines($messageId, $domain)) {
                     $states[] = self::MESSAGE_UNUSED;
 
                     if (!$onlyMissing) {
-                        $exitCode = $exitCode | self::EXIT_CODE_UNUSED;
+                        $exitCode |= self::EXIT_CODE_UNUSED;
                     }
                 }
 
@@ -212,7 +211,7 @@ EOF
                     if ($fallbackCatalogue->defines($messageId, $domain) && $value === $fallbackCatalogue->get($messageId, $domain)) {
                         $states[] = self::MESSAGE_EQUALS_FALLBACK;
 
-                        $exitCode = $exitCode | self::EXIT_CODE_FALLBACK;
+                        $exitCode |= self::EXIT_CODE_FALLBACK;
 
                         break;
                     }
@@ -366,6 +365,9 @@ EOF
         return $fallbackCatalogues;
     }
 
+    /**
+     * @return array<int,string>
+     */
     private function getRootTransPaths(): array
     {
         $transPaths = $this->transPaths;
@@ -376,6 +378,9 @@ EOF
         return $transPaths;
     }
 
+    /**
+     * @return array<int,string>
+     */
     private function getRootCodePaths(KernelInterface $kernel): array
     {
         $codePaths = $this->codePaths;
@@ -398,15 +403,15 @@ EOF
         try {
             foreach ($this->iterateBundles($kernel, $input) as $bundle) {
                 $bundleDir = $bundle->getPath();
-                $transPaths[] = is_dir($bundleDir . '/Resources/translations') ? $bundleDir . '/Resources/translations' : $bundleDir . '/translations';
-                $codePaths[] = is_dir($bundleDir . '/Resources/views') ? $bundleDir . '/Resources/views' : $bundleDir . '/templates';
+                $transPaths[] = is_dir($bundleDir.'/Resources/translations') ? $bundleDir.'/Resources/translations' : $bundleDir.'/translations';
+                $codePaths[] = is_dir($bundleDir.'/Resources/views') ? $bundleDir.'/Resources/views' : $bundleDir.'/templates';
             }
         } catch (\InvalidArgumentException $e) {
             // such a bundle does not exist, so treat the argument as path
             $path = $input->getArgument('bundle');
 
-            $transPaths = [$path . '/translations'];
-            $codePaths = [$path . '/templates'];
+            $transPaths = [$path.'/translations'];
+            $codePaths = [$path.'/templates'];
 
             if (!is_dir($transPaths[0])) {
                 throw new InvalidArgumentException(sprintf('"%s" is neither an enabled bundle nor a directory.', $transPaths[0]));

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -191,12 +191,6 @@ EOF
                 $bundleDir = $foundBundle->getPath();
                 $transPaths = [is_dir($bundleDir.'/Resources/translations') ? $bundleDir.'/Resources/translations' : $bundleDir.'/translations'];
                 $codePaths = [is_dir($bundleDir.'/Resources/views') ? $bundleDir.'/Resources/views' : $bundleDir.'/templates'];
-                if ($this->defaultTransPath) {
-                    $transPaths[] = $this->defaultTransPath;
-                }
-                if ($this->defaultViewsPath) {
-                    $codePaths[] = $this->defaultViewsPath;
-                }
                 $currentName = $foundBundle->getName();
             } catch (\InvalidArgumentException $e) {
                 // such a bundle does not exist, so treat the argument as path


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This PR fix translation debug & update commands. 
It removes duplicated (double):
- using default path to translations & templates
- calling of getters in loops

Additionally, I implemented iteration of requested bundles to reduce copy-paste.

