### PR TITLE
[Security] New Password Policy listener

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -98,6 +98,7 @@ class MainConfiguration implements ConfigurationInterface
         $this->addFirewallsSection($rootNode, $this->factories);
         $this->addAccessControlSection($rootNode);
         $this->addRoleHierarchySection($rootNode);
+        $this->addPasswordPolicySection($rootNode);
 
         return $tb;
     }
@@ -459,6 +460,21 @@ class MainConfiguration implements ConfigurationInterface
                     ->end()
                 ->end()
         ->end();
+    }
+
+    private function addPasswordPolicySection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->fixXmlConfig('password_policy')
+            ->children()
+                ->arrayNode('password_policies')
+                    ->treatNullLike([])
+                    ->treatFalseLike([])
+                    ->treatTrueLike([])
+                    ->prototype('scalar')->end()
+                ->end()
+            ->end()
+        ;
     }
 
     private function getAccessDecisionStrategies(): array

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -190,6 +190,13 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $container->getDefinition('security.access_listener')->setArgument(3, false);
         $container->getDefinition('security.authorization_checker')->setArgument(2, false);
         $container->getDefinition('security.authorization_checker')->setArgument(3, false);
+
+        if (!$config['password_policies']) {
+            $container->removeDefinition('security.password_policy_listener');
+        } else {
+            $policyServices = array_map(static fn (string $id) => new Reference($id), $config['password_policies']);
+            $container->getDefinition('security.password_policy_listener')->setArgument(0, $policyServices);
+        }
     }
 
     private function createStrategyDefinition(string $strategy, bool $allowIfAllAbstainDecisions, bool $allowIfEqualGrantedDeniedDecisions): Definition

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -45,6 +45,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Controller\SecurityTokenValueResolver;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
 use Symfony\Component\Security\Http\EventListener\IsGrantedAttributeListener;
+use Symfony\Component\Security\Http\EventListener\PasswordPolicyListener;
 use Symfony\Component\Security\Http\Firewall;
 use Symfony\Component\Security\Http\FirewallMapInterface;
 use Symfony\Component\Security\Http\HttpUtils;
@@ -298,5 +299,11 @@ return static function (ContainerConfigurator $container) {
         ->set('cache.security_is_granted_attribute_expression_language')
             ->parent('cache.system')
             ->tag('cache.pool')
+
+        ->set('security.password_policy_listener', PasswordPolicyListener::class)
+            ->args([
+                [],
+            ])
+            ->tag('kernel.event_subscriber')
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/PasswordPolicyTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/PasswordPolicyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class PasswordPolicyTest extends AbstractWebTestCase
+{
+    /**
+     * @dataProvider providePassword
+     */
+    public function testLoginFailBecauseThePasswordIsBlacklisted(string $password, string $expectedMessage)
+    {
+        // Given
+        $client = $this->createClient(['test_case' => 'PasswordPolicy', 'root_config' => 'config.yml']);
+
+        // When
+        $client->request('POST', '/chk', [], [], ['CONTENT_TYPE' => 'application/json'], '{"user": {"login": "dunglas", "password": "'.$password.'"}}');
+        $response = $client->getResponse();
+
+        // Then
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame(['error' => $expectedMessage], json_decode($response->getContent(), true));
+    }
+
+    public static function providePassword(): iterable
+    {
+        yield ['foo', 'The password does not fulfill the password policy.'];
+        yield ['short?', 'The password does not fulfill the password policy.'];
+        yield ['Good password?', 'The password does not fulfill the password policy.'];
+
+        // The following password fulfills the password policy, but is not valid.
+        yield ['Is it a v4l1d pasw0rd?', 'Invalid credentials.'];
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordPolicy/BlocklistPasswordPolicy.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordPolicy/BlocklistPasswordPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\app\PasswordPolicy;
+
+use Symfony\Component\Security\Http\Authenticator\Passport\Policy\PasswordPolicyInterface;
+
+final class BlocklistPasswordPolicy implements PasswordPolicyInterface
+{
+    public function verify(#[\SensitiveParameter] string $plaintextPassword): bool
+    {
+        return 'foo' !== $plaintextPassword;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordPolicy/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordPolicy/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle(),
+];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordPolicy/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordPolicy/config.yml
@@ -1,0 +1,51 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+framework:
+    http_method_override: false
+    serializer: ~
+
+security:
+    password_policies:
+        - 'policy.blocklist'
+        - 'policy.constraint_password'
+
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    dunglas: { password: foo, roles: [ROLE_USER] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            json_login:
+                check_path:    /chk
+                username_path: user.login
+                password_path: user.password
+
+    access_control:
+        - { path: ^/foo, roles: ROLE_USER }
+
+
+services:
+    policy.constraint_password.length:
+        class: Symfony\Component\Validator\Constraints\Length
+        arguments:
+            - min: 8
+    policy.constraint_password.strength:
+        class: Symfony\Component\Validator\Constraints\PasswordStrength
+        arguments:
+            - minScore: 2
+
+    policy.constraint_password:
+        class: Symfony\Component\Security\Http\Authenticator\Passport\Policy\PasswordConstraintPolicy
+        arguments:
+            - '@validator'
+            - ['@policy.constraint_password.length', '@policy.constraint_password.strength']
+
+    policy.blocklist:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\app\PasswordPolicy\BlocklistPasswordPolicy

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordPolicy/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordPolicy/routing.yml
@@ -1,0 +1,3 @@
+login_check:
+    path: /chk
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\JsonLoginBundle\Controller\TestController::loginCheckAction }

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -22,7 +22,7 @@ CHANGELOG
  * Remove all classes in the `Core\Encoder\`  sub-namespace, use the `PasswordHasher` component instead
  * Remove methods `getPassword()` and `getSalt()` from `UserInterface`, use `PasswordAuthenticatedUserInterface`
    or `LegacyPasswordAuthenticatedUserInterface` instead
-* `AccessDecisionManager` requires the strategy to be passed as in instance of `AccessDecisionStrategyInterface`
+ * `AccessDecisionManager` requires the strategy to be passed as in instance of `AccessDecisionStrategyInterface`
 
 5.4.21
 ------

--- a/src/Symfony/Component/Security/Core/Exception/PasswordPolicyException.php
+++ b/src/Symfony/Component/Security/Core/Exception/PasswordPolicyException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Exception;
+
+final class PasswordPolicyException extends AuthenticationException
+{
+    public function getMessageKey(): string
+    {
+        return 'The password does not fulfill the password policy.';
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Policy/PasswordConstraintPolicy.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Policy/PasswordConstraintPolicy.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Passport\Policy;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class PasswordConstraintPolicy implements PasswordPolicyInterface
+{
+    /**
+     * @param array<Constraint> $constraints
+     */
+    public function __construct(
+        private readonly ValidatorInterface $validator,
+        private readonly array $constraints = []
+    ) {
+    }
+
+    /**
+     * @throws AuthenticationException
+     */
+    public function verify(#[\SensitiveParameter] string $plaintextPassword): bool
+    {
+        $errors = $this->validator->validate($plaintextPassword, $this->constraints);
+
+        return !$errors->count();
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Policy/PasswordPolicyInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Policy/PasswordPolicyInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Passport\Policy;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+interface PasswordPolicyInterface
+{
+    /**
+     * @throws AuthenticationException
+     */
+    public function verify(#[\SensitiveParameter] string $plaintextPassword): bool;
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.4
 ---
 
+ * Add Password Policy to allow verifying the password using a custom security policy (e.g. password not compromised, change required by IT service, etc.)
  * `UserValueResolver` no longer implements `ArgumentValueResolverInterface`
 
 6.3

--- a/src/Symfony/Component/Security/Http/EventListener/PasswordPolicyListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/PasswordPolicyListener.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Exception\PasswordPolicyException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Policy\PasswordPolicyInterface;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+
+final class PasswordPolicyListener implements EventSubscriberInterface
+{
+    /**
+     * @param PasswordPolicyInterface[] $policies
+     */
+    public function __construct(private readonly array $policies)
+    {
+    }
+
+    public function checkPassport(CheckPassportEvent $event): void
+    {
+        $passport = $event->getPassport();
+        if (!$passport->hasBadge(PasswordCredentials::class)) {
+            return;
+        }
+
+        $badge = $passport->getBadge(PasswordCredentials::class);
+        if ($badge->isResolved()) {
+            return;
+        }
+
+        $plaintextPassword = $badge->getPassword();
+        foreach ($this->policies as $policy) {
+            if (!$policy->verify($plaintextPassword)) {
+                throw new PasswordPolicyException();
+            }
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CheckPassportEvent::class => ['checkPassport', 512],
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordPolicyListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordPolicyListenerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\PasswordPolicyException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\Policy\PasswordPolicyInterface;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Component\Security\Http\EventListener\PasswordPolicyListener;
+
+class PasswordPolicyListenerTest extends TestCase
+{
+    /**
+     * @param array<PasswordPolicyInterface> $policies
+     *
+     * @dataProvider providePassport
+     */
+    public function testPasswordIsNotAcceptable(Passport $passport, array $policies, string $expectedMessage)
+    {
+        // Given
+        $event = new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport);
+        $listener = new PasswordPolicyListener($policies);
+
+        try {
+            // When
+            $listener->checkPassport($event);
+            $this->fail('Expected exception to be thrown');
+        } catch (PasswordPolicyException $e) {
+            // Then
+            $this->assertSame($expectedMessage, $e->getMessageKey());
+        }
+    }
+
+    public static function providePassport(): iterable
+    {
+        yield [
+            new Passport(
+                new UserBadge('test', fn () => new InMemoryUser('test', 'qwerty')),
+                new PasswordCredentials('qwerty')
+            ),
+            [new class() implements PasswordPolicyInterface {
+                public function verify(string $plaintextPassword): bool
+                {
+                    return false;
+                }
+            }],
+            'The password does not fulfill the password policy.',
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#... [**TODO**]

This PR adds the possibility to define security policy on the password.
When at least one rule is defined, the PasswordPolicyListener will be called to verify the submitted password (on login) is acceptable.
The aim of this feature is to enforce the update of passwords.
Hereafter some use cases:
* There were no rules when designing the app. Now password length should be at least 8 characters and short passwords should be changed.
* The minimum password strength was 2 from a scale from 0 to 5. The IT Service decided to increase the minimum strength to 2.
* The user database has leaked and is available on the internet. Leaked passwords are now prohibited.

The listener has a high priority (512, TBD) in order to be called before the user is fetched and the password is checked against the value in the database. The policy is only based on the plain text password value and not on the user state (e.g. last password update).

Todo:
* [x] Tests
* [ ] Documentation
