### PR TITLE
[Mailer] Pass the port from the Mailgun DSN to the MailgunSmtpTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
@@ -98,12 +98,12 @@ class MailgunTransportFactoryTest extends TransportFactoryTestCase
 
         yield [
             new Dsn('mailgun+smtp', 'default', self::USER, self::PASSWORD),
-            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null, $logger),
+            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null,null, $logger),
         ];
 
         yield [
             new Dsn('mailgun+smtps', 'default', self::USER, self::PASSWORD),
-            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null, $logger),
+            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null,null, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
@@ -98,12 +98,12 @@ class MailgunTransportFactoryTest extends TransportFactoryTestCase
 
         yield [
             new Dsn('mailgun+smtp', 'default', self::USER, self::PASSWORD),
-            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null,null, $logger),
+            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null, null, $logger),
         ];
 
         yield [
             new Dsn('mailgun+smtps', 'default', self::USER, self::PASSWORD),
-            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null,null, $logger),
+            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, null, null, $logger),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
@@ -22,9 +22,9 @@ class MailgunSmtpTransport extends EsmtpTransport
 {
     use MailgunHeadersTrait;
 
-    public function __construct(string $username, #[\SensitiveParameter] string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, string $region = null, int $port = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', 465, true, $dispatcher, $logger);
+        parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', $port ?? 465, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunTransportFactory.php
@@ -39,7 +39,7 @@ final class MailgunTransportFactory extends AbstractTransportFactory
         }
 
         if ('mailgun+smtp' === $scheme || 'mailgun+smtps' === $scheme) {
-            return new MailgunSmtpTransport($user, $password, $region, $this->dispatcher, $this->logger);
+            return new MailgunSmtpTransport($user, $password, $region, $port, $this->dispatcher, $this->logger);
         }
 
         throw new UnsupportedSchemeException($dsn, 'mailgun', $this->getSupportedSchemes());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This PR removes the hardcoded port on the Mailgun SMTP transport and replaces it by the value set in the DSN. The original (465) is still the fallback in case `null` is passed.

In the [Mailer docs](https://symfony.com/doc/current/mailer.html#using-a-3rd-party-transport), the following DSN is given as a starting point to use the Mailgun bridge
```
mailgun+smtp://USERNAME:PASSWORD@default
```
Developers might want to tweak this DSN, for example to set the region and/or port:
```
mailgun+smtp://USERNAME:PASSWORD@default:587?region=eu
```
But the port is currently ignored after parsing the DSN.

The current work-around is to *not use* the `mailgun+smtp` transport and stick to the default `smtp://` one:
```
smtp://USERNAME:PASSWORD@smtp.eu.mailgun.org:587
```
This is confusing and having the `mailgun+smtp` DSN parse the port correctly is the behavior I would expect from reading the docs.

References:
>All Mailgun customers should consider using port 587 as their default SMTP port unless you're explicitly blocked by your upstream network or hosting provider.
https://www.mailgun.com/blog/email/which-smtp-port-understanding-ports-25-465-587/

