### PR TITLE
[Tests] Remove `withConsecutive()` calls from tests

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/EventListener/TemplateAttributeListenerTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/EventListener/TemplateAttributeListenerTest.php
@@ -29,12 +29,18 @@ class TemplateAttributeListenerTest extends TestCase
         $twig = $this->createMock(Environment::class);
         $twig->expects($this->exactly(3))
             ->method('render')
-            ->withConsecutive(
-                ['templates/foo.html.twig', ['foo' => 'bar']],
-                ['templates/foo.html.twig', ['bar' => 'Bar', 'buz' => 'def']],
-                ['templates/foo.html.twig', []],
-            )
-            ->willReturn('Bar');
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['templates/foo.html.twig', ['foo' => 'bar']],
+                    ['templates/foo.html.twig', ['bar' => 'Bar', 'buz' => 'def']],
+                    ['templates/foo.html.twig', []],
+                ];
+
+                $this->assertSame(array_shift($series), $args);
+
+                return 'Bar';
+            })
+        ;
 
         $request = new Request();
         $kernel = $this->createMock(HttpKernelInterface::class);

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -146,9 +146,15 @@ class CheckLdapCredentialsListenerTest extends TestCase
 
         $this->ldap
             ->method('bind')
-            ->withConsecutive(
-                ['elsa', 'test1234A$']
-            );
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    ['elsa', 'test1234A$'],
+                    ['', 's3cr3t'],
+                ];
+
+                $this->assertSame(array_shift($series), $args);
+            })
+        ;
         $this->ldap->expects($this->any())->method('escape')->with('Wouter', '', LdapInterface::ESCAPE_FILTER)->willReturn('wouter');
         $this->ldap->expects($this->once())->method('query')->with('{user_identifier}', 'wouter_test')->willReturn($query);
 

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -803,8 +803,11 @@ class LocoProviderTest extends ProviderTestCase
         $loader = $this->getLoader();
         $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
-            ->withConsecutive(...$consecutiveLoadArguments)
-            ->willReturnOnConsecutiveCalls(...$consecutiveLoadReturns);
+            ->willReturnCallback(function (...$args) use (&$consecutiveLoadArguments, &$consecutiveLoadReturns) {
+                $this->assertSame(array_shift($consecutiveLoadArguments), $args);
+
+                return array_shift($consecutiveLoadReturns);
+            });
 
         $provider = self::createProvider(
             new MockHttpClient($responses, 'https://localise.biz/api/'),

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderWithoutTranslatorBagTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderWithoutTranslatorBagTest.php
@@ -61,10 +61,16 @@ class LocoProviderWithoutTranslatorBagTest extends LocoProviderTest
         }
 
         $loader = $this->getLoader();
-        $loader->expects($this->exactly(\count($consecutiveLoadArguments) * 2))
+        $consecutiveLoadArguments = array_merge($consecutiveLoadArguments, $consecutiveLoadArguments);
+        $consecutiveLoadReturns = array_merge($consecutiveLoadReturns, $consecutiveLoadReturns);
+
+        $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
-            ->withConsecutive(...$consecutiveLoadArguments, ...$consecutiveLoadArguments)
-            ->willReturnOnConsecutiveCalls(...$consecutiveLoadReturns, ...$consecutiveLoadReturns);
+            ->willReturnCallback(function (...$args) use (&$consecutiveLoadArguments, &$consecutiveLoadReturns) {
+                $this->assertSame(array_shift($consecutiveLoadArguments), $args);
+
+                return array_shift($consecutiveLoadReturns);
+            });
 
         $provider = $this->createProvider(
             new MockHttpClient($responses, 'https://localise.biz/api/'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

Follows-up https://github.com/symfony/symfony/pull/49621

:information_source: No more `setMethods()` deprecated calls have been found in 6.2.