### PR TITLE
[Messenger] Fix timezone in appveyor tests

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -314,10 +314,10 @@ class WorkerTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(5));
 
-        $clock = new MockClock('2023-03-19 14:00:00');
+        $clock = new MockClock('2023-03-19 14:00:00+00:00');
         $worker = new Worker([$receiver], $bus, $dispatcher, clock: $clock);
         $worker->run(['sleep' => 1000000]);
-        $this->assertEquals(new \DateTimeImmutable('2023-03-19 14:00:03'), $clock->now());
+        $this->assertEquals(new \DateTimeImmutable('2023-03-19 14:00:03+00:00'), $clock->now());
     }
 
     public function testWorkerWithMultipleReceivers()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR fixes this Messenger test on appveyor. This test fails on appveyor due to a different timezone.

![image](https://user-images.githubusercontent.com/6114779/227582097-f1e17e8a-ace2-48f0-a730-8578c5192fc6.png)
