### PR TITLE
[Workflow] display label with new lines + colours properly when rendering a PUML dump

### DIFF
--- a/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
@@ -217,11 +217,17 @@ class PlantUmlDumper implements DumperInterface
     private function getTransitionEscapedWithStyle(MetadataStoreInterface $workflowMetadata, Transition $transition, string $to): string
     {
         $to = $workflowMetadata->getMetadata('label', $transition) ?? $to;
-        $to = str_replace("\n", ' ', $to);
+        // Change new lines symbols to actual '\n' string,
+        // PUML will render them as new lines
+        $to = str_replace("\n", '\n', $to);
 
         $color = $workflowMetadata->getMetadata('color', $transition) ?? null;
 
         if (null !== $color) {
+            // Close and open <font> before and after every '\n' string,
+            // so that the style is applied properly on every line
+            $to = str_replace('\n', sprintf('</font>\n<font color=%1$s>', $color), $to);
+
             $to = sprintf(
                 '<font color=%1$s>%2$s</font>',
                 $color,

--- a/src/Symfony/Component/Workflow/Tests/fixtures/puml/arrow/complex-state-machine-marking.puml
+++ b/src/Symfony/Component/Workflow/Tests/fixtures/puml/arrow/complex-state-machine-marking.puml
@@ -15,7 +15,7 @@ state "b"
 state "c" <<marked>>
 state "d"
 "a" --> "b": "t1"
-"d" -[#Red]-> "b": "<font color=Grey>My custom transition label 3</font>"
+"d" -[#Red]-> "b": "<font color=Grey>My custom transition</font>\n<font color=Grey>label 3</font>"
 "b" -[#Blue]-> "c": "t2"
 "b" --> "d": "t3"
 @enduml

--- a/src/Symfony/Component/Workflow/Tests/fixtures/puml/arrow/complex-state-machine-nomarking.puml
+++ b/src/Symfony/Component/Workflow/Tests/fixtures/puml/arrow/complex-state-machine-nomarking.puml
@@ -15,7 +15,7 @@ state "b"
 state "c"
 state "d"
 "a" --> "b": "t1"
-"d" -[#Red]-> "b": "<font color=Grey>My custom transition label 3</font>"
+"d" -[#Red]-> "b": "<font color=Grey>My custom transition</font>\n<font color=Grey>label 3</font>"
 "b" -[#Blue]-> "c": "t2"
 "b" --> "d": "t3"
 @enduml


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49311
| License       | MIT
| Doc PR        | no

In #49272 I removed the new lines instead of formatting them properly.

The PUML format accept new lines in labels of transitions as long as the source file uses actual `\n` strings instead of line returns (like `PHP_EOL`).

I propose a novel approach that will handle new lines with or without colours.

Compare these outputs from plantuml.com, inputs are based on the [fixtures from Symfony](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Workflow/Tests/fixtures/puml/arrow/complex-state-machine-marking.puml):

### After #49272

New lines are ignored

> ![image](https://user-images.githubusercontent.com/2071331/221030067-5d93b400-493d-4fb2-92d4-5c1490f6d1db.png)


([source](https://www.plantuml.com/plantuml/uml/TOx1IWCn48RlUOeXFHTfgxR8kfIjwCbB5Jo8I3OPsx2Jf2HPj8ZlRfAwKgJc5Bx_ctzc6QBmiJV4195xVpNwGziDYpeImeCsEy8RBJPU61OwRNSY_Q2aZVCA_ThrLgsSj-XXSd7QUTngsLaC0QP7GbeS4JuPfDS8sMtyeOgShofjTTI2wXf6YtaxFv-Srepm7QfipHQB-UgoM8UbnVY77qysb4fBVkji_9i-RNL4ziKEntB1uUYsWRPy-CcS3yC3L9pbmV6upkeLy3X9H2NoF5gZUldbrLkw06G-uVhEuxw-tuFiGtG6eXSsfBNE0eaM2MRLMRRhrDIMfePwB5Moh9Z-19ceGcQSBT6gtj0t))

### Correct output from this PR

With this patch → the second line is Grey and no tag is visible

> ![image](https://user-images.githubusercontent.com/2071331/221025433-81033dfb-cc52-4087-bae8-7560a6c528ba.png)

([source](https://www.plantuml.com/plantuml/uml/TP9DImCn48Rl-HL3UYxILcsHTIbRqPENAdXGaMmojc7pKP8iMiJ_RfBjwg9rJ-6PP-Pz3xlqWRdGQaMOKlRjHSjtQJOaoA0GxgJUARoIREEO9hwHPiVY2_AqiawWMzlMY9Lr1XrCpeuxzrl96uFUmtGWnE20y44WVXNZpSPrfvHrHI6D39AfieJHObxFJoV7DSrSWo9PiyLYlZhFLXUQZN_uSBDIyMYUNriJVayVjZ8W-IHTMSee3BhrjARzYrFuMUwXe2GjZiTbKY-0Xaaa8fB7qHh5ypSlNcC3uAd2vOt3VNcx1zxwO3K4nuoFiTOK9yagdymVMx4Q5SmEGeoeSqIbMimPF6TF3uD4H2OpIfPeHFe7lW00))

---

### Why close and open `<font>` tags?

The output is broken if we use `\n` without taking into account the `<font>` tags → there is a second line but it is black and `</font>` is visible

> ![image](https://user-images.githubusercontent.com/2071331/221025397-153357d1-6518-49db-8596-f8c680827afd.png)

([source](https://www.plantuml.com/plantuml/uml/TP5VI_Cm5CRlyoaEsVLusVRgYjGoEj4hRwRWXOgaoR4BpP-HfEWGlxj9QgN8x5NuFR_pd0FT-C1SwBKYJ2dxzgBbkpGj2J8eX3kf3mgl96iTqyHtqXnOV45EQ-i4kftjZTXQPz31ukoqSx-Nl3FeFImdGbmS43u8nAzcl6lTKAMiAqjfP91CLHNCYdMp_hyuhMdcEXJ9MXN5UdkUhM5fDlxWqybQnTASNriJVgSFUncGV9BXMCeeJ6uRQKF75q_vE3n2GKaQdC-hf5u03Oj8H2IFinsAvnzUliOBWASJBcyS7glR8_3U1wiXE6PyN6lDar6iGGMhyb_IgrZLvAfQzPYxUDwn_0uI4PciADcW4UbVVm40))
