### PR TITLE
[Serializer] Fix reindex normalizedData array in AbstractObjectNormalizer::denormalize()

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -339,7 +339,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             $normalizedData = $this->removeNestedValue($serializedPath->getElements(), $normalizedData);
         }
 
-        $normalizedData = array_merge($normalizedData, $nestedData);
+        $normalizedData = $normalizedData + $nestedData;
 
         $object = $this->instantiateObject($normalizedData, $mappedClass, $context, new \ReflectionClass($mappedClass), $allowedAttributes, $format);
         $resolvedClass = ($this->objectClassResolver)($object);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -787,6 +787,32 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalized = $serializer->normalize(new DummyWithEnumUnion(EnumB::B));
         $this->assertEquals(new DummyWithEnumUnion(EnumB::B), $serializer->denormalize($normalized, DummyWithEnumUnion::class));
     }
+
+    public function testDenormalizeWithNumberAsSerializedNameAndNoArrayReindex()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+
+        $data = [
+            '1' => 'foo',
+            '99' => 'baz',
+        ];
+
+        $obj = new class() {
+            /**
+             * @SerializedName("1")
+             */
+            public $foo;
+
+            /**
+             * @SerializedName("99")
+             */
+            public $baz;
+        };
+
+        $test = $normalizer->denormalize($data, $obj::class);
+        $this->assertSame('foo', $test->foo);
+        $this->assertSame('baz', $test->baz);
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       |  6.2
| Bug fix      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #49538 
| License       | MIT
| Doc PR        | no

In the method `AbstractObjectNormalizer::denormalize()` the index of the array `$normalizedData` is reindexed after an `array_merge`.

This error occurs when a JSON is deserialised and when the SerializedName is numeric. This results in an incorrect mapping to the properties.

```json
{
   "1":  "John",
   "2": "Doe",
   "10031":  "john.doe@example.com",
}

```
Array before merge:

```php
array (
  1 => 'John',
  2 => 'Doe',
  10031 => 'john.doe@example.com',
)
```

After merge with `array_merge`:

```php
array (
  0 => 'John',
  1 => 'Doe',
  2 => 'john.doe@example.com',
)
```

After merge with `array_replace`:

```php
array (
  0 => 'John',
  1 => 'Doe',
  10031 => 'john.doe@example.com',
)
```

All Serializer unittests run successfully.