### PR TITLE
[DependencyInjection] Deprecate `#[MapDecorated]` in favor of `#[AutowireDecorated]`

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -12,6 +12,7 @@ DependencyInjection
 
  * Deprecate `PhpDumper` options `inline_factories_parameter` and `inline_class_loader_parameter`, use `inline_factories` and `inline_class_loader` instead
  * Deprecate undefined and numeric keys with `service_locator` config, use string aliases instead
+ * Deprecate `#[MapDecorated]`, use `#[AutowireDecorated]` instead
 
 DoctrineBridge
 --------------

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireDecorated.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireDecorated.php
@@ -11,12 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Attribute;
 
-trigger_deprecation('symfony/dependency-injection', '6.3', 'The "%s" class is deprecated, use "%s" instead.', MapDecorated::class, AutowireDecorated::class);
-
-/**
- * @deprecated since Symfony 6.3, use AutowireDecorated instead
- */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class MapDecorated
+class AutowireDecorated
 {
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Allow extending the `Autowire` attribute
  * Add `#[Exclude]` to skip autoregistering a class
  * Add support for autowiring services as closures using `#[AutowireCallable]` or `#[AutowireServiceClosure]`
+ * Deprecate `#[MapDecorated]`, use `#[AutowireDecorated]` instead
 
 6.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\Attribute\MapDecorated;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
 use Symfony\Component\DependencyInjection\Attribute\Target;
@@ -426,7 +426,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
                     new SubscribedService('autowired', 'stdClass', attributes: new Autowire(service: 'service.id')),
                     new SubscribedService('autowired.nullable', 'stdClass', nullable: true, attributes: new Autowire(service: 'service.id')),
                     new SubscribedService('autowired.parameter', 'string', attributes: new Autowire('%parameter.1%')),
-                    new SubscribedService('map.decorated', \stdClass::class, attributes: new MapDecorated()),
+                    new SubscribedService('autowire.decorated', \stdClass::class, attributes: new AutowireDecorated()),
                     new SubscribedService('target', \stdClass::class, attributes: new Target('someTarget')),
                 ];
             }
@@ -449,7 +449,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             'autowired' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'autowired', [new Autowire(service: 'service.id')])),
             'autowired.nullable' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'autowired.nullable', [new Autowire(service: 'service.id')])),
             'autowired.parameter' => new ServiceClosureArgument(new TypedReference('string', 'string', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'autowired.parameter', [new Autowire(service: '%parameter.1%')])),
-            'map.decorated' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'map.decorated', [new MapDecorated()])),
+            'autowire.decorated' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'autowire.decorated', [new AutowireDecorated()])),
             'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'target', [new Target('someTarget')])),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));
@@ -462,7 +462,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             'autowired' => new ServiceClosureArgument(new Reference('service.id')),
             'autowired.nullable' => new ServiceClosureArgument(new Reference('service.id', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
             'autowired.parameter' => new ServiceClosureArgument('foobar'),
-            'map.decorated' => new ServiceClosureArgument(new Reference('.service_locator.EeZIdVM.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
+            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.QVDPERh.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
             'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'someTarget', [new Target('someTarget')])),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\Attribute\MapDecorated;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -80,7 +80,7 @@ class AsDecoratorFoo implements AsDecoratorInterface
 #[AsDecorator(decorates: AsDecoratorFoo::class, priority: 10)]
 class AsDecoratorBar10 implements AsDecoratorInterface
 {
-    public function __construct(string $arg1, #[MapDecorated] AsDecoratorInterface $inner)
+    public function __construct(string $arg1, #[AutowireDecorated] AsDecoratorInterface $inner)
     {
     }
 }
@@ -88,7 +88,7 @@ class AsDecoratorBar10 implements AsDecoratorInterface
 #[AsDecorator(decorates: AsDecoratorFoo::class, priority: 20)]
 class AsDecoratorBar20 implements AsDecoratorInterface
 {
-    public function __construct(string $arg1, #[MapDecorated] AsDecoratorInterface $inner)
+    public function __construct(string $arg1, #[AutowireDecorated] AsDecoratorInterface $inner)
     {
     }
 }
@@ -96,7 +96,7 @@ class AsDecoratorBar20 implements AsDecoratorInterface
 #[AsDecorator(decorates: \NonExistent::class, onInvalid: ContainerInterface::NULL_ON_INVALID_REFERENCE)]
 class AsDecoratorBaz implements AsDecoratorInterface
 {
-    public function __construct(#[MapDecorated] AsDecoratorInterface $inner = null)
+    public function __construct(#[AutowireDecorated] AsDecoratorInterface $inner = null)
     {
     }
 }
@@ -106,7 +106,7 @@ class AutowireNestedAttributes implements AsDecoratorInterface
 {
     public function __construct(
         #[Autowire([
-            'decorated' => new MapDecorated(),
+            'decorated' => new AutowireDecorated(),
             'iterator' => new TaggedIterator('foo'),
             'locator' => new TaggedLocator('foo'),
             'service' => new Autowire(service: 'bar')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

`#[Map*]` are for controller argument resolvers.

`#[Autowire*]` should be used for autowiring (see #49628).

We could also rename `#[TaggedLocator]` and `#[TaggedIterator]` but I feel like the need is less obvious and the cost more important.