### PR TITLE
[Form] Change FormTypeValidatorExtension construct signature

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -10,7 +10,7 @@ DependencyInjection
 Form
 ----
 
- * Remove argument `$legacyErrorMessages` from the constructor of `FormTypeValidatorExtension`
+ * Remove argument `$legacyErrorMessages` from the constructor of `FormTypeValidatorExtension` and `ValidatorExtension`
 
 FrameworkBundle
 ---------------

--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -7,6 +7,11 @@ DependencyInjection
  * Deprecate `PhpDumper` options `inline_factories_parameter` and `inline_class_loader_parameter`, use `inline_factories` and `inline_class_loader` instead
  * Deprecate undefined and numeric keys with `service_locator` config, use string aliases instead
 
+Form
+----
+
+ * Change the signature of `FormTypeValidatorExtension::__construct(ValidatorInterface $validator, bool $legacyErrorMessages = true, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)` to `__construct(ValidatorInterface $validator, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)`
+
 FrameworkBundle
 ---------------
 

--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -10,7 +10,7 @@ DependencyInjection
 Form
 ----
 
- * Change the signature of `FormTypeValidatorExtension::__construct(ValidatorInterface $validator, bool $legacyErrorMessages = true, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)` to `__construct(ValidatorInterface $validator, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)`
+ * Remove argument `$legacyErrorMessages` from the constructor of `FormTypeValidatorExtension`
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
@@ -132,7 +132,6 @@ return static function (ContainerConfigurator $container) {
         ->set('form.type_extension.form.validator', FormTypeValidatorExtension::class)
             ->args([
                 service('validator'),
-                false,
                 service('twig.form.renderer')->ignoreOnInvalid(),
                 service('translator')->ignoreOnInvalid(),
             ])

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 6.3
 ---
 
- * Change the signature of `FormTypeValidatorExtension::__construct(ValidatorInterface $validator, bool $legacyErrorMessages = true, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)` to `__construct(ValidatorInterface $validator, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)`
+ * Remove argument `$legacyErrorMessages` from the constructor of `FormTypeValidatorExtension`
 
 6.2
 ---

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 6.3
 ---
 
- * Remove argument `$legacyErrorMessages` from the constructor of `FormTypeValidatorExtension`
+ * Remove argument `$legacyErrorMessages` from the constructor of `FormTypeValidatorExtension` and `ValidatorExtension`
 
 6.2
 ---

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Change the signature of `FormTypeValidatorExtension::__construct(ValidatorInterface $validator, bool $legacyErrorMessages = true, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)` to `__construct(ValidatorInterface $validator, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)`
+
 6.2
 ---
 

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -31,19 +31,15 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
     private ViolationMapper $violationMapper;
 
     /**
-     * @param ValidatorInterface         $validator
      * @param FormRendererInterface|null $formRenderer
      * @param TranslatorInterface|null   $translator
      */
-    public function __construct(ValidatorInterface $validator/* , FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null*/)
+    public function __construct(ValidatorInterface $validator, /* FormRendererInterface */ $formRenderer = null, /* TranslatorInterface */ $translator = null)
     {
-        if (\func_num_args() > 3) {
-            trigger_deprecation('symfony/form', '6.3', 'The signature of constructor requires 3 arguments: "ValidatorInterface $validator, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null". Passing argument $legacyErrorMessages is deprecated.', __METHOD__);
-            $formRenderer = func_get_arg(2);
-            $translator = func_get_arg(3);
-        } else {
-            $formRenderer = func_get_arg(1);
-            $translator = func_get_arg(2);
+        if (\is_bool($formRenderer)) {
+            trigger_deprecation('symfony/form', '6.3', 'The signature of "%s" constructor requires 3 arguments: "ValidatorInterface $validator, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null". Passing argument $legacyErrorMessages is deprecated.', __CLASS__);
+            $formRenderer = $translator;
+            $translator = 4 <= \func_num_args() ? func_get_arg(3) : null;
         }
 
         $this->validator = $validator;

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -29,10 +29,23 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
 {
     private ValidatorInterface $validator;
     private ViolationMapper $violationMapper;
-    private bool $legacyErrorMessages;
 
-    public function __construct(ValidatorInterface $validator, bool $legacyErrorMessages = true, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)
+    /**
+     * @param ValidatorInterface         $validator
+     * @param FormRendererInterface|null $formRenderer
+     * @param TranslatorInterface|null   $translator
+     */
+    public function __construct(ValidatorInterface $validator/* , FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null*/)
     {
+        if (\func_num_args() > 3) {
+            trigger_deprecation('symfony/form', '6.3', 'The signature of constructor requires 3 arguments: "ValidatorInterface $validator, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null". Passing argument $legacyErrorMessages is deprecated.', __METHOD__);
+            $formRenderer = func_get_arg(2);
+            $translator = func_get_arg(3);
+        } else {
+            $formRenderer = func_get_arg(1);
+            $translator = func_get_arg(2);
+        }
+
         $this->validator = $validator;
         $this->violationMapper = new ViolationMapper($formRenderer, $translator);
     }

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -42,6 +42,14 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
             $translator = 4 <= \func_num_args() ? func_get_arg(3) : null;
         }
 
+        if (null !== $formRenderer && !$formRenderer instanceof FormRendererInterface) {
+            throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be an instance of "%s" or null, "%s" given.', __METHOD__, FormRendererInterface::class, get_debug_type($formRenderer)));
+        }
+
+        if (null !== $translator && !$translator instanceof TranslatorInterface) {
+            throw new \TypeError(sprintf('Argument 3 passed to "%s()" must be an instance of "%s" or null, "%s" given.', __METHOD__, TranslatorInterface::class, get_debug_type($formRenderer)));
+        }
+
         $this->validator = $validator;
         $this->violationMapper = new ViolationMapper($formRenderer, $translator);
     }

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -43,6 +43,14 @@ class ValidatorExtension extends AbstractExtension
             $translator = 4 <= \func_num_args() ? func_get_arg(3) : null;
         }
 
+        if (null !== $formRenderer && !$formRenderer instanceof FormRendererInterface) {
+            throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be an instance of "%s" or null, "%s" given.', __METHOD__, FormRendererInterface::class, get_debug_type($formRenderer)));
+        }
+
+        if (null !== $translator && !$translator instanceof TranslatorInterface) {
+            throw new \TypeError(sprintf('Argument 3 passed to "%s()" must be an instance of "%s" or null, "%s" given.', __METHOD__, TranslatorInterface::class, get_debug_type($translator)));
+        }
+
         $metadata = $validator->getMetadataFor(\Symfony\Component\Form\Form::class);
 
         // Register the form constraints in the validator programmatically.

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -60,7 +60,7 @@ class ValidatorExtension extends AbstractExtension
     protected function loadTypeExtensions(): array
     {
         return [
-            new Type\FormTypeValidatorExtension($this->validator, $this->legacyErrorMessages, $this->formRenderer, $this->translator),
+            new Type\FormTypeValidatorExtension($this->validator, $this->formRenderer, $this->translator),
             new Type\RepeatedTypeValidatorExtension(),
             new Type\SubmitTypeValidatorExtension(),
         ];

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -30,11 +30,18 @@ class ValidatorExtension extends AbstractExtension
     private ValidatorInterface $validator;
     private ?FormRendererInterface $formRenderer;
     private ?TranslatorInterface $translator;
-    private bool $legacyErrorMessages;
 
-    public function __construct(ValidatorInterface $validator, bool $legacyErrorMessages = true, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null)
+    /**
+     * @param FormRendererInterface|null $formRenderer
+     * @param TranslatorInterface|null   $translator
+     */
+    public function __construct(ValidatorInterface $validator, /* FormRendererInterface */ $formRenderer = null, /* TranslatorInterface */ $translator = null)
     {
-        $this->legacyErrorMessages = $legacyErrorMessages;
+        if (\is_bool($formRenderer)) {
+            trigger_deprecation('symfony/form', '6.3', 'The signature of "%s" constructor requires 3 arguments: "ValidatorInterface $validator, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null". Passing argument $legacyErrorMessages is deprecated.', __CLASS__);
+            $formRenderer = $translator;
+            $translator = 4 <= \func_num_args() ? func_get_arg(3) : null;
+        }
 
         $metadata = $validator->getMetadataFor(\Symfony\Component\Form\Form::class);
 

--- a/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
@@ -39,6 +39,6 @@ trait ValidatorExtensionTrait
         $this->validator->expects($this->any())->method('getMetadataFor')->will($this->returnValue($metadata));
         $this->validator->expects($this->any())->method('validate')->will($this->returnValue(new ConstraintViolationList()));
 
-        return new ValidatorExtension($this->validator, false);
+        return new ValidatorExtension($this->validator);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
@@ -23,7 +23,7 @@ class FormValidatorPerformanceTest extends FormPerformanceTestCase
     protected function getExtensions()
     {
         return [
-            new ValidatorExtension(Validation::createValidator(), false),
+            new ValidatorExtension(Validation::createValidator()),
         ];
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -76,7 +76,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
     public function testGroupSequenceWithConstraintsOption()
     {
         $form = Forms::createFormFactoryBuilder()
-            ->addExtension(new ValidatorExtension(Validation::createValidator(), false))
+            ->addExtension(new ValidatorExtension(Validation::createValidator()))
             ->getFormFactory()
             ->create(FormTypeTest::TESTED_TYPE, null, ['validation_groups' => new GroupSequence(['First', 'Second'])])
             ->add('field', TextTypeTest::TESTED_TYPE, [

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -55,6 +55,46 @@ class ValidatorExtensionTest extends TestCase
         $this->assertCount(0, $metadata->getPropertyMetadata('children'));
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyWithBadFormRendererType()
+    {
+        $metadata = new ClassMetadata(Form::class);
+
+        $metadataFactory = new FakeMetadataFactory();
+        $metadataFactory->addMetadata($metadata);
+
+        $validator = Validation::createValidatorBuilder()
+            ->setMetadataFactory($metadataFactory)
+            ->getValidator();
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument 2 passed to "Symfony\Component\Form\Extension\Validator\ValidatorExtension::__construct()" must be an instance of "Symfony\Component\Form\FormRendererInterface" or null, "stdClass" given.');
+
+        new ValidatorExtension($validator, new \stdClass());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyWithBadTranslatorType()
+    {
+        $metadata = new ClassMetadata(Form::class);
+
+        $metadataFactory = new FakeMetadataFactory();
+        $metadataFactory->addMetadata($metadata);
+
+        $validator = Validation::createValidatorBuilder()
+            ->setMetadataFactory($metadataFactory)
+            ->getValidator();
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument 3 passed to "Symfony\Component\Form\Extension\Validator\ValidatorExtension::__construct()" must be an instance of "Symfony\Contracts\Translation\TranslatorInterface" or null, "stdClass" given.');
+
+        new ValidatorExtension($validator, null, new \stdClass());
+    }
+
     public function test2Dot5ValidationApi()
     {
         $metadata = new ClassMetadata(Form::class);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form as FormConstraint;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser;
@@ -24,6 +25,36 @@ use Symfony\Component\Validator\Validation;
 
 class ValidatorExtensionTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
+    public function testLegacy2Dot5ValidationApi()
+    {
+        $this->expectDeprecation('Since symfony/form 6.3: The signature of "Symfony\Component\Form\Extension\Validator\ValidatorExtension" constructor requires 3 arguments: "ValidatorInterface $validator, FormRendererInterface $formRenderer = null, TranslatorInterface $translator = null". Passing argument $legacyErrorMessages is deprecated.');
+
+        $metadata = new ClassMetadata(Form::class);
+
+        $metadataFactory = new FakeMetadataFactory();
+        $metadataFactory->addMetadata($metadata);
+
+        $validator = Validation::createValidatorBuilder()
+            ->setMetadataFactory($metadataFactory)
+            ->getValidator();
+
+        $extension = new ValidatorExtension($validator, false);
+
+        $this->assertInstanceOf(ValidatorTypeGuesser::class, $extension->loadTypeGuesser());
+
+        $this->assertCount(1, $metadata->getConstraints());
+        $this->assertInstanceOf(FormConstraint::class, $metadata->getConstraints()[0]);
+
+        $this->assertSame(CascadingStrategy::NONE, $metadata->cascadingStrategy);
+        $this->assertSame(TraversalStrategy::NONE, $metadata->traversalStrategy);
+        $this->assertCount(0, $metadata->getPropertyMetadata('children'));
+    }
+
     public function test2Dot5ValidationApi()
     {
         $metadata = new ClassMetadata(Form::class);
@@ -35,7 +66,7 @@ class ValidatorExtensionTest extends TestCase
             ->setMetadataFactory($metadataFactory)
             ->getValidator();
 
-        $extension = new ValidatorExtension($validator, false);
+        $extension = new ValidatorExtension($validator);
 
         $this->assertInstanceOf(ValidatorTypeGuesser::class, $extension->loadTypeGuesser());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


`$legacyErrorMessages` is required in `FormTypeValidatorExtension` construct but it is not used anymore in class. This PR deprecate passing this argument.