### PR TITLE
[String] Use same alphabet in ByteString::fromRandom test

### DIFF
--- a/src/Symfony/Component/String/Tests/ByteStringTest.php
+++ b/src/Symfony/Component/String/Tests/ByteStringTest.php
@@ -28,7 +28,7 @@ class ByteStringTest extends AbstractAsciiTestCase
 
         self::assertSame(32, $random->length());
         foreach ($random->chunk() as $char) {
-            self::assertNotNull((new ByteString('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'))->indexOf($char));
+            self::assertNotNull((new ByteString('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'))->indexOf($char));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets | NA
| License | MIT
| Doc PR | NA

`testFromRandom` in `ByteStringTest` tests the fromRandom method in ByteString, but uses a different alphabet. Apparently, some characters were left out in the alphabet of ByteString to prevent confusion. I believe the same alphabet should be used in the test.
