### PR TITLE
[Console] Make sure signals registered by `SignalableCommandInterface` commands are defined in the PCNTL extension

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Event\ConsoleSignalEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\NamespaceNotFoundException;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -1004,6 +1005,12 @@ class Application implements ResetInterface
         if ($commandSignals || $this->dispatcher && $this->signalsToDispatchEvent) {
             if (!$this->signalRegistry) {
                 throw new RuntimeException('Unable to subscribe to signal events. Make sure that the `pcntl` extension is installed and that "pcntl_*" functions are not disabled by your php.ini\'s "disable_functions" directive.');
+            }
+
+            foreach (array_merge($commandSignals, $this->signalsToDispatchEvent) as $signal) {
+                if (!SignalRegistry::isValidSignal($signal)) {
+                    throw new InvalidArgumentException(sprintf('Signal "%d" is not valid, make sure to use one of the "SIG*" constants as defined by the "pcntl" extension.', $signal));
+                }
             }
 
             if (Terminal::hasSttyAvailable()) {

--- a/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
+++ b/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
@@ -15,6 +15,8 @@ final class SignalRegistry
 {
     private array $signalHandlers = [];
 
+    private static array $availableSignals;
+
     public function __construct()
     {
         if (\function_exists('pcntl_async_signals')) {
@@ -40,6 +42,13 @@ final class SignalRegistry
     public static function isSupported(): bool
     {
         return \function_exists('pcntl_signal');
+    }
+
+    public static function isValidSignal(int $signal): bool
+    {
+        static::$availableSignals ??= get_defined_constants(true)['pcntl'] ?? [];
+
+        return $signal < 32 && \in_array($signal, static::$availableSignals, true);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/SignalRegistry/SignalRegistryTest.php
+++ b/src/Symfony/Component/Console/Tests/SignalRegistry/SignalRegistryTest.php
@@ -131,4 +131,19 @@ class SignalRegistryTest extends TestCase
         $this->assertTrue($isHandled1);
         $this->assertTrue($isHandled2);
     }
+
+    public function testIsValidSignalWithPcntlConstantButValueIsTooHigh()
+    {
+        $this->assertFalse(SignalRegistry::isValidSignal(\PCNTL_ENAMETOOLONG));
+    }
+
+    public function testIsValidSignalWithInvalidSignalCode()
+    {
+        $this->assertFalse(SignalRegistry::isValidSignal(-12));
+    }
+
+    public function testIsValidSignal()
+    {
+        $this->assertTrue(SignalRegistry::isValidSignal(\SIGINT));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | No need I guess

Makes me think that adding a similar method to check a signal existence as a string in `SignalRegistry` could be leveraged in https://github.com/symfony/symfony/pull/49750