### PR TITLE
[Console] Fix fatal error when accessing Application::signalRegistry without pcntl

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -87,7 +87,7 @@ class Application implements ResetInterface
     private string $defaultCommand;
     private bool $singleCommand = false;
     private bool $initialized = false;
-    private SignalRegistry $signalRegistry;
+    private ?SignalRegistry $signalRegistry = null;
     private array $signalsToDispatchEvent = [];
 
     public function __construct(string $name = 'UNKNOWN', string $version = 'UNKNOWN')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |
