### PR TITLE
[OptionsResolver] add `ignoreUndefined()` method to allow skip not interesting options

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `OptionsResolver::ignoreUndefined()` to ignore not defined options while resolving
+
 6.0
 ---
 

--- a/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
+++ b/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
@@ -134,4 +134,16 @@ final class OptionConfigurator
 
         return $this;
     }
+
+    /**
+     * Sets whether ignore undefined options.
+     *
+     * @return $this
+     */
+    public function ignoreUndefined(bool $ignore = true): static
+    {
+        $this->resolver->setIgnoreUndefined($ignore);
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -141,6 +141,11 @@ class OptionsResolver implements Options
     private $prototypeIndex;
 
     /**
+     * Whether to ignore undefined options.
+     */
+    private bool $ignoreUndefined = false;
+
+    /**
      * Sets the default value of a given option.
      *
      * If the default value should be set based on other options, you can pass
@@ -862,7 +867,7 @@ class OptionsResolver implements Options
         $clone = clone $this;
 
         // Make sure that no unknown options are passed
-        $diff = array_diff_key($options, $clone->defined);
+        $diff = $this->ignoreUndefined ? [] : array_diff_key($options, $clone->defined);
 
         if (\count($diff) > 0) {
             ksort($clone->defined);
@@ -873,6 +878,10 @@ class OptionsResolver implements Options
 
         // Override options set by the user
         foreach ($options as $option => $value) {
+            if ($this->ignoreUndefined && !isset($clone->defined[$option])) {
+                continue;
+            }
+
             $clone->given[$option] = true;
             $clone->defaults[$option] = $value;
             unset($clone->resolved[$option], $clone->lazy[$option]);
@@ -1208,6 +1217,18 @@ class OptionsResolver implements Options
         }
 
         return \count($this->defaults);
+    }
+
+    /**
+     * Sets whether ignore undefined options.
+     *
+     * @return $this
+     */
+    public function setIgnoreUndefined(bool $ignore = true): static
+    {
+        $this->ignoreUndefined = $ignore;
+
+        return $this;
     }
 
     /**

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -36,6 +36,28 @@ class OptionsResolverTest extends TestCase
         $this->resolver = new OptionsResolver();
     }
 
+    /**
+     * @dataProvider provideResolveWithIgnoreUndefined
+     */
+    public function testResolveWithIgnoreUndefined(array $defaults, array $options, array $expected)
+    {
+        $this->resolver
+            ->setDefaults($defaults)
+            ->setIgnoreUndefined();
+
+        $this->assertSame($expected, $this->resolver->resolve($options));
+    }
+
+    public static function provideResolveWithIgnoreUndefined(): array
+    {
+        return [
+            'no defaults options, undefined resolves empty' => [[], ['c' => 4, 'd' => 5], []],
+            'empty options resolves defaults' => [['a' => '1', 'b' => '2'], [], ['a' => '1', 'b' => '2']],
+            'undefined options resolves defaults' => [['a' => '1', 'b' => '2'], ['c' => 3, 'd' => 4], ['a' => '1', 'b' => '2']],
+            'resolves defined' => [['a' => '1', 'b' => '2'], ['a' => '10', 'c' => '3'], ['b' => '2', 'a' => '10']],
+        ];
+    }
+
     public function testResolveFailsIfNonExistingOption()
     {
         $this->expectException(UndefinedOptionsException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #45370
| License       | MIT
| Doc PR        | NOT ADDED


Allow to ignore not defined options to allow skip not interesting options when working with big set of shared configuration or just not to describe all the options provided by third party provider

