### PR TITLE
[Mailer] Reflect sandbox state in `MailjetApiTransport::__toString()`

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -45,6 +45,10 @@ class MailjetApiTransportTest extends TestCase
                 (new MailjetApiTransport(self::USER, self::PASSWORD))->setHost('example.com'),
                 'mailjet+api://example.com',
             ],
+            [
+                (new MailjetApiTransport(self::USER, self::PASSWORD, sandbox: true))->setHost('example.com'),
+                'mailjet+api://example.com?sandbox=true',
+            ],
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -66,7 +66,7 @@ class MailjetApiTransport extends AbstractApiTransport
 
     public function __toString(): string
     {
-        return sprintf('mailjet+api://%s', $this->getEndpoint());
+        return sprintf('mailjet+api://%s', $this->getEndpoint().($this->sandbox ? '?sandbox=true' : ''));
     }
 
     protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/49429#issuecomment-1438655741
| License       | MIT
| Doc PR        | _NA_

Follow-up of https://github.com/symfony/symfony/pull/49429

8.2 tests failure seems unrelated.