### PR TITLE
[Mailer][Translation] Remove some `static` occurrences that may cause unstable tests

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport;
 
 use AsyncAws\Core\Configuration;
 use AsyncAws\Ses\SesClient;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesHttpAsyncAwsTransport;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesSmtpTransport;
@@ -23,9 +25,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class SesTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new SesTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new SesTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -63,108 +65,107 @@ class SesTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $client = self::getClient();
-        $dispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $client = new MockHttpClient();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('ses+api', 'default', self::USER, self::PASSWORD),
-            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1']), null, $client, $logger), $dispatcher, $logger),
+            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+api', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-2']),
-            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2']), null, $client, $logger), $dispatcher, $logger),
+            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+api', 'example.com', self::USER, self::PASSWORD, 8080),
-            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080']), null, $client, $logger), $dispatcher, $logger),
+            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+api', 'default', self::USER, self::PASSWORD, null, ['session_token' => 'se$sion']),
-            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'sessionToken' => 'se$sion']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+api', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-2', 'session_token' => 'se$sion']),
-            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2', 'sessionToken' => 'se$sion']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+api', 'example.com', self::USER, self::PASSWORD, 8080, ['session_token' => 'se$sion']),
-            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080', 'sessionToken' => 'se$sion']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+https', 'default', self::USER, self::PASSWORD),
-            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1']), null, $client, $logger), $dispatcher, $logger),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses', 'default', self::USER, self::PASSWORD),
-            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1']), null, $client, $logger), $dispatcher, $logger),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+https', 'example.com', self::USER, self::PASSWORD, 8080),
-            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080']), null, $client, $logger), $dispatcher, $logger),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+https', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-2']),
-            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2']), null, $client, $logger), $dispatcher, $logger),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+https', 'default', self::USER, self::PASSWORD, null, ['session_token' => 'se$sion']),
-            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'sessionToken' => 'se$sion']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses', 'default', self::USER, self::PASSWORD, null, ['session_token' => 'se$sion']),
-            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'sessionToken' => 'se$sion']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+https', 'example.com', self::USER, self::PASSWORD, 8080, ['session_token' => 'se$sion']),
-            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080', 'sessionToken' => 'se$sion']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+https', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-2', 'session_token' => 'se$sion']),
-            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2', 'sessionToken' => 'se$sion']), null, $client, $logger), null, $logger),
         ];
 
         yield [
             new Dsn('ses+smtp', 'default', self::USER, self::PASSWORD),
-            new SesSmtpTransport(self::USER, self::PASSWORD, null, $dispatcher, $logger),
+            new SesSmtpTransport(self::USER, self::PASSWORD, null, null, $logger),
         ];
 
         yield [
             new Dsn('ses+smtp', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1']),
-            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger),
+            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', null, $logger),
         ];
 
         yield [
             new Dsn('ses+smtps', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1']),
-            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger),
+            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', null, $logger),
         ];
 
         yield [
             new Dsn('ses+smtps', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1', 'ping_threshold' => '10']),
-            (new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger))->setPingThreshold(10),
+            (new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', null, $logger))->setPingThreshold(10),
         ];
 
         yield [
             new Dsn('ses+smtp', 'custom.vpc.endpoint', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1']),
-            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger, 'custom.vpc.endpoint'),
+            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', null, $logger, 'custom.vpc.endpoint'),
         ];
 
         yield [
             new Dsn('ses+smtps', 'custom.vpc.endpoint', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1']),
-            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger, 'custom.vpc.endpoint'),
+            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', null, $logger, 'custom.vpc.endpoint'),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\Google\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Google\Transport\GmailSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Google\Transport\GmailTransportFactory;
 use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
@@ -19,9 +21,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class GmailTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new GmailTransportFactory(self::getDispatcher(), null, self::getLogger());
+        return new GmailTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -51,17 +53,17 @@ class GmailTransportFactoryTest extends TransportFactoryTestCase
     {
         yield [
             new Dsn('gmail', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, self::getDispatcher(), self::getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, null, new NullLogger()),
         ];
 
         yield [
             new Dsn('gmail+smtp', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, self::getDispatcher(), self::getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, null, new NullLogger()),
         ];
 
         yield [
             new Dsn('gmail+smtps', 'default', self::USER, self::PASSWORD),
-            new GmailSmtpTransport(self::USER, self::PASSWORD, self::getDispatcher(), self::getLogger()),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, null, new NullLogger()),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\Infobip\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipApiTransport;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipTransportFactory;
@@ -20,9 +22,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class InfobipApiTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new InfobipTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new InfobipTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -55,27 +57,26 @@ class InfobipApiTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $dispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('infobip+api', 'example.com', self::PASSWORD),
-            (new InfobipApiTransport(self::PASSWORD, self::getClient(), $dispatcher, $logger))->setHost('example.com'),
+            (new InfobipApiTransport(self::PASSWORD, new MockHttpClient(), null, $logger))->setHost('example.com'),
         ];
 
         yield [
             new Dsn('infobip', 'default', self::PASSWORD),
-            new InfobipSmtpTransport(self::PASSWORD, $dispatcher, $logger),
+            new InfobipSmtpTransport(self::PASSWORD, null, $logger),
         ];
 
         yield [
             new Dsn('infobip+smtp', 'default', self::PASSWORD),
-            new InfobipSmtpTransport(self::PASSWORD, $dispatcher, $logger),
+            new InfobipSmtpTransport(self::PASSWORD, null, $logger),
         ];
 
         yield [
             new Dsn('infobip+smtps', 'default', self::PASSWORD),
-            new InfobipSmtpTransport(self::PASSWORD, $dispatcher, $logger),
+            new InfobipSmtpTransport(self::PASSWORD, null, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/MailPace/Tests/Transport/MailPaceTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailPace/Tests/Transport/MailPaceTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\MailPace\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\MailPace\Transport\MailPaceApiTransport;
 use Symfony\Component\Mailer\Bridge\MailPace\Transport\MailPaceSmtpTransport;
 use Symfony\Component\Mailer\Bridge\MailPace\Transport\MailPaceTransportFactory;
@@ -20,9 +22,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 final class MailPaceTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new MailPaceTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new MailPaceTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -55,32 +57,31 @@ final class MailPaceTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $dispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('mailpace+api', 'default', self::USER),
-            new MailPaceApiTransport(self::USER, self::getClient(), $dispatcher, $logger),
+            new MailPaceApiTransport(self::USER, new MockHttpClient(), null, $logger),
         ];
 
         yield [
             new Dsn('mailpace+api', 'example.com', self::USER, '', 8080),
-            (new MailPaceApiTransport(self::USER, self::getClient(), $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new MailPaceApiTransport(self::USER, new MockHttpClient(), null, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('mailpace', 'default', self::USER),
-            new MailPaceSmtpTransport(self::USER, $dispatcher, $logger),
+            new MailPaceSmtpTransport(self::USER, null, $logger),
         ];
 
         yield [
             new Dsn('mailpace+smtp', 'default', self::USER),
-            new MailPaceSmtpTransport(self::USER, $dispatcher, $logger),
+            new MailPaceSmtpTransport(self::USER, null, $logger),
         ];
 
         yield [
             new Dsn('mailpace+smtps', 'default', self::USER),
-            new MailPaceSmtpTransport(self::USER, $dispatcher, $logger),
+            new MailPaceSmtpTransport(self::USER, null, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\Mailchimp\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillApiTransport;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillHttpTransport;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillSmtpTransport;
@@ -21,9 +23,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class MandrillTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new MandrillTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new MandrillTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -61,43 +63,42 @@ class MandrillTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $client = self::getClient();
-        $dispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $client = new MockHttpClient();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('mandrill+api', 'default', self::USER),
-            new MandrillApiTransport(self::USER, $client, $dispatcher, $logger),
+            new MandrillApiTransport(self::USER, $client, null, $logger),
         ];
 
         yield [
             new Dsn('mandrill+api', 'example.com', self::USER, '', 8080),
-            (new MandrillApiTransport(self::USER, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new MandrillApiTransport(self::USER, $client, null, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('mandrill', 'default', self::USER),
-            new MandrillHttpTransport(self::USER, $client, $dispatcher, $logger),
+            new MandrillHttpTransport(self::USER, $client, null, $logger),
         ];
 
         yield [
             new Dsn('mandrill+https', 'default', self::USER),
-            new MandrillHttpTransport(self::USER, $client, $dispatcher, $logger),
+            new MandrillHttpTransport(self::USER, $client, null, $logger),
         ];
 
         yield [
             new Dsn('mandrill+https', 'example.com', self::USER, '', 8080),
-            (new MandrillHttpTransport(self::USER, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new MandrillHttpTransport(self::USER, $client, null, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('mandrill+smtp', 'default', self::USER, self::PASSWORD),
-            new MandrillSmtpTransport(self::USER, self::PASSWORD, $dispatcher, $logger),
+            new MandrillSmtpTransport(self::USER, self::PASSWORD, null, $logger),
         ];
 
         yield [
             new Dsn('mandrill+smtps', 'default', self::USER, self::PASSWORD),
-            new MandrillSmtpTransport(self::USER, self::PASSWORD, $dispatcher, $logger),
+            new MandrillSmtpTransport(self::USER, self::PASSWORD, null, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\Mailgun\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunApiTransport;
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunHttpTransport;
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunSmtpTransport;
@@ -21,9 +23,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class MailgunTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new MailgunTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new MailgunTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -61,48 +63,47 @@ class MailgunTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $client = self::getClient();
-        $dispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $client = new MockHttpClient();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('mailgun+api', 'default', self::USER, self::PASSWORD),
-            new MailgunApiTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger),
+            new MailgunApiTransport(self::USER, self::PASSWORD, null, $client, null, $logger),
         ];
 
         yield [
             new Dsn('mailgun+api', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu']),
-            new MailgunApiTransport(self::USER, self::PASSWORD, 'eu', $client, $dispatcher, $logger),
+            new MailgunApiTransport(self::USER, self::PASSWORD, 'eu', $client, null, $logger),
         ];
 
         yield [
             new Dsn('mailgun+api', 'example.com', self::USER, self::PASSWORD, 8080),
-            (new MailgunApiTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new MailgunApiTransport(self::USER, self::PASSWORD, null, $client, null, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('mailgun', 'default', self::USER, self::PASSWORD),
-            new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger),
+            new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, null, $logger),
         ];
 
         yield [
             new Dsn('mailgun+https', 'default', self::USER, self::PASSWORD),
-            new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger),
+            new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, null, $logger),
         ];
 
         yield [
             new Dsn('mailgun+https', 'example.com', self::USER, self::PASSWORD, 8080),
-            (new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, null, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('mailgun+smtp', 'default', self::USER, self::PASSWORD),
-            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, $dispatcher, $logger),
+            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null, $logger),
         ];
 
         yield [
             new Dsn('mailgun+smtps', 'default', self::USER, self::PASSWORD),
-            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, $dispatcher, $logger),
+            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\Mailjet\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetApiTransport;
 use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetTransportFactory;
@@ -20,9 +22,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class MailjetTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new MailjetTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new MailjetTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -55,32 +57,31 @@ class MailjetTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $dispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('mailjet+api', 'default', self::USER, self::PASSWORD),
-            new MailjetApiTransport(self::USER, self::PASSWORD, self::getClient(), $dispatcher, $logger),
+            new MailjetApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, $logger),
         ];
 
         yield [
             new Dsn('mailjet+api', 'example.com', self::USER, self::PASSWORD),
-            (new MailjetApiTransport(self::USER, self::PASSWORD, self::getClient(), $dispatcher, $logger))->setHost('example.com'),
+            (new MailjetApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, $logger))->setHost('example.com'),
         ];
 
         yield [
             new Dsn('mailjet', 'default', self::USER, self::PASSWORD),
-            new MailjetSmtpTransport(self::USER, self::PASSWORD, $dispatcher, $logger),
+            new MailjetSmtpTransport(self::USER, self::PASSWORD, null, $logger),
         ];
 
         yield [
             new Dsn('mailjet+smtp', 'default', self::USER, self::PASSWORD),
-            new MailjetSmtpTransport(self::USER, self::PASSWORD, $dispatcher, $logger),
+            new MailjetSmtpTransport(self::USER, self::PASSWORD, null, $logger),
         ];
 
         yield [
             new Dsn('mailjet+smtps', 'default', self::USER, self::PASSWORD),
-            new MailjetSmtpTransport(self::USER, self::PASSWORD, $dispatcher, $logger),
+            new MailjetSmtpTransport(self::USER, self::PASSWORD, null, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/OhMySmtp/Tests/Transport/OhMySmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/OhMySmtp/Tests/Transport/OhMySmtpTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\OhMySmtp\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\OhMySmtp\Transport\OhMySmtpApiTransport;
 use Symfony\Component\Mailer\Bridge\OhMySmtp\Transport\OhMySmtpSmtpTransport;
 use Symfony\Component\Mailer\Bridge\OhMySmtp\Transport\OhMySmtpTransportFactory;
@@ -23,9 +25,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
  */
 final class OhMySmtpTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new OhMySmtpTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new OhMySmtpTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -58,32 +60,31 @@ final class OhMySmtpTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $dispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('ohmysmtp+api', 'default', self::USER),
-            new OhMySmtpApiTransport(self::USER, self::getClient(), $dispatcher, $logger),
+            new OhMySmtpApiTransport(self::USER, new MockHttpClient(), null, $logger),
         ];
 
         yield [
             new Dsn('ohmysmtp+api', 'example.com', self::USER, '', 8080),
-            (new OhMySmtpApiTransport(self::USER, self::getClient(), $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new OhMySmtpApiTransport(self::USER, new MockHttpClient(), null, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('ohmysmtp', 'default', self::USER),
-            new OhMySmtpSmtpTransport(self::USER, $dispatcher, $logger),
+            new OhMySmtpSmtpTransport(self::USER, null, $logger),
         ];
 
         yield [
             new Dsn('ohmysmtp+smtp', 'default', self::USER),
-            new OhMySmtpSmtpTransport(self::USER, $dispatcher, $logger),
+            new OhMySmtpSmtpTransport(self::USER, null, $logger),
         ];
 
         yield [
             new Dsn('ohmysmtp+smtps', 'default', self::USER),
-            new OhMySmtpSmtpTransport(self::USER, $dispatcher, $logger),
+            new OhMySmtpSmtpTransport(self::USER, null, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\Postmark\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkApiTransport;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
@@ -20,9 +22,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class PostmarkTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new PostmarkTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new PostmarkTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -55,42 +57,41 @@ class PostmarkTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $dispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('postmark+api', 'default', self::USER),
-            new PostmarkApiTransport(self::USER, self::getClient(), $dispatcher, $logger),
+            new PostmarkApiTransport(self::USER, new MockHttpClient(), null, $logger),
         ];
 
         yield [
             new Dsn('postmark+api', 'example.com', self::USER, '', 8080),
-            (new PostmarkApiTransport(self::USER, self::getClient(), $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new PostmarkApiTransport(self::USER, new MockHttpClient(), null, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('postmark+api', 'example.com', self::USER, '', 8080, ['message_stream' => 'broadcasts']),
-            (new PostmarkApiTransport(self::USER, self::getClient(), $dispatcher, $logger))->setHost('example.com')->setPort(8080)->setMessageStream('broadcasts'),
+            (new PostmarkApiTransport(self::USER, new MockHttpClient(), null, $logger))->setHost('example.com')->setPort(8080)->setMessageStream('broadcasts'),
         ];
 
         yield [
             new Dsn('postmark', 'default', self::USER),
-            new PostmarkSmtpTransport(self::USER, $dispatcher, $logger),
+            new PostmarkSmtpTransport(self::USER, null, $logger),
         ];
 
         yield [
             new Dsn('postmark+smtp', 'default', self::USER),
-            new PostmarkSmtpTransport(self::USER, $dispatcher, $logger),
+            new PostmarkSmtpTransport(self::USER, null, $logger),
         ];
 
         yield [
             new Dsn('postmark+smtps', 'default', self::USER),
-            new PostmarkSmtpTransport(self::USER, $dispatcher, $logger),
+            new PostmarkSmtpTransport(self::USER, null, $logger),
         ];
 
         yield [
             new Dsn('postmark+smtps', 'default', self::USER, null, null, ['message_stream' => 'broadcasts']),
-            (new PostmarkSmtpTransport(self::USER, $dispatcher, $logger))->setMessageStream('broadcasts'),
+            (new PostmarkSmtpTransport(self::USER, null, $logger))->setMessageStream('broadcasts'),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "psr/event-dispatcher": "^1",
         "symfony/mailer": "^5.4.21|^6.2.7"
     },
     "require-dev": {

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\Sendgrid\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridApiTransport;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
@@ -20,9 +22,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class SendgridTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new SendgridTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new SendgridTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -55,32 +57,31 @@ class SendgridTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $dispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('sendgrid+api', 'default', self::USER),
-            new SendgridApiTransport(self::USER, self::getClient(), $dispatcher, $logger),
+            new SendgridApiTransport(self::USER, new MockHttpClient(), null, $logger),
         ];
 
         yield [
             new Dsn('sendgrid+api', 'example.com', self::USER, '', 8080),
-            (new SendgridApiTransport(self::USER, self::getClient(), $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new SendgridApiTransport(self::USER, new MockHttpClient(), null, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('sendgrid', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, null, $logger),
         ];
 
         yield [
             new Dsn('sendgrid+smtp', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, null, $logger),
         ];
 
         yield [
             new Dsn('sendgrid+smtps', 'default', self::USER),
-            new SendgridSmtpTransport(self::USER, $dispatcher, $logger),
+            new SendgridSmtpTransport(self::USER, null, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/Tests/Transport/SendinblueTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\Sendinblue\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Sendinblue\Transport\SendinblueApiTransport;
 use Symfony\Component\Mailer\Bridge\Sendinblue\Transport\SendinblueSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Sendinblue\Transport\SendinblueTransportFactory;
@@ -20,9 +22,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class SendinblueTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new SendinblueTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new SendinblueTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -52,22 +54,22 @@ class SendinblueTransportFactoryTest extends TransportFactoryTestCase
     {
         yield [
             new Dsn('sendinblue', 'default', self::USER, self::PASSWORD),
-            new SendinblueSmtpTransport(self::USER, self::PASSWORD, self::getDispatcher(), self::getLogger()),
+            new SendinblueSmtpTransport(self::USER, self::PASSWORD, null, new NullLogger()),
         ];
 
         yield [
             new Dsn('sendinblue+smtp', 'default', self::USER, self::PASSWORD),
-            new SendinblueSmtpTransport(self::USER, self::PASSWORD, self::getDispatcher(), self::getLogger()),
+            new SendinblueSmtpTransport(self::USER, self::PASSWORD, null, new NullLogger()),
         ];
 
         yield [
             new Dsn('sendinblue+smtp', 'default', self::USER, self::PASSWORD, 465),
-            new SendinblueSmtpTransport(self::USER, self::PASSWORD, self::getDispatcher(), self::getLogger()),
+            new SendinblueSmtpTransport(self::USER, self::PASSWORD, null, new NullLogger()),
         ];
 
         yield [
             new Dsn('sendinblue+api', 'default', self::USER),
-            new SendinblueApiTransport(self::USER, self::getClient(), self::getDispatcher(), self::getLogger()),
+            new SendinblueApiTransport(self::USER, new MockHttpClient(), null, new NullLogger()),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -6,6 +6,12 @@ CHANGELOG
 
  * Add `MessageEvent::reject()` to allow rejecting an email before sending it
 
+6.2.7
+-----
+
+ * [BC BREAK] The following data providers for `TransportFactoryTestCase` are now static:
+  `supportsProvider()`, `createProvider()`, `unsupportedSchemeProvider()`and `incompleteDsnProvider()`
+
 6.2
 ---
 
@@ -22,14 +28,6 @@ CHANGELOG
 ---
 
  * The `HttpTransportException` class takes a string at first argument
-
-5.4.21
-------
-
- * [BC BREAK] The following data providers for `TransportFactoryTestCase` are now static:
-  `supportsProvider()`, `createProvider()`, `unsupportedSchemeProvider()`and `incompleteDsnProvider()`
- * [BC BREAK] The following data providers for `TransportTestCase` are now static:
-  `toStringProvider()`, `supportedMessagesProvider()` and `unsupportedMessagesProvider()`
 
 5.4
 ---

--- a/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Mailer\Test;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
-use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Exception\IncompleteDsnException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\Dsn;
@@ -33,11 +31,11 @@ abstract class TransportFactoryTestCase extends TestCase
     protected const USER = 'u$er';
     protected const PASSWORD = 'pa$s';
 
-    protected static $dispatcher;
-    protected static $client;
-    protected static $logger;
+    protected $dispatcher;
+    protected $client;
+    protected $logger;
 
-    abstract public static function getFactory(): TransportFactoryInterface;
+    abstract public function getFactory(): TransportFactoryInterface;
 
     abstract public static function supportsProvider(): iterable;
 
@@ -102,22 +100,18 @@ abstract class TransportFactoryTestCase extends TestCase
         $factory->create($dsn);
     }
 
-    protected static function getDispatcher(): EventDispatcherInterface
+    protected function getDispatcher(): EventDispatcherInterface
     {
-        return self::$dispatcher ??= new class() implements EventDispatcherInterface {
-            public function dispatch($event, string $eventName = null): object
-            {
-            }
-        };
+        return $this->dispatcher ??= $this->createMock(EventDispatcherInterface::class);
     }
 
-    protected static function getClient(): HttpClientInterface
+    protected function getClient(): HttpClientInterface
     {
-        return self::$client ??= new MockHttpClient();
+        return $this->client ??= $this->createMock(HttpClientInterface::class);
     }
 
-    protected static function getLogger(): LoggerInterface
+    protected function getLogger(): LoggerInterface
     {
-        return self::$logger ??= new NullLogger();
+        return $this->logger ??= $this->createMock(LoggerInterface::class);
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Command/MailerTestCommandTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Command/MailerTestCommandTest.php
@@ -30,10 +30,12 @@ class MailerTestCommandTest extends TestCase
         $mailer
             ->expects($this->once())
             ->method('send')
-            ->with(self::callback(static fn (Email $message): bool => $message->getFrom()[0]->getAddress() === $from &&
-            $message->getTo()[0]->getAddress() === $to &&
-            $message->getSubject() === $subject &&
-            $message->getTextBody() === $body))
+            ->with(self::callback(static fn (Email $message) => [$from, $to, $subject, $body] === [
+                $message->getFrom()[0]->getAddress(),
+                $message->getTo()[0]->getAddress(),
+                $message->getSubject(),
+                $message->getTextBody(),
+            ]))
         ;
 
         $tester = new CommandTester(new MailerTestCommand($mailer));
@@ -53,7 +55,7 @@ class MailerTestCommandTest extends TestCase
         $mailer
             ->expects($this->once())
             ->method('send')
-            ->with(self::callback(static fn (Email $message): bool => $message->getHeaders()->getHeaderBody('X-Transport') === $transport))
+            ->with(self::callback(static fn (Email $message) => $message->getHeaders()->getHeaderBody('X-Transport') === $transport))
         ;
 
         $tester = new CommandTester(new MailerTestCommand($mailer));

--- a/src/Symfony/Component/Mailer/Tests/Transport/NullTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/NullTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\NullTransport;
@@ -19,9 +21,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class NullTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new NullTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new NullTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -36,7 +38,7 @@ class NullTransportFactoryTest extends TransportFactoryTestCase
     {
         yield [
             new Dsn('null', 'null'),
-            new NullTransport(self::getDispatcher(), self::getLogger()),
+            new NullTransport(null, new NullLogger()),
         ];
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\SendmailTransport;
@@ -19,9 +21,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class SendmailTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new SendmailTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new SendmailTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -36,12 +38,12 @@ class SendmailTransportFactoryTest extends TransportFactoryTestCase
     {
         yield [
             new Dsn('sendmail+smtp', 'default'),
-            new SendmailTransport(null, self::getDispatcher(), self::getLogger()),
+            new SendmailTransport(null, null, new NullLogger()),
         ];
 
         yield [
             new Dsn('sendmail+smtp', 'default', null, null, null, ['command' => '/usr/sbin/sendmail -oi -t']),
-            new SendmailTransport('/usr/sbin/sendmail -oi -t', self::getDispatcher(), self::getLogger()),
+            new SendmailTransport('/usr/sbin/sendmail -oi -t', null, new NullLogger()),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Tests\Transport\Smtp;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
@@ -20,9 +22,9 @@ use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class EsmtpTransportFactoryTest extends TransportFactoryTestCase
 {
-    public static function getFactory(): TransportFactoryInterface
+    public function getFactory(): TransportFactoryInterface
     {
-        return new EsmtpTransportFactory(self::getDispatcher(), self::getClient(), self::getLogger());
+        return new EsmtpTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -45,17 +47,16 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
 
     public static function createProvider(): iterable
     {
-        $eventDispatcher = self::getDispatcher();
-        $logger = self::getLogger();
+        $logger = new NullLogger();
 
-        $transport = new EsmtpTransport('localhost', 25, false, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('localhost', 25, false, null, $logger);
 
         yield [
             new Dsn('smtp', 'localhost'),
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 99, true, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 99, true, null, $logger);
         $transport->setUsername(self::USER);
         $transport->setPassword(self::PASSWORD);
 
@@ -64,21 +65,21 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
 
         yield [
             new Dsn('smtps', 'example.com'),
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
 
         yield [
             new Dsn('smtps', 'example.com', '', '', 465),
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
         /** @var SocketStream $stream */
         $stream = $transport->getStream();
         $streamOptions = $stream->getStreamOptions();
@@ -101,14 +102,14 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
 
         yield [
             Dsn::fromString('smtps://:@example.com?verify_peer='),
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
         $transport->setLocalDomain('example.com');
 
         yield [
@@ -116,7 +117,7 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
         $transport->setMaxPerSecond(2.0);
 
         yield [
@@ -124,7 +125,7 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
         $transport->setRestartThreshold(10, 1);
 
         yield [
@@ -132,7 +133,7 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
         $transport->setPingThreshold(10);
 
         yield [

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation\Bridge\Loco\Tests;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Translation\Bridge\Loco\LocoProvider;
@@ -29,40 +30,40 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class LocoProviderTest extends ProviderTestCase
 {
-    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface
+    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, TranslatorBagInterface $translatorBag = null): ProviderInterface
     {
-        return new LocoProvider($client, $loader, $logger, $defaultLocale, $endpoint, self::getTranslatorBag());
+        return new LocoProvider($client, $loader, $logger, $defaultLocale, $endpoint, $translatorBag ?? new TranslatorBag());
     }
 
     public static function toStringProvider(): iterable
     {
         yield [
-            self::createProvider(self::getClient()->withOptions([
+            self::createProvider((new MockHttpClient())->withOptions([
                 'base_uri' => 'https://localise.biz/api/',
                 'headers' => [
                     'Authorization' => 'Loco API_KEY',
                 ],
-            ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/'),
+            ]), new ArrayLoader(), new NullLogger(), 'en', 'localise.biz/api/'),
             'loco://localise.biz/api/',
         ];
 
         yield [
-            self::createProvider(self::getClient()->withOptions([
+            self::createProvider((new MockHttpClient())->withOptions([
                 'base_uri' => 'https://example.com',
                 'headers' => [
                     'Authorization' => 'Loco API_KEY',
                 ],
-            ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'example.com'),
+            ]), new ArrayLoader(), new NullLogger(), 'en', 'example.com'),
             'loco://example.com',
         ];
 
         yield [
-            self::createProvider(self::getClient()->withOptions([
+            self::createProvider((new MockHttpClient())->withOptions([
                 'base_uri' => 'https://example.com:99',
                 'headers' => [
                     'Authorization' => 'Loco API_KEY',
                 ],
-            ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'example.com:99'),
+            ]), new ArrayLoader(), new NullLogger(), 'en', 'example.com:99'),
             'loco://example.com:99',
         ];
     }
@@ -247,7 +248,7 @@ class LocoProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');
 
         $provider->write($translatorBag);
     }
@@ -281,7 +282,7 @@ class LocoProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to add new translation key "a" to Loco: (status code: "500").');
@@ -333,7 +334,7 @@ class LocoProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to create tag "messages" on Loco.');
@@ -393,7 +394,7 @@ class LocoProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to tag assets with "messages" on Loco.');
@@ -453,7 +454,7 @@ class LocoProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to tag asset "messages__a,messages__b" with "messages" on Loco.');
@@ -527,7 +528,7 @@ class LocoProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to create locale "en" on Loco.');
@@ -604,7 +605,7 @@ class LocoProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to get assets from Loco.');
@@ -689,7 +690,7 @@ class LocoProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => ['Authorization' => 'Loco API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'localise.biz/api/');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to add translation for key "messages__a" in locale "en" to Loco.');
@@ -702,13 +703,12 @@ class LocoProviderTest extends ProviderTestCase
      */
     public function testReadForOneLocaleAndOneDomain(string $locale, string $domain, string $responseContent, TranslatorBag $expectedTranslatorBag)
     {
-        static::$loader = $this->createMock(LoaderInterface::class);
-        static::$loader->expects($this->once())
+        $loader = $this->getLoader();
+        $loader->expects($this->once())
             ->method('load')
             ->willReturn((new XliffFileLoader())->load($responseContent, $locale, $domain));
 
-        static::$translatorBag = $this->createMock(TranslatorBagInterface::class);
-        static::$translatorBag->expects($this->any())
+        $this->getTranslatorBag()->expects($this->any())
             ->method('getCatalogue')
             ->willReturn(new MessageCatalogue($locale));
 
@@ -717,7 +717,7 @@ class LocoProviderTest extends ProviderTestCase
             'headers' => [
                 'Authorization' => 'Loco API_KEY',
             ],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $loader, new NullLogger(), 'en', 'localise.biz/api/', $this->getTranslatorBag());
         $translatorBag = $provider->read([$domain], [$locale]);
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
         foreach ($translatorBag->getCatalogues() as $catalogue) {
@@ -744,14 +744,13 @@ class LocoProviderTest extends ProviderTestCase
             }
         }
 
-        static::$loader = $this->createMock(LoaderInterface::class);
-        static::$loader->expects($this->exactly(\count($consecutiveLoadArguments)))
+        $loader = $this->getLoader();
+        $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
             ->withConsecutive(...$consecutiveLoadArguments)
             ->willReturnOnConsecutiveCalls(...$consecutiveLoadReturns);
 
-        static::$translatorBag = $this->createMock(TranslatorBagInterface::class);
-        static::$translatorBag->expects($this->any())
+        $this->getTranslatorBag()->expects($this->any())
             ->method('getCatalogue')
             ->willReturn(new MessageCatalogue($locale));
 
@@ -760,7 +759,7 @@ class LocoProviderTest extends ProviderTestCase
             'headers' => [
                 'Authorization' => 'Loco API_KEY',
             ],
-        ]), static::getLoader(), self::getLogger(), self::getDefaultLocale(), 'localise.biz/api/');
+        ]), $loader, $this->getLogger(), 'en', 'localise.biz/api/', $this->getTranslatorBag());
         $translatorBag = $provider->read($domains, $locales);
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
         foreach ($translatorBag->getCatalogues() as $catalogue) {
@@ -798,8 +797,8 @@ class LocoProviderTest extends ProviderTestCase
             }
         }
 
-        static::$loader = $this->createMock(LoaderInterface::class);
-        static::$loader->expects($this->exactly(\count($consecutiveLoadArguments)))
+        $loader = $this->getLoader();
+        $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
             ->withConsecutive(...$consecutiveLoadArguments)
             ->willReturnOnConsecutiveCalls(...$consecutiveLoadReturns);
@@ -812,7 +811,7 @@ class LocoProviderTest extends ProviderTestCase
             'localise.biz/api/'
         );
 
-        self::$translatorBag = $provider->read($domains, $locales);
+        $this->translatorBag = $provider->read($domains, $locales);
 
         $responses = [];
 
@@ -839,7 +838,8 @@ class LocoProviderTest extends ProviderTestCase
             $this->getLoader(),
             $this->getLogger(),
             $this->getDefaultLocale(),
-            'localise.biz/api/'
+            'localise.biz/api/',
+            $this->getTranslatorBag()
         );
 
         $translatorBag = $provider->read($domains, $locales);
@@ -888,9 +888,9 @@ class LocoProviderTest extends ProviderTestCase
                     return new MockResponse();
                 },
             ], 'https://localise.biz/api/'),
-            self::getLoader(),
-            self::getLogger(),
-            self::getDefaultLocale(),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
             'localise.biz/api/'
         );
 
@@ -920,9 +920,9 @@ class LocoProviderTest extends ProviderTestCase
                     return new MockResponse('', ['http_code' => 500]);
                 },
             ], 'https://localise.biz/api/'),
-            self::getLoader(),
-            self::getLogger(),
-            self::getDefaultLocale(),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
             'localise.biz/api/'
         );
 

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderWithoutTranslatorBagTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderWithoutTranslatorBagTest.php
@@ -19,12 +19,13 @@ use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\TranslatorBag;
+use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class LocoProviderWithoutTranslatorBagTest extends LocoProviderTest
 {
-    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface
+    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, TranslatorBagInterface $translatorBag = null): ProviderInterface
     {
         return new LocoProvider($client, $loader, $logger, $defaultLocale, $endpoint, null);
     }
@@ -59,8 +60,8 @@ class LocoProviderWithoutTranslatorBagTest extends LocoProviderTest
             }
         }
 
-        static::$loader = $this->createMock(LoaderInterface::class);
-        static::$loader->expects($this->exactly(\count($consecutiveLoadArguments) * 2))
+        $loader = $this->getLoader();
+        $loader->expects($this->exactly(\count($consecutiveLoadArguments) * 2))
             ->method('load')
             ->withConsecutive(...$consecutiveLoadArguments, ...$consecutiveLoadArguments)
             ->willReturnOnConsecutiveCalls(...$consecutiveLoadReturns, ...$consecutiveLoadReturns);

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation\Bridge\Lokalise\Tests;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Translation\Bridge\Lokalise\LokaliseProvider;
@@ -23,12 +24,13 @@ use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\Test\ProviderTestCase;
 use Symfony\Component\Translation\TranslatorBag;
+use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class LokaliseProviderTest extends ProviderTestCase
 {
-    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface
+    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, TranslatorBagInterface $translatorBag = null): ProviderInterface
     {
         return new LokaliseProvider($client, $loader, $logger, $defaultLocale, $endpoint);
     }
@@ -36,26 +38,26 @@ class LokaliseProviderTest extends ProviderTestCase
     public static function toStringProvider(): iterable
     {
         yield [
-            self::createProvider(self::getclient()->withOptions([
+            self::createProvider((new MockHttpClient())->withOptions([
                 'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
                 'headers' => ['X-Api-Token' => 'API_KEY'],
-            ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'api.lokalise.com'),
+            ]), new ArrayLoader(), new NullLogger(), 'en', 'api.lokalise.com'),
             'lokalise://api.lokalise.com',
         ];
 
         yield [
-            self::createProvider(self::getclient()->withOptions([
+            self::createProvider((new MockHttpClient())->withOptions([
                 'base_uri' => 'https://example.com',
                 'headers' => ['X-Api-Token' => 'API_KEY'],
-            ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'example.com'),
+            ]), new ArrayLoader(), new NullLogger(), 'en', 'example.com'),
             'lokalise://example.com',
         ];
 
         yield [
-            self::createProvider(self::getclient()->withOptions([
+            self::createProvider((new MockHttpClient())->withOptions([
                 'base_uri' => 'https://example.com:99',
                 'headers' => ['X-Api-Token' => 'API_KEY'],
-            ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'example.com:99'),
+            ]), new ArrayLoader(), new NullLogger(), 'en', 'example.com:99'),
             'lokalise://example.com:99',
         ];
     }
@@ -232,7 +234,7 @@ class LokaliseProviderTest extends ProviderTestCase
         ]))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'api.lokalise.com');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
 
         $translatorBag = new TranslatorBag();
         $translatorBag->addCatalogue(new MessageCatalogue('en', [
@@ -262,7 +264,7 @@ class LokaliseProviderTest extends ProviderTestCase
         ]))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'api.lokalise.com');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
 
         $translatorBag = new TranslatorBag();
         $translatorBag->addCatalogue(new MessageCatalogue('en', [
@@ -304,7 +306,7 @@ class LokaliseProviderTest extends ProviderTestCase
         ]))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'api.lokalise.com');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
 
         $translatorBag = new TranslatorBag();
         $translatorBag->addCatalogue(new MessageCatalogue('en', [
@@ -362,7 +364,7 @@ class LokaliseProviderTest extends ProviderTestCase
         ]))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'api.lokalise.com');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
 
         $translatorBag = new TranslatorBag();
         $translatorBag->addCatalogue(new MessageCatalogue('en', [
@@ -443,7 +445,7 @@ class LokaliseProviderTest extends ProviderTestCase
         ]))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'api.lokalise.com');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
 
         $translatorBag = new TranslatorBag();
         $translatorBag->addCatalogue(new MessageCatalogue('en', [
@@ -536,7 +538,7 @@ class LokaliseProviderTest extends ProviderTestCase
         ]))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'api.lokalise.com');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
 
         $translatorBag = new TranslatorBag();
         $translatorBag->addCatalogue(new MessageCatalogue('en', [
@@ -580,15 +582,15 @@ class LokaliseProviderTest extends ProviderTestCase
             ]));
         };
 
-        static::$loader = $this->createMock(LoaderInterface::class);
-        static::$loader->expects($this->once())
+        $loader = $this->getLoader();
+        $loader->expects($this->once())
             ->method('load')
             ->willReturn((new XliffFileLoader())->load($responseContent, $locale, $domain));
 
         $provider = self::createProvider((new MockHttpClient($response))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), self::getLoader(), self::getLogger(), self::getDefaultLocale(), 'api.lokalise.com');
+        ]), $loader, $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
         $translatorBag = $provider->read([$domain], [$locale]);
 
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
@@ -623,7 +625,7 @@ class LokaliseProviderTest extends ProviderTestCase
             }, []),
         ]));
 
-        $loader = self::getLoader();
+        $loader = $this->getLoader();
         $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
             ->withConsecutive(...$consecutiveLoadArguments)
@@ -632,7 +634,7 @@ class LokaliseProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($response))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
             'headers' => ['X-Api-Token' => 'API_KEY'],
-        ]), $loader, self::getLogger(), self::getDefaultLocale(), 'api.lokalise.com');
+        ]), $loader, $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
 
         $translatorBag = $provider->read($domains, $locales);
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
@@ -714,9 +716,9 @@ class LokaliseProviderTest extends ProviderTestCase
                 $getKeysIdsForValidatorsDomainResponse,
                 $deleteResponse,
             ], 'https://api.lokalise.com/api2/projects/PROJECT_ID/'),
-            self::getLoader(),
-            self::getLogger(),
-            self::getDefaultLocale(),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
             'api.lokalise.com'
         );
 

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+6.2.7
+-----
+
+ * [BC BREAK] The following data providers for `ProviderFactoryTestCase` are now static:
+   `supportsProvider()`, `createProvider()`, `unsupportedSchemeProvider()`and `incompleteDsnProvider()`
+ * [BC BREAK] `ProviderTestCase::toStringProvider()` is now static
+
 6.2
 ---
 
@@ -13,13 +20,6 @@ CHANGELOG
 
  * Parameters implementing `TranslatableInterface` are processed
  * Add the file extension to the `XliffFileDumper` constructor
-
-5.4.21
-------
-
- * [BC BREAK] The following data providers for `ProviderFactoryTestCase` are now static:
-   `supportsProvider()`, `createProvider()`, `unsupportedSchemeProvider()`and `incompleteDsnProvider()`
- * [BC BREAK] `ProviderTestCase::toStringProvider()` is now static
 
 5.4
 ---

--- a/src/Symfony/Component/Translation/Test/ProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Test/ProviderTestCase.php
@@ -11,15 +11,13 @@
 
 namespace Symfony\Component\Translation\Test;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
 use Symfony\Component\Translation\Loader\LoaderInterface;
-use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Provider\ProviderInterface;
-use Symfony\Component\Translation\TranslatorBag;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -32,14 +30,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 abstract class ProviderTestCase extends TestCase
 {
-    protected static HttpClientInterface $client;
-    protected static LoggerInterface $logger;
-    protected static string $defaultLocale;
-    protected static LoaderInterface $loader;
-    protected static XliffFileDumper $xliffFileDumper;
-    protected static TranslatorBagInterface $translatorBag;
+    protected HttpClientInterface $client;
+    protected LoggerInterface|MockObject $logger;
+    protected string $defaultLocale;
+    protected LoaderInterface|MockObject $loader;
+    protected XliffFileDumper|MockObject $xliffFileDumper;
+    protected TranslatorBagInterface|MockObject $translatorBag;
 
-    abstract public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface;
+    abstract public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, TranslatorBagInterface $translatorBag = null): ProviderInterface;
 
     /**
      * @return iterable<array{0: ProviderInterface, 1: string}>
@@ -54,38 +52,33 @@ abstract class ProviderTestCase extends TestCase
         $this->assertSame($expected, (string) $provider);
     }
 
-    protected static function getClient(): MockHttpClient
+    protected function getClient(): MockHttpClient
     {
-        return static::$client ??= new MockHttpClient();
+        return $this->client ??= new MockHttpClient();
     }
 
-    protected static function getLoader(): LoaderInterface
+    protected function getLoader(): LoaderInterface
     {
-        return static::$loader ??= new class() implements LoaderInterface {
-            public function load($resource, string $locale, string $domain = 'messages'): MessageCatalogue
-            {
-                return new MessageCatalogue($locale);
-            }
-        };
+        return $this->loader ??= $this->createMock(LoaderInterface::class);
     }
 
-    protected static function getLogger(): LoggerInterface
+    protected function getLogger(): LoggerInterface
     {
-        return static::$logger ??= new NullLogger();
+        return $this->logger ??= $this->createMock(LoggerInterface::class);
     }
 
-    protected static function getDefaultLocale(): string
+    protected function getDefaultLocale(): string
     {
-        return static::$defaultLocale ??= 'en';
+        return $this->defaultLocale ??= 'en';
     }
 
-    protected static function getXliffFileDumper(): XliffFileDumper
+    protected function getXliffFileDumper(): XliffFileDumper
     {
-        return static::$xliffFileDumper ??= new XliffFileDumper();
+        return $this->xliffFileDumper ??= $this->createMock(XliffFileDumper::class);
     }
 
-    protected static function getTranslatorBag(): TranslatorBagInterface
+    protected function getTranslatorBag(): TranslatorBagInterface
     {
-        return self::$translatorBag ??= new TranslatorBag();
+        return $this->translatorBag ??= $this->createMock(TranslatorBagInterface::class);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

I had a little tchat with @nicolas-grekas who warned me that a few of my late edits on static data providers are a bit dangerous. Indeed, some helper methods were using static properties, which could lead to some leaks between test cases, and/or unstable tests.

Helper classes doing so, found in `Translation` and `Mailer`, have been reverted to non-static ones. Data-providers are of course still statics and have been adapted to not use those methods.

The targeted branch is 6.3 and this is intended, as requested by Nicolas. If you need any help during the backport of these edits, I'll be happy to help again!

ℹ️ A lot of notifier bridges has been introduced in 6.3 and their data providers weren't updated. I also bundled this change in the PR, which should fix 6.3 pipeline as well.

Finally, I updated `SmsapiTransportFactoryTest::missingRequiredOptionProvider`. As the `from` option has been made optional, the only dataset provided failed.