### PR TITLE
[Tests] Replace `setMethods()` by `onlyMethods()` and `addMethods()`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -34,7 +34,7 @@ class DoctrineExtensionTest extends TestCase
 
         $this->extension = $this
             ->getMockBuilder(AbstractDoctrineExtension::class)
-            ->setMethods([
+            ->onlyMethods([
                 'getMappingResourceConfigDirectory',
                 'getObjectManagerElementName',
                 'getMappingObjectDefaultName',

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\Bridge\Doctrine\Tests\Form\ChoiceList;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\GuidType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Version;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\ORMQueryBuilderLoader;
@@ -46,8 +48,8 @@ class ORMQueryBuilderLoaderTest extends TestCase
     {
         $em = DoctrineTestHelper::createTestEntityManager();
 
-        $query = $this->getMockBuilder(\QueryMock::class)
-            ->setMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
+        $query = $this->getMockBuilder(QueryMock::class)
+            ->onlyMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
             ->getMock();
 
         $query
@@ -61,7 +63,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder(\Doctrine\ORM\QueryBuilder::class)
             ->setConstructorArgs([$em])
-            ->setMethods(['getQuery'])
+            ->onlyMethods(['getQuery'])
             ->getMock();
 
         $qb->expects($this->once())
@@ -79,8 +81,8 @@ class ORMQueryBuilderLoaderTest extends TestCase
     {
         $em = DoctrineTestHelper::createTestEntityManager();
 
-        $query = $this->getMockBuilder(\QueryMock::class)
-            ->setMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
+        $query = $this->getMockBuilder(QueryMock::class)
+            ->onlyMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
             ->getMock();
 
         $query
@@ -94,7 +96,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder(\Doctrine\ORM\QueryBuilder::class)
             ->setConstructorArgs([$em])
-            ->setMethods(['getQuery'])
+            ->onlyMethods(['getQuery'])
             ->getMock();
 
         $qb->expects($this->once())
@@ -115,8 +117,8 @@ class ORMQueryBuilderLoaderTest extends TestCase
     {
         $em = DoctrineTestHelper::createTestEntityManager();
 
-        $query = $this->getMockBuilder(\QueryMock::class)
-            ->setMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
+        $query = $this->getMockBuilder(QueryMock::class)
+            ->onlyMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
             ->getMock();
 
         $query
@@ -130,7 +132,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder(\Doctrine\ORM\QueryBuilder::class)
             ->setConstructorArgs([$em])
-            ->setMethods(['getQuery'])
+            ->onlyMethods(['getQuery'])
             ->getMock();
 
         $qb->expects($this->once())
@@ -160,8 +162,8 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $em = DoctrineTestHelper::createTestEntityManager();
 
-        $query = $this->getMockBuilder(\QueryMock::class)
-            ->setMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
+        $query = $this->getMockBuilder(QueryMock::class)
+            ->onlyMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
             ->getMock();
 
         $query
@@ -175,7 +177,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder(\Doctrine\ORM\QueryBuilder::class)
             ->setConstructorArgs([$em])
-            ->setMethods(['getQuery'])
+            ->onlyMethods(['getQuery'])
             ->getMock();
 
         $qb->expects($this->once())
@@ -207,7 +209,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder(\Doctrine\ORM\QueryBuilder::class)
             ->setConstructorArgs([$em])
-            ->setMethods(['getQuery'])
+            ->onlyMethods(['getQuery'])
             ->getMock();
 
         $qb->expects($this->never())
@@ -234,8 +236,8 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $em = DoctrineTestHelper::createTestEntityManager();
 
-        $query = $this->getMockBuilder(\QueryMock::class)
-            ->setMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
+        $query = $this->getMockBuilder(QueryMock::class)
+            ->onlyMethods(['setParameter', 'getResult', 'getSql', '_doExecute'])
             ->getMock();
 
         $query
@@ -249,7 +251,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder(\Doctrine\ORM\QueryBuilder::class)
             ->setConstructorArgs([$em])
-            ->setMethods(['getQuery'])
+            ->onlyMethods(['getQuery'])
             ->getMock();
         $qb->expects($this->once())
             ->method('getQuery')
@@ -276,5 +278,26 @@ class ORMQueryBuilderLoaderTest extends TestCase
             ['Symfony\Bridge\Doctrine\Tests\Fixtures\UuidIdEntity'],
             ['Symfony\Bridge\Doctrine\Tests\Fixtures\UlidIdEntity'],
         ];
+    }
+}
+
+class QueryMock extends AbstractQuery
+{
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return array|string
+     */
+    public function getSQL()
+    {
+    }
+
+    /**
+     * @return Result|int
+     */
+    protected function _doExecute()
+    {
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
@@ -30,7 +30,7 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder(DbalLogger::class)
             ->setConstructorArgs([$logger, null])
-            ->setMethods(['log'])
+            ->onlyMethods(['log'])
             ->getMock()
         ;
 
@@ -62,7 +62,7 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder(DbalLogger::class)
             ->setConstructorArgs([$logger, null])
-            ->setMethods(['log'])
+            ->onlyMethods(['log'])
             ->getMock()
         ;
 
@@ -85,7 +85,7 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder(DbalLogger::class)
             ->setConstructorArgs([$logger, null])
-            ->setMethods(['log'])
+            ->onlyMethods(['log'])
             ->getMock()
         ;
 
@@ -116,7 +116,7 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder(DbalLogger::class)
             ->setConstructorArgs([$logger, null])
-            ->setMethods(['log'])
+            ->onlyMethods(['log'])
             ->getMock()
         ;
 
@@ -144,7 +144,7 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder(DbalLogger::class)
             ->setConstructorArgs([$logger, null])
-            ->setMethods(['log'])
+            ->onlyMethods(['log'])
             ->getMock()
         ;
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -211,7 +211,7 @@ class EntityUserProviderTest extends TestCase
     private function getObjectManager($repository)
     {
         $em = $this->getMockBuilder(ObjectManager::class)
-            ->setMethods(['getClassMetadata', 'getRepository'])
+            ->onlyMethods(['getClassMetadata', 'getRepository'])
             ->getMockForAbstractClass();
         $em->expects($this->any())
             ->method('getRepository')

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -96,7 +96,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
     protected function createRepositoryMock()
     {
         $repository = $this->getMockBuilder(ObjectRepository::class)
-            ->setMethods(['findByCustom', 'find', 'findAll', 'findOneBy', 'findBy', 'getClassName'])
+            ->onlyMethods(['find', 'findAll', 'findOneBy', 'findBy', 'getClassName'])
+            ->addMethods(['findByCustom'])
             ->getMock()
         ;
 

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -64,7 +64,7 @@ class ConsoleHandlerTest extends TestCase
         $levelName = Logger::getLevelName($level);
         $levelName = sprintf('%-9s', $levelName);
 
-        $realOutput = $this->getMockBuilder(Output::class)->setMethods(['doWrite'])->getMock();
+        $realOutput = $this->getMockBuilder(Output::class)->onlyMethods(['doWrite'])->getMock();
         $realOutput->setVerbosity($verbosity);
         if ($realOutput->isDebug()) {
             $log = "16:21:54 $levelName [app] My info message\n";

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -136,7 +136,7 @@ class AnnotationsCacheWarmerTest extends TestCase
         $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
         $warmer = $this->getMockBuilder(AnnotationsCacheWarmer::class)
             ->setConstructorArgs([new AnnotationReader(), $cacheFile])
-            ->setMethods(['doWarmUp'])
+            ->onlyMethods(['doWarmUp'])
             ->getMock();
 
         $warmer->method('doWarmUp')->willReturnCallback(function ($cacheDir, ArrayAdapter $arrayAdapter) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/RouterCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/RouterCacheWarmerTest.php
@@ -21,9 +21,9 @@ class RouterCacheWarmerTest extends TestCase
 {
     public function testWarmUpWithWarmebleInterface()
     {
-        $containerMock = $this->getMockBuilder(ContainerInterface::class)->setMethods(['get', 'has'])->getMock();
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['get', 'has'])->getMock();
 
-        $routerMock = $this->getMockBuilder(testRouterInterfaceWithWarmebleInterface::class)->setMethods(['match', 'generate', 'getContext', 'setContext', 'getRouteCollection', 'warmUp'])->getMock();
+        $routerMock = $this->getMockBuilder(testRouterInterfaceWithWarmebleInterface::class)->onlyMethods(['match', 'generate', 'getContext', 'setContext', 'getRouteCollection', 'warmUp'])->getMock();
         $containerMock->expects($this->any())->method('get')->with('router')->willReturn($routerMock);
         $routerCacheWarmer = new RouterCacheWarmer($containerMock);
 
@@ -34,9 +34,9 @@ class RouterCacheWarmerTest extends TestCase
 
     public function testWarmUpWithoutWarmebleInterface()
     {
-        $containerMock = $this->getMockBuilder(ContainerInterface::class)->setMethods(['get', 'has'])->getMock();
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['get', 'has'])->getMock();
 
-        $routerMock = $this->getMockBuilder(testRouterInterfaceWithoutWarmebleInterface::class)->setMethods(['match', 'generate', 'getContext', 'setContext', 'getRouteCollection'])->getMock();
+        $routerMock = $this->getMockBuilder(testRouterInterfaceWithoutWarmebleInterface::class)->onlyMethods(['match', 'generate', 'getContext', 'setContext', 'getRouteCollection'])->getMock();
         $containerMock->expects($this->any())->method('get')->with('router')->willReturn($routerMock);
         $routerCacheWarmer = new RouterCacheWarmer($containerMock);
         $this->expectException(\LogicException::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
@@ -64,7 +64,7 @@ class KernelBrowserTest extends AbstractWebTestCase
     private function getKernelMock()
     {
         $mock = $this->getMockBuilder($this->getKernelClass())
-            ->setMethods(['shutdown', 'boot', 'handle', 'getContainer'])
+            ->onlyMethods(['shutdown', 'boot', 'handle', 'getContainer'])
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -609,7 +609,7 @@ class RouterTest extends TestCase
             ->willReturn($routes)
         ;
 
-        $sc = $this->getMockBuilder(Container::class)->setMethods(['get'])->getMock();
+        $sc = $this->getMockBuilder(Container::class)->onlyMethods(['get'])->getMock();
 
         $sc
             ->expects($this->once())

--- a/src/Symfony/Bundle/SecurityBundle/Tests/EventListener/VoteListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/EventListener/VoteListenerTest.php
@@ -26,7 +26,7 @@ class VoteListenerTest extends TestCase
         $traceableAccessDecisionManager = $this
             ->getMockBuilder(TraceableAccessDecisionManager::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addVoterVote'])
+            ->onlyMethods(['addVoterVote'])
             ->getMock();
 
         $traceableAccessDecisionManager

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -215,7 +215,7 @@ class ChainAdapterTest extends AdapterTestCase
 
         $adapter1 = $this->getMockBuilder(FilesystemAdapter::class)
             ->setConstructorArgs(['', 2])
-            ->setMethods(['save'])
+            ->onlyMethods(['save'])
             ->getMock();
         $adapter1->expects($this->once())
             ->method('save')
@@ -224,7 +224,7 @@ class ChainAdapterTest extends AdapterTestCase
 
         $adapter2 = $this->getMockBuilder(FilesystemAdapter::class)
             ->setConstructorArgs(['', 4])
-            ->setMethods(['save'])
+            ->onlyMethods(['save'])
             ->getMock();
         $adapter2->expects($this->once())
             ->method('save')

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -21,7 +21,7 @@ class MaxIdLengthAdapterTest extends TestCase
     {
         $cache = $this->getMockBuilder(MaxIdLengthAdapter::class)
             ->setConstructorArgs([str_repeat('-', 10)])
-            ->setMethods(['doHave', 'doFetch', 'doDelete', 'doSave', 'doClear'])
+            ->onlyMethods(['doHave', 'doFetch', 'doDelete', 'doSave', 'doClear'])
             ->getMock();
 
         $cache->expects($this->exactly(2))

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -716,7 +716,7 @@ class ApplicationTest extends TestCase
 
     public function testFindNamespaceDoesNotFailOnDeepSimilarNamespaces()
     {
-        $application = $this->getMockBuilder(Application::class)->setMethods(['getNamespaces'])->getMock();
+        $application = $this->getMockBuilder(Application::class)->onlyMethods(['getNamespaces'])->getMock();
         $application->expects($this->once())
             ->method('getNamespaces')
             ->willReturn(['foo:sublong', 'bar:sub']);
@@ -876,7 +876,7 @@ class ApplicationTest extends TestCase
 
     public function testRenderExceptionLineBreaks()
     {
-        $application = $this->getMockBuilder(Application::class)->setMethods(['getTerminalWidth'])->getMock();
+        $application = $this->getMockBuilder(Application::class)->addMethods(['getTerminalWidth'])->getMock();
         $application->setAutoExit(false);
         $application->expects($this->any())
             ->method('getTerminalWidth')
@@ -1103,7 +1103,7 @@ class ApplicationTest extends TestCase
     {
         $exception = new \Exception('', 4);
 
-        $application = $this->getMockBuilder(Application::class)->setMethods(['doRun'])->getMock();
+        $application = $this->getMockBuilder(Application::class)->onlyMethods(['doRun'])->getMock();
         $application->setAutoExit(false);
         $application->expects($this->once())
             ->method('doRun')
@@ -1142,7 +1142,7 @@ class ApplicationTest extends TestCase
     {
         $exception = new \Exception('', 0);
 
-        $application = $this->getMockBuilder(Application::class)->setMethods(['doRun'])->getMock();
+        $application = $this->getMockBuilder(Application::class)->onlyMethods(['doRun'])->getMock();
         $application->setAutoExit(false);
         $application->expects($this->once())
             ->method('doRun')
@@ -1185,7 +1185,7 @@ class ApplicationTest extends TestCase
     {
         $exception = new \Exception('', $exceptionCode);
 
-        $application = $this->getMockBuilder(Application::class)->setMethods(['doRun'])->getMock();
+        $application = $this->getMockBuilder(Application::class)->onlyMethods(['doRun'])->getMock();
         $application->setAutoExit(false);
         $application->expects($this->once())
             ->method('doRun')

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -61,7 +61,7 @@ class MergeExtensionConfigurationPassTest extends TestCase
 
     public function testExtensionLoadGetAMergeExtensionConfigurationContainerBuilderInstance()
     {
-        $extension = $this->getMockBuilder(FooExtension::class)->setMethods(['load'])->getMock();
+        $extension = $this->getMockBuilder(FooExtension::class)->onlyMethods(['load'])->getMock();
         $extension->expects($this->once())
             ->method('load')
             ->with($this->isType('array'), $this->isInstanceOf(MergeExtensionConfigurationContainerBuilder::class))
@@ -77,7 +77,7 @@ class MergeExtensionConfigurationPassTest extends TestCase
 
     public function testExtensionConfigurationIsTrackedByDefault()
     {
-        $extension = $this->getMockBuilder(FooExtension::class)->setMethods(['getConfiguration'])->getMock();
+        $extension = $this->getMockBuilder(FooExtension::class)->onlyMethods(['getConfiguration'])->getMock();
         $extension->expects($this->exactly(2))
             ->method('getConfiguration')
             ->willReturn(new FooConfiguration());

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -874,7 +874,7 @@ class FormTest extends TestCase
     {
         $field = $this
             ->getMockBuilder(FormField::class)
-            ->setMethods(['getName', 'getValue', 'setValue', 'initialize'])
+            ->onlyMethods(['getName', 'getValue', 'setValue', 'initialize'])
             ->disableOriginalConstructor()
             ->getMock()
         ;

--- a/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
@@ -35,7 +35,7 @@ trait ValidatorExtensionTrait
         }
 
         $this->validator = $this->createMock(ValidatorInterface::class);
-        $metadata = $this->getMockBuilder(ClassMetadata::class)->setConstructorArgs([''])->setMethods(['addPropertyConstraint'])->getMock();
+        $metadata = $this->getMockBuilder(ClassMetadata::class)->setConstructorArgs([''])->onlyMethods(['addPropertyConstraint'])->getMock();
         $this->validator->expects($this->any())->method('getMetadataFor')->will($this->returnValue($metadata));
         $this->validator->expects($this->any())->method('validate')->will($this->returnValue(new ConstraintViolationList()));
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -45,7 +45,7 @@ class MemcachedSessionHandlerTest extends TestCase
 
         $this->memcached = $this->getMockBuilder(\Memcached::class)
             ->disableOriginalConstructor()
-            ->setMethods($methodsToMock)
+            ->onlyMethods($methodsToMock)
             ->getMock();
 
         $this->storage = new MemcachedSessionHandler(

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -26,7 +26,7 @@ class LoggerDataCollectorTest extends TestCase
     {
         $logger = $this
             ->getMockBuilder(DebugLoggerInterface::class)
-            ->setMethods(['countErrors', 'getLogs', 'clear'])
+            ->onlyMethods(['countErrors', 'getLogs', 'clear'])
             ->getMock();
         $logger->expects($this->once())->method('countErrors')->willReturn(123);
         $logger->expects($this->exactly(2))->method('getLogs')->willReturn([]);
@@ -66,7 +66,7 @@ class LoggerDataCollectorTest extends TestCase
 
         $logger = $this
             ->getMockBuilder(DebugLoggerInterface::class)
-            ->setMethods(['countErrors', 'getLogs', 'clear'])
+            ->onlyMethods(['countErrors', 'getLogs', 'clear'])
             ->getMock();
 
         $logger->expects($this->once())->method('countErrors')->willReturn(0);
@@ -100,7 +100,7 @@ class LoggerDataCollectorTest extends TestCase
 
         $logger = $this
             ->getMockBuilder(DebugLoggerInterface::class)
-            ->setMethods(['countErrors', 'getLogs', 'clear'])
+            ->onlyMethods(['countErrors', 'getLogs', 'clear'])
             ->getMock();
         $logger->expects($this->once())->method('countErrors')->with(null);
         $logger->expects($this->exactly(2))->method('getLogs')->with(null)->willReturn([]);
@@ -121,7 +121,7 @@ class LoggerDataCollectorTest extends TestCase
 
         $logger = $this
             ->getMockBuilder(DebugLoggerInterface::class)
-            ->setMethods(['countErrors', 'getLogs', 'clear'])
+            ->onlyMethods(['countErrors', 'getLogs', 'clear'])
             ->getMock();
         $logger->expects($this->once())->method('countErrors')->with($subRequest);
         $logger->expects($this->exactly(2))->method('getLogs')->with($subRequest)->willReturn([]);
@@ -139,7 +139,7 @@ class LoggerDataCollectorTest extends TestCase
     {
         $logger = $this
             ->getMockBuilder(DebugLoggerInterface::class)
-            ->setMethods(['countErrors', 'getLogs', 'clear'])
+            ->onlyMethods(['countErrors', 'getLogs', 'clear'])
             ->getMock();
         $logger->expects($this->once())->method('countErrors')->willReturn($nb);
         $logger->expects($this->exactly(2))->method('getLogs')->willReturn($logs);
@@ -171,7 +171,7 @@ class LoggerDataCollectorTest extends TestCase
     {
         $logger = $this
             ->getMockBuilder(DebugLoggerInterface::class)
-            ->setMethods(['countErrors', 'getLogs', 'clear'])
+            ->onlyMethods(['countErrors', 'getLogs', 'clear'])
             ->getMock();
         $logger->expects($this->once())->method('clear');
 

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -48,7 +48,7 @@ class TraceableEventDispatcherTest extends TestCase
     public function testStopwatchCheckControllerOnRequestEvent()
     {
         $stopwatch = $this->getMockBuilder(Stopwatch::class)
-            ->setMethods(['isStarted'])
+            ->onlyMethods(['isStarted'])
             ->getMock();
         $stopwatch->expects($this->once())
             ->method('isStarted')
@@ -64,7 +64,7 @@ class TraceableEventDispatcherTest extends TestCase
     public function testStopwatchStopControllerOnRequestEvent()
     {
         $stopwatch = $this->getMockBuilder(Stopwatch::class)
-            ->setMethods(['isStarted', 'stop'])
+            ->onlyMethods(['isStarted', 'stop'])
             ->getMock();
         $stopwatch->expects($this->once())
             ->method('isStarted')

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -76,7 +76,7 @@ class LocaleListenerTest extends TestCase
         $context = $this->createMock(RequestContext::class);
         $context->expects($this->once())->method('setParameter')->with('_locale', 'es');
 
-        $router = $this->getMockBuilder(Router::class)->setMethods(['getContext'])->disableOriginalConstructor()->getMock();
+        $router = $this->getMockBuilder(Router::class)->onlyMethods(['getContext'])->disableOriginalConstructor()->getMock();
         $router->expects($this->once())->method('getContext')->willReturn($context);
 
         $request = Request::create('/');
@@ -92,7 +92,7 @@ class LocaleListenerTest extends TestCase
         $context = $this->createMock(RequestContext::class);
         $context->expects($this->once())->method('setParameter')->with('_locale', 'es');
 
-        $router = $this->getMockBuilder(Router::class)->setMethods(['getContext'])->disableOriginalConstructor()->getMock();
+        $router = $this->getMockBuilder(Router::class)->onlyMethods(['getContext'])->disableOriginalConstructor()->getMock();
         $router->expects($this->once())->method('getContext')->willReturn($context);
 
         $parentRequest = Request::create('/');

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -232,7 +232,7 @@ class EsiTest extends TestCase
 
     protected function getCache($request, $response)
     {
-        $cache = $this->getMockBuilder(HttpCache::class)->setMethods(['getRequest', 'handle'])->disableOriginalConstructor()->getMock();
+        $cache = $this->getMockBuilder(HttpCache::class)->onlyMethods(['getRequest', 'handle'])->disableOriginalConstructor()->getMock();
         $cache->expects($this->any())
               ->method('getRequest')
               ->willReturn($request)

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -41,7 +41,7 @@ class HttpCacheTest extends HttpCacheTestCase
         // implements TerminableInterface
         $kernelMock = $this->getMockBuilder(Kernel::class)
             ->disableOriginalConstructor()
-            ->setMethods(['terminate', 'registerBundles', 'registerContainerConfiguration'])
+            ->onlyMethods(['terminate', 'registerBundles', 'registerContainerConfiguration'])
             ->getMock();
 
         $kernelMock->expects($this->once())

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -190,7 +190,7 @@ class SsiTest extends TestCase
 
     protected function getCache($request, $response)
     {
-        $cache = $this->getMockBuilder(HttpCache::class)->setMethods(['getRequest', 'handle'])->disableOriginalConstructor()->getMock();
+        $cache = $this->getMockBuilder(HttpCache::class)->onlyMethods(['getRequest', 'handle'])->disableOriginalConstructor()->getMock();
         $cache->expects($this->any())
               ->method('getRequest')
               ->willReturn($request)

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -155,7 +155,8 @@ class HttpKernelBrowserTest extends TestCase
         $file = $this
             ->getMockBuilder(UploadedFile::class)
             ->setConstructorArgs([$source, 'original', 'mime/original', \UPLOAD_ERR_OK, true])
-            ->setMethods(['getSize', 'getClientSize'])
+            ->onlyMethods(['getSize'])
+            ->addMethods(['getClientSize'])
             ->getMock()
         ;
         /* should be modified when the getClientSize will be removed */

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -361,7 +361,7 @@ class HttpKernelTest extends TestCase
     {
         $request = new Request();
 
-        $stack = $this->getMockBuilder(RequestStack::class)->setMethods(['push', 'pop'])->getMock();
+        $stack = $this->getMockBuilder(RequestStack::class)->onlyMethods(['push', 'pop'])->getMock();
         $stack->expects($this->once())->method('push')->with($this->equalTo($request));
         $stack->expects($this->once())->method('pop');
 

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -148,7 +148,7 @@ class KernelTest extends TestCase
 
     public function testClassCacheIsNotLoadedByDefault()
     {
-        $kernel = $this->getKernel(['initializeBundles', 'doLoadClassCache']);
+        $kernel = $this->getKernel(['initializeBundles'], [], false, ['doLoadClassCache']);
         $kernel->expects($this->never())
             ->method('doLoadClassCache');
 
@@ -449,7 +449,7 @@ EOF
         // implements TerminableInterface
         $httpKernelMock = $this->getMockBuilder(HttpKernel::class)
             ->disableOriginalConstructor()
-            ->setMethods(['terminate'])
+            ->onlyMethods(['terminate'])
             ->getMock();
 
         $httpKernelMock
@@ -630,7 +630,7 @@ EOF
     {
         $bundle = $this
             ->getMockBuilder(BundleInterface::class)
-            ->setMethods(['getPath', 'getName'])
+            ->onlyMethods(['getPath', 'getName'])
             ->disableOriginalConstructor()
         ;
 
@@ -661,16 +661,21 @@ EOF
      * @param array $methods Additional methods to mock (besides the abstract ones)
      * @param array $bundles Bundles to register
      */
-    protected function getKernel(array $methods = [], array $bundles = [], bool $debug = false): Kernel
+    protected function getKernel(array $methods = [], array $bundles = [], bool $debug = false, array $methodsToAdd = []): Kernel
     {
         $methods[] = 'registerBundles';
 
-        $kernel = $this
+        $kernelMockBuilder = $this
             ->getMockBuilder(KernelForTest::class)
-            ->setMethods($methods)
+            ->onlyMethods($methods)
             ->setConstructorArgs(['test', $debug])
-            ->getMock()
         ;
+
+        if (0 !== \count($methodsToAdd)) {
+            $kernelMockBuilder->addMethods($methodsToAdd);
+        }
+
+        $kernel = $kernelMockBuilder->getMock();
         $kernel->expects($this->any())
             ->method('registerBundles')
             ->willReturn($bundles)

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -45,7 +45,7 @@ class ProfilerTest extends TestCase
     public function testReset()
     {
         $collector = $this->getMockBuilder(DataCollectorInterface::class)
-            ->setMethods(['collect', 'getName', 'reset'])
+            ->onlyMethods(['collect', 'getName', 'reset'])
             ->getMock();
         $collector->expects($this->any())->method('getName')->willReturn('mock');
         $collector->expects($this->once())->method('reset');

--- a/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
@@ -25,7 +25,7 @@ class ProcessFailedExceptionTest extends TestCase
      */
     public function testProcessFailedExceptionThrowsException()
     {
-        $process = $this->getMockBuilder(Process::class)->setMethods(['isSuccessful'])->setConstructorArgs([['php']])->getMock();
+        $process = $this->getMockBuilder(Process::class)->onlyMethods(['isSuccessful'])->setConstructorArgs([['php']])->getMock();
         $process->expects($this->once())
             ->method('isSuccessful')
             ->willReturn(true);
@@ -49,7 +49,7 @@ class ProcessFailedExceptionTest extends TestCase
         $errorOutput = 'FATAL: Unexpected error';
         $workingDirectory = getcwd();
 
-        $process = $this->getMockBuilder(Process::class)->setMethods(['isSuccessful', 'getOutput', 'getErrorOutput', 'getExitCode', 'getExitCodeText', 'isOutputDisabled', 'getWorkingDirectory'])->setConstructorArgs([[$cmd]])->getMock();
+        $process = $this->getMockBuilder(Process::class)->onlyMethods(['isSuccessful', 'getOutput', 'getErrorOutput', 'getExitCode', 'getExitCodeText', 'isOutputDisabled', 'getWorkingDirectory'])->setConstructorArgs([[$cmd]])->getMock();
         $process->expects($this->once())
             ->method('isSuccessful')
             ->willReturn(false);
@@ -97,7 +97,7 @@ class ProcessFailedExceptionTest extends TestCase
         $exitText = 'General error';
         $workingDirectory = getcwd();
 
-        $process = $this->getMockBuilder(Process::class)->setMethods(['isSuccessful', 'isOutputDisabled', 'getExitCode', 'getExitCodeText', 'getOutput', 'getErrorOutput', 'getWorkingDirectory'])->setConstructorArgs([[$cmd]])->getMock();
+        $process = $this->getMockBuilder(Process::class)->onlyMethods(['isSuccessful', 'isOutputDisabled', 'getExitCode', 'getExitCodeText', 'getOutput', 'getErrorOutput', 'getWorkingDirectory'])->setConstructorArgs([[$cmd]])->getMock();
         $process->expects($this->once())
             ->method('isSuccessful')
             ->willReturn(false);

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
@@ -82,7 +82,7 @@ class ObjectLoaderTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $service = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['loadRoutes'])
+            ->addMethods(['loadRoutes'])
             ->getMock();
         $service->expects($this->once())
             ->method('loadRoutes')

--- a/src/Symfony/Component/Routing/Tests/Matcher/CompiledRedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/CompiledRedirectableUrlMatcherTest.php
@@ -26,7 +26,7 @@ class CompiledRedirectableUrlMatcherTest extends RedirectableUrlMatcherTest
 
         return $this->getMockBuilder(TestCompiledRedirectableUrlMatcher::class)
             ->setConstructorArgs([$compiledRoutes, $context ?? new RequestContext()])
-            ->setMethods(['redirect'])
+            ->onlyMethods(['redirect'])
             ->getMock();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
@@ -486,7 +486,7 @@ class CompiledUrlMatcherDumperTest extends TestCase
 
         return $this->getMockBuilder(TestCompiledUrlMatcher::class)
             ->setConstructorArgs([$compiledRoutes, new RequestContext()])
-            ->setMethods(['redirect'])
+            ->onlyMethods(['redirect'])
             ->getMock();
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -201,7 +201,7 @@ class AuthenticationProviderManagerTest extends TestCase
         } elseif (null !== $exception) {
             $provider->expects($this->once())
                      ->method('authenticate')
-                     ->willThrowException($this->getMockBuilder($exception)->setMethods(null)->getMock())
+                     ->willThrowException($this->getMockBuilder($exception)->onlyMethods([])->getMock())
             ;
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
@@ -58,7 +58,7 @@ class AnonymousAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken($secret)
     {
-        $token = $this->getMockBuilder(AnonymousToken::class)->setMethods(['getSecret'])->disableOriginalConstructor()->getMock();
+        $token = $this->getMockBuilder(AnonymousToken::class)->onlyMethods(['getSecret'])->disableOriginalConstructor()->getMock();
         $token->expects($this->any())
               ->method('getSecret')
               ->willReturn($secret)

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -310,7 +310,7 @@ class DaoAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken()
     {
-        $mock = $this->getMockBuilder(UsernamePasswordToken::class)->setMethods(['getCredentials', 'getUser', 'getProviderKey'])->disableOriginalConstructor()->getMock();
+        $mock = $this->getMockBuilder(UsernamePasswordToken::class)->onlyMethods(['getCredentials', 'getUser', 'getProviderKey'])->disableOriginalConstructor()->getMock();
         $mock
             ->expects($this->any())
             ->method('getProviderKey')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -96,7 +96,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken($user = false, $credentials = false)
     {
-        $token = $this->getMockBuilder(PreAuthenticatedToken::class)->setMethods(['getUser', 'getCredentials', 'getFirewallName'])->disableOriginalConstructor()->getMock();
+        $token = $this->getMockBuilder(PreAuthenticatedToken::class)->onlyMethods(['getUser', 'getCredentials', 'getFirewallName'])->disableOriginalConstructor()->getMock();
         if (false !== $user) {
             $token->expects($this->once())
                   ->method('getUser')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -108,7 +108,7 @@ class RememberMeAuthenticationProviderTest extends TestCase
                 ->willReturn([]);
         }
 
-        $token = $this->getMockBuilder(RememberMeToken::class)->setMethods(['getFirewallName'])->setConstructorArgs([$user, 'foo', $secret])->getMock();
+        $token = $this->getMockBuilder(RememberMeToken::class)->onlyMethods(['getFirewallName'])->setConstructorArgs([$user, 'foo', $secret])->getMock();
         $token
             ->expects($this->once())
             ->method('getFirewallName')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -232,7 +232,7 @@ class UserAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken()
     {
-        $mock = $this->getMockBuilder(UsernamePasswordToken::class)->setMethods(['getCredentials', 'getFirewallName', 'getRoles'])->disableOriginalConstructor()->getMock();
+        $mock = $this->getMockBuilder(UsernamePasswordToken::class)->onlyMethods(['getCredentials', 'getFirewallName'])->addMethods(['getRoles'])->disableOriginalConstructor()->getMock();
         $mock
             ->expects($this->any())
             ->method('getFirewallName')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
@@ -31,7 +31,7 @@ class UsageTrackingTokenStorageTest extends TestCase
 
             $request = new Request();
             $request->setSession($session);
-            $requestStack = $this->getMockBuilder(RequestStack::class)->setMethods(['getSession'])->getMock();
+            $requestStack = $this->getMockBuilder(RequestStack::class)->onlyMethods(['getSession'])->getMock();
             $requestStack->push($request);
             $requestStack->expects($this->any())->method('getSession')->willReturnCallback(function () use ($session, &$sessionAccess) {
                 ++$sessionAccess;

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -186,17 +186,17 @@ class TraceableAccessDecisionManagerTest extends TestCase
     {
         $voter1 = $this
             ->getMockBuilder(VoterInterface::class)
-            ->setMethods(['vote'])
+            ->onlyMethods(['vote'])
             ->getMock();
 
         $voter2 = $this
             ->getMockBuilder(VoterInterface::class)
-            ->setMethods(['vote'])
+            ->onlyMethods(['vote'])
             ->getMock();
 
         $voter3 = $this
             ->getMockBuilder(VoterInterface::class)
-            ->setMethods(['vote'])
+            ->onlyMethods(['vote'])
             ->getMock();
 
         $sut = new TraceableAccessDecisionManager(new AccessDecisionManager([$voter1, $voter2, $voter3]));

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -160,7 +160,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
     public function testSessionIsNotInstantiatedOnStatelessFirewall()
     {
         $sessionFactory = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['__invoke'])
+            ->addMethods(['__invoke'])
             ->getMock();
 
         $sessionFactory->expects($this->never())

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -42,7 +42,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
         $this->session = $this->createMock(SessionInterface::class);
         $this->request = $this->createMock(Request::class);
         $this->request->expects($this->any())->method('getSession')->willReturn($this->session);
-        $this->exception = $this->getMockBuilder(AuthenticationException::class)->setMethods(['getMessage'])->getMock();
+        $this->exception = $this->getMockBuilder(AuthenticationException::class)->onlyMethods(['getMessage'])->getMock();
     }
 
     public function testForward()

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
@@ -136,7 +136,7 @@ class CheckCredentialsListenerTest extends TestCase
         $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
 
         $passport = $this->getMockBuilder(Passport::class)
-            ->setMethods(['addBadge'])
+            ->onlyMethods(['addBadge'])
             ->setConstructorArgs([new UserBadge('wouter', function () { return $this->user; }), new PasswordCredentials('ThePa$$word'), [new PasswordUpgradeBadge('ThePa$$word')]])
             ->getMock();
 
@@ -153,7 +153,7 @@ class CheckCredentialsListenerTest extends TestCase
         $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
 
         $passport = $this->getMockBuilder(Passport::class)
-            ->setMethods(['addBadge'])
+            ->onlyMethods(['addBadge'])
             ->setConstructorArgs([new UserBadge('wouter', function () { return $this->user; }), new PasswordCredentials('ThePa$$word'), [new PasswordUpgradeBadge('ThePa$$word')]])
             ->getMock();
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -366,7 +366,7 @@ class ContextListenerTest extends TestCase
 
     public function testSessionIsNotReported()
     {
-        $usageReporter = $this->getMockBuilder(\stdClass::class)->setMethods(['__invoke'])->getMock();
+        $usageReporter = $this->getMockBuilder(\stdClass::class)->addMethods(['__invoke'])->getMock();
         $usageReporter->expects($this->never())->method('__invoke');
 
         $session = new Session(new MockArraySessionStorage(), null, null, $usageReporter);

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -139,12 +139,8 @@ abstract class ConstraintValidatorTestCase extends TestCase
             'validatePropertyValue',
             'getViolations',
         ];
-        // PHPUnit 10 removed MockBuilder::setMethods()
-        if (method_exists($contextualValidatorMockBuilder, 'onlyMethods')) {
-            $contextualValidatorMockBuilder->onlyMethods($contextualValidatorMethods);
-        } else {
-            $contextualValidatorMockBuilder->setMethods($contextualValidatorMethods);
-        }
+
+        $contextualValidatorMockBuilder->onlyMethods($contextualValidatorMethods);
         $contextualValidator = $contextualValidatorMockBuilder->getMock();
         $contextualValidator->expects($this->any())
             ->method('atPath')

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -2091,7 +2091,7 @@ class RecursiveValidatorTest extends TestCase
         $validator = $this
             ->getMockBuilder(RecursiveValidator::class)
             ->disableOriginalConstructor()
-            ->setMethods(['startContext'])
+            ->onlyMethods(['startContext'])
             ->getMock();
         $validator
             ->expects($this->once())
@@ -2125,7 +2125,7 @@ class RecursiveValidatorTest extends TestCase
         $validator = $this
             ->getMockBuilder(RecursiveValidator::class)
             ->disableOriginalConstructor()
-            ->setMethods(['startContext'])
+            ->onlyMethods(['startContext'])
             ->getMock();
         $validator
             ->expects($this->once())

--- a/src/Symfony/Contracts/Tests/Cache/CacheTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Cache/CacheTraitTest.php
@@ -34,7 +34,7 @@ class CacheTraitTest extends TestCase
             ->with('computed data');
 
         $cache = $this->getMockBuilder(TestPool::class)
-            ->setMethods(['getItem', 'save'])
+            ->onlyMethods(['getItem', 'save'])
             ->getMock();
         $cache->expects($this->once())
             ->method('getItem')
@@ -60,7 +60,7 @@ class CacheTraitTest extends TestCase
             ->method('set');
 
         $cache = $this->getMockBuilder(TestPool::class)
-            ->setMethods(['getItem', 'save'])
+            ->onlyMethods(['getItem', 'save'])
             ->getMock();
 
         $cache->expects($this->once())
@@ -91,7 +91,7 @@ class CacheTraitTest extends TestCase
             ->with('computed data');
 
         $cache = $this->getMockBuilder(TestPool::class)
-            ->setMethods(['getItem', 'save'])
+            ->onlyMethods(['getItem', 'save'])
             ->getMock();
 
         $cache->expects($this->once())
@@ -111,7 +111,7 @@ class CacheTraitTest extends TestCase
     public function testExceptionOnNegativeBeta()
     {
         $cache = $this->getMockBuilder(TestPool::class)
-            ->setMethods(['getItem', 'save'])
+            ->onlyMethods(['getItem', 'save'])
             ->getMock();
 
         $callback = function (CacheItemInterface $item) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`setMethods()` is deprecated and must be replaced by `onlyMethods()` and `addMethods()`. This PR fixes this 🙂 
