### PR TITLE
[WebProfilerBundle] Render original (not encoded) email headers

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -121,18 +121,18 @@
                                                 <h3 class="tab-title">Headers</h3>
                                                 <div class="tab-content">
                                                     <span class="label">Subject</span>
-                                                    <h2 class="m-t-10">{{ message.headers.get('subject').bodyAsString() ?? '(empty)' }}</h2>
+                                                    <h2 class="m-t-10">{{ message.getSubject() ?? '(empty)' }}</h2>
                                                     <div class="row">
                                                         <div class="col col-4">
                                                             <span class="label">From</span>
-                                                            <pre class="prewrap">{{ (message.headers.get('from').bodyAsString() ?? '(empty)')|replace({'From:': ''}) }}</pre>
+                                                            <pre class="prewrap">{{ message.getFrom()|map(addr => addr.toString())|join(', ')|default('(empty)') }}</pre>
 
                                                             <span class="label">To</span>
-                                                            <pre class="prewrap">{{ (message.headers.get('to').bodyAsString() ?? '(empty)')|replace({'To:': ''}) }}</pre>
+                                                            <pre class="prewrap">{{ message.getTo()|map(addr => addr.toString())|join(', ')|default('(empty)') }}</pre>
                                                         </div>
                                                         <div class="col">
                                                             <span class="label">Headers</span>
-                                                            <pre class="prewrap">{% for header in message.headers.all|filter(header => (header.name ?? '') not in ['Subject', 'From', 'To']) %}
+                                                            <pre class="prewrap">{% for header in message.headers.all|filter(header => (header.name ?? '')|lower not in ['subject', 'from', 'to']) %}
                                                                 {{- header.toString }}
                                                             {%~ endfor %}</pre>
                                                         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Backported version of https://github.com/symfony/symfony/pull/49400
