### PR TITLE
[Messenger] make StopWorkerOnSignalsListener listen by default on SIGTERM and SIGINT

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -73,6 +73,7 @@ Messenger
    `Symfony\Component\Messenger\Transport\InMemoryTransportFactory` in favor of
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport` and
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransportFactory`
+ * Deprecate `StopWorkerOnSigtermSignalListener` in favor of `StopWorkerOnSignalsListener`
 
 Notifier
 --------

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -23,7 +23,7 @@ use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnCustomStopExceptionListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
-use Symfony\Component\Messenger\EventListener\StopWorkerOnSigtermSignalListener;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnSignalsListener;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
@@ -198,8 +198,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'messenger'])
 
-        ->set('messenger.listener.stop_worker_on_sigterm_signal_listener', StopWorkerOnSigtermSignalListener::class)
+        ->set('messenger.listener.stop_worker_signals_listener', StopWorkerOnSignalsListener::class)
             ->args([
+                null,
                 service('logger')->ignoreOnInvalid(),
             ])
             ->tag('kernel.event_subscriber')

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -11,6 +11,9 @@ CHANGELOG
    `Symfony\Component\Messenger\Transport\InMemory\InMemoryTransportFactory`
  * Allow passing a string instead of an array in `TransportNamesStamp`
  * Allow to define batch size when using `BatchHandlerTrait` with `getBatchSize()`
+ * Deprecate `StopWorkerOnSigtermSignalListener` in favor of
+   `StopWorkerOnSignalsListener` and make it configurable with SIGINT and
+   SIGTERM by default
 
 6.2
 ---

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSignalsListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSignalsListener.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerStartedEvent;
+
+/**
+ * @author Tobias Schultze <http://tobion.de>
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class StopWorkerOnSignalsListener implements EventSubscriberInterface
+{
+    private array $signals;
+    private ?LoggerInterface $logger;
+
+    public function __construct(array $signals = null, LoggerInterface $logger = null)
+    {
+        if (null === $signals && \defined('SIGTERM')) {
+            $signals = [SIGTERM, SIGINT];
+        }
+        $this->signals = $signals;
+        $this->logger = $logger;
+    }
+
+    public function onWorkerStarted(WorkerStartedEvent $event): void
+    {
+        foreach ($this->signals as $signal) {
+            pcntl_signal($signal, function () use ($event, $signal) {
+                $this->logger?->info('Received signal {signal}.', ['signal' => $signal, 'transport_names' => $event->getWorker()->getMetadata()->getTransportNames()]);
+
+                $event->getWorker()->stop();
+            });
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        if (!\function_exists('pcntl_signal')) {
+            return [];
+        }
+
+        return [
+            WorkerStartedEvent::class => ['onWorkerStarted', 100],
+        ];
+    }
+}

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
@@ -11,39 +11,19 @@
 
 namespace Symfony\Component\Messenger\EventListener;
 
+trigger_deprecation('symfony/messenger', '6.3', '"%s" is deprecated, use "%s" instead.', StopWorkerOnSigtermSignalListener::class, StopWorkerOnSignalsListener::class);
+
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 
 /**
  * @author Tobias Schultze <http://tobion.de>
+ *
+ * @deprecated since Symfony 6.3, use the StopWorkerOnSignalsListener instead
  */
-class StopWorkerOnSigtermSignalListener implements EventSubscriberInterface
+class StopWorkerOnSigtermSignalListener extends StopWorkerOnSignalsListener
 {
-    private ?LoggerInterface $logger;
-
     public function __construct(LoggerInterface $logger = null)
     {
-        $this->logger = $logger;
-    }
-
-    public function onWorkerStarted(WorkerStartedEvent $event): void
-    {
-        pcntl_signal(\SIGTERM, function () use ($event) {
-            $this->logger?->info('Received SIGTERM signal.', ['transport_names' => $event->getWorker()->getMetadata()->getTransportNames()]);
-
-            $event->getWorker()->stop();
-        });
-    }
-
-    public static function getSubscribedEvents(): array
-    {
-        if (!\function_exists('pcntl_signal')) {
-            return [];
-        }
-
-        return [
-            WorkerStartedEvent::class => ['onWorkerStarted', 100],
-        ];
+        parent::__construct([SIGTERM], $logger);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #49156
| License       | MIT
| Doc PR        | no need I guess
