### PR TITLE
[Serializer] Groups annotation/attribute on class

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -18,11 +18,11 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  *
  * @Annotation
  * @NamedArgumentConstructor
- * @Target({"PROPERTY", "METHOD"})
+ * @Target({"PROPERTY", "METHOD", "CLASS"})
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_CLASS)]
 class Groups
 {
     /**

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate Doctrine annotations support in favor of native attributes
  * Deprecate passing an annotation reader to the constructor of `AnnotationLoader`
+ * Allow the `Groups` attribute/annotation on classes
 
 6.3
 ---

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -56,6 +56,7 @@ class AnnotationLoader implements LoaderInterface
         $reflectionClass = $classMetadata->getReflectionClass();
         $className = $reflectionClass->name;
         $loaded = false;
+        $classGroups = [];
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
 
@@ -65,6 +66,11 @@ class AnnotationLoader implements LoaderInterface
                     $annotation->getTypeProperty(),
                     $annotation->getMapping()
                 ));
+                continue;
+            }
+
+            if ($annotation instanceof Groups) {
+                $classGroups = $annotation->getGroups();
             }
         }
 
@@ -75,6 +81,10 @@ class AnnotationLoader implements LoaderInterface
             }
 
             if ($property->getDeclaringClass()->name === $className) {
+                foreach ($classGroups as $group) {
+                    $attributesMetadata[$property->name]->addGroup($group);
+                }
+
                 foreach ($this->loadAnnotations($property) as $annotation) {
                     if ($annotation instanceof Groups) {
                         foreach ($annotation->getGroups() as $group) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/GroupClassDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/GroupClassDummy.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @Groups({"a"})
+ */
+class GroupClassDummy
+{
+    /**
+     * @Groups({"b"})
+     */
+    private $foo;
+
+    /**
+     * @Groups({"c", "d"})
+     */
+    private $bar;
+
+    private $baz;
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function setFoo($foo): void
+    {
+        $this->foo = $foo;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    public function setBar($bar): void
+    {
+        $this->bar = $bar;
+    }
+
+    public function getBaz()
+    {
+        return $this->baz;
+    }
+
+    public function setBaz($baz): void
+    {
+        $this->baz = $baz;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupClassDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupClassDummy.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[Groups('a')]
+class GroupClassDummy
+{
+    #[Groups('b')]
+    private $foo;
+
+    #[Groups(['c', 'd'])]
+    private $bar;
+
+    private $baz;
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function setFoo($foo): void
+    {
+        $this->foo = $foo;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    public function setBar($bar): void
+    {
+        $this->bar = $bar;
+    }
+
+    public function getBaz()
+    {
+        return $this->baz;
+    }
+
+    public function setBaz($baz): void
+    {
+        $this->baz = $baz;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
@@ -192,6 +192,24 @@ abstract class AnnotationLoaderTestCase extends TestCase
         self::assertArrayHasKey('extraValue2', $attributes);
     }
 
+    public function testLoadGroupsOnClass()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace().'\GroupClassDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+
+        self::assertCount(3, $classMetadata->getAttributesMetadata());
+
+        self::assertArrayHasKey('foo', $attributesMetadata);
+        self::assertArrayHasKey('bar', $attributesMetadata);
+        self::assertArrayHasKey('baz', $attributesMetadata);
+
+        self::assertSame(['a', 'b'], $attributesMetadata['foo']->getGroups());
+        self::assertSame(['a', 'c', 'd'], $attributesMetadata['bar']->getGroups());
+        self::assertSame(['a'], $attributesMetadata['baz']->getGroups());
+    }
+
     abstract protected function createLoader(): AnnotationLoader;
 
     abstract protected function getNamespace(): string;

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1278,6 +1278,28 @@ class SerializerTest extends TestCase
         }
     }
 
+    public function testGroupsOnClassSerialization()
+    {
+        $obj = new Fixtures\Attributes\GroupClassDummy();
+        $obj->setFoo('foo');
+        $obj->setBar('bar');
+        $obj->setBaz('baz');
+
+        $serializer = new Serializer(
+            [
+                new ObjectNormalizer(),
+            ],
+            [
+                'json' => new JsonEncoder(),
+            ]
+        );
+
+        $this->assertSame(
+            '{"foo":"foo","bar":"bar","baz":"baz"}',
+            $serializer->serialize($obj, 'json', ['groups' => ['a']])
+        );
+    }
+
     public static function provideCollectDenormalizationErrors(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | TODO

This change adds option to use `Groups` attribute on class. Doing that will add specified group to each property.

Example, this:
```php
class MyEntity
{
    #[Groups('group1')]
    private $foo;
    #[Groups('group1')]
    private $bar;

// getters and setters...
}
```
can be replaced with this
```php
#[Groups('group1')]
class MyEntity
{
    private $foo;
    private $bar;

// getters and setters...
}
```

  

It also works with promoted properties.
This:
```php
class View
{
    public function __construct(
        #[Groups('group1')] public readonly string $foo,
        #[Groups('group1')] public readonly string $bar
    ){
    }
}
```
can be replaced with this:
```php
#[Groups('group1')]
class View
{
    public function __construct(
        public readonly string $foo,
        public readonly string $bar
    ){
    }
}
```
