### PR TITLE
Fix issue 49786

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -25,18 +25,20 @@ use Symfony\Component\Form\FormInterface;
 class ResizeFormListener implements EventSubscriberInterface
 {
     protected $type;
-    protected $options;
+    protected $entryOptions;
+    protected $prototypeOptions;
     protected $allowAdd;
     protected $allowDelete;
 
     private \Closure|bool $deleteEmpty;
 
-    public function __construct(string $type, array $options = [], bool $allowAdd = false, bool $allowDelete = false, bool|callable $deleteEmpty = false)
+    public function __construct(string $type, array $entryOptions = [], array $prototypeOptions = [], bool $allowAdd = false, bool $allowDelete = false, bool|callable $deleteEmpty = false)
     {
         $this->type = $type;
         $this->allowAdd = $allowAdd;
         $this->allowDelete = $allowDelete;
-        $this->options = $options;
+        $this->entryOptions = $entryOptions;
+        $this->prototypeOptions = $prototypeOptions;
         $this->deleteEmpty = \is_bool($deleteEmpty) ? $deleteEmpty : $deleteEmpty(...);
     }
 
@@ -68,7 +70,7 @@ class ResizeFormListener implements EventSubscriberInterface
         foreach ($data as $name => $value) {
             $form->add($name, $this->type, array_replace([
                 'property_path' => '['.$name.']',
-            ], $this->options));
+            ], $this->entryOptions));
         }
     }
 
@@ -96,7 +98,7 @@ class ResizeFormListener implements EventSubscriberInterface
                 if (!$form->has($name)) {
                     $form->add($name, $this->type, array_replace([
                         'property_path' => '['.$name.']',
-                    ], $this->options));
+                    ], $this->prototypeOptions));
                 }
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -40,6 +40,7 @@ class CollectionType extends AbstractType
         $resizeListener = new ResizeFormListener(
             $options['entry_type'],
             $options['entry_options'],
+            array_replace($options['entry_options'], $options['prototype_options']),
             $options['allow_add'],
             $options['allow_delete'],
             $options['delete_empty']

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -59,7 +59,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [1 => 'string', 2 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], false, false);
+        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], [], false, false);
         $listener->preSetData($event);
 
         $this->assertFalse($this->form->has('0'));
@@ -72,7 +72,7 @@ class ResizeFormListenerTest extends TestCase
         $this->expectException(UnexpectedTypeException::class);
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->preSetData($event);
     }
 
@@ -80,7 +80,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $data = null;
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener(TextType::class, [], false, false);
+        $listener = new ResizeFormListener(TextType::class, [], [], false, false);
         $listener->preSetData($event);
 
         $this->assertSame(0, $this->form->count());
@@ -92,7 +92,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'string', 1 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], true, false);
+        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], [], true, false);
         $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));
@@ -106,7 +106,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));
@@ -120,7 +120,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('0'));
@@ -133,7 +133,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'string', 2 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));
@@ -145,7 +145,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('1'));
@@ -157,7 +157,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = null;
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('1'));
@@ -170,7 +170,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = '';
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('1'));
@@ -182,7 +182,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'first', 1 => 'second', 2 => 'third'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->onSubmit($event);
 
         $this->assertEquals([1 => 'second'], $event->getData());
@@ -194,7 +194,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'first', 1 => 'second', 2 => 'third'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->onSubmit($event);
 
         $this->assertEquals($data, $event->getData());
@@ -205,7 +205,7 @@ class ResizeFormListenerTest extends TestCase
         $this->expectException(UnexpectedTypeException::class);
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->onSubmit($event);
     }
 
@@ -215,7 +215,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = null;
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->onSubmit($event);
 
         $this->assertEquals([], $event->getData());
@@ -227,7 +227,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = new \ArrayObject([0 => 'first', 1 => 'second', 2 => 'third']);
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->onSubmit($event);
 
         $this->assertArrayNotHasKey(0, $event->getData());
@@ -240,7 +240,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = new ArrayCollection([0 => 'first', 1 => 'second', 2 => 'third']);
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->onSubmit($event);
 
         $this->assertArrayNotHasKey(0, $event->getData());
@@ -258,7 +258,7 @@ class ResizeFormListenerTest extends TestCase
             $this->form->get($child)->submit($dat);
         }
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true, true);
+        $listener = new ResizeFormListener('text', [], [], false, true, true);
         $listener->onSubmit($event);
 
         $this->assertEquals([0 => 'first'], $event->getData());
@@ -288,7 +288,7 @@ class ResizeFormListenerTest extends TestCase
         $callback = function ($data) {
             return null === $data['name'];
         };
-        $listener = new ResizeFormListener('text', [], false, true, $callback);
+        $listener = new ResizeFormListener('text', [], [], false, true, $callback);
         $listener->onSubmit($event);
 
         $this->assertEquals(['0' => ['name' => 'John']], $event->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -447,6 +447,29 @@ class CollectionTypeTest extends BaseTypeTestCase
         $this->assertSame('foo', $form->createView()->vars['prototype']->vars['help']);
     }
 
+    public function testPrototypeOptionsAppliedToNewFields()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, ['first'], [
+            'allow_add' => true,
+            'prototype' => true,
+            'entry_type' => TextTypeTest::TESTED_TYPE,
+            'entry_options' => [
+                'disabled' => true,
+            ],
+            'prototype_options' => [
+                'disabled' => false,
+            ],
+        ]);
+
+        $form->submit(['first_changed', 'second']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertSame('first', $form[0]->getData());
+        $this->assertSame('second', $form[1]->getData());
+        $this->assertSame(['first', 'second'], $form->getData());
+    }
+
     public function testEntriesBlockPrefixes()
     {
         $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
@@ -14,6 +14,86 @@ where:
  - `TOKEN` is your Telegram token
  - `CHAT_ID` is your Telegram chat id
 
+Adding Interactions to a Message
+--------------------------------
+
+With a Telegram message, you can use the `TelegramOptions` class to add
+[message options](https://core.telegram.org/bots/api).
+
+```php
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button\InlineKeyboardButton;
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\InlineKeyboardMarkup;
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('');
+
+// Create Telegram options
+$telegramOptions = (new TelegramOptions())
+    ->chatId('@symfonynotifierdev')
+    ->parseMode('MarkdownV2')
+    ->disableWebPagePreview(true)
+    ->disableNotification(true)
+    ->replyMarkup((new InlineKeyboardMarkup())
+        ->inlineKeyboard([
+            (new InlineKeyboardButton('Visit symfony.com'))
+                ->url('https://symfony.com/'),
+        ])
+    );
+
+// Add the custom options to the chat message and send the message
+$chatMessage->options($telegramOptions);
+
+$chatter->send($chatMessage);
+```
+
+Updating Messages
+-----------------
+
+The `TelegramOptions::edit()` method was introduced in Symfony 6.2.
+
+When working with interactive callback buttons, you can use the `TelegramOptions`
+to reference a previous message to edit.
+
+```php
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button\InlineKeyboardButton;
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\InlineKeyboardMarkup;
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('Are you really sure?');
+$telegramOptions = (new TelegramOptions())
+    ->chatId($chatId)
+    ->edit($messageId) // extracted from callback payload or SentMessage
+    ->replyMarkup((new InlineKeyboardMarkup())
+        ->inlineKeyboard([
+            (new InlineKeyboardButton('Absolutely'))->callbackData('yes'),
+        ])
+    );
+```
+
+Answering Callback Queries
+--------------------------
+
+The `TelegramOptions::answerCallbackQuery()` method was introduced in Symfony 6.3.
+
+When sending message with inline keyboard buttons with callback data, you can use
+`TelegramOptions` to [answer callback queries](https://core.telegram.org/bots/api#answercallbackquery).
+
+```php
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('Thank you!');
+$telegramOptions = (new TelegramOptions())
+    ->chatId($chatId)
+    ->answerCallbackQuery(
+        callbackQueryId: '12345', // extracted from callback
+        showAlert: true,
+        cacheTime: 1,
+    );
+```
+
 Resources
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49786
| License       | MIT

This pull request provides a fix for issue 49786. 

By passing the prototypeOptions to the ResizeFormListener from the CollectionType and applying it to new fields it makes the prototypeOptions function as intended. Otherwise the use case such as in this blog aren't possible: https://symfony.com/blog/new-in-symfony-6-1-customizable-collection-prototypes

I've updated the existing ResizeFormListener tests to handle the new signature and added a new test to the CollectionType which would fail without this fix and pass with the fix.
