### PR TITLE
[Validator] Fix translation of AtLeastOneOf constraint message

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AtLeastOneOfValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AtLeastOneOfValidator.php
@@ -31,7 +31,11 @@ class AtLeastOneOfValidator extends ConstraintValidator
 
         $validator = $this->context->getValidator();
 
-        $messages = [$constraint->message];
+        // Build a first violation to have the base message of the constraint translated
+        $baseMessageContext = clone $this->context;
+        $baseMessageContext->buildViolation($constraint->message)->addViolation();
+        $baseViolations = $baseMessageContext->getViolations();
+        $messages = [(string) $baseViolations->get(\count($baseViolations) - 1)->getMessage()];
 
         foreach ($constraint->constraints as $key => $item) {
             if (!\in_array($this->context->getGroup(), $item->groups, true)) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\IdenticalTo;
+use Symfony\Component\Validator\Constraints\IsNull;
 use Symfony\Component\Validator\Constraints\Language;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\LessThan;
@@ -37,6 +38,9 @@ use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Mapping\MetadataInterface;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 use Symfony\Component\Validator\Validation;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorTrait;
 
 /**
  * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
@@ -257,6 +261,40 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
         ]), 'senior');
 
         $this->assertCount(1, $violations);
+    }
+
+    public function testTranslatorIsCalledOnConstraintBaseMessageAndViolations()
+    {
+        $translator = new class() implements TranslatorInterface, LocaleAwareInterface {
+            use TranslatorTrait;
+
+            public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null): string
+            {
+                if ('This value should satisfy at least one of the following constraints:' === $id) {
+                    return 'Dummy translation:';
+                }
+
+                if ('This value should be null.' === $id) {
+                    return 'Dummy violation.';
+                }
+
+                return $id;
+            }
+        };
+
+        $validator = Validation::createValidatorBuilder()
+            ->setTranslator($translator)
+            ->getValidator()
+        ;
+
+        $violations = $validator->validate('Test', [
+            new AtLeastOneOf([
+                new IsNull(),
+            ]),
+        ]);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('Dummy translation: [1] Dummy violation.', $violations->get(0)->getMessage());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41317
| License       | MIT
| Doc PR        | _NA_

New try after Nicolas' hint on https://github.com/symfony/symfony/pull/41325.
This is a much simpler solution using execution context to get the base message of the constraint translated.

~I tried to create the relevant test case, but other locales doesn't seem to be available in validators test cases.~ I'm having a look at a test case in a dummy locale after https://github.com/symfony/symfony/pull/49484#issuecomment-1439118960

When using another locale, the base message of the constraint is actually translated now:

<img width="1238" alt="image" src="https://user-images.githubusercontent.com/2144837/220455120-c17e7ac6-81c5-4dd0-a2fc-b100a6a00688.png">
