### PR TITLE
[Validator] Implement countUnit option for Length constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `Uuid::TIME_BASED_VERSIONS` to match that a UUID being validated embeds a timestamp
  * Add the `pattern` parameter in violations of the `Regex` constraint
  * Add a `NoSuspiciousCharacters` constraint to validate a string is not a spoofing attempt
+ * Add the `countUnit` option to the `Length` constraint to allow counting the string length either by code points (like before, now the default setting `Length::COUNT_CODEPOINTS`), bytes (`Length::COUNT_BYTES`) or graphemes (`Length::COUNT_GRAPHEMES`)
 
 6.2
 ---

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -36,6 +36,16 @@ class Length extends Constraint
         self::INVALID_CHARACTERS_ERROR => 'INVALID_CHARACTERS_ERROR',
     ];
 
+    public const COUNT_BYTES = 'bytes';
+    public const COUNT_CODEPOINTS = 'codepoints';
+    public const COUNT_GRAPHEMES = 'graphemes';
+
+    private const VALID_COUNT_UNITS = [
+        self::COUNT_BYTES,
+        self::COUNT_CODEPOINTS,
+        self::COUNT_GRAPHEMES,
+    ];
+
     /**
      * @deprecated since Symfony 6.1, use const ERROR_NAMES instead
      */
@@ -49,13 +59,19 @@ class Length extends Constraint
     public $min;
     public $charset = 'UTF-8';
     public $normalizer;
+    /* @var self::COUNT_* */
+    public string $countUnit = self::COUNT_CODEPOINTS;
 
+    /**
+     * @param self::COUNT_*|null $countUnit
+     */
     public function __construct(
         int|array $exactly = null,
         int $min = null,
         int $max = null,
         string $charset = null,
         callable $normalizer = null,
+        string $countUnit = null,
         string $exactMessage = null,
         string $minMessage = null,
         string $maxMessage = null,
@@ -84,6 +100,7 @@ class Length extends Constraint
         $this->max = $max;
         $this->charset = $charset ?? $this->charset;
         $this->normalizer = $normalizer ?? $this->normalizer;
+        $this->countUnit = $countUnit ?? $this->countUnit;
         $this->exactMessage = $exactMessage ?? $this->exactMessage;
         $this->minMessage = $minMessage ?? $this->minMessage;
         $this->maxMessage = $maxMessage ?? $this->maxMessage;
@@ -95,6 +112,10 @@ class Length extends Constraint
 
         if (null !== $this->normalizer && !\is_callable($this->normalizer)) {
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
+        }
+
+        if (!\in_array($this->countUnit, self::VALID_COUNT_UNITS)) {
+            throw new InvalidArgumentException(sprintf('The "countUnit" option must be one of the "%s"::COUNT_* constants ("%s" given).', __CLASS__, $this->countUnit));
         }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
@@ -43,6 +43,25 @@ class LengthTest extends TestCase
         new Length(['min' => 0, 'max' => 10, 'normalizer' => new \stdClass()]);
     }
 
+    public function testDefaultCountUnitIsUsed()
+    {
+        $length = new Length(['min' => 0, 'max' => 10]);
+        $this->assertSame(Length::COUNT_CODEPOINTS, $length->countUnit);
+    }
+
+    public function testNonDefaultCountUnitCanBeSet()
+    {
+        $length = new Length(['min' => 0, 'max' => 10, 'countUnit' => Length::COUNT_GRAPHEMES]);
+        $this->assertSame(Length::COUNT_GRAPHEMES, $length->countUnit);
+    }
+
+    public function testInvalidCountUnitThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('The "countUnit" option must be one of the "%s"::COUNT_* constants ("%s" given).', Length::class, 'nonExistentCountUnit'));
+        new Length(['min' => 0, 'max' => 10, 'countUnit' => 'nonExistentCountUnit']);
+    }
+
     public function testConstraintDefaultOption()
     {
         $constraint = new Length(5);

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class LengthValidatorTest extends ConstraintValidatorTestCase
 {
+    // 🧚‍♀️ "Woman Fairy" emoji ZWJ sequence
+    private const SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES = "\u{1F9DA}\u{200D}\u{2640}\u{FE0F}";
+
     protected function createValidator(): LengthValidator
     {
         return new LengthValidator();
@@ -152,6 +155,30 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Length(['min' => 3, 'max' => 3, 'normalizer' => 'trim']);
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidGraphemesValues()
+    {
+        $constraint = new Length(min: 1, max: 1, countUnit: Length::COUNT_GRAPHEMES);
+        $this->validator->validate(self::SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidCodepointsValues()
+    {
+        $constraint = new Length(min: 4, max: 4, countUnit: Length::COUNT_CODEPOINTS);
+        $this->validator->validate(self::SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidBytesValues()
+    {
+        $constraint = new Length(min: 13, max: 13, countUnit: Length::COUNT_BYTES);
+        $this->validator->validate(self::SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES, $constraint);
 
         $this->assertNoViolation();
     }
@@ -320,5 +347,35 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
                 ->setCode(Length::INVALID_CHARACTERS_ERROR)
                 ->assertRaised();
         }
+    }
+
+    public function testInvalidValuesExactDefaultCountUnitWithGraphemeInput()
+    {
+        $constraint = new Length(min: 1, max: 1, exactMessage: 'myMessage');
+
+        $this->validator->validate(self::SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.self::SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES.'"')
+            ->setParameter('{{ limit }}', 1)
+            ->setInvalidValue(self::SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES)
+            ->setPlural(1)
+            ->setCode(Length::NOT_EQUAL_LENGTH_ERROR)
+            ->assertRaised();
+    }
+
+    public function testInvalidValuesExactBytesCountUnitWithGraphemeInput()
+    {
+        $constraint = new Length(min: 1, max: 1, countUnit: Length::COUNT_BYTES, exactMessage: 'myMessage');
+
+        $this->validator->validate(self::SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.self::SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES.'"')
+            ->setParameter('{{ limit }}', 1)
+            ->setInvalidValue(self::SINGLE_GRAPHEME_WITH_FOUR_CODEPOINTS_AND_THIRTEEN_BYTES)
+            ->setPlural(1)
+            ->setCode(Length::NOT_EQUAL_LENGTH_ERROR)
+            ->assertRaised();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #49309
| License       | MIT
| Doc PR        | symfony/symfony-docs#17948

This implements the `countUnit` option for the `Length` constraint as proposed and discussed in https://github.com/symfony/symfony/issues/49309. That allows to control which strlen-method is used to count the string length for the `Length` constraint:

- `Length::COUNT_BYTES` counts with `\strlen()`
- `Length::COUNT_CODEPOINTS` counts with `\mb_strlen()` (default setting reflecting the former behavior)
- `Length::COUNT_GRAPHEMES` counts with `\grapheme_strlen()` (e.g. emojis count as 1)

Also implements the corresponding tests.

Examples:

```` php
// count unicode characters like emojis by their bytes for your legacy database needs
new Length(max: 255, countUnit: Length::COUNT_BYTES);
// count unicode characters like emojis by their codepoints for your more modern database needs
new Length(max: 255); // that is the default like before or set explicitly to Length::COUNT_CODEPOINTS)
// count unicode graphemes (or ZWJ sequences) like emojis as 1 length for your fancy emoji-only microblogging service
new Length(max: 280, countUnit: Length::COUNT_GRAPHEMES);
````