### PR TITLE
[HttpFoundation] Prevent PHP notice by calling ini_set() only when needed in NativeFileSessionHandler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
@@ -45,7 +45,12 @@ class NativeFileSessionHandler extends \SessionHandler
             throw new \RuntimeException(sprintf('Session Storage was not able to create directory "%s".', $baseDir));
         }
 
-        ini_set('session.save_path', $savePath);
-        ini_set('session.save_handler', 'files');
+        if (ini_get('session.save_path') !== $savePath) {
+            ini_set('session.save_path', $savePath);
+        }
+
+        if (ini_get('session.save_handler') !== 'files') {
+            ini_set('session.save_handler', 'files');
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Needed on 6.3 because we use the session handler in PdoSessionHandlerSchemaListener