### PR TITLE
[HttpFoundation] Use `@final` to make `UrlHelper` mockable

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Create migration for session table when pdo handler is used
  * Add support for Relay PHP extension for Redis
  * The `Response::sendHeaders()` method now takes an optional HTTP status code as parameter, allowing to send informational responses such as Early Hints responses (103 status code)
+ * Use `@final` to make `UrlHelper` mockable
 
 6.2
 ---

--- a/src/Symfony/Component/HttpFoundation/UrlHelper.php
+++ b/src/Symfony/Component/HttpFoundation/UrlHelper.php
@@ -17,8 +17,10 @@ use Symfony\Component\Routing\RequestContext;
  * A helper service for manipulating URLs within and outside the request scope.
  *
  * @author Valentin Udaltsov <udaltsov.valentin@gmail.com>
+ *
+ * @final
  */
-final class UrlHelper
+class UrlHelper
 {
     private RequestStack $requestStack;
     private ?RequestContext $requestContext;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Similar to #29955 the `UrlHelper` is a useful class, but mocking it is a PITA. Using the `@final` annotation should prevent adding an extra maintenance burden while at the same time allowing it to be mocked in tests.