### PR TITLE
[ExpressionLanguage] Add `is_json()` and `is_xml()` expression functions

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `enum` expression function
  * Deprecate loose comparisons when using the "in" operator; normalize the array parameter
    so it only has the expected types or implement loose matching in your own expression function
+ * Add `is_json()` and `is_xml()` expression functions
 
 6.2
 ---

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -162,6 +162,20 @@ class ExpressionLanguage
                 return $value;
             }
         ));
+
+        $this->addFunction(new ExpressionFunction('is_json',
+            static fn ($str): string => sprintf("\is_string(\$v = (%s)) && json_validate(\$v)", $str),
+            static function ($arguments, $str): bool {
+                return \is_string($str) && json_validate($str);
+            }
+        ));
+
+        $this->addFunction(new ExpressionFunction('is_xml',
+            static fn ($str): string => sprintf("(\is_string(\$v = (%s)) && (new \DOMDocument())->loadXML(\$v, \\LIBXML_NOERROR))", $str),
+            static function ($arguments, $str): bool {
+                return \is_string($str) && (new \DOMDocument())->loadXML($str, \LIBXML_NOERROR);
+            }
+        ));
     }
 
     private function getLexer(): Lexer

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -127,6 +127,74 @@ class ExpressionLanguageTest extends TestCase
         $this->assertSame(FooBackedEnum::Bar, $result);
     }
 
+    public function testIsJsonWithValidInputFunction()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $this->assertTrue($expressionLanguage->evaluate('is_json(fooJson)', [
+            'fooJson' => '{"foo": true}',
+        ]));
+    }
+
+    public function testCompiledIsJsonWithValidInputFunction()
+    {
+        $result = false;
+        $expressionLanguage = new ExpressionLanguage();
+        eval(sprintf('$result = %s;', $expressionLanguage->compile('is_json(\'{"foo": true}\')')));
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsJsonWithInvalidInputFunction()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $this->assertFalse($expressionLanguage->evaluate('is_json(fooJson)', [
+            'fooJson' => '{"malformed": true',
+        ]));
+    }
+
+    public function testCompiledIsJsonWithInvalidInputFunction()
+    {
+        $result = true;
+        $expressionLanguage = new ExpressionLanguage();
+        eval(sprintf('$result = %s;', $expressionLanguage->compile('is_json(\'{"malformed": true\')')));
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsXmlWithValidInputFunction()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $this->assertTrue($expressionLanguage->evaluate('is_xml(fooXml)', [
+            'fooXml' => '<node></node>',
+        ]));
+    }
+
+    public function testCompiledIsXmlWithValidInputFunction()
+    {
+        $result = false;
+        $expressionLanguage = new ExpressionLanguage();
+        eval(sprintf('$result = %s;', $expressionLanguage->compile('is_xml(\'<node></node>\')')));
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsXmlWithInvalidInputFunction()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $this->assertFalse($expressionLanguage->evaluate('is_xml(fooXml)', [
+            'fooXml' => '<?xml version="1.0"',
+        ]));
+    }
+
+    public function testCompiledIsXmlWithInvalidInputFunction()
+    {
+        $result = true;
+        $expressionLanguage = new ExpressionLanguage();
+        eval(sprintf('$result = %s;', $expressionLanguage->compile('is_xml(\'<?xml version="1.0"\')')));
+
+        $this->assertFalse($result);
+    }
+
     public function testProviders()
     {
         $expressionLanguage = new ExpressionLanguage(null, [new TestProvider()]);

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -19,6 +19,7 @@
         "php": ">=8.1",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/cache": "^5.4|^6.0",
+        "symfony/polyfill-php83": "^1.27",
         "symfony/service-contracts": "^2.5|^3"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

The addition of these utils functions can be leveraged like this, for example:

```php
namespace App\Controller;

use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\HttpKernel\Attribute\AsController;
use Symfony\Component\Routing\Annotation\Route;

#[AsController]
class FooController extends AbstractController
{
    #[Route('/', condition: 'is_json(request.getContent())')]
    public function index(): Response
    {
        // ...
    }
}
```

Or like this:

```php
use Symfony\Component\Validator\Constraints\Expression;

#[Expression(
    expression: "is_json(this.body) and this.type == 'json' or is_xml(this.body) and this.type == 'xml'",
    message: "Body and type of payload mismatch"
)]
class Payload
{
    public string $body;

    public string $type;
}
```