### PR TITLE
[Console] Add missing ZSH mention in DumpCompletionCommand help

### DIFF
--- a/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
+++ b/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
@@ -52,10 +52,12 @@ final class DumpCompletionCommand extends Command
             default => ['~/.bashrc', "/etc/bash_completion.d/$commandName"],
         };
 
+        $supportedShells = implode(', ', $this->getSupportedShells());
+
         $this
             ->setHelp(<<<EOH
 The <info>%command.name%</> command dumps the shell completion script required
-to use shell autocompletion (currently, bash and fish completion is supported).
+to use shell autocompletion (currently, {$supportedShells} completion are supported).
 
 <comment>Static installation
 -------------------</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

See https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Console/Resources/completion.zsh

And I check, it doesn't exist on 5.4

