### PR TITLE
[DependencyInjection] Only dump array keys when value is not a list

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1796,9 +1796,10 @@ EOF;
             if ($value && $interpolate && false !== $param = array_search($value, $this->container->getParameterBag()->all(), true)) {
                 return $this->dumpValue("%$param%");
             }
+            $isList = array_is_list($value);
             $code = [];
             foreach ($value as $k => $v) {
-                $code[] = sprintf('%s => %s', $this->dumpValue($k, $interpolate), $this->dumpValue($v, $interpolate));
+                $code[] = $isList ? $this->dumpValue($v, $interpolate) : sprintf('%s => %s', $this->dumpValue($k, $interpolate), $this->dumpValue($v, $interpolate));
             }
 
             return sprintf('[%s]', implode(', ', $code));

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
@@ -31,7 +31,7 @@ class getClosureService extends ProjectServiceContainer
 
         $container->services['closure'] = $instance = new \stdClass();
 
-        $instance->closures = [0 => #[\Closure(name: 'foo', class: 'FooClass')] static function () use ($containerRef): ?\stdClass {
+        $instance->closures = [#[\Closure(name: 'foo', class: 'FooClass')] static function () use ($containerRef): ?\stdClass {
             $container = $containerRef->get();
 
             return ($container->services['foo'] ?? null);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
@@ -63,7 +63,7 @@ class ProjectServiceContainer extends Container
 
         $b = ($container->privates['App\\Schema'] ?? self::getSchemaService($container));
         $c = new \App\Registry();
-        $c->processor = [0 => $a, 1 => $instance];
+        $c->processor = [$a, $instance];
 
         $d = new \App\Processor($c, $a);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -385,7 +385,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->services['manager3'];
         }
         $b = new \stdClass();
-        $b->listener = [0 => $a];
+        $b->listener = [$a];
 
         return $container->services['manager3'] = new \stdClass($b);
     }
@@ -588,7 +588,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
         $container->privates['manager4'] = $instance = new \stdClass($a);
 
-        $a->listener = [0 => ($container->services['listener4'] ?? self::getListener4Service($container))];
+        $a->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -219,7 +219,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
     {
         $container->services['connection3'] = $instance = new \stdClass();
 
-        $instance->listener = [0 => ($container->services['listener3'] ?? self::getListener3Service($container))];
+        $instance->listener = [($container->services['listener3'] ?? self::getListener3Service($container))];
 
         return $instance;
     }
@@ -233,7 +233,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
     {
         $container->services['connection4'] = $instance = new \stdClass();
 
-        $instance->listener = [0 => ($container->services['listener4'] ?? self::getListener4Service($container))];
+        $instance->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
@@ -62,15 +62,15 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
         $instance->foo1 = ($container->services['foo1'] ?? null);
         $instance->foo2 = null;
         $instance->foo3 = ($container->privates['foo3'] ?? null);
-        $instance->closures = [0 => #[\Closure(name: 'foo1', class: 'stdClass')] static function () use ($containerRef) {
+        $instance->closures = [#[\Closure(name: 'foo1', class: 'stdClass')] static function () use ($containerRef) {
             $container = $containerRef->get();
 
             return ($container->services['foo1'] ?? null);
-        }, 1 => #[\Closure(name: 'foo2')] static function () use ($containerRef) {
+        }, #[\Closure(name: 'foo2')] static function () use ($containerRef) {
             $container = $containerRef->get();
 
             return null;
-        }, 2 => #[\Closure(name: 'foo3', class: 'stdClass')] static function () use ($containerRef) {
+        }, #[\Closure(name: 'foo3', class: 'stdClass')] static function () use ($containerRef) {
             $container = $containerRef->get();
 
             return ($container->privates['foo3'] ?? null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  |no 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When the value is a list, there is no point in dumping the keys.