### PR TITLE
[FrameworkBundle] Fix services usages output for text descriptor

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -361,7 +361,7 @@ class TextDescriptor extends Descriptor
         }
 
         $inEdges = null !== $builder && isset($options['id']) ? $this->getServiceEdges($builder, $options['id']) : [];
-        $tableRows[] = ['Usages', $inEdges ? implode(', ', $inEdges) : 'none'];
+        $tableRows[] = ['Usages', $inEdges ? implode(\PHP_EOL, $inEdges) : 'none'];
 
         $options['output']->table($tableHeaders, $tableRows);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

If service is being used by lots of other services, the debug container command becomes unreadable, because `Usages` expands table. Replacing `, ` separator with new line fixes this issue
