### PR TITLE
[Translation] Wrap call to \Locale::setDefault from LocaleSwitcher in a class_exists call

### DIFF
--- a/src/Symfony/Component/Translation/LocaleSwitcher.php
+++ b/src/Symfony/Component/Translation/LocaleSwitcher.php
@@ -34,7 +34,10 @@ class LocaleSwitcher implements LocaleAwareInterface
 
     public function setLocale(string $locale): void
     {
-        \Locale::setDefault($this->locale = $locale);
+        if (class_exists(\Locale::class)) {
+            \Locale::setDefault($locale);
+        }
+        $this->locale = $locale;
         $this->requestContext?->setParameter('_locale', $locale);
 
         foreach ($this->localeAwareServices as $service) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/a - see below
| License       | MIT
| Doc PR        | n/a

In #45793 a new LocaleSwitcher was added which uses the \Locale class from ext-intl.
On upgrading an English only project from 5.4 to 6.2, I received the following error as we don't have the ext-intl extension

```
Error: Class "Locale" not found
```

I searched for previous PRs to add a dependency on `ext-intl` and [came across one](https://github.com/symfony/symfony/issues/49280) for the string component directing the user to install a polyfill.

Should symfony/translation therefore depend on the polyfill - otherwise updating is broken without manually installing the polyfill?

If so, here's a PR for that.

Keep up the good work folks :heart: 