### PR TITLE
[Security] Remove `@internal` tag on `TraceableAuthenticator::getAuthenticator()`

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -100,9 +100,6 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
         return $this->authenticator instanceof InteractiveAuthenticatorInterface && $this->authenticator->isInteractive();
     }
 
-    /**
-     * @internal
-     */
     public function getAuthenticator(): AuthenticatorInterface
     {
         return $this->authenticator;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | See #49015 
| License       | MIT

Following the [discussion](https://github.com/symfony/symfony/pull/49015#issuecomment-1445347380) in #49015 I made this PR 