### PR TITLE
[Validator] New `PasswordStrength` constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -152,7 +152,8 @@
         "symfony/security-acl": "~2.8|~3.0",
         "twig/cssinliner-extra": "^2.12|^3",
         "twig/inky-extra": "^2.12|^3",
-        "twig/markdown-extra": "^2.12|^3"
+        "twig/markdown-extra": "^2.12|^3",
+        "bjeavons/zxcvbn-php": "^1.0"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `Uuid::TIME_BASED_VERSIONS` to match that a UUID being validated embeds a timestamp
  * Add the `pattern` parameter in violations of the `Regex` constraint
  * Add a `NoSuspiciousCharacters` constraint to validate a string is not a spoofing attempt
+ * Add a `PasswordStrength` constraint to check the strength of a password (requires `bjeavons/zxcvbn-php` library)
  * Add the `countUnit` option to the `Length` constraint to allow counting the string length either by code points (like before, now the default setting `Length::COUNT_CODEPOINTS`), bytes (`Length::COUNT_BYTES`) or graphemes (`Length::COUNT_GRAPHEMES`)
  * Add the `filenameMaxLength` option to the `File` constraint
  * Add the `exclude` option to the `Cascade` constraint

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\LogicException;
+use ZxcvbnPhp\Zxcvbn;
+
+/**
+ * @Annotation
+ *
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class PasswordStrength extends Constraint
+{
+    public const PASSWORD_STRENGTH_ERROR = '4234df00-45dd-49a4-b303-a75dbf8b10d8';
+    public const RESTRICTED_USER_INPUT_ERROR = 'd187ff45-bf23-4331-aa87-c24a36e9b400';
+
+    protected const ERROR_NAMES = [
+        self::PASSWORD_STRENGTH_ERROR => 'PASSWORD_STRENGTH_ERROR',
+        self::RESTRICTED_USER_INPUT_ERROR => 'RESTRICTED_USER_INPUT_ERROR',
+    ];
+
+    public string $lowStrengthMessage = 'The password strength is too low. Please use a stronger password.';
+
+    public int $minScore = 2;
+
+    public string $restrictedDataMessage = 'The password contains the following restricted data: {{ wordList }}.';
+
+    /**
+     * @var array<string>
+     */
+    public array $restrictedData = [];
+
+    public function __construct(mixed $options = null, array $groups = null, mixed $payload = null)
+    {
+        if (!class_exists(Zxcvbn::class)) {
+            throw new LogicException(sprintf('The "%s" class requires the "bjeavons/zxcvbn-php" library. Try running "composer require bjeavons/zxcvbn-php".', self::class));
+        }
+
+        if (isset($options['minScore']) && (!\is_int($options['minScore']) || $options['minScore'] < 1 || $options['minScore'] > 4)) {
+            throw new ConstraintDefinitionException(sprintf('The parameter "minScore" of the "%s" constraint must be an integer between 1 and 4.', static::class));
+        }
+
+        if (isset($options['restrictedData'])) {
+            array_walk($options['restrictedData'], static function (mixed $value): void {
+                if (!\is_string($value)) {
+                    throw new ConstraintDefinitionException(sprintf('The parameter "restrictedData" of the "%s" constraint must be a list of strings.', static::class));
+                }
+            });
+        }
+        parent::__construct($options, $groups, $payload);
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use ZxcvbnPhp\Matchers\DictionaryMatch;
+use ZxcvbnPhp\Matchers\MatchInterface;
+use ZxcvbnPhp\Zxcvbn;
+
+final class PasswordStrengthValidator extends ConstraintValidator
+{
+    public function validate(#[\SensitiveParameter] mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof PasswordStrength) {
+            throw new UnexpectedTypeException($constraint, PasswordStrength::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!\is_string($value)) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        $zxcvbn = new Zxcvbn();
+        $strength = $zxcvbn->passwordStrength($value, $constraint->restrictedData);
+
+        if ($strength['score'] < $constraint->minScore) {
+            $this->context->buildViolation($constraint->lowStrengthMessage)
+                ->setCode(PasswordStrength::PASSWORD_STRENGTH_ERROR)
+                ->addViolation();
+        }
+        $wordList = $this->findRestrictedUserInputs($strength['sequence'] ?? []);
+        if (0 !== \count($wordList)) {
+            $this->context->buildViolation($constraint->restrictedDataMessage, [
+                '{{ wordList }}' => implode(', ', $wordList),
+            ])
+                ->setCode(PasswordStrength::RESTRICTED_USER_INPUT_ERROR)
+                ->addViolation();
+        }
+    }
+
+    /**
+     * @param array<MatchInterface> $sequence
+     *
+     * @return array<string>
+     */
+    private function findRestrictedUserInputs(array $sequence): array
+    {
+        $found = [];
+
+        foreach ($sequence as $item) {
+            if (!$item instanceof DictionaryMatch) {
+                continue;
+            }
+            if ('user_inputs' === $item->dictionaryName) {
+                $found[] = $item->token;
+            }
+        }
+
+        return $found;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+class PasswordStrengthTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $constraint = new PasswordStrength();
+        $this->assertEquals(2, $constraint->minScore);
+        $this->assertEquals([], $constraint->restrictedData);
+    }
+
+    public function testConstructorWithParameters()
+    {
+        $constraint = new PasswordStrength([
+            'minScore' => 3,
+            'restrictedData' => ['foo', 'bar'],
+        ]);
+
+        $this->assertEquals(3, $constraint->minScore);
+        $this->assertEquals(['foo', 'bar'], $constraint->restrictedData);
+    }
+
+    public function testInvalidScoreOfZero()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The parameter "minScore" of the "Symfony\Component\Validator\Constraints\PasswordStrength" constraint must be an integer between 1 and 4.');
+        new PasswordStrength(['minScore' => 0]);
+    }
+
+    public function testInvalidScoreOfFive()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The parameter "minScore" of the "Symfony\Component\Validator\Constraints\PasswordStrength" constraint must be an integer between 1 and 4.');
+        new PasswordStrength(['minScore' => 5]);
+    }
+
+    public function testInvalidRestrictedData()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The parameter "restrictedData" of the "Symfony\Component\Validator\Constraints\PasswordStrength" constraint must be a list of strings.');
+        new PasswordStrength(['restrictedData' => [123]]);
+    }
+}

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -40,7 +40,8 @@
         "symfony/property-info": "^5.4|^6.0",
         "symfony/translation": "^5.4|^6.0",
         "doctrine/annotations": "^1.13|^2",
-        "egulias/email-validator": "^2.1.10|^3|^4"
+        "egulias/email-validator": "^2.1.10|^3|^4",
+        "bjeavons/zxcvbn-php": "^1.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.13",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18124

This PR adds a new constraint `PasswordStrength`. This constraint is able to determine if the password strength (or any other string) fulfils with the minimum requirement.
It leverages on [`bjeavons/zxcvbn-php`](https://github.com/bjeavons/zxcvbn-php) which is required when this constraint is used.

Example:

```php
<?php

declare(strict_types=1);

namespace App\Form;

use Symfony\Component\Form\AbstractType;
use Symfony\Component\Form\Extension\Core\Type\PasswordType;
use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\OptionsResolver\OptionsResolver;
use Symfony\Component\Validator\Constraints\NotBlank;
use Symfony\Component\Validator\Constraints\PasswordStrength;

final class ChangePasswordFormType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $restrictedData = $options['restrictedData'] ?? [];

        $builder
            ->add('plainPassword', RepeatedType::class, [
                'type' => PasswordType::class,
                'options' => [
                    'attr' => [
                        'autocomplete' => 'new-password',
                    ],
                ],
                'first_options' => [
                    'constraints' => [
                        new NotBlank(),
                        new PasswordStrength(['restrictedData' => $restrictedData])
                    ],
                    'label' => 'New password',
                ],
                'second_options' => [
                    'label' => 'Repeat the new password',
                ],
                'mapped' => false,
            ])
        ;
    }

    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setDefaults([
            'restrictedData' => [],
        ])
            ->setAllowedTypes('restrictedData', 'string[]')
        ;
    }
}
```

Then from e.g. a controller

```php
$form = $this->createForm(ChangePasswordFormType::class, null, [
    'restrictedData' => [
        $user->getUsername(),
        $user->getEmail(),
        $user->getGivenName(),
        $user->getFamilyName(),
        'ApplicationName', // Arbitrary data
    ],
]);
```

It can be added as a property attribute:

```php
<?php

declare(strict_types=1);

namespace App\Form;

use Symfony\Component\Validator\Constraints\NotBlank;
use Symfony\Component\Validator\Constraints\PasswordStrength;

final class ChangePasswordFormData
{
    #[NotBlank]
    #[PasswordStrength]
    public string $password = '';
}
```

Options:
* `lowStrengthMessage`: the message in case of a weak password (default: `The password strength is too low. Please use a stronger password.`)
* `minScore`: 0 means a weak password, 4 means a very good password (default: `2`)
* `restrictedData`: a list of restricted data e.g. user information such as ID, username, email, given name, last name or application information (default: `[]`)
* `restrictedDataMessage`: the message in case of the restricted data in the password (default: `The password contains at least one restricted data: {{ wordList }}.`)