### PR TITLE
[DependencyInjection] Exclude current id from non-existent references alternatives

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
@@ -90,7 +90,7 @@ class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
     {
         $alternatives = [];
         foreach ($this->container->getServiceIds() as $knownId) {
-            if ('' === $knownId || '.' === $knownId[0]) {
+            if ('' === $knownId || '.' === $knownId[0] || $knownId === $this->currentId) {
                 continue;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
@@ -124,6 +124,19 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
         $this->process($container);
     }
 
+    public function testCurrentIdIsExcludedFromAlternatives()
+    {
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The service "app.my_service" has a dependency on a non-existent service "app.my_service2".');
+
+        $container = new ContainerBuilder();
+        $container
+            ->register('app.my_service', \stdClass::class)
+            ->addArgument(new Reference('app.my_service2'));
+
+        $this->process($container);
+    }
+
     private function process(ContainerBuilder $container)
     {
         $pass = new CheckExceptionOnInvalidReferenceBehaviorPass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

Targeting 6.3 as an improvement.  

Before: `The service "app.my_service" has a dependency on a non-existent service "app.my_service2". Did you mean this: "app.my_service"?`

After: `The service "app.my_service" has a dependency on a non-existent service "app.my_service2".`