### PR TITLE
Avoid leading .. for temporary files from Filesystem recursive remove

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -170,7 +170,7 @@ class Filesystem
                 }
             } elseif (is_dir($file)) {
                 if (!$isRecursive) {
-                    $tmpName = \dirname(realpath($file)).'/.'.strrev(strtr(base64_encode(random_bytes(2)), '/=', '-.'));
+                    $tmpName = \dirname(realpath($file)).'/.'.strrev(strtr(base64_encode(random_bytes(2)), '/=', '-_'));
 
                     if (file_exists($tmpName)) {
                         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

Method `Filesystem::doRemove` is using renaming of parent directory before recursive removal, in order to implement atomic remove.

This is a good thing, but to implement this is generating a random path name, with a modified base64 which replaces base64's `=` sign with `.`. This may lead to directory named as `path/..8U6/`  which freaked out our synchronization tools and security log scanner.

Since the leading `.` is already (correctly) hard-coded, I see no issue in using `_` as a safer alternative.

