### PR TITLE
[Messenger] Fix `evaluate()` calls in `WorkerTest`

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -188,7 +188,7 @@ class WorkerTest extends TestCase
         $eventDispatcher->expects($this->exactly(5))
             ->method('dispatch')
             ->willReturnCallback(function ($event) use (&$series) {
-                array_shift($series)->evaluate($event, '', true);
+                array_shift($series)->evaluate($event);
 
                 if ($event instanceof WorkerRunningEvent) {
                     $event->getWorker()->stop();
@@ -223,7 +223,7 @@ class WorkerTest extends TestCase
         $eventDispatcher->expects($this->exactly(5))
             ->method('dispatch')
             ->willReturnCallback(function ($event) use (&$series) {
-                array_shift($series)->evaluate($event, '', true);
+                array_shift($series)->evaluate($event);
 
                 if ($event instanceof WorkerRunningEvent) {
                     $event->getWorker()->stop();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

Just two little tweaks in tests to fix `evaluate()` calls :+1: 
