### PR TITLE
[VarDumper] Add a caster for the FlattenException

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\VarDumper\Caster;
 
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\ErrorHandler\Exception\SilencedErrorContext;
 use Symfony\Component\VarDumper\Cloner\Stub;
 use Symfony\Component\VarDumper\Exception\ThrowingCasterException;
@@ -283,6 +284,16 @@ class ExceptionCaster
         }
         if ($frame->keepArgs && !empty($f['args'])) {
             $a[$prefix.'arguments'] = new ArgsStub($f['args'], $f['function'], $f['class']);
+        }
+
+        return $a;
+    }
+
+    public static function castFlattenException(FlattenException $e, array $a, Stub $stub, bool $isNested)
+    {
+        if ($isNested) {
+            $k = sprintf(Caster::PATTERN_PRIVATE, FlattenException::class, 'traceAsString');
+            $a[$k] = new CutStub($a[$k]);
         }
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -95,6 +95,7 @@ abstract class AbstractCloner implements ClonerInterface
         'Symfony\Component\VarDumper\Caster\TraceStub' => ['Symfony\Component\VarDumper\Caster\ExceptionCaster', 'castTraceStub'],
         'Symfony\Component\VarDumper\Caster\FrameStub' => ['Symfony\Component\VarDumper\Caster\ExceptionCaster', 'castFrameStub'],
         'Symfony\Component\VarDumper\Cloner\AbstractCloner' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'cutInternals'],
+        'Symfony\Component\ErrorHandler\Exception\FlattenException' => ['Symfony\Component\VarDumper\Caster\ExceptionCaster', 'castFlattenException'],
         'Symfony\Component\ErrorHandler\Exception\SilencedErrorContext' => ['Symfony\Component\VarDumper\Caster\ExceptionCaster', 'castSilencedErrorContext'],
 
         'Imagine\Image\ImageInterface' => ['Symfony\Component\VarDumper\Caster\ImagineCaster', 'castImage'],

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Tests\Caster;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\ErrorHandler\Exception\SilencedErrorContext;
 use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Caster\ExceptionCaster;
@@ -353,5 +354,34 @@ Exception {
 EODUMP;
 
         $this->assertDumpMatchesFormat($expectedDump, $e, Caster::EXCLUDE_VERBOSE);
+    }
+
+    /**
+     * @requires function \Symfony\Component\ErrorHandler\Exception\FlattenException::create
+     */
+    public function testFlattenException()
+    {
+        $f = FlattenException::createFromThrowable(new \Exception('Hello'));
+
+        $expectedDump = <<<'EODUMP'
+array:1 [
+  0 => Symfony\Component\ErrorHandler\Exception\FlattenException {
+    -message: "Hello"
+    -code: 0
+    -previous: null
+    -trace: array:13 %a
+    -traceAsString: ""…%d
+    -class: "Exception"
+    -statusCode: 500
+    -statusText: "Internal Server Error"
+    -headers: []
+    -file: "%s/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php"
+    -line: %d
+    -asString: null
+  }
+]
+EODUMP;
+
+        $this->assertDumpMatchesFormat($expectedDump, [$f], Caster::EXCLUDE_VERBOSE);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

The information is duplicated, and when debuging messenger errors, the output is way too verbose.
This PR enchance the situation.
