### PR TITLE
[Serializer] CsvEncoder: allow the nested array parsing to be disabled

### DIFF
--- a/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/CsvEncoderContextBuilder.php
@@ -76,7 +76,7 @@ final class CsvEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the key separator when (un)flattening arrays.
      */
-    public function withKeySeparator(?string $keySeparator): static
+    public function withKeySeparator(string|false|null $keySeparator): static
     {
         return $this->with(CsvEncoder::KEY_SEPARATOR_KEY, $keySeparator);
     }

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -154,7 +154,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
                     $headerCount = array_fill(0, $nbCols, 1);
                 } else {
                     foreach ($cols as $col) {
-                        $header = explode($keySeparator, $col ?? '');
+                        $header = false === $keySeparator ? [$col] : explode($keySeparator, $col ?? '');
                         $headers[] = $header;
                         $headerCount[] = \count($header);
                     }

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
@@ -70,16 +70,7 @@ class CsvEncoderContextBuilderTest extends TestCase
         ]];
 
         yield 'With false key separator' => [[
-            CsvEncoder::DELIMITER_KEY => ';',
-            CsvEncoder::ENCLOSURE_KEY => '"',
-            CsvEncoder::ESCAPE_CHAR_KEY => '\\',
             CsvEncoder::KEY_SEPARATOR_KEY => false,
-            CsvEncoder::HEADERS_KEY => ['h1', 'h2'],
-            CsvEncoder::ESCAPE_FORMULAS_KEY => true,
-            CsvEncoder::AS_COLLECTION_KEY => true,
-            CsvEncoder::NO_HEADERS_KEY => false,
-            CsvEncoder::END_OF_LINE => 'EOL',
-            CsvEncoder::OUTPUT_UTF8_BOM_KEY => false,
         ]];
 
         yield 'With null values' => [[

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
@@ -70,7 +70,16 @@ class CsvEncoderContextBuilderTest extends TestCase
         ]];
 
         yield 'With false key separator' => [[
+            CsvEncoder::DELIMITER_KEY => ';',
+            CsvEncoder::ENCLOSURE_KEY => '"',
+            CsvEncoder::ESCAPE_CHAR_KEY => '\\',
             CsvEncoder::KEY_SEPARATOR_KEY => false,
+            CsvEncoder::HEADERS_KEY => ['h1', 'h2'],
+            CsvEncoder::ESCAPE_FORMULAS_KEY => true,
+            CsvEncoder::AS_COLLECTION_KEY => true,
+            CsvEncoder::NO_HEADERS_KEY => false,
+            CsvEncoder::END_OF_LINE => 'EOL',
+            CsvEncoder::OUTPUT_UTF8_BOM_KEY => false,
         ]];
 
         yield 'With null values' => [[

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/CsvEncoderContextBuilderTest.php
@@ -69,6 +69,19 @@ class CsvEncoderContextBuilderTest extends TestCase
             CsvEncoder::OUTPUT_UTF8_BOM_KEY => false,
         ]];
 
+        yield 'With false key separator' => [[
+            CsvEncoder::DELIMITER_KEY => ';',
+            CsvEncoder::ENCLOSURE_KEY => '"',
+            CsvEncoder::ESCAPE_CHAR_KEY => '\\',
+            CsvEncoder::KEY_SEPARATOR_KEY => false,
+            CsvEncoder::HEADERS_KEY => ['h1', 'h2'],
+            CsvEncoder::ESCAPE_FORMULAS_KEY => true,
+            CsvEncoder::AS_COLLECTION_KEY => true,
+            CsvEncoder::NO_HEADERS_KEY => false,
+            CsvEncoder::END_OF_LINE => 'EOL',
+            CsvEncoder::OUTPUT_UTF8_BOM_KEY => false,
+        ]];
+
         yield 'With null values' => [[
             CsvEncoder::DELIMITER_KEY => null,
             CsvEncoder::ENCLOSURE_KEY => null,

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -566,6 +566,21 @@ CSV
             , 'csv'));
     }
 
+    public function testDecodeWithDisabledNestedArrays()
+    {
+        $expected = [
+            ['foo' => 'a', 'bar.baz.bat' => 'b'],
+            ['foo' => 'c', 'bar.baz.bat' => 'd'],
+        ];
+
+        $this->assertEquals($expected, $this->encoder->decode(<<<'CSV'
+foo,bar.baz.bat
+a,b
+c,d
+CSV
+            , 'csv', [CsvEncoder::KEY_SEPARATOR_KEY => false]));
+    }
+
     public function testDecodeCustomSettings()
     {
         $this->encoder = new CsvEncoder([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18127

By default, `CsvEncoder` decoding process explodes the headers automatically based on the `.` character to generate nested arrays, the separation character being configurable based on our needs. For instance:

```csv
username,birth.day,birth.month,birth.year
deuchnord,9,6,1993
```

Would result in the following PHP array:

```php
[
    "username" => "deuchnord",
    "birth" => [
        "day" => 9,
        "month => 6,
        "year" => 1993
    ]
]
```

This is a very nice feature, but in some cases, we prefer to skip the generation of those nested arrays.
This PR provides a way to disable it by simply setting the already existent `CsvEncoder::KEY_SEPARATOR_KEY` option to `false`, so the same CSV above now results to:

```php
[
    "username" => "deuchnord",
    "birth.day" => 9,
    "birth.month => 6,
    "birth.year" => 1993
]
```