### PR TITLE
[Cache] Fix php7 compat on 5.4: null coalescing assignment operator

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -339,7 +339,7 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
      */
     protected function getId($key)
     {
-        if ('pgsql' !== $this->platformName ??= $this->getPlatformName()) {
+        if ('pgsql' !== $this->getPlatformName()) {
             return parent::getId($key);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Not needed


It looks like #49848 accidentally introduced a syntax not compat with php 7.2/7.3. So, an annoying little PR to fix that.