### PR TITLE
[Mime] Added getDispostion() in TextPart

### DIFF
--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -95,6 +95,16 @@ class TextPart extends AbstractPart
 
         return $this;
     }
+    
+    /**
+     * Gets the current content disposition
+     *
+     * @return string Current content disposition
+     */
+    public function getDisposition(): string
+    {
+        return $this->disposition;
+    }
 
     /**
      * Sets the name of the file (used by FormDataPart).


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | N/A

Added getDispostion() in TextPart to get current content disposition.
It would be nice to get the current content disposition in TextPart. This is needed to determine if an attachment is inline or not.