### PR TITLE
 Create `#[Serialize]` Attribute to serialize Controller Result

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -263,6 +263,7 @@ class FrameworkExtension extends Extension
 
         if (!class_exists(ControllerAttributesListener::class)) {
             $container->removeDefinition('kernel.controller_attributes_listener');
+            $container->removeDefinition('serialize_controller_result_listener');
         }
 
         if (!ContainerBuilder::willBeAvailable('symfony/clock', ClockInterface::class, ['symfony/framework-bundle'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\IsSignatureValidAttributeListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener;
 use Symfony\Component\HttpKernel\EventListener\ResponseListener;
+use Symfony\Component\HttpKernel\EventListener\SerializeControllerResultAttributeListener;
 use Symfony\Component\HttpKernel\EventListener\ValidateRequestListener;
 
 return static function (ContainerConfigurator $container) {
@@ -177,5 +178,11 @@ return static function (ContainerConfigurator $container) {
             ->parent('cache.system')
             ->private()
             ->tag('cache.pool')
+
+        ->set('serialize_controller_result_listener', SerializeControllerResultAttributeListener::class)
+        ->args([
+            service('serializer')->nullOnInvalid(),
+        ])
+        ->tag('kernel.event_subscriber')
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
@@ -12,12 +12,16 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\HttpKernel\Attribute\Serialize;
+use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class ApiAttributesTest extends AbstractWebTestCase
@@ -894,6 +898,90 @@ class ApiAttributesTest extends AbstractWebTestCase
             'expectedStatusCode' => 422,
         ];
     }
+
+    #[RequiresMethod(ControllerAttributesListener::class, 'beforeController')]
+    #[DataProvider('serializeProvider')]
+    public function testSerialize(string $uri, string $format, string $expectedResponse, int $expectedStatusCode, array $expectedHeaders = [])
+    {
+        $client = self::createClient(['test_case' => 'ApiAttributesTest']);
+
+        $client->request('GET', $uri);
+
+        $response = $client->getResponse();
+        self::assertSame($expectedStatusCode, $response->getStatusCode());
+
+        match ($format) {
+            'json' => self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent()),
+            'xml' => self::assertXmlStringEqualsXmlString($expectedResponse, $response->getContent()),
+            'pdf' => null,
+            default => throw new \InvalidArgumentException(\sprintf('Unsupported format "%s".', $format)),
+        };
+
+        foreach ($expectedHeaders as $header => $expectedHeaderValue) {
+            self::assertSame($expectedHeaderValue, $response->headers->get($header));
+        }
+    }
+
+    public static function serializeProvider(): iterable
+    {
+        yield 'serialize controller result into json' => [
+            'uri' => '/serialize-controller-result',
+            'format' => 'json',
+            'expectedResponse' => <<<'JSON'
+                {
+                    "id": 101,
+                    "name": "Laptop",
+                    "createdAt": "31.12.2021 12:34:56"
+                }
+                JSON,
+            'expectedStatusCode' => 201,
+            'expectedHeaders' => [
+                'Content-Type' => 'application/json',
+                'X-Custom-Header' => 'abc',
+            ],
+        ];
+
+        yield 'serialize controller result into json with format passed' => [
+            'uri' => '/serialize-controller-result.json',
+            'format' => 'json',
+            'expectedResponse' => <<<'JSON'
+                {
+                    "id": 101,
+                    "name": "Laptop",
+                    "createdAt": "31.12.2021 12:34:56"
+                }
+                JSON,
+            'expectedStatusCode' => 201,
+            'expectedHeaders' => [
+                'Content-Type' => 'application/json',
+                'X-Custom-Header' => 'abc',
+            ],
+        ];
+
+        yield 'serialize controller result into xml with format passed' => [
+            'uri' => '/serialize-controller-result.xml',
+            'format' => 'xml',
+            'expectedResponse' => <<<'XML'
+                    <response>
+                        <id>101</id>
+                        <name>Laptop</name>
+                        <createdAt>31.12.2021 12:34:56</createdAt>
+                    </response>
+                XML,
+            'expectedStatusCode' => 201,
+            'expectedHeaders' => [
+                'Content-Type' => 'text/xml; charset=UTF-8',
+                'X-Custom-Header' => 'abc',
+            ],
+        ];
+
+        yield 'unsupported format should throw exception' => [
+            'uri' => '/serialize-controller-result.pdf',
+            'format' => 'pdf',
+            'expectedResponse' => '',
+            'expectedStatusCode' => 415,
+        ];
+    }
 }
 
 class WithMapQueryStringToNullableAttributeController
@@ -991,6 +1079,15 @@ class WithMapRequestToNonNullableAttributeWithoutDefaultValueController
     }
 }
 
+class WithSerializeAttributeController
+{
+    #[Serialize(201, ['X-Custom-Header' => 'abc'], [DateTimeNormalizer::FORMAT_KEY => 'd.m.Y H:i:s'])]
+    public function __invoke(): Product
+    {
+        return new Product(101, 'Laptop', new \DateTimeImmutable('2021-12-31T12:34:56+00:00'));
+    }
+}
+
 class QueryString
 {
     public function __construct(
@@ -1017,6 +1114,16 @@ class RequestBody
         #[Assert\Length(min: 10)]
         public readonly string $comment,
         public readonly bool $approved,
+    ) {
+    }
+}
+
+class Product
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+        public readonly \DateTimeImmutable $createdAt,
     ) {
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/routing.yml
@@ -21,3 +21,11 @@ map_request_to_attribute_with_default_value:
 map_request_to_non_nullable_attribute_without_default_value:
     path: /map-request-to-non-nullable-attribute-without-default-value.{_format}
     controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithMapRequestToNonNullableAttributeWithoutDefaultValueController
+
+serialize_controller_result:
+    path: /serialize-controller-result
+    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithSerializeAttributeController
+
+serialize_controller_result_with_format:
+    path: /serialize-controller-result.{_format}
+    controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\WithSerializeAttributeController

--- a/src/Symfony/Component/HttpKernel/Attribute/Serialize.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/Serialize.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+/**
+ * Controller tag to serialize response.
+ *
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class Serialize
+{
+    /**
+     * @param int                  $code    The HTTP status code (200 "OK" by default)
+     * @param array<string, mixed> $headers Extra headers to set on the response
+     * @param array<string, mixed> $context The serialization context passed to the serializer
+     */
+    public function __construct(
+        public readonly int $code = 200,
+        public readonly array $headers = [],
+        public readonly array $context = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
  * Allow using Expression or \Closure for `validationGroups` in `#[MapRequestPayload]` and `#[MapQueryString]`
  * Deprecate passing a `ControllerArgumentsEvent` to the `ViewEvent` constructor; pass a `ControllerArgumentsMetadata` instead
  * Support variadic argument with `#[MapRequestPayload]`
+ * Add `#[Serialize]` to serialize values returned by controllers
 
 8.0
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/SerializeControllerResultAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SerializeControllerResultAttributeListener.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\Serialize;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Serializer\Exception\UnsupportedFormatException;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ */
+final class SerializeControllerResultAttributeListener implements EventSubscriberInterface
+{
+    public function __construct(private readonly ?SerializerInterface $serializer)
+    {
+    }
+
+    /**
+     * @param ControllerAttributeEvent<Serialize> $event
+     */
+    public function onView(ControllerAttributeEvent $event): void
+    {
+        $kernelEvent = $event->kernelEvent;
+
+        if (!$kernelEvent instanceof ViewEvent) {
+            return;
+        }
+
+        if (!$this->serializer) {
+            throw new \LogicException(\sprintf('The "symfony/serializer" component is required to use the "#[%s]" attribute. Try running "composer require symfony/serializer".', Serialize::class));
+        }
+
+        $request = $kernelEvent->getRequest();
+        $controllerResult = $kernelEvent->getControllerResult();
+        $format = $request->getRequestFormat('json');
+
+        try {
+            $data = $this->serializer->serialize($controllerResult, $format, $event->attribute->context);
+        } catch (UnsupportedFormatException $exception) {
+            throw new UnsupportedMediaTypeHttpException(\sprintf('Unsupported format "%s".', $format), $exception->getPrevious());
+        }
+
+        $headers = $this->mergeHeaders($event->attribute, $request, $format);
+        $response = new Response($data, $event->attribute->code, $headers);
+
+        $kernelEvent->setResponse($response);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::VIEW.'.'.Serialize::class => 'onView',
+        ];
+    }
+
+    /**
+     * @return array<string, scalar>
+     */
+    private function mergeHeaders(Serialize $attribute, Request $request, string $format): array
+    {
+        $headers = array_combine(
+            array_map('strtolower', array_keys($attribute->headers)),
+            array_values($attribute->headers),
+        );
+
+        if (!isset($headers['content-type'])) {
+            $headers['content-type'] = $request->getMimeType($format);
+        }
+
+        return $headers;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SerializeControllerResultListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SerializeControllerResultListenerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\Serialize;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsMetadata;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\EventListener\SerializeControllerResultAttributeListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class SerializeControllerResultListenerTest extends TestCase
+{
+    public function testSerializeAttribute()
+    {
+        $controllerResult = new ProductCreated(10);
+        $responseBody = '{"productId": 10}';
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('serialize')
+            ->with($controllerResult, 'json', ['foo' => 'bar'])
+            ->willReturn($responseBody);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $request = new Request();
+
+        $controller = new GetApiController();
+        $requestType = HttpKernelInterface::MAIN_REQUEST;
+        $viewEvent = new ViewEvent(
+            $kernel,
+            $request,
+            $requestType,
+            $controllerResult,
+            new ControllerArgumentsMetadata(
+                new ControllerEvent($kernel, $controller, $request, $requestType),
+                new ControllerArgumentsEvent(
+                    $kernel,
+                    $controller,
+                    [],
+                    $request,
+                    $requestType,
+                ),
+            ),
+        );
+
+        $listener = new SerializeControllerResultAttributeListener($serializer);
+        $listener->onView(new ControllerAttributeEvent(new Serialize(201, ['X-Test-Header' => 'abc'], ['foo' => 'bar']), $viewEvent));
+
+        $response = $viewEvent->getResponse();
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame($responseBody, $response->getContent());
+        self::assertSame('abc', $response->headers->get('X-Test-Header'));
+    }
+}
+
+class ProductCreated
+{
+    public function __construct(public readonly int $productId)
+    {
+    }
+}
+
+class GetApiController
+{
+    #[Serialize(201, ['X-Test-Header' => 'abc'], ['foo' => 'bar'])]
+    public function __invoke(): ProductCreated
+    {
+        return new ProductCreated(10);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TBD

`#[Serialize(code: 200, headers: [], context: [])]` Allows automatically serialize Controller Result to format based on Request format.

## Usage example :hammer: 
```php
final readonly class Product
{
    public function __construct(public int $id, public string $name)
    {
    }
}

final readonly class GetProductController
{
    #[Serialize]
    public function __invoke(): Product
    {
        return new Product(1, 'Asus UX550');
    }
}

final readonly class ProductCreated
{
    public function __construct(public int $id)
    {
    }
}

final readonly class CreateProductController
{
    #[Serialize(201)]
    public function __invoke(): ProductCreated
    {
        return new ProductCreated(1);
    }
}

# same controller without annotation: repeatable annoying boilerplate which has no sense to write
final readonly class CreateProductControllerLegacy
{
    public function __construct(private SerializerInterface $serializer)
    {
    }

    #[OA\Response(response: 201, description: 'Successful response', content: new Model(type: ProductCreated::class))]
    public function __invoke(): JsonResponse
    {
        $data = new ProductCreated(1);
        $serialized = $this->serializer->serialize($data, 'json');

        return JsonResponse::fromJsonString($serialized, JsonResponse::HTTP_CREATED);
    }
}
```

## Todo
- [x] add functional tests once #49138 will be merged