### PR TITLE
[Validator] Remove `bjeavons/zxcvbn-php` in favor of a builtin solution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -152,8 +152,7 @@
         "symfony/security-acl": "~2.8|~3.0",
         "twig/cssinliner-extra": "^2.12|^3",
         "twig/inky-extra": "^2.12|^3",
-        "twig/markdown-extra": "^2.12|^3",
-        "bjeavons/zxcvbn-php": "^1.0"
+        "twig/markdown-extra": "^2.12|^3"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
  * Add `Uuid::TIME_BASED_VERSIONS` to match that a UUID being validated embeds a timestamp
  * Add the `pattern` parameter in violations of the `Regex` constraint
  * Add a `NoSuspiciousCharacters` constraint to validate a string is not a spoofing attempt
- * Add a `PasswordStrength` constraint to check the strength of a password (requires `bjeavons/zxcvbn-php` library)
+ * Add a `PasswordStrength` constraint to check the strength of a password
  * Add the `countUnit` option to the `Length` constraint to allow counting the string length either by code points (like before, now the default setting `Length::COUNT_CODEPOINTS`), bytes (`Length::COUNT_BYTES`) or graphemes (`Length::COUNT_GRAPHEMES`)
  * Add the `filenameMaxLength` option to the `File` constraint
  * Add the `exclude` option to the `Cascade` constraint

--- a/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrength.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
-use Symfony\Component\Validator\Exception\LogicException;
-use ZxcvbnPhp\Zxcvbn;
 
 /**
  * @Annotation
@@ -26,42 +24,28 @@ use ZxcvbnPhp\Zxcvbn;
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class PasswordStrength extends Constraint
 {
+    public const STRENGTH_VERY_WEAK = 0;
+    public const STRENGTH_WEAK = 1;
+    public const STRENGTH_REASONABLE = 2;
+    public const STRENGTH_STRONG = 3;
+    public const STRENGTH_VERY_STRONG = 4;
+
     public const PASSWORD_STRENGTH_ERROR = '4234df00-45dd-49a4-b303-a75dbf8b10d8';
-    public const RESTRICTED_USER_INPUT_ERROR = 'd187ff45-bf23-4331-aa87-c24a36e9b400';
 
     protected const ERROR_NAMES = [
         self::PASSWORD_STRENGTH_ERROR => 'PASSWORD_STRENGTH_ERROR',
-        self::RESTRICTED_USER_INPUT_ERROR => 'RESTRICTED_USER_INPUT_ERROR',
     ];
 
-    public string $lowStrengthMessage = 'The password strength is too low. Please use a stronger password.';
+    public string $message = 'The password strength is too low. Please use a stronger password.';
 
-    public int $minScore = 2;
+    public int $minScore;
 
-    public string $restrictedDataMessage = 'The password contains the following restricted data: {{ wordList }}.';
-
-    /**
-     * @var array<string>
-     */
-    public array $restrictedData = [];
-
-    public function __construct(mixed $options = null, array $groups = null, mixed $payload = null)
+    public function __construct(int $minScore = self::STRENGTH_REASONABLE, mixed $options = null, array $groups = null, mixed $payload = null)
     {
-        if (!class_exists(Zxcvbn::class)) {
-            throw new LogicException(sprintf('The "%s" class requires the "bjeavons/zxcvbn-php" library. Try running "composer require bjeavons/zxcvbn-php".', self::class));
-        }
-
-        if (isset($options['minScore']) && (!\is_int($options['minScore']) || $options['minScore'] < 1 || $options['minScore'] > 4)) {
+        if (isset($minScore) && (!\is_int($minScore) || $minScore < 1 || $minScore > 4)) {
             throw new ConstraintDefinitionException(sprintf('The parameter "minScore" of the "%s" constraint must be an integer between 1 and 4.', static::class));
         }
-
-        if (isset($options['restrictedData'])) {
-            array_walk($options['restrictedData'], static function (mixed $value): void {
-                if (!\is_string($value)) {
-                    throw new ConstraintDefinitionException(sprintf('The parameter "restrictedData" of the "%s" constraint must be a list of strings.', static::class));
-                }
-            });
-        }
+        $options['minScore'] = $minScore;
         parent::__construct($options, $groups, $payload);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthTest.php
@@ -20,39 +20,27 @@ class PasswordStrengthTest extends TestCase
     public function testConstructor()
     {
         $constraint = new PasswordStrength();
-        $this->assertEquals(2, $constraint->minScore);
-        $this->assertEquals([], $constraint->restrictedData);
+        $this->assertSame(2, $constraint->minScore);
     }
 
     public function testConstructorWithParameters()
     {
-        $constraint = new PasswordStrength([
-            'minScore' => 3,
-            'restrictedData' => ['foo', 'bar'],
-        ]);
+        $constraint = new PasswordStrength(minScore: PasswordStrength::STRENGTH_STRONG);
 
-        $this->assertEquals(3, $constraint->minScore);
-        $this->assertEquals(['foo', 'bar'], $constraint->restrictedData);
+        $this->assertSame(PasswordStrength::STRENGTH_STRONG, $constraint->minScore);
     }
 
     public function testInvalidScoreOfZero()
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('The parameter "minScore" of the "Symfony\Component\Validator\Constraints\PasswordStrength" constraint must be an integer between 1 and 4.');
-        new PasswordStrength(['minScore' => 0]);
+        new PasswordStrength(minScore: PasswordStrength::STRENGTH_VERY_WEAK);
     }
 
     public function testInvalidScoreOfFive()
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('The parameter "minScore" of the "Symfony\Component\Validator\Constraints\PasswordStrength" constraint must be an integer between 1 and 4.');
-        new PasswordStrength(['minScore' => 5]);
-    }
-
-    public function testInvalidRestrictedData()
-    {
-        $this->expectException(ConstraintDefinitionException::class);
-        $this->expectExceptionMessage('The parameter "restrictedData" of the "Symfony\Component\Validator\Constraints\PasswordStrength" constraint must be a list of strings.');
-        new PasswordStrength(['restrictedData' => [123]]);
+        new PasswordStrength(minScore: 5);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
@@ -25,16 +25,19 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getValidValues
      */
-    public function testValidValues(string $value)
+    public function testValidValues(string $value, int $expectedStrength)
     {
-        $this->validator->validate($value, new PasswordStrength());
+        $this->validator->validate($value, new PasswordStrength(minScore: $expectedStrength));
 
         $this->assertNoViolation();
     }
 
     public static function getValidValues(): iterable
     {
-        yield ['This 1s a very g00d Pa55word! ;-)'];
+        yield ['How-is this 🤔?!', PasswordStrength::STRENGTH_WEAK];
+        yield ['Reasonable-pwd-❤️', PasswordStrength::STRENGTH_REASONABLE];
+        yield ['This 1s a very g00d Pa55word! ;-)', PasswordStrength::STRENGTH_VERY_STRONG];
+        yield ['pudding-smack-👌🏼-fox-😎', PasswordStrength::STRENGTH_VERY_STRONG];
     }
 
     /**
@@ -59,23 +62,10 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
             PasswordStrength::PASSWORD_STRENGTH_ERROR,
         ];
         yield [
-            new PasswordStrength([
-                'minScore' => 4,
-            ]),
+            new PasswordStrength(minScore: PasswordStrength::STRENGTH_VERY_STRONG),
             'Good password?',
             'The password strength is too low. Please use a stronger password.',
             PasswordStrength::PASSWORD_STRENGTH_ERROR,
-        ];
-        yield [
-            new PasswordStrength([
-                'restrictedData' => ['symfony'],
-            ]),
-            'SyMfONY-framework-john',
-            'The password contains the following restricted data: {{ wordList }}.',
-            PasswordStrength::RESTRICTED_USER_INPUT_ERROR,
-            [
-                '{{ wordList }}' => 'SyMfONY',
-            ],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -40,8 +40,7 @@
         "symfony/property-info": "^5.4|^6.0",
         "symfony/translation": "^5.4|^6.0",
         "doctrine/annotations": "^1.13|^2",
-        "egulias/email-validator": "^2.1.10|^3|^4",
-        "bjeavons/zxcvbn-php": "^1.0"
+        "egulias/email-validator": "^2.1.10|^3|^4"
     },
     "conflict": {
         "doctrine/annotations": "<1.13",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #49831
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18124 will be updated


As per the discussion in #49831, this PR aims at removing `bjeavons/zxcvbn-php` in favor of a builtin solution.
The password strength estimator is a PHP implementation of [deanilvincent/check-password-strength](https://github.com/deanilvincent/check-password-strength/blob/master/index.js), but can be changed at will.