### PR TITLE
[Notifier] Add "retry" and "expire" options to Pushover bridge

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverOptions.php
@@ -125,6 +125,30 @@ final class PushoverOptions implements MessageOptionsInterface
     }
 
     /**
+     * @see https://pushover.net/api#priority
+     *
+     * @return $this
+     */
+    public function expire(int $seconds): static
+    {
+        $this->options['expire'] = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * @see https://pushover.net/api#priority
+     *
+     * @return $this
+     */
+    public function retry(int $seconds): static
+    {
+        $this->options['retry'] = $seconds;
+
+        return $this;
+    }
+
+    /**
      * @see https://pushover.net/api#sounds
      *
      * @return $this


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Add "retry" and "expire" options to handle "Emergency Priority", according to  [Pushover API documentation](https://pushover.net/api#priority) :

> To send an emergency-priority notification, the priority parameter must be set to 2 and the retry and expire parameters must be supplied.