### PR TITLE
[Messenger] Fix `TransportNamesStamp` deserialization

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
@@ -17,14 +17,14 @@ namespace Symfony\Component\Messenger\Stamp;
 final class TransportNamesStamp implements StampInterface
 {
     /**
-     * @param string[] $transports Transport names to be used for the message
+     * @param string[] $transportNames Transport names to be used for the message
      */
-    public function __construct(private array $transports)
+    public function __construct(private array $transportNames)
     {
     }
 
     public function getTransportNames(): array
     {
-        return $this->transports;
+        return $this->transportNames;
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Stamp/TransportNamesStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/TransportNamesStampTest.php
@@ -12,7 +12,13 @@
 namespace Symfony\Component\Messenger\Tests\Stamp;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 
 class TransportNamesStampTest extends TestCase
 {
@@ -26,5 +32,22 @@ class TransportNamesStampTest extends TestCase
         foreach ($configuredSenders as $key => $sender) {
             $this->assertSame($sender, $stampSenders[$key]);
         }
+    }
+
+    public function testDeserialization()
+    {
+        $stamp = new TransportNamesStamp(['foo']);
+        $serializer = new Serializer(
+            new SymfonySerializer([
+                new ArrayDenormalizer(),
+                new ObjectNormalizer(),
+            ], [new JsonEncoder()])
+        );
+
+        $deserializedEnvelope = $serializer->decode($serializer->encode(new Envelope(new \stdClass(), [$stamp])));
+
+        $deserializedStamp = $deserializedEnvelope->last(TransportNamesStamp::class);
+        $this->assertInstanceOf(TransportNamesStamp::class, $deserializedStamp);
+        $this->assertEquals($stamp, $deserializedStamp);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #49574, https://github.com/symfony/symfony/issues/31490#issuecomment-1439927253
| License       | MIT
| Doc PR        | n/a

Currently, when ones use `TransportNameStamp` the following exception can occur if they don't use native PHP serialization:

```
In Serializer.php line 125:

  [Symfony\Component\Messenger\Exception\MessageDecodingFailedException]
  Could not decode stamp: Cannot create an instance of "Symfony\Component\Messenger\Stamp\TransportNamesStamp" from serialized data because its constructor requires parameter "transports" to be present.

In AbstractNormalizer.php line 384:

  [Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException]
  Cannot create an instance of "Symfony\Component\Messenger\Stamp\TransportNamesStamp" from serialized data because its constructor requires parameter "transports" to be present.

```

This PR renames `TransportNamesStamp` constructor argument in order to match the accessor method (`getTransportNames`) so that deserialization works when using the Serializer.

I know this is technically a (small) BC break but Symfony's BC does not cover named arguments if I remember correctly.