### PR TITLE
[DependencyInjection] Only include `$containerRef` in compiled container when needed

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1817,8 +1817,6 @@ EOF;
                         $returnedType = sprintf(': %s\%s', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $value->getInvalidBehavior() ? '' : '?', str_replace(['|', '&'], ['|\\', '&\\'], $value->getType()));
                     }
 
-                    $code = sprintf('return %s;', $code);
-
                     $attribute = '';
                     if ($value instanceof Reference) {
                         $attribute = 'name: '.$this->dumpValue((string) $value, $interpolate);
@@ -1829,9 +1827,14 @@ EOF;
 
                         $attribute = sprintf('#[\Closure(%s)] ', $attribute);
                     }
-                    $this->addContainerRef = true;
 
-                    return sprintf("%sfunction () use (\$containerRef)%s {\n            \$container = \$containerRef->get();\n\n            %s\n        }", $attribute, $returnedType, $code);
+                    if (str_contains($code, '$container')) {
+                        $this->addContainerRef = true;
+
+                        return sprintf("%sfunction () use (\$containerRef)%s {\n            \$container = \$containerRef->get();\n\n            return %s;\n        }", $attribute, $returnedType, $code);
+                    }
+
+                    return sprintf('%sfn ()%s => %s', $attribute, $returnedType, $code);
                 }
 
                 if ($value instanceof IteratorArgument) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_closure_argument_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_closure_argument_compiled.php
@@ -73,12 +73,6 @@ class ProjectServiceContainer extends Container
      */
     protected static function getServiceClosureInvalidService($container)
     {
-        $containerRef = $container->ref;
-
-        return $container->services['service_closure_invalid'] = new \Bar(function () use ($containerRef) {
-            $container = $containerRef->get();
-
-            return NULL;
-        });
+        return $container->services['service_closure_invalid'] = new \Bar(fn () => NULL);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -82,11 +82,7 @@ class ProjectServiceContainer extends Container
             $container = $containerRef->get();
 
             return ($container->privates['baz_service'] ??= new \stdClass());
-        }, 'nil' => function () use ($containerRef) {
-            $container = $containerRef->get();
-
-            return NULL;
-        }]);
+        }, 'nil' => fn () => NULL]);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
@@ -66,11 +66,7 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
             $container = $containerRef->get();
 
             return ($container->services['foo1'] ?? null);
-        }, #[\Closure(name: 'foo2')] function () use ($containerRef) {
-            $container = $containerRef->get();
-
-            return null;
-        }, #[\Closure(name: 'foo3', class: 'stdClass')] function () use ($containerRef) {
+        }, #[\Closure(name: 'foo2')] fn () => null, #[\Closure(name: 'foo3', class: 'stdClass')] function () use ($containerRef) {
             $container = $containerRef->get();
 
             return ($container->privates['foo3'] ?? null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  |no
| Deprecations? |no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

When passing an array to the `ServiceClosureArgument`, the compiled container can be optimized.

Only when the `$containerRef` is used, it should be included.

