### PR TITLE
[DependencyInjection] Improve dumping closure of service closure

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1156,6 +1156,10 @@ EOTXT
 
             if (['Closure', 'fromCallable'] === $callable && [0] === array_keys($definition->getArguments())) {
                 $callable = $definition->getArgument(0);
+                if ($callable instanceof ServiceClosureArgument) {
+                    return $return.$this->dumpValue($callable).$tail;
+                }
+
                 $arguments = ['...'];
 
                 if ($callable instanceof Reference || $callable instanceof Definition) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1601,6 +1601,11 @@ PHP
             ->setFactory(['Closure', 'fromCallable'])
             ->setArguments([new Reference('bar')]);
         $container->register('bar', 'stdClass');
+        $container->register('closure_of_service_closure', 'Closure')
+            ->setPublic('true')
+            ->setFactory(['Closure', 'fromCallable'])
+            ->setArguments([new ServiceClosureArgument(new Reference('bar2'))]);
+        $container->register('bar2', 'stdClass');
         $container->compile();
         $dumper = new PhpDumper($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure.php
@@ -23,6 +23,7 @@ class ProjectServiceContainer extends Container
         $this->services = $this->privates = [];
         $this->methodMap = [
             'closure' => 'getClosureService',
+            'closure_of_service_closure' => 'getClosureOfServiceClosureService',
         ];
 
         $this->aliases = [];
@@ -42,6 +43,7 @@ class ProjectServiceContainer extends Container
     {
         return [
             'bar' => true,
+            'bar2' => true,
         ];
     }
 
@@ -53,5 +55,21 @@ class ProjectServiceContainer extends Container
     protected static function getClosureService($container)
     {
         return $container->services['closure'] = (new \stdClass())->__invoke(...);
+    }
+
+    /**
+     * Gets the public 'closure_of_service_closure' shared service.
+     *
+     * @return \Closure
+     */
+    protected static function getClosureOfServiceClosureService($container)
+    {
+        $containerRef = $container->ref;
+
+        return $container->services['closure_of_service_closure'] = #[\Closure(name: 'bar2', class: 'stdClass')] static function () use ($containerRef) {
+            $container = $containerRef->get();
+
+            return ($container->privates['bar2'] ??= new \stdClass());
+        };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Replaces https://github.com/symfony/symfony/pull/49413 as an improvement

Dumping `(...)` at the end of a `\Closure` is useless.