### PR TITLE
[WebProfilerBundle] Fix the rendering of query explanation with Postgresql

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -2079,7 +2079,7 @@ tr.log-status-silenced > td:first-child:before {
     max-width: 888px;
 }
 .width-full .sql-explain {
-    max-width: min-content;
+    max-width: unset;
 }
 .sql-explain table td, .sql-explain table tr {
     word-break: normal;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

Postgresql (and some other platforms) provide a textual query explanation rather than a tabular one.
The previous styles were working only for a tabular display. For text allowing to break words, `min-content` is the width of a single letter.

With the old code (introduced in #46750), a query explanation looks like that when using Postgresql (well, with a lot more lines that what is included in the screenshot):
![image](https://user-images.githubusercontent.com/439401/220405453-ffdb0b24-91fe-4ba5-aeb6-4a919b07d007.png)

After the change, it looks like that (including only the first few lines), which is a lot easier to read:
![image](https://user-images.githubusercontent.com/439401/220405829-8a279d4f-2f1a-42db-bae1-2fd4d4279550.png)

