### PR TITLE
[Mailer] Add option to enable Sandbox via dsn option sandbox=true

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add sandbox option
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/README.md
@@ -8,6 +8,7 @@ Configuration examples:
 ```dotenv
 # API
 MAILER_DSN=mailjet+api://$PUBLIC_KEY:$PRIVATE_KEY@default
+MAILER_DSN=mailjet+api://$PUBLIC_KEY:$PRIVATE_KEY@default?sandbox=true
 # SMTP
 MAILER_DSN=mailjet+smtp://$PUBLIC_KEY:$PRIVATE_KEY@default
 ```

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -318,7 +318,6 @@ class MailjetApiTransportTest extends TestCase
 
         $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
         $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
-        $method->setAccessible(true);
         self::assertSame(
             [
                 'Messages' => [
@@ -364,6 +363,59 @@ class MailjetApiTransportTest extends TestCase
                         'TrackOpen' => 'account_default',
                     ],
                 ],
+                'SandBoxMode' => false,
+            ],
+            $method->invoke($transport, $email, $envelope)
+        );
+
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD, sandbox: true);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        self::assertSame(
+            [
+                'Messages' => [
+                    [
+                        'From' => [
+                            'Email' => 'foo@example.com',
+                            'Name' => 'Foo',
+                        ],
+                        'To' => [
+                            [
+                                'Email' => 'bar@example.com',
+                                'Name' => '',
+                            ],
+                        ],
+                        'Subject' => 'Sending email to mailjet API',
+                        'Attachments' => [],
+                        'InlinedAttachments' => [],
+                        'ReplyTo' => [
+                            'Email' => 'qux@example.com',
+                            'Name' => 'Qux',
+                        ],
+                        'Headers' => [
+                            'X-authorized-header' => 'authorized',
+                        ],
+                        'TemplateLanguage' => true,
+                        'TemplateID' => 12345,
+                        'TemplateErrorReporting' => [
+                            'Email' => 'errors@mailjet.com',
+                            'Name' => 'Error Email',
+                        ],
+                        'TemplateErrorDeliver' => true,
+                        'Variables' => [
+                            'varname1' => 'value1',
+                            'varname2' => 'value2',
+                            'varname3' => 'value3',
+                        ],
+                        'CustomID' => 'CustomValue',
+                        'EventPayload' => 'Eticket,1234,row,15,seat,B',
+                        'CustomCampaign' => 'SendAPI_campaign',
+                        'DeduplicateCampaign' => true,
+                        'Priority' => 2,
+                        'TrackClick' => 'account_default',
+                        'TrackOpen' => 'account_default',
+                    ],
+                ],
+                'SandBoxMode' => true,
             ],
             $method->invoke($transport, $email, $envelope)
         );

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -53,11 +53,13 @@ class MailjetApiTransport extends AbstractApiTransport
 
     private string $privateKey;
     private string $publicKey;
+    private bool $sandbox;
 
-    public function __construct(string $publicKey, string $privateKey, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $publicKey, string $privateKey, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null, bool $sandbox = false)
     {
         $this->publicKey = $publicKey;
         $this->privateKey = $privateKey;
+        $this->sandbox = $sandbox;
 
         parent::__construct($client, $dispatcher, $logger);
     }
@@ -153,6 +155,7 @@ class MailjetApiTransport extends AbstractApiTransport
 
         return [
             'Messages' => [$message],
+            'SandBoxMode' => $this->sandbox,
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetTransportFactory.php
@@ -24,9 +24,10 @@ class MailjetTransportFactory extends AbstractTransportFactory
         $user = $this->getUser($dsn);
         $password = $this->getPassword($dsn);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $sandbox = filter_var($dsn->getOption('sandbox', false), \FILTER_VALIDATE_BOOL);
 
         if ('mailjet+api' === $scheme) {
-            return (new MailjetApiTransport($user, $password, $this->client, $this->dispatcher, $this->logger))->setHost($host);
+            return (new MailjetApiTransport($user, $password, $this->client, $this->dispatcher, $this->logger, $sandbox))->setHost($host);
         }
 
         if (\in_array($scheme, ['mailjet+smtp', 'mailjet+smtps', 'mailjet'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no 
| Tickets       | Fix #49410
| License       | MIT
| Doc PR        | -

Mailjet introduced a Sandbox Mode https://dev.mailjet.com/email/guides/send-api-v31/#sandbox-mode that allows to use the API but not sending any email e.g. for debugging.

`MAILER_DSN=mailjet+api://$PUBLIC_KEY:$PRIVATE_KEY@default?sandbox=true`
