### PR TITLE
[Form] Deprecate not configuring the "widget" option of date/time form types

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -29,6 +29,11 @@ DoctrineBridge
  * Deprecate `MessengerTransportDoctrineSchemaSubscriber` in favor of `MessengerTransportDoctrineSchemaListener`
  * Deprecate `RememberMeTokenProviderDoctrineSchemaSubscriber` in favor of `RememberMeTokenProviderDoctrineSchemaListener`
 
+Form
+----
+
+ * Deprecate not configuring the "widget" option of date/time form types, it will default to "single_text" in v7
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3HorizontalLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3HorizontalLayoutTestCase.php
@@ -15,7 +15,7 @@ abstract class AbstractBootstrap3HorizontalLayoutTestCase extends AbstractBootst
 {
     public function testLabelOnForm()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', null, ['widget' => 'choice']);
         $view = $form->createView();
         $this->renderWidget($view, ['label' => 'foo']);
         $html = $this->renderLabel($view);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
@@ -19,7 +19,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 {
     public function testLabelOnForm()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', null, ['widget' => 'choice']);
         $view = $form->createView();
         $this->renderWidget($view, ['label' => 'foo']);
         $html = $this->renderLabel($view);
@@ -1561,6 +1561,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', date('Y').'-02-03 04:05:06', [
             'input' => 'string',
             'with_seconds' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1598,6 +1599,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1637,6 +1639,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', $data, [
             'input' => 'array',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1674,6 +1677,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', date('Y').'-02-03 04:05:06', [
             'input' => 'string',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1907,6 +1911,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType', '2000-02-03', [
             'input' => 'string',
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1937,6 +1942,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
             'input' => 'string',
             'placeholder' => '',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -2465,6 +2471,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', [
             'input' => 'string',
             'with_seconds' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -2492,6 +2499,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', [
             'input' => 'string',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -2579,6 +2587,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -2606,6 +2615,7 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
             'input' => 'string',
             'required' => false,
             'placeholder' => ['hour' => 'Change&Me'],
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
@@ -47,7 +47,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTestCase extends AbstractBootst
 
     public function testLabelOnForm()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', null, ['widget' => 'choice']);
         $view = $form->createView();
         $this->renderWidget($view, ['label' => 'foo']);
         $html = $this->renderLabel($view);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
@@ -57,7 +57,7 @@ abstract class AbstractBootstrap4LayoutTestCase extends AbstractBootstrap3Layout
 
     public function testLabelOnForm()
     {
-        $form = $this->factory->createNamed('name', DateType::class);
+        $form = $this->factory->createNamed('name', DateType::class, null, ['widget' => 'choice']);
         $view = $form->createView();
         $this->renderWidget($view, ['label' => 'foo']);
         $html = $this->renderLabel($view);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5HorizontalLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5HorizontalLayoutTestCase.php
@@ -86,7 +86,7 @@ abstract class AbstractBootstrap5HorizontalLayoutTestCase extends AbstractBootst
 
     public function testLabelOnForm()
     {
-        $form = $this->factory->createNamed('name', DateType::class);
+        $form = $this->factory->createNamed('name', DateType::class, null, ['widget' => 'choice']);
         $view = $form->createView();
         $this->renderWidget($view, ['label' => 'foo']);
         $html = $this->renderLabel($view);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
@@ -1006,6 +1006,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
         $form = $this->factory->createNamed('name', DateTimeType::class, date('Y').'-02-03 04:05:06', [
             'input' => 'string',
             'with_seconds' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1059,6 +1060,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1112,6 +1114,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
         $form = $this->factory->createNamed('name', DateTimeType::class, $data, [
             'input' => 'array',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1163,6 +1166,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
         $form = $this->factory->createNamed('name', DateTimeType::class, date('Y').'-02-03 04:05:06', [
             'input' => 'string',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1387,6 +1391,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
     {
         $form = $this->factory->createNamed('name', BirthdayType::class, '2000-02-03', [
             'input' => 'string',
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1421,6 +1426,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
             'input' => 'string',
             'placeholder' => '',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1598,6 +1604,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
         $form = $this->factory->createNamed('name', TimeType::class, '04:05:06', [
             'input' => 'string',
             'with_seconds' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1631,6 +1638,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
         $form = $this->factory->createNamed('name', TimeType::class, '04:05:06', [
             'input' => 'string',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1714,6 +1722,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
@@ -1747,6 +1756,7 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
             'input' => 'string',
             'required' => false,
             'placeholder' => ['hour' => 'Change&Me'],
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Don't render seconds for HTML5 date pickers unless "with_seconds" is explicitly set
  * Add a `placeholder_attr` option to `ChoiceType`
+ * Deprecate not configuring the "widget" option of date/time form types, it will default to "single_text" in v7
 
 6.2
 ---

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -248,7 +248,12 @@ class DateTimeType extends AbstractType
             'view_timezone' => null,
             'format' => self::HTML5_FORMAT,
             'date_format' => null,
-            'widget' => null,
+            'widget' => function (Options $options) {
+                trigger_deprecation('symfony/form', '6.3', 'Not configuring the "widget" option is deprecated. It will default to "single_text" in Symfony 7.0.');
+
+                return null;
+                // return 'single_text';
+            },
             'date_widget' => $dateWidget,
             'time_widget' => $timeWidget,
             'with_minutes' => true,

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -148,16 +148,11 @@ class DateTimeType extends AbstractType
                 $timeOptions['label'] = false;
             }
 
-            if (null !== $options['date_widget']) {
-                $dateOptions['widget'] = $options['date_widget'];
-            }
+            $dateOptions['widget'] = $options['date_widget'] ?? $options['widget'] ?? 'choice';
+            $timeOptions['widget'] = $options['time_widget'] ?? $options['widget'] ?? 'choice';
 
             if (null !== $options['date_label']) {
                 $dateOptions['label'] = $options['date_label'];
-            }
-
-            if (null !== $options['time_widget']) {
-                $timeOptions['widget'] = $options['time_widget'];
             }
 
             if (null !== $options['time_label']) {
@@ -236,26 +231,15 @@ class DateTimeType extends AbstractType
     {
         $compound = static fn (Options $options) => 'single_text' !== $options['widget'];
 
-        // Defaults to the value of "widget"
-        $dateWidget = static fn (Options $options) => 'single_text' === $options['widget'] ? null : $options['widget'];
-
-        // Defaults to the value of "widget"
-        $timeWidget = static fn (Options $options) => 'single_text' === $options['widget'] ? null : $options['widget'];
-
         $resolver->setDefaults([
             'input' => 'datetime',
             'model_timezone' => null,
             'view_timezone' => null,
             'format' => self::HTML5_FORMAT,
             'date_format' => null,
-            'widget' => function (Options $options) {
-                trigger_deprecation('symfony/form', '6.3', 'Not configuring the "widget" option is deprecated. It will default to "single_text" in Symfony 7.0.');
-
-                return null;
-                // return 'single_text';
-            },
-            'date_widget' => $dateWidget,
-            'time_widget' => $timeWidget,
+            'widget' => null,
+            'date_widget' => null,
+            'time_widget' => null,
             'with_minutes' => true,
             'with_seconds' => false,
             'html5' => true,
@@ -325,19 +309,20 @@ class DateTimeType extends AbstractType
 
             return $dateFormat;
         });
-        $resolver->setNormalizer('date_widget', static function (Options $options, $dateWidget) {
-            if (null !== $dateWidget && 'single_text' === $options['widget']) {
-                throw new LogicException(sprintf('Cannot use the "date_widget" option of the "%s" when the "widget" option is set to "single_text".', self::class));
+        $resolver->setNormalizer('widget', static function (Options $options, $widget) {
+            if ('single_text' === $widget) {
+                if (null !== $options['date_widget']) {
+                    throw new LogicException(sprintf('Cannot use the "date_widget" option of the "%s" when the "widget" option is set to "single_text".', self::class));
+                }
+                if (null !== $options['time_widget']) {
+                    throw new LogicException(sprintf('Cannot use the "time_widget" option of the "%s" when the "widget" option is set to "single_text".', self::class));
+                }
+            } elseif (null === $widget && null === $options['date_widget'] && null === $options['time_widget']) {
+                trigger_deprecation('symfony/form', '6.3', 'Not configuring the "widget" option of form type "datetime" is deprecated. It will default to "single_text" in Symfony 7.0.');
+                // return 'single_text';
             }
 
-            return $dateWidget;
-        });
-        $resolver->setNormalizer('time_widget', static function (Options $options, $timeWidget) {
-            if (null !== $timeWidget && 'single_text' === $options['widget']) {
-                throw new LogicException(sprintf('Cannot use the "time_widget" option of the "%s" when the "widget" option is set to "single_text".', self::class));
-            }
-
-            return $timeWidget;
+            return $widget;
         });
         $resolver->setNormalizer('html5', static function (Options $options, $html5) {
             if ($html5 && self::HTML5_FORMAT !== $options['format']) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -260,7 +260,12 @@ class DateType extends AbstractType
             'years' => range((int) date('Y') - 5, (int) date('Y') + 5),
             'months' => range(1, 12),
             'days' => range(1, 31),
-            'widget' => 'choice',
+            'widget' => function (Options $options) {
+                trigger_deprecation('symfony/form', '6.3', 'Not configuring the "widget" option explicitly is deprecated, its default value will change to "single_text" in 7.0.');
+
+                return 'choice';
+                // return 'single_text';
+            },
             'input' => 'datetime',
             'format' => $format,
             'model_timezone' => null,

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -260,11 +260,10 @@ class DateType extends AbstractType
             'years' => range((int) date('Y') - 5, (int) date('Y') + 5),
             'months' => range(1, 12),
             'days' => range(1, 31),
-            'widget' => function (Options $options) {
-                trigger_deprecation('symfony/form', '6.3', 'Not configuring the "widget" option explicitly is deprecated, its default value will change to "single_text" in 7.0.');
+            'widget' => static function (Options $options) {
+                trigger_deprecation('symfony/form', '6.3', 'Not configuring the "widget" option of form type "date" is deprecated. It will default to "single_text" in Symfony 7.0.');
 
                 return 'choice';
-                // return 'single_text';
             },
             'input' => 'datetime',
             'format' => $format,

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -312,11 +312,10 @@ class TimeType extends AbstractType
             'hours' => range(0, 23),
             'minutes' => range(0, 59),
             'seconds' => range(0, 59),
-            'widget' => function (Options $options) {
-                trigger_deprecation('symfony/form', '6.3', 'Not configuring the "widget" option explicitly is deprecated, its default value will change to "single_text" in 7.0.');
+            'widget' => static function (Options $options) {
+                trigger_deprecation('symfony/form', '6.3', 'Not configuring the "widget" option of form type "time" is deprecated. It will default to "single_text" in Symfony 7.0.');
 
                 return 'choice';
-                // return 'single_text';
             },
             'input' => 'datetime',
             'input_format' => 'H:i:s',

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -312,7 +312,12 @@ class TimeType extends AbstractType
             'hours' => range(0, 23),
             'minutes' => range(0, 59),
             'seconds' => range(0, 59),
-            'widget' => 'choice',
+            'widget' => function (Options $options) {
+                trigger_deprecation('symfony/form', '6.3', 'Not configuring the "widget" option explicitly is deprecated, its default value will change to "single_text" in 7.0.');
+
+                return 'choice';
+                // return 'single_text';
+            },
             'input' => 'datetime',
             'input_format' => 'H:i:s',
             'with_minutes' => true,

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTestCase.php
@@ -175,7 +175,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
 
     public function testLabelOnForm()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', null, ['widget' => 'choice']);
         $view = $form->createView();
         $this->renderWidget($view, ['label' => 'foo']);
         $html = $this->renderLabel($view);
@@ -1327,6 +1327,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', date('Y').'-02-03 04:05:06', [
             'input' => 'string',
             'with_seconds' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -1367,6 +1368,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -1408,6 +1410,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', $data, [
             'input' => 'array',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -1447,6 +1450,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', date('Y').'-02-03 04:05:06', [
             'input' => 'string',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -1654,7 +1658,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
     public function testDateErrorBubbling()
     {
         $form = $this->factory->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('date', 'Symfony\Component\Form\Extension\Core\Type\DateType')
+            ->add('date', 'Symfony\Component\Form\Extension\Core\Type\DateType', ['widget' => 'choice'])
             ->getForm();
         $form->get('date')->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
@@ -1667,6 +1671,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType', '2000-02-03', [
             'input' => 'string',
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -1693,6 +1698,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
             'input' => 'string',
             'placeholder' => '',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -2127,6 +2133,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', [
             'input' => 'string',
             'with_seconds' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -2151,6 +2158,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', [
             'input' => 'string',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -2230,6 +2238,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -2255,6 +2264,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
             'input' => 'string',
             'required' => false,
             'placeholder' => ['hour' => 'Change&Me'],
+            'widget' => 'choice',
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -2277,7 +2287,7 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
     public function testTimeErrorBubbling()
     {
         $form = $this->factory->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('time', 'Symfony\Component\Form\Extension\Core\Type\TimeType')
+            ->add('time', 'Symfony\Component\Form\Extension\Core\Type\TimeType', ['widget' => 'choice'])
             ->getForm();
         $form->get('time')->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/CoreExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/CoreExtensionTest.php
@@ -24,7 +24,7 @@ class CoreExtensionTest extends TestCase
             ->getFormFactory();
 
         $form = $formFactory->createBuilder()
-            ->add('foo', 'Symfony\Component\Form\Extension\Core\Type\DateType')
+            ->add('foo', 'Symfony\Component\Form\Extension\Core\Type\DateType', ['widget' => 'choice'])
             ->getForm();
         $form->submit('foo');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -25,6 +25,7 @@ class BirthdayTypeTest extends DateTypeTest
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'years' => 'bad value',
+            'widget' => 'choice',
         ]);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -330,7 +330,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->assertInstanceOf(FormInterface::class, $this->factory->create(static::TESTED_TYPE, new \DateTime()));
+        $this->assertInstanceOf(FormInterface::class, $this->factory->create(static::TESTED_TYPE, new \DateTime(), ['widget' => 'choice']));
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
@@ -348,6 +348,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'required' => false,
             'with_seconds' => true,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -364,6 +365,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'required' => true,
             'with_seconds' => true,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -380,6 +382,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'placeholder' => 'Empty',
             'with_seconds' => true,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -403,6 +406,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
                 'second' => 'Empty second',
             ],
             'with_seconds' => true,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -425,6 +429,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
                 'second' => 'Empty second',
             ],
             'with_seconds' => true,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -447,6 +452,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
                 'second' => 'Empty second',
             ],
             'with_seconds' => true,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -536,7 +542,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
     public function testDateTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null);
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['widget' => 'choice']);
 
         $form['date']->addError($error);
 
@@ -549,6 +555,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $error = new FormError('Invalid!');
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'date_widget' => 'single_text',
+            'time_widget' => 'choice',
         ]);
 
         $form['date']->addError($error);
@@ -560,7 +567,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
     public function testTimeTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null);
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['widget' => 'choice']);
 
         $form['time']->addError($error);
 
@@ -573,6 +580,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $error = new FormError('Invalid!');
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'time_widget' => 'single_text',
+            'date_widget' => 'choice',
         ]);
 
         $form['time']->addError($error);
@@ -585,6 +593,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -602,6 +611,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'choice_translation_domain' => 'messages',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -623,6 +633,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
                 'second' => 'test',
             ],
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -675,6 +686,7 @@ class DateTimeTypeTest extends BaseTypeTestCase
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'empty_data' => $emptyData,
+            'widget' => 'choice',
         ]);
         $form->submit(null);
 
@@ -734,5 +746,10 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $form->submit('2018-01-14T21:29:00');
 
         $this->assertSame('14/01/2018 21:29:00 +00:00', $form->getData());
+    }
+
+    protected function getTestOptions(): array
+    {
+        return ['widget' => 'choice'];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -50,6 +50,7 @@ class DateTypeTest extends BaseTypeTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'input' => 'fake_input',
+            'widget' => 'choice',
         ]);
     }
 
@@ -379,6 +380,7 @@ class DateTypeTest extends BaseTypeTestCase
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'format' => $format,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -416,6 +418,7 @@ class DateTypeTest extends BaseTypeTestCase
         $this->factory->create(static::TESTED_TYPE, null, [
             'months' => [6, 7],
             'format' => 'yy',
+            'widget' => 'choice',
         ]);
     }
 
@@ -435,6 +438,7 @@ class DateTypeTest extends BaseTypeTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'format' => 105,
+            'widget' => 'choice',
         ]);
     }
 
@@ -443,6 +447,7 @@ class DateTypeTest extends BaseTypeTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'format' => [],
+            'widget' => 'choice',
         ]);
     }
 
@@ -451,6 +456,7 @@ class DateTypeTest extends BaseTypeTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'years' => 'bad value',
+            'widget' => 'choice',
         ]);
     }
 
@@ -459,6 +465,7 @@ class DateTypeTest extends BaseTypeTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'months' => 'bad value',
+            'widget' => 'choice',
         ]);
     }
 
@@ -467,6 +474,7 @@ class DateTypeTest extends BaseTypeTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'days' => 'bad value',
+            'widget' => 'choice',
         ]);
     }
 
@@ -523,6 +531,7 @@ class DateTypeTest extends BaseTypeTestCase
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'years' => [2010, 2011],
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -539,6 +548,7 @@ class DateTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'months' => [6, 7],
             'format' => \IntlDateFormatter::SHORT,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -559,6 +569,7 @@ class DateTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'months' => [1, 4],
             'format' => 'dd.MMM.yy',
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -579,6 +590,7 @@ class DateTypeTest extends BaseTypeTestCase
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'months' => [1, 4],
             'format' => 'dd.MMMM.yy',
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -598,6 +610,7 @@ class DateTypeTest extends BaseTypeTestCase
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'months' => [1, 4],
             'format' => 'dd.MMMM.yy',
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -612,6 +625,7 @@ class DateTypeTest extends BaseTypeTestCase
         \Locale::setDefault('en');
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'days' => [6, 7],
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -679,7 +693,7 @@ class DateTypeTest extends BaseTypeTestCase
 
         \Locale::setDefault('de_AT');
 
-        $view = $this->factory->create(static::TESTED_TYPE)
+        $view = $this->factory->create(static::TESTED_TYPE, null, ['widget' => 'choice'])
             ->createView();
 
         $this->assertSame('{{ day }}{{ month }}{{ year }}', $view->vars['date_pattern']);
@@ -694,6 +708,7 @@ class DateTypeTest extends BaseTypeTestCase
 
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'format' => \IntlDateFormatter::LONG,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -704,6 +719,7 @@ class DateTypeTest extends BaseTypeTestCase
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'format' => 'MMyyyydd',
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -714,6 +730,7 @@ class DateTypeTest extends BaseTypeTestCase
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'format' => 'MM*yyyy*dd',
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -740,6 +757,7 @@ class DateTypeTest extends BaseTypeTestCase
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             // EEEE, d 'de' MMMM 'de' y
             'format' => \IntlDateFormatter::FULL,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -760,7 +778,7 @@ class DateTypeTest extends BaseTypeTestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->assertInstanceOf(FormInterface::class, $this->factory->create(static::TESTED_TYPE, new \DateTime()));
+        $this->assertInstanceOf(FormInterface::class, $this->factory->create(static::TESTED_TYPE, new \DateTime(), ['widget' => 'choice']));
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
@@ -777,6 +795,7 @@ class DateTypeTest extends BaseTypeTestCase
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'required' => false,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -789,6 +808,7 @@ class DateTypeTest extends BaseTypeTestCase
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
             'required' => true,
+            'widget' => 'choice',
         ])
             ->createView();
 
@@ -800,6 +820,7 @@ class DateTypeTest extends BaseTypeTestCase
     public function testPassPlaceholderAsString()
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
             'placeholder' => 'Empty',
         ])
             ->createView();
@@ -812,6 +833,7 @@ class DateTypeTest extends BaseTypeTestCase
     public function testPassPlaceholderAsArray()
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
             'placeholder' => [
                 'year' => 'Empty year',
                 'month' => 'Empty month',
@@ -828,6 +850,7 @@ class DateTypeTest extends BaseTypeTestCase
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
             'required' => false,
             'placeholder' => [
                 'year' => 'Empty year',
@@ -844,6 +867,7 @@ class DateTypeTest extends BaseTypeTestCase
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
             'required' => true,
             'placeholder' => [
                 'year' => 'Empty year',
@@ -956,6 +980,7 @@ class DateTypeTest extends BaseTypeTestCase
     public function testYears()
     {
         $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
             'years' => [1900, 2000, 2040],
         ])
             ->createView();
@@ -970,7 +995,7 @@ class DateTypeTest extends BaseTypeTestCase
 
     public function testPassDefaultChoiceTranslationDomain()
     {
-        $form = $this->factory->create(static::TESTED_TYPE);
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['widget' => 'choice']);
 
         $view = $form->createView();
         $this->assertFalse($view['year']->vars['choice_translation_domain']);
@@ -981,6 +1006,7 @@ class DateTypeTest extends BaseTypeTestCase
     public function testPassChoiceTranslationDomainAsString()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
             'choice_translation_domain' => 'messages',
         ]);
 
@@ -993,6 +1019,7 @@ class DateTypeTest extends BaseTypeTestCase
     public function testPassChoiceTranslationDomainAsArray()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
             'choice_translation_domain' => [
                 'year' => 'foo',
                 'day' => 'test',
@@ -1025,6 +1052,7 @@ class DateTypeTest extends BaseTypeTestCase
     public function testSubmitNullUsesDefaultEmptyData($emptyData = [], $expectedData = null)
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
             'empty_data' => $emptyData,
         ]);
         $form->submit(null);
@@ -1082,5 +1110,10 @@ class DateTypeTest extends BaseTypeTestCase
         $form->submit('2018-01-14');
 
         $this->assertSame('14/01/2018', $form->getData());
+    }
+
+    protected function getTestOptions(): array
+    {
+        return ['widget' => 'choice'];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -28,6 +28,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
+            'widget' => 'choice',
         ]);
 
         $input = [
@@ -49,6 +50,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime_immutable',
+            'widget' => 'choice',
         ]);
 
         $input = [
@@ -71,6 +73,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
+            'widget' => 'choice',
         ]);
 
         $input = [
@@ -106,6 +109,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
+            'widget' => 'choice',
         ]);
 
         $input = [
@@ -127,6 +131,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
+            'widget' => 'choice',
         ]);
 
         $input = [
@@ -288,6 +293,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'input' => 'datetime',
             'with_seconds' => true,
             'reference_date' => new \DateTimeImmutable('2019-01-01', new \DateTimeZone('UTC')),
+            'widget' => 'choice',
         ]);
         $form->setData(new \DateTime('2022-01-01 15:09:10', new \DateTimeZone('UTC')));
 
@@ -307,6 +313,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'input' => 'datetime',
             'with_seconds' => true,
             'reference_date' => new \DateTimeImmutable('2019-07-12', new \DateTimeZone('UTC')),
+            'widget' => 'choice',
         ]);
         $form->setData(new \DateTime('2022-04-29 15:09:10', new \DateTimeZone('UTC')));
 
@@ -358,6 +365,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'input' => 'datetime',
             'with_seconds' => true,
             'reference_date' => new \DateTimeImmutable('2019-01-01', new \DateTimeZone('UTC')),
+            'widget' => 'choice',
         ]);
         $form->submit([
             'hour' => '16',
@@ -376,6 +384,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'input' => 'datetime',
             'with_seconds' => true,
             'reference_date' => new \DateTimeImmutable('2019-07-12', new \DateTimeZone('UTC')),
+            'widget' => 'choice',
         ]);
         $form->submit([
             'hour' => '16',
@@ -456,6 +465,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'view_timezone' => 'UTC',
             'input' => 'datetime',
             'with_minutes' => false,
+            'widget' => 'choice',
         ]);
 
         $form->setData(new \DateTime('03:04:05 UTC'));
@@ -470,6 +480,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'view_timezone' => 'UTC',
             'input' => 'datetime',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $form->setData(new \DateTime('03:04:05 UTC'));
@@ -485,6 +496,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'input' => 'string',
             'with_seconds' => true,
             'reference_date' => new \DateTimeImmutable('2013-01-01 00:00:00', new \DateTimeZone('America/New_York')),
+            'widget' => 'choice',
         ]);
 
         $dateTime = new \DateTime('2013-01-01 12:04:05');
@@ -512,6 +524,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'input' => 'datetime',
             'with_seconds' => true,
             'reference_date' => new \DateTimeImmutable('now', new \DateTimeZone('America/New_York')),
+            'widget' => 'choice',
         ]);
 
         $dateTime = new \DateTime('12:04:05');
@@ -540,6 +553,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'input' => 'datetime',
             'with_seconds' => true,
             'reference_date' => new \DateTimeImmutable('2019-07-12', new \DateTimeZone('UTC')),
+            'widget' => 'choice',
         ]);
 
         $form->setData(new \DateTime('2019-07-24 14:09:10', new \DateTimeZone('UTC')));
@@ -557,6 +571,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'view_timezone' => 'Europe/Berlin',
             'input' => 'datetime',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $form->setData(new \DateTime('2019-07-24 14:09:10', new \DateTimeZone('UTC')));
@@ -568,6 +583,7 @@ class TimeTypeTest extends BaseTypeTestCase
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'hours' => [6, 7],
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -582,6 +598,7 @@ class TimeTypeTest extends BaseTypeTestCase
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'minutes' => [6, 7],
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -597,6 +614,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'seconds' => [6, 7],
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -733,7 +751,7 @@ class TimeTypeTest extends BaseTypeTestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->assertInstanceOf(FormInterface::class, $this->factory->create(static::TESTED_TYPE, new \DateTime()));
+        $this->assertInstanceOf(FormInterface::class, $this->factory->create(static::TESTED_TYPE, new \DateTime(), ['widget' => 'choice']));
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
@@ -789,6 +807,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'required' => false,
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -802,6 +821,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'required' => true,
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -815,6 +835,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'placeholder' => 'Empty',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -832,6 +853,7 @@ class TimeTypeTest extends BaseTypeTestCase
                 'second' => 'Empty second',
             ],
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -849,6 +871,7 @@ class TimeTypeTest extends BaseTypeTestCase
                 'second' => 'Empty second',
             ],
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -866,6 +889,7 @@ class TimeTypeTest extends BaseTypeTestCase
                 'second' => 'Empty second',
             ],
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -934,6 +958,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $this->factory->create(static::TESTED_TYPE, null, [
             'with_minutes' => false,
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
     }
 
@@ -942,6 +967,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'hours' => 'bad value',
+            'widget' => 'choice',
         ]);
     }
 
@@ -950,6 +976,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'minutes' => 'bad value',
+            'widget' => 'choice',
         ]);
     }
 
@@ -958,6 +985,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->factory->create(static::TESTED_TYPE, null, [
             'seconds' => 'bad value',
+            'widget' => 'choice',
         ]);
     }
 
@@ -968,6 +996,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'Europe/Berlin',
             'reference_date' => new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin')),
+            'widget' => 'choice',
         ]);
     }
 
@@ -976,6 +1005,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'view_timezone' => 'Europe/Berlin',
             'reference_date' => new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin')),
+            'widget' => 'choice',
         ]);
 
         $this->assertSame('Europe/Berlin', $form->getConfig()->getOption('model_timezone'));
@@ -985,6 +1015,7 @@ class TimeTypeTest extends BaseTypeTestCase
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'model_timezone' => 'Europe/Berlin',
+            'widget' => 'choice',
         ]);
 
         $this->assertSame('Europe/Berlin', $form->getConfig()->getOption('view_timezone'));
@@ -992,7 +1023,7 @@ class TimeTypeTest extends BaseTypeTestCase
 
     public function testPassDefaultChoiceTranslationDomain()
     {
-        $form = $this->factory->create(static::TESTED_TYPE);
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['widget' => 'choice']);
 
         $view = $form->createView();
         $this->assertFalse($view['hour']->vars['choice_translation_domain']);
@@ -1004,6 +1035,7 @@ class TimeTypeTest extends BaseTypeTestCase
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'choice_translation_domain' => 'messages',
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -1020,6 +1052,7 @@ class TimeTypeTest extends BaseTypeTestCase
                 'second' => 'test',
             ],
             'with_seconds' => true,
+            'widget' => 'choice',
         ]);
 
         $view = $form->createView();
@@ -1039,6 +1072,7 @@ class TimeTypeTest extends BaseTypeTestCase
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'empty_data' => $emptyData,
+            'widget' => 'choice',
         ]);
         $form->submit(null);
 
@@ -1055,6 +1089,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'view_timezone' => 'Europe/Berlin',
             'reference_date' => new \DateTimeImmutable('01-01-2021 12:34:56', new \DateTimeZone('UTC')),
             'input' => 'array',
+            'widget' => 'choice',
         ]);
 
         $input = [
@@ -1082,6 +1117,7 @@ class TimeTypeTest extends BaseTypeTestCase
             'view_timezone' => 'Europe/Berlin',
             'reference_date' => new \DateTimeImmutable('01-05-2021 12:34:56', new \DateTimeZone('UTC')),
             'input' => 'array',
+            'widget' => 'choice',
         ]);
 
         $this->assertSame($input, $form->getData());
@@ -1123,5 +1159,10 @@ class TimeTypeTest extends BaseTypeTestCase
             'Compound text field lazy' => ['text', $lazyEmptyData, $expectedData],
             'Compound choice field lazy' => ['choice', $lazyEmptyData, $expectedData],
         ];
+    }
+
+    protected function getTestOptions(): array
+    {
+        return ['widget' => 'choice'];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BirthdayTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BirthdayTypeValidatorExtensionTest.php
@@ -20,7 +20,7 @@ class BirthdayTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(BirthdayType::class, null, $options);
+        return $this->factory->create(BirthdayType::class, null, $options + ['widget' => 'choice']);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTimeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTimeTypeValidatorExtensionTest.php
@@ -20,7 +20,7 @@ class DateTimeTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(DateTimeType::class, null, $options);
+        return $this->factory->create(DateTimeType::class, null, $options + ['widget' => 'choice']);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTypeValidatorExtensionTest.php
@@ -20,7 +20,7 @@ class DateTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(DateType::class, null, $options);
+        return $this->factory->create(DateType::class, null, $options + ['widget' => 'choice']);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimeTypeValidatorExtensionTest.php
@@ -20,7 +20,7 @@ class TimeTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(TimeType::class, null, $options);
+        return $this->factory->create(TimeType::class, null, $options + ['widget' => 'choice']);
     }
 
     public function testInvalidMessage()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Related to a suggestion made on https://github.com/symfony/symfony-docs/issues/16600
| License       | MIT
| Doc PR        | TODO

This PR proposes to change the default value of the `widget` option of date/time form types to `single_text`, so that the corresponding input fields are rendered using native HTML5 widgets by default.

It does so by deprecating *not* setting the `widget` option, so that we can change the default in Symfony 7.