### PR TITLE
[Security] AccessListener Class : remove deprecated conditions in supports and authenticate methods

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -50,10 +50,7 @@ class AccessListener extends AbstractListener
         [$attributes] = $this->map->getPatterns($request);
         $request->attributes->set('_access_control_attributes', $attributes);
 
-        if ($attributes && (
-            (\defined(AuthenticatedVoter::class.'::IS_AUTHENTICATED_ANONYMOUSLY') ? [AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] !== $attributes : true)
-            && [AuthenticatedVoter::PUBLIC_ACCESS] !== $attributes
-        )) {
+        if ($attributes && [AuthenticatedVoter::PUBLIC_ACCESS] !== $attributes) {
             return true;
         }
 
@@ -72,10 +69,9 @@ class AccessListener extends AbstractListener
         $attributes = $request->attributes->get('_access_control_attributes');
         $request->attributes->remove('_access_control_attributes');
 
-        if (!$attributes || ((
-            (\defined(AuthenticatedVoter::class.'::IS_AUTHENTICATED_ANONYMOUSLY') ? [AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] === $attributes : false)
-            || [AuthenticatedVoter::PUBLIC_ACCESS] === $attributes
-        ) && $event instanceof LazyResponseEvent)) {
+        if (!$attributes || (
+            [AuthenticatedVoter::PUBLIC_ACCESS] === $attributes && $event instanceof LazyResponseEvent
+        )) {
             return;
         }
 


### PR DESCRIPTION
…methods from AccessListener class

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR is about the deprecation of IS_AUTHENTICATED_ANONYMOUSLY in the AuthenticatedVoter.

Since IS_AUTHENTICATED_ANONYMOUSLY as been removed from Voter, it can be misleading if it's still in use in the AccessListener Class. I removed it since the condition wasn't usefull anymore.