### PR TITLE
[WebProfilerBundle] Add clickable entry view to debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add a "role=img" and an explicit title in the .svg file used by the web debug toolbar
    to improve accessibility with screen readers for blind users
+ * Add a clickable link to the entry view twig file in the toolbar
 
 6.1
 ---

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -46,6 +46,21 @@
     {% endset %}
 
     {% set text %}
+        {% set template = collector.templates|keys|first %}
+        {% set file = collector.templatePaths[template]|default(false) %}
+        {% set link = file ? file|file_link(1) : false %}
+        <div class="sf-toolbar-info-piece">
+            <b>Entry View</b>
+            <span>
+                 {% if link %}
+                     <a href="{{ link }}" title="{{ file }}" class="stretched-link">
+                         {{ template }}
+                     </a>
+                 {% else %}
+                     {{ template }}
+                 {% endif %}
+            </span>
+        </div>
         <div class="sf-toolbar-info-piece">
             <b>Render Time</b>
             <span>{{ time }} ms</span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Just a proposed idea. 

One of the great parts of the tool bar is the Clickable IDE integration to quickly jump to the Controller method that the page is rendered from.

example:

<img width="409" alt="ScreenShot-2023-03-31-21 01 07" src="https://user-images.githubusercontent.com/400092/229218485-e07d2588-9421-453a-a4cb-93c0d34f13e1.png">


One thing I find myself doing often is needing to get to the rendered view (a twig returned by the controller method with `return $this->render('template.twig.html,[]);` etc.  To do that I need to Hover the toolbar left corner, move up and click the controller, wait for phpStorm to load the controller file, then scroll down to find the rendered view, then go and find it manually in the tree (or with the [phpStorm Symfony plugin (amazing plugin)](https://plugins.jetbrains.com/plugin/7219-symfony-support) use the gutter icon to select the view).

After this PR the first template used in the stack will be rendered into to the twig debug toolbar (much like the controller in the request toolbar) and will be clickable if the [IDE integration is enabled](https://symfony.com/doc/current/reference/configuration/framework.html#ide) meaning less clicks to get from the webpage to the twig template to make changes in HTML quickly. 

Just a thought, would make less clicks...thoughts?

<img width="551" alt="ScreenShot-2023-03-31-20 46 24" src="https://user-images.githubusercontent.com/400092/229217786-e516c8a5-817d-4767-8d85-60521265b1a0.png">
