### PR TITLE
[FrameworkBundle] remove scheduler debug command definition if the component is not installed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -536,6 +536,8 @@ class FrameworkExtension extends Extension
                 throw new LogicException('Scheduler support cannot be enabled as the Messenger component is not '.(interface_exists(MessageBusInterface::class) ? 'enabled.' : 'installed. Try running "composer require symfony/messenger".'));
             }
             $this->registerSchedulerConfiguration($config['scheduler'], $container, $loader);
+        } else {
+            $container->removeDefinition('console.command.scheduler_debug');
         }
 
         // messenger depends on validation being registered


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49818
| License       | MIT
| Doc PR        | 