### PR TITLE
[ErrorHandler] Rewrite logic to dump exception properties and fix serializing FlattenException

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
-use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
 /**
@@ -69,7 +69,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
             $headers['X-Debug-Exception-File'] = rawurlencode($exception->getFile()).':'.$exception->getLine();
         }
 
-        $exception = FlattenException::createFromThrowable($exception, null, $headers);
+        $exception = FlattenException::createWithDataRepresentation($exception, null, $headers);
 
         return $exception->setAsString($this->renderException($exception));
     }
@@ -149,21 +149,12 @@ class HtmlErrorRenderer implements ErrorRendererInterface
         ]);
     }
 
-    private function dumpValue(mixed $value): string
+    private function dumpValue(Data $value): string
     {
-        $cloner = new VarCloner();
-        $data = $cloner->cloneVar($value);
-
         $dumper = new HtmlDumper();
         $dumper->setTheme('light');
-        $dumper->setOutput($output = fopen('php://memory', 'r+'));
-        $dumper->dump($data);
 
-        $dump = stream_get_contents($output, -1, 0);
-        rewind($output);
-        ftruncate($output, 0);
-
-        return $dump;
+        return $dumper->dump($value, true);
     }
 
     private function formatArgs(array $args): string

--- a/src/Symfony/Component/ErrorHandler/Resources/views/traces.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/traces.html.php
@@ -25,11 +25,11 @@
                     <p class="break-long-words trace-message"><?= $this->escape($exception['message']); ?></p>
                 <?php } ?>
             </div>
-            <?php if ($exception['properties']) { ?>
+            <?php if (\count($exception['data'] ?? [])) { ?>
                 <details class="exception-properties-wrapper">
                     <summary>Show exception properties</summary>
                     <div class="exception-properties">
-                        <?= $this->dumpValue($exception['properties']) ?>
+                        <?= $this->dumpValue($exception['data']) ?>
                     </div>
                 </details>
             <?php } ?>

--- a/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
@@ -209,7 +209,7 @@ class FlattenExceptionTest extends TestCase
                     'namespace' => '', 'short_class' => '', 'class' => '', 'type' => '', 'function' => '', 'file' => 'foo.php', 'line' => 123,
                     'args' => [],
                 ]],
-                'properties' => [],
+                'data' => null,
             ],
         ], $flattened->toArray());
     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
@@ -26,7 +26,7 @@ class ExceptionDataCollector extends DataCollector
     {
         if (null !== $exception) {
             $this->data = [
-                'exception' => FlattenException::createFromThrowable($exception),
+                'exception' => FlattenException::createWithDataRepresentation($exception),
             ];
         }
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ExceptionDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ExceptionDataCollectorTest.php
@@ -23,7 +23,7 @@ class ExceptionDataCollectorTest extends TestCase
     {
         $e = new \Exception('foo', 500);
         $c = new ExceptionDataCollector();
-        $flattened = FlattenException::createFromThrowable($e);
+        $flattened = FlattenException::createWithDataRepresentation($e);
         $trace = $flattened->getTrace();
 
         $this->assertFalse($c->hasException());

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/error-handler": "^6.1",
+        "symfony/error-handler": "^6.3",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/http-foundation": "^5.4.21|^6.2.7",
         "symfony/polyfill-ctype": "^1.8",

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -306,7 +306,7 @@ class ExceptionCaster
         if (empty($a[$xPrefix.'previous'])) {
             unset($a[$xPrefix.'previous']);
         }
-        unset($a[$xPrefix.'string'], $a[Caster::PREFIX_DYNAMIC.'xdebug_message'], $a[Caster::PREFIX_DYNAMIC.'__destructorException']);
+        unset($a[$xPrefix.'string'], $a[Caster::PREFIX_DYNAMIC.'xdebug_message']);
 
         if (isset($a[Caster::PREFIX_PROTECTED.'message']) && str_contains($a[Caster::PREFIX_PROTECTED.'message'], "@anonymous\0")) {
             $a[Caster::PREFIX_PROTECTED.'message'] = preg_replace_callback('/[a-zA-Z_\x7f-\xff][\\\\a-zA-Z0-9_\x7f-\xff]*+@anonymous\x00.*?\.php(?:0x?|:[0-9]++\$)[0-9a-fA-F]++/', fn ($m) => class_exists($m[0], false) ? (get_parent_class($m[0]) ?: key(class_implements($m[0])) ?: 'class').'@anonymous' : $m[0], $a[Caster::PREFIX_PROTECTED.'message']);

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -16,7 +16,6 @@ namespace Symfony\Component\VarDumper\Cloner;
  */
 class VarCloner extends AbstractCloner
 {
-    private static string $gid;
     private static array $arrayCache = [];
 
     protected function doClone(mixed $var): array
@@ -41,7 +40,6 @@ class VarCloner extends AbstractCloner
         $stub = null;                   // Stub capturing the main properties of an original item value
                                         // or null if the original value is used directly
 
-        $gid = self::$gid ??= hash('xxh128', random_bytes(6)); // Unique string used to detect the special $GLOBALS variable
         $arrayStub = new Stub();
         $arrayStub->type = Stub::TYPE_ARRAY;
         $fromObjCast = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The implementation in #49620 was flawed. This fixes it.

/cc @lyrixx FYI