### PR TITLE
Introduce new OpenApi component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "symfony/mime": "self.version",
         "symfony/monolog-bridge": "self.version",
         "symfony/notifier": "self.version",
+        "symfony/openapi": "self.version",
         "symfony/options-resolver": "self.version",
         "symfony/password-hasher": "self.version",
         "symfony/process": "self.version",

--- a/src/Symfony/Component/OpenApi/.gitattributes
+++ b/src/Symfony/Component/OpenApi/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/OpenApi/.gitignore
+++ b/src/Symfony/Component/OpenApi/.gitignore
@@ -1,0 +1,4 @@
+composer.lock
+phpunit.xml
+vendor/
+.phpunit.result.cache

--- a/src/Symfony/Component/OpenApi/Builder/OpenApiBuilder.php
+++ b/src/Symfony/Component/OpenApi/Builder/OpenApiBuilder.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Builder;
+
+use Symfony\Component\OpenApi\Configurator\CallbackRequestConfigurator;
+use Symfony\Component\OpenApi\Configurator\ComponentsConfigurator;
+use Symfony\Component\OpenApi\Configurator\EncodingConfigurator;
+use Symfony\Component\OpenApi\Configurator\ExampleConfigurator;
+use Symfony\Component\OpenApi\Configurator\InfoConfigurator;
+use Symfony\Component\OpenApi\Configurator\LinkConfigurator;
+use Symfony\Component\OpenApi\Configurator\MediaTypeConfigurator;
+use Symfony\Component\OpenApi\Configurator\OperationConfigurator;
+use Symfony\Component\OpenApi\Configurator\ParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\PathItemConfigurator;
+use Symfony\Component\OpenApi\Configurator\QueryParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\QueryParametersConfigurator;
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Configurator\RequestBodyConfigurator;
+use Symfony\Component\OpenApi\Configurator\ResponseConfigurator;
+use Symfony\Component\OpenApi\Configurator\ResponsesConfigurator;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Configurator\SecuritySchemeConfigurator;
+use Symfony\Component\OpenApi\Configurator\ServerConfigurator;
+use Symfony\Component\OpenApi\Configurator\TagConfigurator;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class OpenApiBuilder implements OpenApiBuilderInterface
+{
+    public function schema(SchemaConfigurator|ReferenceConfigurator|string $definition = null): SchemaConfigurator|ReferenceConfigurator
+    {
+        return SchemaConfigurator::createFromDefinition($definition);
+    }
+
+    public function callbackRequest(): CallbackRequestConfigurator
+    {
+        return new CallbackRequestConfigurator();
+    }
+
+    public function components(): ComponentsConfigurator
+    {
+        return new ComponentsConfigurator();
+    }
+
+    public function content(): MediaTypeConfigurator
+    {
+        return new MediaTypeConfigurator();
+    }
+
+    public function encoding(): EncodingConfigurator
+    {
+        return new EncodingConfigurator();
+    }
+
+    public function example(): ExampleConfigurator
+    {
+        return new ExampleConfigurator();
+    }
+
+    public function info(): InfoConfigurator
+    {
+        return new InfoConfigurator();
+    }
+
+    public function link(): LinkConfigurator
+    {
+        return new LinkConfigurator();
+    }
+
+    public function mediaType(): MediaTypeConfigurator
+    {
+        return new MediaTypeConfigurator();
+    }
+
+    public function operation(): OperationConfigurator
+    {
+        return new OperationConfigurator($this);
+    }
+
+    public function parameter(string $name): ParameterConfigurator
+    {
+        return new ParameterConfigurator($name);
+    }
+
+    public function queryParameter(string $name): QueryParameterConfigurator
+    {
+        return new QueryParameterConfigurator($name);
+    }
+
+    public function queryParameters(): QueryParametersConfigurator
+    {
+        return new QueryParametersConfigurator($this);
+    }
+
+    public function pathItem(): PathItemConfigurator
+    {
+        return new PathItemConfigurator($this);
+    }
+
+    public function reference(string $ref): ReferenceConfigurator
+    {
+        return new ReferenceConfigurator($ref);
+    }
+
+    public function requestBody(): RequestBodyConfigurator
+    {
+        return new RequestBodyConfigurator();
+    }
+
+    public function response(): ResponseConfigurator
+    {
+        return new ResponseConfigurator();
+    }
+
+    public function responses(): ResponsesConfigurator
+    {
+        return new ResponsesConfigurator();
+    }
+
+    public function securityScheme(): SecuritySchemeConfigurator
+    {
+        return new SecuritySchemeConfigurator();
+    }
+
+    public function server(string $url): ServerConfigurator
+    {
+        return new ServerConfigurator($url);
+    }
+
+    public function tag(): TagConfigurator
+    {
+        return new TagConfigurator();
+    }
+}

--- a/src/Symfony/Component/OpenApi/Builder/OpenApiBuilderInterface.php
+++ b/src/Symfony/Component/OpenApi/Builder/OpenApiBuilderInterface.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Builder;
+
+use Symfony\Component\OpenApi\Configurator\CallbackRequestConfigurator;
+use Symfony\Component\OpenApi\Configurator\ComponentsConfigurator;
+use Symfony\Component\OpenApi\Configurator\EncodingConfigurator;
+use Symfony\Component\OpenApi\Configurator\ExampleConfigurator;
+use Symfony\Component\OpenApi\Configurator\InfoConfigurator;
+use Symfony\Component\OpenApi\Configurator\LinkConfigurator;
+use Symfony\Component\OpenApi\Configurator\MediaTypeConfigurator;
+use Symfony\Component\OpenApi\Configurator\OperationConfigurator;
+use Symfony\Component\OpenApi\Configurator\ParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\PathItemConfigurator;
+use Symfony\Component\OpenApi\Configurator\QueryParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\QueryParametersConfigurator;
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Configurator\RequestBodyConfigurator;
+use Symfony\Component\OpenApi\Configurator\ResponseConfigurator;
+use Symfony\Component\OpenApi\Configurator\ResponsesConfigurator;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Configurator\SecuritySchemeConfigurator;
+use Symfony\Component\OpenApi\Configurator\ServerConfigurator;
+use Symfony\Component\OpenApi\Configurator\TagConfigurator;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+interface OpenApiBuilderInterface
+{
+    public function schema(SchemaConfigurator|ReferenceConfigurator|string $definition = null): SchemaConfigurator|ReferenceConfigurator;
+
+    public function callbackRequest(): CallbackRequestConfigurator;
+
+    public function components(): ComponentsConfigurator;
+
+    public function content(): MediaTypeConfigurator;
+
+    public function encoding(): EncodingConfigurator;
+
+    public function example(): ExampleConfigurator;
+
+    public function info(): InfoConfigurator;
+
+    public function link(): LinkConfigurator;
+
+    public function mediaType(): MediaTypeConfigurator;
+
+    public function operation(): OperationConfigurator;
+
+    public function parameter(string $name): ParameterConfigurator;
+
+    public function queryParameter(string $name): QueryParameterConfigurator;
+
+    public function queryParameters(): QueryParametersConfigurator;
+
+    public function pathItem(): PathItemConfigurator;
+
+    public function reference(string $ref): ReferenceConfigurator;
+
+    public function requestBody(): RequestBodyConfigurator;
+
+    public function response(): ResponseConfigurator;
+
+    public function responses(): ResponsesConfigurator;
+
+    public function securityScheme(): SecuritySchemeConfigurator;
+
+    public function server(string $url): ServerConfigurator;
+
+    public function tag(): TagConfigurator;
+}

--- a/src/Symfony/Component/OpenApi/CHANGELOG.md
+++ b/src/Symfony/Component/OpenApi/CHANGELOG.md
@@ -1,0 +1,8 @@
+CHANGELOG
+=========
+
+6.3
+---
+
+* Add the component as experimental
+

--- a/src/Symfony/Component/OpenApi/Compiler/DocumentationCompiler.php
+++ b/src/Symfony/Component/OpenApi/Compiler/DocumentationCompiler.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Compiler;
+
+use Symfony\Component\OpenApi\Configurator\DocumentationConfigurator;
+use Symfony\Component\OpenApi\Documentation\DocumentationInterface;
+use Symfony\Component\OpenApi\Loader\ComponentsLoaderInterface;
+use Symfony\Component\OpenApi\Model\OpenApi;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class DocumentationCompiler implements DocumentationCompilerInterface
+{
+    /**
+     * @param iterable<ComponentsLoaderInterface> $componentsLoaders
+     */
+    public function __construct(private iterable $componentsLoaders = [])
+    {
+    }
+
+    public function compile(DocumentationInterface $doc): OpenApi
+    {
+        // Instanciate root configurator
+        $rootConfigurator = new DocumentationConfigurator();
+
+        // Load components for this doc
+        foreach ($this->componentsLoaders as $loader) {
+            $doc->loadComponents($rootConfigurator, $loader);
+        }
+
+        // Apply user documentation details
+        $doc->configure($rootConfigurator);
+
+        // Compile the documentation
+        return $rootConfigurator->build($doc->getIdentifier(), $doc->getVersion());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Compiler/DocumentationCompilerInterface.php
+++ b/src/Symfony/Component/OpenApi/Compiler/DocumentationCompilerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Compiler;
+
+use Symfony\Component\OpenApi\Documentation\DocumentationInterface;
+use Symfony\Component\OpenApi\Model\OpenApi;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+interface DocumentationCompilerInterface
+{
+    public function compile(DocumentationInterface $doc): OpenApi;
+}

--- a/src/Symfony/Component/OpenApi/Configurator/CallbackRequestConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/CallbackRequestConfigurator.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\CallbackRequest;
+use Symfony\Component\OpenApi\Model\PathItem;
+use Symfony\Component\OpenApi\Model\Reference;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class CallbackRequestConfigurator
+{
+    use Traits\ExtensionsTrait;
+
+    private string $expression = '';
+    private PathItem|Reference|null $definition = null;
+
+    public function build(): CallbackRequest
+    {
+        return new CallbackRequest($this->expression, $this->definition, $this->specificationExtensions);
+    }
+
+    public function expression(string $expression): static
+    {
+        $this->expression = $expression;
+
+        return $this;
+    }
+
+    public function definition(ReferenceConfigurator|PathItemConfigurator $definition): static
+    {
+        $this->definition = $definition->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/ComponentsConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/ComponentsConfigurator.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Components;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class ComponentsConfigurator
+{
+    use Traits\ExtensionsTrait;
+
+    private array $schemas = [];
+    private array $responses = [];
+    private array $parameters = [];
+    private array $examples = [];
+    private array $requestBodies = [];
+    private array $securitySchemes = [];
+    private array $links = [];
+    private array $callbacks = [];
+    private array $pathItems = [];
+
+    public function build(Components $toMergeWith = null): Components
+    {
+        if (!$toMergeWith) {
+            $toMergeWith = new Components();
+        }
+
+        return new Components(
+            array_merge($toMergeWith->getSchemas() ?: [], $this->schemas) ?: null,
+            array_merge($toMergeWith->getResponses() ?: [], $this->responses) ?: null,
+            array_merge($toMergeWith->getParameters() ?: [], $this->parameters) ?: null,
+            array_merge($toMergeWith->getExamples() ?: [], $this->examples) ?: null,
+            array_merge($toMergeWith->getRequestBodies() ?: [], $this->requestBodies) ?: null,
+            array_merge($toMergeWith->getSecuritySchemes() ?: [], $this->securitySchemes) ?: null,
+            array_merge($toMergeWith->getLinks() ?: [], $this->links) ?: null,
+            array_merge($toMergeWith->getCallbacks() ?: [], $this->callbacks) ?: null,
+            array_merge($toMergeWith->getPathItems() ?: [], $this->pathItems) ?: null,
+            array_merge($toMergeWith->getSpecificationExtensions() ?: [], $this->specificationExtensions) ?: [],
+        );
+    }
+
+    /**
+     * @return $this
+     */
+    public function schema(string $name, SchemaConfigurator|string $schema): static
+    {
+        $this->schemas[ReferenceConfigurator::normalize($name)] = SchemaConfigurator::createFromDefinition($schema)->build();
+
+        return $this;
+    }
+
+    public function response(string $name, ResponseConfigurator $response): static
+    {
+        $this->responses[ReferenceConfigurator::normalize($name)] = $response->build();
+
+        return $this;
+    }
+
+    public function parameter(string $name, ParameterConfigurator $parameter): static
+    {
+        $this->parameters[ReferenceConfigurator::normalize($name)] = $parameter->build();
+
+        return $this;
+    }
+
+    public function example(string $name, ExampleConfigurator $example): static
+    {
+        $this->examples[ReferenceConfigurator::normalize($name)] = $example->build();
+
+        return $this;
+    }
+
+    public function requestBody(string $name, RequestBodyConfigurator $requestBody): static
+    {
+        $this->requestBodies[ReferenceConfigurator::normalize($name)] = $requestBody->build();
+
+        return $this;
+    }
+
+    public function securityScheme(string $name, SecuritySchemeConfigurator $securityScheme): static
+    {
+        $this->securitySchemes[ReferenceConfigurator::normalize($name)] = $securityScheme->build();
+
+        return $this;
+    }
+
+    public function callback(string $name, CallbackRequestConfigurator $callback): static
+    {
+        $this->callbacks[ReferenceConfigurator::normalize($name)] = $callback->build();
+
+        return $this;
+    }
+
+    public function link(string $name, LinkConfigurator $link): static
+    {
+        $this->links[ReferenceConfigurator::normalize($name)] = $link->build();
+
+        return $this;
+    }
+
+    public function pathItem(string $name, PathItemConfigurator $pathItem): static
+    {
+        $reference = ReferenceConfigurator::normalize($name);
+        $this->pathItems[$reference] = $pathItem->build($this->pathItems[$reference] ?? null);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/DocumentationConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/DocumentationConfigurator.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Components;
+use Symfony\Component\OpenApi\Model\OpenApi;
+use Symfony\Component\OpenApi\Model\PathItem;
+use Symfony\Component\OpenApi\Model\SecurityRequirement;
+use Symfony\Component\OpenApi\Model\Tag;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class DocumentationConfigurator
+{
+    use Traits\ExtensionsTrait;
+    use Traits\ExternalDocsTrait;
+    use Traits\ServersTrait;
+
+    private string $version = '3.1.0';
+    private ?string $jsonSchemaDialect = null;
+    private ?InfoConfigurator $info = null;
+    private ?Components $components = null;
+
+    /**
+     * @var Tag[]
+     */
+    private array $tags = [];
+
+    /**
+     * @var array<string, PathItem>
+     */
+    private array $paths = [];
+
+    /**
+     * @var array<string, PathItem>
+     */
+    private array $webhooks = [];
+
+    /**
+     * @var SecurityRequirement[]
+     */
+    private array $securityRequirements = [];
+
+    public function build(string $identifier = '', string $version = ''): OpenApi
+    {
+        return new OpenApi(
+            version: $this->version,
+            info: ($this->info ?: new InfoConfigurator())->build($identifier, $version),
+            servers: $this->servers ?: null,
+            paths: $this->paths ?: null,
+            webhooks: $this->webhooks ?: null,
+            components: $this->components,
+            security: $this->securityRequirements,
+            tags: $this->tags ?: null,
+            externalDocs: $this->externalDocs,
+            jsonSchemaDialect: $this->jsonSchemaDialect,
+            specificationExtensions: $this->specificationExtensions,
+        );
+    }
+
+    public function version(string $version): static
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    public function jsonSchemaDialect(string $jsonSchemaDialect): static
+    {
+        $this->jsonSchemaDialect = $jsonSchemaDialect;
+
+        return $this;
+    }
+
+    public function info(InfoConfigurator $info): static
+    {
+        $this->info = $info;
+
+        return $this;
+    }
+
+    public function components(ComponentsConfigurator $components): static
+    {
+        $this->components = $components->build($this->components);
+
+        return $this;
+    }
+
+    public function tag(TagConfigurator|string $tag): static
+    {
+        $this->tags[] = \is_string($tag) ? new Tag($tag) : $tag->build();
+
+        return $this;
+    }
+
+    public function path(string $path, PathItemConfigurator|ReferenceConfigurator $pathItem): static
+    {
+        $this->paths[$path] = $pathItem->build($this->paths[$path] ?? null);
+
+        return $this;
+    }
+
+    public function webhook(string $name, PathItemConfigurator|ReferenceConfigurator $pathItem): static
+    {
+        $this->webhooks[$name] = $pathItem->build();
+
+        return $this;
+    }
+
+    public function securityRequirement(string $name, array $config = []): static
+    {
+        $this->securityRequirements[] = new SecurityRequirement($name, $config);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/EncodingConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/EncodingConfigurator.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Encoding;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class EncodingConfigurator
+{
+    use Traits\ExtensionsTrait;
+    use Traits\HeadersTrait;
+
+    private ?string $contentType = null;
+    private ?string $style = null;
+    private ?bool $explode = null;
+    private ?bool $allowReserved = null;
+
+    public function build(): ?Encoding
+    {
+        return new Encoding(
+            $this->contentType,
+            $this->headers,
+            $this->style,
+            $this->explode,
+            $this->allowReserved,
+            $this->specificationExtensions,
+        );
+    }
+
+    public function contentType(string $contentType): static
+    {
+        $this->contentType = $contentType;
+
+        return $this;
+    }
+
+    public function style(string $style): static
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    public function explode(bool $explode): static
+    {
+        $this->explode = $explode;
+
+        return $this;
+    }
+
+    public function allowReserved(bool $allowReserved): static
+    {
+        $this->allowReserved = $allowReserved;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/ExampleConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/ExampleConfigurator.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Example;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class ExampleConfigurator
+{
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\SummaryTrait;
+
+    private mixed $value = null;
+    private ?string $externalValue = null;
+
+    public function build(): Example
+    {
+        return new Example(
+            $this->summary,
+            $this->description,
+            $this->value,
+            $this->externalValue,
+            $this->specificationExtensions,
+        );
+    }
+
+    public function value(mixed $value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function externalValue(string $externalValue): static
+    {
+        $this->externalValue = $externalValue;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/InfoConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/InfoConfigurator.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Contact;
+use Symfony\Component\OpenApi\Model\Info;
+use Symfony\Component\OpenApi\Model\License;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class InfoConfigurator
+{
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\SummaryTrait;
+
+    private string $title = '';
+    private string $version = '';
+    private ?string $termsOfService = null;
+    private ?Contact $contact = null;
+    private ?License $license = null;
+
+    public function build(string $identifier = '', string $version = ''): Info
+    {
+        return new Info(
+            title: $this->title ?: $identifier,
+            version: $this->version ?: $version,
+            summary: $this->summary,
+            description: $this->description,
+            termsOfService: $this->termsOfService,
+            contact: $this->contact,
+            license: $this->license,
+            specificationExtensions: $this->specificationExtensions,
+        );
+    }
+
+    public function title(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function version(string $version): static
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    public function termsOfService(string $termsOfService): static
+    {
+        $this->termsOfService = $termsOfService;
+
+        return $this;
+    }
+
+    public function contact(string $name = null, string $url = null, string $email = null, array $specificationExtensions = []): static
+    {
+        $this->contact = new Contact($name, $url, $email, $specificationExtensions);
+
+        return $this;
+    }
+
+    public function license(string $name, string $identifier = null, string $url = null, array $specificationExtensions = []): static
+    {
+        $this->license = new License($name, $identifier, $url, $specificationExtensions);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/LinkConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/LinkConfigurator.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Link;
+use Symfony\Component\OpenApi\Model\Server;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class LinkConfigurator
+{
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\ParametersTrait;
+
+    private ?string $operationRef = null;
+    private ?string $operationId = null;
+    private mixed $requestBody = null;
+    private ?Server $server = null;
+
+    public function build(): Link
+    {
+        return new Link(
+            $this->operationRef,
+            $this->operationId,
+            $this->parameters ?: null,
+            $this->requestBody,
+            $this->description,
+            $this->server,
+            $this->specificationExtensions,
+        );
+    }
+
+    public function operationRef(?string $operationRef): static
+    {
+        $this->operationRef = $operationRef;
+
+        return $this;
+    }
+
+    public function operationId(?string $operationId): static
+    {
+        $this->operationId = $operationId;
+
+        return $this;
+    }
+
+    public function requestBody(mixed $requestBody): static
+    {
+        $this->requestBody = $requestBody;
+
+        return $this;
+    }
+
+    public function server(ServerConfigurator|string $server): static
+    {
+        $this->server = \is_string($server) ? (new ServerConfigurator($server))->build() : $server->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/MediaTypeConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/MediaTypeConfigurator.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Encoding;
+use Symfony\Component\OpenApi\Model\MediaType;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class MediaTypeConfigurator
+{
+    use Traits\ExamplesTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\SchemaTrait;
+
+    /**
+     * @var array<string, Encoding>
+     */
+    private array $encodings = [];
+
+    public function build(): MediaType
+    {
+        return new MediaType(
+            $this->schema,
+            $this->example,
+            $this->examples ?: null,
+            $this->encodings ?: null,
+            $this->specificationExtensions,
+        );
+    }
+
+    public function encoding(string $name, EncodingConfigurator $encoding): static
+    {
+        $this->encodings[$name] = $encoding->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/OperationConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/OperationConfigurator.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Model\CallbackRequest;
+use Symfony\Component\OpenApi\Model\Operation;
+use Symfony\Component\OpenApi\Model\Reference;
+use Symfony\Component\OpenApi\Model\RequestBody;
+use Symfony\Component\OpenApi\Model\Responses;
+use Symfony\Component\OpenApi\Model\SecurityRequirement;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class OperationConfigurator
+{
+    use Traits\DeprecatedTrait;
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\ExternalDocsTrait;
+    use Traits\ParametersTrait;
+    use Traits\QueryParametersTrait;
+    use Traits\ServersTrait;
+    use Traits\SummaryTrait;
+
+    private ?string $operationId = null;
+
+    /**
+     * @var string[]
+     */
+    private array $tags = [];
+
+    private RequestBody|Reference|null $requestBody = null;
+    private Responses|null $responses = null;
+
+    /**
+     * @var array<string, CallbackRequest|Reference>
+     */
+    private array $callbacks = [];
+
+    /**
+     * @var SecurityRequirement[]|null
+     */
+    private ?array $securityRequirements = null;
+
+    public function __construct(OpenApiBuilderInterface $openApiBuilder)
+    {
+        $this->openApiBuilder = $openApiBuilder;
+    }
+
+    public function build(): Operation
+    {
+        return new Operation(
+            operationId: $this->operationId,
+            summary: $this->summary,
+            description: $this->description,
+            deprecated: $this->deprecated,
+            tags: $this->tags ?: null,
+            externalDocs: $this->externalDocs,
+            parameters: array_merge($this->parameters, $this->queryParameters) ?: null,
+            requestBody: $this->requestBody,
+            responses: $this->responses,
+            callbacks: $this->callbacks ?: null,
+            security: $this->securityRequirements,
+            servers: $this->servers ?: null,
+            specificationExtensions: $this->specificationExtensions,
+        );
+    }
+
+    public function operationId(string $operationId): static
+    {
+        $this->operationId = $operationId;
+
+        return $this;
+    }
+
+    public function tag(string $tag): static
+    {
+        $this->tags[] = $tag;
+
+        return $this;
+    }
+
+    public function responses(ResponsesConfigurator $responses): static
+    {
+        $this->responses = $responses->build();
+
+        return $this;
+    }
+
+    public function requestBody(RequestBodyConfigurator|ReferenceConfigurator|string $requestBody): static
+    {
+        if (\is_string($requestBody)) {
+            $requestBody = new ReferenceConfigurator('#/components/requestBodies/'.ReferenceConfigurator::normalize($requestBody));
+        }
+
+        $this->requestBody = $requestBody->build();
+
+        return $this;
+    }
+
+    public function callback(string $name, CallbackRequestConfigurator|ReferenceConfigurator|string $callbackRequest): static
+    {
+        if (\is_string($callbackRequest)) {
+            $callbackRequest = new ReferenceConfigurator('#/components/callbacks/'.ReferenceConfigurator::normalize($callbackRequest));
+        }
+
+        $this->callbacks[$name] = $callbackRequest->build();
+
+        return $this;
+    }
+
+    public function securityRequirement(?string $name, array $config = []): static
+    {
+        // Allow not having security
+        if (null === $name) {
+            $this->securityRequirements[] = new SecurityRequirement(SecurityRequirement::NONE, []);
+
+            return $this;
+        }
+
+        $this->securityRequirements[] = new SecurityRequirement($name, $config);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/ParameterConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/ParameterConfigurator.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\ParameterIn;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class ParameterConfigurator
+{
+    use Traits\ContentTrait;
+    use Traits\DeprecatedTrait;
+    use Traits\DescriptionTrait;
+    use Traits\ExamplesTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\NameTrait;
+    use Traits\SchemaTrait;
+
+    private ?ParameterIn $in = null;
+    private ?bool $required = null;
+    private ?bool $allowEmptyValue = null;
+    private ?string $style = null;
+    private ?bool $explode = null;
+    private ?bool $allowReserved = null;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function build(bool $asHeader = false): Parameter
+    {
+        return new Parameter(
+            $asHeader ? null : $this->name,
+            $asHeader ? null : $this->in,
+            $this->description,
+            $this->required,
+            $this->deprecated,
+            $this->allowEmptyValue,
+            $this->style,
+            $this->explode,
+            $this->allowReserved,
+            $this->schema,
+            $this->example,
+            $this->examples,
+            $this->content ?: null,
+            $this->specificationExtensions,
+        );
+    }
+
+    public function in(ParameterIn $in): static
+    {
+        $this->in = $in;
+
+        return $this;
+    }
+
+    public function required(bool $required): static
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    public function allowEmptyValue(bool $allowEmptyValue): static
+    {
+        $this->allowEmptyValue = $allowEmptyValue;
+
+        return $this;
+    }
+
+    public function style(string $style): static
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    public function explode(bool $explode): static
+    {
+        $this->explode = $explode;
+
+        return $this;
+    }
+
+    public function allowReserved(bool $allowReserved): static
+    {
+        $this->allowReserved = $allowReserved;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/PathItemConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/PathItemConfigurator.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Model\Operation;
+use Symfony\Component\OpenApi\Model\PathItem;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class PathItemConfigurator
+{
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\ParametersTrait;
+    use Traits\QueryParametersTrait;
+    use Traits\ServersTrait;
+    use Traits\SummaryTrait;
+
+    private ?string $ref = null;
+    private ?Operation $get = null;
+    private ?Operation $post = null;
+    private ?Operation $put = null;
+    private ?Operation $patch = null;
+    private ?Operation $delete = null;
+    private ?Operation $head = null;
+    private ?Operation $options = null;
+    private ?Operation $trace = null;
+
+    public function __construct(OpenApiBuilderInterface $openApiBuilder)
+    {
+        $this->openApiBuilder = $openApiBuilder;
+    }
+
+    public function build(PathItem $toMergeWith = null): PathItem
+    {
+        return new PathItem(
+            ref: $this->ref ?: $toMergeWith?->getRef(),
+            summary: $this->summary ?: $toMergeWith?->getSummary(),
+            description: $this->description ?: $toMergeWith?->getDescription(),
+            get: $this->get ?: $toMergeWith?->getGet(),
+            put: $this->put ?: $toMergeWith?->getPut(),
+            post: $this->post ?: $toMergeWith?->getPost(),
+            patch: $this->patch ?: $toMergeWith?->getPatch(),
+            delete: $this->delete ?: $toMergeWith?->getDelete(),
+            head: $this->head ?: $toMergeWith?->getHead(),
+            options: $this->options ?: $toMergeWith?->getOptions(),
+            trace: $this->trace ?: $toMergeWith?->getTrace(),
+            servers: $this->servers ?: $toMergeWith?->getServers() ?: null,
+            parameters: array_merge($this->parameters, $this->queryParameters) ?: $toMergeWith?->getParameters() ?: null,
+            specificationExtensions: $this->specificationExtensions ?: $toMergeWith?->getSpecificationExtensions() ?: [],
+        );
+    }
+
+    public function ref(string $ref): static
+    {
+        $this->ref = $ref;
+
+        return $this;
+    }
+
+    public function get(OperationConfigurator $get): static
+    {
+        $this->get = $get->build();
+
+        return $this;
+    }
+
+    public function post(OperationConfigurator $post): static
+    {
+        $this->post = $post->build();
+
+        return $this;
+    }
+
+    public function put(OperationConfigurator $put): static
+    {
+        $this->put = $put->build();
+
+        return $this;
+    }
+
+    public function patch(OperationConfigurator $patch): static
+    {
+        $this->patch = $patch->build();
+
+        return $this;
+    }
+
+    public function delete(OperationConfigurator $delete): static
+    {
+        $this->delete = $delete->build();
+
+        return $this;
+    }
+
+    public function head(OperationConfigurator $head): static
+    {
+        $this->head = $head->build();
+
+        return $this;
+    }
+
+    public function options(OperationConfigurator $options): static
+    {
+        $this->options = $options->build();
+
+        return $this;
+    }
+
+    public function trace(OperationConfigurator $trace): static
+    {
+        $this->trace = $trace->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/QueryParameterConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/QueryParameterConfigurator.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\ParameterIn;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class QueryParameterConfigurator
+{
+    use Traits\ContentTrait;
+    use Traits\DeprecatedTrait;
+    use Traits\DescriptionTrait;
+    use Traits\ExamplesTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\NameTrait;
+    use Traits\SchemaTrait;
+
+    private ?bool $required = null;
+    private ?bool $allowEmptyValue = null;
+    private ?string $style = null;
+    private ?bool $explode = null;
+    private ?bool $allowReserved = null;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function build(): Parameter
+    {
+        return new Parameter(
+            $this->name,
+            ParameterIn::QUERY,
+            $this->description,
+            $this->required,
+            $this->deprecated,
+            $this->allowEmptyValue,
+            $this->style,
+            $this->explode,
+            $this->allowReserved,
+            $this->schema,
+            $this->example,
+            $this->examples,
+            $this->content ?: null,
+            $this->specificationExtensions,
+        );
+    }
+
+    public function required(bool $required): static
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    public function allowEmptyValue(bool $allowEmptyValue): static
+    {
+        $this->allowEmptyValue = $allowEmptyValue;
+
+        return $this;
+    }
+
+    public function style(string $style): static
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    public function explode(bool $explode): static
+    {
+        $this->explode = $explode;
+
+        return $this;
+    }
+
+    public function allowReserved(bool $allowReserved): static
+    {
+        $this->allowReserved = $allowReserved;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/QueryParametersConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/QueryParametersConfigurator.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Model\OpenApiTrait;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class QueryParametersConfigurator
+{
+    use OpenApiTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\QueryParametersTrait;
+
+    public function __construct(OpenApiBuilderInterface $openApiBuilder)
+    {
+        $this->openApiBuilder = $openApiBuilder;
+    }
+
+    public static function createFromDefinition(self|ReferenceConfigurator|string $definition, OpenApiBuilderInterface $openApiBuilder): self|ReferenceConfigurator
+    {
+        // Empty schema
+        if (!$definition) {
+            return new self($openApiBuilder);
+        }
+
+        // Direct configurator or reference
+        if ($definition instanceof self || $definition instanceof ReferenceConfigurator) {
+            return $definition;
+        }
+
+        // Parameter reference
+        if (!method_exists($definition, 'describeQueryParameters')) {
+            return new ReferenceConfigurator('#/components/parameters/'.ReferenceConfigurator::normalize($definition));
+        }
+
+        // Describe
+        $configurator = new self($openApiBuilder);
+        \call_user_func([$definition, 'describeQueryParameters'], $configurator, $openApiBuilder);
+
+        return $configurator;
+    }
+
+    public function getParameters(): array
+    {
+        return $this->queryParameters;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/ReferenceConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/ReferenceConfigurator.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Reference;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class ReferenceConfigurator
+{
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\SummaryTrait;
+
+    public function __construct(private readonly string $ref)
+    {
+    }
+
+    public static function normalize(?string $ref): ?string
+    {
+        if (!$ref) {
+            throw new \InvalidArgumentException('Missing reference name passed to '.__CLASS__.'::'.__METHOD__.'()');
+        }
+
+        return preg_replace('/[^a-zA-Z0-9\.\-\_]+/', '_', $ref);
+    }
+
+    public function build(): Reference
+    {
+        return new Reference(
+            $this->ref,
+            $this->summary,
+            $this->description,
+            $this->specificationExtensions,
+        );
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/RequestBodyConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/RequestBodyConfigurator.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\RequestBody;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class RequestBodyConfigurator
+{
+    use Traits\ContentTrait;
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+
+    private ?bool $required = null;
+
+    public function build(): RequestBody
+    {
+        return new RequestBody($this->content, $this->description, $this->required, $this->specificationExtensions);
+    }
+
+    public function required(bool $required): static
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/ResponseConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/ResponseConfigurator.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Response;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class ResponseConfigurator
+{
+    use Traits\ContentTrait;
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\HeadersTrait;
+    use Traits\LinksTrait;
+
+    public function build(): Response
+    {
+        return new Response(
+            $this->description ?: '',
+            $this->headers ?: null,
+            $this->content ?: null,
+            $this->links ?: null,
+            $this->specificationExtensions,
+        );
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/ResponsesConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/ResponsesConfigurator.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Reference;
+use Symfony\Component\OpenApi\Model\Response;
+use Symfony\Component\OpenApi\Model\Responses;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class ResponsesConfigurator
+{
+    use Traits\ExtensionsTrait;
+    use Traits\ResponsesTrait;
+
+    private Response|Reference|null $default = null;
+
+    public function build(): Responses
+    {
+        return new Responses($this->default, $this->responses ?: null, $this->specificationExtensions);
+    }
+
+    public function default(ResponseConfigurator|ReferenceConfigurator|string $response): static
+    {
+        if (\is_string($response)) {
+            $response = new ReferenceConfigurator('#/components/responses/'.ReferenceConfigurator::normalize($response));
+        }
+
+        $this->default = $response->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/SchemaConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/SchemaConfigurator.php
@@ -1,0 +1,453 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Discriminator;
+use Symfony\Component\OpenApi\Model\Reference;
+use Symfony\Component\OpenApi\Model\Schema;
+use Symfony\Component\OpenApi\Model\Xml;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class SchemaConfigurator
+{
+    use Traits\DeprecatedTrait;
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\ExternalDocsTrait;
+
+    private const PHP_TO_OPENAPI_TYPE = [
+        'null' => 'null',
+        'string' => 'string',
+        'number' => 'number',
+        'float' => 'number',
+        'double' => 'number',
+        'integer' => 'integer',
+        'int' => 'integer',
+        'boolean' => 'boolean',
+        'bool' => 'boolean',
+        'array' => 'array',
+        'object' => 'object',
+    ];
+
+    private ?string $title = null;
+    private ?int $multipleOf = null;
+    private ?int $maximum = null;
+    private ?bool $exclusiveMaximum = null;
+    private ?int $minimum = null;
+    private ?bool $exclusiveMinimum = null;
+    private ?int $maxLength = null;
+    private ?int $minLength = null;
+    private ?string $pattern = null;
+    private ?int $maxItems = null;
+    private ?int $minItems = null;
+    private ?bool $uniqueItems = null;
+    private ?int $maxProperties = null;
+    private ?int $minProperties = null;
+    private ?array $required = null;
+    private ?array $enum = null;
+    private ?array $type = null;
+    private Schema|Reference|null $not = null;
+    private Schema|Reference|null $items = null;
+    private ?string $format = null;
+    private mixed $default = null;
+    private ?bool $readOnly = null;
+    private ?bool $writeOnly = null;
+    private mixed $example = null;
+    private ?Discriminator $discriminator = null;
+    private ?Xml $xml = null;
+    private Schema|Reference|false|null $additionalProperties = null;
+
+    /**
+     * @var array<string, Schema|Reference>|null
+     */
+    private ?array $properties = null;
+
+    /**
+     * @var array<Schema|Reference>|null
+     */
+    private ?array $allOf = null;
+
+    /**
+     * @var array<Schema|Reference>|null
+     */
+    private ?array $oneOf = null;
+
+    /**
+     * @var array<Schema|Reference>|null
+     */
+    private ?array $anyOf = null;
+
+    public static function createFromDefinition(self|ReferenceConfigurator|string|array $definition = null): self|ReferenceConfigurator
+    {
+        // Empty schema
+        if (!$definition) {
+            return new self();
+        }
+
+        // Direct schema or reference
+        if ($definition instanceof self || $definition instanceof ReferenceConfigurator) {
+            return $definition;
+        }
+
+        // Array: types list
+        if (\is_array($definition)) {
+            return (new self())->type($definition);
+        }
+
+        $typeDefinition = '?' === $definition[0] ? mb_substr($definition, 1) : $definition;
+
+        // Native type
+        if (isset(self::PHP_TO_OPENAPI_TYPE[$typeDefinition])) {
+            return (new self())->type($definition);
+        }
+
+        // Schema reference
+        $reference = new ReferenceConfigurator('#/components/schemas/'.ReferenceConfigurator::normalize($typeDefinition));
+
+        return '?' === $definition[0] ? (new self())->oneOf([$reference, 'null']) : $reference;
+    }
+
+    public function build(): Schema
+    {
+        return new Schema(
+            title: $this->title,
+            multipleOf: $this->multipleOf,
+            maximum: $this->maximum,
+            exclusiveMaximum: $this->exclusiveMaximum,
+            minimum: $this->minimum,
+            exclusiveMinimum: $this->exclusiveMinimum,
+            maxLength: $this->maxLength,
+            minLength: $this->minLength,
+            pattern: $this->pattern,
+            maxItems: $this->maxItems,
+            minItems: $this->minItems,
+            uniqueItems: $this->uniqueItems,
+            maxProperties: $this->maxProperties,
+            minProperties: $this->minProperties,
+            required: $this->required,
+            enum: $this->enum,
+            type: $this->type,
+            allOf: $this->allOf,
+            oneOf: $this->oneOf,
+            anyOf: $this->anyOf,
+            not: $this->not,
+            items: $this->items,
+            properties: $this->properties,
+            description: $this->description,
+            format: $this->format,
+            default: $this->default,
+            readOnly: $this->readOnly,
+            writeOnly: $this->writeOnly,
+            example: $this->example,
+            deprecated: $this->deprecated,
+            discriminator: $this->discriminator,
+            xml: $this->xml,
+            externalDocs: $this->externalDocs,
+            additionalProperties: $this->additionalProperties,
+            specificationExtensions: $this->specificationExtensions,
+        );
+    }
+
+    public function property(string $name, self|ReferenceConfigurator|string $definition): static
+    {
+        $this->properties[$name] = self::createFromDefinition($definition)->build();
+
+        return $this;
+    }
+
+    public function title(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function multipleOf(int $multipleOf): static
+    {
+        $this->multipleOf = $multipleOf;
+
+        return $this;
+    }
+
+    public function maximum(int $maximum): static
+    {
+        $this->maximum = $maximum;
+
+        return $this;
+    }
+
+    public function exclusiveMaximum(bool $exclusiveMaximum): static
+    {
+        $this->exclusiveMaximum = $exclusiveMaximum;
+
+        return $this;
+    }
+
+    public function minimum(int $minimum): static
+    {
+        $this->minimum = $minimum;
+
+        return $this;
+    }
+
+    public function exclusiveMinimum(bool $exclusiveMinimum): static
+    {
+        $this->exclusiveMinimum = $exclusiveMinimum;
+
+        return $this;
+    }
+
+    public function maxLength(int $maxLength): static
+    {
+        $this->maxLength = $maxLength;
+
+        return $this;
+    }
+
+    public function minLength(int $minLength): static
+    {
+        $this->minLength = $minLength;
+
+        return $this;
+    }
+
+    public function pattern(string $pattern): static
+    {
+        $this->pattern = $pattern;
+
+        return $this;
+    }
+
+    public function maxItems(int $maxItems): static
+    {
+        $this->maxItems = $maxItems;
+
+        return $this;
+    }
+
+    public function minItems(int $minItems): static
+    {
+        $this->minItems = $minItems;
+
+        return $this;
+    }
+
+    public function uniqueItems(bool $uniqueItems): static
+    {
+        $this->uniqueItems = $uniqueItems;
+
+        return $this;
+    }
+
+    public function maxProperties(int $maxProperties): static
+    {
+        $this->maxProperties = $maxProperties;
+
+        return $this;
+    }
+
+    public function minProperties(int $minProperties): static
+    {
+        $this->minProperties = $minProperties;
+
+        return $this;
+    }
+
+    public function required(array $required): static
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * @template T of \UnitEnum
+     *
+     * @param array|class-string<T> $enum
+     *
+     * @return $this
+     */
+    public function enum(array|string $enum): static
+    {
+        if (\is_string($enum)) {
+            if (!enum_exists($enum)) {
+                throw new \InvalidArgumentException('Parameter #1 $enum of method '.__CLASS__.'::'.__METHOD__.' expects an array or an enum, string given.');
+            }
+
+            $enum = $enum::cases();
+        }
+
+        $this->enum = $enum;
+
+        return $this;
+    }
+
+    public function type(array|string $typeDefinitions): static
+    {
+        // Only
+        if (\is_string($typeDefinitions)) {
+            if ('?' === $typeDefinitions[0]) {
+                $typeDefinitions = array_unique([mb_substr($typeDefinitions, 1), 'null']);
+            } else {
+                $typeDefinitions = [$typeDefinitions];
+            }
+        }
+
+        $types = [];
+        foreach ($typeDefinitions as $definition) {
+            $definition = mb_strtolower($definition);
+
+            if (!isset(self::PHP_TO_OPENAPI_TYPE[$definition])) {
+                throw new \InvalidArgumentException('Type '.$definition.' is not a valid OpenApi type.');
+            }
+
+            $types[] = self::PHP_TO_OPENAPI_TYPE[$definition];
+        }
+
+        $this->type = $types;
+
+        return $this;
+    }
+
+    /**
+     * @param array<SchemaConfigurator|ReferenceConfigurator|string> $allOf
+     */
+    public function allOf(array $allOf): static
+    {
+        $this->allOf = [];
+        foreach ($allOf as $definition) {
+            $this->allOf[] = self::createFromDefinition($definition)->build();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array<SchemaConfigurator|ReferenceConfigurator|string> $oneOf
+     */
+    public function oneOf(array $oneOf): static
+    {
+        $this->oneOf = [];
+        foreach ($oneOf as $definition) {
+            $this->oneOf[] = self::createFromDefinition($definition)->build();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array<SchemaConfigurator|ReferenceConfigurator|string> $anyOf
+     */
+    public function anyOf(array $anyOf): static
+    {
+        $this->anyOf = [];
+        foreach ($anyOf as $definition) {
+            $this->anyOf[] = self::createFromDefinition($definition)->build();
+        }
+
+        return $this;
+    }
+
+    public function not(self|ReferenceConfigurator|string $not): static
+    {
+        $this->not = self::createFromDefinition($not)->build();
+
+        return $this;
+    }
+
+    public function items(self|ReferenceConfigurator|string $items): static
+    {
+        $this->items = self::createFromDefinition($items)->build();
+
+        return $this;
+    }
+
+    public function format(string $format): static
+    {
+        $this->format = $format;
+
+        return $this;
+    }
+
+    public function default(mixed $default): static
+    {
+        $this->default = $default;
+
+        return $this;
+    }
+
+    public function nullable(bool $nullable): static
+    {
+        if ($nullable) {
+            $this->type = array_unique(array_merge($this->type ?: [], ['null']));
+        } else {
+            $this->type = array_filter($this->type ?: [], static fn (string $t) => 'null' !== $t);
+        }
+
+        return $this;
+    }
+
+    public function readOnly(bool $readOnly): static
+    {
+        $this->readOnly = $readOnly;
+
+        return $this;
+    }
+
+    public function writeOnly(bool $writeOnly): static
+    {
+        $this->writeOnly = $writeOnly;
+
+        return $this;
+    }
+
+    public function example(mixed $example): static
+    {
+        $this->example = $example;
+
+        return $this;
+    }
+
+    public function discriminator(string $propertyName, array $mapping = null, array $specificationExtensions = []): static
+    {
+        $this->discriminator = new Discriminator($propertyName, $mapping, $specificationExtensions);
+
+        return $this;
+    }
+
+    public function xml(
+        string $name = null,
+        string $namespace = null,
+        string $prefix = null,
+        bool $attribute = null,
+        bool $wrapped = null,
+        array $specificationExtensions = [],
+    ): static {
+        $this->xml = new Xml($name, $namespace, $prefix, $attribute, $wrapped, $specificationExtensions);
+
+        return $this;
+    }
+
+    public function additionalProperties(self|ReferenceConfigurator|string|false $additionalProperties): static
+    {
+        if (false === $additionalProperties) {
+            $this->additionalProperties = false;
+        } else {
+            $this->additionalProperties = self::createFromDefinition($additionalProperties)->build();
+        }
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/SecuritySchemeConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/SecuritySchemeConfigurator.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\OauthFlows;
+use Symfony\Component\OpenApi\Model\SecurityScheme;
+use Symfony\Component\OpenApi\Model\SecuritySchemeIn;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class SecuritySchemeConfigurator
+{
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\NameTrait;
+
+    private string $type = '';
+    private ?SecuritySchemeIn $in = null;
+    private ?string $scheme = null;
+    private ?string $bearerFormat = null;
+    private ?string $openIdConnectUrl = null;
+    private ?OauthFlows $flows = null;
+
+    public function build(): SecurityScheme
+    {
+        return new SecurityScheme(
+            type: $this->type,
+            name: $this->name,
+            in: $this->in,
+            scheme: $this->scheme,
+            description: $this->description,
+            bearerFormat: $this->bearerFormat,
+            openIdConnectUrl: $this->openIdConnectUrl,
+            flows: $this->flows,
+            specificationExtensions: $this->specificationExtensions,
+        );
+    }
+
+    public function type(string $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function in(SecuritySchemeIn $in): static
+    {
+        $this->in = $in;
+
+        return $this;
+    }
+
+    public function scheme(string $scheme): static
+    {
+        $this->scheme = $scheme;
+
+        return $this;
+    }
+
+    public function bearerFormat(string $bearerFormat): static
+    {
+        $this->bearerFormat = $bearerFormat;
+
+        return $this;
+    }
+
+    public function openIdConnectUrl(string $openIdConnectUrl): static
+    {
+        $this->openIdConnectUrl = $openIdConnectUrl;
+
+        return $this;
+    }
+
+    public function flows(OauthFlows $flows): static
+    {
+        $this->flows = $flows;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/ServerConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/ServerConfigurator.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Server;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class ServerConfigurator
+{
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\ServerVariablesTrait;
+
+    public function __construct(private readonly string $url)
+    {
+    }
+
+    public function build(): Server
+    {
+        return new Server($this->url, $this->description, $this->variables ?: null, $this->specificationExtensions);
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/TagConfigurator.php
+++ b/src/Symfony/Component/OpenApi/Configurator/TagConfigurator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator;
+
+use Symfony\Component\OpenApi\Model\Tag;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class TagConfigurator
+{
+    use Traits\DescriptionTrait;
+    use Traits\ExtensionsTrait;
+    use Traits\ExternalDocsTrait;
+    use Traits\NameTrait;
+
+    public function build(): Tag
+    {
+        return new Tag($this->name ?: '', $this->description, $this->externalDocs, $this->specificationExtensions);
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/ContentTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/ContentTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Configurator\MediaTypeConfigurator;
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Model\MediaType;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait ContentTrait
+{
+    /**
+     * @var array<string, MediaType>
+     */
+    private array $content = [];
+
+    public function content(string $contentType, MediaTypeConfigurator|SchemaConfigurator|ReferenceConfigurator|string $mediaType): static
+    {
+        if (!$mediaType instanceof MediaTypeConfigurator) {
+            $mediaType = (new MediaTypeConfigurator())->schema($mediaType);
+        }
+
+        $this->content[$contentType] = $mediaType->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/DeprecatedTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/DeprecatedTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait DeprecatedTrait
+{
+    private ?bool $deprecated = null;
+
+    public function deprecated(bool $deprecated): static
+    {
+        $this->deprecated = $deprecated;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/DescriptionTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/DescriptionTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait DescriptionTrait
+{
+    private ?string $description = null;
+
+    public function description(string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/ExamplesTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/ExamplesTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Configurator\ExampleConfigurator;
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Model\Example;
+use Symfony\Component\OpenApi\Model\Reference;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait ExamplesTrait
+{
+    private mixed $example = null;
+
+    /**
+     * @var array<string, Example|Reference>|null
+     */
+    private ?array $examples = null;
+
+    public function example(mixed $name, ExampleConfigurator|ReferenceConfigurator $example = null): static
+    {
+        if ($example) {
+            $this->examples[$name] = $example->build();
+        } else {
+            $this->example = $name;
+        }
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/ExtensionsTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/ExtensionsTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait ExtensionsTrait
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $specificationExtensions = [];
+
+    public function specificationExtension(string $name, mixed $value): static
+    {
+        $this->specificationExtensions[$name] = $value;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/ExternalDocsTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/ExternalDocsTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Model\ExternalDocumentation;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait ExternalDocsTrait
+{
+    private ?ExternalDocumentation $externalDocs = null;
+
+    public function externalDocs(string $url, string $description = null, array $specificationExtensions = []): static
+    {
+        $this->externalDocs = new ExternalDocumentation($url, $description, $specificationExtensions);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/HeadersTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/HeadersTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Configurator\ParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\Reference;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait HeadersTrait
+{
+    /**
+     * @var array<string, Parameter|Reference>
+     */
+    private array $headers = [];
+
+    public function header(string $name, ParameterConfigurator|ReferenceConfigurator|string $header): static
+    {
+        if (\is_string($header)) {
+            $header = new ReferenceConfigurator('#/components/headers/'.ReferenceConfigurator::normalize($header));
+        }
+
+        if ($header instanceof ReferenceConfigurator) {
+            $this->headers[$name] = $header->build();
+
+            return $this;
+        }
+
+        $this->headers[$name] = $header->build(asHeader: true);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/LinksTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/LinksTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Configurator\LinkConfigurator;
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Model\Link;
+use Symfony\Component\OpenApi\Model\Reference;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait LinksTrait
+{
+    /**
+     * @var array<string, Link|Reference>
+     */
+    private array $links = [];
+
+    public function link(string $name, LinkConfigurator|ReferenceConfigurator|string $link): static
+    {
+        if (\is_string($link)) {
+            $link = new ReferenceConfigurator('#/components/links/'.ReferenceConfigurator::normalize($link));
+        }
+
+        $this->links[$name] = $link->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/NameTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/NameTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait NameTrait
+{
+    private ?string $name = null;
+
+    public function name(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/ParametersTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/ParametersTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Configurator\ParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\Reference;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait ParametersTrait
+{
+    /**
+     * @var array<Parameter|Reference>
+     */
+    private array $parameters = [];
+
+    public function parameter(ParameterConfigurator|ReferenceConfigurator|string $parameter): static
+    {
+        if (\is_string($parameter)) {
+            $parameter = new ReferenceConfigurator('#/components/parameters/'.ReferenceConfigurator::normalize($parameter));
+        }
+
+        $this->parameters[] = $parameter->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/QueryParametersTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/QueryParametersTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Configurator\QueryParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\QueryParametersConfigurator;
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\Reference;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait QueryParametersTrait
+{
+    /**
+     * @var array<Parameter|Reference>
+     */
+    private array $queryParameters = [];
+    private ?OpenApiBuilderInterface $openApiBuilder = null;
+
+    public function queryParameter(QueryParameterConfigurator|ReferenceConfigurator|string $parameter): static
+    {
+        if (\is_string($parameter)) {
+            $parameter = new ReferenceConfigurator('#/components/parameters/'.ReferenceConfigurator::normalize($parameter));
+        }
+
+        $this->queryParameters[] = $parameter->build();
+
+        return $this;
+    }
+
+    public function queryParameters(QueryParametersConfigurator|string $parameters): static
+    {
+        $configurator = QueryParametersConfigurator::createFromDefinition($parameters, $this->openApiBuilder);
+
+        if ($configurator instanceof ReferenceConfigurator) {
+            $this->queryParameters[] = $configurator->build();
+
+            return $this;
+        }
+
+        $this->queryParameters = array_merge($this->queryParameters, $configurator->getParameters());
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/ResponsesTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/ResponsesTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Configurator\ResponseConfigurator;
+use Symfony\Component\OpenApi\Model\Reference;
+use Symfony\Component\OpenApi\Model\Response;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait ResponsesTrait
+{
+    /**
+     * @var array<string, Response|Reference>
+     */
+    private array $responses = [];
+
+    public function response(string $name, ResponseConfigurator|ReferenceConfigurator|string $response): static
+    {
+        if (\is_string($response)) {
+            $response = new ReferenceConfigurator('#/components/responses/'.ReferenceConfigurator::normalize($response));
+        }
+
+        $this->responses[$name] = $response->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/SchemaTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/SchemaTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Model\Reference;
+use Symfony\Component\OpenApi\Model\Schema;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait SchemaTrait
+{
+    private Schema|Reference|null $schema = null;
+
+    public function schema(SchemaConfigurator|ReferenceConfigurator|string $schema): static
+    {
+        $this->schema = SchemaConfigurator::createFromDefinition($schema)->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/ServerVariablesTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/ServerVariablesTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Model\ServerVariable;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait ServerVariablesTrait
+{
+    /**
+     * @var array<string, ServerVariable>
+     */
+    private array $variables = [];
+
+    public function variable(string $name, string $default, string $description = null, array $enum = null, array $specificationExtensions = []): static
+    {
+        $this->variables[$name] = new ServerVariable($default, $description, $enum, $specificationExtensions);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/ServersTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/ServersTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+use Symfony\Component\OpenApi\Configurator\ServerConfigurator;
+use Symfony\Component\OpenApi\Model\Server;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait ServersTrait
+{
+    /**
+     * @var Server[]
+     */
+    private array $servers = [];
+
+    public function server(ServerConfigurator|string $server): static
+    {
+        $this->servers[] = \is_string($server) ? (new ServerConfigurator($server))->build() : $server->build();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Configurator/Traits/SummaryTrait.php
+++ b/src/Symfony/Component/OpenApi/Configurator/Traits/SummaryTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Configurator\Traits;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait SummaryTrait
+{
+    private ?string $summary = null;
+
+    public function summary(string $summary): static
+    {
+        $this->summary = $summary;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Documentation/AbstractDocumentation.php
+++ b/src/Symfony/Component/OpenApi/Documentation/AbstractDocumentation.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Documentation;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilder;
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Configurator\DocumentationConfigurator;
+use Symfony\Component\OpenApi\Loader\ComponentsLoaderInterface;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+abstract class AbstractDocumentation implements DocumentationInterface
+{
+    protected function getOpenApiBuilder(): OpenApiBuilderInterface
+    {
+        return new OpenApiBuilder();
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'api';
+    }
+
+    public function getVersion(): string
+    {
+        return '1.0.0';
+    }
+
+    public function loadComponents(DocumentationConfigurator $doc, ComponentsLoaderInterface $loader): void
+    {
+        $doc->components($loader->load($this->getOpenApiBuilder()));
+    }
+}

--- a/src/Symfony/Component/OpenApi/Documentation/DocumentationInterface.php
+++ b/src/Symfony/Component/OpenApi/Documentation/DocumentationInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Documentation;
+
+use Symfony\Component\OpenApi\Configurator\DocumentationConfigurator;
+use Symfony\Component\OpenApi\Loader\ComponentsLoaderInterface;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+interface DocumentationInterface
+{
+    public function getIdentifier(): string;
+
+    public function getVersion(): string;
+
+    public function configure(DocumentationConfigurator $doc): void;
+
+    public function loadComponents(DocumentationConfigurator $doc, ComponentsLoaderInterface $loader): void;
+}

--- a/src/Symfony/Component/OpenApi/Documentation/PartialDocumentationInterface.php
+++ b/src/Symfony/Component/OpenApi/Documentation/PartialDocumentationInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Documentation;
+
+use Symfony\Component\OpenApi\Configurator\DocumentationConfigurator;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+interface PartialDocumentationInterface
+{
+    public function configure(DocumentationConfigurator $doc): void;
+}

--- a/src/Symfony/Component/OpenApi/Dumper/DumperInterface.php
+++ b/src/Symfony/Component/OpenApi/Dumper/DumperInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Dumper;
+
+use Symfony\Component\OpenApi\Model\OpenApi;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+interface DumperInterface
+{
+    public function dump(OpenApi $compiledDoc): string;
+}

--- a/src/Symfony/Component/OpenApi/Dumper/JsonDumper.php
+++ b/src/Symfony/Component/OpenApi/Dumper/JsonDumper.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Dumper;
+
+use Symfony\Component\OpenApi\Model\OpenApi;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class JsonDumper implements DumperInterface
+{
+    public function __construct(private int $flags = \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR)
+    {
+    }
+
+    public function dump(OpenApi $compiledDoc): string
+    {
+        $json = json_encode($compiledDoc->toArray(), $this->flags);
+
+        // Marker to allow no security
+        return str_replace('"__NO_SECURITY": []', '', $json);
+    }
+}

--- a/src/Symfony/Component/OpenApi/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/OpenApi/Dumper/YamlDumper.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Dumper;
+
+use Symfony\Component\OpenApi\Model\OpenApi;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class YamlDumper implements DumperInterface
+{
+    public function __construct(
+        private int $inline = 10,
+        private int $indent = 4,
+        private int $flags = Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE,
+    ) {
+    }
+
+    public function dump(OpenApi $compiledDoc): string
+    {
+        $yaml = Yaml::dump($compiledDoc->toArray(), $this->inline, $this->indent, $this->flags);
+
+        // Marker to allow no security
+        return str_replace('__NO_SECURITY: []', '{}', $yaml);
+    }
+}

--- a/src/Symfony/Component/OpenApi/LICENSE
+++ b/src/Symfony/Component/OpenApi/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2023-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/OpenApi/Loader/ComponentsLoaderInterface.php
+++ b/src/Symfony/Component/OpenApi/Loader/ComponentsLoaderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Loader;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Configurator\ComponentsConfigurator;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+interface ComponentsLoaderInterface
+{
+    public function load(OpenApiBuilderInterface $openApi): ComponentsConfigurator;
+}

--- a/src/Symfony/Component/OpenApi/Loader/SelfDescribingQueryParametersInterface.php
+++ b/src/Symfony/Component/OpenApi/Loader/SelfDescribingQueryParametersInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Loader;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Configurator\QueryParametersConfigurator;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+interface SelfDescribingQueryParametersInterface
+{
+    public static function describeQueryParameters(QueryParametersConfigurator $queryParams, OpenApiBuilderInterface $openApi): void;
+}

--- a/src/Symfony/Component/OpenApi/Loader/SelfDescribingSchemaInterface.php
+++ b/src/Symfony/Component/OpenApi/Loader/SelfDescribingSchemaInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Loader;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+interface SelfDescribingSchemaInterface
+{
+    public static function describeSchema(SchemaConfigurator $schema, OpenApiBuilderInterface $openApi): void;
+}

--- a/src/Symfony/Component/OpenApi/Loader/SelfDescribingSchemaLoader.php
+++ b/src/Symfony/Component/OpenApi/Loader/SelfDescribingSchemaLoader.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Loader;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Configurator\ComponentsConfigurator;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class SelfDescribingSchemaLoader implements ComponentsLoaderInterface
+{
+    /**
+     * @param iterable<class-string<SelfDescribingSchemaInterface>> $selfDescribingSchemas
+     */
+    public function __construct(private iterable $selfDescribingSchemas = [])
+    {
+    }
+
+    public function load(OpenApiBuilderInterface $openApi): ComponentsConfigurator
+    {
+        $components = $openApi->components();
+
+        foreach ($this->selfDescribingSchemas as $selfDescribingSchema) {
+            $configurator = $openApi->schema()->type('object');
+            \call_user_func([$selfDescribingSchema, 'describeSchema'], $configurator, $openApi);
+
+            $components->schema($selfDescribingSchema, $configurator);
+        }
+
+        return $components;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/CallbackRequest.php
+++ b/src/Symfony/Component/OpenApi/Model/CallbackRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class CallbackRequest
+{
+    public function __construct(
+        private readonly string $expression,
+        private readonly PathItem|Reference|null $definition,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    public function getDefinition(): Reference|PathItem|null
+    {
+        return $this->definition;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'expression' => $this->getExpression(),
+            'definition' => $this->getDefinition()?->toArray(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Components.php
+++ b/src/Symfony/Component/OpenApi/Model/Components.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Components implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, Schema|Reference>|null          $schemas
+     * @param array<string, Response|Reference>|null        $responses
+     * @param array<string, Parameter|Reference>|null       $parameters
+     * @param array<string, Example|Reference>|null         $examples
+     * @param array<string, RequestBody|Reference>|null     $requestBodies
+     * @param array<string, SecurityScheme|Reference>|null  $securitySchemes
+     * @param array<string, Link|Reference>|null            $links
+     * @param array<string, CallbackRequest|Reference>|null $callbacks
+     * @param array<string, PathItem|Reference>|null        $pathItems
+     */
+    public function __construct(
+        private readonly ?array $schemas = null,
+        private readonly ?array $responses = null,
+        private readonly ?array $parameters = null,
+        private readonly ?array $examples = null,
+        private readonly ?array $requestBodies = null,
+        private readonly ?array $securitySchemes = null,
+        private readonly ?array $links = null,
+        private readonly ?array $callbacks = null,
+        private readonly ?array $pathItems = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, Schema|Reference>|null
+     */
+    public function getSchemas(): ?array
+    {
+        return $this->schemas;
+    }
+
+    /**
+     * @return array<string, Response|Reference>|null
+     */
+    public function getResponses(): ?array
+    {
+        return $this->responses;
+    }
+
+    /**
+     * @return array<string, Parameter|Reference>|null
+     */
+    public function getParameters(): ?array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @return array<string, Example|Reference>|null
+     */
+    public function getExamples(): ?array
+    {
+        return $this->examples;
+    }
+
+    /**
+     * @return array<string, RequestBody|Reference>|null
+     */
+    public function getRequestBodies(): ?array
+    {
+        return $this->requestBodies;
+    }
+
+    /**
+     * @return array<string, SecurityScheme|Reference>|null
+     */
+    public function getSecuritySchemes(): ?array
+    {
+        return $this->securitySchemes;
+    }
+
+    /**
+     * @return array<string, Link|Reference>|null
+     */
+    public function getLinks(): ?array
+    {
+        return $this->links;
+    }
+
+    /**
+     * @return array<string, CallbackRequest|Reference>|null
+     */
+    public function getCallbacks(): ?array
+    {
+        return $this->callbacks;
+    }
+
+    /**
+     * @return array<string, PathItem|Reference>|null
+     */
+    public function getPathItems(): ?array
+    {
+        return $this->pathItems;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'schemas' => $this->normalizeCollection($this->getSchemas()),
+            'responses' => $this->normalizeCollection($this->getResponses()),
+            'parameters' => $this->normalizeCollection($this->getParameters()),
+            'examples' => $this->normalizeCollection($this->getExamples()),
+            'requestBodies' => $this->normalizeCollection($this->getRequestBodies()),
+            'securitySchemes' => $this->normalizeCollection($this->getSecuritySchemes()),
+            'links' => $this->normalizeCollection($this->getLinks()),
+            'callbacks' => $this->normalizeCollection($this->getCallbacks()),
+            'pathItems' => $this->normalizeCollection($this->getPathItems()), // ??
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Contact.php
+++ b/src/Symfony/Component/OpenApi/Model/Contact.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Contact implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly ?string $name = null,
+        private readonly ?string $url = null,
+        private readonly ?string $email = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->getName(),
+            'email' => $this->getEmail(),
+            'url' => $this->getUrl(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Discriminator.php
+++ b/src/Symfony/Component/OpenApi/Model/Discriminator.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Discriminator implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, string>|null $mapping
+     */
+    public function __construct(
+        private readonly string $propertyName,
+        private readonly ?array $mapping = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getPropertyName(): string
+    {
+        return $this->propertyName;
+    }
+
+    public function getMapping(): ?array
+    {
+        return $this->mapping;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'propertyName' => $this->getPropertyName(),
+            'mapping' => $this->normalizeCollection($this->getMapping()),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Encoding.php
+++ b/src/Symfony/Component/OpenApi/Model/Encoding.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Encoding implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, Parameter|Reference>|null $headers
+     */
+    public function __construct(
+        private readonly ?string $contentType = null,
+        private readonly ?array $headers = null,
+        private readonly ?string $style = null,
+        private readonly ?bool $explode = null,
+        private readonly ?bool $allowReserved = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getContentType(): ?string
+    {
+        return $this->contentType;
+    }
+
+    /**
+     * @return array<string, Parameter|Reference>|null
+     */
+    public function getHeaders(): ?array
+    {
+        return $this->headers;
+    }
+
+    public function getStyle(): ?string
+    {
+        return $this->style;
+    }
+
+    public function isExplode(): ?bool
+    {
+        return $this->explode;
+    }
+
+    public function allowReserved(): ?bool
+    {
+        return $this->allowReserved;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'contentType' => $this->getContentType(),
+            'headers' => $this->normalizeCollection($this->getHeaders()),
+            'style' => $this->getStyle(),
+            'explode' => $this->isExplode(),
+            'allowReserved' => $this->allowReserved(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Example.php
+++ b/src/Symfony/Component/OpenApi/Model/Example.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Example implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly ?string $summary = null,
+        private readonly ?string $description = null,
+        private readonly mixed $value = null,
+        private readonly ?string $externalValue = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function getExternalValue(): ?string
+    {
+        return $this->externalValue;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'summary' => $this->getSummary(),
+            'description' => $this->getDescription(),
+            'value' => $this->normalizeCollection($this->getValue()),
+            'externalValue' => $this->getExternalValue(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/ExternalDocumentation.php
+++ b/src/Symfony/Component/OpenApi/Model/ExternalDocumentation.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class ExternalDocumentation implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly string $url,
+        private readonly ?string $description = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'description' => $this->getDescription(),
+            'url' => $this->getUrl(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Info.php
+++ b/src/Symfony/Component/OpenApi/Model/Info.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Info implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly string $title,
+        private readonly string $version,
+        private readonly ?string $summary = null,
+        private readonly ?string $description = null,
+        private readonly ?string $termsOfService = null,
+        private readonly ?Contact $contact = null,
+        private readonly ?License $license = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getTermsOfService(): ?string
+    {
+        return $this->termsOfService;
+    }
+
+    public function getContact(): ?Contact
+    {
+        return $this->contact;
+    }
+
+    public function getLicense(): ?License
+    {
+        return $this->license;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'title' => $this->getTitle(),
+            'description' => $this->getDescription(),
+            'termsOfService' => $this->getTermsOfService(),
+            'contact' => $this->getContact()?->toArray(),
+            'license' => $this->getLicense()?->toArray(),
+            'version' => $this->getVersion(),
+            'summary' => $this->getSummary(), // ??
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/License.php
+++ b/src/Symfony/Component/OpenApi/Model/License.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class License implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly string $name,
+        private readonly ?string $identifier = null,
+        private readonly ?string $url = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getIdentifier(): ?string
+    {
+        return $this->identifier;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->getName(),
+            'url' => $this->getUrl(),
+            'identifier' => $this->getIdentifier(), // ??
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Link.php
+++ b/src/Symfony/Component/OpenApi/Model/Link.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Link implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly ?string $operationRef = null,
+        private readonly ?string $operationId = null,
+        private readonly ?array $parameters = null,
+        private readonly mixed $requestBody = null,
+        private readonly ?string $description = null,
+        private readonly ?Server $server = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getOperationRef(): ?string
+    {
+        return $this->operationRef;
+    }
+
+    public function getOperationId(): ?string
+    {
+        return $this->operationId;
+    }
+
+    public function getParameters(): ?array
+    {
+        return $this->parameters;
+    }
+
+    public function getRequestBody(): mixed
+    {
+        return $this->requestBody;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getServer(): ?Server
+    {
+        return $this->server;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'operationRef' => $this->getOperationRef(),
+            'operationId' => $this->getOperationId(),
+            'parameters' => $this->normalizeCollection($this->getParameters()),
+            'requestBody' => $this->getRequestBody(),
+            'description' => $this->getDescription(),
+            'server' => $this->getServer()?->toArray(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/MediaType.php
+++ b/src/Symfony/Component/OpenApi/Model/MediaType.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class MediaType implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, Example|Reference>|null $examples
+     * @param array<string, Encoding>|null          $encodings
+     */
+    public function __construct(
+        private readonly Schema|Reference|null $schema = null,
+        private readonly mixed $example = null,
+        private readonly ?array $examples = null,
+        private readonly ?array $encodings = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getSchema(): Schema|Reference|null
+    {
+        return $this->schema;
+    }
+
+    public function getExample(): mixed
+    {
+        return $this->example;
+    }
+
+    /**
+     * @return array<string, Example|Reference>|null
+     */
+    public function getExamples(): ?array
+    {
+        return $this->examples;
+    }
+
+    /**
+     * @return array<string, Encoding>|null
+     */
+    public function getEncodings(): ?array
+    {
+        return $this->encodings;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'schema' => $this->getSchema()?->toArray(),
+            'example' => $this->getExample(),
+            'examples' => $this->normalizeCollection($this->getExamples()),
+            'encoding' => $this->normalizeCollection($this->getEncodings()),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/OauthFlow.php
+++ b/src/Symfony/Component/OpenApi/Model/OauthFlow.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class OauthFlow implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, string> $scopes
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        private readonly string $authorizationUrl,
+
+        #[Assert\NotBlank]
+        private readonly string $tokenUrl,
+
+        #[Assert\NotBlank]
+        #[Assert\All([new Assert\Type('string')])]
+        private readonly array $scopes = [],
+
+        private readonly ?string $refreshUrl = null,
+
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getAuthorizationUrl(): string
+    {
+        return $this->authorizationUrl;
+    }
+
+    public function getTokenUrl(): string
+    {
+        return $this->tokenUrl;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getScopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function getRefreshUrl(): ?string
+    {
+        return $this->refreshUrl;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'authorizationUrl' => $this->getAuthorizationUrl(),
+            'tokenUrl' => $this->getTokenUrl(),
+            'refreshUrl' => $this->getRefreshUrl(),
+            'scopes' => $this->normalizeCollection($this->getScopes()),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/OauthFlows.php
+++ b/src/Symfony/Component/OpenApi/Model/OauthFlows.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class OauthFlows implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        #[Assert\Valid]
+        private readonly ?OauthFlow $implicit = null,
+
+        #[Assert\Valid]
+        private readonly ?OauthFlow $password = null,
+
+        #[Assert\Valid]
+        private readonly ?OauthFlow $clientCredentials = null,
+
+        #[Assert\Valid]
+        private readonly ?OauthFlow $authorizationCode = null,
+
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getImplicit(): ?OauthFlow
+    {
+        return $this->implicit;
+    }
+
+    public function getPassword(): ?OauthFlow
+    {
+        return $this->password;
+    }
+
+    public function getClientCredentials(): ?OauthFlow
+    {
+        return $this->clientCredentials;
+    }
+
+    public function getAuthorizationCode(): ?OauthFlow
+    {
+        return $this->authorizationCode;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'implicit' => $this->getImplicit()?->toArray(),
+            'password' => $this->getPassword()?->toArray(),
+            'clientCredentials' => $this->getClientCredentials()?->toArray(),
+            'authorizationCode' => $this->getAuthorizationCode()?->toArray(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/OpenApi.php
+++ b/src/Symfony/Component/OpenApi/Model/OpenApi.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+use Symfony\Component\OpenApi\Configurator\InfoConfigurator;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class OpenApi implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param Server[]|null                          $servers
+     * @param array<string, PathItem|Reference>|null $paths
+     * @param array<string, PathItem|Reference>|null $webhooks
+     * @param SecurityRequirement[]|null             $security
+     * @param Tag[]|null                             $tags
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Choice(['3.1.0'])]
+        private readonly string $version,
+
+        #[Assert\Valid]
+        private readonly Info $info,
+
+        #[Assert\All([new Assert\Type(Server::class), new Assert\Valid()])]
+        private readonly ?array $servers = null,
+
+        #[Assert\All([new Assert\Type([PathItem::class, Reference::class]), new Assert\Valid()])]
+        private readonly ?array $paths = null,
+
+        #[Assert\All([new Assert\Type([PathItem::class, Reference::class]), new Assert\Valid()])]
+        private readonly ?array $webhooks = null,
+
+        #[Assert\Valid]
+        private readonly ?Components $components = null,
+
+        #[Assert\All([new Assert\Type(SecurityRequirement::class), new Assert\Valid()])]
+        private readonly ?array $security = null,
+
+        #[Assert\All([new Assert\Type(Tag::class), new Assert\Valid()])]
+        private readonly ?array $tags = null,
+
+        #[Assert\Valid]
+        private readonly ?ExternalDocumentation $externalDocs = null,
+
+        #[Assert\Url]
+        private readonly ?string $jsonSchemaDialect = null,
+
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function getInfo(): Info
+    {
+        return $this->info;
+    }
+
+    /**
+     * @return Server[]|null
+     */
+    public function getServers(): ?array
+    {
+        return $this->servers;
+    }
+
+    /**
+     * @return array<string, PathItem>|null
+     */
+    public function getPaths(): ?array
+    {
+        return $this->paths;
+    }
+
+    /**
+     * @return array<string, PathItem>|null
+     */
+    public function getWebhooks(): ?array
+    {
+        return $this->webhooks;
+    }
+
+    public function getComponents(): ?Components
+    {
+        return $this->components;
+    }
+
+    /**
+     * @return SecurityRequirement[]|null
+     */
+    public function getSecurity(): ?array
+    {
+        return $this->security;
+    }
+
+    /**
+     * @return Tag[]|null
+     */
+    public function getTags(): ?array
+    {
+        return $this->tags;
+    }
+
+    public function getExternalDocs(): ?ExternalDocumentation
+    {
+        return $this->externalDocs;
+    }
+
+    public function getJsonSchemaDialect(): ?string
+    {
+        return $this->jsonSchemaDialect;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        $exported = array_filter([
+            'openapi' => $this->version,
+            'info' => $this->info->toArray() ?: (new InfoConfigurator())->build()->toArray(),
+            'servers' => $this->normalizeCollection($this->servers),
+            'paths' => $this->normalizeCollection($this->paths),
+            'components' => $this->components->toArray(),
+            'tags' => $this->normalizeCollection($this->tags),
+            'externalDocs' => $this->externalDocs?->toArray(),
+            'jsonSchemaDialect' => $this->jsonSchemaDialect,
+            'webhooks' => $this->normalizeCollection($this->webhooks),
+        ] + $this->getSpecificationExtensions());
+
+        $exported += ['security' => $this->normalizeCollection($this->security)];
+
+        return $exported;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/OpenApiModel.php
+++ b/src/Symfony/Component/OpenApi/Model/OpenApiModel.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+interface OpenApiModel
+{
+    public function toArray(): array;
+}

--- a/src/Symfony/Component/OpenApi/Model/OpenApiTrait.php
+++ b/src/Symfony/Component/OpenApi/Model/OpenApiTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+trait OpenApiTrait
+{
+    public function toArray(): array
+    {
+        return [];
+    }
+
+    private function normalizeCollection(?array $items): ?array
+    {
+        if (null === $items) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach ($items as $key => $item) {
+            if ($item instanceof OpenApiModel) {
+                $normalized[$key] = $item->toArray();
+            } elseif ($item instanceof \BackedEnum) {
+                $normalized[$key] = $item->value;
+            } else {
+                $normalized[$key] = $item;
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Operation.php
+++ b/src/Symfony/Component/OpenApi/Model/Operation.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Operation implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param string[]|null                                 $tags
+     * @param array<Parameter|Reference>|null               $parameters
+     * @param array<string, CallbackRequest|Reference>|null $callbacks
+     * @param SecurityRequirement[]|null                    $security
+     * @param Server[]|null                                 $servers
+     */
+    public function __construct(
+        private readonly ?string $operationId = null,
+        private readonly ?string $summary = null,
+        private readonly ?string $description = null,
+        private readonly ?bool $deprecated = null,
+        private readonly ?array $tags = null,
+        private readonly ?ExternalDocumentation $externalDocs = null,
+        private readonly ?array $parameters = null,
+        private readonly RequestBody|Reference|null $requestBody = null,
+        private readonly ?Responses $responses = null,
+        private readonly ?array $callbacks = null,
+        private readonly ?array $security = null,
+        private readonly ?array $servers = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getOperationId(): ?string
+    {
+        return $this->operationId;
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getDeprecated(): ?bool
+    {
+        return $this->deprecated;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getTags(): ?array
+    {
+        return $this->tags;
+    }
+
+    public function getExternalDocs(): ?ExternalDocumentation
+    {
+        return $this->externalDocs;
+    }
+
+    /**
+     * @return array<Parameter|Reference>|null
+     */
+    public function getParameters(): ?array
+    {
+        return $this->parameters;
+    }
+
+    public function getRequestBody(): RequestBody|Reference|null
+    {
+        return $this->requestBody;
+    }
+
+    public function getResponses(): ?Responses
+    {
+        return $this->responses;
+    }
+
+    /**
+     * @return array<string, CallbackRequest|Reference>|null
+     */
+    public function getCallbacks(): ?array
+    {
+        return $this->callbacks;
+    }
+
+    /**
+     * @return SecurityRequirement[]|null
+     */
+    public function getSecurity(): ?array
+    {
+        return $this->security;
+    }
+
+    /**
+     * @return Server[]|null
+     */
+    public function getServers(): ?array
+    {
+        return $this->servers;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        $exported = array_filter([
+            'tags' => $this->normalizeCollection($this->getTags()),
+            'summary' => $this->getSummary(),
+            'description' => $this->getDescription(),
+            'externalDocs' => $this->externalDocs?->toArray(),
+            'operationId' => $this->getOperationId(),
+            'parameters' => $this->normalizeCollection($this->getParameters()),
+            'requestBody' => $this->getRequestBody()?->toArray(),
+            'responses' => $this->getResponses()?->toArray(),
+            'callbacks' => $this->normalizeCollection($this->getCallbacks()),
+            'deprecated' => $this->getDeprecated(),
+            'servers' => $this->normalizeCollection($this->getServers()),
+        ] + $this->getSpecificationExtensions());
+
+        if (null !== $this->security) {
+            $exportedSecurity = $this->normalizeCollection($this->getSecurity());
+            if ($exportedSecurity === [['__NO_SECURITY' => []]]) {
+                $exportedSecurity = [];
+            }
+
+            $exported += ['security' => $exportedSecurity];
+        }
+
+        return $exported;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Parameter.php
+++ b/src/Symfony/Component/OpenApi/Model/Parameter.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Parameter implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, Example|Reference>|null $examples
+     * @param array<string, MediaType>|null         $content
+     */
+    public function __construct(
+        private readonly ?string $name = null,
+        private readonly ?ParameterIn $in = null,
+        private readonly ?string $description = null,
+        private readonly ?bool $required = null,
+        private readonly ?bool $deprecated = null,
+        private readonly ?bool $allowEmptyValue = null,
+        private readonly ?string $style = null,
+        private readonly ?bool $explode = null,
+        private readonly ?bool $allowReserved = null,
+        private readonly ?Schema $schema = null,
+        private readonly mixed $example = null,
+        private readonly ?array $examples = null,
+        private readonly ?array $content = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getIn(): ?ParameterIn
+    {
+        return $this->in;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getRequired(): ?bool
+    {
+        return $this->required;
+    }
+
+    public function getDeprecated(): ?bool
+    {
+        return $this->deprecated;
+    }
+
+    public function getAllowEmptyValue(): ?bool
+    {
+        return $this->allowEmptyValue;
+    }
+
+    public function getStyle(): ?string
+    {
+        return $this->style;
+    }
+
+    public function getExplode(): ?bool
+    {
+        return $this->explode;
+    }
+
+    public function getAllowReserved(): ?bool
+    {
+        return $this->allowReserved;
+    }
+
+    public function getSchema(): ?Schema
+    {
+        return $this->schema;
+    }
+
+    public function getExample(): mixed
+    {
+        return $this->example;
+    }
+
+    /**
+     * @return array<string, Example|Reference>|null
+     */
+    public function getExamples(): ?array
+    {
+        return $this->examples;
+    }
+
+    /**
+     * @return array<string, MediaType>|null
+     */
+    public function getContent(): ?array
+    {
+        return $this->content;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->getName(),
+            'in' => $this->getIn()?->value,
+            'description' => $this->getDescription(),
+            'required' => $this->getRequired(),
+            'deprecated' => $this->getDeprecated(),
+            'allowEmptyValue' => $this->getAllowEmptyValue(),
+            'style' => $this->getStyle(),
+            'explode' => $this->getExplode(),
+            'allowReserved' => $this->getAllowReserved(),
+            'schema' => $this->getSchema()?->toArray(),
+            'example' => $this->getExample(),
+            'examples' => $this->normalizeCollection($this->getExamples()),
+            'content' => $this->normalizeCollection($this->getContent()),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/ParameterIn.php
+++ b/src/Symfony/Component/OpenApi/Model/ParameterIn.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+enum ParameterIn: string
+{
+    case PATH = 'path';
+    case QUERY = 'query';
+    case HEADER = 'header';
+    case COOKIE = 'cookie';
+}

--- a/src/Symfony/Component/OpenApi/Model/PathItem.php
+++ b/src/Symfony/Component/OpenApi/Model/PathItem.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class PathItem implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param Server[]|null                   $servers
+     * @param array<Parameter|Reference>|null $parameters
+     */
+    public function __construct(
+        private readonly ?string $ref = null,
+        private readonly ?string $summary = null,
+        private readonly ?string $description = null,
+        private readonly ?Operation $get = null,
+        private readonly ?Operation $put = null,
+        private readonly ?Operation $post = null,
+        private readonly ?Operation $patch = null,
+        private readonly ?Operation $delete = null,
+        private readonly ?Operation $head = null,
+        private readonly ?Operation $options = null,
+        private readonly ?Operation $trace = null,
+        private readonly ?array $servers = null,
+        private readonly ?array $parameters = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getRef(): ?string
+    {
+        return $this->ref;
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getGet(): ?Operation
+    {
+        return $this->get;
+    }
+
+    public function getPut(): ?Operation
+    {
+        return $this->put;
+    }
+
+    public function getPost(): ?Operation
+    {
+        return $this->post;
+    }
+
+    public function getPatch(): ?Operation
+    {
+        return $this->patch;
+    }
+
+    public function getDelete(): ?Operation
+    {
+        return $this->delete;
+    }
+
+    public function getHead(): ?Operation
+    {
+        return $this->head;
+    }
+
+    public function getOptions(): ?Operation
+    {
+        return $this->options;
+    }
+
+    public function getTrace(): ?Operation
+    {
+        return $this->trace;
+    }
+
+    /**
+     * @return Server[]|null
+     */
+    public function getServers(): ?array
+    {
+        return $this->servers;
+    }
+
+    /**
+     * @return array<Parameter|Reference>|null
+     */
+    public function getParameters(): ?array
+    {
+        return $this->parameters;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            '$ref' => $this->getRef(),
+            'summary' => $this->getSummary(),
+            'description' => $this->getDescription(),
+            'get' => $this->getGet()?->toArray(),
+            'put' => $this->getPut()?->toArray(),
+            'post' => $this->getPost()?->toArray(),
+            'delete' => $this->getDelete()?->toArray(),
+            'options' => $this->getOptions()?->toArray(),
+            'head' => $this->getHead()?->toArray(),
+            'patch' => $this->getPatch()?->toArray(),
+            'trace' => $this->getTrace()?->toArray(),
+            'servers' => $this->normalizeCollection($this->getServers()),
+            'parameters' => $this->normalizeCollection($this->getParameters()),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Reference.php
+++ b/src/Symfony/Component/OpenApi/Model/Reference.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Reference implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly string $ref,
+        private readonly ?string $summary = null,
+        private readonly ?string $description = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getRef(): string
+    {
+        return $this->ref;
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            '$ref' => $this->getRef(),
+            'summary' => $this->getSummary(), // ??
+            'description' => $this->getDescription(), // ??
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/RequestBody.php
+++ b/src/Symfony/Component/OpenApi/Model/RequestBody.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class RequestBody implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, MediaType> $content
+     */
+    public function __construct(
+        private readonly array $content,
+        private readonly ?string $description = null,
+        private readonly ?bool $required = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, MediaType>
+     */
+    public function getContent(): array
+    {
+        return $this->content;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getRequired(): ?bool
+    {
+        return $this->required;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'description' => $this->getDescription(),
+            'content' => $this->normalizeCollection($this->getContent()),
+            'required' => $this->getRequired(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Response.php
+++ b/src/Symfony/Component/OpenApi/Model/Response.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Response implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, Parameter|Reference>|null $headers
+     * @param array<string, Link|Reference>|null      $links
+     */
+    public function __construct(
+        private readonly string $description,
+        private readonly ?array $headers = null,
+        private readonly ?array $content = null,
+        private readonly ?array $links = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return array<string, Parameter|Reference>|null
+     */
+    public function getHeaders(): ?array
+    {
+        return $this->headers;
+    }
+
+    public function getContent(): ?array
+    {
+        return $this->content;
+    }
+
+    /**
+     * @return array<string, Link|Reference>|null
+     */
+    public function getLinks(): ?array
+    {
+        return $this->links;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'description' => $this->getDescription(),
+            'headers' => $this->normalizeCollection($this->getHeaders()),
+            'content' => $this->normalizeCollection($this->getContent()),
+            'links' => $this->normalizeCollection($this->getLinks()),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Responses.php
+++ b/src/Symfony/Component/OpenApi/Model/Responses.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Responses implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, Response|Reference>|null $byHttpStatusCode
+     */
+    public function __construct(
+        private readonly Response|Reference|null $default = null,
+        private readonly ?array $byHttpStatusCode = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getDefault(): Response|Reference|null
+    {
+        return $this->default;
+    }
+
+    /**
+     * @return array<string, Response|Reference>|null
+     */
+    public function getByHttpStatusCode(): ?array
+    {
+        return $this->byHttpStatusCode;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'default' => $this->getDefault()?->toArray(),
+        ] + $this->normalizeCollection($this->getByHttpStatusCode()) + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Schema.php
+++ b/src/Symfony/Component/OpenApi/Model/Schema.php
@@ -1,0 +1,292 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Schema implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, self|Reference>|null $properties
+     */
+    public function __construct(
+        private readonly ?string $title = null,
+        private readonly ?int $multipleOf = null,
+        private readonly ?int $maximum = null,
+        private readonly ?bool $exclusiveMaximum = null,
+        private readonly ?int $minimum = null,
+        private readonly ?bool $exclusiveMinimum = null,
+        private readonly ?int $maxLength = null,
+        private readonly ?int $minLength = null,
+        private readonly ?string $pattern = null,
+        private readonly ?int $maxItems = null,
+        private readonly ?int $minItems = null,
+        private readonly ?bool $uniqueItems = null,
+        private readonly ?int $maxProperties = null,
+        private readonly ?int $minProperties = null,
+        private readonly ?array $required = null,
+        private readonly ?array $enum = null,
+        private readonly ?array $type = null,
+        private readonly ?array $allOf = null,
+        private readonly ?array $oneOf = null,
+        private readonly ?array $anyOf = null,
+        private readonly self|Reference|null $not = null,
+        private readonly self|Reference|null $items = null,
+        private readonly ?array $properties = null,
+        private readonly ?string $description = null,
+        private readonly ?string $format = null,
+        private readonly mixed $default = null,
+        private readonly ?bool $readOnly = null,
+        private readonly ?bool $writeOnly = null,
+        private readonly mixed $example = null,
+        private readonly ?bool $deprecated = null,
+        private readonly ?Discriminator $discriminator = null,
+        private readonly ?Xml $xml = null,
+        private readonly ?ExternalDocumentation $externalDocs = null,
+        private readonly self|Reference|false|null $additionalProperties = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function getMultipleOf(): ?int
+    {
+        return $this->multipleOf;
+    }
+
+    public function getMaximum(): ?int
+    {
+        return $this->maximum;
+    }
+
+    public function isExclusiveMaximum(): ?bool
+    {
+        return $this->exclusiveMaximum;
+    }
+
+    public function getMinimum(): ?int
+    {
+        return $this->minimum;
+    }
+
+    public function isExclusiveMinimum(): ?bool
+    {
+        return $this->exclusiveMinimum;
+    }
+
+    public function getMaxLength(): ?int
+    {
+        return $this->maxLength;
+    }
+
+    public function getMinLength(): ?int
+    {
+        return $this->minLength;
+    }
+
+    public function getPattern(): ?string
+    {
+        return $this->pattern;
+    }
+
+    public function getMaxItems(): ?int
+    {
+        return $this->maxItems;
+    }
+
+    public function getMinItems(): ?int
+    {
+        return $this->minItems;
+    }
+
+    public function isUniqueItems(): ?bool
+    {
+        return $this->uniqueItems;
+    }
+
+    public function getMaxProperties(): ?int
+    {
+        return $this->maxProperties;
+    }
+
+    public function getMinProperties(): ?int
+    {
+        return $this->minProperties;
+    }
+
+    public function getRequired(): ?array
+    {
+        return $this->required;
+    }
+
+    public function getEnum(): ?array
+    {
+        return $this->enum;
+    }
+
+    public function getType(): ?array
+    {
+        return $this->type;
+    }
+
+    public function getAllOf(): ?array
+    {
+        return $this->allOf;
+    }
+
+    public function getOneOf(): ?array
+    {
+        return $this->oneOf;
+    }
+
+    public function getAnyOf(): ?array
+    {
+        return $this->anyOf;
+    }
+
+    public function getNot(): self|Reference|null
+    {
+        return $this->not;
+    }
+
+    public function getItems(): self|Reference|null
+    {
+        return $this->items;
+    }
+
+    public function getProperties(): ?array
+    {
+        return $this->properties;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getFormat(): ?string
+    {
+        return $this->format;
+    }
+
+    public function getDefault(): mixed
+    {
+        return $this->default;
+    }
+
+    public function isNullable(): ?bool
+    {
+        return null === $this->type ? null : \in_array('null', $this->type, true);
+    }
+
+    public function isReadOnly(): ?bool
+    {
+        return $this->readOnly;
+    }
+
+    public function isWriteOnly(): ?bool
+    {
+        return $this->writeOnly;
+    }
+
+    public function getExample(): mixed
+    {
+        return $this->example;
+    }
+
+    public function isDeprecated(): ?bool
+    {
+        return $this->deprecated;
+    }
+
+    public function getDiscriminator(): ?Discriminator
+    {
+        return $this->discriminator;
+    }
+
+    public function getXml(): ?Xml
+    {
+        return $this->xml;
+    }
+
+    public function getExternalDocs(): ?ExternalDocumentation
+    {
+        return $this->externalDocs;
+    }
+
+    public function getAdditionalProperties(): self|bool|Reference|null
+    {
+        return $this->additionalProperties;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        $data = [
+            'title' => $this->getTitle(),
+            'multipleOf' => $this->getMultipleOf(),
+            'maximum' => $this->getMaximum(),
+            'exclusiveMaximum' => $this->isExclusiveMaximum(),
+            'minimum' => $this->getMinimum(),
+            'exclusiveMinimum' => $this->isExclusiveMinimum(),
+            'maxLength' => $this->getMaxLength(),
+            'minLength' => $this->getMinLength(),
+            'pattern' => $this->getPattern(),
+            'maxItems' => $this->getMaxItems(),
+            'minItems' => $this->getMinItems(),
+            'uniqueItems' => $this->isUniqueItems(),
+            'maxProperties' => $this->getMaxProperties(),
+            'minProperties' => $this->getMinProperties(),
+            'required' => $this->normalizeCollection($this->getRequired()),
+            'enum' => $this->normalizeCollection($this->getEnum()),
+            'type' => $this->getType(),
+            'allOf' => $this->normalizeCollection($this->getAllOf()),
+            'oneOf' => $this->normalizeCollection($this->getOneOf()),
+            'anyOf' => $this->normalizeCollection($this->getAnyOf()),
+            'not' => $this->getNot()?->toArray(),
+            'items' => $this->getItems()?->toArray(),
+            'properties' => $this->normalizeCollection($this->getProperties()),
+            'description' => $this->getDescription(),
+            'format' => $this->getFormat(),
+            'default' => $this->getDefault(),
+            'discriminator' => $this->getDiscriminator()?->toArray(),
+            'readOnly' => $this->isReadOnly(),
+            'writeOnly' => $this->isWriteOnly(),
+            'xml' => $this->getXml()?->toArray(),
+            'externalDocs' => $this->getExternalDocs()?->toArray(),
+            'example' => $this->getExample(),
+            'deprecated' => $this->isDeprecated(),
+        ];
+
+        if (null !== $this->additionalProperties) {
+            if (false === $this->additionalProperties) {
+                $data['additionalProperties'] = false;
+            } else {
+                $data['additionalProperties'] = $this->additionalProperties->toArray();
+            }
+        }
+
+        return array_filter($data + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/SecurityRequirement.php
+++ b/src/Symfony/Component/OpenApi/Model/SecurityRequirement.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class SecurityRequirement implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public const NONE = '__NO_SECURITY';
+
+    /**
+     * @param string[] $config
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly array $config = [],
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            $this->getName() => array_filter([
+                $this->normalizeCollection($this->getConfig()),
+            ]),
+        ];
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/SecurityScheme.php
+++ b/src/Symfony/Component/OpenApi/Model/SecurityScheme.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class SecurityScheme implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly string $type,
+        private readonly ?string $name = null,
+        private readonly ?SecuritySchemeIn $in = null,
+        private readonly ?string $scheme = null,
+        private readonly ?string $description = null,
+        private readonly ?string $bearerFormat = null,
+        private readonly ?string $openIdConnectUrl = null,
+        private readonly ?OauthFlows $flows = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getIn(): ?SecuritySchemeIn
+    {
+        return $this->in;
+    }
+
+    public function getScheme(): ?string
+    {
+        return $this->scheme;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getBearerFormat(): ?string
+    {
+        return $this->bearerFormat;
+    }
+
+    public function getOpenIdConnectUrl(): ?string
+    {
+        return $this->openIdConnectUrl;
+    }
+
+    public function getFlows(): ?OauthFlows
+    {
+        return $this->flows;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'type' => $this->getType(),
+            'description' => $this->getDescription(),
+            // invalid in 3.1
+//            'name' => $this->getName(),
+//            'in' => $this->getIn()?->value,
+            'scheme' => $this->getScheme(),
+            'bearerFormat' => $this->getBearerFormat(),
+            'flows' => $this->getFlows()?->toArray(),
+            'openIdConnectUrl' => $this->getOpenIdConnectUrl(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/SecuritySchemeIn.php
+++ b/src/Symfony/Component/OpenApi/Model/SecuritySchemeIn.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+enum SecuritySchemeIn: string
+{
+    case QUERY = 'query';
+    case HEADER = 'header';
+    case COOKIE = 'cookie';
+}

--- a/src/Symfony/Component/OpenApi/Model/Server.php
+++ b/src/Symfony/Component/OpenApi/Model/Server.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Server implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param array<string, ServerVariable>|null $variables
+     */
+    public function __construct(
+        private readonly string $url,
+        private readonly ?string $description = null,
+        private readonly ?array $variables = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return array<string, ServerVariable>|null
+     */
+    public function getVariables(): ?array
+    {
+        return $this->variables;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'url' => $this->getUrl(),
+            'description' => $this->getDescription(),
+            'variables' => $this->normalizeCollection($this->getVariables()),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/ServerVariable.php
+++ b/src/Symfony/Component/OpenApi/Model/ServerVariable.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class ServerVariable implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    /**
+     * @param string[]|null $enum
+     */
+    public function __construct(
+        private readonly string $default,
+        private readonly ?string $description = null,
+        private readonly ?array $enum = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getDefault(): string
+    {
+        return $this->default;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getEnum(): ?array
+    {
+        return $this->enum;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'enum' => $this->getEnum(),
+            'default' => $this->getDefault(),
+            'description' => $this->getDescription(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Tag.php
+++ b/src/Symfony/Component/OpenApi/Model/Tag.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Tag implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly string $name,
+        private readonly ?string $description = null,
+        private readonly ?ExternalDocumentation $externalDocs = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getExternalDocs(): ?ExternalDocumentation
+    {
+        return $this->externalDocs;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->getName(),
+            'description' => $this->getDescription(),
+            'externalDocs' => $this->getExternalDocs()?->toArray(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Model/Xml.php
+++ b/src/Symfony/Component/OpenApi/Model/Xml.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Selency Team <tech@selency.fr>
+ */
+class Xml implements OpenApiModel
+{
+    use OpenApiTrait;
+
+    public function __construct(
+        private readonly ?string $name = null,
+        private readonly ?string $namespace = null,
+        private readonly ?string $prefix = null,
+        private readonly ?bool $attribute = null,
+        private readonly ?bool $wrapped = null,
+        private readonly array $specificationExtensions = [],
+    ) {
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function getPrefix(): ?string
+    {
+        return $this->prefix;
+    }
+
+    public function isAttribute(): ?bool
+    {
+        return $this->attribute;
+    }
+
+    public function isWrapped(): ?bool
+    {
+        return $this->wrapped;
+    }
+
+    public function getSpecificationExtensions(): array
+    {
+        return $this->specificationExtensions;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->getName(),
+            'namespace' => $this->getNamespace(),
+            'prefix' => $this->getPrefix(),
+            'attribute' => $this->isAttribute(),
+            'wrapped' => $this->isWrapped(),
+        ] + $this->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/README.md
+++ b/src/Symfony/Component/OpenApi/README.md
@@ -1,0 +1,302 @@
+# Symfony OpenAPI
+
+The OpenApi component provides a user-friendly, object-oriented API to build
+OpenAPI specifications using PHP.
+
+## Sponsor
+
+The Symfony OpenApi component is [backed][1] by [Selency][2].
+
+Selency is a team of 80 people, each more committed than the last to
+promoting second-hand goods and doing something positive for our planet.
+Open-Source is perfectly aligned with our values, leading us to contribute
+back to the Symfony ecosystem through a series of components.
+
+Help Symfony by [sponsoring][3] its development!
+
+## Usage
+
+Symfony OpenApi implements the OpenApi standard in its version 3.1. It allows to build
+documentations using PHP objects, giving more flexibility and reusability to OpenApi
+definitions. All features of OpenApi 3.1 are supported.
+
+### Writing documentation
+
+The OpenApi component provides object-oriented PHP tools to build the documentation
+definition:
+
+```php
+use Symfony\Component\OpenApi\Documentation\AbstractDocumentation;
+
+class Documentation extends AbstractDocumentation
+{
+    public function getIdentifier(): string
+    {
+        return 'myapi';
+    }
+
+    public function getVersion(): string
+    {
+        return '1.3.4';
+    }
+
+    public function configure(DocumentationConfigurator $doc): void
+    {
+        $doc->info($this->openApi->info()
+            ->title('Monolith API')
+            ->description(file_get_contents(__DIR__.'/Resources/info_description.md'))
+            ->contact(name: 'API support', url: 'https://symfony.com', email: 'contact@symfony.com')
+            ->specificationExtension('x-logo', [
+                'url' => 'https://symfony.com/logos/symfony_black_02.png',
+                'altText' => 'Symfony logo',
+            ])
+            ->license('MIT')
+        );
+
+        $doc->externalDocs(url: 'https://github.com/symfony/openapi', description: 'OpenApi component');
+
+        $doc->server($this->openApi->server('https://api.symfony.local')->description('Local'))
+            ->server($this->openApi->server('https://api.symfony-staging.com')->description('Staging'))
+            ->server($this->openApi->server('https://api.symfony.com')->description('Prod'));
+
+        $doc->securityRequirement(self::REF_SECURITY_USER_JWT);
+
+        $doc->path('/health', $this->openApi->pathItem()
+            ->get($this->openApi->operation()
+                ->tag('Health')
+                ->operationId('app.health.check')
+                ->summary('Health check')
+                ->description('Check the API is up and available.')
+                ->securityRequirement(null)
+                ->responses($this->openApi->responses()
+                    ->response('200', $this->openApi->response()
+                        ->description('When the API is up and available.')
+                        ->content('application/json', $this->openApi->schema()
+                            ->property('name', $this->openApi->schema()->type('string')->description('Name for this API')->example('Selency API'))
+                            ->property('env', $this->openApi->schema()->type('string')->description('Current environment of this instance of the API')->example('prod'))
+                        )
+                    )
+                    ->response('500', $this->openApi->response()->description('When the API is unavailable due to a backend problem.'))
+                )
+            )
+        );
+
+        // ...
+    }
+}
+
+// Build a read-only model representing the documentation
+$compiler = new DocumentationCompiler();
+$openApiDefinition = $compiler->compile($doc);
+
+// Compile it as YAML or JSON for usage in other tools
+$openApiYaml = (new Dumper\YamlDumper())->dump($openApiDefinition);
+$openApiJson = (new Dumper\JsonDumper())->dump($openApiDefinition);
+```
+
+### Splitting documentations in multiple files
+
+The component provides a concept of Partial documentations to allow splitting the documentation
+in multiple files for readability:
+
+```php
+// HealthDocumentation.php
+use Symfony\Component\OpenApi\Documentation\PartialDocumentationInterface;
+
+#[AutoconfigureTag('app.partial_documentation')]
+class HealthDocumentation implements PartialDocumentationInterface
+{
+    public function __construct(private OpenApiBuilderInterface $openApi)
+    {
+    }
+
+    public function configure(DocumentationConfigurator $doc): void
+    {
+        $doc->path('/health', $this->openApi->pathItem()
+            ->get($this->openApi->operation()
+                ->tag('Health')
+                ->operationId('app.health.check')
+                ->summary('Health check')
+                ->description('Check the API is up and available. Mostly used by the infrastructure to check for readiness.')
+                ->securityRequirement(null)
+                ->responses($this->openApi->responses()
+                    ->response('200', $this->openApi->response()
+                        ->description('When the API is up and available.')
+                        ->content('application/json', $this->openApi->schema()
+                            ->property('name', $this->openApi->schema()->type('string')->description('Name for this API')->example('Selency API'))
+                            ->property('env', $this->openApi->schema()->type('string')->description('Current environment of this instance of the API')->example('prod'))
+                        )
+                    )
+                    ->response('500', $this->openApi->response()->description('When the API is unavailable due to a backend problem.'))
+                )
+            )
+        );
+    }
+}
+
+
+// Documentation.php
+class Documentation extends AbstractDocumentation
+{
+    private iterable $partialsDocs;
+
+    public function __construct(
+        private Builder\OpenApiBuilder $openApi,
+        #[TaggedIterator(tag: 'app.partial_documentation')] iterable $partialsDocs,
+    ) {
+        $this->partialsDocs = $partialsDocs;
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'myapi';
+    }
+
+    public function getVersion(): string
+    {
+        return '1.3.4';
+    }
+
+    public function configure(DocumentationConfigurator $doc): void
+    {
+        $doc->info($this->openApi->info()
+            ->title('Monolith API')
+            ->description(file_get_contents(__DIR__.'/Resources/info_description.md'))
+            ->contact(name: 'API support', url: 'https://symfony.com', email: 'contact@symfony.com')
+            ->specificationExtension('x-logo', [
+                'url' => 'https://symfony.com/logos/symfony_black_02.png',
+                'altText' => 'Symfony logo',
+            ])
+            ->license('MIT')
+        );
+
+        // ...
+
+        // Apply partial documentations
+        foreach ($this->partialsDocs as $partialsDoc) {
+            $partialsDoc->configure($doc);
+        }
+    }
+}
+```
+
+### Store documentation close to your application code
+
+The OpenApi component provides two interfaces to help maintaining documentation by storing it close
+to your code:
+
+* `SelfDescribingSchemaInterface` can be implemented by classes describing a schema (request, response, payloads, ...) ;
+* `SelfDescribingQueryParametersInterface` can be implemented by classes describing a list of query parameters ;
+
+These interfaces are especially useful when using objects to handle inputs and outputs of your API:
+
+```php
+class AuthRegisterPayload implements SelfDescribingSchemaInterface
+{
+    #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
+    #[Assert\NotBlank]
+    public $email;
+
+    #[Assert\Type(type: 'string')]
+    #[Assert\NotBlank]
+    public $firstName;
+
+    #[Assert\Type(type: 'string')]
+    #[Assert\NotBlank]
+    public $lastName;
+
+    #[Assert\Type(type: 'string')]
+    #[Assert\NotBlank]
+    public $password;
+
+    public static function describeSchema(SchemaConfigurator $schema, OpenApiBuilderInterface $openApi): void
+    {
+        $schema
+            ->title('AuthRegister')
+            ->required(['email', 'firstName', 'lastName', 'password'])
+            ->property('email', $openApi->schema()
+                ->type('string')
+                ->description('User\'s email')
+                ->example('john.doe@domain.com')
+            )
+            ->property('firstName', $openApi->schema()
+                ->type('string')
+                ->description('User\'s first name')
+                ->example('John')
+            )
+            ->property('lastName', $openApi->schema()
+                ->type('string')
+                ->description('User\'s last name')
+                ->example('Doe')
+            )
+            ->property('password', $openApi->schema()
+                ->type('string')
+                ->description('User\'s plaintext password')
+            )
+        ;
+    }
+}
+```
+
+You can then load these self-describing schemas/query params classes by providing the
+dedicated loader during compilation:
+
+```php
+// Build a read-only model representing the documentation
+$compiler = new DocumentationCompiler([
+    new \Symfony\Component\OpenApi\Loader\SelfDescribingSchemaLoader([
+        AuthRegisterPayload::class,
+    ])
+]);
+
+$openApiDefinition = $compiler->compile($doc);
+```
+
+> **Note**: in a Symfony application, SelfDescribingSchemaInterface and
+> SelfDescribingQueryParametersInterface class are automatically added to the compiler,
+> you don't need to do anything.
+
+And use them in your definitions:
+
+```php
+class Documentation extends AbstractDocumentation
+{
+    // ...
+
+    public function configure(DocumentationConfigurator $doc): void
+    {
+        // ...
+
+        $doc->path('/auth/register', $this->openApi->pathItem()
+            ->post($this->openApi->operation()
+                ->tag('Auth')
+                ->operationId('app.auth.register')
+                ->summary('Auth registration')
+                ->description('Register as a user.')
+                ->securityRequirement(null)
+                ->requestBody($this->openApi->requestBody()
+                    ->content('application/json', AuthRegisterPayload::class)
+                )
+                ->responses($this->openApi->responses()
+                    ->response('200', $this->openApi->response()
+                        ->content('application/json', AuthRegisterOutput::class)
+                    )
+                )
+            )
+        );
+
+        // ...
+    }
+}
+```
+
+## Resources
+
+* [Contributing](https://symfony.com/doc/current/contributing/index.html)
+* [Report issues](https://github.com/symfony/symfony/issues) and
+  [send Pull Requests](https://github.com/symfony/symfony/pulls)
+  in the [main Symfony repository](https://github.com/symfony/symfony)
+
+[1]: https://symfony.com/backers
+[2]: https://www.selency.fr
+[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/AbstractConfiguratorTestCase.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/AbstractConfiguratorTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractConfiguratorTestCase extends TestCase
+{
+    /**
+     * @template C
+     * @template M
+     *
+     * @param class-string<C> $configuratorClass
+     * @param class-string<M> $modelClass
+     *
+     * @return array{0: C, 1: M}
+     */
+    protected function createConfiguratorMock(string $configuratorClass, string $modelClass): array
+    {
+        $configurator = $this->createMock($configuratorClass);
+        $configurator->method('build')->willReturn($model = $this->createMock($modelClass));
+
+        return [$configurator, $model];
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/CallbackRequestConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/CallbackRequestConfiguratorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\CallbackRequestConfigurator;
+use Symfony\Component\OpenApi\Configurator\PathItemConfigurator;
+use Symfony\Component\OpenApi\Model\CallbackRequest;
+use Symfony\Component\OpenApi\Model\PathItem;
+
+class CallbackRequestConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $configurator = new CallbackRequestConfigurator();
+
+        $callback = $configurator->build();
+        $this->assertInstanceOf(CallbackRequest::class, $callback);
+        $this->assertSame('', $callback->getExpression());
+        $this->assertNull($callback->getDefinition());
+        $this->assertSame([], $callback->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        [$pathItemConfigurator, $pathItem] = $this->createConfiguratorMock(PathItemConfigurator::class, PathItem::class);
+
+        $configurator = (new CallbackRequestConfigurator())
+            ->expression('{$request.query.queryUrl}')
+            ->definition($pathItemConfigurator)
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $callback = $configurator->build();
+        $this->assertInstanceOf(CallbackRequest::class, $callback);
+        $this->assertSame('{$request.query.queryUrl}', $callback->getExpression());
+        $this->assertSame($pathItem, $callback->getDefinition());
+        $this->assertSame(['x-ext' => 'value'], $callback->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/ComponentsConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/ComponentsConfiguratorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\CallbackRequestConfigurator;
+use Symfony\Component\OpenApi\Configurator\ComponentsConfigurator;
+use Symfony\Component\OpenApi\Configurator\ExampleConfigurator;
+use Symfony\Component\OpenApi\Configurator\LinkConfigurator;
+use Symfony\Component\OpenApi\Configurator\ParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\PathItemConfigurator;
+use Symfony\Component\OpenApi\Configurator\RequestBodyConfigurator;
+use Symfony\Component\OpenApi\Configurator\ResponseConfigurator;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Configurator\SecuritySchemeConfigurator;
+use Symfony\Component\OpenApi\Model\CallbackRequest;
+use Symfony\Component\OpenApi\Model\Components;
+use Symfony\Component\OpenApi\Model\Example;
+use Symfony\Component\OpenApi\Model\Link;
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\PathItem;
+use Symfony\Component\OpenApi\Model\RequestBody;
+use Symfony\Component\OpenApi\Model\Response;
+use Symfony\Component\OpenApi\Model\Schema;
+use Symfony\Component\OpenApi\Model\SecurityScheme;
+
+class ComponentsConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $components = (new ComponentsConfigurator())->build();
+        $this->assertInstanceOf(Components::class, $components);
+        $this->assertNull($components->getSchemas());
+        $this->assertNull($components->getResponses());
+        $this->assertNull($components->getParameters());
+        $this->assertNull($components->getExamples());
+        $this->assertNull($components->getRequestBodies());
+        $this->assertNull($components->getSecuritySchemes());
+        $this->assertNull($components->getLinks());
+        $this->assertNull($components->getCallbacks());
+        $this->assertNull($components->getPathItems());
+        $this->assertSame([], $components->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        [$schemaConfigurator, $schema] = $this->createConfiguratorMock(SchemaConfigurator::class, Schema::class);
+        [$responseConfigurator, $response] = $this->createConfiguratorMock(ResponseConfigurator::class, Response::class);
+        [$parameterConfigurator, $parameter] = $this->createConfiguratorMock(ParameterConfigurator::class, Parameter::class);
+        [$exampleConfigurator, $example] = $this->createConfiguratorMock(ExampleConfigurator::class, Example::class);
+        [$requestBodyConfigurator, $requestBody] = $this->createConfiguratorMock(RequestBodyConfigurator::class, RequestBody::class);
+        [$securitySchemeConfigurator, $securityScheme] = $this->createConfiguratorMock(SecuritySchemeConfigurator::class, SecurityScheme::class);
+        [$linkConfigurator, $link] = $this->createConfiguratorMock(LinkConfigurator::class, Link::class);
+        [$callbackRequestConfigurator, $callbackRequest] = $this->createConfiguratorMock(CallbackRequestConfigurator::class, CallbackRequest::class);
+        [$pathItemConfigurator, $pathItem] = $this->createConfiguratorMock(PathItemConfigurator::class, PathItem::class);
+
+        $configurator = (new ComponentsConfigurator())
+            ->schema('SchemaName', $schemaConfigurator)
+            ->response('ResponseName', $responseConfigurator)
+            ->parameter('ParameterName', $parameterConfigurator)
+            ->example('ExampleName', $exampleConfigurator)
+            ->requestBody('RequestBodyName', $requestBodyConfigurator)
+            ->securityScheme('SecuritySchemeName', $securitySchemeConfigurator)
+            ->link('LinkName', $linkConfigurator)
+            ->callback('CallbackRequestName', $callbackRequestConfigurator)
+            ->pathItem('PathItemName', $pathItemConfigurator)
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $components = $configurator->build();
+        $this->assertInstanceOf(Components::class, $components);
+        $this->assertSame($schema, $components->getSchemas()['SchemaName']);
+        $this->assertSame($response, $components->getResponses()['ResponseName']);
+        $this->assertSame($parameter, $components->getParameters()['ParameterName']);
+        $this->assertSame($example, $components->getExamples()['ExampleName']);
+        $this->assertSame($requestBody, $components->getRequestBodies()['RequestBodyName']);
+        $this->assertSame($securityScheme, $components->getSecuritySchemes()['SecuritySchemeName']);
+        $this->assertSame($link, $components->getLinks()['LinkName']);
+        $this->assertSame($callbackRequest, $components->getCallbacks()['CallbackRequestName']);
+        $this->assertSame($pathItem, $components->getPathItems()['PathItemName']);
+        $this->assertSame(['x-ext' => 'value'], $components->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/DocumentationConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/DocumentationConfiguratorTest.php
@@ -1,0 +1,257 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilder;
+use Symfony\Component\OpenApi\Configurator\DocumentationConfigurator;
+use Symfony\Component\OpenApi\Model\ParameterIn;
+use Symfony\Component\OpenApi\Tests\Loader\MockSelfDescribingSchema;
+
+class DocumentationConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testConfigureEmpty(): void
+    {
+        $configurator = new DocumentationConfigurator();
+
+        $doc = $configurator->build();
+        $this->assertSame('3.1.0', $doc->getVersion());
+        $this->assertNull($doc->getJsonSchemaDialect());
+        $this->assertSame([], $doc->getSpecificationExtensions());
+
+        $info = $doc->getInfo();
+        $this->assertNotNull($info);
+        $this->assertSame('', $info->getTitle());
+        $this->assertSame('', $info->getVersion());
+        $this->assertNull($info->getSummary());
+        $this->assertNull($info->getDescription());
+        $this->assertNull($info->getTermsOfService());
+        $this->assertNull($info->getContact());
+        $this->assertNull($info->getLicense());
+        $this->assertSame([], $info->getSpecificationExtensions());
+
+        $this->assertNull($doc->getServers());
+        $this->assertNull($doc->getPaths());
+        $this->assertNull($doc->getWebhooks());
+        $this->assertNull($doc->getComponents());
+        $this->assertSame([], $doc->getSecurity());
+        $this->assertNull($doc->getTags());
+        $this->assertNull($doc->getExternalDocs());
+    }
+
+    public function testConfigureFull(): void
+    {
+        $builder = new OpenApiBuilder();
+
+        /*
+         * Build the documentation using the configurator
+         */
+        $doc = (new DocumentationConfigurator())
+            ->version('3.1.0')
+            ->jsonSchemaDialect('https://selency.fr')
+            ->externalDocs('https://selency.fr', 'Description example', ['x-key' => 'value'])
+            ->securityRequirement('product_auth', ['product:read', 'product:write'])
+            ->specificationExtension('x-key', 'value')
+
+            ->info($builder->info()
+                ->title('Symfony OpenApi')
+                ->version('1.2.3')
+                ->summary('Summary example')
+                ->description('Description example')
+                ->termsOfService('https://symfony.com/tos')
+                ->contact(
+                    name: 'Titouan Galopin',
+                    url: 'https://selency.fr',
+                    email: 'contact@selency.fr',
+                    specificationExtensions: ['x-key' => 'value'],
+                )
+                ->license(
+                    name: 'MIT License',
+                    identifier: 'MIT',
+                    url: 'https://opensource.org/licenses/MIT',
+                    specificationExtensions: ['x-key' => 'value']
+                )
+                ->specificationExtension('x-key', 'value')
+            )
+
+            ->server('http://localhost')
+            ->server($builder->server('https://staging.selency.fr')
+                ->description('Staging')
+                ->variable('token', 'token-staging', specificationExtensions: ['x-key' => 'value'])
+                ->variable('version', 'v2', 'Version to use', ['v1', 'v2'], ['x-key' => 'value'])
+                ->specificationExtension('x-key', 'value')
+            )
+            ->server($builder->server('https://selency.fr')
+                ->description('Prod')
+                ->variable('token', 'token-prod', specificationExtensions: ['x-key' => 'value'])
+                ->variable('version', 'v1', 'Version to use', ['v1', 'v2'], ['x-key' => 'value'])
+                ->specificationExtension('x-key', 'value')
+            )
+
+            ->components($builder->components()
+                ->schema('mock_schema', MockSelfDescribingSchema::class)
+                ->schema('empty_schema', $builder->schema())
+                ->response('created', $builder->response()->description('When the user was successfully created'))
+                ->pathItem('health', $builder->pathItem()->description('Health check'))
+                ->link('link', $builder->link()->server('http://localhost'))
+                ->parameter('embeds', $builder->parameter('embeds')
+                    ->required(false)
+                    ->in(ParameterIn::QUERY)
+                    ->description('When providing a list of embeds, the API will fetch the values of the links in the payload to provide them in addition to the main payload.')
+                )
+                ->callback('callback', $builder->callbackRequest()
+                    ->expression('{$request.query.queryUrl}')
+                    ->definition($builder->reference('health'))
+                )
+                ->securityScheme('JWT', $builder->securityScheme()->type('JWT')->scheme('http')->name('JWT'))
+            )
+
+            ->tag($builder->tag()
+                ->name('User')
+                ->description('User related endpoints')
+                ->externalDocs('https://selency.fr', 'Description example', ['x-key' => 'value'])
+                ->specificationExtension('x-key', 'value')
+            )
+            ->tag('Product')
+
+            ->path('/users', $builder->pathItem()
+                ->get($builder->operation()
+                    ->description('Get a list of users')
+                    ->parameter($builder->parameter('username')
+                        ->in(ParameterIn::QUERY)
+                        ->required(true)
+                        ->description('When provided, the list will be filtered by username')
+                    )
+                    ->parameter($builder->parameter('Accept')
+                        ->in(ParameterIn::HEADER)
+                        ->required(true)
+                        ->description('When provided, the list will be filtered by username')
+                        ->schema($builder->schema()->enum([
+                            'application/vnd.selency.v1+json',
+                            'application/vnd.selency.v2+json',
+                        ]))
+                        ->example('foo', $builder->example()->value('{"foo": "bar"}'))
+                    )
+                    ->responses($builder->responses()
+                        ->response('200', $builder->response()
+                            ->description('The list of users retrieved')
+                            ->content('application/json', $builder->schema()
+                                ->property('id', 'int')
+                                ->property('username', 'string')
+                                ->property('email', 'string')
+                                ->required(['id', 'username', 'email'])
+                            )
+                        )
+                    )
+                )
+                ->post($builder->operation()
+                    ->description('Create a new user')
+                    ->parameter($builder->reference('api_version_header'))
+                    ->responses($builder->responses()->response('204', $builder->reference('created')))
+                )
+                ->put($builder->operation()
+                    ->description('Create a new user')
+                    ->parameter($builder->reference('api_version_header'))
+                    ->responses($builder->responses()->response('204', $builder->reference('created')))
+                )
+            )
+        ;
+
+        /*
+         * Check the built documentation
+         */
+        $built = $doc->build();
+        $this->assertSame('3.1.0', $built->getVersion());
+        $this->assertSame('https://selency.fr', $built->getJsonSchemaDialect());
+        $this->assertSame(['x-key' => 'value'], $built->getSpecificationExtensions());
+
+        $info = $built->getInfo();
+        $this->assertNotNull($info);
+        $this->assertSame('Symfony OpenApi', $info->getTitle());
+        $this->assertSame('1.2.3', $info->getVersion());
+        $this->assertSame('Summary example', $info->getSummary());
+        $this->assertSame('Description example', $info->getDescription());
+        $this->assertSame('https://symfony.com/tos', $info->getTermsOfService());
+        $this->assertNotNull($info->getContact());
+        $this->assertSame('Titouan Galopin', $info->getContact()->getName());
+        $this->assertSame('https://selency.fr', $info->getContact()->getUrl());
+        $this->assertSame('contact@selency.fr', $info->getContact()->getEmail());
+        $this->assertSame(['x-key' => 'value'], $info->getContact()->getSpecificationExtensions());
+        $this->assertNotNull($info->getLicense());
+        $this->assertSame('MIT License', $info->getLicense()->getName());
+        $this->assertSame('MIT', $info->getLicense()->getIdentifier());
+        $this->assertSame('https://opensource.org/licenses/MIT', $info->getLicense()->getUrl());
+        $this->assertSame(['x-key' => 'value'], $info->getLicense()->getSpecificationExtensions());
+        $this->assertSame(['x-key' => 'value'], $info->getSpecificationExtensions());
+
+        $externalDoc = $built->getExternalDocs();
+        $this->assertNotNull($externalDoc);
+        $this->assertSame('https://selency.fr', $externalDoc->getUrl());
+        $this->assertSame('Description example', $externalDoc->getDescription());
+        $this->assertSame(['x-key' => 'value'], $externalDoc->getSpecificationExtensions());
+
+        $security = $built->getSecurity();
+        $this->assertNotNull($security);
+        $this->assertCount(1, $security);
+        $this->assertSame('product_auth', $security[0]->getName());
+        $this->assertSame(['product:read', 'product:write'], $security[0]->getConfig());
+
+        $servers = $built->getServers();
+        $this->assertNotNull($servers);
+        $this->assertCount(3, $servers);
+
+        $this->assertSame('http://localhost', $servers[0]->getUrl());
+        $this->assertNull($servers[0]->getDescription());
+        $this->assertNull($servers[0]->getVariables());
+        $this->assertSame([], $servers[0]->getSpecificationExtensions());
+
+        $this->assertSame('https://staging.selency.fr', $servers[1]->getUrl());
+        $this->assertSame('Staging', $servers[1]->getDescription());
+        $this->assertCount(2, $servers[1]->getVariables());
+        $this->assertSame(['x-key' => 'value'], $servers[1]->getSpecificationExtensions());
+        $this->assertSame('token-staging', $servers[1]->getVariables()['token']->getDefault());
+        $this->assertNull($servers[1]->getVariables()['token']->getDescription());
+        $this->assertNull($servers[1]->getVariables()['token']->getEnum());
+        $this->assertSame(['x-key' => 'value'], $servers[1]->getVariables()['token']->getSpecificationExtensions());
+        $this->assertSame('v2', $servers[1]->getVariables()['version']->getDefault());
+        $this->assertSame('Version to use', $servers[1]->getVariables()['version']->getDescription());
+        $this->assertSame(['v1', 'v2'], $servers[1]->getVariables()['version']->getEnum());
+        $this->assertSame(['x-key' => 'value'], $servers[1]->getVariables()['version']->getSpecificationExtensions());
+
+        $this->assertSame('https://selency.fr', $servers[2]->getUrl());
+        $this->assertSame('Prod', $servers[2]->getDescription());
+        $this->assertCount(2, $servers[2]->getVariables());
+        $this->assertSame(['x-key' => 'value'], $servers[2]->getSpecificationExtensions());
+        $this->assertSame('token-prod', $servers[2]->getVariables()['token']->getDefault());
+        $this->assertNull($servers[2]->getVariables()['token']->getDescription());
+        $this->assertNull($servers[2]->getVariables()['token']->getEnum());
+        $this->assertSame(['x-key' => 'value'], $servers[2]->getVariables()['token']->getSpecificationExtensions());
+        $this->assertSame('v1', $servers[2]->getVariables()['version']->getDefault());
+        $this->assertSame('Version to use', $servers[2]->getVariables()['version']->getDescription());
+        $this->assertSame(['v1', 'v2'], $servers[2]->getVariables()['version']->getEnum());
+        $this->assertSame(['x-key' => 'value'], $servers[2]->getVariables()['version']->getSpecificationExtensions());
+
+        $tags = $built->getTags();
+        $this->assertNotNull($tags);
+        $this->assertCount(2, $tags);
+
+        $this->assertSame('User', $tags[0]->getName());
+        $this->assertSame('User related endpoints', $tags[0]->getDescription());
+        $this->assertSame(['x-key' => 'value'], $tags[0]->getSpecificationExtensions());
+        $this->assertSame('https://selency.fr', $tags[0]->getExternalDocs()->getUrl());
+        $this->assertSame('Description example', $tags[0]->getExternalDocs()->getDescription());
+        $this->assertSame(['x-key' => 'value'], $tags[0]->getExternalDocs()->getSpecificationExtensions());
+
+        $this->assertSame('Product', $tags[1]->getName());
+        $this->assertNull($tags[1]->getDescription());
+        $this->assertSame([], $tags[1]->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/EncodingConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/EncodingConfiguratorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\EncodingConfigurator;
+use Symfony\Component\OpenApi\Configurator\ParameterConfigurator;
+use Symfony\Component\OpenApi\Model\Encoding;
+use Symfony\Component\OpenApi\Model\Parameter;
+
+class EncodingConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $encoding = (new EncodingConfigurator())->build();
+        $this->assertInstanceOf(Encoding::class, $encoding);
+        $this->assertNull($encoding->getContentType());
+        $this->assertNull($encoding->getStyle());
+        $this->assertNull($encoding->isExplode());
+        $this->assertNull($encoding->allowReserved());
+        $this->assertEmpty($encoding->getHeaders());
+        $this->assertSame([], $encoding->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        [$headerConfigurator, $header] = $this->createConfiguratorMock(ParameterConfigurator::class, Parameter::class);
+
+        $configurator = (new EncodingConfigurator())
+            ->contentType('application/json')
+            ->style('form')
+            ->explode(true)
+            ->allowReserved(false)
+            ->header('Content-Type', $headerConfigurator)
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $encoding = $configurator->build();
+        $this->assertInstanceOf(Encoding::class, $encoding);
+        $this->assertSame('application/json', $encoding->getContentType());
+        $this->assertSame('form', $encoding->getStyle());
+        $this->assertTrue($encoding->isExplode());
+        $this->assertFalse($encoding->allowReserved());
+        $this->assertArrayHasKey('Content-Type', $encoding->getHeaders());
+        $this->assertSame($header, $encoding->getHeaders()['Content-Type']);
+        $this->assertSame(['x-ext' => 'value'], $encoding->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/ExampleConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/ExampleConfiguratorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\ExampleConfigurator;
+use Symfony\Component\OpenApi\Model\Example;
+
+class ExampleConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $configurator = new ExampleConfigurator();
+
+        $example = $configurator->build();
+        $this->assertInstanceOf(Example::class, $example);
+        $this->assertNull($example->getValue());
+        $this->assertNull($example->getExternalValue());
+        $this->assertNull($example->getDescription());
+        $this->assertNull($example->getSummary());
+        $this->assertSame([], $example->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        $configurator = (new ExampleConfigurator())
+            ->value('value')
+            ->externalValue('external value')
+            ->description('description')
+            ->summary('summary')
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $example = $configurator->build();
+        $this->assertInstanceOf(Example::class, $example);
+        $this->assertSame('value', $example->getValue());
+        $this->assertSame('external value', $example->getExternalValue());
+        $this->assertSame('description', $example->getDescription());
+        $this->assertSame('summary', $example->getSummary());
+        $this->assertSame(['x-ext' => 'value'], $example->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/InfoConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/InfoConfiguratorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\InfoConfigurator;
+use Symfony\Component\OpenApi\Model\Info;
+
+class InfoConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $configurator = new InfoConfigurator();
+
+        $info = $configurator->build('', '');
+        $this->assertSame('', $info->getTitle());
+        $this->assertSame('', $info->getVersion());
+        $this->assertNull($info->getSummary());
+        $this->assertNull($info->getDescription());
+        $this->assertNull($info->getTermsOfService());
+        $this->assertNull($info->getContact());
+        $this->assertNull($info->getLicense());
+        $this->assertSame([], $info->getSpecificationExtensions());
+    }
+
+    public function testBuildPartialContactLicense(): void
+    {
+        $configurator = (new InfoConfigurator())
+            ->title('Symfony OpenApi')
+            ->version('1.2.3')
+            ->contact(url: 'https://selency.fr')
+            ->license('MIT License')
+        ;
+
+        $info = $configurator->build();
+        $this->assertSame('Symfony OpenApi', $info->getTitle());
+        $this->assertSame('1.2.3', $info->getVersion());
+        $this->assertNotNull($info->getContact());
+        $this->assertNull($info->getContact()->getName());
+        $this->assertSame('https://selency.fr', $info->getContact()->getUrl());
+        $this->assertNull($info->getContact()->getEmail());
+        $this->assertNotNull($info->getLicense());
+        $this->assertSame('MIT License', $info->getLicense()->getName());
+        $this->assertNull($info->getLicense()->getIdentifier());
+        $this->assertNull($info->getLicense()->getUrl());
+        $this->assertSame([], $info->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        $configurator = (new InfoConfigurator())
+            ->title('Symfony OpenApi')
+            ->version('1.2.3')
+            ->contact(name: 'Selency', url: 'https://selency.fr', email: 'tech@selency.com', specificationExtensions: ['x-ext1' => 'value'])
+            ->license(name: 'MIT License', identifier: 'MIT', url: 'https://example.com', specificationExtensions: ['x-ext2' => 'value'])
+            ->specificationExtension('x-ext3', 'value')
+        ;
+
+        $info = $configurator->build();
+        $this->assertInstanceOf(Info::class, $info);
+        $this->assertSame('Symfony OpenApi', $info->getTitle());
+        $this->assertSame('1.2.3', $info->getVersion());
+        $this->assertSame(['x-ext3' => 'value'], $info->getSpecificationExtensions());
+        $this->assertNotNull($info->getContact());
+        $this->assertSame('Selency', $info->getContact()->getName());
+        $this->assertSame('https://selency.fr', $info->getContact()->getUrl());
+        $this->assertSame('tech@selency.com', $info->getContact()->getEmail());
+        $this->assertSame(['x-ext1' => 'value'], $info->getContact()->getSpecificationExtensions());
+        $this->assertNotNull($info->getLicense());
+        $this->assertSame('MIT License', $info->getLicense()->getName());
+        $this->assertSame('MIT', $info->getLicense()->getIdentifier());
+        $this->assertSame('https://example.com', $info->getLicense()->getUrl());
+        $this->assertSame(['x-ext2' => 'value'], $info->getLicense()->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/LinkConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/LinkConfiguratorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\LinkConfigurator;
+use Symfony\Component\OpenApi\Configurator\ParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\ServerConfigurator;
+use Symfony\Component\OpenApi\Model\Link;
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\Server;
+
+class LinkConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $configurator = new LinkConfigurator();
+
+        $link = $configurator->build();
+        $this->assertInstanceOf(Link::class, $link);
+        $this->assertNull($link->getOperationRef());
+        $this->assertNull($link->getOperationId());
+        $this->assertNull($link->getParameters());
+        $this->assertNull($link->getRequestBody());
+        $this->assertNull($link->getDescription());
+        $this->assertNull($link->getServer());
+        $this->assertSame([], $link->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        [$parameterConfigurator, $parameter] = $this->createConfiguratorMock(ParameterConfigurator::class, Parameter::class);
+        [$serverConfigurator, $server] = $this->createConfiguratorMock(ServerConfigurator::class, Server::class);
+
+        $configurator = (new LinkConfigurator())
+            ->operationRef('reference')
+            ->operationId('id')
+            ->parameter($parameterConfigurator)
+            ->requestBody('request body')
+            ->description('description')
+            ->server($serverConfigurator)
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $link = $configurator->build();
+        $this->assertInstanceOf(Link::class, $link);
+        $this->assertSame('reference', $link->getOperationRef());
+        $this->assertSame('id', $link->getOperationId());
+        $this->assertSame($parameter, $link->getParameters()[0]);
+        $this->assertSame('request body', $link->getRequestBody());
+        $this->assertSame('description', $link->getDescription());
+        $this->assertSame($server, $link->getServer());
+        $this->assertSame(['x-ext' => 'value'], $link->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/MediaTypeConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/MediaTypeConfiguratorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\EncodingConfigurator;
+use Symfony\Component\OpenApi\Configurator\ExampleConfigurator;
+use Symfony\Component\OpenApi\Configurator\MediaTypeConfigurator;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Model\Encoding;
+use Symfony\Component\OpenApi\Model\Example;
+use Symfony\Component\OpenApi\Model\MediaType;
+use Symfony\Component\OpenApi\Model\Schema;
+
+class MediaTypeConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $configurator = new MediaTypeConfigurator();
+
+        $mediaType = $configurator->build();
+        $this->assertInstanceOf(MediaType::class, $mediaType);
+        $this->assertNull($mediaType->getSchema());
+        $this->assertNull($mediaType->getExample());
+        $this->assertNull($mediaType->getExamples());
+        $this->assertNull($mediaType->getEncodings());
+        $this->assertSame([], $mediaType->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        [$schemaConfigurator, $schema] = $this->createConfiguratorMock(SchemaConfigurator::class, Schema::class);
+        [$exampleConfigurator, $example] = $this->createConfiguratorMock(ExampleConfigurator::class, Example::class);
+        [$encodingConfigurator, $encoding] = $this->createConfiguratorMock(EncodingConfigurator::class, Encoding::class);
+
+        $configurator = (new MediaTypeConfigurator())
+            ->schema($schemaConfigurator)
+            ->example('example')
+            ->example('ExampleName', $exampleConfigurator)
+            ->encoding('EncodingName', $encodingConfigurator)
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $mediaType = $configurator->build();
+        $this->assertInstanceOf(MediaType::class, $mediaType);
+        $this->assertSame($schema, $mediaType->getSchema());
+        $this->assertSame('example', $mediaType->getExample());
+        $this->assertSame($example, $mediaType->getExamples()['ExampleName']);
+        $this->assertSame($encoding, $mediaType->getEncodings()['EncodingName']);
+        $this->assertSame(['x-ext' => 'value'], $mediaType->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/OperationConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/OperationConfiguratorTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilder;
+use Symfony\Component\OpenApi\Configurator\CallbackRequestConfigurator;
+use Symfony\Component\OpenApi\Configurator\OperationConfigurator;
+use Symfony\Component\OpenApi\Configurator\ParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\RequestBodyConfigurator;
+use Symfony\Component\OpenApi\Configurator\ResponsesConfigurator;
+use Symfony\Component\OpenApi\Configurator\ServerConfigurator;
+use Symfony\Component\OpenApi\Model\CallbackRequest;
+use Symfony\Component\OpenApi\Model\Operation;
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\RequestBody;
+use Symfony\Component\OpenApi\Model\Responses;
+use Symfony\Component\OpenApi\Model\Server;
+
+class OperationConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $configurator = new OperationConfigurator(new OpenApiBuilder());
+
+        $operation = $configurator->build();
+        $this->assertInstanceOf(Operation::class, $operation);
+        $this->assertNull($operation->getOperationId());
+        $this->assertNull($operation->getSummary());
+        $this->assertNull($operation->getDescription());
+        $this->assertNull($operation->getDeprecated());
+        $this->assertNull($operation->getTags());
+        $this->assertNull($operation->getExternalDocs());
+        $this->assertNull($operation->getParameters());
+        $this->assertNull($operation->getRequestBody());
+        $this->assertNull($operation->getResponses());
+        $this->assertNull($operation->getCallbacks());
+        $this->assertNull($operation->getSecurity());
+        $this->assertNull($operation->getServers());
+        $this->assertSame([], $operation->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        [$parameterConfigurator, $parameter] = $this->createConfiguratorMock(ParameterConfigurator::class, Parameter::class);
+        [$requestBodyConfigurator, $requestBody] = $this->createConfiguratorMock(RequestBodyConfigurator::class, RequestBody::class);
+        [$responsesConfigurator, $responses] = $this->createConfiguratorMock(ResponsesConfigurator::class, Responses::class);
+        [$callbackRequestConfigurator, $callbackRequest] = $this->createConfiguratorMock(CallbackRequestConfigurator::class, CallbackRequest::class);
+        [$serverConfigurator, $server] = $this->createConfiguratorMock(ServerConfigurator::class, Server::class);
+
+        $configurator = (new OperationConfigurator(new OpenApiBuilder()))
+            ->operationId('operation_id')
+            ->summary('summary')
+            ->description('description')
+            ->deprecated(true)
+            ->tag('TagName')
+            ->externalDocs('https://selency.fr', 'Description example', ['x-key' => 'value'])
+            ->parameter($parameterConfigurator)
+            ->requestBody($requestBodyConfigurator)
+            ->responses($responsesConfigurator)
+            ->callback('CallbackName', $callbackRequestConfigurator)
+            ->securityRequirement('SecurityRequirement', ['config' => 'value'])
+            ->server($serverConfigurator)
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $operation = $configurator->build();
+        $this->assertInstanceOf(Operation::class, $operation);
+        $this->assertSame('operation_id', $operation->getOperationId());
+        $this->assertSame('summary', $operation->getSummary());
+        $this->assertSame('description', $operation->getDescription());
+        $this->assertTrue($operation->getDeprecated());
+        $this->assertSame(['TagName'], $operation->getTags());
+        $this->assertNotNull($operation->getExternalDocs());
+        $this->assertSame('https://selency.fr', $operation->getExternalDocs()->getUrl());
+        $this->assertSame('Description example', $operation->getExternalDocs()->getDescription());
+        $this->assertSame(['x-key' => 'value'], $operation->getExternalDocs()->getSpecificationExtensions());
+        $this->assertSame($parameter, $operation->getParameters()[0]);
+        $this->assertSame($requestBody, $operation->getRequestBody());
+        $this->assertSame($responses, $operation->getResponses());
+        $this->assertSame($callbackRequest, $operation->getCallbacks()['CallbackName']);
+        $this->assertSame('SecurityRequirement', $operation->getSecurity()[0]->getName());
+        $this->assertSame(['config' => 'value'], $operation->getSecurity()[0]->getConfig());
+        $this->assertSame($server, $operation->getServers()[0]);
+        $this->assertSame(['x-ext' => 'value'], $operation->getSpecificationExtensions());
+    }
+
+    public function testSecurityRequirementUseGlobal(): void
+    {
+        $operation = (new OperationConfigurator(new OpenApiBuilder()))->build();
+        $this->assertSame([], $operation->toArray());
+    }
+
+    public function testSecurityRequirementForceNone(): void
+    {
+        $operation = (new OperationConfigurator(new OpenApiBuilder()))
+            ->securityRequirement(null)
+            ->build();
+
+        $this->assertSame(['security' => []], $operation->toArray());
+    }
+
+    public function testSecurityRequirementAllowNone(): void
+    {
+        $operation = (new OperationConfigurator(new OpenApiBuilder()))
+            ->securityRequirement(null)
+            ->securityRequirement('JWTBearer')
+            ->build();
+
+        $this->assertSame([
+            'security' => [
+                ['__NO_SECURITY' => []],
+                ['JWTBearer' => []],
+            ],
+        ], $operation->toArray());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/ParameterConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/ParameterConfiguratorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\ExampleConfigurator;
+use Symfony\Component\OpenApi\Configurator\MediaTypeConfigurator;
+use Symfony\Component\OpenApi\Configurator\ParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Model\Example;
+use Symfony\Component\OpenApi\Model\MediaType;
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\ParameterIn;
+use Symfony\Component\OpenApi\Model\Schema;
+
+class ParameterConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $configurator = new ParameterConfigurator('name');
+
+        $parameter = $configurator->build();
+        $this->assertInstanceOf(Parameter::class, $parameter);
+        $this->assertSame('name', $parameter->getName());
+        $this->assertNull($parameter->getIn());
+        $this->assertNull($parameter->getDescription());
+        $this->assertNull($parameter->getRequired());
+        $this->assertNull($parameter->getDeprecated());
+        $this->assertNull($parameter->getAllowEmptyValue());
+        $this->assertNull($parameter->getStyle());
+        $this->assertNull($parameter->getExplode());
+        $this->assertNull($parameter->getAllowReserved());
+        $this->assertNull($parameter->getSchema());
+        $this->assertNull($parameter->getExample());
+        $this->assertNull($parameter->getExamples());
+        $this->assertNull($parameter->getContent());
+        $this->assertSame([], $parameter->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        [$schemaConfigurator, $schema] = $this->createConfiguratorMock(SchemaConfigurator::class, Schema::class);
+        [$exampleConfigurator, $example] = $this->createConfiguratorMock(ExampleConfigurator::class, Example::class);
+        [$mediaTypeConfigurator, $mediaType] = $this->createConfiguratorMock(MediaTypeConfigurator::class, MediaType::class);
+
+        $configurator = (new ParameterConfigurator('name'))
+            ->name('renamed')
+            ->in(ParameterIn::HEADER)
+            ->description('description')
+            ->required(true)
+            ->deprecated(true)
+            ->allowEmptyValue(true)
+            ->style('style')
+            ->explode(true)
+            ->allowReserved(true)
+            ->schema($schemaConfigurator)
+            ->example('example')
+            ->example('ExampleName', $exampleConfigurator)
+            ->content('application/json', $mediaTypeConfigurator)
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $parameter = $configurator->build();
+        $this->assertInstanceOf(Parameter::class, $parameter);
+        $this->assertSame('renamed', $parameter->getName());
+        $this->assertSame(ParameterIn::HEADER, $parameter->getIn());
+        $this->assertSame('description', $parameter->getDescription());
+        $this->assertTrue($parameter->getRequired());
+        $this->assertTrue($parameter->getDeprecated());
+        $this->assertTrue($parameter->getAllowEmptyValue());
+        $this->assertSame('style', $parameter->getStyle());
+        $this->assertTrue($parameter->getExplode());
+        $this->assertTrue($parameter->getAllowReserved());
+        $this->assertSame($schema, $parameter->getSchema());
+        $this->assertSame('example', $parameter->getExample());
+        $this->assertSame($example, $parameter->getExamples()['ExampleName']);
+        $this->assertSame($mediaType, $parameter->getContent()['application/json']);
+        $this->assertSame(['x-ext' => 'value'], $parameter->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/QueryParameterConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/QueryParameterConfiguratorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\ExampleConfigurator;
+use Symfony\Component\OpenApi\Configurator\MediaTypeConfigurator;
+use Symfony\Component\OpenApi\Configurator\QueryParameterConfigurator;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Model\Example;
+use Symfony\Component\OpenApi\Model\MediaType;
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\ParameterIn;
+use Symfony\Component\OpenApi\Model\Schema;
+
+class QueryParameterConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $configurator = new QueryParameterConfigurator('name');
+
+        $parameter = $configurator->build();
+        $this->assertInstanceOf(Parameter::class, $parameter);
+        $this->assertSame('name', $parameter->getName());
+        $this->assertSame(ParameterIn::QUERY, $parameter->getIn());
+        $this->assertNull($parameter->getDescription());
+        $this->assertNull($parameter->getRequired());
+        $this->assertNull($parameter->getDeprecated());
+        $this->assertNull($parameter->getAllowEmptyValue());
+        $this->assertNull($parameter->getStyle());
+        $this->assertNull($parameter->getExplode());
+        $this->assertNull($parameter->getAllowReserved());
+        $this->assertNull($parameter->getSchema());
+        $this->assertNull($parameter->getExample());
+        $this->assertNull($parameter->getExamples());
+        $this->assertNull($parameter->getContent());
+        $this->assertSame([], $parameter->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        [$schemaConfigurator, $schema] = $this->createConfiguratorMock(SchemaConfigurator::class, Schema::class);
+        [$exampleConfigurator, $example] = $this->createConfiguratorMock(ExampleConfigurator::class, Example::class);
+        [$mediaTypeConfigurator, $mediaType] = $this->createConfiguratorMock(MediaTypeConfigurator::class, MediaType::class);
+
+        $configurator = (new QueryParameterConfigurator('name'))
+            ->name('renamed')
+            ->description('description')
+            ->required(true)
+            ->deprecated(true)
+            ->allowEmptyValue(true)
+            ->style('style')
+            ->explode(true)
+            ->allowReserved(true)
+            ->schema($schemaConfigurator)
+            ->example('example')
+            ->example('ExampleName', $exampleConfigurator)
+            ->content('application/json', $mediaTypeConfigurator)
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $parameter = $configurator->build();
+        $this->assertInstanceOf(Parameter::class, $parameter);
+        $this->assertSame('renamed', $parameter->getName());
+        $this->assertSame(ParameterIn::QUERY, $parameter->getIn());
+        $this->assertSame('description', $parameter->getDescription());
+        $this->assertTrue($parameter->getRequired());
+        $this->assertTrue($parameter->getDeprecated());
+        $this->assertTrue($parameter->getAllowEmptyValue());
+        $this->assertSame('style', $parameter->getStyle());
+        $this->assertTrue($parameter->getExplode());
+        $this->assertTrue($parameter->getAllowReserved());
+        $this->assertSame($schema, $parameter->getSchema());
+        $this->assertSame('example', $parameter->getExample());
+        $this->assertSame($example, $parameter->getExamples()['ExampleName']);
+        $this->assertSame($mediaType, $parameter->getContent()['application/json']);
+        $this->assertSame(['x-ext' => 'value'], $parameter->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/QueryParametersConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/QueryParametersConfiguratorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilder;
+use Symfony\Component\OpenApi\Configurator\QueryParametersConfigurator;
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Model\Parameter;
+use Symfony\Component\OpenApi\Model\ParameterIn;
+use Symfony\Component\OpenApi\Tests\Configurator\fixtures\ClassWithoutQueryParameterDescribeMethod;
+use Symfony\Component\OpenApi\Tests\Configurator\fixtures\ClassWithQueryParameterDescribeMethod;
+
+class QueryParametersConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testEmpty(): void
+    {
+        $configurator = new QueryParametersConfigurator(new OpenApiBuilder());
+
+        $this->assertEmpty($configurator->getParameters());
+    }
+
+    public function testAddQueryParameters(): void
+    {
+        $configurator = new QueryParametersConfigurator(new OpenApiBuilder());
+
+        $configurator
+            ->queryParameter('test1')
+            ->queryParameter('test2')
+        ;
+
+        $parameters = $configurator->getParameters();
+
+        $this->assertCount(2, $parameters);
+        $this->assertSame('#/components/parameters/test1', $parameters[0]->getRef());
+        $this->assertSame('#/components/parameters/test2', $parameters[1]->getRef());
+    }
+
+    public function testFromDefinitionEmpty(): void
+    {
+        $configurator = QueryParametersConfigurator::createFromDefinition('', new OpenApiBuilder());
+
+        $this->assertInstanceOf(QueryParametersConfigurator::class, $configurator);
+        $this->assertEmpty($configurator->getParameters());
+    }
+
+    public function testFromDefinitionQueryParameter(): void
+    {
+        $definition = new QueryParametersConfigurator(new OpenApiBuilder());
+        $configurator = QueryParametersConfigurator::createFromDefinition($definition, new OpenApiBuilder());
+
+        $this->assertSame($configurator, $definition);
+    }
+
+    public function testFromDefinitionReference(): void
+    {
+        $definition = new ReferenceConfigurator('test');
+        $configurator = QueryParametersConfigurator::createFromDefinition($definition, new OpenApiBuilder());
+
+        $this->assertSame($configurator, $definition);
+    }
+
+    public function testFromDefinitionClassWithoutDescribe(): void
+    {
+        /** @var ReferenceConfigurator $configurator */
+        $configurator = QueryParametersConfigurator::createFromDefinition(ClassWithoutQueryParameterDescribeMethod::class, new OpenApiBuilder());
+
+        $this->assertInstanceOf(ReferenceConfigurator::class, $configurator);
+        $this->assertSame(
+            '#/components/parameters/Symfony_Component_OpenApi_Tests_Configurator_fixtures_ClassWithoutQueryParameterDescribeMethod',
+            $configurator->build()->getRef()
+        );
+    }
+
+    public function testFromDefinitionClassWithDescribe(): void
+    {
+        /** @var QueryParametersConfigurator $configurator */
+        $configurator = QueryParametersConfigurator::createFromDefinition(ClassWithQueryParameterDescribeMethod::class, new OpenApiBuilder());
+
+        $this->assertInstanceOf(QueryParametersConfigurator::class, $configurator);
+
+        $parameters = $configurator->getParameters();
+
+        $this->assertCount(1, $parameters);
+
+        /** @var Parameter $parameter */
+        $parameter = $parameters[0];
+
+        $this->assertInstanceOf(Parameter::class, $parameter);
+        $this->assertSame('test', $parameter->getName());
+        $this->assertSame(ParameterIn::QUERY, $parameter->getIn());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/ReferenceConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/ReferenceConfiguratorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\ReferenceConfigurator;
+use Symfony\Component\OpenApi\Model\Reference;
+
+class ReferenceConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function provideNormalize(): iterable
+    {
+        yield ['ReferenceName', 'ReferenceName'];
+        yield ['App\\Transformer\\ExampleTransformer', 'App_Transformer_ExampleTransformer'];
+        yield ['file.php', 'file.php'];
+        yield ['invalid-name', 'invalid-name'];
+        yield ['invalid_name', 'invalid_name'];
+        yield ['invalid||name', 'invalid_name'];
+    }
+
+    /**
+     * @dataProvider provideNormalize
+     */
+    public function testNormalize(string $input, string $expectedOutput): void
+    {
+        $this->assertSame($expectedOutput, ReferenceConfigurator::normalize($input));
+    }
+
+    public function testBuildEmpty(): void
+    {
+        $configurator = new ReferenceConfigurator('#/components/schemas/ReferenceName');
+
+        $reference = $configurator->build();
+        $this->assertInstanceOf(Reference::class, $reference);
+        $this->assertSame('#/components/schemas/ReferenceName', $reference->getRef());
+        $this->assertNull($reference->getDescription());
+        $this->assertNull($reference->getSummary());
+        $this->assertSame([], $reference->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        $configurator = (new ReferenceConfigurator('#/components/schemas/ReferenceName'))
+            ->description('description')
+            ->summary('summary')
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $reference = $configurator->build();
+        $this->assertInstanceOf(Reference::class, $reference);
+        $this->assertSame('#/components/schemas/ReferenceName', $reference->getRef());
+        $this->assertSame('description', $reference->getDescription());
+        $this->assertSame('summary', $reference->getSummary());
+        $this->assertSame(['x-ext' => 'value'], $reference->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/SchemaConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/SchemaConfiguratorTest.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Model\Discriminator;
+use Symfony\Component\OpenApi\Model\ExternalDocumentation;
+use Symfony\Component\OpenApi\Model\Reference;
+use Symfony\Component\OpenApi\Model\Schema;
+use Symfony\Component\OpenApi\Model\Xml;
+
+class SchemaConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testDefinitionEmpty(): void
+    {
+        $schema = SchemaConfigurator::createFromDefinition()->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertNull($schema->getType());
+        $this->assertNull($schema->isNullable());
+        $this->assertSame([], $schema->toArray());
+    }
+
+    public function testDefinitionNull(): void
+    {
+        $schema = SchemaConfigurator::createFromDefinition('null')->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertSame(['null'], $schema->getType());
+        $this->assertTrue($schema->isNullable());
+        $this->assertSame(['type' => ['null']], $schema->toArray());
+    }
+
+    public function testDefinitionTypeNullableOverriden(): void
+    {
+        $schema = SchemaConfigurator::createFromDefinition()->nullable(true)->type('string')->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertSame(['string'], $schema->getType());
+        $this->assertFalse($schema->isNullable());
+        $this->assertSame(['type' => ['string']], $schema->toArray());
+    }
+
+    public function testDefinitionTypeNullable(): void
+    {
+        $schema = SchemaConfigurator::createFromDefinition()->type('string')->nullable(true)->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertSame(['string', 'null'], $schema->getType());
+        $this->assertTrue($schema->isNullable());
+        $this->assertSame(['type' => ['string', 'null']], $schema->toArray());
+    }
+
+    public function testDefinitionFloat(): void
+    {
+        $schema = SchemaConfigurator::createFromDefinition('float')->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertSame(['number'], $schema->getType());
+        $this->assertFalse($schema->isNullable());
+        $this->assertSame(['type' => ['number']], $schema->toArray());
+    }
+
+    public function testDefinitionNullableString(): void
+    {
+        $schema = SchemaConfigurator::createFromDefinition('?string')->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertSame(['string', 'null'], $schema->getType());
+        $this->assertTrue($schema->isNullable());
+        $this->assertSame(['type' => ['string', 'null']], $schema->toArray());
+    }
+
+    public function testDefinitionRecursive(): void
+    {
+        $schema = SchemaConfigurator::createFromDefinition(SchemaConfigurator::createFromDefinition('?string'))->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertSame(['string', 'null'], $schema->getType());
+        $this->assertTrue($schema->isNullable());
+    }
+
+    public function testDefinitionReference(): void
+    {
+        $reference = SchemaConfigurator::createFromDefinition('ReferenceName')->build();
+        $this->assertInstanceOf(Reference::class, $reference);
+        $this->assertSame('#/components/schemas/ReferenceName', $reference->getRef());
+    }
+
+    public function testDefinitionArray(): void
+    {
+        $schema = SchemaConfigurator::createFromDefinition(['float', 'null'])->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertSame(['number', 'null'], $schema->getType());
+        $this->assertTrue($schema->isNullable());
+    }
+
+    public function testBuildEmpty(): void
+    {
+        $schema = (new SchemaConfigurator())->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertNull($schema->getTitle());
+        $this->assertNull($schema->getDescription());
+        $this->assertNull($schema->getMultipleOf());
+        $this->assertNull($schema->getMaximum());
+        $this->assertNull($schema->isExclusiveMaximum());
+        $this->assertNull($schema->getMinimum());
+        $this->assertNull($schema->isExclusiveMinimum());
+        $this->assertNull($schema->getMaxLength());
+        $this->assertNull($schema->getMinLength());
+        $this->assertNull($schema->getPattern());
+        $this->assertNull($schema->getMaxItems());
+        $this->assertNull($schema->getMinItems());
+        $this->assertNull($schema->isUniqueItems());
+        $this->assertNull($schema->getMaxProperties());
+        $this->assertNull($schema->getMinProperties());
+        $this->assertNull($schema->getRequired());
+        $this->assertNull($schema->getEnum());
+        $this->assertNull($schema->getType());
+        $this->assertNull($schema->getFormat());
+        $this->assertNull($schema->getDefault());
+        $this->assertNull($schema->isNullable());
+        $this->assertNull($schema->isReadOnly());
+        $this->assertNull($schema->isWriteOnly());
+        $this->assertNull($schema->getExample());
+        $this->assertNull($schema->isDeprecated());
+        $this->assertSame([], $schema->getSpecificationExtensions());
+        $this->assertNull($schema->getDiscriminator());
+        $this->assertNull($schema->getXml());
+        $this->assertNull($schema->getExternalDocs());
+    }
+
+    public function testBuildFull(): void
+    {
+        $configurator = (new SchemaConfigurator())
+            ->title('title')
+            ->description('description')
+            ->multipleOf(2)
+            ->maximum(100)
+            ->exclusiveMaximum(true)
+            ->minimum(10)
+            ->exclusiveMinimum(true)
+            ->maxLength(5)
+            ->minLength(3)
+            ->pattern('^[a-zA-Z]*$')
+            ->maxItems(5)
+            ->minItems(2)
+            ->uniqueItems(true)
+            ->maxProperties(3)
+            ->minProperties(1)
+            ->required(['foo', 'bar'])
+            ->enum(['foo', 'bar'])
+            ->type('?string')
+            ->format('binary')
+            ->default('foo')
+            ->readOnly(true)
+            ->writeOnly(true)
+            ->example('foo')
+            ->discriminator(propertyName: 'type', mapping: ['mapping' => 'value'], specificationExtensions: ['x-ext2' => 'value'])
+            ->xml(name: 'name', namespace: 'namespace', prefix: 'prefix', attribute: true, wrapped: true, specificationExtensions: ['x-ext3' => 'value'])
+            ->externalDocs(url: 'https://example.com', description: 'external docs', specificationExtensions: ['x-ext4' => 'value'])
+            ->deprecated(true)
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $schema = $configurator->build();
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertSame('title', $schema->getTitle());
+        $this->assertSame('description', $schema->getDescription());
+        $this->assertSame(2, $schema->getMultipleOf());
+        $this->assertSame(100, $schema->getMaximum());
+        $this->assertTrue($schema->isExclusiveMaximum());
+        $this->assertSame(10, $schema->getMinimum());
+        $this->assertTrue($schema->isExclusiveMinimum());
+        $this->assertSame(5, $schema->getMaxLength());
+        $this->assertSame(3, $schema->getMinLength());
+        $this->assertSame('^[a-zA-Z]*$', $schema->getPattern());
+        $this->assertSame(5, $schema->getMaxItems());
+        $this->assertSame(2, $schema->getMinItems());
+        $this->assertTrue($schema->isUniqueItems());
+        $this->assertSame(3, $schema->getMaxProperties());
+        $this->assertSame(1, $schema->getMinProperties());
+        $this->assertSame(['foo', 'bar'], $schema->getRequired());
+        $this->assertSame(['foo', 'bar'], $schema->getEnum());
+        $this->assertSame(['string', 'null'], $schema->getType());
+        $this->assertSame('binary', $schema->getFormat());
+        $this->assertSame('foo', $schema->getDefault());
+        $this->assertTrue($schema->isNullable());
+        $this->assertTrue($schema->isReadOnly());
+        $this->assertTrue($schema->isWriteOnly());
+        $this->assertSame('foo', $schema->getExample());
+        $this->assertTrue($schema->isDeprecated());
+        $this->assertSame(['x-ext' => 'value'], $schema->getSpecificationExtensions());
+        $this->assertInstanceOf(Discriminator::class, $schema->getDiscriminator());
+        $this->assertSame('type', $schema->getDiscriminator()->getPropertyName());
+        $this->assertSame(['mapping' => 'value'], $schema->getDiscriminator()->getMapping());
+        $this->assertSame(['x-ext2' => 'value'], $schema->getDiscriminator()->getSpecificationExtensions());
+        $this->assertInstanceOf(Xml::class, $schema->getXml());
+        $this->assertSame('name', $schema->getXml()->getName());
+        $this->assertSame('namespace', $schema->getXml()->getNamespace());
+        $this->assertSame('prefix', $schema->getXml()->getPrefix());
+        $this->assertTrue($schema->getXml()->isAttribute());
+        $this->assertTrue($schema->getXml()->isWrapped());
+        $this->assertSame(['x-ext3' => 'value'], $schema->getXml()->getSpecificationExtensions());
+        $this->assertInstanceOf(ExternalDocumentation::class, $schema->getExternalDocs());
+        $this->assertSame('https://example.com', $schema->getExternalDocs()->getUrl());
+        $this->assertSame('external docs', $schema->getExternalDocs()->getDescription());
+        $this->assertSame(['x-ext4' => 'value'], $schema->getExternalDocs()->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/TagConfiguratorTest.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/TagConfiguratorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Configurator;
+
+use Symfony\Component\OpenApi\Configurator\TagConfigurator;
+use Symfony\Component\OpenApi\Model\ExternalDocumentation;
+use Symfony\Component\OpenApi\Model\Tag;
+
+class TagConfiguratorTest extends AbstractConfiguratorTestCase
+{
+    public function testBuildEmpty(): void
+    {
+        $configurator = new TagConfigurator();
+
+        $tag = $configurator->build();
+        $this->assertInstanceOf(Tag::class, $tag);
+        $this->assertSame('', $tag->getName());
+        $this->assertNull($tag->getDescription());
+        $this->assertNull($tag->getExternalDocs());
+        $this->assertSame([], $tag->getSpecificationExtensions());
+    }
+
+    public function testBuildFull(): void
+    {
+        $configurator = (new TagConfigurator())
+            ->name('name')
+            ->description('description')
+            ->externalDocs(url: 'https://example.com', description: 'external docs', specificationExtensions: ['x-ext2' => 'value'])
+            ->specificationExtension('x-ext', 'value')
+        ;
+
+        $tag = $configurator->build();
+        $this->assertInstanceOf(Tag::class, $tag);
+        $this->assertSame('name', $tag->getName());
+        $this->assertSame('description', $tag->getDescription());
+        $this->assertSame(['x-ext' => 'value'], $tag->getSpecificationExtensions());
+        $this->assertInstanceOf(ExternalDocumentation::class, $tag->getExternalDocs());
+        $this->assertSame('https://example.com', $tag->getExternalDocs()->getUrl());
+        $this->assertSame('external docs', $tag->getExternalDocs()->getDescription());
+        $this->assertSame(['x-ext2' => 'value'], $tag->getExternalDocs()->getSpecificationExtensions());
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/fixtures/ClassWithQueryParameterDescribeMethod.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/fixtures/ClassWithQueryParameterDescribeMethod.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\OpenApi\Tests\Configurator\fixtures;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Configurator\QueryParametersConfigurator;
+
+class ClassWithQueryParameterDescribeMethod
+{
+    public static function describeQueryParameters(QueryParametersConfigurator $configurator, OpenApiBuilderInterface $openApi): void
+    {
+        $configurator
+            ->queryParameter($openApi->queryParameter('test'))
+        ;
+    }
+}

--- a/src/Symfony/Component/OpenApi/Tests/Configurator/fixtures/ClassWithoutQueryParameterDescribeMethod.php
+++ b/src/Symfony/Component/OpenApi/Tests/Configurator/fixtures/ClassWithoutQueryParameterDescribeMethod.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\OpenApi\Tests\Configurator\fixtures;
+
+class ClassWithoutQueryParameterDescribeMethod
+{
+}

--- a/src/Symfony/Component/OpenApi/Tests/Loader/MockSelfDescribingSchema.php
+++ b/src/Symfony/Component/OpenApi/Tests/Loader/MockSelfDescribingSchema.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OpenApi\Tests\Loader;
+
+use Symfony\Component\OpenApi\Builder\OpenApiBuilderInterface;
+use Symfony\Component\OpenApi\Configurator\SchemaConfigurator;
+use Symfony\Component\OpenApi\Loader\SelfDescribingSchemaInterface;
+
+class MockSelfDescribingSchema implements SelfDescribingSchemaInterface
+{
+    public static function describeSchema(SchemaConfigurator $schema, OpenApiBuilderInterface $openApi): void
+    {
+        $schema
+            ->title('Mock')
+            ->property('username', 'string')
+            ->property('status', $openApi->schema()->enum(['active', 'banned']))
+        ;
+    }
+}

--- a/src/Symfony/Component/OpenApi/composer.json
+++ b/src/Symfony/Component/OpenApi/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "symfony/openapi",
+    "type": "library",
+    "description": "Provides a user-friendly, object-oriented library to build OpenAPI specifications using PHP.",
+    "keywords": ["openapi", "api", "specification", "documentation"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Titouan Galopin",
+            "email": "galopintitouan@gmail.com"
+        },
+        {
+            "name": "Selency Team",
+            "homepage": "https://selency.fr"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.1"
+    },
+    "require-dev": {
+        "symfony/validator": "^6.2",
+        "symfony/var-dumper": "^6.2",
+        "symfony/phpunit-bridge": "^6.2"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\OpenApi\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/OpenApi/phpunit.xml.dist
+++ b/src/Symfony/Component/OpenApi/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony OpenApi Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/issues/17987

This PR proposes the introduction of a new OpenApi component to the Symfony ecosystem. The component aims at providing a user-friendly, object-oriented API to build OpenAPI specifications using PHP.

This component's proposal comes from difficulties we (at Selency) encountered while trying to implement a high-quality documentation using alternatives (like NelmioApiDocBundle or swagger-php):

1. AFAIK existing OpenApi packages in PHP are focused on the code: it is usually difficult to create a documentation independant from the structure of the application. They work using attributes and focus on describing the code, not the usage of the API. This leads to resulting documentations being difficult to use by consumers.
2. In addition, because such packages are so tied to the code, it is difficult to maintain multiple documentations at the same time: this means it's difficult to create different documentations for different API versions in the same codebase. 

To address these issues, our proposal is instead to rely on PHP and its capabilities: in the same way we can now define services in PHP with autocompleted method names and linting, this component proposes the ability to describe an OpenApi documentation in PHP, and then dump it as JSON or YAML for usage in other tools. All features of OpenApi v3.1 are supported.

**Simple usage example**

```php
use Symfony\Component\OpenApi\Documentation\AbstractDocumentation;

class Documentation extends AbstractDocumentation
{
    public function getIdentifier(): string
    {
        return 'myapi';
    }

    public function getVersion(): string
    {
        return '1.3.4';
    }

    public function configure(DocumentationConfigurator $doc): void
    {
        $doc->info($this->openApi->info()
            ->title('Monolith API')
            ->description(file_get_contents(__DIR__.'/Resources/info_description.md'))
            ->contact(name: 'API support', url: 'https://symfony.com', email: 'contact@symfony.com')
            ->specificationExtension('x-logo', [
                'url' => 'https://symfony.com/logos/symfony_black_02.png',
                'altText' => 'Symfony logo',
            ])
            ->license('MIT')
        );

        $doc->externalDocs(url: 'https://github.com/symfony/openapi', description: 'OpenApi component');

        $doc->server($this->openApi->server('https://api.symfony.local')->description('Local'))
            ->server($this->openApi->server('https://api.symfony-staging.com')->description('Staging'))
            ->server($this->openApi->server('https://api.symfony.com')->description('Prod'));

        $doc->securityRequirement(self::REF_SECURITY_USER_JWT);

        $doc->path('/health', $this->openApi->pathItem()
            ->get($this->openApi->operation()
                ->tag('Health')
                ->operationId('app.health.check')
                ->summary('Health check')
                ->description('Check the API is up and available.')
                ->securityRequirement(null)
                ->responses($this->openApi->responses()
                    ->response('200', $this->openApi->response()
                        ->description('When the API is up and available.')
                        ->content('application/json', $this->openApi->schema()
                            ->property('name', $this->openApi->schema()->type('string')->description('Name for this API')->example('Selency API'))
                            ->property('env', $this->openApi->schema()->type('string')->description('Current environment of this instance of the API')->example('prod'))
                        )
                    )
                    ->response('500', $this->openApi->response()->description('When the API is unavailable due to a backend problem.'))
                )
            )
        );

        // ...
    }
}

// Build a read-only model representing the documentation
$compiler = new DocumentationCompiler();
$openApiDefinition = $compiler->compile($doc);

// Compile it as YAML or JSON for usage in other tools
$openApiYaml = (new Dumper\YamlDumper())->dump($openApiDefinition);
$openApiJson = (new Dumper\JsonDumper())->dump($openApiDefinition);
```

You can find more advanced usages in the [README](https://github.com/symfony/symfony/blob/6f6d638d632b46bb93b3c4bbd64232fedab3c2ac/src/Symfony/Component/OpenApi/README.md).

> **Note:** without having concerted our efforts, I recently realized that this component works very nicely with https://github.com/symfony/symfony/pull/49138 as well, by giving the possibility to put the documentation in payloads.

If this component is approved, I plan to do the FrameworkBundle integration right after to automate several aspects of its usage: self-describing schemas/query params loading, openapi directory creation in the project, ...