### PR TITLE
Fix Integration tests skipped with Redis cluster

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,11 +45,11 @@ jobs:
           LDAP_USERS: a
           LDAP_PASSWORDS: a
       redis:
-        image: redis:6.0.0
+        image: redis:6.2.8
         ports:
           - 16379:6379
       redis-cluster:
-        image: grokzen/redis-cluster:latest
+        image: grokzen/redis-cluster:6.2.8
         ports:
           - 7000:7000
           - 7001:7001
@@ -61,7 +61,7 @@ jobs:
         env:
           STANDALONE: 1
       redis-sentinel:
-        image: bitnami/redis-sentinel:6.0
+        image: bitnami/redis-sentinel:6.2.8
         ports:
           - 26379:26379
         env:

--- a/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
@@ -41,7 +41,7 @@ class FirePHPHandler extends BaseFirePHPHandler
         }
 
         $request = $event->getRequest();
-        if (!preg_match('{\bFirePHP/\d+\.\d+\b}', $request->headers->get('User-Agent'))
+        if (!preg_match('{\bFirePHP/\d+\.\d+\b}', $request->headers->get('User-Agent', ''))
             && !$request->headers->has('X-FirePHP-Version')) {
             self::$sendHeaders = false;
             $this->headers = [];

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Handler\FirePHPHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class FirePHPHandlerTest extends TestCase
+{
+    public function testOnKernelResponseShouldNotTriggerDeprecation()
+    {
+        $request = Request::create('/');
+        $request->headers->remove('User-Agent');
+
+        $response = new Response('foo');
+        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $error = null;
+        set_error_handler(function ($type, $message) use (&$error) { $error = $message; }, \E_DEPRECATED);
+
+        $listener = new FirePHPHandler();
+        $listener->onKernelResponse($event);
+        restore_error_handler();
+
+        $this->assertNull($error);
+    }
+}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -90,6 +90,10 @@
         {%- if required -%}
             {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) -%}
         {%- endif -%}
+        {%- if parent_label_class is defined -%}
+            {% set embed_label_classes = parent_label_class|split(' ')|filter(class => class in ['checkbox-inline', 'radio-inline']) %}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ embed_label_classes|join(' '))|trim}) -%}
+        {% endif %}
         {%- if label is not same as(false) and label is empty -%}
             {%- if label_format is not empty -%}
                 {%- set label = label_format|replace({

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -283,6 +283,10 @@
         {%- if required -%}
             {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) -%}
         {%- endif -%}
+        {%- if parent_label_class is defined -%}
+            {% set embed_label_classes = parent_label_class|split(' ')|filter(class => class in ['checkbox-inline', 'radio-inline']) %}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ embed_label_classes|join(' '))|trim}) -%}
+        {% endif %}
         {%- if label is not same as(false) and label is empty -%}
             {%- if label_format is not empty -%}
                 {%- set label = label_format|replace({

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -253,6 +253,10 @@
     {% if errors|length > 0 -%}
         {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' error')|trim}) %}
     {% endif %}
+    {%- if parent_label_class is defined -%}
+        {% set embed_label_classes = parent_label_class|split(' ')|filter(class => class in ['checkbox-inline', 'radio-inline']) %}
+        {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ embed_label_classes|join(' '))|trim}) -%}
+    {% endif %}
     {% if label is empty %}
         {%- if label_format is not empty -%}
             {% set label = label_format|replace({

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -83,7 +83,7 @@ return static function (ContainerConfigurator $container) {
                 service_locator([
                     'security.token_storage' => service('security.token_storage'),
                     'security.authorization_checker' => service('security.authorization_checker'),
-                    'security.user_authenticator' => service('security.user_authenticator')->ignoreOnInvalid(),
+                    'security.authenticator.managers_locator' => service('security.authenticator.managers_locator')->ignoreOnInvalid(),
                     'request_stack' => service('request_stack'),
                     'security.firewall.map' => service('security.firewall.map'),
                     'security.user_checker' => service('security.user_checker'),

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -69,7 +69,7 @@ class Security extends LegacySecurity
         $authenticator = $this->getAuthenticator($authenticatorName, $firewallName);
 
         $this->container->get('security.user_checker')->checkPreAuth($user);
-        $this->container->get('security.user_authenticator')->authenticateUser($user, $authenticator, $request);
+        $this->container->get('security.authenticator.managers_locator')->get($firewallName)->authenticateUser($user, $authenticator, $request);
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
@@ -40,7 +40,16 @@ security:
             custom_authenticators:
                 - 'Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator'
             provider: main
+        second:
+            pattern: ^/second
+            form_login:
+                check_path: /second/login/check
+            custom_authenticators:
+                - 'Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator'
+            provider: main
 
     access_control:
         - { path: '^/main/login/check$', roles: IS_AUTHENTICATED_FULLY }
         - { path: '^/main/logged-in$', roles: IS_AUTHENTICATED_FULLY }
+        - { path: '^/second/login/check$', roles: IS_AUTHENTICATED_FULLY }
+        - { path: '^/second/logged-in$', roles: IS_AUTHENTICATED_FULLY }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/routing.yml
@@ -9,3 +9,11 @@ logged-in:
 force-logout:
     path: /main/force-logout
     controller: Symfony\Bundle\SecurityBundle\Tests\Functional\LogoutController::logout
+
+second-force-login:
+    path: /second/force-login
+    controller: Symfony\Bundle\SecurityBundle\Tests\Functional\ForceLoginController::welcome
+
+second-logged-in:
+    path: /second/logged-in
+    controller: Symfony\Bundle\SecurityBundle\Tests\Functional\LoggedInController

--- a/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
@@ -141,7 +141,7 @@ class SecurityTest extends TestCase
             ->willReturnMap([
                 ['request_stack', $requestStack],
                 ['security.firewall.map', $firewallMap],
-                ['security.user_authenticator', $userAuthenticator],
+                ['security.authenticator.managers_locator', new ServiceLocator(['main' => fn () => $userAuthenticator])],
                 ['security.user_checker', $userChecker],
             ])
         ;

--- a/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php
+++ b/src/Symfony/Component/Cache/Messenger/EarlyExpirationHandler.php
@@ -73,7 +73,8 @@ class EarlyExpirationHandler implements MessageHandlerInterface
         $startTime = microtime(true);
         $pool = $message->findPool($this->reverseContainer);
         $callback = $message->findCallback($this->reverseContainer);
-        $value = $callback($item);
+        $save = true;
+        $value = $callback($item, $save);
         $setMetadata($item, $startTime);
         $pool->save($item->set($value));
     }

--- a/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationHandlerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationHandlerTest.php
@@ -12,14 +12,15 @@
 namespace Symfony\Component\Cache\Tests\Messenger;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\Messenger\EarlyExpirationHandler;
 use Symfony\Component\Cache\Messenger\EarlyExpirationMessage;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ReverseContainer;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\Cache\CallbackInterface;
 
 /**
  * @requires function Symfony\Component\DependencyInjection\ReverseContainer::__construct
@@ -40,8 +41,8 @@ class EarlyExpirationHandlerTest extends TestCase
         $item = $pool->getItem('foo');
         $item->set(234);
 
-        $computationService = new class() {
-            public function __invoke(CacheItem $item)
+        $computationService = new class() implements CallbackInterface {
+            public function __invoke(CacheItemInterface $item, bool &$save)
             {
                 usleep(30000);
                 $item->expiresAfter(3600);

--- a/src/Symfony/Component/Form/Extension/PasswordHasher/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/PasswordHasher/EventListener/PasswordHasherListener.php
@@ -37,6 +37,10 @@ class PasswordHasherListener
 
     public function registerPassword(FormEvent $event)
     {
+        if (null === $event->getData() || '' === $event->getData()) {
+            return;
+        }
+
         $this->assertNotMapped($event->getForm());
 
         $this->passwords[] = [

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -35,7 +35,7 @@ class RedisExtIntegrationTest extends TestCase
         }
 
         try {
-            $this->redis = new \Redis();
+            $this->redis = $this->createRedisClient();
             $this->connection = Connection::fromDsn(getenv('MESSENGER_REDIS_DSN'), ['sentinel_master' => getenv('MESSENGER_REDIS_SENTINEL_MASTER') ?: null], $this->redis);
             $this->connection->cleanup();
             $this->connection->setup();
@@ -222,7 +222,8 @@ class RedisExtIntegrationTest extends TestCase
         $connection = Connection::fromDsn(getenv('MESSENGER_REDIS_DSN'),
             ['lazy' => true,
              'delete_after_ack' => true,
-             'sentinel_master' => getenv('MESSENGER_REDIS_SENTINEL_MASTER') ?: null, ], $this->redis);
+             'sentinel_master' => getenv('MESSENGER_REDIS_SENTINEL_MASTER') ?: null,
+            ], $this->redis);
 
         $connection->add('1', []);
         $this->assertNotEmpty($message = $connection->get());

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RelayExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RelayExtIntegrationTest.php
@@ -25,4 +25,39 @@ class RelayExtIntegrationTest extends RedisExtIntegrationTest
     {
         return new Relay();
     }
+
+    public function testConnectionSendAndGetDelayed()
+    {
+        self::markTestSkipped('This test doesn\'t work with relay.');
+    }
+
+    public function testConnectionSendDelayedMessagesWithSameContent()
+    {
+        self::markTestSkipped('This test doesn\'t work with relay.');
+    }
+
+    public function testLazy()
+    {
+        self::markTestSkipped('This test doesn\'t work with relay.');
+    }
+
+    public function testDbIndex()
+    {
+        self::markTestSkipped('This test doesn\'t work with relay.');
+    }
+
+    public function testGetNonBlocking()
+    {
+        self::markTestSkipped('This test doesn\'t work with relay.');
+    }
+
+    public function testGetAfterReject()
+    {
+        self::markTestSkipped('This test doesn\'t work with relay.');
+    }
+
+    public function testJsonError()
+    {
+        self::markTestSkipped('This test doesn\'t work with relay.');
+    }
 }

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -712,7 +712,7 @@ class LocoProviderTest extends ProviderTestCase
             'headers' => [
                 'Authorization' => 'Loco API_KEY',
             ],
-        ]), $loader, new NullLogger(), 'en', 'localise.biz/api/', $this->getTranslatorBag());
+        ]), $loader, new NullLogger(), 'en', 'localise.biz/api/');
         $translatorBag = $provider->read([$domain], [$locale]);
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
         foreach ($translatorBag->getCatalogues() as $catalogue) {
@@ -750,7 +750,7 @@ class LocoProviderTest extends ProviderTestCase
             'headers' => [
                 'Authorization' => 'Loco API_KEY',
             ],
-        ]), $loader, $this->getLogger(), 'en', 'localise.biz/api/', $this->getTranslatorBag());
+        ]), $loader, $this->getLogger(), 'en', 'localise.biz/api/');
         $translatorBag = $provider->read($domains, $locales);
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
         foreach ($translatorBag->getCatalogues() as $catalogue) {

--- a/src/Symfony/Component/Translation/Test/ProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Test/ProviderTestCase.php
@@ -17,7 +17,6 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\Provider\ProviderInterface;
-use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -35,7 +34,7 @@ abstract class ProviderTestCase extends TestCase
     protected $loader;
     protected $xliffFileDumper;
 
-    abstract public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, TranslatorBagInterface $translatorBag = null): ProviderInterface;
+    abstract public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface;
 
     /**
      * @return iterable<array{0: ProviderInterface, 1: string}>

--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -98,12 +98,13 @@ trait ServiceSubscriberTrait
      */
     public function setContainer(ContainerInterface $container)
     {
-        $this->container = $container;
-
+        $ret = null;
         if (method_exists(get_parent_class(self::class) ?: '', __FUNCTION__)) {
-            return parent::setContainer($container);
+            $ret = parent::setContainer($container);
         }
 
-        return null;
+        $this->container = $container;
+
+        return $ret;
     }
 }

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -81,6 +81,18 @@ class ServiceSubscriberTraitTest extends TestCase
         $this->assertSame([], $service::getSubscribedServices());
     }
 
+    public function testSetContainerCalledFirstOnParent()
+    {
+        $container1 = new class([]) implements ContainerInterface {
+            use ServiceLocatorTrait;
+        };
+        $container2 = clone $container1;
+
+        $testService = new TestService2();
+        $this->assertNull($testService->setContainer($container1));
+        $this->assertSame($container1, $testService->setContainer($container2));
+    }
+
     /**
      * @requires PHP 8
      *
@@ -160,4 +172,23 @@ class ParentWithMagicCall
 
 class Service3
 {
+}
+
+class ParentTestService2
+{
+    /** @var ContainerInterface */
+    protected $container;
+
+    public function setContainer(ContainerInterface $container)
+    {
+        $previous = $this->container;
+        $this->container = $container;
+
+        return $previous;
+    }
+}
+
+class TestService2 extends ParentTestService2 implements ServiceSubscriberInterface
+{
+    use ServiceSubscriberTrait;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49285
| License       | MIT
| Doc PR        | n/a

It seems to me, that the `getenv('MESSENGER_REDIS_SENTINEL_MASTER')` in the `setUp()` might return `false` because it's unset. To ignore the sentinel, it must be null:
https://github.com/symfony/symfony/blob/090033332fa4eb5e7475111136b1cce260edffa4/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php#L95-L100
