### PR TITLE
[Translation] Extract constraint class names instead of relying on service declaration

### DIFF
--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
@@ -105,8 +105,8 @@ class TranslatorPass implements CompilerPassInterface
             $fqcn = $namespace.'\\'.$className;
 
             if (
-                true === class_exists($fqcn) &&
-                true === is_subclass_of($fqcn, Constraint::class)
+                class_exists($fqcn) &&
+                is_subclass_of($fqcn, Constraint::class)
             ) {
                 $classes[] = $className;
             }

--- a/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslatorPassTest.php
+++ b/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslatorPassTest.php
@@ -18,10 +18,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Translation\DependencyInjection\TranslatorPass;
 use Symfony\Component\Translation\Extractor\Visitor\ConstraintVisitor;
-use Symfony\Component\Validator\Constraints\IsbnValidator;
-use Symfony\Component\Validator\Constraints\LengthValidator;
-use Symfony\Component\Validator\Constraints\NotBlankValidator;
-use Symfony\Component\Validator\Constraints\TimeValidator;
 
 class TranslatorPassTest extends TestCase
 {
@@ -132,19 +128,13 @@ class TranslatorPassTest extends TestCase
             ->setArguments([null, null, null, null]);
         $container->register('validator');
         $constraintVisitor = $container->register('translation.extractor.visitor.constraint', ConstraintVisitor::class);
-        $container->register('validator.not_blank', NotBlankValidator::class)
-            ->addTag('validator.constraint_validator');
-        $container->register('validator.isbn', IsbnValidator::class)
-            ->addTag('validator.constraint_validator');
-        $container->register('validator.length', LengthValidator::class)
-            ->addTag('validator.constraint_validator');
-        $container->register('validator.time', '%foo.time.validator.class%')
-            ->addTag('validator.constraint_validator');
-        $container->setParameter('foo.time.validator.class', TimeValidator::class);
 
         $pass = new TranslatorPass();
         $pass->process($container);
 
-        $this->assertSame(['NotBlank', 'Isbn', 'Length', 'Time'], $constraintVisitor->getArgument(0));
+        $this->assertContains('NotBlank', $constraintVisitor->getArgument(0));
+        $this->assertContains('Isbn', $constraintVisitor->getArgument(0));
+        $this->assertContains('Length', $constraintVisitor->getArgument(0));
+        $this->assertContains('Time', $constraintVisitor->getArgument(0));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49397
| License       | MIT
| Doc PR        | 

This is an alternative solution to [this one](https://github.com/symfony/symfony/pull/49779) involving a fix translator side.
See it as a discussion support first, more than a definitive proposal.

Instead of relying on service declaration to inject the constraint names to the ConstraintVisitor, we extract them from files and return all class names of classes extending Constraint.

The private method looks like the one we can find in the `DebugCommand` and I'm not really sure it has its place directly in the TranslatorPass but this is a first draft and I hope someone can lead me in the right direction to move stuff at the right place.

Contrary to my first PR this solution excludes userland constraints. It also exclude constraints from other places than `Symfony/Component/Validator/Constraints` directory (like `UniqueEntity` for example).

To include them all, we would probably need to:
- add the service declaration of external constraint like UniqueEntity
- keep the old way to get all tagged services 
- merge the result with the one provided in this PR

Userland constraint would be included at the condition of being declared as services.