### PR TITLE
[HttpClient] Preserve MockResponse reference in MockHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -121,6 +121,16 @@ class MockResponse implements ResponseInterface, StreamableInterface
     public static function fromRequest(string $method, string $url, array $options, ResponseInterface $mock): self
     {
         $response = new self([]);
+        if ($mock instanceof self) {
+            $r = $response;
+            $response = $mock;
+            $mock = clone $mock;
+            $response->body = $r->body;
+            $response->info = $r->info;
+            $response->requestMethod = $method;
+            $response->requestUrl = $url;
+        }
+
         $response->requestOptions = $options;
         $response->id = ++self::$idSequence;
         $response->shouldBuffer = $options['buffer'] ?? true;
@@ -135,12 +145,6 @@ class MockResponse implements ResponseInterface, StreamableInterface
         $response->info['max_duration'] = $options['max_duration'] ?? null;
         $response->info['url'] = $url;
         $response->info['original_url'] = $url;
-
-        if ($mock instanceof self) {
-            $mock->requestOptions = $response->requestOptions;
-            $mock->requestMethod = $method;
-            $mock->requestUrl = $url;
-        }
 
         self::writeRequest($response, $options, $mock);
         $response->body[] = [$options, $mock];

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -533,4 +533,10 @@ class MockHttpClientTest extends HttpClientTestCase
         $client->reset();
         $this->assertSame(0, $client->getRequestsCount());
     }
+
+    public function testMockResponseReferenceIsPreserved()
+    {
+        $client = new MockHttpClient($mockResponse = new MockResponse());
+        $this->assertSame($mockResponse, $client->request('GET', 'https://example.com'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | -
| Tickets       | https://github.com/symfony/symfony/pull/49796#pullrequestreview-1365190448
| License       | MIT
| Doc PR        | -

I think it's possible to return the same reference with this strategy. WDYT?