### PR TITLE
[Messenger] Add a way to redispatch a message

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -24,6 +24,7 @@ use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTranspor
 use Symfony\Component\Messenger\EventListener\StopWorkerOnCustomStopExceptionListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnSignalsListener;
+use Symfony\Component\Messenger\Handler\RedispatchMessageHandler;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
@@ -219,5 +220,11 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('message bus locator'),
                 service('messenger.default_bus'),
             ])
+
+        ->set('messenger.redispatch_message_handler', RedispatchMessageHandler::class)
+            ->args([
+                service('messenger.default_bus'),
+            ])
+            ->tag('messenger.message_handler')
     ;
 };

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Deprecate `StopWorkerOnSigtermSignalListener` in favor of
    `StopWorkerOnSignalsListener` and make it configurable with SIGINT and
    SIGTERM by default
+ * Add `RedispatchMessage` and `RedispatchMessageHandler`
 
 6.2
 ---

--- a/src/Symfony/Component/Messenger/Handler/RedispatchMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Handler/RedispatchMessageHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+use Symfony\Component\Messenger\Message\RedispatchMessage;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+
+final class RedispatchMessageHandler
+{
+    public function __construct(
+        private MessageBusInterface $bus,
+    ) {
+    }
+
+    public function __invoke(RedispatchMessage $message)
+    {
+        $this->bus->dispatch($message->envelope, [new TransportNamesStamp($message->transportNames)]);
+    }
+}

--- a/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
+++ b/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Message;
+
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * @internal
+ */
+final class RedispatchMessage
+{
+    /**
+     * @param object|Envelope $message        The message or the message pre-wrapped in an envelope
+     * @param string[]|string $transportNames Transport names to be used for the message
+     */
+    public function __construct(
+        public readonly object $envelope,
+        public readonly array|string $transportNames = [],
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | -

This was part of the Scheduler PR, but was removed as it was controversial.
Instead of having it by default in Scheduler, I've made it generic in Messenger.

If one wants to use it with Scheduler, they can use this:

```php
new RedispatchMessage($msg, 'async');
```
