### PR TITLE
[Serializer] Add flag to require all properties to be listed in the input

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.3
 ---
 
+ * Add `AbstractNormalizer::REQUIRE_ALL_PROPERTIES` context flag to require all properties to be listed in the input instead of falling back to null for nullable ones
  * Add `XmlEncoder::SAVE_OPTIONS` context option
  * Add `BackedEnumNormalizer::ALLOW_INVALID_VALUES` context option
  * Add `UnsupportedFormatException` which is thrown when there is no decoder for a given format

--- a/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
@@ -164,4 +164,13 @@ abstract class AbstractNormalizerContextBuilder implements ContextBuilderInterfa
     {
         return $this->with(AbstractNormalizer::IGNORED_ATTRIBUTES, $ignoredAttributes);
     }
+
+    /**
+     * Configures requiring all properties to be listed in the input instead
+     * of falling back to null for nullable ones.
+     */
+    public function withRequireAllProperties(?bool $requireAllProperties = true): static
+    {
+        return $this->with(AbstractNormalizer::REQUIRE_ALL_PROPERTIES, $requireAllProperties);
+    }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -113,6 +113,12 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     public const IGNORED_ATTRIBUTES = 'ignored_attributes';
 
     /**
+     * Require all properties to be listed in the input instead of falling
+     * back to null for nullable ones.
+     */
+    public const REQUIRE_ALL_PROPERTIES = 'require_all_properties';
+
+    /**
      * @internal
      */
     protected const CIRCULAR_REFERENCE_LIMIT_COUNTERS = 'circular_reference_limit_counters';
@@ -383,7 +389,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                     $params[] = $this->defaultContext[self::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class][$key];
                 } elseif ($constructorParameter->isDefaultValueAvailable()) {
                     $params[] = $constructorParameter->getDefaultValue();
-                } elseif ($constructorParameter->hasType() && $constructorParameter->getType()->allowsNull()) {
+                } elseif (!($context[self::REQUIRE_ALL_PROPERTIES] ?? $this->defaultContext[self::REQUIRE_ALL_PROPERTIES] ?? false) && $constructorParameter->hasType() && $constructorParameter->getType()->allowsNull()) {
                     $params[] = null;
                 } else {
                     if (!isset($context['not_normalizable_value_exceptions'])) {

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
@@ -45,6 +45,7 @@ class AbstractNormalizerContextBuilderTest extends TestCase
             ->withCallbacks($values[AbstractNormalizer::CALLBACKS])
             ->withCircularReferenceHandler($values[AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER])
             ->withIgnoredAttributes($values[AbstractNormalizer::IGNORED_ATTRIBUTES])
+            ->withRequireAllProperties($values[AbstractNormalizer::REQUIRE_ALL_PROPERTIES])
             ->toArray();
 
         $this->assertEquals($values, $context);
@@ -65,6 +66,7 @@ class AbstractNormalizerContextBuilderTest extends TestCase
             AbstractNormalizer::CALLBACKS => [static function (): void {}],
             AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => static function (): void {},
             AbstractNormalizer::IGNORED_ATTRIBUTES => ['attribute3'],
+            AbstractNormalizer::REQUIRE_ALL_PROPERTIES => true,
         ]];
 
         yield 'With null values' => [[
@@ -77,6 +79,7 @@ class AbstractNormalizerContextBuilderTest extends TestCase
             AbstractNormalizer::CALLBACKS => null,
             AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => null,
             AbstractNormalizer::IGNORED_ATTRIBUTES => null,
+            AbstractNormalizer::REQUIRE_ALL_PROPERTIES => null,
         ]];
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
@@ -164,6 +165,15 @@ class AbstractNormalizerTest extends TestCase
         $dummy = $normalizer->denormalize([], NullableConstructorArgumentDummy::class);
 
         $this->assertNull($dummy->getFoo());
+    }
+
+    public function testObjectWithNullableNonOptionalConstructorArgumentWithoutInputAndRequireAllProperties()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $this->expectException(MissingConstructorArgumentsException::class);
+
+        $normalizer->denormalize([], NullableConstructorArgumentDummy::class, null, [AbstractNormalizer::REQUIRE_ALL_PROPERTIES => true]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49504
| License       | MIT
| Doc PR        | symfony/symfony-docs#17979

The PR #40522 introduced a fallback for nullable properties to be set to `null` when they aren't provided as parameters.

A drawback of that approach is that it easier for bugs to appear through typos or renamings of those properties. I think the current implementation makes perfect sense as a default. Therefore, this PR introduces a new context flag that prevents that fallback behaviour. This way nothing changes for existing systems, but for people wanting more control, it's possible to set a flag.

### Example

```php
final class Product
{
    public function __construct(
        public string $name,
        public ?int $costsInCent,
    ) {
    }
}

// This works and results in $costsInCent as null
$product = $this->serializer->deserialize(
    '{"name": "foo"}', 
    Product::class, 
    JsonEncoder::FORMAT,
);

// When using the flag, only the following JSON is valid
$product = $this->serializer->deserialize(
    '{"name": "foo", "costsInCent": null}',
    Product::class,
    JsonEncoder::FORMAT,
    [
        AbstractNormalizer::PREVENT_NULLABLE_FALLBACK => true,
    ],
);

// This would result in an error due to missing parameters
$product = $this->serializer->deserialize(
    '{"name": "foo"}',
    Product::class,
    JsonEncoder::FORMAT,
    [
        AbstractNormalizer::PREVENT_NULLABLE_FALLBACK => true,
    ],
);
```