### PR TITLE
[Security] Add argument `$exceptionCode` to `#[IsGranted]`

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -24,9 +24,9 @@ class AccessDeniedException extends RuntimeException
     private array $attributes = [];
     private mixed $subject = null;
 
-    public function __construct(string $message = 'Access Denied.', \Throwable $previous = null)
+    public function __construct(string $message = 'Access Denied.', \Throwable $previous = null, int $code = 403)
     {
-        parent::__construct($message, 403, $previous);
+        parent::__construct($message, $code, $previous);
     }
 
     public function getAttributes(): array

--- a/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
@@ -42,6 +42,11 @@ final class IsGranted
          * If null, Security\Core's AccessDeniedException will be used.
          */
         public ?int $statusCode = null,
+
+        /**
+         * If set, will add the exception code to thrown exception.
+         */
+        public ?int $exceptionCode = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `RememberMeBadge` to `JsonLoginAuthenticator` and enable reading parameter in JSON request body
+ * Add argument `$exceptionCode` to `#[IsGranted]`
 
 6.2
 ---

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -66,10 +66,10 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
                 $message = $attribute->message ?: sprintf('Access Denied by #[IsGranted(%s)] on controller', $this->getIsGrantedString($attribute));
 
                 if ($statusCode = $attribute->statusCode) {
-                    throw new HttpException($statusCode, $message);
+                    throw new HttpException($statusCode, $message, code: $attribute->exceptionCode ?? 0);
                 }
 
-                $accessDeniedException = new AccessDeniedException($message);
+                $accessDeniedException = new AccessDeniedException($message, code: $attribute->exceptionCode ?? 403);
                 $accessDeniedException->setAttributes($attribute->attribute);
                 $accessDeniedException->setSubject($subject);
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -384,4 +384,50 @@ class IsGrantedAttributeListenerTest extends TestCase
         $listener = new IsGrantedAttributeListener($authChecker, new ExpressionLanguage());
         $listener->onKernelControllerArguments($event);
     }
+
+    public function testHttpExceptionWithExceptionCode()
+    {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Exception Code');
+        $this->expectExceptionCode(10010);
+
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->any())
+            ->method('isGranted')
+            ->willReturn(false);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsGrantedAttributeMethodsController(), 'exceptionCodeInHttpException'],
+            [],
+            new Request(),
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testAccessDeniedExceptionWithExceptionCode()
+    {
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Exception Code');
+        $this->expectExceptionCode(10010);
+
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->any())
+            ->method('isGranted')
+            ->willReturn(false);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsGrantedAttributeMethodsController(), 'exceptionCodeInAccessDeniedException'],
+            [],
+            new Request(),
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
+        $listener->onKernelControllerArguments($event);
+    }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
@@ -45,6 +45,16 @@ class IsGrantedAttributeMethodsController
     {
     }
 
+    #[IsGranted(attribute: 'ROLE_ADMIN', message: 'Exception Code Http', statusCode: 404, exceptionCode: 10010)]
+    public function exceptionCodeInHttpException()
+    {
+    }
+
+    #[IsGranted(attribute: 'ROLE_ADMIN', message: 'Exception Code Access Denied', exceptionCode: 10010)]
+    public function exceptionCodeInAccessDeniedException()
+    {
+    }
+
     #[IsGranted(attribute: new Expression('"ROLE_ADMIN" in role_names or is_granted("POST_VIEW", subject)'), subject: 'post')]
     public function withExpressionInAttribute($post)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        |

In my current project, we transform HttpExceptions into a custom JsonResponse with fields like
`success: false, message: "No access to account.", exceptionCode: 10010`. To throw the exception, the IsGranted-attribute is used with a custom voter. The problem here is, that, in order to return a specific exception-code, we have to throw the Http-exception inside the voter, instead of just returning `false` as intended. 
This is only viable in our case, since we have priority as our access decision strategy.

My suggestion here is to extend the properties of IsGranted by `exceptionCode` and throw a HttpException inside the IsGrantedListener, whenever the property is used. So the same behaviour as with the `statusCode ` property.

Example:
`#[IsGranted(attribute: 'ROLE_ADMIN', message: 'No access to account.', statusCode: 403, exceptionCode: 10010)]`
