### PR TITLE
[Mailer] [PostMark Mailer] Allow setting the message stream from the mailable headers

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\UnstructuredHeader;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -109,6 +110,12 @@ class PostmarkApiTransport extends AbstractApiTransport
 
             if ($header instanceof MetadataHeader) {
                 $payload['Metadata'][$header->getKey()] = $header->getValue();
+
+                continue;
+            }
+            
+            if($header instanceof UnstructuredHeader && in_array($header->getName(), ['MessageStream', 'X-PM-MessageStream']) ) {
+                $payload['MessageStream'] = $header->getValue();
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -113,8 +113,8 @@ class PostmarkApiTransport extends AbstractApiTransport
 
                 continue;
             }
-            
-            if($header instanceof UnstructuredHeader && in_array($header->getName(), ['MessageStream', 'X-PM-MessageStream']) ) {
+
+            if ($header instanceof UnstructuredHeader && \in_array($header->getName(), ['MessageStream', 'X-PM-MessageStream'])) {
                 $payload['MessageStream'] = $header->getValue();
 
                 continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

_This is my first PR to a big OS framework project, please forgive me if I forgot something or didn't fully respect the form(al) requirements_

### Problem
I noticed that when setting the message stream via the headers of a Mailable in Laravel, this is not persisted when in the config the `mail.postmark.message_stream_id` is set, because `$payload['MessageStream]` is dominant over the header variables.

### A bit more background
So, in a Laravel mailable, the code below for setting the `X-PM-MessageStream` or `MessageStream` through the headers does not work:

```php
public function headers(): Headers
    {
        return new Headers(
            text: [
                'X-PM-MessageStream' => 'fitce-broadcasts',
                'MessageStream' => 'fitce-broadcasts',
            ],
        );
    }
```

I don't understand why, but in `PostmarkApiTransport`, the check on the message stream header is not triggered, as the header, set through the above code (in the Laravel Mailable), will always be of the type `UnstructuredHeader`
```php
if ($header instanceof MessageStreamHeader) {
                $payload['MessageStream'] = $header->getValue();

                continue;
            }
```

### Solution alternative
My first thought was to update the lines below to not set a message stream if the payload headers have a `MessageStream` or `X-PM-MessageStream`, because then the Postmark servers will use the Header variable to select the stream.
```php
if (null !== $this->messageStream && !isset($payload['MessageStream'])) {
            $payload['MessageStream'] = $this->messageStream;
        }
```
But this would result in a rather messy code for the check, 

### Proposed solution
Therefore I believe it is better to add an extra check on the available headers and set the `$payload['MessageStream']` when the headers contain a value for `X-PM-MessageStream` or `MessageStream`.

