### PR TITLE
[Translation] Improve message extraction performance for big code bases

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/PhpAstExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpAstExtractor.php
@@ -64,7 +64,9 @@ final class PhpAstExtractor extends AbstractFileExtractor implements ExtractorIn
 
     protected function canBeExtracted(string $file): bool
     {
-        return 'php' === pathinfo($file, \PATHINFO_EXTENSION) && $this->isFile($file);
+        return 'php' === pathinfo($file, \PATHINFO_EXTENSION)
+            && $this->isFile($file)
+            && preg_match('/\bt\(|->trans\(|TranslatableMessage|Symfony\\\\Component\\\\Validator\\\\Constraints/i', file_get_contents($file));
     }
 
     protected function extractFromDirectory(array|string $resource): iterable|Finder

--- a/src/Symfony/Component/Translation/Extractor/Visitor/ConstraintVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/ConstraintVisitor.php
@@ -21,8 +21,6 @@ use PhpParser\NodeVisitor;
  */
 final class ConstraintVisitor extends AbstractVisitor implements NodeVisitor
 {
-    private const CONSTRAINT_VALIDATION_MESSAGE_PATTERN = '/[a-zA-Z]*message/i';
-
     public function __construct(
         private readonly array $constraintClassNames = []
     ) {
@@ -65,7 +63,7 @@ final class ConstraintVisitor extends AbstractVisitor implements NodeVisitor
         }
 
         if ($this->hasNodeNamedArguments($node)) {
-            $messages = $this->getStringArguments($node, self::CONSTRAINT_VALIDATION_MESSAGE_PATTERN, true);
+            $messages = $this->getStringArguments($node, '/message/i', true);
         } else {
             if (!$arg->value instanceof Node\Expr\Array_) {
                 // There is no way to guess which argument is a message to be translated.
@@ -81,7 +79,7 @@ final class ConstraintVisitor extends AbstractVisitor implements NodeVisitor
                     continue;
                 }
 
-                if (!preg_match(self::CONSTRAINT_VALIDATION_MESSAGE_PATTERN, $item->key->value ?? '')) {
+                if (false === stripos($item->key->value ?? '', 'message')) {
                     continue;
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/pull/49585 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | 

As discussed in https://github.com/symfony/symfony/pull/49585, we try to extract messages from all src/ directory in `translation:debug` and `translation:extract` commands. But, it's not necessary to look into all files, as we can easily detect if a file contains something about translation (with some regexes).

This PR filter files before messages extraction, and it divide by at least 3 the time used to extract messages from an app with 100 000 php files.