### PR TITLE
[Scheduler] allow `MessageGenerator`'s to return `RecurringMessage[]`

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/MessageGeneratorInterface.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGeneratorInterface.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Component\Scheduler\Generator;
 
+use Symfony\Component\Scheduler\RecurringMessage;
+
 /**
  * @experimental
  */
 interface MessageGeneratorInterface
 {
     /**
-     * @return iterable<object>
+     * @return iterable<object|RecurringMessage>
      */
     public function getMessages(): iterable;
 }

--- a/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
+++ b/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
@@ -12,10 +12,14 @@
 namespace Symfony\Component\Scheduler\Messenger;
 
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Scheduler\RecurringMessage;
 
 /**
  * @experimental
  */
 final class ScheduledStamp implements NonSendableStampInterface
 {
+    public function __construct(public readonly RecurringMessage $recurringMessage)
+    {
+    }
 }

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -15,6 +15,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\Generator\MessageGeneratorInterface;
+use Symfony\Component\Scheduler\RecurringMessage;
 
 /**
  * @experimental
@@ -29,7 +30,11 @@ class SchedulerTransport implements TransportInterface
     public function get(): iterable
     {
         foreach ($this->messageGenerator->getMessages() as $message) {
-            yield Envelope::wrap($message, [new ScheduledStamp()]);
+            if (!$message instanceof RecurringMessage) {
+                throw new LogicException(sprintf('Messages from "%s" must be instances of "%s". Got "%s".', __CLASS__, RecurringMessage::class, get_debug_type($message)));
+            }
+
+            yield Envelope::wrap($message->getMessage(), [new ScheduledStamp($message)]);
         }
     }
 

--- a/src/Symfony/Component/Scheduler/Scheduler.php
+++ b/src/Symfony/Component/Scheduler/Scheduler.php
@@ -66,6 +66,10 @@ final class Scheduler
             $ran = false;
             foreach ($this->generators as $generator) {
                 foreach ($generator->getMessages() as $message) {
+                    if ($message instanceof RecurringMessage) {
+                        $message = $message->getMessage();
+                    }
+
                     $this->handlers[$message::class]($message);
                     $ran = true;
                 }

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -47,7 +47,8 @@ class MessageGeneratorTest extends TestCase
 
         foreach ($runs as $time => $expected) {
             $now = self::makeDateTime($time);
-            $this->assertSame($expected, iterator_to_array($scheduler->getMessages()));
+            $messages = array_map(fn (RecurringMessage $m) => $m->getMessage(), iterator_to_array($scheduler->getMessages()));
+            $this->assertSame($expected, $messages);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

- Ensures `SchedulerTransport` returns `RecurringMessage[]`
- Adds `RecurringMessage` to `ScheduledStamp`.

As discussed in #49838 and a companion to #49864.
