### PR TITLE
Add dispatcher getter

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1087,6 +1087,11 @@ class Application implements ResetInterface
         return [new HelpCommand(), new ListCommand(), new CompleteCommand(), new DumpCompletionCommand()];
     }
 
+    protected function getDispatcher()
+    {
+        return $this->dispatcher;
+    }
+
     /**
      * Gets the default helper set with the helpers that should always be available.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

Apparently a decision was made long ago in 2011 to make a lot of properties `private` (https://github.com/symfony/symfony/commit/b940cc6f40fab9cf2c5fd529a3ef97edc33b0509). I see some problems with that regarding extensibility and would've preferred a `protected` scope (e.g. Laravel depends on some Symfony components).

I'm not sure what the current stance is to change all these properties to `protected` (I would've preferred `protected` properties in most if not all classes), but I have decided to just be specific here for my usecase and add a getter for the `dispatcher` property that I need in a custom class that extends from this Symfony class (I want to send my own events but I cant currently since the property is `private`).

I've also targeted the 6.0 branch so hopefully this can be merged up as well.