### PR TITLE
Register and tag validators in container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -227,7 +227,6 @@ use Symfony\Component\Translation\PseudoLocalizationTranslator;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\Component\Uid\UuidV4;
-use Symfony\Component\Validator\Constraints\ExpressionLanguageSyntaxValidator;
 use Symfony\Component\Validator\Constraints\ExpressionSyntaxValidator;
 use Symfony\Component\Validator\Constraints\WhenValidator;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
@@ -1560,10 +1559,6 @@ class FrameworkExtension extends Extension
 
         if (!class_exists(ExpressionSyntaxValidator::class)) {
             $container->removeDefinition('validator.expression_syntax');
-        }
-
-        if (!class_exists(ExpressionLanguageSyntaxValidator::class)) {
-            $container->removeDefinition('validator.expression_language_syntax');
         }
 
         if (!class_exists(WhenValidator::class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -227,6 +227,8 @@ use Symfony\Component\Translation\PseudoLocalizationTranslator;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\Component\Uid\UuidV4;
+use Symfony\Component\Validator\Constraints\ExpressionLanguageSyntaxValidator;
+use Symfony\Component\Validator\Constraints\ExpressionSyntaxValidator;
 use Symfony\Component\Validator\Constraints\WhenValidator;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
@@ -1554,6 +1556,14 @@ class FrameworkExtension extends Extension
 
         if (!class_exists(ExpressionLanguage::class)) {
             $container->removeDefinition('validator.expression_language');
+        }
+
+        if (!class_exists(ExpressionSyntaxValidator::class)) {
+            $container->removeDefinition('validator.expression_syntax');
+        }
+
+        if (!class_exists(ExpressionLanguageSyntaxValidator::class)) {
+            $container->removeDefinition('validator.expression_language_syntax');
         }
 
         if (!class_exists(WhenValidator::class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -14,9 +14,59 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Validator\Constraints\AtLeastOneOfValidator;
+use Symfony\Component\Validator\Constraints\BicValidator;
+use Symfony\Component\Validator\Constraints\BlankValidator;
+use Symfony\Component\Validator\Constraints\CardSchemeValidator;
+use Symfony\Component\Validator\Constraints\ChoiceValidator;
+use Symfony\Component\Validator\Constraints\CidrValidator;
+use Symfony\Component\Validator\Constraints\CountryValidator;
+use Symfony\Component\Validator\Constraints\CountValidator;
+use Symfony\Component\Validator\Constraints\CssColorValidator;
+use Symfony\Component\Validator\Constraints\CurrencyValidator;
+use Symfony\Component\Validator\Constraints\DateTimeValidator;
+use Symfony\Component\Validator\Constraints\DateValidator;
+use Symfony\Component\Validator\Constraints\DivisibleByValidator;
 use Symfony\Component\Validator\Constraints\EmailValidator;
+use Symfony\Component\Validator\Constraints\EqualToValidator;
+use Symfony\Component\Validator\Constraints\ExpressionLanguageSyntaxValidator;
+use Symfony\Component\Validator\Constraints\ExpressionSyntaxValidator;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
+use Symfony\Component\Validator\Constraints\FileValidator;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqualValidator;
+use Symfony\Component\Validator\Constraints\GreaterThanValidator;
+use Symfony\Component\Validator\Constraints\HostnameValidator;
+use Symfony\Component\Validator\Constraints\IbanValidator;
+use Symfony\Component\Validator\Constraints\IdenticalToValidator;
+use Symfony\Component\Validator\Constraints\ImageValidator;
+use Symfony\Component\Validator\Constraints\IpValidator;
+use Symfony\Component\Validator\Constraints\IsbnValidator;
+use Symfony\Component\Validator\Constraints\IsFalseValidator;
+use Symfony\Component\Validator\Constraints\IsinValidator;
+use Symfony\Component\Validator\Constraints\IsNullValidator;
+use Symfony\Component\Validator\Constraints\IssnValidator;
+use Symfony\Component\Validator\Constraints\IsTrueValidator;
+use Symfony\Component\Validator\Constraints\JsonValidator;
+use Symfony\Component\Validator\Constraints\LanguageValidator;
+use Symfony\Component\Validator\Constraints\LengthValidator;
+use Symfony\Component\Validator\Constraints\LessThanOrEqualValidator;
+use Symfony\Component\Validator\Constraints\LessThanValidator;
+use Symfony\Component\Validator\Constraints\LocaleValidator;
+use Symfony\Component\Validator\Constraints\LuhnValidator;
+use Symfony\Component\Validator\Constraints\NotBlankValidator;
 use Symfony\Component\Validator\Constraints\NotCompromisedPasswordValidator;
+use Symfony\Component\Validator\Constraints\NotEqualToValidator;
+use Symfony\Component\Validator\Constraints\NotIdenticalToValidator;
+use Symfony\Component\Validator\Constraints\NotNullValidator;
+use Symfony\Component\Validator\Constraints\RangeValidator;
+use Symfony\Component\Validator\Constraints\RegexValidator;
+use Symfony\Component\Validator\Constraints\TimeValidator;
+use Symfony\Component\Validator\Constraints\TimezoneValidator;
+use Symfony\Component\Validator\Constraints\TypeValidator;
+use Symfony\Component\Validator\Constraints\UlidValidator;
+use Symfony\Component\Validator\Constraints\UniqueValidator;
+use Symfony\Component\Validator\Constraints\UrlValidator;
+use Symfony\Component\Validator\Constraints\UuidValidator;
 use Symfony\Component\Validator\Constraints\WhenValidator;
 use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
@@ -109,5 +159,255 @@ return static function (ContainerConfigurator $container) {
                 service('property_info'),
             ])
             ->tag('validator.auto_mapper')
+
+        ->set('validator.at_least_one_of', AtLeastOneOfValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => AtLeastOneOfValidator::class,
+            ])
+
+        ->set('validator.bic', BicValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => BicValidator::class,
+            ])
+
+        ->set('validator.blank', BlankValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => BlankValidator::class,
+            ])
+
+        ->set('validator.card_scheme', CardSchemeValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => CardSchemeValidator::class,
+            ])
+
+        ->set('validator.choice', ChoiceValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => ChoiceValidator::class,
+            ])
+
+        ->set('validator.cidr', CidrValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => CidrValidator::class,
+            ])
+
+        ->set('validator.count', CountValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => CountValidator::class,
+            ])
+
+        ->set('validator.country', CountryValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => CountryValidator::class,
+            ])
+
+        ->set('validator.css_color', CssColorValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => CssColorValidator::class,
+            ])
+
+        ->set('validator.currency', CurrencyValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => CurrencyValidator::class,
+            ])
+
+        ->set('validator.date', DateValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => DateValidator::class,
+            ])
+
+        ->set('validator.date_time', DateTimeValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => DateTimeValidator::class,
+            ])
+
+        ->set('validator.divisible_by', DivisibleByValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => DivisibleByValidator::class,
+            ])
+
+        ->set('validator.equal_to', EqualToValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => EqualToValidator::class,
+            ])
+
+        ->set('validator.expression_language_syntax', ExpressionLanguageSyntaxValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => ExpressionLanguageSyntaxValidator::class,
+            ])
+
+        ->set('validator.expression_syntax', ExpressionSyntaxValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => ExpressionSyntaxValidator::class,
+            ])
+
+        ->set('validator.file', FileValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => FileValidator::class,
+            ])
+
+        ->set('validator.greater_than', GreaterThanValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => GreaterThanValidator::class,
+            ])
+
+        ->set('validator.greater_than_or_equal', GreaterThanOrEqualValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => GreaterThanOrEqualValidator::class,
+            ])
+
+        ->set('validator.hostname', HostnameValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => HostnameValidator::class,
+            ])
+
+        ->set('validator.iban', IbanValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => IbanValidator::class,
+            ])
+
+        ->set('validator.identical_to', IdenticalToValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => IdenticalToValidator::class,
+            ])
+
+        ->set('validator.image', ImageValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => ImageValidator::class,
+            ])
+
+        ->set('validator.ip', IpValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => IpValidator::class,
+            ])
+
+        ->set('validator.isbn', IsbnValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => IsbnValidator::class,
+            ])
+
+        ->set('validator.is_false', IsFalseValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => IsFalseValidator::class,
+            ])
+
+        ->set('validator.isin', IsinValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => IsinValidator::class,
+            ])
+
+        ->set('validator.is_null', IsNullValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => IsNullValidator::class,
+            ])
+
+        ->set('validator.issn', IssnValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => IssnValidator::class,
+            ])
+
+        ->set('validator.is_true', IsTrueValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => IsTrueValidator::class,
+            ])
+
+        ->set('validator.json', JsonValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => JsonValidator::class,
+            ])
+
+        ->set('validator.language', LanguageValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => LanguageValidator::class,
+            ])
+
+        ->set('validator.length', LengthValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => LengthValidator::class,
+            ])
+
+        ->set('validator.less_than', LessThanValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => LessThanValidator::class,
+            ])
+
+        ->set('validator.less_than_or_equal', LessThanOrEqualValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => LessThanOrEqualValidator::class,
+            ])
+
+        ->set('validator.locale', LocaleValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => LocaleValidator::class,
+            ])
+
+        ->set('validator.luhn', LuhnValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => LuhnValidator::class,
+            ])
+
+        ->set('validator.not_blank', NotBlankValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => NotBlankValidator::class,
+            ])
+
+        ->set('validator.not_equal_to', NotEqualToValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => NotEqualToValidator::class,
+            ])
+
+        ->set('validator.not_identical_to', NotIdenticalToValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => NotIdenticalToValidator::class,
+            ])
+
+        ->set('validator.not_null', NotNullValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => NotNullValidator::class,
+            ])
+
+        ->set('validator.range', RangeValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => RangeValidator::class,
+            ])
+
+        ->set('validator.regex', RegexValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => RegexValidator::class,
+            ])
+
+        ->set('validator.time', TimeValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => TimeValidator::class,
+            ])
+
+        ->set('validator.timezone', TimezoneValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => TimezoneValidator::class,
+            ])
+
+        ->set('validator.type', TypeValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => TypeValidator::class,
+            ])
+
+        ->set('validator.ulid', UlidValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => UlidValidator::class,
+            ])
+
+        ->set('validator.unique', UniqueValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => UniqueValidator::class,
+            ])
+
+        ->set('validator.url', UrlValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => UrlValidator::class,
+            ])
+
+        ->set('validator.uuid', UuidValidator::class)
+            ->tag('validator.constraint_validator', [
+                'alias' => UuidValidator::class,
+            ])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -29,7 +29,6 @@ use Symfony\Component\Validator\Constraints\DateValidator;
 use Symfony\Component\Validator\Constraints\DivisibleByValidator;
 use Symfony\Component\Validator\Constraints\EmailValidator;
 use Symfony\Component\Validator\Constraints\EqualToValidator;
-use Symfony\Component\Validator\Constraints\ExpressionLanguageSyntaxValidator;
 use Symfony\Component\Validator\Constraints\ExpressionSyntaxValidator;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
 use Symfony\Component\Validator\Constraints\FileValidator;
@@ -229,12 +228,6 @@ return static function (ContainerConfigurator $container) {
         ->set('validator.equal_to', EqualToValidator::class)
             ->tag('validator.constraint_validator', [
                 'alias' => EqualToValidator::class,
-            ])
-
-        ->set('validator.expression_language_syntax', ExpressionLanguageSyntaxValidator::class)
-            ->args([service('validator.expression_language')->nullOnInvalid()])
-            ->tag('validator.constraint_validator', [
-                'alias' => ExpressionLanguageSyntaxValidator::class,
             ])
 
         ->set('validator.expression_syntax', ExpressionSyntaxValidator::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -166,6 +166,7 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('validator.bic', BicValidator::class)
+            ->args([service('property_accessor')->nullOnInvalid()])
             ->tag('validator.constraint_validator', [
                 'alias' => BicValidator::class,
             ])
@@ -231,11 +232,13 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('validator.expression_language_syntax', ExpressionLanguageSyntaxValidator::class)
+            ->args([service('validator.expression_language')->nullOnInvalid()])
             ->tag('validator.constraint_validator', [
                 'alias' => ExpressionLanguageSyntaxValidator::class,
             ])
 
         ->set('validator.expression_syntax', ExpressionSyntaxValidator::class)
+            ->args([service('validator.expression_language')->nullOnInvalid()])
             ->tag('validator.constraint_validator', [
                 'alias' => ExpressionSyntaxValidator::class,
             ])
@@ -366,6 +369,7 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('validator.range', RangeValidator::class)
+            ->args([service('property_accessor')->nullOnInvalid()])
             ->tag('validator.constraint_validator', [
                 'alias' => RangeValidator::class,
             ])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49397
| License       | MIT
| Doc PR        | 

This PR register validators related to a constraints having violation messages as services in container and tag them so the `TranslatorPass` take them into account when extracting constraint messages in attributes.

This PR is a first draft with the solution suggested by @MatTheCat in the related ticket.

It will also extract userland constraint messages if validators are declared as service.