### PR TITLE
[Mailer] Update Infobip API transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
@@ -70,7 +70,7 @@ class InfobipApiTransportTest extends TestCase
         $this->transport->send($email);
 
         $this->assertSame('POST', $this->response->getRequestMethod());
-        $this->assertSame('https://99999.api.infobip.com/email/2/send', $this->response->getRequestUrl());
+        $this->assertSame('https://99999.api.infobip.com/email/3/send', $this->response->getRequestUrl());
         $options = $this->response->getRequestOptions();
         $this->arrayHasKey('headers');
         $this->assertCount(4, $options['headers']);

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
@@ -31,7 +31,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class InfobipApiTransport extends AbstractApiTransport
 {
-    private const API_VERSION = '2';
+    private const API_VERSION = '3';
 
     private string $key;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

# 📍 Context

Infobip send an email to their customers that do not use the latest API release: **V3**

They inform that everything is backward compatible and can be easily upgraded without any changes.

# 🛠️ Changes

This PR change the version used from the V2 to the V3.