### PR TITLE
[Serializer] Preserve array keys while denormalize variadic parameters

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -362,8 +362,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         }
 
                         $variadicParameters = [];
-                        foreach ($data[$paramName] as $parameterData) {
-                            $variadicParameters[] = $this->denormalizeParameter($reflectionClass, $constructorParameter, $paramName, $parameterData, $context, $format);
+                        foreach ($data[$paramName] as $parameterKey => $parameterData) {
+                            $variadicParameters[$parameterKey] = $this->denormalizeParameter($reflectionClass, $constructorParameter, $paramName, $parameterData, $context, $format);
                         }
 
                         $params = array_merge($params, $variadicParameters);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -201,6 +201,36 @@ class AbstractNormalizerTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider getNormalizer
+     */
+    public function testVariadicSerializationWithPreservingKeys(AbstractNormalizer $normalizer)
+    {
+        $d1 = new Dummy();
+        $d1->foo = 'Foo';
+        $d1->bar = 'Bar';
+        $d1->baz = 'Baz';
+        $d1->qux = 'Quz';
+        $d2 = new Dummy();
+        $d2->foo = 'FOO';
+        $d2->bar = 'BAR';
+        $d2->baz = 'BAZ';
+        $d2->qux = 'QUZ';
+        $arr = ['d1' => $d1, 'd2' => $d2];
+        $obj = new VariadicConstructorTypedArgsDummy(...$arr);
+
+        $serializer = new Serializer([$normalizer], [new JsonEncoder()]);
+        $normalizer->setSerializer($serializer);
+        $this->assertEquals(
+            '{"foo":{"d1":{"foo":"Foo","bar":"Bar","baz":"Baz","qux":"Quz"},"d2":{"foo":"FOO","bar":"BAR","baz":"BAZ","qux":"QUZ"}}}',
+            $data = $serializer->serialize($obj, 'json')
+        );
+
+        $dummy = $normalizer->denormalize(json_decode($data, true), VariadicConstructorTypedArgsDummy::class);
+        $this->assertInstanceOf(VariadicConstructorTypedArgsDummy::class, $dummy);
+        $this->assertEquals($arr, $dummy->getFoo());
+    }
+
     public static function getNormalizer()
     {
         $extractor = new PhpDocExtractor();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49616
| License       | MIT
| Doc PR        | Let me know if needed
| PHP        | 8.1.15

Hi Symfony folks!

I've struggled with denormalization issue.
It appears when serialize an object with variadic parameter from associative array.
Currently, after denormalization array keys get reset and it is not compatible with previous version of object.

Example:
```php
<?php

declare(strict_types=1);

use Symfony\Component\Serializer\Encoder\JsonEncoder;
use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
use Symfony\Component\Serializer\Serializer;

require_once __DIR__ . "/vendor/autoload.php";


final class Dummy {
    public function __construct(public readonly string $i)
    {
    }
}

final class DummyWithVariadic {
    public $dummies;
    public function __construct(Dummy ...$dummies)
    {
        $this->dummies = $dummies;
    }
}

$serializer = new Serializer([$normalizer = new PropertyNormalizer()], [new JsonEncoder()]);
$normalizer->setSerializer($serializer);

$dummies = ["d1" => new Dummy("d1 value"), "d2" => new Dummy("d2 value")];
$object  = new DummyWithVariadic(...$dummies);
var_dump($object);
/* Output:
class DummyWithVariadic#310 (1) {
  public $dummies =>
  array(2) {
    'd1' =>
    class Dummy#308 (1) {
      public readonly string $i =>
      string(8) "d1 value"
    }
    'd2' =>
    class Dummy#309 (1) {
      public readonly string $i =>
      string(8) "d2 value"
    }
  }
}
*/

$json = $serializer->serialize($object, "json");
echo $json . PHP_EOL;
/* Output:
{"dummies":{"d1":{"i":"d1 value"},"d2":{"i":"d2 value"}}}
*/

$deserialized = $serializer->deserialize($json, DummyWithVariadic::class, "json");
var_dump($deserialized);
/* Output:
class DummyWithVariadic#315 (1) {
  public $dummies =>
  array(2) {
    [0] =>
    class Dummy#319 (1) {
      public readonly string $i =>
      string(8) "d1 value"
    }
    [1] =>
    class Dummy#320 (1) {
      public readonly string $i =>
      string(8) "d2 value"
    }
  }
}
*/

$jsonFromDeserialized = $serializer->serialize($deserialized, "json");
echo $jsonFromDeserialized . PHP_EOL;
/* Output:
{"dummies":[{"i":"d1 value"},{"i":"d2 value"}]}
*/

var_dump($json === $jsonFromDeserialized); // And now the deserialization result without respected array keys :(
/* Output:
bool(false)
*/
```

Let me know if we can add this fix for earlier versions 🙌 
>  Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).

I hope it's not , feedback is appreciated!
> Never break backward compatibility (see https://symfony.com/bc)

