### PR TITLE
[Mime] Added getDispostion() to TextPart to get current content disposition.

### DIFF
--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Support detection of related parts if `Content-Id` is used instead of the name
+ * Add `TextPart::getDispostion()`
 
 6.2
 ---

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -97,6 +97,14 @@ class TextPart extends AbstractPart
     }
 
     /**
+     * @return ?string null or one of attachment, inline, or form-data
+     */
+    public function getDisposition(): ?string
+    {
+        return $this->disposition;
+    }
+
+    /**
      * Sets the name of the file (used by FormDataPart).
      *
      * @return $this


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Added getDispostion() in TextPart to get current content disposition.
It would be nice to get the current content disposition in TextPart. This is needed to determine if an attachment is inline or not.