### PR TITLE
[Scheduler] Change documentation link to for the scheduler

### DIFF
--- a/src/Symfony/Component/Scheduler/README.md
+++ b/src/Symfony/Component/Scheduler/README.md
@@ -11,7 +11,7 @@ are not covered by Symfony's
 Resources
 ---------
 
-* [Documentation](https://symfony.com/doc/current/scheduler.html)
+* [Documentation](https://symfony.com/components/Scheduler)
 * [Contributing](https://symfony.com/doc/current/contributing/index.html)
 * [Report issues](https://github.com/symfony/symfony/issues) and
   [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
Pointing to the correct documentation link for the scheduler component.

| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

