### PR TITLE
[Translation] Speed up TranslationDebugCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -400,7 +400,6 @@ EOF
     private function getRootCodePaths(KernelInterface $kernel): array
     {
         $codePaths = $this->codePaths;
-        $codePaths[] = $kernel->getProjectDir().'/src';
         if ($this->defaultViewsPath) {
             $codePaths[] = $this->defaultViewsPath;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The `TranslationDebugCommand` is currently very very slow. I was digging in Symfony codebase and it turns out that Symfony has quite a few optimizations to limit the search paths for this command to only files where translator is used and twig templates:
- [TranslatorPass.php](https://github.com/symfony/symfony/blob/5b1a20d083348d3e26c710865d2238c3362af550/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php#L75-L82)
- [TranslatorPathsPass.php](https://github.com/symfony/symfony/blob/5b1a20d083348d3e26c710865d2238c3362af550/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php#L72-L75)

But all of this hard work is then thrown out of the window by the command itself adding `$kernel->getProjectDir().'/src'` to the list - making it impossible to search only the optimized list and searching the entire project anyway. In my case the command takes over 5 minutes with this line but less then 5 *seconds* when I remove it while keeping the exact same result.