### PR TITLE
[FrameworkBundle] Workflow - Fix LogicException about a wrong configuration of "enabled" node

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -350,7 +350,7 @@ class Configuration implements ConfigurationInterface
 
                                 foreach ($workflows as $key => $workflow) {
                                     if (isset($workflow['enabled']) && false === $workflow['enabled']) {
-                                        throw new LogicException(sprintf('Cannot disable a single workflow. Remove the configuration for the workflow "%s" instead.', $workflow['name']));
+                                        throw new LogicException(sprintf('Cannot disable a single workflow. Remove the configuration for the workflow "%s" instead.', $key));
                                     }
 
                                     unset($workflows[$key]['enabled']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | /
| License       | MIT
| Doc PR        | /

When I try to configure the YAML node "enabled" under a workflow configuration:
```yaml
framework:
    workflows:
        order_approval_state:
            enabled: false # <--- HERE
            type: state_machine 
            supports: 
                - AppBundle\Entity\OrderApproval
```

The following exception is thrown:
```php
//vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
if (isset($workflow['enabled']) && false === $workflow['enabled']) {
    throw new LogicException(sprintf('Cannot disable a single workflow. Remove the configuration for the workflow "%s" instead.', $workflow['name']));
}
```
But it actually throws the following PHP error:
```bash
In Configuration.php line 262:
                                 
  Notice: Undefined index: name  
```
I think we should use the **`$key` variable instead of this undefined index.**
`$key` contains the workflow name.

When changing, I get the attempted exception:
```bash
In Configuration.php line 262:
                                                                                                               
  Cannot disable a single workflow. Remove the configuration for the workflow "order_approval_state" instead.                                                                                                                                  
 ```

(I took a look in 6.2, it doesn't fix yet.)