### PR TITLE
[FrameworkBundle] Allow to pass signals to `StopWorkerOnSignalsListener` in XML config and as plain strings

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Deprecate the `--show-arguments` option of the `container:debug` command, as arguments are now always shown
  * Add `RateLimiterFactoryInterface` as an alias of the `limiter` service
  * Add `framework.validation.disable_translation` option
+ * Add support for signal plain name in the `messenger.stop_worker_on_signals` configuration
 
 7.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -609,6 +609,7 @@
             <xsd:element name="routing" type="messenger_routing" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="transport" type="messenger_transport" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="bus" type="messenger_bus" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="stop-worker-on-signal" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="default-bus" type="xsd:string" />
         <xsd:attribute name="enabled" type="xsd:boolean" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | Todo

Follow-up of https://github.com/symfony/symfony/pull/49702 to improve DX. This PR allows to provide signals this way:

```yaml
framework:
    messenger:
        transports:
            async: '%env(MESSENGER_TRANSPORT_DSN)%'

        stop_worker_on_signals:
            - SIGINT
            - SIGUSR1
```

XML:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<container xmlns="http://symfony.com/schema/dic/services"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:framework="http://symfony.com/schema/dic/symfony"
           xsi:schemaLocation="http://symfony.com/schema/dic/services
        https://symfony.com/schema/dic/services/services-1.0.xsd
        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">

    <framework:config>
        <framework:messenger ...>
            <framework:stop-worker-on-signal>SIGINT</framework:stop-worker-on-signal>
            <framework:stop-worker-on-signal>SIGTERM</framework:stop-worker-on-signal>
            <framework:stop-worker-on-signal>SIGUSR1</framework:stop-worker-on-signal>
            <framework:stop-worker-on-signal>123</framework:stop-worker-on-signal>
        </framework:messenger>
    </framework:config>
</container>
```