### PR TITLE
[FrameworkBundle] Fix wiring session.handler when handler_id is null

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1178,16 +1178,8 @@ class FrameworkExtension extends Extension
 
         // session handler (the internal callback registered with PHP session management)
         if (null === $config['handler_id']) {
-            // Set the handler class to be null
-            if ($container->hasDefinition('session.storage.native')) {
-                $container->getDefinition('session.storage.native')->replaceArgument(1, null);
-                $container->getDefinition('session.storage.php_bridge')->replaceArgument(0, null);
-            } else {
-                $container->getDefinition('session.storage.factory.native')->replaceArgument(1, null);
-                $container->getDefinition('session.storage.factory.php_bridge')->replaceArgument(0, null);
-            }
-
-            $container->setAlias('session.handler', 'session.handler.native_file');
+            $config['save_path'] = null;
+            $container->setAlias('session.handler', 'session.handler.native');
         } else {
             $container->resolveEnvPlaceholders($config['handler_id'], null, $usedEnvs);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -133,6 +133,11 @@ return static function (ContainerConfigurator $container) {
             ])
             ->deprecate('symfony/framework-bundle', '5.3', 'The "%service_id%" service is deprecated, use "session.storage.factory.mock_file" instead.')
 
+        ->set('session.handler.native', StrictSessionHandler::class)
+            ->args([
+                inline_service(\SessionHandler::class),
+            ])
+
         ->set('session.handler.native_file', StrictSessionHandler::class)
             ->args([
                 inline_service(NativeFileSessionHandler::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -648,9 +648,8 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $container = $this->createContainerFromFile('session');
 
         $this->assertTrue($container->hasAlias(SessionInterface::class), '->registerSessionConfiguration() loads session.xml');
-        $this->assertNull($container->getDefinition('session.storage.factory.native')->getArgument(1));
-        $this->assertNull($container->getDefinition('session.storage.factory.php_bridge')->getArgument(0));
-        $this->assertSame('session.handler.native_file', (string) $container->getAlias('session.handler'));
+        $this->assertNull($container->getParameter('session.save_path'));
+        $this->assertSame('session.handler.native', (string) $container->getAlias('session.handler'));
 
         $expected = ['session_factory', 'session', 'initialized_session', 'logger', 'session_collector'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
@@ -667,9 +666,8 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $container = $this->createContainerFromFile('session_legacy');
 
         $this->assertTrue($container->hasAlias(SessionInterface::class), '->registerSessionConfiguration() loads session.xml');
-        $this->assertNull($container->getDefinition('session.storage.native')->getArgument(1));
-        $this->assertNull($container->getDefinition('session.storage.php_bridge')->getArgument(0));
-        $this->assertSame('session.handler.native_file', (string) $container->getAlias('session.handler'));
+        $this->assertNull($container->getParameter('session.save_path'));
+        $this->assertSame('session.handler.native', (string) $container->getAlias('session.handler'));
 
         $expected = ['session_factory', 'session', 'initialized_session', 'logger', 'session_collector'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
@@ -49,7 +49,11 @@ class NativeFileSessionHandler extends \SessionHandler
             throw new \RuntimeException(sprintf('Session Storage was not able to create directory "%s".', $baseDir));
         }
 
-        ini_set('session.save_path', $savePath);
-        ini_set('session.save_handler', 'files');
+        if ($savePath !== \ini_get('session.save_path')) {
+            ini_set('session.save_path', $savePath);
+        }
+        if ('files' !== \ini_get('session.save_handler')) {
+            ini_set('session.save_handler', 'files');
+        }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -455,9 +455,10 @@ class NativeSessionStorage implements SessionStorageInterface
      */
     public function setSaveHandler($saveHandler = null)
     {
-        if (!$saveHandler instanceof AbstractProxy &&
-            !$saveHandler instanceof \SessionHandlerInterface &&
-            null !== $saveHandler) {
+        if (!$saveHandler instanceof AbstractProxy
+            && !$saveHandler instanceof \SessionHandlerInterface
+            && null !== $saveHandler
+        ) {
             throw new \InvalidArgumentException('Must be instance of AbstractProxy; implement \SessionHandlerInterface; or be null.');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When the session `handler_id` is null, we currently set the `$handler` argument of the storage/factory services to null, which means to them "create your own handler internally from the native one". This means that the `session.handler` service is "a lie": it's not the real handler used by the storage. It also means that the `%session.save_path%` parameter is lying too, because it is set to `%kernel.cache_dir%/sessions` (by default), while the storage will use `ini_get('session.save_path')` in practice.

This issue is 10 years old... #5290
