### PR TITLE
[HttpClient] Add hint about `timeout` and `max_duration` options

### DIFF
--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -55,7 +55,7 @@ interface HttpClientInterface
         'proxy' => null,        // string - by default, the proxy-related env vars handled by curl SHOULD be honored
         'no_proxy' => null,     // string - a comma separated list of hosts that do not require a proxy to be reached
         'timeout' => null,      // float - the idle timeout - defaults to ini_get('default_socket_timeout')
-        'max_duration' => 0,    // float - the maximum execution time for the request+response as a whole;
+        'max_duration' => 0,    // float - the maximum execution time (in seconds) for the request+response as a whole;
                                 //   a value lower than or equal to 0 means it is unlimited
         'bindto' => '0',        // string - the interface or the local socket to bind to
         'verify_peer' => true,  // see https://php.net/context.ssl for the following options


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When reading the PHPDoc or the documentation (https://symfony.com/doc/current/http_client.html#dealing-with-network-timeouts), we don't know if we must pass seconds or milliseconds.

I believe `max_duration` is waiting for seconds, given the code from the `CurlHttpClient`:
<img width="912" alt="image" src="https://user-images.githubusercontent.com/2103975/226627443-10dada66-4e55-4aff-9d33-de30c733b3f3.png">
