### PR TITLE
[HttpClient] Add ServerSentEvent::getArrayData() to get the SSE's data decoded as an array directly

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `UriTemplateHttpClient` to use URI templates as specified in the RFC 6570
+ * Add `ServerSentEvent::getArrayData()` to get the Server-Sent Event's data decoded as an array when it's a JSON payload
 
 6.2
 ---

--- a/src/Symfony/Component/HttpClient/Chunk/ServerSentEvent.php
+++ b/src/Symfony/Component/HttpClient/Chunk/ServerSentEvent.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpClient\Chunk;
 
+use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Contracts\HttpClient\ChunkInterface;
 
 /**
@@ -23,6 +24,7 @@ final class ServerSentEvent extends DataChunk implements ChunkInterface
     private string $id = '';
     private string $type = 'message';
     private float $retry = 0;
+    private ?array $jsonData = null;
 
     public function __construct(string $content)
     {
@@ -75,5 +77,31 @@ final class ServerSentEvent extends DataChunk implements ChunkInterface
     public function getRetry(): float
     {
         return $this->retry;
+    }
+
+    /**
+     * Gets the SSE data decoded as an array when it's a JSON payload.
+     */
+    public function getArrayData(): array
+    {
+        if (null !== $this->jsonData) {
+            return $this->jsonData;
+        }
+
+        if ('' === $this->data) {
+            throw new JsonException(sprintf('Server-Sent Event%s data is empty.', '' !== $this->id ? sprintf(' "%s"', $this->id) : ''));
+        }
+
+        try {
+            $jsonData = json_decode($this->data, true, 512, \JSON_BIGINT_AS_STRING | \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new JsonException(sprintf('Decoding Server-Sent Event%s failed: ', '' !== $this->id ? sprintf(' "%s"', $this->id) : '').$e->getMessage(), $e->getCode());
+        }
+
+        if (!\is_array($jsonData)) {
+            throw new JsonException(sprintf('JSON content was expected to decode to an array, "%s" returned in Server-Sent Event%s.', get_debug_type($jsonData), '' !== $this->id ? sprintf(' "%s"', $this->id) : ''));
+        }
+
+        return $this->jsonData = $jsonData;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Although the data field in SSEs can be "anything", it's really common that it's a JSON payload.

Just like we have a shortcut in responses (`ResponseInterface::toArray()`), I think it's worth having a shortcut in `ServerSentEvent` to avoid writing boilerplate code again and again :sweat_smile: 