### PR TITLE
[HttpFoundation] Use separate caches for IpUtils checkIp4 and checkIp6

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -73,7 +73,7 @@ class IpUtils
             return false;
         }
 
-        $cacheKey = $requestIp.'-'.$ip;
+        $cacheKey = $requestIp.'-'.$ip.'-v4';
         if (isset(self::$checkedIps[$cacheKey])) {
             return self::$checkedIps[$cacheKey];
         }
@@ -126,7 +126,7 @@ class IpUtils
             return false;
         }
 
-        $cacheKey = $requestIp.'-'.$ip;
+        $cacheKey = $requestIp.'-'.$ip.'-v6';
         if (isset(self::$checkedIps[$cacheKey])) {
             return self::$checkedIps[$cacheKey];
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -19,6 +19,21 @@ class IpUtilsTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
+    public function testSeparateCachesPerProtocol()
+    {
+        $ip = '192.168.52.1';
+        $subnet = '192.168.0.0/16';
+
+        $this->assertFalse(IpUtils::checkIp6($ip, $subnet));
+        $this->assertTrue(IpUtils::checkIp4($ip, $subnet));
+
+        $ip = '2a01:198:603:0:396e:4789:8e99:890f';
+        $subnet = '2a01:198:603:0::/65';
+
+        $this->assertFalse(IpUtils::checkIp4($ip, $subnet));
+        $this->assertTrue(IpUtils::checkIp6($ip, $subnet));
+    }
+
     /**
      * @dataProvider getIpv4Data
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49749
| License       | MIT
| Doc PR        | N/A

Fixed issue #49749 
