### PR TITLE
[RequestStack ] Change visibility of $request property from private to protected

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RequestStack.php
+++ b/src/Symfony/Component/HttpFoundation/RequestStack.php
@@ -24,7 +24,7 @@ class RequestStack
     /**
      * @var Request[]
      */
-    private array $requests = [];
+    protected array $requests = [];
 
     /**
      * Pushes a Request on the stack.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 for features / 5.4 or 6.2 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #49554
| License       | MIT
| Doc PR        | -

In the [RequestStack.php](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/HttpFoundation/RequestStack.php) the property `$requests` is marked as private, which makes it impossible to operate with it in children classes.

Will be good to change it to `protected` to allow interaction with it in children's classes. For example, for my project, I need an additional function to clear (reset) the list of all requests, without popping-out one by one via `pop()`, and can't do it now via extending Symfony's RequestStack, because of the property is private.