### PR TITLE
[Messenger][Process] add `RunProcessMessage` and `RunProcessMessageHandler`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -129,6 +129,7 @@ use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\Notifier\Recipient\Recipient;
 use Symfony\Component\Notifier\TexterInterface;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface as NotifierTransportFactoryInterface;
+use Symfony\Component\Process\Messenger\RunProcessMessageHandler;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
@@ -239,6 +240,12 @@ class FrameworkExtension extends Extension
         }
 
         $container->registerAliasForArgument('parameter_bag', PsrContainerInterface::class);
+
+        $loader->load('process.php');
+
+        if (!class_exists(RunProcessMessageHandler::class)) {
+            $container->removeDefinition('process.messenger.process_message_handler');
+        }
 
         if ($this->hasConsole()) {
             $loader->load('console.php');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/process.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/process.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Process\Messenger\RunProcessMessageHandler;
+
+return static function (ContainerConfigurator $container) {
+    $container
+        ->services()
+            ->set('process.messenger.process_message_handler', RunProcessMessageHandler::class)
+                ->tag('messenger.message_handler')
+    ;
+};

--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add `RunProcessMessage` and `RunProcessMessageHandler`
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Process/Exception/RunProcessFailedException.php
+++ b/src/Symfony/Component/Process/Exception/RunProcessFailedException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Exception;
+
+use Symfony\Component\Process\Messenger\RunProcessContext;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class RunProcessFailedException extends RuntimeException
+{
+    public function __construct(ProcessFailedException $exception, public readonly RunProcessContext $context)
+    {
+        parent::__construct($exception->getMessage(), $exception->getCode());
+    }
+}

--- a/src/Symfony/Component/Process/Messenger/RunProcessContext.php
+++ b/src/Symfony/Component/Process/Messenger/RunProcessContext.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Messenger;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class RunProcessContext extends RunProcessMessage
+{
+    public readonly ?int $exitCode;
+    public readonly ?string $output;
+    public readonly ?string $errorOutput;
+
+    public function __construct(RunProcessMessage $message, Process $process)
+    {
+        parent::__construct($message->command, $message->cwd, $message->env, $message->input, $message->timeout);
+
+        $this->exitCode = $process->getExitCode();
+        $this->output = $process->isOutputDisabled() ? null : $process->getOutput();
+        $this->errorOutput = $process->isOutputDisabled() ? null : $process->getErrorOutput();
+    }
+}

--- a/src/Symfony/Component/Process/Messenger/RunProcessMessage.php
+++ b/src/Symfony/Component/Process/Messenger/RunProcessMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Messenger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class RunProcessMessage implements \Stringable
+{
+    public function __construct(
+        public readonly array $command,
+        public readonly ?string $cwd = null,
+        public readonly ?array $env = null,
+        public readonly mixed $input = null,
+        public readonly ?float $timeout = 60.0,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return \implode(' ', $this->command);
+    }
+}

--- a/src/Symfony/Component/Process/Messenger/RunProcessMessageHandler.php
+++ b/src/Symfony/Component/Process/Messenger/RunProcessMessageHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Messenger;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Exception\RunProcessFailedException;
+use Symfony\Component\Process\Process;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class RunProcessMessageHandler
+{
+    public function __invoke(RunProcessMessage $message): RunProcessContext
+    {
+        $process = new Process($message->command, $message->cwd, $message->env, $message->input, $message->timeout);
+
+        try {
+            return new RunProcessContext($message, $process->mustRun());
+        } catch (ProcessFailedException $e) {
+            throw new RunProcessFailedException($e, new RunProcessContext($message, $e->getProcess()));
+        }
+    }
+}

--- a/src/Symfony/Component/Process/Tests/Messenger/RunProcessMessageHandlerTest.php
+++ b/src/Symfony/Component/Process/Tests/Messenger/RunProcessMessageHandlerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests\Messenger;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\RunProcessFailedException;
+use Symfony\Component\Process\Messenger\RunProcessMessage;
+use Symfony\Component\Process\Messenger\RunProcessMessageHandler;
+
+class RunProcessMessageHandlerTest extends TestCase
+{
+    public function testRunSuccessfulProcess()
+    {
+        $context = (new RunProcessMessageHandler())(new RunProcessMessage(['ls'], cwd: __DIR__));
+
+        $this->assertSame(['ls'], $context->command);
+        $this->assertSame(0, $context->exitCode);
+        $this->assertStringContainsString(basename(__FILE__), $context->output);
+    }
+
+    public function testRunFailedProcess()
+    {
+        try {
+            (new RunProcessMessageHandler())(new RunProcessMessage(['invalid']));
+        } catch (RunProcessFailedException $e) {
+            $this->assertSame(['invalid'], $e->context->command);
+            $this->assertSame(127, $e->context->exitCode);
+
+            return;
+        }
+
+        $this->fail('Exception not thrown');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

When reviewing how I could replace my cron scheduler with symfony/scheduler, I realized I need a way to schedule processes.

## Usage

```php
use Symfony\Component\Process\Exception\RunProcessFailedException;
use Symfony\Component\Process\Messenger\RunProcessMessage;

try {
    $context = $bus->dispatch(new RunProcessMessage('something'));

    $context->exitCode; // int
    $context->output; // string
    $context->errorOutput; // string
catch(RunProcessFailedException $e) {
    $e->context->exitCode; // int
    $e->context->output; // string
    $e->context->errorOutput; // string
}
```

TODO:
- [x] wire up
- [x] tests
