### PR TITLE
[HttpKernel] Add `PageExpiredHttpException`

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
  * Add `#[WithLogLevel]` for defining log levels for exceptions
  * Add `skip_response_headers` to the `HttpCache` options
+ * Add `PageExpiredHttpException`
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Exception/PageExpiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PageExpiredHttpException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class PageExpiredHttpException extends HttpException
+{
+    public function __construct(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
+    {
+        parent::__construct(419, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/PageExpiredHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/PageExpiredHttpExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\PageExpiredHttpException;
+
+class PageExpiredHttpExceptionTest extends HttpExceptionTest
+{
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
+    {
+        return new PageExpiredHttpException($message, $previous, $code, $headers);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

Our production application generates invoices available on a Google Cloud Storage's bucket. This invoice is available a certain amount of time before being deleted.

In the case this amount of time as been exceeded and the file no longer exist on the bucket, we would like to throw a `PageExpiredHttpException` to inform the user the invoice (or more generally, the resource) is no longer available and needs to be generated again (elsewhere in our app, not on the fly when requesting the file).

The HTTP code 419 seems the more appropriate to reflect this state.