### PR TITLE
[Mime] support overwriting form encoding

### DIFF
--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -32,7 +32,7 @@ class DataPart extends TextPart
     /**
      * @param resource|string|File $body Use a File instance to defer loading the file until rendering
      */
-    public function __construct($body, string $filename = null, string $contentType = null, string $encoding = null)
+    public function __construct($body, string $filename = null, string $contentType = null, string $encoding = null, string $formEncoding = null)
     {
         unset($this->_parent);
 
@@ -45,7 +45,7 @@ class DataPart extends TextPart
 
         parent::__construct($body, null, $subtype, $encoding);
 
-        $this->formEncoding = $encoding ?? '8bit';
+        $this->formEncoding = $formEncoding ?? '8bit';
 
         if (null !== $filename) {
             $this->filename = $filename;
@@ -56,7 +56,7 @@ class DataPart extends TextPart
 
     public static function fromPath(string $path, string $name = null, string $contentType = null, string $encoding = null): self
     {
-        return new self(new File($path), $name, $contentType, $encoding);
+        return new self(new File($path), $name, $contentType, $encoding, $encoding);
     }
 
     /**

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -26,6 +26,9 @@ class DataPart extends TextPart
     private $mediaType;
     private $cid;
 
+    /** @internal */
+    private $formEncoding;
+
     /**
      * @param resource|string|File $body Use a File instance to defer loading the file until rendering
      */
@@ -42,6 +45,8 @@ class DataPart extends TextPart
 
         parent::__construct($body, null, $subtype, $encoding);
 
+        $this->formEncoding = $encoding ?? '8bit';
+
         if (null !== $filename) {
             $this->filename = $filename;
             $this->setName($filename);
@@ -49,9 +54,9 @@ class DataPart extends TextPart
         $this->setDisposition('attachment');
     }
 
-    public static function fromPath(string $path, string $name = null, string $contentType = null): self
+    public static function fromPath(string $path, string $name = null, string $contentType = null, string $encoding = null): self
     {
-        return new self(new File($path), $name, $contentType);
+        return new self(new File($path), $name, $contentType, $encoding);
     }
 
     /**

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -26,7 +26,6 @@ class DataPart extends TextPart
     private $mediaType;
     private $cid;
 
-    /** @internal */
     private $formEncoding;
 
     /**

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -530,6 +530,7 @@ class EmailTest extends TestCase
         {
             "filename": "test.txt",
             "mediaType": "application",
+            "formEncoding": "8bit",
             "body": "Some Text file",
             "charset": null,
             "subtype": "octet-stream",

--- a/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
@@ -47,6 +47,27 @@ class FormDataPartTest extends TestCase
         $this->assertEquals([$t, $b, $c], $f->getParts());
     }
 
+    public function testConstructorWithBase64Encoding()
+    {
+        $r = new \ReflectionProperty(TextPart::class, 'encoding');
+
+        $d = DataPart::fromPath($file = __DIR__.'/../../Fixtures/mimetypes/test.gif', null, null, '8bit');
+        $e = DataPart::fromPath($file = __DIR__.'/../../Fixtures/mimetypes/test.gif', null, null, 'base64');
+        $f = new FormDataPart([
+            'foo' => clone $d,
+            'bar' => clone $e
+        ]);
+        $d->setDisposition('form-data');
+        $d->setName('foo');
+        $d->getHeaders()->setMaxLineLength(\PHP_INT_MAX);
+        $r->setValue($d, '8bit');
+        $e->setDisposition('form-data');
+        $e->setName('bar');
+        $e->getHeaders()->setMaxLineLength(\PHP_INT_MAX);
+        $r->setValue($e, 'base64');
+        $this->assertEquals([$d, $e], $f->getParts());
+    }
+
     public function testNestedArrayParts()
     {
         $p1 = new TextPart('content', 'utf-8', 'plain', '8bit');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #49315 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#18002 <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
The data part on it's own defaults to base64 because charset is null, but in a form it's forced to 8bit,  which is a good default, but it may be overwritten.