### PR TITLE
[Contracts] Fix setting $container before calling parent::setContainer in ServiceSubscriberTrait

### DIFF
--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -98,12 +98,13 @@ trait ServiceSubscriberTrait
      */
     public function setContainer(ContainerInterface $container)
     {
-        $this->container = $container;
-
+        $ret = null;
         if (method_exists(get_parent_class(self::class) ?: '', __FUNCTION__)) {
-            return parent::setContainer($container);
+            $ret = parent::setContainer($container);
         }
 
-        return null;
+        $this->container = $container;
+
+        return $ret;
     }
 }

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -81,6 +81,18 @@ class ServiceSubscriberTraitTest extends TestCase
         $this->assertSame([], $service::getSubscribedServices());
     }
 
+    public function testSetContainerCalledFirstOnParent()
+    {
+        $container1 = new class([]) implements ContainerInterface {
+            use ServiceLocatorTrait;
+        };
+        $container2 = clone $container1;
+
+        $testService = new TestService2();
+        $this->assertNull($testService->setContainer($container1));
+        $this->assertSame($container1, $testService->setContainer($container2));
+    }
+
     /**
      * @requires PHP 8
      *
@@ -160,4 +172,23 @@ class ParentWithMagicCall
 
 class Service3
 {
+}
+
+class ParentTestService2
+{
+    /** @var ContainerInterface */
+    protected $container;
+
+    public function setContainer(ContainerInterface $container)
+    {
+        $previous = $this->container;
+        $this->container = $container;
+
+        return $previous;
+    }
+}
+
+class TestService2 extends ParentTestService2 implements ServiceSubscriberInterface
+{
+    use ServiceSubscriberTrait;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49382
| License       | MIT

This changes the `setContainer` method of `ServiceSubscriberTrait` so that it calls `parent::setContainer` first, before updating `$this->container`. This is so that the parent method can work correctly if it relies on the old container value.

This is particularly relevant for `AbstractController`, since it returns the old container value. When used with `ServiceSubscriberTrait`, it returned the _new_ container rather than the old one. This, in turn, caused incorrect behavior in framework bundle's `ControllerResolver`, as described in #49382.