### PR TITLE
[Scheduler] `debug:schedule` refinements

### DIFF
--- a/src/Symfony/Component/Scheduler/Command/DebugCommand.php
+++ b/src/Symfony/Component/Scheduler/Command/DebugCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\ScheduleProviderInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
@@ -98,9 +99,24 @@ final class DebugCommand extends Command
         $message = $recurringMessage->getMessage();
         $trigger = $recurringMessage->getTrigger();
 
+        if ($message instanceof Envelope) {
+            $message = $message->getMessage();
+        }
+
+        $messageName = (new \ReflectionClass($message))->getShortName();
+        $triggerName = (new \ReflectionClass($trigger))->getShortName();
+
+        if ($message instanceof \Stringable) {
+            $messageName .= ": {$message}";
+        }
+
+        if ($trigger instanceof \Stringable) {
+            $triggerName .= ": {$trigger}";
+        }
+
         return [
-            $message instanceof \Stringable ? (string) $message : (new \ReflectionClass($message))->getShortName(),
-            $trigger instanceof \Stringable ? (string) $trigger : (new \ReflectionClass($trigger))->getShortName(),
+            $messageName,
+            $triggerName,
             $recurringMessage->getTrigger()->getNextRunDate(now())->format(\DateTimeInterface::ATOM),
         ];
     }

--- a/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
@@ -30,7 +30,7 @@ final class CronExpressionTrigger implements TriggerInterface, \Stringable
 
     public function __toString(): string
     {
-        return "cron: {$this->expression->getExpression()}";
+        return $this->expression->getExpression();
     }
 
     public static function fromSpec(string $expression = '* * * * *'): self


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Followup to #49795
| License       | MIT
| Doc PR        | n/a

Some fixes/refinements to the output:
1. If the message is an envelope, unwrap
2. prefix stringable message/trigger with short class name

```
 --------------------------- -------------------------------------- --------------------------- 
  Message                     Trigger                                Next Run                   
 --------------------------- -------------------------------------- --------------------------- 
  DoSomething: do something   CronExpressionTrigger: * * * * *       2023-03-25T08:03:00-04:00  
 --------------------------- -------------------------------------- ---------------------------
```