### PR TITLE
[PHPUnit bridge] Do not register error handler under PHPUnit 10

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -24,6 +24,11 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL') && !class_exists(\PHPUnit\TextUI\Comman
     return;
 }
 
+// Detect if we're under PHPUnit 10 (not compatible yet!)
+if (class_exists(\PHPUnit\Event\Event::class)) {
+    return;
+}
+
 // Enforce a consistent locale
 setlocale(\LC_ALL, 'C');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49069 (partially)
| License       | MIT

This is motivated by https://github.com/symfony/symfony/issues/49069#issuecomment-1435769998, until #49069 is fully addressed.

What happens is that PHPUnit 10 now registers its own error handler to trap notice/warnings/deprecations and make them flow through its new event system. The PHPUnit 10 compat for the deprecations handler will have to leverage those events, but as of now having two error handlers is just causing errors, and it does not make sense spending work to make them compatible. Hence, this patch.