### PR TITLE
[Scheduler] Fix PHPUnit deprecation on abstract test cases naming

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/AbstractTriggerTestCase.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/AbstractTriggerTestCase.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Scheduler\Trigger\DatePeriodTrigger;
 use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
-abstract class AbstractTriggerTest extends TestCase
+abstract class AbstractTriggerTestCase extends TestCase
 {
     /**
      * @dataProvider providerGetNextRunDate

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/DatePeriodTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/DatePeriodTriggerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Scheduler\Tests\Trigger;
 
 use Symfony\Component\Scheduler\Trigger\DatePeriodTrigger;
 
-class DatePeriodTriggerTest extends AbstractTriggerTest
+class DatePeriodTriggerTest extends AbstractTriggerTestCase
 {
     public static function providerGetNextRunDate(): iterable
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | _NA_

Abstract test case classes with "Test" suffix are deprecated since PHPUnit 9.6.