### PR TITLE
[Mailer] Update default Mailgun port

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
@@ -24,7 +24,7 @@ class MailgunSmtpTransport extends EsmtpTransport
 
     public function __construct(string $username, #[\SensitiveParameter] string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', 465, true, $dispatcher, $logger);
+        parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', 587, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `MessageEvent::reject()` to allow rejecting an email before sending it
+ * Change the default port for the `mailgun+smtp` transport from 465 to 587
 
 6.2.7
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Alternative to https://github.com/symfony/symfony/pull/49768. Instead of passing the port from the DSN, update the default to 587, which is recommended by Mailgun.

I've also opened a docs PR to clarify that specific bridge DSNs ignore the port: https://github.com/symfony/symfony-docs/pull/18118
