### PR TITLE
[HttpFoundation] Add IpUtils::isPrivateIp

### DIFF
--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -30,21 +30,6 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
 {
     use HttpClientTrait;
 
-    private const PRIVATE_SUBNETS = [
-        '127.0.0.0/8',
-        '10.0.0.0/8',
-        '192.168.0.0/16',
-        '172.16.0.0/12',
-        '169.254.0.0/16',
-        '0.0.0.0/8',
-        '240.0.0.0/4',
-        '::1/128',
-        'fc00::/7',
-        'fe80::/10',
-        '::ffff:0:0/96',
-        '::/128',
-    ];
-
     private HttpClientInterface $client;
     private string|array|null $subnets;
 
@@ -74,7 +59,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
 
         $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, &$lastPrimaryIp): void {
             if ($info['primary_ip'] !== $lastPrimaryIp) {
-                if ($info['primary_ip'] && IpUtils::checkIp($info['primary_ip'], $subnets ?? self::PRIVATE_SUBNETS)) {
+                if ($info['primary_ip'] && IpUtils::checkIp($info['primary_ip'], $subnets ?? IpUtils::PRIVATE_SUBNETS)) {
                     throw new TransportException(sprintf('IP "%s" is blocked for "%s".', $info['primary_ip'], $info['url']));
                 }
 

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -42,6 +42,9 @@
         "symfony/process": "^5.4|^6.0",
         "symfony/stopwatch": "^5.4|^6.0"
     },
+    "conflict": {
+        "symfony/http-foundation": "<6.3"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HttpClient\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Create migration for session table when pdo handler is used
  * Add support for Relay PHP extension for Redis
  * The `Response::sendHeaders()` method now takes an optional HTTP status code as parameter, allowing to send informational responses such as Early Hints responses (103 status code)
+ * Add `IpUtils::isPrivateIp`
  * Deprecate conversion of invalid values in `ParameterBag::getInt()` and `ParameterBag::getBoolean()`,
  * Deprecate ignoring invalid values when using `ParameterBag::filter()`, unless flag `FILTER_NULL_ON_FAILURE` is set
 

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -18,6 +18,21 @@ namespace Symfony\Component\HttpFoundation;
  */
 class IpUtils
 {
+    public const PRIVATE_SUBNETS = [
+        '127.0.0.0/8',    // RFC1700 (Loopback)
+        '10.0.0.0/8',     // RFC1918
+        '192.168.0.0/16', // RFC1918
+        '172.16.0.0/12',  // RFC1918
+        '169.254.0.0/16', // RFC3927
+        '0.0.0.0/8',      // RFC5735
+        '240.0.0.0/4',    // RFC1112
+        '::1/128',        // Loopback
+        'fc00::/7',       // Unique Local Address
+        'fe80::/10',      // Link Local Address
+        '::ffff:0:0/96',  // IPv4 translations
+        '::/128',         // Unspecified address
+    ];
+
     private static array $checkedIps = [];
 
     /**
@@ -190,5 +205,13 @@ class IpUtils
         }
 
         return $ip;
+    }
+
+    /**
+     * Checks if an IPv4 or IPv6 address is contained in the list of private IP subnets.
+     */
+    public static function isPrivateIp(string $requestIp): bool
+    {
+        return self::checkIp($requestIp, self::PRIVATE_SUBNETS);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -154,4 +154,35 @@ class IpUtilsTest extends TestCase
             [false, '1.2.3.4', '256.256.256/0'], // invalid CIDR notation
         ];
     }
+
+    /**
+     * @dataProvider getIsPrivateIpData
+     */
+    public function testIsPrivateIp(string $ip, bool $matches)
+    {
+        $this->assertSame($matches, IpUtils::isPrivateIp($ip));
+    }
+
+    public static function getIsPrivateIpData(): array
+    {
+        return [
+            // private
+            ['127.0.0.1',       true],
+            ['10.0.0.1',        true],
+            ['192.168.0.1',     true],
+            ['172.16.0.1',      true],
+            ['169.254.0.1',     true],
+            ['0.0.0.1',         true],
+            ['240.0.0.1',       true],
+            ['::1',             true],
+            ['fc00::1',         true],
+            ['fe80::1',         true],
+            ['::ffff:0:1',      true],
+            ['fd00::1',         true],
+
+            // public
+            ['104.26.14.6',             false],
+            ['2606:4700:20::681a:e06',  false],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | N/A
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18102

This is only my second PR for this project, so I hope I followed all the guidelines correctly.
Recently I had more and more use cases where I had to make exceptions (mostly rate limiting) for private IP ranges.

Symfony currently does not provide an easy way to check if an IP is private or public but implements such logic internally (private constant) for the [NoPrivateNetworkHttpClient](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php).

This PR intents to make the private subnet list reusable by adding it to [IpUtils](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/HttpFoundation/IpUtils.php).

In the original PR of the NoPrivateNetworkHttpClient it was also briefly mentioned that this constant may have value when made public. https://github.com/symfony/symfony/pull/35566#discussion_r374111850

I think symfony should and always should have exposed this constant.

