### PR TITLE
[MonologBridge] Fix Monolog/Logger final deprecation

### DIFF
--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Logger implements LoggerInterface, DebugLoggerInterface, ResetInterface
+class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface, ResetInterface
 {
     use MonologApiTrait;
 
@@ -152,47 +152,47 @@ class Logger implements LoggerInterface, DebugLoggerInterface, ResetInterface
         return null;
     }
 
-    public function emergency(\Stringable|string $message, array $context = []): void
+    public function emergency($message, array $context = []): void
     {
         $this->logger->emergency($message, $context);
     }
 
-    public function alert(\Stringable|string $message, array $context = []): void
+    public function alert($message, array $context = []): void
     {
         $this->logger->alert($message, $context);
     }
 
-    public function critical(\Stringable|string $message, array $context = []): void
+    public function critical($message, array $context = []): void
     {
         $this->logger->critical($message, $context);
     }
 
-    public function error(\Stringable|string $message, array $context = []): void
+    public function error($message, array $context = []): void
     {
         $this->logger->error($message, $context);
     }
 
-    public function warning(\Stringable|string $message, array $context = []): void
+    public function warning($message, array $context = []): void
     {
         $this->logger->warning($message, $context);
     }
 
-    public function notice(\Stringable|string $message, array $context = []): void
+    public function notice($message, array $context = []): void
     {
         $this->logger->notice($message, $context);
     }
 
-    public function info(\Stringable|string $message, array $context = []): void
+    public function info($message, array $context = []): void
     {
         $this->logger->info($message, $context);
     }
 
-    public function debug(\Stringable|string $message, array $context = []): void
+    public function debug($message, array $context = []): void
     {
         $this->logger->debug($message, $context);
     }
 
-    public function log($level, \Stringable|string $message, array $context = []): void
+    public function log($level, $message, array $context = []): void
     {
         $this->logger->log($level, $message, $context);
     }

--- a/src/Symfony/Bridge/Monolog/MonologApiTrait.php
+++ b/src/Symfony/Bridge/Monolog/MonologApiTrait.php
@@ -32,7 +32,7 @@ trait MonologApiTrait
      * @see BaseLogger::$name
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    protected string $name;
+    protected $name;
 
     /**
      * @see BaseLogger::$handlers
@@ -40,7 +40,7 @@ trait MonologApiTrait
      *
      * @var list<HandlerInterface>
      */
-    protected array $handlers;
+    protected $handlers;
 
     /**
      * @see BaseLogger::$processors
@@ -48,34 +48,35 @@ trait MonologApiTrait
      *
      * @var array<(callable(LogRecord): LogRecord)|ProcessorInterface>
      */
-    protected array $processors;
+    protected $processors;
 
     /**
      * @see BaseLogger::$microsecondTimestamps
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    protected bool $microsecondTimestamps = true;
+    protected $microsecondTimestamps = true;
 
     /**
      * @see BaseLogger::$timezone
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    protected DateTimeZone $timezone;
+    protected $timezone;
 
     /**
      * @see BaseLogger::$exceptionHandler
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    protected Closure|null $exceptionHandler = null;
+    protected $exceptionHandler = null;
 
     /**
      * @see BaseLogger::__construct
-     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     * @deprecated Creating an instance of Monolog\Logger through this method is deprecated. Please use ::setLogger
      */
     public function __construct() // string $name, array $handlers = [], array $processors = [], DateTimeZone|null $timezone = null
     {
         $args = \func_get_args();
         if ([] !== $args) {
+            trigger_deprecation('symfony/monolog-bridge', '6.3', 'The "%s" class extending "%s" is deprecated. In the future, this class will stop extending it.', self::class, BaseLogger::class);
             $this->logger = new BaseLogger(...$args);
         }
     }
@@ -125,9 +126,9 @@ trait MonologApiTrait
      * @see BaseLogger::removeHandler
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    public function removeHandler(int $handlerIndex): void
+    public function removeHandler(callable $callback): void
     {
-        $this->logger->removeHandler($handlerIndex);
+        $this->logger->removeHandler($callback);
     }
 
     /**
@@ -174,9 +175,9 @@ trait MonologApiTrait
      * @see BaseLogger::removeProcessor
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    public function removeProcessor(int $processorIndex): void
+    public function removeProcessor(callable $callback): void
     {
-        $this->logger->removeProcessor($processorIndex);
+        $this->logger->removeProcessor($callback);
     }
 
     /**
@@ -241,7 +242,7 @@ trait MonologApiTrait
      * @see BaseLogger::toMonologLevel
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    public static function toMonologLevel(string|int|Level $level): Level
+    public static function toMonologLevel($level): int
     {
         return BaseLogger::toMonologLevel($level);
     }
@@ -259,7 +260,7 @@ trait MonologApiTrait
      * @see BaseLogger::setExceptionHandler
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    public function setExceptionHandler(Closure|null $callback): self
+    public function setExceptionHandler(?callable $callback): self
     {
         $this->logger->setExceptionHandler($callback);
 
@@ -270,7 +271,7 @@ trait MonologApiTrait
      * @see BaseLogger::getExceptionHandler
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    public function getExceptionHandler(): Closure|null
+    public function getExceptionHandler(): ?callable
     {
         return $this->logger->getExceptionHandler();
     }
@@ -299,7 +300,7 @@ trait MonologApiTrait
      * @see BaseLogger::handleException
      * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
      */
-    protected function handleException(Throwable $e, LogRecord $record): void
+    protected function handleException(Throwable $e, array $record): void
     {
         $this->logger->handleException($e, $record);
     }

--- a/src/Symfony/Bridge/Monolog/MonologApiTrait.php
+++ b/src/Symfony/Bridge/Monolog/MonologApiTrait.php
@@ -1,0 +1,324 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog;
+
+use Monolog\Handler\HandlerInterface;
+use Monolog\Level;
+use Monolog\Logger as BaseLogger;
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+use Closure;
+use DateTimeImmutable;
+use DateTimeZone;
+use Throwable;
+
+/**
+ * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+ */
+trait MonologApiTrait
+{
+    protected BaseLogger $logger;
+
+    /**
+     * @see BaseLogger::$name
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    protected string $name;
+
+    /**
+     * @see BaseLogger::$handlers
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     *
+     * @var list<HandlerInterface>
+     */
+    protected array $handlers;
+
+    /**
+     * @see BaseLogger::$processors
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     *
+     * @var array<(callable(LogRecord): LogRecord)|ProcessorInterface>
+     */
+    protected array $processors;
+
+    /**
+     * @see BaseLogger::$microsecondTimestamps
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    protected bool $microsecondTimestamps = true;
+
+    /**
+     * @see BaseLogger::$timezone
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    protected DateTimeZone $timezone;
+
+    /**
+     * @see BaseLogger::$exceptionHandler
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    protected Closure|null $exceptionHandler = null;
+
+    /**
+     * @see BaseLogger::__construct
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function __construct() // string $name, array $handlers = [], array $processors = [], DateTimeZone|null $timezone = null
+    {
+        $args = \func_get_args();
+        if ([] !== $args) {
+            $this->logger = new BaseLogger(...$args);
+        }
+    }
+
+    /**
+     * @see BaseLogger::getName
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function getName(): string
+    {
+        return $this->logger->name;
+    }
+
+    /**
+     * @see BaseLogger::withName
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function withName(string $name): self
+    {
+        $new = clone $this;
+        $new->setLogger($this->logger->withName($name));
+
+        return $new;
+    }
+
+    /**
+     * @see BaseLogger::pushHandler
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function pushHandler(HandlerInterface $handler): self
+    {
+        $this->logger->pushHandler($handler);
+
+        return $this;
+    }
+
+    /**
+     * @see BaseLogger::popHandler
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function popHandler(): HandlerInterface
+    {
+        return $this->logger->popHandler();
+    }
+
+    /**
+     * @see BaseLogger::removeHandler
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function removeHandler(int $handlerIndex): void
+    {
+        $this->logger->removeHandler($handlerIndex);
+    }
+
+    /**
+     * @see BaseLogger::setHandlers
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function setHandlers(array $handlers): self
+    {
+        $this->logger->setHandlers($handlers);
+
+        return $this;
+    }
+
+    /**
+     * @see BaseLogger::getHandlers
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function getHandlers(): array
+    {
+        return $this->logger->getHandlers();
+    }
+
+    /**
+     * @see BaseLogger::pushProcessor
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function pushProcessor(ProcessorInterface|callable $callback): self
+    {
+        $this->logger->pushProcessor($callback);
+
+        return $this;
+    }
+
+    /**
+     * @see BaseLogger::popProcessor
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function popProcessor(): callable
+    {
+        return $this->logger->popProcessor();
+    }
+
+    /**
+     * @see BaseLogger::removeProcessor
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function removeProcessor(int $processorIndex): void
+    {
+        $this->logger->removeProcessor($processorIndex);
+    }
+
+    /**
+     * @see BaseLogger::getProcessors
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function getProcessors(): array
+    {
+        return $this->logger->getProcessors();
+    }
+
+    /**
+     * @see BaseLogger::useMicrosecondTimestamps
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function useMicrosecondTimestamps(bool $micro): self
+    {
+        $this->logger->useMicrosecondTimestamps($micro);
+
+        return $this;
+    }
+
+    /**
+     * @see BaseLogger::useLoggingLoopDetection
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function useLoggingLoopDetection(bool $detectCycles): self
+    {
+        $this->logger->useLoggingLoopDetection($detectCycles);
+
+        return $this;
+    }
+
+    /**
+     * @see BaseLogger::addRecord()
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function addRecord(int|Level $level, string $message, array $context = [], DateTimeImmutable $datetime = null): bool
+    {
+        return $this->logger->addRecord($level, $message, $context, $datetime);
+    }
+
+    /**
+     * @see BaseLogger::close
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function close(): void
+    {
+        $this->logger->close();
+    }
+
+    /**
+     * @see BaseLogger::getLevelName
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public static function getLevelName(int|Level $level): string
+    {
+        return BaseLogger::getLevelName($level);
+    }
+
+    /**
+     * @see BaseLogger::toMonologLevel
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public static function toMonologLevel(string|int|Level $level): Level
+    {
+        return BaseLogger::toMonologLevel($level);
+    }
+
+    /**
+     * @see BaseLogger::isHandling
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function isHandling(int|string|Level $level): bool
+    {
+        return $this->logger->isHandling($level);
+    }
+
+    /**
+     * @see BaseLogger::setExceptionHandler
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function setExceptionHandler(Closure|null $callback): self
+    {
+        $this->logger->setExceptionHandler($callback);
+
+        return $this;
+    }
+
+    /**
+     * @see BaseLogger::getExceptionHandler
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function getExceptionHandler(): Closure|null
+    {
+        return $this->logger->getExceptionHandler();
+    }
+
+    /**
+     * @see BaseLogger::setTimezone
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function setTimezone(DateTimeZone $tz): self
+    {
+        $this->logger->setTimezone($tz);
+
+        return $this;
+    }
+
+    /**
+     * @see BaseLogger::getTimezone
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function getTimezone(): DateTimeZone
+    {
+        return $this->logger->getTimezone();
+    }
+
+    /**
+     * @see BaseLogger::handleException
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    protected function handleException(Throwable $e, LogRecord $record): void
+    {
+        $this->logger->handleException($e, $record);
+    }
+
+    /**
+     * @see BaseLogger::__serialize
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function __serialize(): array
+    {
+        return $this->logger->__serialize();
+    }
+
+    /**
+     * @see BaseLogger::__unserialize
+     * @deprecated This has been copied over from \Monolog\Logger for compatibility reasons, and might be removed eventually.
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->logger->__unserialize($data);
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Tests/LegacyLoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LegacyLoggerTest.php
@@ -16,10 +16,22 @@ use Monolog\ResettableInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @group legacy
+ */
 class LegacyLoggerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    public function testConstructWillTriggerDeprecation()
+    {
+        $this->expectDeprecation('Since symfony/monolog-bridge 6.3: The "Symfony\Bridge\Monolog\Logger" class extending "Monolog\Logger" is deprecated. In the future, this class will stop extending it.');
+        new Logger(__METHOD__);
+    }
+
     public function testGetLogsWithoutDebugProcessor()
     {
         $handler = new TestHandler();

--- a/src/Symfony/Bridge/Monolog/Tests/LegacyLoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LegacyLoggerTest.php
@@ -18,7 +18,7 @@ use Symfony\Bridge\Monolog\Logger;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Component\HttpFoundation\Request;
 
-class LoggerTest extends TestCase
+class LegacyLoggerTest extends TestCase
 {
     public function testGetLogsWithoutDebugProcessor()
     {

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests;
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger as BaseLogger;
+use Monolog\ResettableInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Logger;
+use Symfony\Bridge\Monolog\Processor\DebugProcessor;
+use Symfony\Component\HttpFoundation\Request;
+
+class LoggerTest extends TestCase
+{
+    public function testGetLogsWithoutDebugProcessor()
+    {
+        $handler = new TestHandler();
+        $logger = new Logger();
+        $baseLogger = new BaseLogger(__METHOD__, [$handler]);
+        $logger->setLogger($baseLogger);
+
+        $logger->error('error message');
+        $this->assertSame([], $logger->getLogs());
+    }
+
+    public function testCountErrorsWithoutDebugProcessor()
+    {
+        $handler = new TestHandler();
+        $logger = new Logger();
+        $baseLogger = new BaseLogger(__METHOD__, [$handler]);
+        $logger->setLogger($baseLogger);
+
+        $logger->error('error message');
+        $this->assertSame(0, $logger->countErrors());
+    }
+
+    public function testGetLogsWithDebugProcessor()
+    {
+        $handler = new TestHandler();
+        $processor = new DebugProcessor();
+        $logger = new Logger();
+        $baseLogger = new BaseLogger(__METHOD__, [$handler], [$processor]);
+        $logger->setLogger($baseLogger);
+
+        $logger->error('error message');
+        $this->assertCount(1, $logger->getLogs());
+    }
+
+    public function testCountErrorsWithDebugProcessor()
+    {
+        $handler = new TestHandler();
+        $processor = new DebugProcessor();
+        $logger = new Logger();
+        $baseLogger = new BaseLogger(__METHOD__, [$handler], [$processor]);
+        $logger->setLogger($baseLogger);
+
+        $logger->debug('test message');
+        $logger->info('test message');
+        $logger->notice('test message');
+        $logger->warning('test message');
+
+        $logger->error('test message');
+        $logger->critical('test message');
+        $logger->alert('test message');
+        $logger->emergency('test message');
+
+        $this->assertSame(4, $logger->countErrors());
+    }
+
+    public function testGetLogsWithDebugProcessor2()
+    {
+        $handler = new TestHandler();
+        $logger = new Logger();
+        $baseLogger = new BaseLogger('test', [$handler]);
+        $logger->setLogger($baseLogger);
+        $logger->pushProcessor(new DebugProcessor());
+
+        $logger->info('test');
+        $this->assertCount(1, $logger->getLogs());
+        [$record] = $logger->getLogs();
+
+        $this->assertEquals('test', $record['message']);
+        $this->assertEquals(Logger::INFO, $record['priority']);
+    }
+
+    public function testGetLogsWithDebugProcessor3()
+    {
+        $request = new Request();
+        $processor = $this->createMock(DebugProcessor::class);
+        $processor->expects($this->once())->method('getLogs')->with($request);
+        $processor->expects($this->once())->method('countErrors')->with($request);
+
+        $handler = new TestHandler();
+        $logger = new Logger();
+        $baseLogger = new BaseLogger('test', [$handler]);
+        $logger->setLogger($baseLogger);
+        $logger->pushProcessor($processor);
+
+        $logger->getLogs($request);
+        $logger->countErrors($request);
+    }
+
+    public function testClear()
+    {
+        $handler = new TestHandler();
+        $logger = new Logger();
+        $baseLogger = new BaseLogger('test', [$handler]);
+        $logger->setLogger($baseLogger);
+        $logger->pushProcessor(new DebugProcessor());
+
+        $logger->info('test');
+        $logger->clear();
+
+        $this->assertEmpty($logger->getLogs());
+        $this->assertSame(0, $logger->countErrors());
+    }
+
+    public function testReset()
+    {
+        $handler = new TestHandler();
+        $logger = new Logger();
+        $baseLogger = new BaseLogger('test', [$handler]);
+        $logger->setLogger($baseLogger);
+        $logger->pushProcessor(new DebugProcessor());
+
+        $logger->info('test');
+        $logger->reset();
+
+        $this->assertEmpty($logger->getLogs());
+        $this->assertSame(0, $logger->countErrors());
+        if (class_exists(ResettableInterface::class)) {
+            $this->assertEmpty($handler->getRecords());
+        }
+    }
+
+    public function testInheritedClassCallGetLogsWithoutArgument()
+    {
+        $loggerChild = new ClassThatInheritLogger('test');
+        $this->assertSame([], $loggerChild->getLogs());
+    }
+
+    public function testInheritedClassCallCountErrorsWithoutArgument()
+    {
+        $loggerChild = new ClassThatInheritLogger('test');
+        $this->assertEquals(0, $loggerChild->countErrors());
+    }
+}

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -20,7 +20,8 @@
         "monolog/monolog": "dev-remove-handlers-processors",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/http-kernel": "^5.4|^6.0",
-        "psr/log": "^2.0 || ^3.0"
+        "psr/log": "^2.0 || ^3.0",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "symfony/console": "^5.4|^6.0",

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -17,9 +17,10 @@
     ],
     "require": {
         "php": ">=8.1",
-        "monolog/monolog": "^1.25.1|^2|^3",
+        "monolog/monolog": "dev-remove-handlers-processors",
         "symfony/service-contracts": "^2.5|^3",
-        "symfony/http-kernel": "^5.4|^6.0"
+        "symfony/http-kernel": "^5.4|^6.0",
+        "psr/log": "^2.0 || ^3.0"
     },
     "require-dev": {
         "symfony/console": "^5.4|^6.0",
@@ -46,5 +47,11 @@
             "/Tests/"
         ]
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:joaojacome/monolog"
+        }
+    ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #47096
| License       | MIT

Updated MonologBridge\Logger so it doesn't extend Monolog\Logger

This shouldn't break any BC. An adapter for the public Monolog\Logger methods has been created as a trait. The trait has been created as "deprecated", so it can be removed later.

This change depends on a change in the upstream Monolog class. An MR has been opened for monolog to cover that. (https://github.com/Seldaek/monolog/pull/1796)


