### PR TITLE
[DependencyInjection] Use short arrow closure for EmptyIterator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -368,9 +368,7 @@ class getLazyContextService extends ProjectServiceContainer
 
             yield 'k1' => ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'));
             yield 'k2' => $container;
-        }, 2), new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0));
+        }, 2), new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 }
 
@@ -391,9 +389,7 @@ class getLazyContextIgnoreInvalidRefService extends ProjectServiceContainer
             $container = $containerRef->get();
 
             yield 0 => ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'));
-        }, 1), new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0));
+        }, 1), new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -337,9 +337,7 @@ class ProjectServiceContainer extends Container
 
             yield 'k1' => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
             yield 'k2' => $container;
-        }, 2), new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0));
+        }, 2), new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 
     /**
@@ -355,9 +353,7 @@ class ProjectServiceContainer extends Container
             $container = $containerRef->get();
 
             yield 0 => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
-        }, 1), new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0));
+        }, 1), new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -360,9 +360,7 @@ class ProjectServiceContainer extends Container
 
             yield 'k1' => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
             yield 'k2' => $container;
-        }, 2), new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0));
+        }, 2), new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 
     /**
@@ -380,9 +378,7 @@ class ProjectServiceContainer extends Container
             $container = $containerRef->get();
 
             yield 0 => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
-        }, 1), new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0));
+        }, 1), new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -559,9 +559,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getMailerInline_MailerService($container)
     {
-        return $container->privates['mailer_inline.mailer'] = new \stdClass((new \FactoryCircular(new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0)))->create());
+        return $container->privates['mailer_inline.mailer'] = new \stdClass((new \FactoryCircular(new RewindableGenerator(fn () => new \EmptyIterator(), 0)))->create());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -559,9 +559,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getMailerInline_TransportFactoryService($container)
     {
-        return $container->services['mailer_inline.transport_factory'] = new \FactoryCircular(new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0));
+        return $container->services['mailer_inline.transport_factory'] = new \FactoryCircular(new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -337,9 +337,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
             yield 'k1' => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
             yield 'k2' => $container;
-        }, 2), new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0));
+        }, 2), new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 
     /**
@@ -355,9 +353,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
             $container = $containerRef->get();
 
             yield 0 => ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
-        }, 1), new RewindableGenerator(function () {
-            return new \EmptyIterator();
-        }, 0));
+        }, 1), new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      |no
| New feature?  |no 
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

Small fix while working on the previous PR. 

/cc @nicolas-grekas 