### PR TITLE
[BrowserKit] Improve the error message when `submitForm()` can't find the form

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -333,6 +333,11 @@ abstract class AbstractBrowser
         }
 
         $buttonNode = $this->crawler->selectButton($button);
+
+        if (0 === $buttonNode->count()) {
+            throw new \InvalidArgumentException(sprintf('There is no button with "%s" as its content, id, value or name.', $button));
+        }
+
         $form = $buttonNode->form($fieldValues, $method);
 
         return $this->submit($form, [], $serverParameters);

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -350,15 +350,14 @@ class AbstractBrowserTest extends TestCase
         $client->setNextResponse(new Response('<html><form action="/foo"><input type="submit" /></form></html>'));
         $client->request('GET', 'http://www.example.com/foo/foobar');
 
-        try {
-            $client->submitForm('Register', [
-                'username' => 'username',
-                'password' => 'password',
-            ], 'POST');
-            $this->fail('->submitForm() throws a \InvalidArgumentException if the form could not be found');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf(\InvalidArgumentException::class, $e, '->submitForm() throws a \InvalidArgumentException if the form could not be found');
-        }
+        $this->expectExceptionObject(
+            new \InvalidArgumentException('There is no button with "Register" as its content, id, value or name.')
+        );
+
+        $client->submitForm('Register', [
+            'username' => 'username',
+            'password' => 'password',
+        ], 'POST');
     }
 
     public function testSubmitPreserveAuth()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #49826 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When form is not found, error message is now `The form doesn't contain any button with "Save changes" as its content, id, value or name.` instead of `The current node list is empty.`
