### PR TITLE
[CssSelector] Add support for :scope

### DIFF
--- a/src/Symfony/Component/CssSelector/CHANGELOG.md
+++ b/src/Symfony/Component/CssSelector/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+-----
+
+ * Add support for `:scope`
+
 4.4.0
 -----
 

--- a/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
+++ b/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
@@ -43,6 +43,11 @@ class SyntaxErrorException extends ParseException
         return new self('Got nested ::not().');
     }
 
+    public static function notAtTheStartOfASelector(string $pseudoElement): self
+    {
+        return new self(sprintf('Got immediate child pseudo-element ":%s" not at the start of a selector', $pseudoElement));
+    }
+
     public static function stringAsFunctionArgument(): self
     {
         return new self('String not allowed as function argument.');

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -19,7 +19,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\Tokenizer;
  * CSS selector parser.
  *
  * This component is a port of the Python cssselect library,
- * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
+ * which is copyright Ian Bicking, @see https://github.com/scrapy/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
  *
@@ -192,7 +192,18 @@ class Parser implements ParserInterface
 
                 if (!$stream->getPeek()->isDelimiter(['('])) {
                     $result = new Node\PseudoNode($result, $identifier);
-
+                    if ('Pseudo[Element[*]:scope]' === $result->__toString()) {
+                        $used = \count($stream->getUsed());
+                        if (!(2 === $used
+                           || 3 === $used && $stream->getUsed()[0]->isWhiteSpace()
+                           || $used >= 3 && $stream->getUsed()[$used - 3]->isDelimiter([','])
+                           || $used >= 4
+                                && $stream->getUsed()[$used - 3]->isWhiteSpace()
+                                && $stream->getUsed()[$used - 4]->isDelimiter([','])
+                        )) {
+                            throw SyntaxErrorException::notAtTheStartOfASelector('scope');
+                        }
+                    }
                     continue;
                 }
 

--- a/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
@@ -146,6 +146,12 @@ class ParserTest extends TestCase
             // unicode escape: \20 ==  (space)
             ['*[aval="\'\20  \'"]', ['Attribute[Element[*][aval = \'\'  \'\']]']],
             ["*[aval=\"'\\20\r\n '\"]", ['Attribute[Element[*][aval = \'\'  \'\']]']],
+            [':scope > foo', ['CombinedSelector[Pseudo[Element[*]:scope] > Element[foo]]']],
+            [':scope > foo bar > div', ['CombinedSelector[CombinedSelector[CombinedSelector[Pseudo[Element[*]:scope] > Element[foo]] <followed> Element[bar]] > Element[div]]']],
+            [':scope > #foo #bar', ['CombinedSelector[CombinedSelector[Pseudo[Element[*]:scope] > Hash[Element[*]#foo]] <followed> Hash[Element[*]#bar]]']],
+            [':scope', ['Pseudo[Element[*]:scope]']],
+            ['foo bar, :scope > div', ['CombinedSelector[Element[foo] <followed> Element[bar]]', 'CombinedSelector[Pseudo[Element[*]:scope] > Element[div]]']],
+            ['foo bar,:scope > div', ['CombinedSelector[Element[foo] <followed> Element[bar]]', 'CombinedSelector[Pseudo[Element[*]:scope] > Element[div]]']],
         ];
     }
 
@@ -176,6 +182,7 @@ class ParserTest extends TestCase
             [':lang(fr', SyntaxErrorException::unexpectedToken('an argument', new Token(Token::TYPE_FILE_END, '', 8))->getMessage()],
             [':contains("foo', SyntaxErrorException::unclosedString(10)->getMessage()],
             ['foo!', SyntaxErrorException::unexpectedToken('selector', new Token(Token::TYPE_DELIMITER, '!', 3))->getMessage()],
+            [':scope > div :scope header', SyntaxErrorException::notAtTheStartOfASelector('scope')->getMessage()],
         ];
     }
 

--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -219,6 +219,8 @@ HTML
             ['e + f', "e/following-sibling::*[(name() = 'f') and (position() = 1)]"],
             ['e ~ f', 'e/following-sibling::f'],
             ['div#container p', "div[@id = 'container']/descendant-or-self::*/p"],
+            [':scope > div[dataimg="<testmessage>"]', "*[1]/div[@dataimg = '<testmessage>']"],
+            [':scope', '*[1]'],
         ];
     }
 
@@ -411,6 +413,9 @@ HTML
             ['div[class|=dialog]', 50], // ? Seems right
             ['div[class!=madeup]', 243], // ? Seems right
             ['div[class~=dialog]', 51], // ? Seems right
+            [':scope > div', 1],
+            [':scope > div > div[class=dialog]', 1],
+            [':scope > div div', 242],
         ];
     }
 }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
@@ -30,6 +30,7 @@ class PseudoClassExtension extends AbstractExtension
     {
         return [
             'root' => $this->translateRoot(...),
+            'scope' => $this->translateScopePseudo(...),
             'first-child' => $this->translateFirstChild(...),
             'last-child' => $this->translateLastChild(...),
             'first-of-type' => $this->translateFirstOfType(...),
@@ -43,6 +44,11 @@ class PseudoClassExtension extends AbstractExtension
     public function translateRoot(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition('not(parent::*)');
+    }
+
+    public function translateScopePseudo(XPathExpr $xpath): XPathExpr
+    {
+        return $xpath->addCondition('1');
     }
 
     public function translateFirstChild(XPathExpr $xpath): XPathExpr


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 6.3
| Bug fix      | no
| New feature  | yes
| Deprecations | no
| Tickets       | Fix [#48773](https://github.com/symfony/symfony/issues/48773)
| License       | MIT
| Doc PR       | 

This PR adds support for  ':scope' selector 
