### PR TITLE
[Messenger] Fix TransportNamesStamp for serialization

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/TransportNamesStamp.php
@@ -17,14 +17,17 @@ namespace Symfony\Component\Messenger\Stamp;
 final class TransportNamesStamp implements StampInterface
 {
     /**
-     * @param string[] $transports Transport names to be used for the message
+     * @param string[] $transportNames Transport names to be used for the message
      */
-    public function __construct(private array $transports)
+    public function __construct(private array $transportNames)
     {
     }
 
+    /**
+     * @return string[]
+     */
     public function getTransportNames(): array
     {
-        return $this->transports;
+        return $this->transportNames;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #49574 
| License       | MIT
| Doc PR        | N/A

See Ticket: the name of the getter should match the name in the constructor for proper serialization and deserialization using `Symfony\Component\Messenger\Transport\Serialization\Serializer`
