### PR TITLE
[FrameworkBundle] Fix denyAccessUnlessGranted for mixed attributes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -239,7 +239,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     {
         if (!$this->isGranted($attribute, $subject)) {
             $exception = $this->createAccessDeniedException($message);
-            $exception->setAttributes($attribute);
+            $exception->setAttributes([$attribute]);
             $exception->setSubject($subject);
 
             throw $exception;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -387,6 +387,40 @@ class AbstractControllerTest extends TestCase
         $controller->denyAccessUnlessGranted('foo');
     }
 
+    /**
+     * @dataProvider provideDenyAccessUnlessGrantedSetsAttributesAsArray
+     */
+    public function testdenyAccessUnlessGrantedSetsAttributesAsArray($attribute, $exceptionAttributes)
+    {
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->method('isGranted')->willReturn(false);
+
+        $container = new Container();
+        $container->set('security.authorization_checker', $authorizationChecker);
+
+        $controller = $this->createController();
+        $controller->setContainer($container);
+
+        try {
+            $controller->denyAccessUnlessGranted($attribute);
+            $this->fail('there was no exception to check');
+        } catch (AccessDeniedException $e) {
+            $this->assertSame($exceptionAttributes, $e->getAttributes());
+        }
+    }
+
+    public static function provideDenyAccessUnlessGrantedSetsAttributesAsArray()
+    {
+        $obj = new \stdClass();
+        $obj->foo = 'bar';
+
+        return [
+            'string attribute' => ['foo', ['foo']],
+            'array attribute' => [[1, 3, 3, 7], [[1, 3, 3, 7]]],
+            'object attribute' => [$obj, [$obj]],
+        ];
+    }
+
     public function testRenderViewTwig()
     {
         $twig = $this->createMock(Environment::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Tickets       | -
| License       | MIT
| Doc PR        | -


Checking authorization against anything that isn't `array|string` will cause PHP errors now. The method `AbstractController::denyAccessUnlessGranted()` sets the given *single* attribute into the exception in case of denied access. The `AuthorizationCheckerInterface` defines that the attribute can be anything, even objects. The parameter type hint `array|string` of `AccessDeniedException::setAttributes()` want's an array of attributes (or a string for convenience). 

# Example

```php
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

class MyCustomAttribute
{
}

class ProfileController extends AbstractController
{
    public function index(): Response
    {
        $this->denyAccessUnlessGranted(new MyCustomAttribute()); // 💥 ERROR: Symfony\Component\Security\Core\Exception\AccessDeniedException::setAttributes(): Argument #1 ($attributes) must be of type array|string, [...]

        $user = $this->getUser();

        return new Response('Well hi there '.$user->getFirstName());
    }
}
```

# The fix

As the given attribute is a *single* attribute: always wrap it into an array when creating the exception, because the exception expects an array of attributes.