### PR TITLE
[FrameworkBundle] Allow disabling dumping of container to XML to improve performance

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Allow setting private services with the test container
  * Register alias for argument for workflow services with workflow name only
  * Configure the `ErrorHandler` on `FrameworkBundle::boot()`
+ * Allow setting `debug.container.dump` to `false` to disable dumping the container to XML
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
@@ -39,7 +39,7 @@ trait BuildDebugContainerTrait
             return $this->containerBuilder;
         }
 
-        if (!$kernel->isDebug() || !(new ConfigCache($kernel->getContainer()->getParameter('debug.container.dump'), true))->isFresh()) {
+        if (!$kernel->isDebug() || !$kernel->getContainer()->getParameter('debug.container.dump') || !(new ConfigCache($kernel->getContainer()->getParameter('debug.container.dump'), true))->isFresh()) {
             $buildContainer = \Closure::bind(function () {
                 $this->initializeBundles();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -77,7 +77,7 @@ final class ContainerLintCommand extends Command
         $kernel = $this->getApplication()->getKernel();
         $kernelContainer = $kernel->getContainer();
 
-        if (!$kernel->isDebug() || !(new ConfigCache($kernelContainer->getParameter('debug.container.dump'), true))->isFresh()) {
+        if (!$kernel->isDebug() || !$kernelContainer->getParameter('debug.container.dump') || !(new ConfigCache($kernelContainer->getParameter('debug.container.dump'), true))->isFresh()) {
             if (!$kernel instanceof Kernel) {
                 throw new RuntimeException(sprintf('This command does not support the application kernel: "%s" does not extend "%s".', get_debug_type($kernel), Kernel::class));
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -292,7 +292,7 @@ abstract class Descriptor implements DescriptorInterface
             return [];
         }
 
-        if (!is_file($container->getParameter('debug.container.dump'))) {
+        if (!$container->getParameter('debug.container.dump') || !is_file($container->getParameter('debug.container.dump'))) {
             return [];
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
@@ -30,6 +30,10 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (!$container->getParameter('debug.container.dump')) {
+            return;
+        }
+
         $cache = new ConfigCache($container->getParameter('debug.container.dump'), true);
         if (!$cache->isFresh()) {
             $cache->write((new XmlDumper($container))->dump(), $container->getResources());

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1087,7 +1087,7 @@ class FrameworkExtension extends Extension
 
         $debug = $container->getParameter('kernel.debug');
 
-        if ($debug) {
+        if ($debug && !$container->hasParameter('debug.container.dump')) {
             $container->setParameter('debug.container.dump', '%kernel.build_dir%/%kernel.container_class%.xml');
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -50,6 +50,19 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString('public', $tester->getDisplay());
     }
 
+    public function testNoDumpedXML()
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml', 'debug' => true, 'debug.container.dump' => false]);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'debug:container']);
+
+        $this->assertStringContainsString('public', $tester->getDisplay());
+    }
+
     public function testPrivateAlias()
     {
         static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

In debug mode, when the container is compiled, an XML file is automatically generated. This file is used by various commands like:
- `debug:container`
- `lint:container`
- `config:dump-reference`
- `debug:autowiring`
- `debug:router`

But generating this file comes with a price. When your container grows, the XML file grows, and the time to compile this file increases.

In our large application this file became 20MB and took 2 seconds to generate every time the cache needed to be recompiled. For us, the benefit of this file does not outweigh the decrease in performance.

Therefore I'd like to disable this dumping and accept the consequences for less debug possibilities.

To disable this, one can set the `debug.container.dump` parameter to `false`.
