### PR TITLE
[WebProfilerBundle] Add a link of the current rendered template on the twig tab of the web debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add a "role=img" and an explicit title in the .svg file used by the web debug toolbar
    to improve accessibility with screen readers for blind users
+ * Add a link of the current rendered template on the twig tab of the web debug toolbar
+   to improve user experience and make the debug easier
 
 6.1
 ---

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -62,6 +62,19 @@
             <b>Macro Calls</b>
             <span class="sf-toolbar-status">{{ collector.macrocount }}</span>
         </div>
+        {% if collector.templates|keys %}
+            <div class="sf-toolbar-info-piece">
+                <b>Current rendered template</b>
+                {%- set template = collector.templates|keys|first -%}
+                {%- set file = collector.templatePaths[template]|default(false) -%}
+                {%- set link = file ? file|file_link(1) : false -%}
+                {% if link %}
+                    <a href="{{ link }}" title="{{ file }}">{{ template }}</a>
+                {% else %}
+                    {{ template }}
+                {% endif %}
+            </div>
+        {% endif %}
     {% endset %}
 
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}


### PR DESCRIPTION
[WebProfilerBundle] Add link to the web debug toolbar twig tab.

| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I added a link on the twig tab of the debug toolbar.
This link refers the last and current rendered template.
It improves the developer experience and avoid using CMD + Click (or CTRL + Click) on the twig tab to show the template.
It make the debug easier, especially if you set up IDE navigation.

Hope it'll help other developers.

![link_twig](https://user-images.githubusercontent.com/98017015/226566849-7f5e7ffd-f5f7-4e58-aa1e-6dc941d95c48.png)
