### PR TITLE
[ErrorHandler] do not serialize collected properties in FlattenException

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -403,4 +403,22 @@ class FlattenException
 
         return rtrim($message);
     }
+
+    public function __sleep(): array
+    {
+        return [
+            'message',
+            'code',
+            'previous',
+            'trace',
+            'traceAsString',
+            'class',
+            'statusCode',
+            'statusText',
+            'headers',
+            'file',
+            'line',
+            'asString',
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

see the currently failing tests of the SecurityBundle