### PR TITLE
[Cache][Messenger] fixed CallbackInterface support in async expiration handler

### DIFF
--- a/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php
+++ b/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php
@@ -73,7 +73,8 @@ class EarlyExpirationHandler implements MessageHandlerInterface
         $startTime = microtime(true);
         $pool = $message->findPool($this->reverseContainer);
         $callback = $message->findCallback($this->reverseContainer);
-        $value = $callback($item);
+        $save = true;
+        $value = $callback($item, $save);
         $setMetadata($item, $startTime);
         $pool->save($item->set($value));
     }

--- a/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationHandlerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationHandlerTest.php
@@ -12,14 +12,15 @@
 namespace Symfony\Component\Cache\Tests\Messenger;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\Messenger\EarlyExpirationHandler;
 use Symfony\Component\Cache\Messenger\EarlyExpirationMessage;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ReverseContainer;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\Cache\CallbackInterface;
 
 /**
  * @requires function Symfony\Component\DependencyInjection\ReverseContainer::__construct
@@ -40,8 +41,8 @@ class EarlyExpirationHandlerTest extends TestCase
         $item = $pool->getItem('foo');
         $item->set(234);
 
-        $computationService = new class() {
-            public function __invoke(CacheItem $item)
+        $computationService = new class() implements CallbackInterface {
+            public function __invoke(CacheItemInterface $item, bool &$save)
             {
                 usleep(30000);
                 $item->expiresAfter(3600);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Adds support for CallbackInterface in EarlyExpirationHandler and thus fixes async cache recomputing for callables that implement CallbackInterface. Earlier similar errors were fixed in #31879.