### PR TITLE
[VarDumper] Add `JsonStub` and leverage it in `SymfonyCaster::castHttpClientResponse()`

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add support of named arguments to `dd()` and `dump()` to display the argument name
  * Add support for `Relay\Relay`
  * Add display of invisible characters
+ * Add `JsonStub`
 
 6.2
 ---

--- a/src/Symfony/Component/VarDumper/Caster/JsonStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/JsonStub.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Represents a JSON resource.
+ *
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class JsonStub extends Stub
+{
+    public function __construct(mixed $value)
+    {
+        $this->value = json_decode($value, true);
+    }
+
+    public function __toString(): string
+    {
+        return \is_array($this->value) ? json_encode($this->value) : $this->value;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Caster/StubCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/StubCaster.php
@@ -101,4 +101,15 @@ class StubCaster
 
         return $a;
     }
+
+    public static function castJson(JsonStub $jsonStub, array $a, Stub $stub): array
+    {
+        $a = [];
+        $stub->class = '';
+
+        $a[Caster::PREFIX_VIRTUAL.'plain'] = (string) $jsonStub;
+        $a[Caster::PREFIX_VIRTUAL.'decoded'] = $jsonStub->value;
+
+        return $a;
+    }
 }

--- a/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
@@ -74,6 +74,11 @@ class SymfonyCaster
             $a[Caster::PREFIX_VIRTUAL.$k] = $v;
         }
 
+        $content = $response->getContent();
+        if (json_validate($content)) {
+            $a[Caster::PREFIX_VIRTUAL.'JSON content'] = new JsonStub($content);
+        }
+
         return $a;
     }
 

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -29,6 +29,7 @@ abstract class AbstractCloner implements ClonerInterface
         'Symfony\Component\VarDumper\Caster\ConstStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castStub'],
         'Symfony\Component\VarDumper\Caster\EnumStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castEnum'],
         'Symfony\Component\VarDumper\Caster\ScalarStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castScalar'],
+        'Symfony\Component\VarDumper\Caster\JsonStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castJson'],
 
         'Fiber' => ['Symfony\Component\VarDumper\Caster\FiberCaster', 'castFiber'],
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\VarDumper\Tests\Caster;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarDumper\Caster\ArgsStub;
 use Symfony\Component\VarDumper\Caster\ClassStub;
+use Symfony\Component\VarDumper\Caster\JsonStub;
 use Symfony\Component\VarDumper\Caster\LinkStub;
 use Symfony\Component\VarDumper\Caster\ScalarStub;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
@@ -95,6 +96,26 @@ EODUMP;
         $expectedDump = <<<'EODUMP'
 array:1 [
   0 => 🐛
+]
+EODUMP;
+
+        $this->assertDumpMatchesFormat($expectedDump, $args);
+    }
+
+    public function testJsonStub()
+    {
+        $args = [new JsonStub('[{"test": 123}]')];
+
+        $expectedDump = <<<'EODUMP'
+array:1 [
+  0 => {
+    plain: "[{"test":123}]"
+    decoded: array:1 [
+      0 => array:1 [
+        "test" => 123
+      ]
+    ]
+  }
 ]
 EODUMP;
 
@@ -217,7 +238,7 @@ EODUMP;
 
         $expectedDump = <<<'EODUMP'
 <foo></foo><bar><span class=sf-dump-note>array:1</span> [<samp data-depth=1 class=sf-dump-expanded>
-  <span class=sf-dump-index>0</span> => "<a href="%sStubCasterTest.php:209" rel="noopener noreferrer"><span class=sf-dump-str title="19 characters">Exception@anonymous</span></a>"
+  <span class=sf-dump-index>0</span> => "<a href="%sStubCasterTest.php:%d" rel="noopener noreferrer"><span class=sf-dump-str title="19 characters">Exception@anonymous</span></a>"
 </samp>]
 </bar>
 EODUMP;

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/polyfill-mbstring": "~1.0"
+        "symfony/polyfill-mbstring": "~1.0",
+        "symfony/polyfill-php83": "^1.27"
     },
     "require-dev": {
         "ext-iconv": "*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | To do

A fancier way to display JSON strings with VarDumper, especially when dumping HttpClient responses where we often want to see the decoded JSON we get in the response.

![](https://user-images.githubusercontent.com/2144837/222947113-a382657a-423e-4141-bb8a-5821a0890cee.png)
