### PR TITLE
[HttpClient] Allow using multiple base_uri as array for retries

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `UriTemplateHttpClient` to use URI templates as specified in the RFC 6570
  * Add `ServerSentEvent::getArrayData()` to get the Server-Sent Event's data decoded as an array when it's a JSON payload
+ * Allow array of urls as `base_uri` option value in `RetryableHttpClient` to retry on a new url each time
 
 6.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #43327 
| License       | MIT
| Doc PR        | TBD

This pull request enhances the `RetryableHttpClient` by allowing the use of an array of URLs as the `base_uri` option. This enables retries on different base URIs for each retry attempt, providing increased reliability and flexibility for making HTTP requests.

Basic usage :
```php
use Symfony\Component\HttpClient\RetryableHttpClient;

$client = new RetryableHttpClient(
    HttpClient::create(),
    new GenericRetryStrategy([500], 0),
    1
);

$response = $client->request('GET', 'foo-bar', [
    'base_uri' => [
        'http://example.com/a/', // first request will use this base uri
        'http://example.com/b/', // if first request fails, the second base uri will be used
    ],
]);
```

Usage with base uri shuffling :
```php
use Symfony\Component\HttpClient\RetryableHttpClient;

$client = new RetryableHttpClient(
    HttpClient::create(),
    new GenericRetryStrategy([500], 0),
    3
);

$response = $client->request('GET', 'foo-bar', [
    'base_uri' => [
        'http://example.com/a/',
        [
            'http://example.com/b/', // base uri passed inside a nested array will be shuffled
            'http://example.com/c/',
        ]
        'http://example.com/d/', // the order of the non-nested base uris is preserved
    ],
]);
```