### PR TITLE
[Messenger] Allow to define batch size when using `BatchHandlerTrait` with `getBatchSize()`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport` and
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransportFactory`
  * Allow passing a string instead of an array in `TransportNamesStamp`
+ * Allow to define batch size when using `BatchHandlerTrait` with `getBatchSize()`
 
 6.2
 ---

--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
@@ -55,7 +55,7 @@ trait BatchHandlerTrait
 
     private function shouldFlush(): bool
     {
-        return 10 <= \count($this->jobs);
+        return $this->getBatchSize() <= \count($this->jobs);
     }
 
     /**
@@ -64,4 +64,9 @@ trait BatchHandlerTrait
      * @list<array{0: object, 1: Acknowledger}> $jobs A list of pairs of messages and their corresponding acknowledgers
      */
     abstract private function process(array $jobs): void;
+
+    private function getBatchSize(): int
+    {
+        return 10;
+    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -179,9 +179,9 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
                 return $this->handle($message, $ack);
             }
 
-            private function shouldFlush()
+            private function getBatchSize(): int
             {
-                return 2 <= \count($this->jobs);
+                return 2;
             }
 
             private function process(array $jobs): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

Because of the nature of `BatchHandlerTrait`, the flush logic may often be the same. Because of this, I think this could be nice to define the batch size by just overriding a `getBatchSize()` method of the trait, instead of having to override the whole `shouldFlush()` method. 🙂 
