### PR TITLE
[FrameworkBundle] Rename limiter’s `strategy` to `policy` in XSD

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -748,7 +748,7 @@
         <xsd:attribute name="lock-factory" type="xsd:string" />
         <xsd:attribute name="storage-service" type="xsd:string" />
         <xsd:attribute name="cache-pool" type="xsd:string" />
-        <xsd:attribute name="strategy" type="xsd:string" />
+        <xsd:attribute name="policy" type="xsd:string" />
         <xsd:attribute name="limit" type="xsd:int" />
         <xsd:attribute name="interval" type="xsd:string" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/rate_limiter.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/rate_limiter.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:rate-limiter>
+            <framework:limiter
+                name="sliding_window"
+                policy="sliding_window"
+                limit="30"
+                lock-factory="null"
+            />
+        </framework:rate-limiter>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
 
 class XmlFrameworkExtensionTest extends FrameworkExtensionTestCase
 {
@@ -65,5 +66,12 @@ class XmlFrameworkExtensionTest extends FrameworkExtensionTestCase
             'log_level' => null,
             'status_code' => 500,
         ], $configuration[\Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException::class]);
+    }
+
+    public function testRateLimiter()
+    {
+        $container = $this->createContainerFromFile('rate_limiter');
+
+        $this->assertTrue($container->hasDefinition('limiter.sliding_window'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49671 
| License       | MIT
| Doc PR        | N/A

https://github.com/symfony/symfony/pull/38664 renamed `strategy` to `policy` but did not update the XSD.