### PR TITLE
[Serializer] Add missing withSaveOptions method to XmlEncoderContextBuilder

### DIFF
--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -90,6 +90,18 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     }
 
     /**
+     * Configures the DOMDocument::saveXml options bitmask.
+     *
+     * @see https://www.php.net/manual/en/libxml.constants.php
+     *
+     * @param positive-int|null $saveOptions
+     */
+    public function withSaveOptions(?int $saveOptions): static
+    {
+        return $this->with(XmlEncoder::SAVE_OPTIONS, $saveOptions);
+    }
+
+    /**
      * Configures whether to keep empty nodes.
      */
     public function withRemoveEmptyTags(?bool $removeEmptyTags): static

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
@@ -41,6 +41,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             ->withEncoding($values[XmlEncoder::ENCODING])
             ->withFormatOutput($values[XmlEncoder::FORMAT_OUTPUT])
             ->withLoadOptions($values[XmlEncoder::LOAD_OPTIONS])
+            ->withSaveOptions($values[XmlEncoder::SAVE_OPTIONS])
             ->withRemoveEmptyTags($values[XmlEncoder::REMOVE_EMPTY_TAGS])
             ->withRootNodeName($values[XmlEncoder::ROOT_NODE_NAME])
             ->withStandalone($values[XmlEncoder::STANDALONE])
@@ -63,6 +64,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::ENCODING => 'UTF-8',
             XmlEncoder::FORMAT_OUTPUT => false,
             XmlEncoder::LOAD_OPTIONS => \LIBXML_COMPACT,
+            XmlEncoder::SAVE_OPTIONS => \LIBXML_NOERROR,
             XmlEncoder::REMOVE_EMPTY_TAGS => true,
             XmlEncoder::ROOT_NODE_NAME => 'root',
             XmlEncoder::STANDALONE => false,
@@ -77,6 +79,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::ENCODING => null,
             XmlEncoder::FORMAT_OUTPUT => null,
             XmlEncoder::LOAD_OPTIONS => null,
+            XmlEncoder::SAVE_OPTIONS => null,
             XmlEncoder::REMOVE_EMPTY_TAGS => null,
             XmlEncoder::ROOT_NODE_NAME => null,
             XmlEncoder::STANDALONE => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Add missing `withSaveOptions` method to `XmlEncoderContextBuilder` to handle `XmlEncoder::SAVE_OPTIONS` context value.
