### PR TITLE
Remove unused private methods

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
@@ -292,9 +292,4 @@ class FlattenExceptionTest extends TestCase
         $this->assertSame($exception->getTraceAsString(), $flattened->getTraceAsString());
         $this->assertSame($exception->__toString(), $flattened->getAsString());
     }
-
-    private function createException($foo): \Exception
-    {
-        return new \Exception();
-    }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -854,25 +854,6 @@ class DefaultChoiceListFactoryTest extends TestCase
         $this->assertFlatViewWithlabelTranslationParameters($view);
     }
 
-    private function assertScalarListWithChoiceValues(ChoiceListInterface $list)
-    {
-        $this->assertSame(['a', 'b', 'c', 'd'], $list->getValues());
-
-        $this->assertSame([
-            'a' => 'a',
-            'b' => 'b',
-            'c' => 'c',
-            'd' => 'd',
-        ], $list->getChoices());
-
-        $this->assertSame([
-            'a' => 'A',
-            'b' => 'B',
-            'c' => 'C',
-            'd' => 'D',
-        ], $list->getOriginalKeys());
-    }
-
     private function assertObjectListWithGeneratedValues(ChoiceListInterface $list)
     {
         $this->assertSame(['0', '1', '2', '3'], $list->getValues());
@@ -889,25 +870,6 @@ class DefaultChoiceListFactoryTest extends TestCase
             1 => 'B',
             2 => 'C',
             3 => 'D',
-        ], $list->getOriginalKeys());
-    }
-
-    private function assertScalarListWithCustomValues(ChoiceListInterface $list)
-    {
-        $this->assertSame(['a', 'b', '1', '2'], $list->getValues());
-
-        $this->assertSame([
-            'a' => 'a',
-            'b' => 'b',
-            1 => 'c',
-            2 => 'd',
-        ], $list->getChoices());
-
-        $this->assertSame([
-            'a' => 'A',
-            'b' => 'B',
-            1 => 'C',
-            2 => 'D',
         ], $list->getOriginalKeys());
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -524,11 +524,6 @@ class Connection
         $this->autoSetup = false;
     }
 
-    private function getCurrentTimeInMilliseconds(): int
-    {
-        return (int) (microtime(true) * 1000);
-    }
-
     public function cleanup(): void
     {
         static $unlink = true;

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -114,9 +114,4 @@ class CollectionConfigurator
 
         return $this;
     }
-
-    private function createRoute(string $path): Route
-    {
-        return (clone $this->route)->setPath($path);
-    }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -449,22 +449,4 @@ EOTXT
 
         $this->assertSame($expectedOut, $out);
     }
-
-    private function getSpecialVars()
-    {
-        foreach (array_keys($GLOBALS) as $var) {
-            if ('GLOBALS' !== $var) {
-                unset($GLOBALS[$var]);
-            }
-        }
-
-        $var = function &() {
-            $var = [];
-            $var[] = &$var;
-
-            return $var;
-        };
-
-        return eval('return [$var(), $GLOBALS, &$GLOBALS];');
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


I searched all unused private methods in codebase and found these