### PR TITLE
[Lock] Add `LockableResourceInterface` and `LockableResourceTrait`

### DIFF
--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -7,21 +7,22 @@ CHANGELOG
  * Create migration for lock table when DoctrineDbalStore is used
  * Add support for Relay PHP extension for Redis
  * Renamed the `gcProbablity` option to `gcProbability` to fix a typo in its name
+ * Add `LockableResourceInterface` and `LockableResourceTrait`
 
 6.0
 ---
 
-* Remove the `NotSupportedException`. It shouldn't be thrown anymore
-* Remove the `RetryTillSaveStore`. Logic has been moved in `Lock` and is not needed anymore
-* Remove support of Doctrine DBAL in `PdoStore` and `PostgreSqlStore`
+ * Remove the `NotSupportedException`. It shouldn't be thrown anymore
+ * Remove the `RetryTillSaveStore`. Logic has been moved in `Lock` and is not needed anymore
+ * Remove support of Doctrine DBAL in `PdoStore` and `PostgreSqlStore`
 
 5.4
 ---
 
-* Add `DoctrineDbalStore` identical to `PdoStore` for `Doctrine\DBAL\Connection` or DBAL url
-* Deprecate usage of `PdoStore` with `Doctrine\DBAL\Connection` or DBAL url
-* Add `DoctrineDbalPostgreSqlStore` identical to `PdoPostgreSqlStore` for `Doctrine\DBAL\Connection` or DBAL url
-* Deprecate usage of `PdoPostgreSqlStore` with `Doctrine\DBAL\Connection` or DBAL url
+ * Add `DoctrineDbalStore` identical to `PdoStore` for `Doctrine\DBAL\Connection` or DBAL url
+ * Deprecate usage of `PdoStore` with `Doctrine\DBAL\Connection` or DBAL url
+ * Add `DoctrineDbalPostgreSqlStore` identical to `PdoPostgreSqlStore` for `Doctrine\DBAL\Connection` or DBAL url
+ * Deprecate usage of `PdoPostgreSqlStore` with `Doctrine\DBAL\Connection` or DBAL url
 
 5.2.0
 -----

--- a/src/Symfony/Component/Lock/Key.php
+++ b/src/Symfony/Component/Lock/Key.php
@@ -25,9 +25,9 @@ final class Key
     private array $state = [];
     private bool $serializable = true;
 
-    public function __construct(string $resource)
+    public function __construct(LockableResourceInterface|string $resource)
     {
-        $this->resource = $resource;
+        $this->resource = $resource instanceof LockableResourceInterface ? $resource->getResourceIdentifier() : $resource;
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Lock/LockFactory.php
+++ b/src/Symfony/Component/Lock/LockFactory.php
@@ -64,4 +64,16 @@ class LockFactory implements LoggerAwareInterface
 
         return $lock;
     }
+
+    /**
+     * Creates a lock from the given LockableResource.
+     *
+     * @param LockableResourceInterface $lockableResource The key containing the lock's state
+     * @param float|null                $ttl              Maximum expected lock duration in seconds
+     * @param bool                      $autoRelease      Whether to automatically release the lock or not when the lock instance is destroyed
+     */
+    public function createLockFromLockableResource(LockableResourceInterface $lockableResource, ?float $ttl = 300.0, bool $autoRelease = true): LockInterface
+    {
+        return $this->createLockFromKey(new Key($lockableResource), $ttl, $autoRelease);
+    }
 }

--- a/src/Symfony/Component/Lock/LockableResourceInterface.php
+++ b/src/Symfony/Component/Lock/LockableResourceInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+interface LockableResourceInterface
+{
+    public function getResourceIdentifier(): string;
+}

--- a/src/Symfony/Component/Lock/LockableResourceTrait.php
+++ b/src/Symfony/Component/Lock/LockableResourceTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+trait LockableResourceTrait
+{
+    private ?Uuid $resourceIdentifier = null;
+
+    public function getResourceIdentifier(): string
+    {
+        return $this->resourceIdentifier ??= Uuid::v7();
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Fixtures/DummyLockableResource.php
+++ b/src/Symfony/Component/Lock/Tests/Fixtures/DummyLockableResource.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Fixtures;
+
+use Symfony\Component\Lock\LockableResourceInterface;
+use Symfony\Component\Lock\LockableResourceTrait;
+
+class DummyLockableResource implements LockableResourceInterface
+{
+    use LockableResourceTrait;
+}

--- a/src/Symfony/Component/Lock/Tests/KeyTest.php
+++ b/src/Symfony/Component/Lock/Tests/KeyTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Lock\Exception\UnserializableKeyException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\Tests\Fixtures\DummyLockableResource;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
@@ -38,5 +39,13 @@ class KeyTest extends TestCase
 
         $this->expectException(UnserializableKeyException::class);
         serialize($key);
+    }
+
+    public function testLockableResource()
+    {
+        $resource = new DummyLockableResource();
+        $key = new Key($resource);
+
+        $this->assertSame($resource->getResourceIdentifier(), (string) $key);
     }
 }

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -22,7 +22,8 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.13|^3.0",
-        "predis/predis": "~1.0"
+        "predis/predis": "~1.0",
+        "symfony/uid": "^6.2"
     },
     "conflict": {
         "doctrine/dbal": "<2.13",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | To do

The use of the Lock component, at this time, may require exposing the implementation of locked resources. This is done for example by creating a Key that takes the identifier of the resource as primary key.

The goal of this new interface and this new feature is to not need to expose the implementation of an object to create the Key that goes with it. This allows a stronger decorrelation of the implementation of the object to be locked with Lock.

This allows to simply lock a resource this way:

```php
use Symfony\Component\Lock\LockableResourceInterface;
use Symfony\Component\Lock\LockableResourceTrait;

class DummyResource implements LockableResourceInterface
{
    use LockableResourceTrait;

    public function __construct()
    {
        // ...
    }

    // ...
}

// Then create and acquire the lock:
$resource = new DummyResource();

$lock = $this->lockFactory->createLockFromLockableResource($resource);
$lock->acquire();
```