### PR TITLE
[HttpClient] Fix not calling the on progress callback when canceling a MockResponse

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -110,6 +110,10 @@ class MockResponse implements ResponseInterface, StreamableInterface
         } catch (TransportException $e) {
             // ignore errors when canceling
         }
+
+        $onProgress = $this->requestOptions['on_progress'] ?? static function () {};
+        $dlSize = isset($this->headers['content-encoding']) || 'HEAD' === $this->info['http_method'] || \in_array($this->info['http_code'], [204, 304], true) ? 0 : (int) ($this->headers['content-length'][0] ?? 0);
+        $onProgress($this->offset, $dlSize, $this->info);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I want to assert that a response is canceled under certain circumstances.

My first approach was to get the info from the MockResponse I pass as the response factory to the MockHttpClient but this one is lost since a new instance is created when the request method is called.

My next approach was to wrap the MockHttpClient I pass to the class I'm testing with a TraceableHttpClient. But it doesn't work because the traced info is outdated. The problem seems to be that the on-progress callback is not called when a MockResponse is canceled.