### PR TITLE
[Cache] Support Redis cluster connections with predis/predis:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,7 @@
         "php-http/httplug": "^1.0|^2.0",
         "phpdocumentor/reflection-docblock": "^5.2",
         "phpstan/phpdoc-parser": "^1.0",
-        "predis/predis": "~1.1",
+        "predis/predis": "^1.1|^2.0",
         "psr/http-client": "^1.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
         "symfony/mercure-bundle": "^0.3",

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for Relay PHP extension for Redis
+ * Updates to allow Redis cluster connections using predis/predis:^2.0
 
 6.1
 ---

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -15,6 +15,8 @@ use Predis\Command\Redis\UNLINK;
 use Predis\Connection\Aggregate\ClusterInterface;
 use Predis\Connection\Aggregate\RedisCluster;
 use Predis\Connection\Aggregate\ReplicationInterface;
+use Predis\Connection\Cluster\ClusterInterface as Predis2ClusterInterface;
+use Predis\Connection\Cluster\RedisCluster as Predis2RedisCluster;
 use Predis\Response\ErrorInterface;
 use Predis\Response\Status;
 use Relay\Relay;
@@ -376,7 +378,7 @@ trait RedisTrait
 
         $result = [];
 
-        if ($this->redis instanceof \Predis\ClientInterface && $this->redis->getConnection() instanceof ClusterInterface) {
+        if ($this->redis instanceof \Predis\ClientInterface && ($this->redis->getConnection() instanceof ClusterInterface || $this->redis->getConnection() instanceof Predis2ClusterInterface)) {
             $values = $this->pipeline(function () use ($ids) {
                 foreach ($ids as $id) {
                     yield 'get' => [$id];
@@ -476,7 +478,7 @@ trait RedisTrait
             return true;
         }
 
-        if ($this->redis instanceof \Predis\ClientInterface && $this->redis->getConnection() instanceof ClusterInterface) {
+        if ($this->redis instanceof \Predis\ClientInterface && ($this->redis->getConnection() instanceof ClusterInterface || $this->redis->getConnection() instanceof Predis2ClusterInterface)) {
             static $del;
             $del ??= (class_exists(UNLINK::class) ? 'unlink' : 'del');
 
@@ -534,7 +536,7 @@ trait RedisTrait
         $ids = [];
         $redis ??= $this->redis;
 
-        if ($redis instanceof \RedisCluster || ($redis instanceof \Predis\ClientInterface && $redis->getConnection() instanceof RedisCluster)) {
+        if ($redis instanceof \RedisCluster || ($redis instanceof \Predis\ClientInterface && ($redis->getConnection() instanceof RedisCluster || $redis->getConnection() instanceof Predis2RedisCluster))) {
             // phpredis & predis don't support pipelining with RedisCluster
             // see https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#pipelining
             // see https://github.com/nrk/predis/issues/267#issuecomment-123781423
@@ -596,7 +598,7 @@ trait RedisTrait
         $hosts = [$this->redis];
         if ($this->redis instanceof \Predis\ClientInterface) {
             $connection = $this->redis->getConnection();
-            if ($connection instanceof ClusterInterface && $connection instanceof \Traversable) {
+            if (($connection instanceof ClusterInterface || $connection instanceof Predis2ClusterInterface) && $connection instanceof \Traversable) {
                 $hosts = [];
                 foreach ($connection as $c) {
                     $hosts[] = new \Predis\Client($c);

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "cache/integration-tests": "dev-master",
         "doctrine/dbal": "^2.13.1|^3.0",
-        "predis/predis": "^1.1",
+        "predis/predis": "^1.1|^2.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
         "symfony/config": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisClusterSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisClusterSessionHandlerTest.php
@@ -20,6 +20,9 @@ class PredisClusterSessionHandlerTest extends AbstractRedisSessionHandlerTestCas
 {
     protected function createRedisClient(string $host): Client
     {
-        return new Client([array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379])]);
+        return new Client(
+            [array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379])],
+            ['cluster' => 'redis']
+        );
     }
 }

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.13.1|^3.0",
-        "predis/predis": "~1.0",
+        "predis/predis": "^1.1|^2.0",
         "symfony/cache": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4",

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.13|^3.0",
-        "predis/predis": "~1.0"
+        "predis/predis": "^1.1|^2.0"
     },
     "conflict": {
         "doctrine/dbal": "<2.13",

--- a/src/Symfony/Component/Semaphore/composer.json
+++ b/src/Symfony/Component/Semaphore/composer.json
@@ -24,7 +24,7 @@
         "psr/log": "^1|^2|^3"
     },
     "require-dev": {
-        "predis/predis": "~1.0"
+        "predis/predis": "^1.1|^2.0"
     },
     "conflict": {
         "symfony/cache": "<6.2"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

In v2 of predis/predis some classes related to cluster connections were reorganized. This PR expands the checks in RedisTrait to also work with the new version of Predis.

Previous tests appear to cover this change, and I didn't see any updates needed to documentation, etc. but please let me know if I missed anything. I have been running this locally for a couple of days and while my usage has been limited it has been working well so far

I did change the composer constraint for predis/predis from tilde to caret which I was a bit hesitant about, but they should be functionally equivalent in this case and it looked like the caret constraint was more standard. Let me know if that is not an appropriate change and I will switch back to the tilde constraint.
