### PR TITLE
Update MailerSend product name

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "symfony/mailer-send-mailer",
+    "name": "symfony/mailersend-mailer",
     "type": "symfony-mailer-bridge",
     "description": "Symfony MailerSend Mailer Bridge",
     "keywords": [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hello, i am lead developer at MailerSend. We've just submitted our Mailer driver and there seems to be a typo. Our product name is `MailerSend` https://www.mailersend.com/, and the new composer.json file has `mailer-send-driver`. Can we please fix it? Thanks.