### PR TITLE
[HttpKernel] Renamed "pinned" to "targeted" for value resolvers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -83,7 +83,7 @@ use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpClient\UriTemplateHttpClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Attribute\AsPinnedValueResolver;
+use Symfony\Component\HttpKernel\Attribute\AsTargetedValueResolver;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\BackedEnumValueResolver;
@@ -692,8 +692,8 @@ class FrameworkExtension extends Extension
             $definition->addTag('messenger.message_handler', $tagAttributes);
         });
 
-        $container->registerAttributeForAutoconfiguration(AsPinnedValueResolver::class, static function (ChildDefinition $definition, AsPinnedValueResolver $attribute): void {
-            $definition->addTag('controller.pinned_value_resolver', $attribute->name ? ['name' => $attribute->name] : []);
+        $container->registerAttributeForAutoconfiguration(AsTargetedValueResolver::class, static function (ChildDefinition $definition, AsTargetedValueResolver $attribute): void {
+            $definition->addTag('controller.targeted_value_resolver', $attribute->name ? ['name' => $attribute->name] : []);
         });
 
         if (!$container->getParameter('kernel.debug')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -46,7 +46,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('argument_metadata_factory'),
                 abstract_arg('argument value resolvers'),
-                abstract_arg('pinned value resolvers'),
+                abstract_arg('targeted value resolvers'),
             ])
 
         ->set('argument_resolver.backed_enum_resolver', BackedEnumValueResolver::class)

--- a/src/Symfony/Component/HttpKernel/Attribute/AsTargetedValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/AsTargetedValueResolver.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\HttpKernel\Attribute;
 
 /**
- * Service tag to autoconfigure pinned value resolvers.
+ * Service tag to autoconfigure targeted value resolvers.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class AsPinnedValueResolver
+class AsTargetedValueResolver
 {
     public function __construct(
         public readonly ?string $name = null,

--- a/src/Symfony/Component/HttpKernel/Attribute/ValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/ValueResolver.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 class ValueResolver
 {
     /**
-     * @param class-string<ValueResolverInterface>|string $name
+     * @param class-string<ValueResolverInterface>|string $resolver
      */
     public function __construct(
-        public string $name,
+        public string $resolver,
         public bool $disabled = false,
     ) {
     }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
  * Use an instance of `Psr\Clock\ClockInterface` to generate the current date time in `DateTimeValueResolver`
  * Add `#[WithLogLevel]` for defining log levels for exceptions
  * Add `skip_response_headers` to the `HttpCache` options
- * Introduce pinnable value resolvers with `#[ValueResolver]` and `#[AsPinnedValueResolver]`
+ * Introduce targeted value resolvers with `#[ValueResolver]` and `#[AsTargetedValueResolver]`
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -58,11 +58,11 @@ final class ArgumentResolver implements ArgumentResolverInterface
                 $resolverName = null;
                 foreach ($attributes as $attribute) {
                     if ($attribute->disabled) {
-                        $disabledResolvers[$attribute->name] = true;
+                        $disabledResolvers[$attribute->resolver] = true;
                     } elseif ($resolverName) {
                         throw new \LogicException(sprintf('You can only pin one resolver per argument, but argument "$%s" of "%s()" has more.', $metadata->getName(), $this->getPrettyName($controller)));
                     } else {
-                        $resolverName = $attribute->name;
+                        $resolverName = $attribute->resolver;
                     }
                 }
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
@@ -40,13 +40,13 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
         }
 
         $definitions = $container->getDefinitions();
-        $namedResolvers = $this->findAndSortTaggedServices(new TaggedIteratorArgument('controller.pinned_value_resolver', 'name', needsIndexes: true), $container);
+        $namedResolvers = $this->findAndSortTaggedServices(new TaggedIteratorArgument('controller.targeted_value_resolver', 'name', needsIndexes: true), $container);
         $resolvers = $this->findAndSortTaggedServices(new TaggedIteratorArgument('controller.argument_value_resolver', 'name', needsIndexes: true), $container);
 
         foreach ($resolvers as $name => $resolverReference) {
             $id = (string) $resolverReference;
 
-            if ($definitions[$id]->hasTag('controller.pinned_value_resolver')) {
+            if ($definitions[$id]->hasTag('controller.targeted_value_resolver')) {
                 unset($resolvers[$name]);
             } else {
                 $namedResolvers[$name] ??= clone $resolverReference;

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -285,13 +285,13 @@ class ArgumentResolverTest extends TestCase
         self::getResolver()->getArguments($request, $controller);
     }
 
-    public function testPinnedResolver()
+    public function testTargetedResolver()
     {
         $resolver = self::getResolver([], [DefaultValueResolver::class => new DefaultValueResolver()]);
 
         $request = Request::create('/');
         $request->attributes->set('foo', 'bar');
-        $controller = $this->controllerPinningResolver(...);
+        $controller = $this->controllerTargetingResolver(...);
 
         $this->assertSame([1], $resolver->getArguments($request, $controller));
     }
@@ -307,23 +307,23 @@ class ArgumentResolverTest extends TestCase
         $this->assertSame([1], $resolver->getArguments($request, $controller));
     }
 
-    public function testManyPinnedResolvers()
+    public function testManyTargetedResolvers()
     {
         $resolver = self::getResolver(namedResolvers: []);
 
         $request = Request::create('/');
-        $controller = $this->controllerPinningManyResolvers(...);
+        $controller = $this->controllerTargetingManyResolvers(...);
 
         $this->expectException(\LogicException::class);
         $resolver->getArguments($request, $controller);
     }
 
-    public function testUnknownPinnedResolver()
+    public function testUnknownTargetedResolver()
     {
         $resolver = self::getResolver(namedResolvers: []);
 
         $request = Request::create('/');
-        $controller = $this->controllerPinningUnknownResolver(...);
+        $controller = $this->controllerTargetingUnknownResolver(...);
 
         $this->expectException(ResolverNotFoundException::class);
         $resolver->getArguments($request, $controller);
@@ -369,7 +369,7 @@ class ArgumentResolverTest extends TestCase
     {
     }
 
-    public function controllerPinningResolver(#[ValueResolver(DefaultValueResolver::class)] int $foo = 1)
+    public function controllerTargetingResolver(#[ValueResolver(DefaultValueResolver::class)] int $foo = 1)
     {
     }
 
@@ -377,14 +377,14 @@ class ArgumentResolverTest extends TestCase
     {
     }
 
-    public function controllerPinningManyResolvers(
+    public function controllerTargetingManyResolvers(
         #[ValueResolver(RequestAttributeValueResolver::class)]
         #[ValueResolver(DefaultValueResolver::class)]
         int $foo
     ) {
     }
 
-    public function controllerPinningUnknownResolver(
+    public function controllerTargetingUnknownResolver(
         #[ValueResolver('foo')]
         int $bar
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

"pinned" was introduced in #48992 but a quick chat within the core-team lead to this proposal, which might be preferred. WDYT?