### PR TITLE
Backport option to enable Sandbox via dsn option sandbox=true to 5.4

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+6.3 / 5.4
+-----
+ * Add sandbox option
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/README.md
@@ -8,6 +8,7 @@ Configuration examples:
 ```dotenv
 # API
 MAILER_DSN=mailjet+api://$PUBLIC_KEY:$PRIVATE_KEY@default
+MAILER_DSN=mailjet+api://$PUBLIC_KEY:$PRIVATE_KEY@default?sandbox=true
 # SMTP
 MAILER_DSN=mailjet+smtp://$PUBLIC_KEY:$PRIVATE_KEY@default
 ```

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -43,7 +43,7 @@ class MailjetApiTransport extends AbstractApiTransport
     private $publicKey;
     private $sandbox;
 
-    public function __construct(string $publicKey, string $privateKey, bool $sandbox, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $publicKey, string $privateKey, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null, bool $sandbox)
     {
         $this->publicKey = $publicKey;
         $this->privateKey = $privateKey;
@@ -137,15 +137,10 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['Headers'][$header->getName()] = $header->getBodyAsString();
         }
 
-        $returnArray = [
+        return [
             'Messages' => [$message],
+            'SandBoxMode' => $this->sandbox,
         ];
-
-        if ($this->sandbox) {
-            $returnArray['SandboxMode']=true;
-        }
-
-        return $returnArray;
     }
 
     private function formatAddresses(array $addresses): array

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Bridge\Mailjet\Transport;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
@@ -19,7 +20,6 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -41,7 +41,6 @@ class MailjetApiTransport extends AbstractApiTransport
 
     private $privateKey;
     private $publicKey;
-    private $sandbox;
 
     public function __construct(string $publicKey, string $privateKey, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
@@ -70,13 +69,15 @@ class MailjetApiTransport extends AbstractApiTransport
             $statusCode = $response->getStatusCode();
             $result = $response->toArray(false);
         } catch (DecodingExceptionInterface $e) {
-            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).sprintf(' (code %d).', $statusCode), $response);
+            throw new HttpTransportException(sprintf('Unable to send an email: "%s" (code %d).', $response->getContent(false), $statusCode), $response);
         } catch (TransportExceptionInterface $e) {
             throw new HttpTransportException('Could not reach the remote Mailjet server.', $response, 0, $e);
         }
 
         if (200 !== $statusCode) {
-            throw new HttpTransportException('Unable to send an email: '.$result['Message'].sprintf(' (code %d).', $statusCode), $response);
+            $errorDetails = $result['Messages'][0]['Errors'][0]['ErrorMessage'] ?? $response->getContent(false);
+
+            throw new HttpTransportException(sprintf('Unable to send an email: "%s" (code %d).', $errorDetails, $statusCode), $response);
         }
 
         // The response needs to contains a 'Messages' key that is an array
@@ -134,15 +135,9 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['Headers'][$header->getName()] = $header->getBodyAsString();
         }
 
-        $returnArray = [
+        return [
             'Messages' => [$message],
         ];
-
-        if ($this->sandbox) {
-            $returnArray['SandboxMode']=true;
-        }
-
-        return $returnArray;
     }
 
     private function formatAddresses(array $addresses): array

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -41,11 +41,13 @@ class MailjetApiTransport extends AbstractApiTransport
 
     private $privateKey;
     private $publicKey;
+    private $sandbox;
 
-    public function __construct(string $publicKey, string $privateKey, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $publicKey, string $privateKey, bool $sandbox, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         $this->publicKey = $publicKey;
         $this->privateKey = $privateKey;
+        $this->sandbox = $sandbox;
 
         parent::__construct($client, $dispatcher, $logger);
     }
@@ -135,9 +137,15 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['Headers'][$header->getName()] = $header->getBodyAsString();
         }
 
-        return [
+        $returnArray = [
             'Messages' => [$message],
         ];
+
+        if ($this->sandbox) {
+            $returnArray['SandboxMode']=true;
+        }
+
+        return $returnArray;
     }
 
     private function formatAddresses(array $addresses): array

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetTransportFactory.php
@@ -24,9 +24,10 @@ class MailjetTransportFactory extends AbstractTransportFactory
         $user = $this->getUser($dsn);
         $password = $this->getPassword($dsn);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $sandbox = $dsn->getOption('sandbox') === 'true' ? true : false;
 
         if ('mailjet+api' === $scheme) {
-            return (new MailjetApiTransport($user, $password, $this->client, $this->dispatcher, $this->logger))->setHost($host);
+            return (new MailjetApiTransport($user, $password, $sandbox, $this->client, $this->dispatcher, $this->logger))->setHost($host);
         }
 
         if (\in_array($scheme, ['mailjet+smtp', 'mailjet+smtps', 'mailjet'])) {

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetTransportFactory.php
@@ -24,10 +24,10 @@ class MailjetTransportFactory extends AbstractTransportFactory
         $user = $this->getUser($dsn);
         $password = $this->getPassword($dsn);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
-        $sandbox = $dsn->getOption('sandbox') === 'true';
+        $sandbox = 'true' === $dsn->getOption('sandbox');
 
         if ('mailjet+api' === $scheme) {
-            return (new MailjetApiTransport($user, $password, $sandbox, $this->client, $this->dispatcher, $this->logger))->setHost($host);
+            return (new MailjetApiTransport($user, $password, $this->client, $this->dispatcher, $this->logger, $sandbox))->setHost($host);
         }
 
         if (\in_array($scheme, ['mailjet+smtp', 'mailjet+smtps', 'mailjet'])) {

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetTransportFactory.php
@@ -24,7 +24,7 @@ class MailjetTransportFactory extends AbstractTransportFactory
         $user = $this->getUser($dsn);
         $password = $this->getPassword($dsn);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
-        $sandbox = $dsn->getOption('sandbox') === 'true' ? true : false;
+        $sandbox = $dsn->getOption('sandbox') === 'true';
 
         if ('mailjet+api' === $scheme) {
             return (new MailjetApiTransport($user, $password, $sandbox, $this->client, $this->dispatcher, $this->logger))->setHost($host);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | sync with 6.3  PR https://github.com/symfony/symfony/pull/49429
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no 
| Tickets       | Fix https://github.com/symfony/symfony/issues/49410
| License       | MIT
| Doc PR        | <!--

Created this to have this option in 5.4 as some projects are not yet updated

Mailjet introduced a Sandbox Mode https://dev.mailjet.com/email/guides/send-api-v31/#sandbox-mode that allows to use the API but not sending any email e.g. for debugging.

MAILER_DSN=mailjet+api://$PUBLIC_KEY:$PRIVATE_KEY@default?sandbox=true
