### PR TITLE
[DependencyInjection] Add native return types in compiled container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add `#[AsAlias]` attribute to tell under which alias a service should be registered or to use the implemented interface if no parameter is given
  * Allow to trim XML service parameters value by using `trim="true"` attribute
  * Allow extending the `Autowire` attribute
+ * Add native return types in compiled container
 
 6.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure.php
@@ -49,20 +49,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'closure' shared service.
-     *
-     * @return \Closure
      */
-    protected static function getClosureService($container)
+    protected static function getClosureService($container): \Closure
     {
         return $container->services['closure'] = (new \stdClass())->__invoke(...);
     }
 
     /**
      * Gets the public 'closure_of_service_closure' shared service.
-     *
-     * @return \Closure
      */
-    protected static function getClosureOfServiceClosureService($container)
+    protected static function getClosureOfServiceClosureService($container): \Closure
     {
         $containerRef = $container->ref;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -42,10 +42,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'test' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getTestService($container)
+    protected static function getTestService($container): \stdClass
     {
         return $container->services['test'] = new \stdClass(['only dot' => '.', 'concatenation as value' => '.\'\'.', 'concatenation from the start value' => '\'\'.', '.' => 'dot as a key', '.\'\'.' => 'concatenation as a key', '\'\'.' => 'concatenation from the start key', 'optimize concatenation' => 'string1-string2', 'optimize concatenation with empty string' => 'string1string2', 'optimize concatenation from the start' => 'start', 'optimize concatenation at the end' => 'end', 'new line' => 'string with '."\n".'new line']);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
@@ -22,10 +22,8 @@ class getClosureService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'closure' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         $containerRef = $container->ref;
 
@@ -112,10 +110,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \FooClass
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \FooClass
     {
         return $container->services['foo'] = new \FooClass(new \stdClass());
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -42,10 +42,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'test' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getTestService($container)
+    protected static function getTestService($container): \stdClass
     {
         return $container->services['test'] = new \stdClass(('file://'.\dirname(__DIR__, 1)), [('file://'.\dirname(__DIR__, 1)) => (\dirname(__DIR__, 2).'/')]);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -47,10 +47,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \stdClass
     {
         $a = new \stdClass();
         $a->add($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -46,17 +46,15 @@ class ProjectServiceContainer extends Container
      *
      * @return object A %env(FOO)% instance
      */
-    protected static function getServiceFromAnonymousFactoryService($container)
+    protected static function getServiceFromAnonymousFactoryService($container): object
     {
         return $container->services['service_from_anonymous_factory'] = (new ${($_ = $container->getEnv('FOO')) && false ?: "_"}())->getInstance();
     }
 
     /**
      * Gets the public 'service_with_method_call_and_factory' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getServiceWithMethodCallAndFactoryService($container)
+    protected static function getServiceWithMethodCallAndFactoryService($container): \Bar\FooClass
     {
         $container->services['service_with_method_call_and_factory'] = $instance = new \Bar\FooClass();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
@@ -40,10 +40,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo' shared autowired service.
-     *
-     * @return \Foo
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \Foo
     {
         return $container->services['foo'] = new \Foo();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
@@ -43,10 +43,8 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
     {
         return $container->services['bar'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\Bar($container->getEnv('QUZ'));
     }
@@ -56,7 +54,7 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
      *
      * @return object A %env(FOO)% instance
      */
-    protected static function getTestService($container)
+    protected static function getTestService($container): object
     {
         return $container->services['test'] = new ${($_ = $container->getEnv('FOO')) && false ?: "_"}($container->getEnv('Bar'), 'foo'.$container->getEnv('string:FOO').'baz', $container->getEnv('int:Baz'));
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
@@ -41,20 +41,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'Bar\Foo' shared service.
-     *
-     * @return \Bar\Foo
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \Bar\Foo
     {
         return $container->services['Bar\\Foo'] = new \Bar\Foo();
     }
 
     /**
      * Gets the public 'Foo\Foo' shared service.
-     *
-     * @return \Foo\Foo
      */
-    protected static function getFoo2Service($container)
+    protected static function getFoo2Service($container): \Foo\Foo
     {
         return $container->services['Foo\\Foo'] = new \Foo\Foo();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -32,10 +32,8 @@ class getBAR2Service extends ProjectServiceContainer
 {
     /**
      * Gets the public 'BAR' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         $container->services['BAR'] = $instance = new \stdClass();
 
@@ -51,10 +49,8 @@ class getBAR22Service extends ProjectServiceContainer
 {
     /**
      * Gets the public 'BAR2' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         return $container->services['BAR2'] = new \stdClass();
     }
@@ -66,10 +62,8 @@ class getAServiceService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'a_service' shared service.
-     *
-     * @return \Bar
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar
     {
         return $container->services['a_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
@@ -81,10 +75,8 @@ class getBServiceService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'b_service' shared service.
-     *
-     * @return \Bar
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar
     {
         return $container->services['b_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
@@ -96,10 +88,8 @@ class getBar23Service extends ProjectServiceContainer
 {
     /**
      * Gets the public 'bar2' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         return $container->services['bar2'] = new \stdClass();
     }
@@ -111,10 +101,8 @@ class getBazService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'baz' shared service.
-     *
-     * @return \Baz
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Baz
     {
         $container->services['baz'] = $instance = new \Baz();
 
@@ -130,10 +118,8 @@ class getConfiguredServiceService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'configured_service' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         $container->services['configured_service'] = $instance = new \stdClass();
 
@@ -152,10 +138,8 @@ class getConfiguredServiceSimpleService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'configured_service_simple' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         $container->services['configured_service_simple'] = $instance = new \stdClass();
 
@@ -171,10 +155,8 @@ class getDecoratorServiceService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'decorator_service' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         return $container->services['decorator_service'] = new \stdClass();
     }
@@ -186,10 +168,8 @@ class getDecoratorServiceWithNameService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'decorator_service_with_name' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         return $container->services['decorator_service_with_name'] = new \stdClass();
     }
@@ -202,11 +182,9 @@ class getDeprecatedServiceService extends ProjectServiceContainer
     /**
      * Gets the public 'deprecated_service' shared service.
      *
-     * @return \stdClass
-     *
      * @deprecated Since vendor/package 1.1: The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         trigger_deprecation('vendor/package', '1.1', 'The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.');
 
@@ -220,10 +198,8 @@ class getFactoryServiceService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'factory_service' shared service.
-     *
-     * @return \Bar
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar
     {
         return $container->services['factory_service'] = ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'))->getInstance();
     }
@@ -235,10 +211,8 @@ class getFactoryServiceSimpleService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'factory_service_simple' shared service.
-     *
-     * @return \Bar
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar
     {
         return $container->services['factory_service_simple'] = $container->load('getFactorySimpleService')->getInstance();
     }
@@ -251,11 +225,9 @@ class getFactorySimpleService extends ProjectServiceContainer
     /**
      * Gets the private 'factory_simple' shared service.
      *
-     * @return \SimpleFactoryClass
-     *
      * @deprecated Since vendor/package 1.1: The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \SimpleFactoryClass
     {
         trigger_deprecation('vendor/package', '1.1', 'The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.');
 
@@ -269,10 +241,8 @@ class getFooService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar\FooClass
     {
         $a = ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'));
 
@@ -295,10 +265,8 @@ class getFoo_BazService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'foo.baz' shared service.
-     *
-     * @return \BazClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \BazClass
     {
         $container->services['foo.baz'] = $instance = \BazClass::getInstance();
 
@@ -314,10 +282,8 @@ class getFooBarService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'foo_bar' service.
-     *
-     * @return \Bar\FooClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar\FooClass
     {
         $container->factories['foo_bar'] = function ($container) {
             return new \Bar\FooClass(($container->services['deprecated_service'] ?? $container->load('getDeprecatedServiceService')));
@@ -333,10 +299,8 @@ class getFooWithInlineService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'foo_with_inline' shared service.
-     *
-     * @return \Foo
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Foo
     {
         $container->services['foo_with_inline'] = $instance = new \Foo();
 
@@ -356,10 +320,8 @@ class getLazyContextService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'lazy_context' shared service.
-     *
-     * @return \LazyContext
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \LazyContext
     {
         $containerRef = $container->ref;
 
@@ -378,10 +340,8 @@ class getLazyContextIgnoreInvalidRefService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'lazy_context_ignore_invalid_ref' shared service.
-     *
-     * @return \LazyContext
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \LazyContext
     {
         $containerRef = $container->ref;
 
@@ -399,10 +359,8 @@ class getMethodCall1Service extends ProjectServiceContainer
 {
     /**
      * Gets the public 'method_call1' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar\FooClass
     {
         include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
@@ -422,10 +380,8 @@ class getNewFactoryServiceService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'new_factory_service' shared service.
-     *
-     * @return \FooBarBaz
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \FooBarBaz
     {
         $a = new \FactoryClass();
         $a->foo = 'bar';
@@ -444,10 +400,8 @@ class getNonSharedFooService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'non_shared_foo' service.
-     *
-     * @return \Bar\FooClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar\FooClass
     {
         include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
@@ -465,10 +419,8 @@ class getPreloadSidekickService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'preload_sidekick' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         return $container->services['preload_sidekick'] = new \stdClass();
     }
@@ -480,10 +432,8 @@ class getRuntimeErrorService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'runtime_error' shared service.
-     *
-     * @return \stdClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \stdClass
     {
         return $container->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
     }
@@ -495,10 +445,8 @@ class getServiceFromStaticMethodService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'service_from_static_method' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar\FooClass
     {
         return $container->services['service_from_static_method'] = \Bar\FooClass::getInstance();
     }
@@ -510,10 +458,8 @@ class getTaggedIteratorService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'tagged_iterator' shared service.
-     *
-     * @return \Bar
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar
     {
         $containerRef = $container->ref;
 
@@ -532,10 +478,8 @@ class getThrowingOneService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'throwing_one' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar\FooClass
     {
         return $container->services['throwing_one'] = new \Bar\FooClass(throw new RuntimeException('No-no-no-no'));
     }
@@ -646,10 +590,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \Bar\FooClass
     {
         $a = ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -89,10 +89,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'BAR' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBARService($container)
+    protected static function getBARService($container): \stdClass
     {
         $container->services['BAR'] = $instance = new \stdClass();
 
@@ -103,40 +101,32 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'BAR2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBAR2Service($container)
+    protected static function getBAR2Service($container): \stdClass
     {
         return $container->services['BAR2'] = new \stdClass();
     }
 
     /**
      * Gets the public 'a_service' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getAServiceService($container)
+    protected static function getAServiceService($container): \Bar
     {
         return $container->services['a_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
      * Gets the public 'b_service' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getBServiceService($container)
+    protected static function getBServiceService($container): \Bar
     {
         return $container->services['b_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getBar3Service($container)
+    protected static function getBar3Service($container): \Bar\FooClass
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
@@ -149,20 +139,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBar22Service($container)
+    protected static function getBar22Service($container): \stdClass
     {
         return $container->services['bar2'] = new \stdClass();
     }
 
     /**
      * Gets the public 'baz' shared service.
-     *
-     * @return \Baz
      */
-    protected static function getBazService($container)
+    protected static function getBazService($container): \Baz
     {
         $container->services['baz'] = $instance = new \Baz();
 
@@ -173,10 +159,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'configured_service' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConfiguredServiceService($container)
+    protected static function getConfiguredServiceService($container): \stdClass
     {
         $container->services['configured_service'] = $instance = new \stdClass();
 
@@ -190,10 +174,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'configured_service_simple' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConfiguredServiceSimpleService($container)
+    protected static function getConfiguredServiceSimpleService($container): \stdClass
     {
         $container->services['configured_service_simple'] = $instance = new \stdClass();
 
@@ -204,20 +186,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'decorator_service' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDecoratorServiceService($container)
+    protected static function getDecoratorServiceService($container): \stdClass
     {
         return $container->services['decorator_service'] = new \stdClass();
     }
 
     /**
      * Gets the public 'decorator_service_with_name' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDecoratorServiceWithNameService($container)
+    protected static function getDecoratorServiceWithNameService($container): \stdClass
     {
         return $container->services['decorator_service_with_name'] = new \stdClass();
     }
@@ -225,11 +203,9 @@ class ProjectServiceContainer extends Container
     /**
      * Gets the public 'deprecated_service' shared service.
      *
-     * @return \stdClass
-     *
      * @deprecated Since vendor/package 1.1: The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected static function getDeprecatedServiceService($container)
+    protected static function getDeprecatedServiceService($container): \stdClass
     {
         trigger_deprecation('vendor/package', '1.1', 'The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.');
 
@@ -238,30 +214,24 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'factory_service' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getFactoryServiceService($container)
+    protected static function getFactoryServiceService($container): \Bar
     {
         return $container->services['factory_service'] = ($container->services['foo.baz'] ?? self::getFoo_BazService($container))->getInstance();
     }
 
     /**
      * Gets the public 'factory_service_simple' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getFactoryServiceSimpleService($container)
+    protected static function getFactoryServiceSimpleService($container): \Bar
     {
         return $container->services['factory_service_simple'] = self::getFactorySimpleService($container)->getInstance();
     }
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \Bar\FooClass
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
@@ -279,10 +249,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo.baz' shared service.
-     *
-     * @return \BazClass
      */
-    protected static function getFoo_BazService($container)
+    protected static function getFoo_BazService($container): \BazClass
     {
         $container->services['foo.baz'] = $instance = \BazClass::getInstance();
 
@@ -293,10 +261,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo_bar' service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getFooBarService($container)
+    protected static function getFooBarService($container): \Bar\FooClass
     {
         $container->factories['foo_bar'] = function ($container) {
             return new \Bar\FooClass(($container->services['deprecated_service'] ?? self::getDeprecatedServiceService($container)));
@@ -307,10 +273,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo_with_inline' shared service.
-     *
-     * @return \Foo
      */
-    protected static function getFooWithInlineService($container)
+    protected static function getFooWithInlineService($container): \Foo
     {
         $container->services['foo_with_inline'] = $instance = new \Foo();
 
@@ -325,10 +289,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'lazy_context' shared service.
-     *
-     * @return \LazyContext
      */
-    protected static function getLazyContextService($container)
+    protected static function getLazyContextService($container): \LazyContext
     {
         $containerRef = $container->ref;
 
@@ -342,10 +304,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'lazy_context_ignore_invalid_ref' shared service.
-     *
-     * @return \LazyContext
      */
-    protected static function getLazyContextIgnoreInvalidRefService($container)
+    protected static function getLazyContextIgnoreInvalidRefService($container): \LazyContext
     {
         $containerRef = $container->ref;
 
@@ -358,10 +318,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'method_call1' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getMethodCall1Service($container)
+    protected static function getMethodCall1Service($container): \Bar\FooClass
     {
         include_once '%path%foo.php';
 
@@ -376,10 +334,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'new_factory_service' shared service.
-     *
-     * @return \FooBarBaz
      */
-    protected static function getNewFactoryServiceService($container)
+    protected static function getNewFactoryServiceService($container): \FooBarBaz
     {
         $a = new \FactoryClass();
         $a->foo = 'bar';
@@ -393,40 +349,32 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'preload_sidekick' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPreloadSidekickService($container)
+    protected static function getPreloadSidekickService($container): \stdClass
     {
         return $container->services['preload_sidekick'] = new \stdClass();
     }
 
     /**
      * Gets the public 'runtime_error' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getRuntimeErrorService($container)
+    protected static function getRuntimeErrorService($container): \stdClass
     {
         return $container->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
     }
 
     /**
      * Gets the public 'service_from_static_method' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getServiceFromStaticMethodService($container)
+    protected static function getServiceFromStaticMethodService($container): \Bar\FooClass
     {
         return $container->services['service_from_static_method'] = \Bar\FooClass::getInstance();
     }
 
     /**
      * Gets the public 'tagged_iterator' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getTaggedIteratorService($container)
+    protected static function getTaggedIteratorService($container): \Bar
     {
         $containerRef = $container->ref;
 
@@ -441,11 +389,9 @@ class ProjectServiceContainer extends Container
     /**
      * Gets the private 'factory_simple' shared service.
      *
-     * @return \SimpleFactoryClass
-     *
      * @deprecated Since vendor/package 1.1: The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected static function getFactorySimpleService($container)
+    protected static function getFactorySimpleService($container): \SimpleFactoryClass
     {
         trigger_deprecation('vendor/package', '1.1', 'The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -108,10 +108,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'BAR' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBARService($container)
+    protected static function getBARService($container): \stdClass
     {
         $container->services['BAR'] = $instance = new \stdClass();
 
@@ -122,40 +120,32 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'BAR2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBAR2Service($container)
+    protected static function getBAR2Service($container): \stdClass
     {
         return $container->services['BAR2'] = new \stdClass();
     }
 
     /**
      * Gets the public 'a_service' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getAServiceService($container)
+    protected static function getAServiceService($container): \Bar
     {
         return $container->services['a_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
      * Gets the public 'b_service' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getBServiceService($container)
+    protected static function getBServiceService($container): \Bar
     {
         return $container->services['b_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getBar3Service($container)
+    protected static function getBar3Service($container): \Bar\FooClass
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
@@ -168,20 +158,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBar22Service($container)
+    protected static function getBar22Service($container): \stdClass
     {
         return $container->services['bar2'] = new \stdClass();
     }
 
     /**
      * Gets the public 'baz' shared service.
-     *
-     * @return \Baz
      */
-    protected static function getBazService($container)
+    protected static function getBazService($container): \Baz
     {
         $container->services['baz'] = $instance = new \Baz();
 
@@ -192,10 +178,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'configured_service' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConfiguredServiceService($container)
+    protected static function getConfiguredServiceService($container): \stdClass
     {
         $container->services['configured_service'] = $instance = new \stdClass();
 
@@ -209,10 +193,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'configured_service_simple' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConfiguredServiceSimpleService($container)
+    protected static function getConfiguredServiceSimpleService($container): \stdClass
     {
         $container->services['configured_service_simple'] = $instance = new \stdClass();
 
@@ -223,20 +205,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'decorator_service' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDecoratorServiceService($container)
+    protected static function getDecoratorServiceService($container): \stdClass
     {
         return $container->services['decorator_service'] = new \stdClass();
     }
 
     /**
      * Gets the public 'decorator_service_with_name' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDecoratorServiceWithNameService($container)
+    protected static function getDecoratorServiceWithNameService($container): \stdClass
     {
         return $container->services['decorator_service_with_name'] = new \stdClass();
     }
@@ -244,11 +222,9 @@ class ProjectServiceContainer extends Container
     /**
      * Gets the public 'deprecated_service' shared service.
      *
-     * @return \stdClass
-     *
      * @deprecated Since vendor/package 1.1: The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected static function getDeprecatedServiceService($container)
+    protected static function getDeprecatedServiceService($container): \stdClass
     {
         trigger_deprecation('vendor/package', '1.1', 'The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.');
 
@@ -257,30 +233,24 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'factory_service' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getFactoryServiceService($container)
+    protected static function getFactoryServiceService($container): \Bar
     {
         return $container->services['factory_service'] = ($container->services['foo.baz'] ?? self::getFoo_BazService($container))->getInstance();
     }
 
     /**
      * Gets the public 'factory_service_simple' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getFactoryServiceSimpleService($container)
+    protected static function getFactoryServiceSimpleService($container): \Bar
     {
         return $container->services['factory_service_simple'] = self::getFactorySimpleService($container)->getInstance();
     }
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \Bar\FooClass
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
@@ -298,10 +268,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo.baz' shared service.
-     *
-     * @return \BazClass
      */
-    protected static function getFoo_BazService($container)
+    protected static function getFoo_BazService($container): \BazClass
     {
         include_once $container->targetDir.''.'/Fixtures/includes/classes.php';
 
@@ -314,10 +282,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo_bar' service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getFooBarService($container)
+    protected static function getFooBarService($container): \Bar\FooClass
     {
         $container->factories['foo_bar'] = function ($container) {
             return new \Bar\FooClass(($container->services['deprecated_service'] ?? self::getDeprecatedServiceService($container)));
@@ -328,10 +294,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo_with_inline' shared service.
-     *
-     * @return \Foo
      */
-    protected static function getFooWithInlineService($container)
+    protected static function getFooWithInlineService($container): \Foo
     {
         $container->services['foo_with_inline'] = $instance = new \Foo();
 
@@ -346,10 +310,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'lazy_context' shared service.
-     *
-     * @return \LazyContext
      */
-    protected static function getLazyContextService($container)
+    protected static function getLazyContextService($container): \LazyContext
     {
         $containerRef = $container->ref;
 
@@ -365,10 +327,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'lazy_context_ignore_invalid_ref' shared service.
-     *
-     * @return \LazyContext
      */
-    protected static function getLazyContextIgnoreInvalidRefService($container)
+    protected static function getLazyContextIgnoreInvalidRefService($container): \LazyContext
     {
         $containerRef = $container->ref;
 
@@ -383,10 +343,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'method_call1' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getMethodCall1Service($container)
+    protected static function getMethodCall1Service($container): \Bar\FooClass
     {
         include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
@@ -401,10 +359,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'new_factory_service' shared service.
-     *
-     * @return \FooBarBaz
      */
-    protected static function getNewFactoryServiceService($container)
+    protected static function getNewFactoryServiceService($container): \FooBarBaz
     {
         $a = new \FactoryClass();
         $a->foo = 'bar';
@@ -418,10 +374,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'non_shared_foo' service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getNonSharedFooService($container)
+    protected static function getNonSharedFooService($container): \Bar\FooClass
     {
         include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
@@ -434,40 +388,32 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'preload_sidekick' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPreloadSidekickService($container)
+    protected static function getPreloadSidekickService($container): \stdClass
     {
         return $container->services['preload_sidekick'] = new \stdClass();
     }
 
     /**
      * Gets the public 'runtime_error' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getRuntimeErrorService($container)
+    protected static function getRuntimeErrorService($container): \stdClass
     {
         return $container->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
     }
 
     /**
      * Gets the public 'service_from_static_method' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getServiceFromStaticMethodService($container)
+    protected static function getServiceFromStaticMethodService($container): \Bar\FooClass
     {
         return $container->services['service_from_static_method'] = \Bar\FooClass::getInstance();
     }
 
     /**
      * Gets the public 'tagged_iterator' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getTaggedIteratorService($container)
+    protected static function getTaggedIteratorService($container): \Bar
     {
         $containerRef = $container->ref;
 
@@ -481,10 +427,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'throwing_one' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getThrowingOneService($container)
+    protected static function getThrowingOneService($container): \Bar\FooClass
     {
         return $container->services['throwing_one'] = new \Bar\FooClass(throw new RuntimeException('No-no-no-no'));
     }
@@ -492,11 +436,9 @@ class ProjectServiceContainer extends Container
     /**
      * Gets the private 'factory_simple' shared service.
      *
-     * @return \SimpleFactoryClass
-     *
      * @deprecated Since vendor/package 1.1: The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected static function getFactorySimpleService($container)
+    protected static function getFactorySimpleService($container): \SimpleFactoryClass
     {
         trigger_deprecation('vendor/package', '1.1', 'The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -70,10 +70,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'lazy_foo' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getLazyFooService($container, $lazyLoad = true)
+    protected static function getLazyFooService($container, $lazyLoad = true): \Bar\FooClass
     {
         $containerRef = $container->ref;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
@@ -52,10 +52,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'App\Bus' shared service.
-     *
-     * @return \App\Bus
      */
-    protected static function getBusService($container)
+    protected static function getBusService($container): \App\Bus
     {
         $a = ($container->services['App\\Db'] ?? self::getDbService($container));
 
@@ -75,10 +73,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'App\Db' shared service.
-     *
-     * @return \App\Db
      */
-    protected static function getDbService($container)
+    protected static function getDbService($container): \App\Db
     {
         $container->services['App\\Db'] = $instance = new \App\Db();
 
@@ -89,10 +85,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the private 'App\Schema' shared service.
-     *
-     * @return \App\Schema
      */
-    protected static function getSchemaService($container)
+    protected static function getSchemaService($container): \App\Schema
     {
         $a = ($container->services['App\\Db'] ?? self::getDbService($container));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -103,10 +103,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'bar2' shared service.
-     *
-     * @return \BarCircular
      */
-    protected static function getBar2Service($container)
+    protected static function getBar2Service($container): \BarCircular
     {
         $container->services['bar2'] = $instance = new \BarCircular();
 
@@ -117,10 +115,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'bar3' shared service.
-     *
-     * @return \BarCircular
      */
-    protected static function getBar3Service($container)
+    protected static function getBar3Service($container): \BarCircular
     {
         $container->services['bar3'] = $instance = new \BarCircular();
 
@@ -133,10 +129,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'baz6' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBaz6Service($container)
+    protected static function getBaz6Service($container): \stdClass
     {
         $container->services['baz6'] = $instance = new \stdClass();
 
@@ -147,10 +141,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'connection' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConnectionService($container)
+    protected static function getConnectionService($container): \stdClass
     {
         $a = new \stdClass();
 
@@ -167,10 +159,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'connection2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConnection2Service($container)
+    protected static function getConnection2Service($container): \stdClass
     {
         $a = new \stdClass();
 
@@ -193,10 +183,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'doctrine.entity_manager' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDoctrine_EntityManagerService($container)
+    protected static function getDoctrine_EntityManagerService($container): \stdClass
     {
         $containerRef = $container->ref;
 
@@ -213,10 +201,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \FooCircular
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \FooCircular
     {
         $a = new \BarCircular();
 
@@ -229,10 +215,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'foo2' shared service.
-     *
-     * @return \FooCircular
      */
-    protected static function getFoo2Service($container)
+    protected static function getFoo2Service($container): \FooCircular
     {
         $a = ($container->services['bar2'] ?? self::getBar2Service($container));
 
@@ -245,10 +229,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'foo5' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo5Service($container)
+    protected static function getFoo5Service($container): \stdClass
     {
         $container->services['foo5'] = $instance = new \stdClass();
 
@@ -262,10 +244,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'foo6' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo6Service($container)
+    protected static function getFoo6Service($container): \stdClass
     {
         $container->services['foo6'] = $instance = new \stdClass();
 
@@ -276,10 +256,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'foobar4' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoobar4Service($container)
+    protected static function getFoobar4Service($container): \stdClass
     {
         $a = new \stdClass();
 
@@ -292,10 +270,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'listener3' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getListener3Service($container)
+    protected static function getListener3Service($container): \stdClass
     {
         $container->services['listener3'] = $instance = new \stdClass();
 
@@ -306,10 +282,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'listener4' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getListener4Service($container)
+    protected static function getListener4Service($container): \stdClass
     {
         $a = ($container->privates['manager4'] ?? self::getManager4Service($container));
 
@@ -322,10 +296,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'logger' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getLoggerService($container)
+    protected static function getLoggerService($container): \stdClass
     {
         $a = ($container->services['connection'] ?? self::getConnectionService($container));
 
@@ -342,10 +314,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'manager' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getManagerService($container)
+    protected static function getManagerService($container): \stdClass
     {
         $a = ($container->services['connection'] ?? self::getConnectionService($container));
 
@@ -358,10 +328,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'manager2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getManager2Service($container)
+    protected static function getManager2Service($container): \stdClass
     {
         $a = ($container->services['connection2'] ?? self::getConnection2Service($container));
 
@@ -374,10 +342,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'manager3' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getManager3Service($container, $lazyLoad = true)
+    protected static function getManager3Service($container, $lazyLoad = true): \stdClass
     {
         $a = ($container->services['listener3'] ?? self::getListener3Service($container));
 
@@ -392,10 +358,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'monolog.logger' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMonolog_LoggerService($container)
+    protected static function getMonolog_LoggerService($container): \stdClass
     {
         $container->services['monolog.logger'] = $instance = new \stdClass();
 
@@ -406,10 +370,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'monolog_inline.logger' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMonologInline_LoggerService($container)
+    protected static function getMonologInline_LoggerService($container): \stdClass
     {
         $container->services['monolog_inline.logger'] = $instance = new \stdClass();
 
@@ -420,10 +382,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'pA' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPAService($container)
+    protected static function getPAService($container): \stdClass
     {
         $a = ($container->privates['pC'] ?? self::getPCService($container));
 
@@ -441,10 +401,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'root' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getRootService($container)
+    protected static function getRootService($container): \stdClass
     {
         $a = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
 
@@ -457,10 +415,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the public 'subscriber' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getSubscriberService($container)
+    protected static function getSubscriberService($container): \stdClass
     {
         $a = ($container->services['manager'] ?? self::getManagerService($container));
 
@@ -473,10 +429,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the private 'bar6' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBar6Service($container)
+    protected static function getBar6Service($container): \stdClass
     {
         $a = ($container->services['foo6'] ?? self::getFoo6Service($container));
 
@@ -489,10 +443,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the private 'doctrine.listener' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDoctrine_ListenerService($container)
+    protected static function getDoctrine_ListenerService($container): \stdClass
     {
         $a = ($container->services['doctrine.entity_manager'] ?? self::getDoctrine_EntityManagerService($container));
 
@@ -505,10 +457,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the private 'level5' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getLevel5Service($container)
+    protected static function getLevel5Service($container): \stdClass
     {
         $a = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
 
@@ -521,10 +471,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the private 'mailer.transport' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMailer_TransportService($container)
+    protected static function getMailer_TransportService($container): \stdClass
     {
         $containerRef = $container->ref;
 
@@ -538,10 +486,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the private 'mailer.transport_factory.amazon' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMailer_TransportFactory_AmazonService($container)
+    protected static function getMailer_TransportFactory_AmazonService($container): \stdClass
     {
         $a = new \stdClass();
 
@@ -554,20 +500,16 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the private 'mailer_inline.mailer' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMailerInline_MailerService($container)
+    protected static function getMailerInline_MailerService($container): \stdClass
     {
         return $container->privates['mailer_inline.mailer'] = new \stdClass((new \FactoryCircular(new RewindableGenerator(fn () => new \EmptyIterator(), 0)))->create());
     }
 
     /**
      * Gets the private 'mailer_inline.transport_factory.amazon' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMailerInline_TransportFactory_AmazonService($container)
+    protected static function getMailerInline_TransportFactory_AmazonService($container): \stdClass
     {
         $a = new \stdClass();
         $a->handler = ($container->privates['mailer_inline.mailer'] ?? self::getMailerInline_MailerService($container));
@@ -577,10 +519,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the private 'manager4' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getManager4Service($container, $lazyLoad = true)
+    protected static function getManager4Service($container, $lazyLoad = true): \stdClass
     {
         $a = new \stdClass();
 
@@ -593,10 +533,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the private 'pC' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPCService($container, $lazyLoad = true)
+    protected static function getPCService($container, $lazyLoad = true): \stdClass
     {
         $container->privates['pC'] = $instance = new \stdClass();
 
@@ -607,10 +545,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
     /**
      * Gets the private 'pD' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPDService($container)
+    protected static function getPDService($container): \stdClass
     {
         $a = ($container->services['pA'] ?? self::getPAService($container));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -103,10 +103,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \BarCircular
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \BarCircular
     {
         $container->services['bar'] = $instance = new \BarCircular();
 
@@ -117,10 +115,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'bar3' shared service.
-     *
-     * @return \BarCircular
      */
-    protected static function getBar3Service($container)
+    protected static function getBar3Service($container): \BarCircular
     {
         $container->services['bar3'] = $instance = new \BarCircular();
 
@@ -133,10 +129,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'bar5' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBar5Service($container)
+    protected static function getBar5Service($container): \stdClass
     {
         $a = ($container->services['foo5'] ?? self::getFoo5Service($container));
 
@@ -153,10 +147,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'baz6' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBaz6Service($container)
+    protected static function getBaz6Service($container): \stdClass
     {
         $container->services['baz6'] = $instance = new \stdClass();
 
@@ -167,10 +159,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'connection' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConnectionService($container)
+    protected static function getConnectionService($container): \stdClass
     {
         $a = ($container->services['dispatcher'] ?? self::getDispatcherService($container));
 
@@ -188,10 +178,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'connection2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConnection2Service($container)
+    protected static function getConnection2Service($container): \stdClass
     {
         $a = ($container->services['dispatcher2'] ?? self::getDispatcher2Service($container));
 
@@ -212,10 +200,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'connection3' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConnection3Service($container)
+    protected static function getConnection3Service($container): \stdClass
     {
         $container->services['connection3'] = $instance = new \stdClass();
 
@@ -226,10 +212,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'connection4' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConnection4Service($container)
+    protected static function getConnection4Service($container): \stdClass
     {
         $container->services['connection4'] = $instance = new \stdClass();
 
@@ -240,10 +224,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'dispatcher' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDispatcherService($container, $lazyLoad = true)
+    protected static function getDispatcherService($container, $lazyLoad = true): \stdClass
     {
         $container->services['dispatcher'] = $instance = new \stdClass();
 
@@ -254,10 +236,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'dispatcher2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDispatcher2Service($container, $lazyLoad = true)
+    protected static function getDispatcher2Service($container, $lazyLoad = true): \stdClass
     {
         $container->services['dispatcher2'] = $instance = new \stdClass();
 
@@ -268,10 +248,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'doctrine.entity_listener_resolver' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDoctrine_EntityListenerResolverService($container)
+    protected static function getDoctrine_EntityListenerResolverService($container): \stdClass
     {
         $containerRef = $container->ref;
 
@@ -284,10 +262,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'doctrine.entity_manager' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDoctrine_EntityManagerService($container)
+    protected static function getDoctrine_EntityManagerService($container): \stdClass
     {
         $a = ($container->services['doctrine.entity_listener_resolver'] ?? self::getDoctrine_EntityListenerResolverService($container));
 
@@ -303,10 +279,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'doctrine.listener' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDoctrine_ListenerService($container)
+    protected static function getDoctrine_ListenerService($container): \stdClass
     {
         $a = ($container->services['doctrine.entity_manager'] ?? self::getDoctrine_EntityManagerService($container));
 
@@ -319,10 +293,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \FooCircular
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \FooCircular
     {
         $a = ($container->services['bar'] ?? self::getBarService($container));
 
@@ -335,10 +307,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'foo2' shared service.
-     *
-     * @return \FooCircular
      */
-    protected static function getFoo2Service($container)
+    protected static function getFoo2Service($container): \FooCircular
     {
         $a = new \BarCircular();
 
@@ -351,10 +321,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'foo4' service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo4Service($container)
+    protected static function getFoo4Service($container): \stdClass
     {
         $container->factories['foo4'] = function ($container) {
             $instance = new \stdClass();
@@ -369,10 +337,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'foo5' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo5Service($container)
+    protected static function getFoo5Service($container): \stdClass
     {
         $container->services['foo5'] = $instance = new \stdClass();
 
@@ -383,10 +349,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'foo6' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo6Service($container)
+    protected static function getFoo6Service($container): \stdClass
     {
         $container->services['foo6'] = $instance = new \stdClass();
 
@@ -397,10 +361,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'foobar' shared service.
-     *
-     * @return \FoobarCircular
      */
-    protected static function getFoobarService($container)
+    protected static function getFoobarService($container): \FoobarCircular
     {
         $a = ($container->services['foo'] ?? self::getFooService($container));
 
@@ -413,10 +375,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'foobar2' shared service.
-     *
-     * @return \FoobarCircular
      */
-    protected static function getFoobar2Service($container)
+    protected static function getFoobar2Service($container): \FoobarCircular
     {
         $a = ($container->services['foo2'] ?? self::getFoo2Service($container));
 
@@ -429,20 +389,16 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'foobar3' shared service.
-     *
-     * @return \FoobarCircular
      */
-    protected static function getFoobar3Service($container)
+    protected static function getFoobar3Service($container): \FoobarCircular
     {
         return $container->services['foobar3'] = new \FoobarCircular();
     }
 
     /**
      * Gets the public 'foobar4' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoobar4Service($container)
+    protected static function getFoobar4Service($container): \stdClass
     {
         $a = new \stdClass();
 
@@ -455,10 +411,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'listener3' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getListener3Service($container)
+    protected static function getListener3Service($container): \stdClass
     {
         $container->services['listener3'] = $instance = new \stdClass();
 
@@ -469,10 +423,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'listener4' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getListener4Service($container)
+    protected static function getListener4Service($container): \stdClass
     {
         $a = ($container->privates['manager4'] ?? self::getManager4Service($container));
 
@@ -485,10 +437,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'logger' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getLoggerService($container)
+    protected static function getLoggerService($container): \stdClass
     {
         $a = ($container->services['connection'] ?? self::getConnectionService($container));
 
@@ -505,10 +455,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'mailer.transport' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMailer_TransportService($container)
+    protected static function getMailer_TransportService($container): \stdClass
     {
         $a = ($container->services['mailer.transport_factory'] ?? self::getMailer_TransportFactoryService($container));
 
@@ -521,10 +469,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'mailer.transport_factory' shared service.
-     *
-     * @return \FactoryCircular
      */
-    protected static function getMailer_TransportFactoryService($container)
+    protected static function getMailer_TransportFactoryService($container): \FactoryCircular
     {
         $containerRef = $container->ref;
 
@@ -538,10 +484,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'mailer.transport_factory.amazon' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMailer_TransportFactory_AmazonService($container)
+    protected static function getMailer_TransportFactory_AmazonService($container): \stdClass
     {
         $a = ($container->services['monolog.logger_2'] ?? self::getMonolog_Logger2Service($container));
 
@@ -554,30 +498,24 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'mailer_inline.transport_factory' shared service.
-     *
-     * @return \FactoryCircular
      */
-    protected static function getMailerInline_TransportFactoryService($container)
+    protected static function getMailerInline_TransportFactoryService($container): \FactoryCircular
     {
         return $container->services['mailer_inline.transport_factory'] = new \FactoryCircular(new RewindableGenerator(fn () => new \EmptyIterator(), 0));
     }
 
     /**
      * Gets the public 'mailer_inline.transport_factory.amazon' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMailerInline_TransportFactory_AmazonService($container)
+    protected static function getMailerInline_TransportFactory_AmazonService($container): \stdClass
     {
         return $container->services['mailer_inline.transport_factory.amazon'] = new \stdClass(($container->services['monolog_inline.logger_2'] ?? self::getMonologInline_Logger2Service($container)));
     }
 
     /**
      * Gets the public 'manager' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getManagerService($container)
+    protected static function getManagerService($container): \stdClass
     {
         $a = ($container->services['connection'] ?? self::getConnectionService($container));
 
@@ -590,10 +528,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'manager2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getManager2Service($container)
+    protected static function getManager2Service($container): \stdClass
     {
         $a = ($container->services['connection2'] ?? self::getConnection2Service($container));
 
@@ -606,10 +542,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'manager3' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getManager3Service($container, $lazyLoad = true)
+    protected static function getManager3Service($container, $lazyLoad = true): \stdClass
     {
         $a = ($container->services['connection3'] ?? self::getConnection3Service($container));
 
@@ -622,10 +556,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'monolog.logger' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMonolog_LoggerService($container)
+    protected static function getMonolog_LoggerService($container): \stdClass
     {
         $container->services['monolog.logger'] = $instance = new \stdClass();
 
@@ -636,10 +568,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'monolog.logger_2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMonolog_Logger2Service($container)
+    protected static function getMonolog_Logger2Service($container): \stdClass
     {
         $container->services['monolog.logger_2'] = $instance = new \stdClass();
 
@@ -650,10 +580,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'monolog_inline.logger' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMonologInline_LoggerService($container)
+    protected static function getMonologInline_LoggerService($container): \stdClass
     {
         $container->services['monolog_inline.logger'] = $instance = new \stdClass();
 
@@ -664,10 +592,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'monolog_inline.logger_2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMonologInline_Logger2Service($container)
+    protected static function getMonologInline_Logger2Service($container): \stdClass
     {
         $container->services['monolog_inline.logger_2'] = $instance = new \stdClass();
 
@@ -678,10 +604,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'pA' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPAService($container)
+    protected static function getPAService($container): \stdClass
     {
         $a = ($container->services['pB'] ?? self::getPBService($container));
 
@@ -699,10 +623,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'pB' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPBService($container)
+    protected static function getPBService($container): \stdClass
     {
         $container->services['pB'] = $instance = new \stdClass();
 
@@ -713,10 +635,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'pC' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPCService($container, $lazyLoad = true)
+    protected static function getPCService($container, $lazyLoad = true): \stdClass
     {
         $container->services['pC'] = $instance = new \stdClass();
 
@@ -727,10 +647,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'pD' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPDService($container)
+    protected static function getPDService($container): \stdClass
     {
         $a = ($container->services['pA'] ?? self::getPAService($container));
 
@@ -743,10 +661,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'root' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getRootService($container)
+    protected static function getRootService($container): \stdClass
     {
         $a = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
 
@@ -759,10 +675,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the public 'subscriber' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getSubscriberService($container)
+    protected static function getSubscriberService($container): \stdClass
     {
         $a = ($container->services['manager'] ?? self::getManagerService($container));
 
@@ -775,10 +689,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the private 'bar6' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBar6Service($container)
+    protected static function getBar6Service($container): \stdClass
     {
         $a = ($container->services['foo6'] ?? self::getFoo6Service($container));
 
@@ -791,10 +703,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the private 'level5' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getLevel5Service($container)
+    protected static function getLevel5Service($container): \stdClass
     {
         $a = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
 
@@ -807,20 +717,16 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
 
     /**
      * Gets the private 'mailer_inline.mailer' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getMailerInline_MailerService($container)
+    protected static function getMailerInline_MailerService($container): \stdClass
     {
         return $container->privates['mailer_inline.mailer'] = new \stdClass(($container->services['mailer_inline.transport_factory'] ?? self::getMailerInline_TransportFactoryService($container))->create());
     }
 
     /**
      * Gets the private 'manager4' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getManager4Service($container, $lazyLoad = true)
+    protected static function getManager4Service($container, $lazyLoad = true): \stdClass
     {
         $a = ($container->services['connection4'] ?? self::getConnection4Service($container));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -42,10 +42,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \BarClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \BarClass
     {
         $container->services['bar'] = $instance = new \BarClass();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_closure_argument_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_closure_argument_compiled.php
@@ -42,20 +42,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \Foo
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \Foo
     {
         return $container->services['foo'] = new \Foo();
     }
 
     /**
      * Gets the public 'service_closure' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getServiceClosureService($container)
+    protected static function getServiceClosureService($container): \Bar
     {
         $containerRef = $container->ref;
 
@@ -68,10 +64,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'service_closure_invalid' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getServiceClosureInvalidService($container)
+    protected static function getServiceClosureInvalidService($container): \Bar
     {
         return $container->services['service_closure_invalid'] = new \Bar(fn () => NULL);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
@@ -48,10 +48,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarService($container, $lazyLoad = true)
+    protected static function getBarService($container, $lazyLoad = true): \stdClass
     {
         $containerRef = $container->ref;
 
@@ -64,10 +62,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'baz' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBazService($container, $lazyLoad = true)
+    protected static function getBazService($container, $lazyLoad = true): \stdClass
     {
         $containerRef = $container->ref;
 
@@ -80,10 +76,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'buz' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBuzService($container, $lazyLoad = true)
+    protected static function getBuzService($container, $lazyLoad = true): \stdClass
     {
         $containerRef = $container->ref;
 
@@ -96,10 +90,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFooService($container, $lazyLoad = true)
+    protected static function getFooService($container, $lazyLoad = true): \stdClass
     {
         $containerRef = $container->ref;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
@@ -47,10 +47,8 @@ class Symfony_DI_PhpDumper_Test_Deep_Graph extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \stdClass
     {
         $container->services['bar'] = $instance = new \stdClass();
 
@@ -61,10 +59,8 @@ class Symfony_DI_PhpDumper_Test_Deep_Graph extends Container
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Dumper\FooForDeepGraph
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \Symfony\Component\DependencyInjection\Tests\Dumper\FooForDeepGraph
     {
         $a = ($container->services['bar'] ?? self::getBarService($container));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters.php
@@ -46,10 +46,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \FooClass\Foo
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \FooClass\Foo
     {
         return $container->services['foo'] = new \FooClass\Foo();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters_as_files.txt
@@ -14,10 +14,8 @@ class getFooService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \FooClass\Foo
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \FooClass\Foo
     {
         return $container->services['foo'] = new \FooClass\Foo();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
@@ -51,20 +51,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \stdClass
     {
         return $container->services['bar'] = new \stdClass(($container->privates['bar_%env(BAR)%'] ??= new \stdClass()));
     }
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \stdClass
     {
         return $container->services['foo'] = new \stdClass(($container->privates['bar_%env(BAR)%'] ??= new \stdClass()), ['baz_'.$container->getEnv('string:BAR') => new \stdClass()]);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -89,10 +89,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'BAR' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBARService($container)
+    protected static function getBARService($container): \stdClass
     {
         $container->services['BAR'] = $instance = new \stdClass();
 
@@ -103,40 +101,32 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'BAR2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBAR2Service($container)
+    protected static function getBAR2Service($container): \stdClass
     {
         return $container->services['BAR2'] = new \stdClass();
     }
 
     /**
      * Gets the public 'a_service' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getAServiceService($container)
+    protected static function getAServiceService($container): \Bar
     {
         return $container->services['a_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
      * Gets the public 'b_service' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getBServiceService($container)
+    protected static function getBServiceService($container): \Bar
     {
         return $container->services['b_service'] = ($container->privates['a_factory'] ??= new \Bar())->getBar();
     }
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getBar3Service($container)
+    protected static function getBar3Service($container): \Bar\FooClass
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
@@ -149,20 +139,16 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'bar2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBar22Service($container)
+    protected static function getBar22Service($container): \stdClass
     {
         return $container->services['bar2'] = new \stdClass();
     }
 
     /**
      * Gets the public 'baz' shared service.
-     *
-     * @return \Baz
      */
-    protected static function getBazService($container)
+    protected static function getBazService($container): \Baz
     {
         $container->services['baz'] = $instance = new \Baz();
 
@@ -173,10 +159,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'configured_service' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConfiguredServiceService($container)
+    protected static function getConfiguredServiceService($container): \stdClass
     {
         $container->services['configured_service'] = $instance = new \stdClass();
 
@@ -190,10 +174,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'configured_service_simple' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getConfiguredServiceSimpleService($container)
+    protected static function getConfiguredServiceSimpleService($container): \stdClass
     {
         $container->services['configured_service_simple'] = $instance = new \stdClass();
 
@@ -204,20 +186,16 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'decorator_service' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDecoratorServiceService($container)
+    protected static function getDecoratorServiceService($container): \stdClass
     {
         return $container->services['decorator_service'] = new \stdClass();
     }
 
     /**
      * Gets the public 'decorator_service_with_name' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getDecoratorServiceWithNameService($container)
+    protected static function getDecoratorServiceWithNameService($container): \stdClass
     {
         return $container->services['decorator_service_with_name'] = new \stdClass();
     }
@@ -225,11 +203,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
     /**
      * Gets the public 'deprecated_service' shared service.
      *
-     * @return \stdClass
-     *
      * @deprecated Since vendor/package 1.1: The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected static function getDeprecatedServiceService($container)
+    protected static function getDeprecatedServiceService($container): \stdClass
     {
         trigger_deprecation('vendor/package', '1.1', 'The "deprecated_service" service is deprecated. You should stop using it, as it will be removed in the future.');
 
@@ -238,30 +214,24 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'factory_service' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getFactoryServiceService($container)
+    protected static function getFactoryServiceService($container): \Bar
     {
         return $container->services['factory_service'] = ($container->services['foo.baz'] ?? self::getFoo_BazService($container))->getInstance();
     }
 
     /**
      * Gets the public 'factory_service_simple' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getFactoryServiceSimpleService($container)
+    protected static function getFactoryServiceSimpleService($container): \Bar
     {
         return $container->services['factory_service_simple'] = self::getFactorySimpleService($container)->getInstance();
     }
 
     /**
      * Gets the public 'foo' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \Bar\FooClass
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
@@ -279,10 +249,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'foo.baz' shared service.
-     *
-     * @return \BazClass
      */
-    protected static function getFoo_BazService($container)
+    protected static function getFoo_BazService($container): \BazClass
     {
         $container->services['foo.baz'] = $instance = \BazClass::getInstance();
 
@@ -293,10 +261,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'foo_bar' service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getFooBarService($container)
+    protected static function getFooBarService($container): \Bar\FooClass
     {
         $container->factories['foo_bar'] = function ($container) {
             return new \Bar\FooClass(($container->services['deprecated_service'] ?? self::getDeprecatedServiceService($container)));
@@ -307,10 +273,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'foo_with_inline' shared service.
-     *
-     * @return \Foo
      */
-    protected static function getFooWithInlineService($container)
+    protected static function getFooWithInlineService($container): \Foo
     {
         $container->services['foo_with_inline'] = $instance = new \Foo();
 
@@ -325,10 +289,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'lazy_context' shared service.
-     *
-     * @return \LazyContext
      */
-    protected static function getLazyContextService($container)
+    protected static function getLazyContextService($container): \LazyContext
     {
         $containerRef = $container->ref;
 
@@ -342,10 +304,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'lazy_context_ignore_invalid_ref' shared service.
-     *
-     * @return \LazyContext
      */
-    protected static function getLazyContextIgnoreInvalidRefService($container)
+    protected static function getLazyContextIgnoreInvalidRefService($container): \LazyContext
     {
         $containerRef = $container->ref;
 
@@ -358,10 +318,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'method_call1' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getMethodCall1Service($container)
+    protected static function getMethodCall1Service($container): \Bar\FooClass
     {
         include_once '%path%foo.php';
 
@@ -376,10 +334,8 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'new_factory_service' shared service.
-     *
-     * @return \FooBarBaz
      */
-    protected static function getNewFactoryServiceService($container)
+    protected static function getNewFactoryServiceService($container): \FooBarBaz
     {
         $a = new \FactoryClass();
         $a->foo = 'bar';
@@ -393,40 +349,32 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     /**
      * Gets the public 'preload_sidekick' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPreloadSidekickService($container)
+    protected static function getPreloadSidekickService($container): \stdClass
     {
         return $container->services['preload_sidekick'] = new \stdClass();
     }
 
     /**
      * Gets the public 'runtime_error' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getRuntimeErrorService($container)
+    protected static function getRuntimeErrorService($container): \stdClass
     {
         return $container->services['runtime_error'] = new \stdClass(throw new RuntimeException('Service "errored_definition" is broken.'));
     }
 
     /**
      * Gets the public 'service_from_static_method' shared service.
-     *
-     * @return \Bar\FooClass
      */
-    protected static function getServiceFromStaticMethodService($container)
+    protected static function getServiceFromStaticMethodService($container): \Bar\FooClass
     {
         return $container->services['service_from_static_method'] = \Bar\FooClass::getInstance();
     }
 
     /**
      * Gets the public 'tagged_iterator' shared service.
-     *
-     * @return \Bar
      */
-    protected static function getTaggedIteratorService($container)
+    protected static function getTaggedIteratorService($container): \Bar
     {
         $containerRef = $container->ref;
 
@@ -441,11 +389,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
     /**
      * Gets the private 'factory_simple' shared service.
      *
-     * @return \SimpleFactoryClass
-     *
      * @deprecated Since vendor/package 1.1: The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.
      */
-    protected static function getFactorySimpleService($container)
+    protected static function getFactorySimpleService($container): \SimpleFactoryClass
     {
         trigger_deprecation('vendor/package', '1.1', 'The "factory_simple" service is deprecated. You should stop using it, as it will be removed in the future.');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_requires.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_requires.php
@@ -56,30 +56,24 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists
      */
-    protected static function getParentNotExistsService($container)
+    protected static function getParentNotExistsService($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists
     {
         return $container->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\ParentNotExists'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists();
     }
 
     /**
      * Gets the public 'Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C1' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C1
      */
-    protected static function getC1Service($container)
+    protected static function getC1Service($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C1
     {
         return $container->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C1'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C1();
     }
 
     /**
      * Gets the public 'Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2
      */
-    protected static function getC2Service($container)
+    protected static function getC2Service($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2
     {
         include_once \dirname(__DIR__, 1).'/includes/HotPath/C2.php';
         include_once \dirname(__DIR__, 1).'/includes/HotPath/C3.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_self_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_self_ref.php
@@ -40,10 +40,8 @@ class Symfony_DI_PhpDumper_Test_Inline_Self_Ref extends Container
 
     /**
      * Gets the public 'App\Foo' shared service.
-     *
-     * @return \App\Foo
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \App\Foo
     {
         $a = new \App\Bar();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -57,20 +57,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar_service' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarServiceService($container)
+    protected static function getBarServiceService($container): \stdClass
     {
         return $container->services['bar_service'] = new \stdClass(($container->privates['baz_service'] ??= new \stdClass()));
     }
 
     /**
      * Gets the public 'foo_service' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\ServiceLocator
      */
-    protected static function getFooServiceService($container)
+    protected static function getFooServiceService($container): \Symfony\Component\DependencyInjection\ServiceLocator
     {
         $containerRef = $container->ref;
 
@@ -87,40 +83,32 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'translator.loader_1' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getTranslator_Loader1Service($container)
+    protected static function getTranslator_Loader1Service($container): \stdClass
     {
         return $container->services['translator.loader_1'] = new \stdClass();
     }
 
     /**
      * Gets the public 'translator.loader_2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getTranslator_Loader2Service($container)
+    protected static function getTranslator_Loader2Service($container): \stdClass
     {
         return $container->services['translator.loader_2'] = new \stdClass();
     }
 
     /**
      * Gets the public 'translator.loader_3' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getTranslator_Loader3Service($container)
+    protected static function getTranslator_Loader3Service($container): \stdClass
     {
         return $container->services['translator.loader_3'] = new \stdClass();
     }
 
     /**
      * Gets the public 'translator_1' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator
      */
-    protected static function getTranslator1Service($container)
+    protected static function getTranslator1Service($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator
     {
         $containerRef = $container->ref;
 
@@ -133,10 +121,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'translator_2' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator
      */
-    protected static function getTranslator2Service($container)
+    protected static function getTranslator2Service($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator
     {
         $containerRef = $container->ref;
 
@@ -153,10 +139,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'translator_3' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator
      */
-    protected static function getTranslator3Service($container)
+    protected static function getTranslator3Service($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator
     {
         $containerRef = $container->ref;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_new_in_initializer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_new_in_initializer.php
@@ -40,10 +40,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'foo' shared autowired service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer
     {
         return $container->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer(bar: 234);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_duplicates.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_duplicates.php
@@ -51,20 +51,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \stdClass
     {
         return $container->services['bar'] = new \stdClass((new \stdClass()), (new \stdClass()));
     }
 
     /**
      * Gets the public 'baz' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBazService($container)
+    protected static function getBazService($container): \stdClass
     {
         return $container->services['baz'] = new \stdClass(new \Symfony\Component\DependencyInjection\Argument\ServiceLocator($container->getService, [
             'foo' => [false, 'foo', 'getFooService', false],
@@ -75,10 +71,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the private 'foo' service.
-     *
-     * @return \stdClass
      */
-    protected static function getFooService($container)
+    protected static function getFooService($container): \stdClass
     {
         $container->factories['service_container']['foo'] = function ($container) {
             return new \stdClass();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy.php
@@ -52,20 +52,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \stdClass
     {
         return $container->services['bar'] = new \stdClass((isset($container->factories['service_container']['foo']) ? $container->factories['service_container']['foo']($container) : self::getFooService($container)));
     }
 
     /**
      * Gets the private 'foo' service.
-     *
-     * @return \stdClass
      */
-    protected static function getFooService($container, $lazyLoad = true)
+    protected static function getFooService($container, $lazyLoad = true): \stdClass
     {
         $containerRef = $container->ref;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
@@ -14,10 +14,8 @@ class getNonSharedFooService extends ProjectServiceContainer
 {
     /**
      * Gets the public 'non_shared_foo' service.
-     *
-     * @return \Bar\FooLazyClass
      */
-    public static function do($container, $lazyLoad = true)
+    public static function do($container, $lazyLoad = true): \Bar\FooLazyClass
     {
         $containerRef = $container->ref;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_ghost.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_ghost.php
@@ -52,20 +52,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \stdClass
     {
         return $container->services['bar'] = new \stdClass((isset($container->factories['service_container']['foo']) ? $container->factories['service_container']['foo']($container) : self::getFooService($container)));
     }
 
     /**
      * Gets the private 'foo' service.
-     *
-     * @return \stdClass
      */
-    protected static function getFooService($container, $lazyLoad = true)
+    protected static function getFooService($container, $lazyLoad = true): \stdClass
     {
         $containerRef = $container->ref;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
@@ -48,20 +48,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'bar_service' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarServiceService($container)
+    protected static function getBarServiceService($container): \stdClass
     {
         return $container->services['bar_service'] = new \stdClass(($container->privates['baz_service'] ??= new \stdClass()));
     }
 
     /**
      * Gets the public 'foo_service' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFooServiceService($container)
+    protected static function getFooServiceService($container): \stdClass
     {
         return $container->services['foo_service'] = new \stdClass(($container->privates['baz_service'] ??= new \stdClass()));
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_in_expression.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_in_expression.php
@@ -48,10 +48,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'public_foo' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getPublicFooService($container)
+    protected static function getPublicFooService($container): \stdClass
     {
         return $container->services['public_foo'] = new \stdClass((new \stdClass())->bar);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -52,20 +52,16 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
 
     /**
      * Gets the public 'Symfony\Component\DependencyInjection\Tests\Dumper\Rot13EnvVarProcessor' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Dumper\Rot13EnvVarProcessor
      */
-    protected static function getRot13EnvVarProcessorService($container)
+    protected static function getRot13EnvVarProcessorService($container): \Symfony\Component\DependencyInjection\Tests\Dumper\Rot13EnvVarProcessor
     {
         return $container->services['Symfony\\Component\\DependencyInjection\\Tests\\Dumper\\Rot13EnvVarProcessor'] = new \Symfony\Component\DependencyInjection\Tests\Dumper\Rot13EnvVarProcessor();
     }
 
     /**
      * Gets the public 'container.env_var_processors_locator' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\ServiceLocator
      */
-    protected static function getContainer_EnvVarProcessorsLocatorService($container)
+    protected static function getContainer_EnvVarProcessorsLocatorService($container): \Symfony\Component\DependencyInjection\ServiceLocator
     {
         return $container->services['container.env_var_processors_locator'] = new \Symfony\Component\DependencyInjection\Argument\ServiceLocator($container->getService, [
             'rot13' => ['services', 'Symfony\\Component\\DependencyInjection\\Tests\\Dumper\\Rot13EnvVarProcessor', 'getRot13EnvVarProcessorService', false],

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
@@ -56,10 +56,8 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \stdClass
     {
         $container->services['bar'] = $instance = new \stdClass();
 
@@ -82,30 +80,24 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
 
     /**
      * Gets the public 'foo1' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo1Service($container)
+    protected static function getFoo1Service($container): \stdClass
     {
         return $container->services['foo1'] = new \stdClass();
     }
 
     /**
      * Gets the private 'foo2' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo2Service($container)
+    protected static function getFoo2Service($container): \stdClass
     {
         return $container->privates['foo2'] = new \stdClass();
     }
 
     /**
      * Gets the private 'foo3' service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo3Service($container)
+    protected static function getFoo3Service($container): \stdClass
     {
         $container->factories['service_container']['foo3'] = function ($container) {
             return new \stdClass();
@@ -116,10 +108,8 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
 
     /**
      * Gets the private 'foo4' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo4Service($container)
+    protected static function getFoo4Service($container): \stdClass
     {
         throw new RuntimeException('BOOM');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -56,20 +56,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber
      */
-    protected static function getTestServiceSubscriberService($container)
+    protected static function getTestServiceSubscriberService($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber
     {
         return $container->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber();
     }
 
     /**
      * Gets the public 'foo_service' shared autowired service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber
      */
-    protected static function getFooServiceService($container)
+    protected static function getFooServiceService($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber
     {
         return $container->services['foo_service'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber((new \Symfony\Component\DependencyInjection\Argument\ServiceLocator($container->getService, [
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => ['privates', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition', 'getCustomDefinitionService', false],
@@ -88,20 +84,16 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'late_alias' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1
      */
-    protected static function getLateAliasService($container)
+    protected static function getLateAliasService($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1
     {
         return $container->services['late_alias'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1();
     }
 
     /**
      * Gets the private 'Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition
      */
-    protected static function getCustomDefinitionService($container)
+    protected static function getCustomDefinitionService($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition
     {
         return $container->privates['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tsantos.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tsantos.php
@@ -47,10 +47,8 @@ class ProjectServiceContainer extends Container
 
     /**
      * Gets the public 'tsantos_serializer' shared service.
-     *
-     * @return \TSantos\Serializer\EventEmitterSerializer
      */
-    protected static function getTsantosSerializerService($container)
+    protected static function getTsantosSerializerService($container): \TSantos\Serializer\EventEmitterSerializer
     {
         $a = new \TSantos\Serializer\NormalizerRegistry();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
@@ -50,10 +50,8 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
 
     /**
      * Gets the public 'bar' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \stdClass
     {
         $containerRef = $container->ref;
 
@@ -94,10 +92,8 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
 
     /**
      * Gets the public 'baz' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getBazService($container)
+    protected static function getBazService($container): \stdClass
     {
         $container->services['baz'] = $instance = new \stdClass();
 
@@ -108,10 +104,8 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
 
     /**
      * Gets the public 'foo1' shared service.
-     *
-     * @return \stdClass
      */
-    protected static function getFoo1Service($container)
+    protected static function getFoo1Service($container): \stdClass
     {
         return $container->services['foo1'] = new \stdClass();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
@@ -44,30 +44,24 @@ class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
 
     /**
      * Gets the public 'bar$' shared service.
-     *
-     * @return \FooClass
      */
-    protected static function getBarService($container)
+    protected static function getBarService($container): \FooClass
     {
         return $container->services['bar$'] = new \FooClass();
     }
 
     /**
      * Gets the public 'bar$!' shared service.
-     *
-     * @return \FooClass
      */
-    protected static function getBar2Service($container)
+    protected static function getBar2Service($container): \FooClass
     {
         return $container->services['bar$!'] = new \FooClass();
     }
 
     /**
      * Gets the public 'foo oh-no' shared service.
-     *
-     * @return \FooClass
      */
-    protected static function getFooohnoService($container)
+    protected static function getFooohnoService($container): \FooClass
     {
         return $container->services['foo*/oh-no'] = new \FooClass();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither.php
@@ -47,10 +47,8 @@ class Symfony_DI_PhpDumper_Service_Wither extends Container
 
     /**
      * Gets the public 'wither' shared autowired service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Compiler\Wither
      */
-    protected static function getWitherService($container)
+    protected static function getWitherService($container): \Symfony\Component\DependencyInjection\Tests\Compiler\Wither
     {
         $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\Wither();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
@@ -52,10 +52,8 @@ class Symfony_DI_PhpDumper_Service_Wither_Lazy extends Container
 
     /**
      * Gets the public 'wither' shared autowired service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Compiler\Wither
      */
-    protected static function getWitherService($container, $lazyLoad = true)
+    protected static function getWitherService($container, $lazyLoad = true): \Symfony\Component\DependencyInjection\Tests\Compiler\Wither
     {
         $containerRef = $container->ref;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_staticreturntype.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_staticreturntype.php
@@ -47,10 +47,8 @@ class Symfony_DI_PhpDumper_Service_WitherStaticReturnType extends Container
 
     /**
      * Gets the public 'wither' shared autowired service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\WitherStaticReturnType
      */
-    protected static function getWitherService($container)
+    protected static function getWitherService($container): \Symfony\Component\DependencyInjection\Tests\Fixtures\WitherStaticReturnType
     {
         $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\WitherStaticReturnType();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Why use `@return` doc comments when we can have proper return types.