### PR TITLE
[DoctrineBridge] deprecate doctrine schema subscribers in favor of listeners

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -13,6 +13,13 @@ DependencyInjection
  * Deprecate `PhpDumper` options `inline_factories_parameter` and `inline_class_loader_parameter`, use `inline_factories` and `inline_class_loader` instead
  * Deprecate undefined and numeric keys with `service_locator` config, use string aliases instead
 
+DoctrineBridge
+--------------
+
+ * Deprecate `DoctrineDbalCacheAdapterSchemaSubscriber` in favor of `DoctrineDbalCacheAdapterSchemaListener`
+ * Deprecate `MessengerTransportDoctrineSchemaSubscriber` in favor of `MessengerTransportDoctrineSchemaListener`
+ * Deprecate `RememberMeTokenProviderDoctrineSchemaSubscriber` in favor of `RememberMeTokenProviderDoctrineSchemaListener`
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `AbstractSchemaListener`, `LockStoreSchemaListener` and `PdoSessionHandlerSchemaListener`
+ * Deprecate `DoctrineDbalCacheAdapterSchemaSubscriber` in favor of `DoctrineDbalCacheAdapterSchemaListener`
+ * Deprecate `MessengerTransportDoctrineSchemaSubscriber` in favor of `MessengerTransportDoctrineSchemaListener`
+ * Deprecate `RememberMeTokenProviderDoctrineSchemaSubscriber` in favor of `RememberMeTokenProviderDoctrineSchemaListener`
+
 6.2
 ---
 

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -11,26 +11,13 @@
 
 namespace Symfony\Bridge\Doctrine\SchemaListener;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use Doctrine\ORM\Tools\ToolEvents;
 
-abstract class AbstractSchemaSubscriber implements EventSubscriber
+abstract class AbstractSchemaListener
 {
     abstract public function postGenerateSchema(GenerateSchemaEventArgs $event): void;
-
-    public function getSubscribedEvents(): array
-    {
-        if (!class_exists(ToolEvents::class)) {
-            return [];
-        }
-
-        return [
-            ToolEvents::postGenerateSchema,
-        ];
-    }
 
     protected function getIsSameDatabaseChecker(Connection $connection): \Closure
     {

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaListener.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\SchemaListener;
+
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
+
+/**
+ * Automatically adds the cache table needed for the DoctrineDbalAdapter of
+ * the Cache component.
+ */
+class DoctrineDbalCacheAdapterSchemaListener extends AbstractSchemaListener
+{
+    /**
+     * @param iterable<mixed, DoctrineDbalAdapter> $dbalAdapters
+     */
+    public function __construct(private iterable $dbalAdapters)
+    {
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
+    {
+        $connection = $event->getEntityManager()->getConnection();
+
+        foreach ($this->dbalAdapters as $dbalAdapter) {
+            $dbalAdapter->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaSubscriber.php
@@ -11,33 +11,30 @@
 
 namespace Symfony\Bridge\Doctrine\SchemaListener;
 
-use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Tools\ToolEvents;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
+
+trigger_deprecation('symfony/doctrine-bridge', '6.3', 'The "%s" class is deprecated. Use "%s" instead.', DoctrineDbalCacheAdapterSchemaSubscriber::class, DoctrineDbalCacheAdapterSchemaListener::class);
 
 /**
  * Automatically adds the cache table needed for the DoctrineDbalAdapter of
  * the Cache component.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @deprecated since Symfony 6.3, use {@link DoctrineDbalCacheAdapterSchemaListener} instead
  */
-final class DoctrineDbalCacheAdapterSchemaSubscriber extends AbstractSchemaSubscriber
+final class DoctrineDbalCacheAdapterSchemaSubscriber extends DoctrineDbalCacheAdapterSchemaListener implements EventSubscriber
 {
-    private $dbalAdapters;
-
-    /**
-     * @param iterable<mixed, DoctrineDbalAdapter> $dbalAdapters
-     */
-    public function __construct(iterable $dbalAdapters)
+    public function getSubscribedEvents(): array
     {
-        $this->dbalAdapters = $dbalAdapters;
-    }
-
-    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
-    {
-        $connection = $event->getEntityManager()->getConnection();
-
-        foreach ($this->dbalAdapters as $dbalAdapter) {
-            $dbalAdapter->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
+        if (!class_exists(ToolEvents::class)) {
+            return [];
         }
+
+        return [
+            ToolEvents::postGenerateSchema,
+        ];
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
 
-final class LockStoreSchemaSubscriber extends AbstractSchemaSubscriber
+final class LockStoreSchemaListener extends AbstractSchemaListener
 {
     /**
      * @param iterable<mixed, PersistingStoreInterface> $stores

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaListener.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\SchemaListener;
+
+use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * Automatically adds any required database tables to the Doctrine Schema.
+ */
+class MessengerTransportDoctrineSchemaListener extends AbstractSchemaListener
+{
+    private const PROCESSING_TABLE_FLAG = self::class.':processing';
+
+    /**
+     * @param iterable<mixed, TransportInterface> $transports
+     */
+    public function __construct(private iterable $transports)
+    {
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
+    {
+        $connection = $event->getEntityManager()->getConnection();
+
+        foreach ($this->transports as $transport) {
+            if (!$transport instanceof DoctrineTransport) {
+                continue;
+            }
+
+            $transport->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
+        }
+    }
+
+    public function onSchemaCreateTable(SchemaCreateTableEventArgs $event): void
+    {
+        $table = $event->getTable();
+
+        // if this method triggers a nested create table below, allow Doctrine to work like normal
+        if ($table->hasOption(self::PROCESSING_TABLE_FLAG)) {
+            return;
+        }
+
+        foreach ($this->transports as $transport) {
+            if (!$transport instanceof DoctrineTransport) {
+                continue;
+            }
+
+            if (!$extraSql = $transport->getExtraSetupSqlForTable($table)) {
+                continue;
+            }
+
+            // avoid this same listener from creating a loop on this table
+            $table->addOption(self::PROCESSING_TABLE_FLAG, true);
+            $createTableSql = $event->getPlatform()->getCreateTableSQL($table);
+
+            /*
+             * Add all the SQL needed to create the table and tell Doctrine
+             * to "preventDefault" so that only our SQL is used. This is
+             * the only way to inject some extra SQL.
+             */
+            $event->addSql($createTableSql);
+            foreach ($extraSql as $sql) {
+                $event->addSql($sql);
+            }
+            $event->preventDefault();
+
+            return;
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaSubscriber.php
@@ -11,84 +11,28 @@
 
 namespace Symfony\Bridge\Doctrine\SchemaListener;
 
-use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
+use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Events;
-use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport;
-use Symfony\Component\Messenger\Transport\TransportInterface;
+use Doctrine\ORM\Tools\ToolEvents;
+
+trigger_deprecation('symfony/doctrine-bridge', '6.3', 'The "%s" class is deprecated. Use "%s" instead.', MessengerTransportDoctrineSchemaSubscriber::class, MessengerTransportDoctrineSchemaListener::class);
 
 /**
  * Automatically adds any required database tables to the Doctrine Schema.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @deprecated since Symfony 6.3, use {@link MessengerTransportDoctrineSchemaListener} instead
  */
-final class MessengerTransportDoctrineSchemaSubscriber extends AbstractSchemaSubscriber
+final class MessengerTransportDoctrineSchemaSubscriber extends MessengerTransportDoctrineSchemaListener implements EventSubscriber
 {
-    private const PROCESSING_TABLE_FLAG = self::class.':processing';
-
-    private iterable $transports;
-
-    /**
-     * @param iterable<mixed, TransportInterface> $transports
-     */
-    public function __construct(iterable $transports)
-    {
-        $this->transports = $transports;
-    }
-
-    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
-    {
-        $connection = $event->getEntityManager()->getConnection();
-
-        foreach ($this->transports as $transport) {
-            if (!$transport instanceof DoctrineTransport) {
-                continue;
-            }
-
-            $transport->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
-        }
-    }
-
-    public function onSchemaCreateTable(SchemaCreateTableEventArgs $event): void
-    {
-        $table = $event->getTable();
-
-        // if this method triggers a nested create table below, allow Doctrine to work like normal
-        if ($table->hasOption(self::PROCESSING_TABLE_FLAG)) {
-            return;
-        }
-
-        foreach ($this->transports as $transport) {
-            if (!$transport instanceof DoctrineTransport) {
-                continue;
-            }
-
-            if (!$extraSql = $transport->getExtraSetupSqlForTable($table)) {
-                continue;
-            }
-
-            // avoid this same listener from creating a loop on this table
-            $table->addOption(self::PROCESSING_TABLE_FLAG, true);
-            $createTableSql = $event->getPlatform()->getCreateTableSQL($table);
-
-            /*
-             * Add all the SQL needed to create the table and tell Doctrine
-             * to "preventDefault" so that only our SQL is used. This is
-             * the only way to inject some extra SQL.
-             */
-            $event->addSql($createTableSql);
-            foreach ($extraSql as $sql) {
-                $event->addSql($sql);
-            }
-            $event->preventDefault();
-
-            return;
-        }
-    }
-
     public function getSubscribedEvents(): array
     {
-        $subscribedEvents = parent::getSubscribedEvents();
+        $subscribedEvents = [];
+
+        if (class_exists(ToolEvents::class)) {
+            $subscribedEvents[] = ToolEvents::postGenerateSchema;
+        }
 
         if (class_exists(Events::class)) {
             $subscribedEvents[] = Events::onSchemaCreateTable;

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaListener.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\Doctrine\SchemaListener;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
-final class PdoSessionHandlerSchemaSubscriber extends AbstractSchemaSubscriber
+final class PdoSessionHandlerSchemaListener extends AbstractSchemaListener
 {
     private PdoSessionHandler $sessionHandler;
 
@@ -25,13 +25,12 @@ final class PdoSessionHandlerSchemaSubscriber extends AbstractSchemaSubscriber
         }
     }
 
-    public function getSubscribedEvents(): array
-    {
-        return isset($this->sessionHandler) ? parent::getSubscribedEvents() : [];
-    }
-
     public function postGenerateSchema(GenerateSchemaEventArgs $event): void
     {
+        if (!isset($this->sessionHandler)) {
+            return;
+        }
+
         $connection = $event->getEntityManager()->getConnection();
 
         $this->sessionHandler->configureSchema($event->getSchema(), $this->getIsSameDatabaseChecker($connection));

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaListener.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\SchemaListener;
+
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider;
+use Symfony\Component\Security\Http\RememberMe\PersistentRememberMeHandler;
+use Symfony\Component\Security\Http\RememberMe\RememberMeHandlerInterface;
+
+/**
+ * Automatically adds the rememberme table needed for the {@see DoctrineTokenProvider}.
+ */
+class RememberMeTokenProviderDoctrineSchemaListener extends AbstractSchemaListener
+{
+    /**
+     * @param iterable<mixed, RememberMeHandlerInterface> $rememberMeHandlers
+     */
+    public function __construct(private iterable $rememberMeHandlers)
+    {
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
+    {
+        $connection = $event->getEntityManager()->getConnection();
+
+        foreach ($this->rememberMeHandlers as $rememberMeHandler) {
+            if (
+                $rememberMeHandler instanceof PersistentRememberMeHandler
+                && ($tokenProvider = $rememberMeHandler->getTokenProvider()) instanceof DoctrineTokenProvider
+            ) {
+                $tokenProvider->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaSubscriber.php
@@ -11,39 +11,29 @@
 
 namespace Symfony\Bridge\Doctrine\SchemaListener;
 
-use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Tools\ToolEvents;
 use Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider;
-use Symfony\Component\Security\Http\RememberMe\PersistentRememberMeHandler;
-use Symfony\Component\Security\Http\RememberMe\RememberMeHandlerInterface;
+
+trigger_deprecation('symfony/doctrine-bridge', '6.3', 'The "%s" class is deprecated. Use "%s" instead.', RememberMeTokenProviderDoctrineSchemaSubscriber::class, RememberMeTokenProviderDoctrineSchemaListener::class);
 
 /**
  * Automatically adds the rememberme table needed for the {@see DoctrineTokenProvider}.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @deprecated since Symfony 6.3, use {@link RememberMeTokenProviderDoctrineSchemaListener} instead
  */
-final class RememberMeTokenProviderDoctrineSchemaSubscriber extends AbstractSchemaSubscriber
+final class RememberMeTokenProviderDoctrineSchemaSubscriber extends RememberMeTokenProviderDoctrineSchemaListener implements EventSubscriber
 {
-    private iterable $rememberMeHandlers;
-
-    /**
-     * @param iterable<mixed, RememberMeHandlerInterface> $rememberMeHandlers
-     */
-    public function __construct(iterable $rememberMeHandlers)
+    public function getSubscribedEvents(): array
     {
-        $this->rememberMeHandlers = $rememberMeHandlers;
-    }
-
-    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
-    {
-        $connection = $event->getEntityManager()->getConnection();
-
-        foreach ($this->rememberMeHandlers as $rememberMeHandler) {
-            if (
-                $rememberMeHandler instanceof PersistentRememberMeHandler
-                && ($tokenProvider = $rememberMeHandler->getTokenProvider()) instanceof DoctrineTokenProvider
-            ) {
-                $tokenProvider->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
-            }
+        if (!class_exists(ToolEvents::class)) {
+            return [];
         }
+
+        return [
+            ToolEvents::postGenerateSchema,
+        ];
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaSubscriberTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaSubscriberTest.php
@@ -16,7 +16,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\Doctrine\SchemaListener\DoctrineDbalCacheAdapterSchemaSubscriber;
+use Symfony\Bridge\Doctrine\SchemaListener\DoctrineDbalCacheAdapterSchemaListener;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 
 class DoctrineDbalCacheAdapterSchemaSubscriberTest extends TestCase
@@ -37,7 +37,7 @@ class DoctrineDbalCacheAdapterSchemaSubscriberTest extends TestCase
             ->method('configureSchema')
             ->with($schema, $dbalConnection);
 
-        $subscriber = new DoctrineDbalCacheAdapterSchemaSubscriber([$dbalAdapter]);
+        $subscriber = new DoctrineDbalCacheAdapterSchemaListener([$dbalAdapter]);
         $subscriber->postGenerateSchema($event);
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaSubscriberTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaSubscriberTest.php
@@ -19,7 +19,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\Doctrine\SchemaListener\MessengerTransportDoctrineSchemaSubscriber;
+use Symfony\Bridge\Doctrine\SchemaListener\MessengerTransportDoctrineSchemaListener;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
@@ -43,7 +43,7 @@ class MessengerTransportDoctrineSchemaSubscriberTest extends TestCase
         $otherTransport->expects($this->never())
             ->method($this->anything());
 
-        $subscriber = new MessengerTransportDoctrineSchemaSubscriber([$doctrineTransport, $otherTransport]);
+        $subscriber = new MessengerTransportDoctrineSchemaListener([$doctrineTransport, $otherTransport]);
         $subscriber->postGenerateSchema($event);
     }
 
@@ -69,7 +69,8 @@ class MessengerTransportDoctrineSchemaSubscriberTest extends TestCase
             ->with($table)
             ->willReturn('CREATE TABLE pizza (id integer NOT NULL)');
 
-        $subscriber = new MessengerTransportDoctrineSchemaSubscriber([$otherTransport, $doctrineTransport]);
+        $subscriber = new MessengerTransportDoctrineSchemaListener([$otherTransport, $doctrineTransport]);
+
         $subscriber->onSchemaCreateTable($event);
         $this->assertTrue($event->isDefaultPrevented());
         $this->assertSame([
@@ -92,7 +93,8 @@ class MessengerTransportDoctrineSchemaSubscriberTest extends TestCase
         $platform->expects($this->never())
             ->method('getCreateTableSQL');
 
-        $subscriber = new MessengerTransportDoctrineSchemaSubscriber([$doctrineTransport]);
+        $subscriber = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
+
         $subscriber->onSchemaCreateTable($event);
         $this->assertFalse($event->isDefaultPrevented());
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
@@ -16,10 +16,10 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\Doctrine\SchemaListener\PdoSessionHandlerSchemaSubscriber;
+use Symfony\Bridge\Doctrine\SchemaListener\PdoSessionHandlerSchemaListener;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
-class PdoSessionHandlerSchemaSubscriberTest extends TestCase
+class PdoSessionHandlerSchemaListenerTest extends TestCase
 {
     public function testPostGenerateSchemaPdo()
     {
@@ -36,7 +36,7 @@ class PdoSessionHandlerSchemaSubscriberTest extends TestCase
             ->method('configureSchema')
             ->with($schema, fn () => true);
 
-        $subscriber = new PdoSessionHandlerSchemaSubscriber($pdoSessionHandler);
+        $subscriber = new PdoSessionHandlerSchemaListener($pdoSessionHandler);
         $subscriber->postGenerateSchema($event);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #49387 
| License       | MIT
| Doc PR        | 

As @nicolas-grekas explained in https://github.com/symfony/symfony/issues/49387#issuecomment-1442179095 : 

" Because PdoSessionHandlerSchemaSubscriber is registered as a subscriber, ContainerAwareEventManager must instantiate it to know which events should be listened for. This triggers the instantiation of the session.handler service, which is a NativeFileSessionHandler, and this notice when this is done after headers have been sent."

It was therefore decided to change all the doctrine schema subscribers in favor of listeners in order to avoid this kind of problem. 

Being already present before Symfony 6.3, 
`MessengerTransportDoctrineSchemaSubscriber`, `DoctrineDbalCacheAdapterSchemaSubscriber` and `RememberMeTokenProviderDoctrineSchemaSubscriber`have been deprecated. 

TODO:
- [x] : update DoctrineBundle => in progress
