### PR TITLE
[Scheduler] add schedule name to `ScheduledStamp`

### DIFF
--- a/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
+++ b/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
@@ -18,4 +18,7 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
  */
 final class ScheduledStamp implements NonSendableStampInterface
 {
+    public function __construct(public readonly string $scheduleName)
+    {
+    }
 }

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -23,13 +23,14 @@ class SchedulerTransport implements TransportInterface
 {
     public function __construct(
         private readonly MessageGeneratorInterface $messageGenerator,
+        private readonly string $name,
     ) {
     }
 
     public function get(): iterable
     {
         foreach ($this->messageGenerator->getMessages() as $message) {
-            yield Envelope::wrap($message, [new ScheduledStamp()]);
+            yield Envelope::wrap($message, [new ScheduledStamp($this->name)]);
         }
     }
 

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransportFactory.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransportFactory.php
@@ -48,7 +48,7 @@ class SchedulerTransportFactory implements TransportFactoryInterface
         $schedule = $this->scheduleProviders->get($scheduleName)->getSchedule();
         $checkpoint = new Checkpoint('scheduler_checkpoint_'.$scheduleName, $schedule->getLock(), $schedule->getState());
 
-        return new SchedulerTransport(new MessageGenerator($schedule, $checkpoint, $this->clock));
+        return new SchedulerTransport(new MessageGenerator($schedule, $checkpoint, $this->clock), $scheduleName);
     }
 
     public function supports(string $dsn, array $options): bool

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportFactoryTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportFactoryTest.php
@@ -36,8 +36,8 @@ class SchedulerTransportFactoryTest extends TestCase
         $defaultRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'default']);
         $customRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'custom']);
 
-        $default = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$defaultRecurringMessage]))->getSchedule(), 'default', $clock));
-        $custom = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$customRecurringMessage]))->getSchedule(), 'custom', $clock));
+        $default = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$defaultRecurringMessage]))->getSchedule(), 'default', $clock), 'default');
+        $custom = new SchedulerTransport(new MessageGenerator((new SomeScheduleProvider([$customRecurringMessage]))->getSchedule(), 'custom', $clock), 'custom');
 
         $factory = new SchedulerTransportFactory(
             new Container([

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
@@ -29,11 +29,11 @@ class SchedulerTransportTest extends TestCase
         $generator = $this->createConfiguredMock(MessageGeneratorInterface::class, [
             'getMessages' => $messages,
         ]);
-        $transport = new SchedulerTransport($generator);
+        $transport = new SchedulerTransport($generator, 'default');
 
         foreach ($transport->get() as $envelope) {
             $this->assertInstanceOf(Envelope::class, $envelope);
-            $this->assertNotNull($envelope->last(ScheduledStamp::class));
+            $this->assertSame('default', $envelope->last(ScheduledStamp::class)->scheduleName);
             $this->assertSame(array_shift($messages), $envelope->getMessage());
         }
 
@@ -42,7 +42,7 @@ class SchedulerTransportTest extends TestCase
 
     public function testAckIgnored()
     {
-        $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class));
+        $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class), 'default');
 
         $this->expectNotToPerformAssertions();
         $transport->ack(new Envelope(new \stdClass()));
@@ -50,7 +50,7 @@ class SchedulerTransportTest extends TestCase
 
     public function testRejectException()
     {
-        $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class));
+        $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class), 'default');
 
         $this->expectException(LogicException::class);
         $transport->reject(new Envelope(new \stdClass()));
@@ -58,7 +58,7 @@ class SchedulerTransportTest extends TestCase
 
     public function testSendException()
     {
-        $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class));
+        $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class), 'default');
 
         $this->expectException(LogicException::class);
         $transport->send(new Envelope(new \stdClass()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

As discussed in #49838, it would be nice to have the schedule name available on the stamp.
