### PR TITLE
[DependencyInjection] Keep track of decorated ids

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -119,7 +119,12 @@ EOF
             if ($builder->hasAlias($serviceId)) {
                 $hasAlias[$serviceId] = true;
                 $serviceAlias = $builder->getAlias($serviceId);
-                $serviceLine .= ' <fg=cyan>('.$serviceAlias.')</>';
+
+                if ($builder->hasDefinition($serviceAlias) && $decorated = $builder->getDefinition($serviceAlias)->getTag('container.decorator')) {
+                    $serviceLine .= ' <fg=cyan>('.$decorated[0]['id'].')</>';
+                } else {
+                    $serviceLine .= ' <fg=cyan>('.$serviceAlias.')</>';
+                }
 
                 if ($serviceAlias->isDeprecated()) {
                     $serviceLine .= ' - <fg=magenta>deprecated</>';
@@ -127,6 +132,8 @@ EOF
             } elseif (!$all) {
                 ++$serviceIdsNb;
                 continue;
+            } elseif ($builder->getDefinition($serviceId)->isDeprecated()) {
+                $serviceLine .= ' - <fg=magenta>deprecated</>';
             }
             $text[] = $serviceLine;
             $io->text($text);

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -112,6 +112,10 @@ class DecoratorServicePass extends AbstractRecursivePass
 
             $container->setAlias($inner, $id)->setPublic($public);
         }
+
+        foreach ($decoratingDefinitions as $inner => $definition) {
+            $definition->addTag('container.decorator', ['id' => $inner]);
+        }
     }
 
     protected function processValue(mixed $value, bool $isRoot = false): mixed

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -198,7 +198,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEmpty($container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testProcessMovesTagsFromDecoratedDefinitionToDecoratingDefinitionMultipleTimes()
@@ -221,7 +221,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEmpty($container->getDefinition('deco1')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz']], $container->getDefinition('deco2')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('deco2')->getTags());
     }
 
     public function testProcessLeavesServiceLocatorTagOnOriginalDefinition()
@@ -240,7 +240,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEquals(['container.service_locator' => [0 => []]], $container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testProcessLeavesServiceSubscriberTagOnOriginalDefinition()
@@ -259,7 +259,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEquals(['container.service_subscriber' => [], 'container.service_subscriber.locator' => []], $container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testProcessLeavesProxyTagOnOriginalDefinition()
@@ -278,7 +278,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEquals(['proxy' => 'foo'], $container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testCannotDecorateSyntheticService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
@@ -15,4 +15,6 @@ services:
     decorated:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\StdClassDecorator
         public: true
+        tags:
+            - container.decorator: { id: decorated }
         arguments: [!service { class: stdClass }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
@@ -7,6 +7,8 @@ services:
     foo:
         class: Class2
         public: true
+        tags:
+            - container.decorator: { id: bar }
         file: file.php
         lazy: true
         arguments: [!service { class: Class1 }]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When a service "foo" is decorated by a service "bar", all references to "foo" are replaced by references to "bar".

This has visible side effects e.g. when running `debug:autowiring`, before this PR:
```
Symfony\Contracts\HttpClient\HttpClientInterface (.debug.http_client)
```

After:
```
Symfony\Contracts\HttpClient\HttpClientInterface (http_client)
```

Details matter ;)

This PR replaces #49622 since it's a less invasive way to achieve this behavior.