### PR TITLE
[DependencyInjection] allow extending `Autowire` attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Enable deprecating parameters with `ContainerBuilder::deprecateParameter()`
  * Add `#[AsAlias]` attribute to tell under which alias a service should be registered or to use the implemented interface if no parameter is given
  * Allow to trim XML service parameters value by using `trim="true"` attribute
+ * Allow extending the `Autowire` attribute
 
 6.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -292,11 +292,11 @@ class AutowirePass extends AbstractRecursivePass
             }
 
             if ($checkAttributes) {
-                foreach ($parameter->getAttributes() as $attribute) {
-                    if (\in_array($attribute->getName(), [TaggedIterator::class, TaggedLocator::class, Autowire::class, MapDecorated::class], true)) {
+                foreach ([TaggedIterator::class, TaggedLocator::class, Autowire::class, MapDecorated::class] as $attributeClass) {
+                    foreach ($parameter->getAttributes($attributeClass, Autowire::class === $attributeClass ? \ReflectionAttribute::IS_INSTANCEOF : 0) as $attribute) {
                         $arguments[$index] = $this->processAttribute($attribute->newInstance(), $parameter->allowsNull());
 
-                        continue 2;
+                        continue 3;
                     }
                 }
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1235,7 +1235,7 @@ class AutowirePassTest extends TestCase
 
         $definition = $container->getDefinition(AutowireAttribute::class);
 
-        $this->assertCount(9, $definition->getArguments());
+        $this->assertCount(10, $definition->getArguments());
         $this->assertEquals(new Reference('some.id'), $definition->getArgument(0));
         $this->assertEquals(new Expression("parameter('some.parameter')"), $definition->getArgument(1));
         $this->assertSame('foo/bar', $definition->getArgument(2));
@@ -1244,7 +1244,8 @@ class AutowirePassTest extends TestCase
         $this->assertEquals(new Expression("parameter('some.parameter')"), $definition->getArgument(5));
         $this->assertSame('bar', $definition->getArgument(6));
         $this->assertSame('@bar', $definition->getArgument(7));
-        $this->assertEquals(new Reference('invalid.id', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(8));
+        $this->assertSame('foo', $definition->getArgument(8));
+        $this->assertEquals(new Reference('invalid.id', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(9));
 
         $container->compile();
 
@@ -1257,6 +1258,7 @@ class AutowirePassTest extends TestCase
         $this->assertSame('foo', $service->expressionAsValue);
         $this->assertSame('bar', $service->rawValue);
         $this->assertSame('@bar', $service->escapedRawValue);
+        $this->assertSame('foo', $service->customAutowire);
         $this->assertNull($service->invalid);
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -33,6 +33,15 @@ class AutowireProperty
     public Foo $foo;
 }
 
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class CustomAutowire extends Autowire
+{
+    public function __construct(string $parameter)
+    {
+        parent::__construct(param: $parameter);
+    }
+}
+
 class AutowireAttribute
 {
     public function __construct(
@@ -52,6 +61,8 @@ class AutowireAttribute
         public string $rawValue,
         #[Autowire('@@bar')]
         public string $escapedRawValue,
+        #[CustomAutowire('some.parameter')]
+        public string $customAutowire,
         #[Autowire(service: 'invalid.id')]
         public ?\stdClass $invalid = null,
     ) {

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `#[WithHttpStatus]` for defining status codes for exceptions
  * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
  * Add `#[WithLogLevel]` for defining log levels for exceptions
+ * Allow extending the `Autowire` attribute
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -146,7 +146,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         $args[$p->name] = $bindingValue;
 
                         continue;
-                    } elseif (!$autowire || (!($autowireAttributes ??= $p->getAttributes(Autowire::class)) && (!$type || '\\' !== $target[0]))) {
+                    } elseif (!$autowire || (!($autowireAttributes ??= $p->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF)) && (!$type || '\\' !== $target[0]))) {
                         continue;
                     } elseif (is_subclass_of($type, \UnitEnum::class)) {
                         // do not attempt to register enum typed arguments if not already present in bindings

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -482,7 +482,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $locator = $container->get($locatorId)->get('foo::fooAction');
 
-        $this->assertCount(7, $locator->getProvidedServices());
+        $this->assertCount(8, $locator->getProvidedServices());
         $this->assertInstanceOf(\stdClass::class, $locator->get('service1'));
         $this->assertSame('foo/bar', $locator->get('value'));
         $this->assertSame('foo', $locator->get('expression'));
@@ -490,6 +490,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $this->assertInstanceOf(\stdClass::class, $locator->get('expressionAsValue'));
         $this->assertSame('bar', $locator->get('rawValue'));
         $this->assertSame('@bar', $locator->get('escapedRawValue'));
+        $this->assertSame('foo', $locator->get('customAutowire'));
         $this->assertFalse($locator->has('service2'));
     }
 }
@@ -580,6 +581,15 @@ class WithResponseArgument
     }
 }
 
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class CustomAutowire extends Autowire
+{
+    public function __construct(string $parameter)
+    {
+        parent::__construct(param: $parameter);
+    }
+}
+
 class WithAutowireAttribute
 {
     public function fooAction(
@@ -597,6 +607,8 @@ class WithAutowireAttribute
         string $rawValue,
         #[Autowire('@@bar')]
         string $escapedRawValue,
+        #[CustomAutowire('some.parameter')]
+        string $customAutowire,
         #[Autowire(service: 'invalid.id')]
         \stdClass $service2 = null,
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This allows 3rd party package developers to make custom `Autowire` attribute helpers. Example:

```php
class Repository extends Autowire
{
    public function __construct(string $class)
    {
        parent::__construct(expression: \sprintf("service('some.repository.factory').create('%s')", $class));
    }
}
```

And then it could be used with:

```php
/**
 * @param ObjectRepository<User> $repository
 */
public function __construct(#[Repository(User::class)] private ObjectRepository $repository)
{
}
```