### PR TITLE
[TwigBridge] Fix TwigDataCollector::getTime() return type

### DIFF
--- a/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
+++ b/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
@@ -78,7 +78,7 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
         $templateFinder($this->profile);
     }
 
-    public function getTime(): int
+    public function getTime(): float
     {
         return $this->getProfile()->getDuration() * 1000;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Ref https://github.com/symfony/symfony/pull/49348

It generates implicit incompatible float to int conversion deprecations.