### PR TITLE
[FrameworkBundle] Add scoped httplug clients and deprecate httplugs use like psr18 client

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -56,6 +56,7 @@ FrameworkBundle
 ---------------
 
  * Deprecate the `notifier.logger_notification_listener` service, use the `notifier.notification_logger_listener` service instead
+ * Deprecate the `Http\Client\HttpClient` service, use `Psr\Http\Client\ClientInterface` instead
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,6 +18,8 @@ CHANGELOG
  * Add `framework.http_cache.skip_response_headers` option
  * Display warmers duration on debug verbosity for `cache:clear` command
  * Add `AbstractController::sendEarlyHints()` to send HTTP Early Hints
+ * Add autowiring aliases for `Http\Client\HttpAsyncClient`
+ * Deprecate the `Http\Client\HttpClient` service, use `Psr\Http\Client\ClientInterface` instead
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
 use Composer\InstalledVersions;
 use Doctrine\Common\Annotations\Reader;
+use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Types\ContextFactory;
@@ -2354,8 +2355,10 @@ class FrameworkExtension extends Extension
             $container->removeAlias(ClientInterface::class);
         }
 
-        if (!ContainerBuilder::willBeAvailable('php-http/httplug', HttpClient::class, ['symfony/framework-bundle', 'symfony/http-client'])) {
-            $container->removeDefinition(HttpClient::class);
+        if (!$hasHttplug = ContainerBuilder::willBeAvailable('php-http/httplug', HttpAsyncClient::class, ['symfony/framework-bundle', 'symfony/http-client'])) {
+            $container->removeDefinition('httplug.http_client');
+            $container->removeAlias(HttpAsyncClient::class);
+            $container->removeAlias(HttpClient::class);
         }
 
         if ($this->readConfigEnabled('http_client.retry_failed', $container, $retryOptions)) {
@@ -2424,6 +2427,13 @@ class FrameworkExtension extends Extension
                     ->replaceArgument(0, new Reference($name));
 
                 $container->registerAliasForArgument('psr18.'.$name, ClientInterface::class, $name);
+            }
+
+            if ($hasHttplug) {
+                $container->setDefinition('httplug.'.$name, new ChildDefinition('httplug.http_client'))
+                    ->replaceArgument(0, new Reference($name));
+
+                $container->registerAliasForArgument('httplug.'.$name, HttpAsyncClient::class, $name);
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Http\Client\HttpAsyncClient;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -49,12 +50,16 @@ return static function (ContainerConfigurator $container) {
 
         ->alias(ClientInterface::class, 'psr18.http_client')
 
-        ->set(\Http\Client\HttpClient::class, HttplugClient::class)
+        ->set('httplug.http_client', HttplugClient::class)
             ->args([
                 service('http_client'),
                 service(ResponseFactoryInterface::class)->ignoreOnInvalid(),
                 service(StreamFactoryInterface::class)->ignoreOnInvalid(),
             ])
+
+        ->alias(HttpAsyncClient::class, 'httplug.http_client')
+        ->alias(\Http\Client\HttpClient::class, 'httplug.http_client')
+            ->deprecate('symfony/framework-bundle', '6.3', 'The "%alias_id%" service is deprecated, use "'.ClientInterface::class.'" instead.')
 
         ->set('http_client.abstract_retry_strategy', GenericRetryStrategy::class)
             ->abstract()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #49644 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18064

This MR does 2 closely related things to try to fully integrate the HttplugClient with the unique features it brings and on the other hand deprecate its use like a psr18 client which it is in a pending deprecation state since a long time.

- Added a new services `httplug.http_client` and alias `Http\Client\HttpAsyncClient` to inject the the `HttplugClient`.
- Make the available service `Http\Client\HttpClient` a deprecated alias of it
- Create httplug.<scoped_client_id> services for all scoped clients like it is done with the psr18 ClientInterface

