### PR TITLE
[Tests] Remove occurrences of `withConsecutive()`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -258,14 +258,31 @@ class ApplicationTest extends TestCase
         $container
             ->expects($this->exactly(2))
             ->method('hasParameter')
-            ->withConsecutive(['console.command.ids'], ['console.lazy_command.ids'])
-            ->willReturnOnConsecutiveCalls(true, true)
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['console.command.ids'],
+                    ['console.lazy_command.ids'],
+                ];
+
+                $this->assertSame(array_shift($series), $args);
+
+                return true;
+            })
         ;
+
         $container
             ->expects($this->exactly(2))
             ->method('getParameter')
-            ->withConsecutive(['console.lazy_command.ids'], ['console.command.ids'])
-            ->willReturnOnConsecutiveCalls([], [])
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['console.lazy_command.ids'],
+                    ['console.command.ids'],
+                ];
+
+                $this->assertSame(array_shift($series), $args);
+
+                return [];
+            })
         ;
 
         $kernel = $this->createMock(KernelInterface::class);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\CacheWarmer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\CacheWarmer\ExpressionCacheWarmer;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ParsedExpression;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
 
 class ExpressionCacheWarmerTest extends TestCase
@@ -22,13 +23,21 @@ class ExpressionCacheWarmerTest extends TestCase
     {
         $expressions = [new Expression('A'), new Expression('B')];
 
+        $series = [
+            [$expressions[0], ['token', 'user', 'object', 'subject', 'role_names', 'request', 'trust_resolver']],
+            [$expressions[1], ['token', 'user', 'object', 'subject', 'role_names', 'request', 'trust_resolver']],
+        ];
+
         $expressionLang = $this->createMock(ExpressionLanguage::class);
         $expressionLang->expects($this->exactly(2))
             ->method('parse')
-            ->withConsecutive(
-                [$expressions[0], ['token', 'user', 'object', 'subject', 'role_names', 'request', 'trust_resolver']],
-                [$expressions[1], ['token', 'user', 'object', 'subject', 'role_names', 'request', 'trust_resolver']]
-            );
+            ->willReturnCallback(function (...$args) use (&$series) {
+                $expectedArgs = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $this->createMock(ParsedExpression::class);
+            })
+        ;
 
         (new ExpressionCacheWarmer($expressions, $expressionLang))->warmUp('');
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -26,10 +26,16 @@ class MaxIdLengthAdapterTest extends TestCase
 
         $cache->expects($this->exactly(2))
             ->method('doHave')
-            ->withConsecutive(
-                [$this->equalTo('----------:nWfzGiCgLczv3SSUzXL3kg:')],
-                [$this->equalTo('----------:---------------------------------------')]
-            );
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['----------:nWfzGiCgLczv3SSUzXL3kg:'],
+                    ['----------:---------------------------------------'],
+                ];
+
+                $expectedArgs = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+            })
+        ;
 
         $cache->hasItem(str_repeat('-', 40));
         $cache->hasItem(str_repeat('-', 39));

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
@@ -64,14 +64,17 @@ class ContainerParametersResourceCheckerTest extends TestCase
         yield 'fresh on every identical parameters' => [function (MockObject $container) {
             $container->expects(self::exactly(2))->method('hasParameter')->willReturn(true);
             $container->expects(self::exactly(2))->method('getParameter')
-                ->withConsecutive(
-                    [self::equalTo('locales')],
-                    [self::equalTo('default_locale')]
-                )
-                ->willReturnMap([
-                    ['locales', ['fr', 'en']],
-                    ['default_locale', 'fr'],
-                ])
+                ->willReturnCallback(function (...$args) {
+                    static $series = [
+                        [['locales'], ['fr', 'en']],
+                        [['default_locale'], 'fr'],
+                    ];
+
+                    [$expectedArgs, $return] = array_shift($series);
+                    self::assertSame($expectedArgs, $args);
+
+                    return $return;
+                })
             ;
         }, true];
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
@@ -84,8 +84,18 @@ class StrictSessionHandlerTest extends TestCase
     {
         $handler = $this->createMock(\SessionHandlerInterface::class);
         $handler->expects($this->exactly(2))->method('read')
-            ->withConsecutive(['id1'], ['id2'])
-            ->will($this->onConsecutiveCalls('data1', 'data2'));
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [['id1'], 'data1'],
+                    [['id2'], 'data2'],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
         $proxy = new StrictSessionHandler($handler);
 
         $this->assertTrue($proxy->validateId('id1'));

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
@@ -222,7 +222,13 @@ class DebugHandlersListenerTest extends TestCase
         $handler
             ->expects($this->exactly(\count($expectedCalls)))
             ->method('setDefaultLogger')
-            ->withConsecutive(...$expectedCalls);
+            ->willReturnCallback(function (LoggerInterface $logger, $levels) use (&$expectedCalls) {
+                [$expectedLogger, $expectedLevels] = array_shift($expectedCalls);
+
+                $this->assertSame($expectedLogger, $logger);
+                $this->assertSame($expectedLevels, $levels);
+            })
+        ;
 
         $sut = new DebugHandlersListener(null, $logger, $levels, null, true, true, $deprecationLogger);
         $prevHander = set_exception_handler([$handler, 'handleError']);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
@@ -46,16 +46,18 @@ class LocaleAwareListenerTest extends TestCase
 
     public function testDefaultLocaleIsUsedOnExceptionsInOnKernelRequest()
     {
+        $matcher = $this->exactly(2);
         $this->localeAwareService
-            ->expects($this->exactly(2))
+            ->expects($matcher)
             ->method('setLocale')
-            ->withConsecutive(
-                [$this->anything()],
-                ['en']
-            )
-            ->willReturnOnConsecutiveCalls(
-                $this->throwException(new \InvalidArgumentException())
-            );
+            ->willReturnCallback(function (string $locale) use ($matcher) {
+                if (1 === $matcher->getInvocationCount()) {
+                    throw new \InvalidArgumentException();
+                }
+
+                $this->assertSame('en', $locale);
+            })
+        ;
 
         $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $this->createRequest('fr'), HttpKernelInterface::MAIN_REQUEST);
         $this->listener->onKernelRequest($event);
@@ -90,16 +92,18 @@ class LocaleAwareListenerTest extends TestCase
 
     public function testDefaultLocaleIsUsedOnExceptionsInOnKernelFinishRequest()
     {
+        $matcher = $this->exactly(2);
         $this->localeAwareService
-            ->expects($this->exactly(2))
+            ->expects($matcher)
             ->method('setLocale')
-            ->withConsecutive(
-                [$this->anything()],
-                ['en']
-            )
-            ->willReturnOnConsecutiveCalls(
-                $this->throwException(new \InvalidArgumentException())
-            );
+            ->willReturnCallback(function (string $locale) use ($matcher) {
+                if (1 === $matcher->getInvocationCount()) {
+                    throw new \InvalidArgumentException();
+                }
+
+                $this->assertSame('en', $locale);
+            })
+        ;
 
         $this->requestStack->push($this->createRequest('fr'));
         $this->requestStack->push($subRequest = $this->createRequest('de'));

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -182,10 +182,12 @@ class KernelTest extends TestCase
         $bundle = $this->createMock(Bundle::class);
         $bundle->expects($this->exactly(2))
             ->method('setContainer')
-            ->withConsecutive(
-                [$this->isInstanceOf(ContainerInterface::class)],
-                [null]
-            );
+            ->willReturnCallback(function ($container) {
+                if (null !== $container) {
+                    $this->assertInstanceOf(ContainerInterface::class, $container);
+                }
+            })
+        ;
 
         $kernel = $this->getKernel(['getBundles']);
         $kernel->expects($this->any())

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -170,9 +170,15 @@ class CheckLdapCredentialsListenerTest extends TestCase
 
         $this->ldap
             ->method('bind')
-            ->withConsecutive(
-                ['elsa', 'test1234A$']
-            );
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['elsa', 'test1234A$'],
+                    ['', 's3cr3t'],
+                ];
+
+                $this->assertSame(array_shift($series), $args);
+            })
+        ;
         $this->ldap->expects($this->any())->method('escape')->with('Wouter', '', LdapInterface::ESCAPE_FILTER)->willReturn('wouter');
         $this->ldap->expects($this->once())->method('query')->with('{username}', 'wouter_test')->willReturn($query);
 
@@ -192,9 +198,15 @@ class CheckLdapCredentialsListenerTest extends TestCase
 
         $this->ldap
             ->method('bind')
-            ->withConsecutive(
-                ['elsa', 'test1234A$']
-            );
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['elsa', 'test1234A$'],
+                    ['', 's3cr3t'],
+                ];
+
+                $this->assertSame(array_shift($series), $args);
+            })
+        ;
         $this->ldap->method('escape')->willReturnArgument(0);
         $this->ldap->expects($this->once())->method('query')->willReturn($query);
 

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
@@ -99,22 +99,27 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
     public function testCreatesTableInTransaction(string $platform)
     {
         $conn = $this->createMock(Connection::class);
+
+        $series = [
+            [$this->stringContains('INSERT INTO'), $this->createMock(TableNotFoundException::class)],
+            [$this->matches('create sql stmt'), 1],
+            [$this->stringContains('INSERT INTO'), 1],
+        ];
+
         $conn->expects($this->atLeast(3))
             ->method('executeStatement')
-            ->withConsecutive(
-                [$this->stringContains('INSERT INTO')],
-                [$this->matches('create sql stmt')],
-                [$this->stringContains('INSERT INTO')]
-            )
-            ->will(
-                $this->onConsecutiveCalls(
-                    $this->throwException(
-                        $this->createMock(TableNotFoundException::class)
-                    ),
-                    1,
-                    1
-                )
-            );
+            ->willReturnCallback(function ($sql) use (&$series) {
+                if ([$constraint, $return] = array_shift($series)) {
+                    $constraint->evaluate($sql);
+                }
+
+                if ($return instanceof \Exception) {
+                    throw $return;
+                }
+
+                return $return ?? 1;
+            })
+        ;
 
         $conn->method('isTransactionActive')
             ->willReturn(true);
@@ -145,21 +150,25 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
     public function testTableCreationInTransactionNotSupported()
     {
         $conn = $this->createMock(Connection::class);
+
+        $series = [
+            [$this->stringContains('INSERT INTO'), $this->createMock(TableNotFoundException::class)],
+            [$this->stringContains('INSERT INTO'), 1],
+        ];
+
         $conn->expects($this->atLeast(2))
             ->method('executeStatement')
-            ->withConsecutive(
-                [$this->stringContains('INSERT INTO')],
-                [$this->stringContains('INSERT INTO')]
-            )
-            ->will(
-                $this->onConsecutiveCalls(
-                    $this->throwException(
-                        $this->createMock(TableNotFoundException::class)
-                    ),
-                    1,
-                    1
-                )
-            );
+            ->willReturnCallback(function ($sql) use (&$series) {
+                [$constraint, $return] = array_shift($series);
+                $constraint->evaluate($sql);
+
+                if ($return instanceof \Exception) {
+                    throw $return;
+                }
+
+                return $return;
+            })
+        ;
 
         $conn->method('isTransactionActive')
             ->willReturn(true);
@@ -181,22 +190,26 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
     public function testCreatesTableOutsideTransaction()
     {
         $conn = $this->createMock(Connection::class);
+
+        $series = [
+            [$this->stringContains('INSERT INTO'), $this->createMock(TableNotFoundException::class)],
+            [$this->matches('create sql stmt'), 1],
+            [$this->stringContains('INSERT INTO'), 1],
+        ];
+
         $conn->expects($this->atLeast(3))
             ->method('executeStatement')
-            ->withConsecutive(
-                [$this->stringContains('INSERT INTO')],
-                [$this->matches('create sql stmt')],
-                [$this->stringContains('INSERT INTO')]
-            )
-            ->will(
-                $this->onConsecutiveCalls(
-                    $this->throwException(
-                        $this->createMock(TableNotFoundException::class)
-                    ),
-                    1,
-                    1
-                )
-            );
+            ->willReturnCallback(function ($sql) use (&$series) {
+                [$constraint, $return] = array_shift($series);
+                $constraint->evaluate($sql);
+
+                if ($return instanceof \Exception) {
+                    throw $return;
+                }
+
+                return $return;
+            })
+        ;
 
         $conn->method('isTransactionActive')
             ->willReturn(false);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -311,15 +311,29 @@ class ConnectionTest extends TestCase
         $amqpExchange->expects($this->once())->method('declareExchange');
         $amqpExchange->expects($this->once())->method('publish')->with('body', 'routing_key', \AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2, 'timestamp' => time()]);
         $amqpQueue0->expects($this->once())->method('declareQueue');
-        $amqpQueue0->expects($this->exactly(2))->method('bind')->withConsecutive(
-            [self::DEFAULT_EXCHANGE_NAME, 'binding_key0'],
-            [self::DEFAULT_EXCHANGE_NAME, 'binding_key1']
-        );
+        $amqpQueue0->expects($this->exactly(2))->method('bind')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [self::DEFAULT_EXCHANGE_NAME, 'binding_key0', []],
+                    [self::DEFAULT_EXCHANGE_NAME, 'binding_key1', []],
+                ];
+
+                $expectedArgs = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+            })
+        ;
         $amqpQueue1->expects($this->once())->method('declareQueue');
-        $amqpQueue1->expects($this->exactly(2))->method('bind')->withConsecutive(
-            [self::DEFAULT_EXCHANGE_NAME, 'binding_key2'],
-            [self::DEFAULT_EXCHANGE_NAME, 'binding_key3']
-        );
+        $amqpQueue1->expects($this->exactly(2))->method('bind')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [self::DEFAULT_EXCHANGE_NAME, 'binding_key2', []],
+                    [self::DEFAULT_EXCHANGE_NAME, 'binding_key3', []],
+                ];
+
+                $expectedArgs = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+            })
+        ;
 
         $dsn = 'amqp://localhost?'.
             'exchange[default_publish_routing_key]=routing_key&'.
@@ -349,15 +363,29 @@ class ConnectionTest extends TestCase
         $amqpExchange->expects($this->once())->method('declareExchange');
         $amqpExchange->expects($this->once())->method('publish')->with('body', 'routing_key', \AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2, 'timestamp' => time()]);
         $amqpQueue0->expects($this->once())->method('declareQueue');
-        $amqpQueue0->expects($this->exactly(2))->method('bind')->withConsecutive(
-            [self::DEFAULT_EXCHANGE_NAME, 'binding_key0'],
-            [self::DEFAULT_EXCHANGE_NAME, 'binding_key1']
-        );
+        $amqpQueue0->expects($this->exactly(2))->method('bind')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [self::DEFAULT_EXCHANGE_NAME, 'binding_key0', []],
+                    [self::DEFAULT_EXCHANGE_NAME, 'binding_key1', []],
+                ];
+
+                $expectedArgs = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+            })
+        ;
         $amqpQueue1->expects($this->once())->method('declareQueue');
-        $amqpQueue1->expects($this->exactly(2))->method('bind')->withConsecutive(
-            [self::DEFAULT_EXCHANGE_NAME, 'binding_key2'],
-            [self::DEFAULT_EXCHANGE_NAME, 'binding_key3']
-        );
+        $amqpQueue1->expects($this->exactly(2))->method('bind')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [self::DEFAULT_EXCHANGE_NAME, 'binding_key2', []],
+                    [self::DEFAULT_EXCHANGE_NAME, 'binding_key3', []],
+                ];
+
+                $expectedArgs = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+            })
+        ;
 
         $dsn = 'amqps://localhost?'.
             'cacert=/etc/ssl/certs&'.
@@ -387,9 +415,7 @@ class ConnectionTest extends TestCase
         $amqpExchange->expects($this->once())->method('declareExchange');
         $amqpExchange->expects($this->once())->method('publish')->with('body', null, \AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2, 'timestamp' => time()]);
         $amqpQueue->expects($this->once())->method('declareQueue');
-        $amqpQueue->expects($this->exactly(1))->method('bind')->withConsecutive(
-            [self::DEFAULT_EXCHANGE_NAME, null, ['x-match' => 'all']]
-        );
+        $amqpQueue->expects($this->exactly(1))->method('bind')->with(self::DEFAULT_EXCHANGE_NAME, null, ['x-match' => 'all']);
 
         $dsn = 'amqp://localhost?exchange[type]=headers'.
             '&queues[queue0][binding_arguments][x-match]=all';

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -272,12 +272,22 @@ class ConnectionTest extends TestCase
         $redis = $this->createMock(\Redis::class);
 
         $redis->expects($this->exactly(3))->method('xreadgroup')
-            ->withConsecutive(
-                ['symfony', 'consumer', ['queue' => '0'], 1, null], // first call for pending messages
-                ['symfony', 'consumer', ['queue' => '0'], 1, null], // second call because of claimed message (redisid-123)
-                ['symfony', 'consumer', ['queue' => '>'], 1, null] // third call because of no result (other consumer claimed message redisid-123)
-            )
-            ->willReturnOnConsecutiveCalls([], [], []);
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    // first call for pending messages
+                    [['symfony', 'consumer', ['queue' => '0'], 1, null], []],
+                    // second call because of claimed message (redisid-123)
+                    [['symfony', 'consumer', ['queue' => '0'], 1, null], []],
+                    // third call because of no result (other consumer claimed message redisid-123)
+                    [['symfony', 'consumer', ['queue' => '>'], 1, null], []],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
 
         $redis->expects($this->once())->method('xpending')->willReturn([[
             0 => 'redisid-123', // message-id
@@ -298,14 +308,20 @@ class ConnectionTest extends TestCase
         $redis = $this->createMock(\Redis::class);
 
         $redis->expects($this->exactly(2))->method('xreadgroup')
-            ->withConsecutive(
-                ['symfony', 'consumer', ['queue' => '0'], 1, null], // first call for pending messages
-                ['symfony', 'consumer', ['queue' => '0'], 1, null] // second call because of claimed message (redisid-123)
-            )
-            ->willReturnOnConsecutiveCalls(
-                [], // first call returns no result
-                ['queue' => [['message' => '{"body":"1","headers":[]}']]] // second call returns claimed message (redisid-123)
-            );
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    // first call for pending messages
+                    [['symfony', 'consumer', ['queue' => '0'], 1, null], []],
+                    // second call because of claimed message (redisid-123)
+                    [['symfony', 'consumer', ['queue' => '0'], 1, null], ['queue' => [['message' => '{"body":"1","headers":[]}']]]],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
 
         $redis->expects($this->once())->method('xpending')->willReturn([[
             0 => 'redisid-123', // message-id

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
@@ -173,11 +173,21 @@ class FailedMessagesRemoveCommandTest extends TestCase
     public function testRemoveMultipleMessages()
     {
         $receiver = $this->createMock(ListableReceiverInterface::class);
-        $receiver->expects($this->exactly(3))->method('find')->withConsecutive([20], [30], [40])->willReturnOnConsecutiveCalls(
-            new Envelope(new \stdClass()),
-            null,
-            new Envelope(new \stdClass())
-        );
+
+        $series = [
+            [[20], new Envelope(new \stdClass())],
+            [[30], null],
+            [[40], new Envelope(new \stdClass())],
+        ];
+
+        $receiver->expects($this->exactly(3))->method('find')
+            ->willReturnCallback(function (...$args) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
 
         $command = new FailedMessagesRemoveCommand(
             'failure_receiver',
@@ -197,11 +207,21 @@ class FailedMessagesRemoveCommandTest extends TestCase
     {
         $globalFailureReceiverName = 'failure_receiver';
         $receiver = $this->createMock(ListableReceiverInterface::class);
-        $receiver->expects($this->exactly(3))->method('find')->withConsecutive([20], [30], [40])->willReturnOnConsecutiveCalls(
-            new Envelope(new \stdClass()),
-            null,
-            new Envelope(new \stdClass())
-        );
+
+        $series = [
+            [[20], new Envelope(new \stdClass())],
+            [[30], null],
+            [[40], new Envelope(new \stdClass())],
+        ];
+
+        $receiver->expects($this->exactly(3))->method('find')
+            ->willReturnCallback(function (...$args) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
 
         $serviceLocator = $this->createMock(ServiceLocator::class);
         $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
@@ -227,10 +247,20 @@ class FailedMessagesRemoveCommandTest extends TestCase
     public function testRemoveMultipleMessagesAndDisplayMessages()
     {
         $receiver = $this->createMock(ListableReceiverInterface::class);
-        $receiver->expects($this->exactly(2))->method('find')->withConsecutive([20], [30])->willReturnOnConsecutiveCalls(
-            new Envelope(new \stdClass()),
-            new Envelope(new \stdClass())
-        );
+
+        $series = [
+            [[20], new Envelope(new \stdClass())],
+            [[30], new Envelope(new \stdClass())],
+        ];
+
+        $receiver->expects($this->exactly(2))->method('find')
+            ->willReturnCallback(function (...$args) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
 
         $command = new FailedMessagesRemoveCommand(
             'failure_receiver',
@@ -249,10 +279,20 @@ class FailedMessagesRemoveCommandTest extends TestCase
     {
         $globalFailureReceiverName = 'failure_receiver';
         $receiver = $this->createMock(ListableReceiverInterface::class);
-        $receiver->expects($this->exactly(2))->method('find')->withConsecutive([20], [30])->willReturnOnConsecutiveCalls(
-            new Envelope(new \stdClass()),
-            new Envelope(new \stdClass())
-        );
+
+        $series = [
+            [[20], new Envelope(new \stdClass())],
+            [[30], new Envelope(new \stdClass())],
+        ];
+
+        $receiver->expects($this->exactly(2))->method('find')
+            ->willReturnCallback(function (...$args) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
 
         $serviceLocator = $this->createMock(ServiceLocator::class);
         $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
@@ -29,8 +29,21 @@ class FailedMessagesRetryCommandTest extends TestCase
      */
     public function testBasicRun()
     {
+        $series = [
+            [[10], new Envelope(new \stdClass())],
+            [[12], new Envelope(new \stdClass())],
+        ];
+
         $receiver = $this->createMock(ListableReceiverInterface::class);
-        $receiver->expects($this->exactly(2))->method('find')->withConsecutive([10], [12])->willReturn(new Envelope(new \stdClass()));
+        $receiver->expects($this->exactly(2))->method('find')
+            ->willReturnCallback(function (...$args) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
+
         // message will eventually be ack'ed in Worker
         $receiver->expects($this->exactly(2))->method('ack');
 
@@ -54,8 +67,21 @@ class FailedMessagesRetryCommandTest extends TestCase
 
     public function testBasicRunWithServiceLocator()
     {
+        $series = [
+            [[10], new Envelope(new \stdClass())],
+            [[12], new Envelope(new \stdClass())],
+        ];
+
         $receiver = $this->createMock(ListableReceiverInterface::class);
-        $receiver->expects($this->exactly(2))->method('find')->withConsecutive([10], [12])->willReturn(new Envelope(new \stdClass()));
+        $receiver->expects($this->exactly(2))->method('find')
+            ->willReturnCallback(function (...$args) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
+
         // message will eventually be ack'ed in Worker
         $receiver->expects($this->exactly(2))->method('ack');
 
@@ -119,8 +145,21 @@ EOF;
 
     public function testBasicRunWithServiceLocatorWithSpecificFailureTransport()
     {
+        $series = [
+            [[10], new Envelope(new \stdClass())],
+            [[12], new Envelope(new \stdClass())],
+        ];
+
         $receiver = $this->createMock(ListableReceiverInterface::class);
-        $receiver->expects($this->exactly(2))->method('find')->withConsecutive([10], [12])->willReturn(new Envelope(new \stdClass()));
+        $receiver->expects($this->exactly(2))->method('find')
+            ->willReturnCallback(function (...$args) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
+
         // message will eventually be ack'ed in Worker
         $receiver->expects($this->exactly(2))->method('ack');
 

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
@@ -52,17 +52,21 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             $handlingMiddleware,
         ]);
 
+        $series = [
+            // Third event is dispatch within main dispatch, but before its handling:
+            $thirdEvent,
+            // Then expect main dispatched message to be handled first:
+            $message,
+            // Then, expect events in new transaction to be handled next, in dispatched order:
+            $firstEvent,
+            $secondEvent,
+        ];
+
         $handlingMiddleware->expects($this->exactly(4))
             ->method('handle')
-            ->withConsecutive(
-                // Third event is dispatch within main dispatch, but before its handling:
-                [$this->expectHandledMessage($thirdEvent)],
-                // Then expect main dispatched message to be handled first:
-                [$this->expectHandledMessage($message)],
-                // Then, expect events in new transaction to be handled next, in dispatched order:
-                [$this->expectHandledMessage($firstEvent)],
-                [$this->expectHandledMessage($secondEvent)]
-            )
+            ->with($this->callback(function (Envelope $envelope) use (&$series) {
+                return $envelope->getMessage() === array_shift($series);
+            }))
             ->willReturnOnConsecutiveCalls(
                 $this->willHandleMessage(),
                 $this->willHandleMessage(),
@@ -97,16 +101,20 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             $handlingMiddleware,
         ]);
 
+        $series = [
+            // Expect main dispatched message to be handled first:
+            $message,
+            // Then, expect events in new transaction to be handled next, in dispatched order:
+            $firstEvent,
+            // Next event is still handled despite the previous exception:
+            $secondEvent,
+        ];
+
         $handlingMiddleware->expects($this->exactly(3))
             ->method('handle')
-            ->withConsecutive(
-                // Expect main dispatched message to be handled first:
-                [$this->expectHandledMessage($message)],
-                // Then, expect events in new transaction to be handled next, in dispatched order:
-                [$this->expectHandledMessage($firstEvent)],
-                // Next event is still handled despite the previous exception:
-                [$this->expectHandledMessage($secondEvent)]
-            )
+            ->with($this->callback(function (Envelope $envelope) use (&$series) {
+                return $envelope->getMessage() === array_shift($series);
+            }))
             ->willReturnOnConsecutiveCalls(
                 $this->willHandleMessage(),
                 $this->throwException(new \RuntimeException('Some exception while handling first event')),
@@ -153,22 +161,26 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
         ]);
 
         // Handling $eventL1b will dispatch 2 more events
+        $series = [
+            // Expect main dispatched message to be handled first:
+            $command,
+            $eventL1a,
+            $eventL1b,
+            $eventL1c,
+            // Handle $eventL2a will dispatch event and throw exception
+            $eventL2a,
+            // Make sure $eventL2b is handled, since it was dispatched from $eventL1b
+            $eventL2b,
+            // We don't handle exception L3a since L2a threw an exception.
+            $eventL3b,
+            // Note: $eventL3a should not be handled.
+        ];
+
         $handlingMiddleware->expects($this->exactly(7))
             ->method('handle')
-            ->withConsecutive(
-                // Expect main dispatched message to be handled first:
-                [$this->expectHandledMessage($command)],
-                [$this->expectHandledMessage($eventL1a)],
-                [$this->expectHandledMessage($eventL1b)],
-                [$this->expectHandledMessage($eventL1c)],
-                // Handle $eventL2a will dispatch event and throw exception
-                [$this->expectHandledMessage($eventL2a)],
-                // Make sure $eventL2b is handled, since it was dispatched from $eventL1b
-                [$this->expectHandledMessage($eventL2b)],
-                // We dont handle exception L3a since L2a threw an exception.
-                [$this->expectHandledMessage($eventL3b)]
-                // Note: $eventL3a should not be handled.
-            )
+            ->with($this->callback(function (Envelope $envelope) use (&$series) {
+                return $envelope->getMessage() === array_shift($series);
+            }))
             ->willReturnOnConsecutiveCalls(
                 $this->willHandleMessage(),
                 $this->willHandleMessage(),

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -177,15 +177,19 @@ class WorkerTest extends TestCase
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
+        $series = [
+            $this->isInstanceOf(WorkerStartedEvent::class),
+            $this->isInstanceOf(WorkerMessageReceivedEvent::class),
+            $this->isInstanceOf(WorkerMessageHandledEvent::class),
+            $this->isInstanceOf(WorkerRunningEvent::class),
+            $this->isInstanceOf(WorkerStoppedEvent::class),
+        ];
+
         $eventDispatcher->expects($this->exactly(5))
             ->method('dispatch')
-            ->withConsecutive(
-                [$this->isInstanceOf(WorkerStartedEvent::class)],
-                [$this->isInstanceOf(WorkerMessageReceivedEvent::class)],
-                [$this->isInstanceOf(WorkerMessageHandledEvent::class)],
-                [$this->isInstanceOf(WorkerRunningEvent::class)],
-                [$this->isInstanceOf(WorkerStoppedEvent::class)]
-            )->willReturnCallback(function ($event) {
+            ->willReturnCallback(function ($event) use (&$series) {
+                array_shift($series)->evaluate($event, '', true);
+
                 if ($event instanceof WorkerRunningEvent) {
                     $event->getWorker()->stop();
                 }
@@ -208,15 +212,19 @@ class WorkerTest extends TestCase
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
+        $series = [
+            $this->isInstanceOf(WorkerStartedEvent::class),
+            $this->isInstanceOf(WorkerMessageReceivedEvent::class),
+            $this->isInstanceOf(WorkerMessageFailedEvent::class),
+            $this->isInstanceOf(WorkerRunningEvent::class),
+            $this->isInstanceOf(WorkerStoppedEvent::class),
+        ];
+
         $eventDispatcher->expects($this->exactly(5))
             ->method('dispatch')
-            ->withConsecutive(
-                [$this->isInstanceOf(WorkerStartedEvent::class)],
-                [$this->isInstanceOf(WorkerMessageReceivedEvent::class)],
-                [$this->isInstanceOf(WorkerMessageFailedEvent::class)],
-                [$this->isInstanceOf(WorkerRunningEvent::class)],
-                [$this->isInstanceOf(WorkerStoppedEvent::class)]
-            )->willReturnCallback(function ($event) {
+            ->willReturnCallback(function ($event) use (&$series) {
+                array_shift($series)->evaluate($event, '', true);
+
                 if ($event instanceof WorkerRunningEvent) {
                     $event->getWorker()->stop();
                 }

--- a/src/Symfony/Component/Notifier/Tests/Event/FailedMessageEventTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Event/FailedMessageEventTest.php
@@ -82,12 +82,18 @@ class FailedMessageEventTest extends TestCase
 
         $message = new DummyMessage();
 
+        $series = [
+            new MessageEvent($message),
+            new FailedMessageEvent($message, $transport->exception),
+        ];
+
         $eventDispatcherMock->expects($this->exactly(2))
             ->method('dispatch')
-            ->withConsecutive(
-                [new MessageEvent($message)],
-                [new FailedMessageEvent($message, $transport->exception)]
-            );
+            ->willReturnCallback(function (object $event) use (&$series) {
+                $this->assertEquals(array_shift($series), $event);
+
+                return $event;
+            });
         try {
             $transport->send($message);
         } catch (NullTransportException $exception) {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTestCase.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTestCase.php
@@ -138,12 +138,18 @@ abstract class PropertyAccessorCollectionTestCase extends PropertyAccessorArrayA
         $structure->expects($this->once())
             ->method('removeAxis')
             ->with('fourth');
+
         $structure->expects($this->exactly(2))
             ->method('addAxis')
-            ->withConsecutive(
-                ['first'],
-                ['third']
-            );
+            ->willReturnCallback(function (string $axis) {
+                static $series = [
+                    'first',
+                    'third',
+                ];
+
+                $this->assertSame(array_shift($series), $axis);
+            })
+        ;
 
         $this->propertyAccessor->setValue($car, 'structure.axes', $axesAfter);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
@@ -123,9 +123,15 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $ldap = $this->createMock(LdapInterface::class);
         $ldap
             ->method('bind')
-            ->withConsecutive(
-                ['elsa', 'test1234A$']
-            );
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['elsa', 'test1234A$'],
+                    ['', 'bar'],
+                ];
+
+                $this->assertSame(array_shift($series), $args);
+            })
+        ;
         $ldap
             ->expects($this->once())
             ->method('escape')
@@ -169,9 +175,15 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $ldap = $this->createMock(LdapInterface::class);
         $ldap
             ->method('bind')
-            ->withConsecutive(
-                ['elsa', 'test1234A$']
-            );
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['elsa', 'test1234A$'],
+                    ['', 'bar'],
+                ];
+
+                $this->assertSame(array_shift($series), $args);
+            })
+        ;
         $ldap
             ->expects($this->once())
             ->method('escape')
@@ -213,9 +225,15 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $ldap = $this->createMock(LdapInterface::class);
         $ldap
             ->method('bind')
-            ->withConsecutive(
-                ['elsa', 'test1234A$']
-            );
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['elsa', 'test1234A$'],
+                    ['', 'bar'],
+                ];
+
+                $this->assertSame(array_shift($series), $args);
+            })
+        ;
         $ldap
             ->expects($this->once())
             ->method('query')

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -229,8 +229,17 @@ class AccessDecisionManagerTest extends TestCase
         $voter
             ->expects($this->exactly(2))
             ->method('supportsAttribute')
-            ->withConsecutive(['foo'], ['bar'])
-            ->willReturnOnConsecutiveCalls(false, true);
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [['foo'], false],
+                    [['bar'], true],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            });
         $voter
             ->expects($this->once())
             ->method('supportsType')

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -197,10 +197,15 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
         $this->logger->expects($this->exactly(2))
             ->method('debug')
-            ->withConsecutive(
-                ['Ignoring query parameter "_my_failure_path": not a valid URL.'],
-                ['Authentication failure, redirect triggered.', ['failure_path' => '/login']]
-            );
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['Ignoring query parameter "_my_failure_path": not a valid URL.', []],
+                    ['Authentication failure, redirect triggered.', ['failure_path' => '/login']],
+                ];
+
+                $expectedArgs = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+            });
 
         $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -85,7 +85,19 @@ class PasswordMigratingListenerTest extends TestCase
         // A custom Passport, without an UserBadge
         $passport = $this->createMock(UserPassportInterface::class);
         $passport->method('getUser')->willReturn($this->user);
-        $passport->method('hasBadge')->withConsecutive([PasswordUpgradeBadge::class], [UserBadge::class])->willReturnOnConsecutiveCalls(true, false);
+        $passport->method('hasBadge')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [[PasswordUpgradeBadge::class], true],
+                    [[UserBadge::class], false],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
         $passport->expects($this->once())->method('getBadge')->with(PasswordUpgradeBadge::class)->willReturn(new PasswordUpgradeBadge('pa$$word'));
         // We should never "getBadge" for "UserBadge::class"
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -41,16 +41,20 @@ class ArrayDenormalizerTest extends TestCase
 
     public function testDenormalize()
     {
+        $series = [
+            [[['foo' => 'one', 'bar' => 'two']], new ArrayDummy('one', 'two')],
+            [[['foo' => 'three', 'bar' => 'four']], new ArrayDummy('three', 'four')],
+        ];
+
         $this->serializer->expects($this->exactly(2))
             ->method('denormalize')
-            ->withConsecutive(
-                [['foo' => 'one', 'bar' => 'two']],
-                [['foo' => 'three', 'bar' => 'four']]
-            )
-            ->willReturnOnConsecutiveCalls(
-                new ArrayDummy('one', 'two'),
-                new ArrayDummy('three', 'four')
-            );
+            ->willReturnCallback(function ($data) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, [$data]);
+
+                return $return;
+            })
+        ;
 
         $result = $this->denormalizer->denormalize(
             [
@@ -74,18 +78,24 @@ class ArrayDenormalizerTest extends TestCase
      */
     public function testDenormalizeLegacy()
     {
-        $serializer = $this->createMock(Serializer::class);
+        $firstArray = new ArrayDummy('one', 'two');
+        $secondArray = new ArrayDummy('three', 'four');
 
+        $series = [
+            [[['foo' => 'one', 'bar' => 'two']], $firstArray],
+            [[['foo' => 'three', 'bar' => 'four']], $secondArray],
+        ];
+
+        $serializer = $this->createMock(Serializer::class);
         $serializer->expects($this->exactly(2))
             ->method('denormalize')
-            ->withConsecutive(
-                [['foo' => 'one', 'bar' => 'two']],
-                [['foo' => 'three', 'bar' => 'four']]
-            )
-            ->willReturnOnConsecutiveCalls(
-                new ArrayDummy('one', 'two'),
-                new ArrayDummy('three', 'four')
-            );
+            ->willReturnCallback(function ($data) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, [$data]);
+
+                return $return;
+            })
+        ;
 
         $denormalizer = new ArrayDenormalizer();
 

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -742,8 +742,11 @@ class LocoProviderTest extends ProviderTestCase
         $loader = $this->getLoader();
         $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
-            ->withConsecutive(...$consecutiveLoadArguments)
-            ->willReturnOnConsecutiveCalls(...$consecutiveLoadReturns);
+            ->willReturnCallback(function (...$args) use (&$consecutiveLoadArguments, &$consecutiveLoadReturns) {
+                $this->assertSame(array_shift($consecutiveLoadArguments), $args);
+
+                return array_shift($consecutiveLoadReturns);
+            });
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -627,8 +627,11 @@ class LokaliseProviderTest extends ProviderTestCase
         $loader = $this->getLoader();
         $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
-            ->withConsecutive(...$consecutiveLoadArguments)
-            ->willReturnOnConsecutiveCalls(...$consecutiveLoadReturns);
+            ->willReturnCallback(function (...$args) use (&$consecutiveLoadArguments, &$consecutiveLoadReturns) {
+                $this->assertSame(array_shift($consecutiveLoadArguments), $args);
+
+                return array_shift($consecutiveLoadReturns);
+            });
 
         $provider = self::createProvider((new MockHttpClient($response))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`withConsecutive()` has been deprecated in PHPUnit 9.6 and removed in PHP 10 (https://github.com/sebastianbergmann/phpunit/issues/4564). This PR aims at starting the work to remove these occurrences. There is unfortunately no given migration path, and this requires manual work.

I'll create a meta issue referencing remaining occurrences if this one's merged, to keep track. Some seems pretty hard to remove.

cc @OskarStark this might interest you, as we worked a lot on tests lately 😄 