### PR TITLE
[Translation] TranslatorBag::diff now iterates over catalogue domains instead of operation domains

### DIFF
--- a/src/Symfony/Component/Translation/Tests/TranslatorBagTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorBagTest.php
@@ -66,6 +66,34 @@ class TranslatorBagTest extends TestCase
         ], $this->getAllMessagesFromTranslatorBag($bagResult));
     }
 
+    public function testDiffWithIntlDomain()
+    {
+        $catalogueA = new MessageCatalogue('en', [
+            'domain1+intl-icu' => ['foo' => 'foo', 'bar' => 'bar'],
+            'domain2' => ['baz' => 'baz', 'qux' => 'qux'],
+        ]);
+
+        $bagA = new TranslatorBag();
+        $bagA->addCatalogue($catalogueA);
+
+        $catalogueB = new MessageCatalogue('en', [
+            'domain1' => ['foo' => 'foo'],
+            'domain2' => ['baz' => 'baz', 'corge' => 'corge'],
+        ]);
+
+        $bagB = new TranslatorBag();
+        $bagB->addCatalogue($catalogueB);
+
+        $bagResult = $bagA->diff($bagB);
+
+        $this->assertEquals([
+            'en' => [
+                'domain1' => ['bar' => 'bar'],
+                'domain2' => ['qux' => 'qux'],
+            ],
+        ], $this->getAllMessagesFromTranslatorBag($bagResult));
+    }
+
     public function testIntersect()
     {
         $catalogueA = new MessageCatalogue('en', ['domain1' => ['foo' => 'foo', 'bar' => 'bar'], 'domain2' => ['baz' => 'baz', 'qux' => 'qux']]);

--- a/src/Symfony/Component/Translation/TranslatorBag.php
+++ b/src/Symfony/Component/Translation/TranslatorBag.php
@@ -70,7 +70,7 @@ final class TranslatorBag implements TranslatorBagInterface
             $operation->moveMessagesToIntlDomainsIfPossible(AbstractOperation::NEW_BATCH);
             $newCatalogue = new MessageCatalogue($locale);
 
-            foreach ($operation->getDomains() as $domain) {
+            foreach ($catalogue->getDomains() as $domain) {
                 $newCatalogue->add($operation->getNewMessages($domain), $domain);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #47886 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | 

For Loco Provider (at least, but I'm pretty sure it applies for Lokalise and Crowdin), the `--force` option on `translation:push` command has no effect.

The main cause is located in the `TranslatorBag::diff` method which was iterating over `$operation->getDomains()` to add new messages to the diff catalogue. But, the fact is `$operation->getDomains()` returns all domains *AND* their `+intl-icu` variants! Which is certainly not what we want here.

See the test that covers the case

```php
public function testDiffWithIntlDomain()
{
    $catalogueA = new MessageCatalogue('en', [
        'domain1+intl-icu' => ['foo' => 'foo', 'bar' => 'bar'],
        'domain2' => ['baz' => 'baz', 'qux' => 'qux'],
    ]);

    $bagA = new TranslatorBag();
    $bagA->addCatalogue($catalogueA);

    $catalogueB = new MessageCatalogue('en', [
        'domain1' => ['foo' => 'foo'],
        'domain2' => ['baz' => 'baz', 'corge' => 'corge'],
    ]);

    $bagB = new TranslatorBag();
    $bagB->addCatalogue($catalogueB);

    $bagResult = $bagA->diff($bagB);

    $this->assertEquals([
        'en' => [
            'domain1' => ['bar' => 'bar'],
            'domain2' => ['qux' => 'qux'],
        ],
    ], $this->getAllMessagesFromTranslatorBag($bagResult));
}
```

Without the change, `'foo' => 'foo'` was in the result bag.

Replaces https://github.com/symfony/symfony/pull/47986