### PR TITLE
[Config] Improve performance of GlobResource

### DIFF
--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -100,25 +100,45 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
         if (!file_exists($this->prefix) || (!$this->recursive && '' === $this->pattern)) {
             return;
         }
-        $prefix = str_replace('\\', '/', $this->prefix);
+
+        if (is_file($prefix = str_replace('\\', '/', $this->prefix))) {
+            $prefix = \dirname($prefix);
+            $pattern = basename($prefix).$this->pattern;
+        } else {
+            $pattern = $this->pattern;
+        }
+
+        if (class_exists(Finder::class)) {
+            $regex = Glob::toRegex($pattern);
+            if ($this->recursive) {
+                $regex = substr_replace($regex, '(/|$)', -2, 1);
+            }
+        } else {
+            $regex = null;
+        }
+
+        $prefixLen = \strlen($prefix);
         $paths = null;
 
-        if ('' === $this->pattern && is_file($prefix)) {
-            $paths = [$this->prefix];
-        } elseif (!str_starts_with($this->prefix, 'phar://') && !str_contains($this->pattern, '/**/')) {
-            if ($this->globBrace || !str_contains($this->pattern, '{')) {
-                $paths = glob($this->prefix.$this->pattern, \GLOB_NOSORT | $this->globBrace);
+        if ('' === $this->pattern && is_file($this->prefix)) {
+            $paths = [$this->prefix => null];
+        } elseif (!str_starts_with($this->prefix, 'phar://') && (null !== $regex || !str_contains($this->pattern, '/**/'))) {
+            if (!str_contains($this->pattern, '/**/') && ($this->globBrace || !str_contains($this->pattern, '{'))) {
+                $paths = array_fill_keys(glob($this->prefix.$this->pattern, \GLOB_NOSORT | $this->globBrace), null);
             } elseif (!str_contains($this->pattern, '\\') || !preg_match('/\\\\[,{}]/', $this->pattern)) {
+                $paths = [];
                 foreach ($this->expandGlob($this->pattern) as $p) {
-                    $paths[] = glob($this->prefix.$p, \GLOB_NOSORT);
+                    if (false !== $i = strpos($p, '/**/')) {
+                        $p = substr_replace($p, '/*', $i);
+                    }
+                    $paths += array_fill_keys(glob($this->prefix.$p, \GLOB_NOSORT), false !== $i ? $regex : null);
                 }
-                $paths = array_merge(...$paths);
             }
         }
 
         if (null !== $paths) {
-            natsort($paths);
-            foreach ($paths as $path) {
+            uksort($paths, 'strnatcmp');
+            foreach ($paths as $path => $regex) {
                 if ($this->excludedPrefixes) {
                     $normalizedPath = str_replace('\\', '/', $path);
                     do {
@@ -128,23 +148,25 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
                     } while ($prefix !== $dirPath && $dirPath !== $normalizedPath = \dirname($dirPath));
                 }
 
-                if (is_file($path)) {
+                if (is_file($path) && (null === $regex || preg_match($regex, substr(str_replace('\\', '/', $path), $prefixLen)))) {
                     yield $path => new \SplFileInfo($path);
                 }
                 if (!is_dir($path)) {
                     continue;
                 }
-                if ($this->forExclusion) {
+                if ($this->forExclusion && (null === $regex || preg_match($regex, substr(str_replace('\\', '/', $path), $prefixLen)))) {
                     yield $path => new \SplFileInfo($path);
                     continue;
                 }
-                if (!$this->recursive || isset($this->excludedPrefixes[str_replace('\\', '/', $path)])) {
+                if (!($this->recursive || null !== $regex) || isset($this->excludedPrefixes[str_replace('\\', '/', $path)])) {
                     continue;
                 }
                 $files = iterator_to_array(new \RecursiveIteratorIterator(
                     new \RecursiveCallbackFilterIterator(
                         new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS),
-                        fn (\SplFileInfo $file, $path) => !isset($this->excludedPrefixes[str_replace('\\', '/', $path)]) && '.' !== $file->getBasename()[0]
+                        fn (\SplFileInfo $file, $path) => !isset($this->excludedPrefixes[$path = str_replace('\\', '/', $path)])
+                            && (null === $regex || $file->isDir() || preg_match($regex, substr($path, $prefixLen)))
+                            && '.' !== $file->getBasename()[0]
                     ),
                     \RecursiveIteratorIterator::LEAVES_ONLY
                 ));
@@ -161,22 +183,8 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
         }
 
         if (!class_exists(Finder::class)) {
-            throw new \LogicException(sprintf('Extended glob pattern "%s" cannot be used as the Finder component is not installed.', $this->pattern));
+            throw new \LogicException('Extended glob patterns cannot be used as the Finder component is not installed, try running "composer require symfony/finder".');
         }
-
-        if (is_file($prefix = $this->prefix)) {
-            $prefix = \dirname($prefix);
-            $pattern = basename($prefix).$this->pattern;
-        } else {
-            $pattern = $this->pattern;
-        }
-
-        $regex = Glob::toRegex($pattern);
-        if ($this->recursive) {
-            $regex = substr_replace($regex, '(/|$)', -2, 1);
-        }
-
-        $prefixLen = \strlen($prefix);
 
         yield from (new Finder())
             ->followLinks()

--- a/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
@@ -41,7 +41,7 @@ class GlobResourceTest extends TestCase
 
         $paths = iterator_to_array($resource);
 
-        $file = $dir.\DIRECTORY_SEPARATOR.'Resource'.\DIRECTORY_SEPARATOR.'ConditionalClass.php';
+        $file = $dir.'/Resource'.\DIRECTORY_SEPARATOR.'ConditionalClass.php';
         $this->assertEquals([$file => $file], $paths);
         $this->assertInstanceOf(\SplFileInfo::class, current($paths));
         $this->assertSame($dir, $resource->getPrefix());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49668
| License       | MIT
| Doc PR        | -

When using an extended glob pattern that contains `/**/`, we skip using the native `glob()` function and we fallback to using the Finder component.

For a pattern like `./{apps,src}/**/*Controller.php`, the way finder works in `GlobResource` is that we list all files *recursively* in the directory before the pattern starts (`./` here) and we filter the paths using a regexp.

This PR ensures that we scan only the `apps` and `src` directories when presented with such a pattern.