### PR TITLE
[Tests] Remove `withConsecutive()` calls from tests

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerConfiguratorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerConfiguratorTest.php
@@ -47,21 +47,24 @@ class ErrorHandlerConfiguratorTest extends TestCase
         if ($hasDeprecationLogger) {
             $deprecationLogger = $this->createMock(LoggerInterface::class);
             if (null !== $expectedDeprecationLoggerLevels) {
-                $expectedCalls[] = [$deprecationLogger, $expectedDeprecationLoggerLevels];
+                $expectedCalls[] = [$deprecationLogger, $expectedDeprecationLoggerLevels, false];
             }
         }
 
         if ($hasLogger) {
             $logger = $this->createMock(LoggerInterface::class);
             if (null !== $expectedLoggerLevels) {
-                $expectedCalls[] = [$logger, $expectedLoggerLevels];
+                $expectedCalls[] = [$logger, $expectedLoggerLevels, false];
             }
         }
 
         $handler
             ->expects($this->exactly(\count($expectedCalls)))
             ->method('setDefaultLogger')
-            ->withConsecutive(...$expectedCalls);
+            ->willReturnCallback(function (...$args) use (&$expectedCalls) {
+                $this->assertSame(array_shift($expectedCalls), $args);
+            })
+        ;
 
         $configurator = new ErrorHandlerConfigurator($logger, $levels, null, true, true, $deprecationLogger);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

Last one, introduced in 6.3 :slightly_smiling_face: 