### PR TITLE
[Validator] Throw Symfony/OutOfBounds exception instead of default one in ConstraintViolationList

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator;
 
+use Symfony\Component\Validator\Exception\OutOfBoundsException;
+
 /**
  * Default implementation of {@ConstraintViolationListInterface}.
  *
@@ -77,7 +79,7 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
     public function get(int $offset): ConstraintViolationInterface
     {
         if (!isset($this->violations[$offset])) {
-            throw new \OutOfBoundsException(sprintf('The offset "%s" does not exist.', $offset));
+            throw new OutOfBoundsException(sprintf('The offset "%s" does not exist.', $offset));
         }
 
         return $this->violations[$offset];

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator;
 
+use Symfony\Component\Validator\Exception\OutOfBoundsException;
+
 /**
  * A list of constraint violations.
  *
@@ -42,7 +44,7 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
      *
      * @param int $offset The offset of the violation
      *
-     * @throws \OutOfBoundsException if the offset does not exist
+     * @throws OutOfBoundsException if the offset does not exist
      */
     public function get(int $offset): ConstraintViolationInterface;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Symfony seems to almost always using namespaced Exception rather than default one.
This is useful:
- In order to do custom catch
- When using static analysis and you want to track some exception and exclude others

But the ConstraintViolationList was throwing the PHP OutOfBounds exception even if a namespaced one exists for Validator component. This PR is BC and change this.