### PR TITLE
[Mailer] Add new attributes to Infobip API transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Infobip/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add reporting behavior thanks to new attributes support
+
 6.2
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
@@ -33,6 +33,13 @@ final class InfobipApiTransport extends AbstractApiTransport
 {
     private const API_VERSION = '3';
 
+    private const HEADER_TO_MESSAGE = [
+        'X-Infobip-IntermediateReport' => 'intermediateReport',
+        'X-Infobip-NotifyUrl' => 'notifyUrl',
+        'X-Infobip-NotifyContentType' => 'notifyContentType',
+        'X-Infobip-MessageId' => 'messageId',
+    ];
+
     private string $key;
 
     public function __construct(string $key, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
@@ -122,6 +129,12 @@ final class InfobipApiTransport extends AbstractApiTransport
         }
 
         $this->attachmentsFormData($fields, $email);
+
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($convertConf = self::HEADER_TO_MESSAGE[$header->getName()] ?? false) {
+                $fields[$convertConf] = $header->getBodyAsString();
+            }
+        }
 
         return new FormDataPart($fields);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

# 📍 Context

Infobip has a mechanism to send back SMS status like webhook do.

To do that, we need to add some attributes to the payload.

This MR aim to add this attributes.

It's a need for our company so I hope this new "feature" will be supported by the transport.

# ➕ New feature

New payload attributes was added allowing end users to use the reporting.

| Attribute | Type | Description |
| --- | --- | --- |
| X-Infobip-IntermediateReport | boolean | The real-time Intermediate delivery report that will be sent on your callback server. | 
| X-Infobip-NotifyUrl | string | The URL on your callback server on which the Delivery report will be sent. | 
| X-Infobip-NotifyContentType | string | Preferred Delivery report content type. Can be `application/json` or `application/xml`. |
| X-Infobip-MessageId | string | The ID that uniquely identifies the message sent to a recipient. |

ℹ️ Note that no one of this attributes are required.