### PR TITLE
[DependencyInjection] Add support for `#[Autowire(lazy: class-string)]`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
@@ -25,6 +25,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
 class Autowire
 {
     public readonly string|array|Expression|Reference|ArgumentInterface|null $value;
+    public readonly bool|array $lazy;
 
     /**
      * Use only ONE of the following.
@@ -34,6 +35,7 @@ class Autowire
      * @param string|null                         $expression Expression (ie 'service("some.service").someMethod()')
      * @param string|null                         $env        Environment variable name (ie 'SOME_ENV_VARIABLE')
      * @param string|null                         $param      Parameter name (ie 'some.parameter.name')
+     * @param bool|class-string|class-string[]    $lazy       Whether to use lazy-loading for this argument
      */
     public function __construct(
         string|array|ArgumentInterface $value = null,
@@ -41,9 +43,9 @@ class Autowire
         string $expression = null,
         string $env = null,
         string $param = null,
-        public bool $lazy = false,
+        bool|string|array $lazy = false,
     ) {
-        if ($lazy) {
+        if ($this->lazy = \is_string($lazy) ? [$lazy] : $lazy) {
             if (null !== ($expression ?? $env ?? $param)) {
                 throw new LogicException('#[Autowire] attribute cannot be $lazy and use $expression, $env, or $param.');
             }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -17,7 +17,7 @@ CHANGELOG
  * Add `#[Exclude]` to skip autoregistering a class
  * Add support for generating lazy closures
  * Add support for autowiring services as closures using `#[AutowireCallable]` or `#[AutowireServiceClosure]`
- * Add support for `#[Autowire(lazy: true)]`
+ * Add support for `#[Autowire(lazy: true|class-string)]`
  * Deprecate `#[MapDecorated]`, use `#[AutowireDecorated]` instead
  * Deprecate the `@required` annotation, use the `Symfony\Contracts\Service\Attribute\Required` attribute instead
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -295,12 +295,33 @@ class AutowirePass extends AbstractRecursivePass
                             ->setFactory(['Closure', 'fromCallable'])
                             ->setArguments([$value + [1 => '__invoke']])
                             ->setLazy($attribute->lazy);
-                    } elseif ($attribute->lazy && ($value instanceof Reference ? !$this->container->has($value) || !$this->container->findDefinition($value)->isLazy() : null === $attribute->value && $type)) {
-                        $this->container->register('.lazy.'.$value ??= $getValue(), $type)
+                    } elseif ($lazy = $attribute->lazy) {
+                        $definition = (new Definition($type))
                             ->setFactory('current')
-                            ->setArguments([[$value]])
+                            ->setArguments([[$value ??= $getValue()]])
                             ->setLazy(true);
-                        $value = new Reference('.lazy.'.$value);
+
+                        if (!\is_array($lazy)) {
+                            if (str_contains($type, '|')) {
+                                throw new AutowiringFailedException($this->currentId, sprintf('Cannot use #[Autowire] with option "lazy: true" on union types for service "%s"; set the option to the interface(s) that should be proxied instead.', $this->currentId));
+                            }
+                            $lazy = str_contains($type, '&') ? explode('&', $type) : [];
+                        }
+
+                        if ($lazy) {
+                            if (!class_exists($type) && !interface_exists($type, false)) {
+                                $definition->setClass('object');
+                            }
+                            foreach ($lazy as $v) {
+                                $definition->addTag('proxy', ['interface' => $v]);
+                            }
+                        }
+
+                        if ($definition->getClass() !== (string) $value || $definition->getTag('proxy')) {
+                            $value .= '.'.$this->container->hash([$definition->getClass(), $definition->getTag('proxy')]);
+                        }
+                        $this->container->setDefinition($value = '.lazy.'.$value, $definition);
+                        $value = new Reference($value);
                     }
                     $arguments[$index] = $value;
 

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/LazyServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/LazyServiceInstantiator.php
@@ -29,7 +29,7 @@ final class LazyServiceInstantiator implements InstantiatorInterface
             throw new InvalidArgumentException(sprintf('Cannot instantiate lazy proxy for service "%s".', $id));
         }
 
-        if (!class_exists($proxyClass = $dumper->getProxyClass($definition, $asGhostObject, $class), false)) {
+        if (!class_exists($proxyClass = $dumper->getProxyClass($definition, $asGhostObject), false)) {
             eval($dumper->getProxyCode($definition, $id));
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Service\Attribute\Required;
 
 require __DIR__.'/uniontype_classes.php';
@@ -524,5 +525,14 @@ final class ElsaAction
 {
     public function __construct(NotExisting $notExisting)
     {
+    }
+}
+
+class AAndIInterfaceConsumer
+{
+    public function __construct(
+        #[Autowire(service: 'foo', lazy: true)]
+        AInterface&IInterface $logger,
+    ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute.php
@@ -82,14 +82,14 @@ class Symfony_DI_PhpDumper_Test_Lazy_Autowire_Attribute extends Container
         $containerRef = $container->ref;
 
         if (true === $lazyLoad) {
-            return $container->privates['.lazy.Symfony\\Component\\DependencyInjection\\Tests\\Compiler\\Foo'] = $container->createProxy('FooProxy9f41ec7', static fn () => \FooProxy9f41ec7::createLazyProxy(static fn () => self::getFoo2Service($containerRef->get(), false)));
+            return $container->privates['.lazy.Symfony\\Component\\DependencyInjection\\Tests\\Compiler\\Foo'] = $container->createProxy('FooProxy4048957', static fn () => \FooProxy4048957::createLazyProxy(static fn () => self::getFoo2Service($containerRef->get(), false)));
         }
 
         return ($container->services['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo());
     }
 }
 
-class FooProxy9f41ec7 extends \Symfony\Component\DependencyInjection\Tests\Compiler\Foo implements \Symfony\Component\VarExporter\LazyObjectInterface
+class FooProxy4048957 extends \Symfony\Component\DependencyInjection\Tests\Compiler\Foo implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute_with_intersection.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute_with_intersection.php
@@ -22,7 +22,7 @@ class ProjectServiceContainer extends Container
         $this->ref = \WeakReference::create($this);
         $this->services = $this->privates = [];
         $this->methodMap = [
-            'bar' => 'getBarService',
+            'foo' => 'getFooService',
         ];
 
         $this->aliases = [];
@@ -41,7 +41,7 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            'foo' => true,
+            '.lazy.foo.gDmfket' => true,
         ];
     }
 
@@ -51,39 +51,52 @@ class ProjectServiceContainer extends Container
     }
 
     /**
-     * Gets the public 'bar' shared service.
+     * Gets the public 'foo' shared autowired service.
      *
-     * @return \stdClass
+     * @return \Symfony\Component\DependencyInjection\Tests\Compiler\AAndIInterfaceConsumer
      */
-    protected static function getBarService($container)
+    protected static function getFooService($container)
     {
-        return $container->services['bar'] = new \stdClass((isset($container->factories['service_container']['foo']) ? $container->factories['service_container']['foo']($container) : self::getFooService($container)));
+        $a = ($container->privates['.lazy.foo.gDmfket'] ?? self::get_Lazy_Foo_GDmfketService($container));
+
+        if (isset($container->services['foo'])) {
+            return $container->services['foo'];
+        }
+
+        return $container->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Compiler\AAndIInterfaceConsumer($a);
     }
 
     /**
-     * Gets the private 'foo' service.
+     * Gets the private '.lazy.foo.gDmfket' shared service.
      *
-     * @return \stdClass
+     * @return \object
      */
-    protected static function getFooService($container, $lazyLoad = true)
+    protected static function get_Lazy_Foo_GDmfketService($container, $lazyLoad = true)
     {
         $containerRef = $container->ref;
 
-        $container->factories['service_container']['foo'] ??= self::getFooService(...);
-
         if (true === $lazyLoad) {
-            return $container->createProxy('stdClassGhost2fc7938', static fn () => \stdClassGhost2fc7938::createLazyGhost(static fn ($proxy) => self::getFooService($containerRef->get(), $proxy)));
+            return $container->privates['.lazy.foo.gDmfket'] = $container->createProxy('objectProxy8ac8e9a', static fn () => \objectProxy8ac8e9a::createLazyProxy(static fn () => self::get_Lazy_Foo_GDmfketService($containerRef->get(), false)));
         }
 
-        return $lazyLoad;
+        return ($container->services['foo'] ?? self::getFooService($container));
     }
 }
 
-class stdClassGhost2fc7938 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class objectProxy8ac8e9a implements \Symfony\Component\DependencyInjection\Tests\Compiler\AInterface, \Symfony\Component\DependencyInjection\Tests\Compiler\IInterface, \Symfony\Component\VarExporter\LazyObjectInterface
 {
-    use \Symfony\Component\VarExporter\LazyGhostTrait;
+    use \Symfony\Component\VarExporter\LazyProxyTrait;
 
     private const LAZY_OBJECT_PROPERTY_SCOPES = [];
+
+    public function initializeLazyObject(): \Symfony\Component\DependencyInjection\Tests\Compiler\AInterface&\Symfony\Component\DependencyInjection\Tests\Compiler\IInterface
+    {
+        if ($state = $this->lazyObjectState ?? null) {
+            return $state->realInstance ??= ($state->initializer)();
+        }
+
+        return $this;
+    }
 }
 
 // Help opcache.preload discover always-needed symbols

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -6,11 +6,11 @@ namespace Container%s;
 
 include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
-class FooClassGhost2b16075 extends \Bar\FooClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class FooClassGhostEe53b95 extends \Bar\FooClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 %A
 
-if (!\class_exists('FooClassGhost2b16075', false)) {
-    \class_alias(__NAMESPACE__.'\\FooClassGhost2b16075', 'FooClassGhost2b16075', false);
+if (!\class_exists('FooClassGhostEe53b95', false)) {
+    \class_alias(__NAMESPACE__.'\\FooClassGhostEe53b95', 'FooClassGhostEe53b95', false);
 }
 
     [Container%s/ProjectServiceContainer.php] => <?php
@@ -78,7 +78,7 @@ class ProjectServiceContainer extends Container
         $containerRef = $container->ref;
 
         if (true === $lazyLoad) {
-            return $container->services['lazy_foo'] = $container->createProxy('FooClassGhost2b16075', static fn () => \FooClassGhost2b16075::createLazyGhost(static fn ($proxy) => self::getLazyFooService($containerRef->get(), $proxy)));
+            return $container->services['lazy_foo'] = $container->createProxy('FooClassGhostEe53b95', static fn () => \FooClassGhostEe53b95::createLazyGhost(static fn ($proxy) => self::getLazyFooService($containerRef->get(), $proxy)));
         }
 
         include_once $container->targetDir.''.'/Fixtures/includes/foo_lazy.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
@@ -56,7 +56,7 @@ class ProjectServiceContainer extends Container
         $containerRef = $container->ref;
 
         if (true === $lazyLoad) {
-            return $container->services['bar'] = $container->createProxy('stdClassGhost5a8a5eb', static fn () => \stdClassGhost5a8a5eb::createLazyGhost(static fn ($proxy) => self::getBarService($containerRef->get(), $proxy)));
+            return $container->services['bar'] = $container->createProxy('stdClassGhost2fc7938', static fn () => \stdClassGhost2fc7938::createLazyGhost(static fn ($proxy) => self::getBarService($containerRef->get(), $proxy)));
         }
 
         return $lazyLoad;
@@ -72,7 +72,7 @@ class ProjectServiceContainer extends Container
         $containerRef = $container->ref;
 
         if (true === $lazyLoad) {
-            return $container->services['baz'] = $container->createProxy('stdClassProxy5a8a5eb', static fn () => \stdClassProxy5a8a5eb::createLazyProxy(static fn () => self::getBazService($containerRef->get(), false)));
+            return $container->services['baz'] = $container->createProxy('stdClassProxy2fc7938', static fn () => \stdClassProxy2fc7938::createLazyProxy(static fn () => self::getBazService($containerRef->get(), false)));
         }
 
         return \foo_bar();
@@ -88,7 +88,7 @@ class ProjectServiceContainer extends Container
         $containerRef = $container->ref;
 
         if (true === $lazyLoad) {
-            return $container->services['buz'] = $container->createProxy('stdClassProxy5a8a5eb', static fn () => \stdClassProxy5a8a5eb::createLazyProxy(static fn () => self::getBuzService($containerRef->get(), false)));
+            return $container->services['buz'] = $container->createProxy('stdClassProxy2fc7938', static fn () => \stdClassProxy2fc7938::createLazyProxy(static fn () => self::getBuzService($containerRef->get(), false)));
         }
 
         return \foo_bar();
@@ -104,14 +104,14 @@ class ProjectServiceContainer extends Container
         $containerRef = $container->ref;
 
         if (true === $lazyLoad) {
-            return $container->services['foo'] = $container->createProxy('stdClassGhost5a8a5eb', static fn () => \stdClassGhost5a8a5eb::createLazyGhost(static fn ($proxy) => self::getFooService($containerRef->get(), $proxy)));
+            return $container->services['foo'] = $container->createProxy('stdClassGhost2fc7938', static fn () => \stdClassGhost2fc7938::createLazyGhost(static fn ($proxy) => self::getFooService($containerRef->get(), $proxy)));
         }
 
         return $lazyLoad;
     }
 }
 
-class stdClassGhost5a8a5eb extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class stdClassGhost2fc7938 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyGhostTrait;
 
@@ -123,7 +123,7 @@ class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
 class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
 class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
 
-class stdClassProxy5a8a5eb extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class stdClassProxy2fc7938 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
@@ -24,7 +24,7 @@ class getNonSharedFooService extends ProjectServiceContainer
         $container->factories['non_shared_foo'] ??= self::do(...);
 
         if (true === $lazyLoad) {
-            return $container->createProxy('FooLazyClassGhostF814e3a', static fn () => \FooLazyClassGhostF814e3a::createLazyGhost(static fn ($proxy) => self::do($containerRef->get(), $proxy)));
+            return $container->createProxy('FooLazyClassGhost0fc418d', static fn () => \FooLazyClassGhost0fc418d::createLazyGhost(static fn ($proxy) => self::do($containerRef->get(), $proxy)));
         }
 
         static $include = true;
@@ -39,11 +39,11 @@ class getNonSharedFooService extends ProjectServiceContainer
     }
 }
 
-    [Container%s/FooLazyClassGhostF814e3a.php] => <?php
+    [Container%s/FooLazyClassGhost0fc418d.php] => <?php
 
 namespace Container%s;
 
-class FooLazyClassGhostF814e3a extends \Bar\FooLazyClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+class FooLazyClassGhost0fc418d extends \Bar\FooLazyClass implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyGhostTrait;
 
@@ -55,8 +55,8 @@ class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
 class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
 class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
 
-if (!\class_exists('FooLazyClassGhostF814e3a', false)) {
-    \class_alias(__NAMESPACE__.'\\FooLazyClassGhostF814e3a', 'FooLazyClassGhostF814e3a', false);
+if (!\class_exists('FooLazyClassGhost0fc418d', false)) {
+    \class_alias(__NAMESPACE__.'\\FooLazyClassGhost0fc418d', 'FooLazyClassGhost0fc418d', false);
 }
 
     [Container%s/ProjectServiceContainer.php] => <?php
@@ -141,7 +141,7 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
-require __DIR__.'/Container%s/FooLazyClassGhostF814e3a.php';
+require __DIR__.'/Container%s/FooLazyClassGhost0fc418d.php';
 require __DIR__.'/Container%s/getNonSharedFooService.php';
 
 $classes = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
@@ -60,7 +60,7 @@ class Symfony_DI_PhpDumper_Service_Wither_Lazy extends Container
         $containerRef = $container->ref;
 
         if (true === $lazyLoad) {
-            return $container->services['wither'] = $container->createProxy('WitherProxy94fa281', static fn () => \WitherProxy94fa281::createLazyProxy(static fn () => self::getWitherService($containerRef->get(), false)));
+            return $container->services['wither'] = $container->createProxy('WitherProxy580fe0f', static fn () => \WitherProxy580fe0f::createLazyProxy(static fn () => self::getWitherService($containerRef->get(), false)));
         }
 
         $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\Wither();
@@ -75,7 +75,7 @@ class Symfony_DI_PhpDumper_Service_Wither_Lazy extends Container
     }
 }
 
-class WitherProxy94fa281 extends \Symfony\Component\DependencyInjection\Tests\Compiler\Wither implements \Symfony\Component\VarExporter\LazyObjectInterface
+class WitherProxy580fe0f extends \Symfony\Component\DependencyInjection\Tests\Compiler\Wither implements \Symfony\Component\VarExporter\LazyObjectInterface
 {
     use \Symfony\Component\VarExporter\LazyProxyTrait;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR finishes what started in #49685.

It adds support for defining the interfaces to proxy when using laziness with the Autowire attribute.

```php
    public function __construct(
        #[Autowire(service: 'foo', lazy: FooInterface::class)]
        FooInterface|BarInterface $foo,
    ) {
    }
```

It also adds support for lazy-autowiring of intersection types:

```php
    public function __construct(
        #[Autowire(service: 'foobar', lazy: true)]
        FooInterface&BarInterface $foobar,
    ) {
    }
```