### PR TITLE
[HttpFoundation] add `Request::getPayload()`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -10,7 +10,8 @@ CHANGELOG
  * Create migration for session table when pdo handler is used
  * Add support for Relay PHP extension for Redis
  * The `Response::sendHeaders()` method now takes an optional HTTP status code as parameter, allowing to send informational responses such as Early Hints responses (103 status code)
- * Add `IpUtils::isPrivateIp`
+ * Add `IpUtils::isPrivateIp()`
+ * Add `Request::getPayload(): InputBag`
  * Deprecate conversion of invalid values in `ParameterBag::getInt()` and `ParameterBag::getBoolean()`,
  * Deprecate ignoring invalid values when using `ParameterBag::filter()`, unless flag `FILTER_NULL_ON_FAILURE` is set
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1505,6 +1505,14 @@ class Request
     }
 
     /**
+     * Gets the decoded form or json request body.
+     */
+    public function getPayload(): InputBag
+    {
+        return $this->request->count() ? clone $this->request : new InputBag($this->toArray());
+    }
+
+    /**
      * Gets the request body decoded as array, typically from a JSON payload.
      *
      * @throws JsonException When the body cannot be decoded to an array

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1300,6 +1300,17 @@ class RequestTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $req->toArray());
     }
 
+    public function testGetPayload()
+    {
+        $req = new Request([], [], [], [], [], [], json_encode(['foo' => 'bar']));
+        $this->assertSame(['foo' => 'bar'], $req->getPayload()->all());
+        $req->getPayload()->set('new', 'key');
+        $this->assertSame(['foo' => 'bar'], $req->getPayload()->all());
+
+        $req = new Request([], ['foo' => 'bar'], [], [], [], [], json_encode(['baz' => 'qux']));
+        $this->assertSame(['foo' => 'bar'], $req->getPayload()->all());
+    }
+
     /**
      * @dataProvider provideOverloadedMethods
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #47646
| License       | MIT
| Doc PR        | todo

Alternative for #47938 based on feedback there.

```php
/** @var InputBag $input wrapping either Request::$request or Request::toArray() */
$input = $request->getPayload();
```