### PR TITLE
[Form] CollectionType apply prototypeOptions to ResizeFormListener new fields

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -26,18 +26,20 @@ class ResizeFormListener implements EventSubscriberInterface
 {
     protected $type;
     protected $options;
+    protected $prototypeOptions;
     protected $allowAdd;
     protected $allowDelete;
 
     private \Closure|bool $deleteEmpty;
 
-    public function __construct(string $type, array $options = [], bool $allowAdd = false, bool $allowDelete = false, bool|callable $deleteEmpty = false)
+    public function __construct(string $type, array $options = [], bool $allowAdd = false, bool $allowDelete = false, bool|callable $deleteEmpty = false, array $prototypeOptions = null)
     {
         $this->type = $type;
         $this->allowAdd = $allowAdd;
         $this->allowDelete = $allowDelete;
         $this->options = $options;
         $this->deleteEmpty = \is_bool($deleteEmpty) ? $deleteEmpty : $deleteEmpty(...);
+        $this->prototypeOptions = $prototypeOptions ?? $options;
     }
 
     public static function getSubscribedEvents(): array
@@ -96,7 +98,7 @@ class ResizeFormListener implements EventSubscriberInterface
                 if (!$form->has($name)) {
                     $form->add($name, $this->type, array_replace([
                         'property_path' => '['.$name.']',
-                    ], $this->options));
+                    ], $this->prototypeOptions));
                 }
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -23,6 +23,7 @@ class CollectionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $prototypeOptions = null;
         if ($options['allow_add'] && $options['prototype']) {
             $prototypeOptions = array_replace([
                 'required' => $options['required'],
@@ -42,7 +43,8 @@ class CollectionType extends AbstractType
             $options['entry_options'],
             $options['allow_add'],
             $options['allow_delete'],
-            $options['delete_empty']
+            $options['delete_empty'],
+            $prototypeOptions
         );
 
         $builder->addEventSubscriber($resizeListener);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -447,6 +447,29 @@ class CollectionTypeTest extends BaseTypeTestCase
         $this->assertSame('foo', $form->createView()->vars['prototype']->vars['help']);
     }
 
+    public function testPrototypeOptionsAppliedToNewFields()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, ['first'], [
+            'allow_add' => true,
+            'prototype' => true,
+            'entry_type' => TextTypeTest::TESTED_TYPE,
+            'entry_options' => [
+                'disabled' => true,
+            ],
+            'prototype_options' => [
+                'disabled' => false,
+            ],
+        ]);
+
+        $form->submit(['first_changed', 'second']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertSame('first', $form[0]->getData());
+        $this->assertSame('second', $form[1]->getData());
+        $this->assertSame(['first', 'second'], $form->getData());
+    }
+
     public function testEntriesBlockPrefixes()
     {
         $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [


### PR DESCRIPTION
Fixes issue 49786

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #49786
| License       | MIT

This pull request provides a fix for issue 49786.

By passing the prototypeOptions to the ResizeFormListener from the CollectionType and applying it to new fields it makes the prototypeOptions function as intended. Otherwise the use case such as in this blog aren't possible: https://symfony.com/blog/new-in-symfony-6-1-customizable-collection-prototypes

I've updated the existing ResizeFormListener tests to handle the new signature and added a new test to the CollectionType which would fail without this fix and pass with the fix.