### PR TITLE
[Form] Skip password hashing on empty password

### DIFF
--- a/src/Symfony/Component/Form/Extension/PasswordHasher/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/PasswordHasher/EventListener/PasswordHasherListener.php
@@ -37,6 +37,10 @@ class PasswordHasherListener
 
     public function registerPassword(FormEvent $event)
     {
+        if (null === $event->getData() || '' === $event->getData()) {
+            return;
+        }
+
         $this->assertNotMapped($event->getForm());
 
         $this->passwords[] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When using the new `hash_property_path` option to hash password submitted by forms, we should skip hashing if the submitted password is empty.

- Because empty passwords are not allowed and saving an empty password hash will prevent the user to login his account:
https://github.com/symfony/symfony/blob/8c19af2346ed6ed4021d3efc024e0af138e69794/src/Symfony/Component/Security/Http/EventListener/CheckCredentialsListener.php#L59-L62

- Because a common use case when creating a user profile form is to ignore the "new password" input if it's left blank.
