### PR TITLE
[Validator] Add the `exclude` option to the `Cascade` constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add a `NoSuspiciousCharacters` constraint to validate a string is not a spoofing attempt
  * Add the `countUnit` option to the `Length` constraint to allow counting the string length either by code points (like before, now the default setting `Length::COUNT_CODEPOINTS`), bytes (`Length::COUNT_BYTES`) or graphemes (`Length::COUNT_GRAPHEMES`)
  * Add the `filenameMaxLength` option to the `File` constraint
+ * Add the `exclude` option to the `Cascade` constraint
 
 6.2
 ---

--- a/src/Symfony/Component/Validator/Constraints/Cascade.php
+++ b/src/Symfony/Component/Validator/Constraints/Cascade.php
@@ -23,8 +23,16 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class Cascade extends Constraint
 {
-    public function __construct(array $options = null)
+    public array $exclude = [];
+
+    public function __construct(array|string|null $exclude = null, array $options = null)
     {
+        if (\is_array($exclude) && !array_is_list($exclude)) {
+            $options = array_merge($exclude, $options);
+        } else {
+            $this->exclude = array_flip((array) $exclude);
+        }
+
         if (\is_array($options) && \array_key_exists('groups', $options)) {
             throw new ConstraintDefinitionException(sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
         }

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -194,6 +194,10 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             $this->cascadingStrategy = CascadingStrategy::CASCADE;
 
             foreach ($this->getReflectionClass()->getProperties() as $property) {
+                if (isset($constraint->exclude[$property->getName()])) {
+                    continue;
+                }
+
                 if ($property->hasType() && (('array' === $type = $property->getType()->getName()) || class_exists($type))) {
                     $this->addPropertyConstraint($property->getName(), new Valid());
                 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -351,6 +351,20 @@ class ClassMetadataTest extends TestCase
             'children',
         ], $metadata->getConstrainedProperties());
     }
+
+    public function testCascadeConstraintWithExcludedProperties()
+    {
+        $metadata = new ClassMetadata(CascadingEntity::class);
+
+        $metadata->addConstraint(new Cascade(exclude: ['requiredChild', 'optionalChild']));
+
+        $this->assertSame(CascadingStrategy::CASCADE, $metadata->getCascadingStrategy());
+        $this->assertCount(2, $metadata->properties);
+        $this->assertSame([
+            'staticChild',
+            'children',
+        ], $metadata->getConstrainedProperties());
+    }
 }
 
 class ClassCompositeConstraint extends Composite


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18008

Just a little tweak to the `Cascade` constraint to make it even more useful, as the `groups` option is not available on it.