### PR TITLE
[TwigBridge] Fix flagged malicious url

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Email/zurb_2/main.css
+++ b/src/Symfony/Bridge/Twig/Resources/views/Email/zurb_2/main.css
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 ZURB, inc. -- MIT License
  *
- * https://raw.githubusercontent.com/foundation/foundation-emails/v2.2.1/dist/foundation-emails.css
+ * https://github.com/foundation/foundation-emails/blob/v2.2.1/dist/foundation-emails.css
  */
 
 .wrapper {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #47454
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

We already use github blob links in the codebase, so IMO we can replace `raw.githubusercontent.com`  by  `github.com` link
