### PR TITLE
[Scheduler] add `RecurringMessage::getId()` and prevent duplicates

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/MessageContext.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageContext.php
@@ -22,6 +22,7 @@ final class MessageContext
 {
     public function __construct(
         public readonly string $name,
+        public readonly string $id,
         public readonly TriggerInterface $trigger,
         public readonly \DateTimeImmutable $triggeredAt,
         public readonly ?\DateTimeImmutable $nextTriggerAt = null,

--- a/src/Symfony/Component/Scheduler/Generator/TriggerHeap.php
+++ b/src/Symfony/Component/Scheduler/Generator/TriggerHeap.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\Component\Scheduler\Generator;
 
-use Symfony\Component\Scheduler\Trigger\TriggerInterface;
+use Symfony\Component\Scheduler\RecurringMessage;
 
 /**
  * @internal
  *
- * @extends \SplHeap<array{\DateTimeImmutable, int, TriggerInterface, object}>
+ * @extends \SplHeap<array{\DateTimeImmutable, int, RecurringMessage}>
  *
  * @experimental
  */
@@ -28,8 +28,8 @@ final class TriggerHeap extends \SplHeap
     }
 
     /**
-     * @param array{\DateTimeImmutable, int, TriggerInterface, object} $value1
-     * @param array{\DateTimeImmutable, int, TriggerInterface, object} $value2
+     * @param array{\DateTimeImmutable, int, RecurringMessage} $value1
+     * @param array{\DateTimeImmutable, int, RecurringMessage} $value2
      */
     protected function compare(mixed $value1, mixed $value2): int
     {

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
@@ -34,16 +34,17 @@ class SchedulerTransportTest extends TestCase
         $generator->method('getMessages')->willReturnCallback(function () use ($messages): \Generator {
             $trigger = $this->createMock(TriggerInterface::class);
             $triggerAt = new \DateTimeImmutable('2020-02-20T02:00:00', new \DateTimeZone('UTC'));
-            yield (new MessageContext('default', $trigger, $triggerAt)) => $messages[0];
-            yield (new MessageContext('default', $trigger, $triggerAt)) => $messages[1];
+            yield (new MessageContext('default', 'id1', $trigger, $triggerAt)) => $messages[0];
+            yield (new MessageContext('default', 'id2', $trigger, $triggerAt)) => $messages[1];
         });
         $transport = new SchedulerTransport($generator);
 
-        foreach ($transport->get() as $envelope) {
+        foreach ($transport->get() as $i => $envelope) {
             $this->assertInstanceOf(Envelope::class, $envelope);
             $this->assertNotNull($stamp = $envelope->last(ScheduledStamp::class));
             $this->assertSame(array_shift($messages), $envelope->getMessage());
             $this->assertSame('default', $stamp->messageContext->name);
+            $this->assertSame('id'.$i + 1, $stamp->messageContext->id);
         }
 
         $this->assertEmpty($messages);

--- a/src/Symfony/Component/Scheduler/Tests/RecurringMessageTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/RecurringMessageTest.php
@@ -42,4 +42,13 @@ class RecurringMessageTest extends TestCase
 
         RecurringMessage::cron('#midnight', new \stdClass());
     }
+
+    public function testUniqueId()
+    {
+        $message1 = RecurringMessage::cron('* * * * *', new \stdClass());
+        $message2 = RecurringMessage::cron('* 5 * * *', new \stdClass());
+
+        $this->assertSame($message1->getId(), (clone $message1)->getId());
+        $this->assertNotSame($message1->getId(), $message2->getId());
+    }
 }

--- a/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Scheduler\Exception\LogicException;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Schedule;
+
+class ScheduleTest extends TestCase
+{
+    public function testCannotAddDuplicateMessage()
+    {
+        $schedule = new Schedule();
+        $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()));
+
+        $this->expectException(LogicException::class);
+
+        $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This could allow running specific scheduled tasks manually (via CLI or GUI).
