### PR TITLE
[FrameworkBundle] Add support to easily clear all cache pools

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * Add autowiring aliases for `Http\Client\HttpAsyncClient`
  * Deprecate the `Http\Client\HttpClient` service, use `Psr\Http\Client\ClientInterface` instead
  * Add `stop_worker_on_signals` configuration option to `messenger` to define signals which would stop a worker
+ * Add support for `--all` option to clear all cache pools with `cache:pool:clear` command
 
 6.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\Finder\SplFileInfo;
@@ -76,6 +77,33 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
             ->execute(['pools' => ['unknown_pool']], ['decorated' => false]);
     }
 
+    public function testClearAll()
+    {
+        $tester = $this->createCommandTester(['cache.app_clearer']);
+        $tester->execute(['--all' => true], ['decorated' => false]);
+
+        $tester->assertCommandIsSuccessful('cache:pool:clear exits with 0 in case of success');
+        $this->assertStringContainsString('Clearing all cache pools...', $tester->getDisplay());
+        $this->assertStringContainsString('Calling cache clearer: cache.app_clearer', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
+    }
+
+    public function testClearWithoutPoolNames()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not clear all cache pools, try specifying a specific pool or cache clearer.');
+
+        $this->createCommandTester()->execute(['--all' => true], ['decorated' => false]);
+    }
+
+    public function testClearNoOptions()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Either specify at least one pool name, or provide the --all option to clear all pools.');
+
+        $this->createCommandTester()->execute([], ['decorated' => false]);
+    }
+
     public function testClearFailed()
     {
         $tester = $this->createCommandTester();
@@ -104,10 +132,10 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString('[WARNING] Cache pool "cache.public_pool" could not be cleared.', $tester->getDisplay());
     }
 
-    private function createCommandTester()
+    private function createCommandTester(array $poolNames = null)
     {
         $application = new Application(static::$kernel);
-        $application->add(new CachePoolClearCommand(static::getContainer()->get('cache.global_clearer')));
+        $application->add(new CachePoolClearCommand(static::getContainer()->get('cache.global_clearer'), $poolNames));
 
         return new CommandTester($application->find('cache:pool:clear'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #22047<!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#18072 <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

As suggested in #22047, I've now added a `--all` option to clear all cache pools by just providing that argument to `cache:pool:clear`. I believe this is more convenient than remembering the `cache.global_clearer` clearer alias and more descriptive for the consumer.
