### PR TITLE
[Serializer] Add `XmlEncoder::CDATA_WRAPPING` context option

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Allow the `Groups` attribute/annotation on classes
  * JsonDecode: Add `json_decode_detailed_errors` option
  * Make `ProblemNormalizer` give details about Messenger's `ValidationFailedException`
+ * Add `XmlEncoder::CDATA_WRAPPING` context option
 
 6.3
 ---

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -144,4 +144,12 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     {
         return $this->with(XmlEncoder::VERSION, $version);
     }
+
+    /**
+     * Configures whether to wrap strings within CDATA sections.
+     */
+    public function withCdataWrapping(?bool $cdataWrapping): static
+    {
+        return $this->with(XmlEncoder::CDATA_WRAPPING, $cdataWrapping);
+    }
 }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -58,6 +58,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     public const STANDALONE = 'xml_standalone';
     public const TYPE_CAST_ATTRIBUTES = 'xml_type_cast_attributes';
     public const VERSION = 'xml_version';
+    public const CDATA_WRAPPING = 'cdata_wrapping';
 
     private array $defaultContext = [
         self::AS_COLLECTION => false,
@@ -68,6 +69,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::REMOVE_EMPTY_TAGS => false,
         self::ROOT_NODE_NAME => 'response',
         self::TYPE_CAST_ATTRIBUTES => true,
+        self::CDATA_WRAPPING => true,
     ];
 
     public function __construct(array $defaultContext = [])
@@ -424,9 +426,9 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     /**
      * Checks if a value contains any characters which would require CDATA wrapping.
      */
-    private function needsCdataWrapping(string $val): bool
+    private function needsCdataWrapping(string $val, array $context): bool
     {
-        return preg_match('/[<>&]/', $val);
+        return ($context[self::CDATA_WRAPPING] ?? $this->defaultContext[self::CDATA_WRAPPING]) && preg_match('/[<>&]/', $val);
     }
 
     /**
@@ -454,7 +456,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             return $this->selectNodeType($node, $this->serializer->normalize($val, $format, $context), $format, $context);
         } elseif (is_numeric($val)) {
             return $this->appendText($node, (string) $val);
-        } elseif (\is_string($val) && $this->needsCdataWrapping($val)) {
+        } elseif (\is_string($val) && $this->needsCdataWrapping($val, $context)) {
             return $this->appendCData($node, $val);
         } elseif (\is_string($val)) {
             return $this->appendText($node, $val);

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
@@ -29,8 +29,6 @@ class XmlEncoderContextBuilderTest extends TestCase
 
     /**
      * @dataProvider withersDataProvider
-     *
-     * @param array<string, mixed> $values
      */
     public function testWithers(array $values)
     {
@@ -47,14 +45,12 @@ class XmlEncoderContextBuilderTest extends TestCase
             ->withStandalone($values[XmlEncoder::STANDALONE])
             ->withTypeCastAttributes($values[XmlEncoder::TYPE_CAST_ATTRIBUTES])
             ->withVersion($values[XmlEncoder::VERSION])
+            ->withCdataWrapping($values[XmlEncoder::CDATA_WRAPPING])
             ->toArray();
 
         $this->assertSame($values, $context);
     }
 
-    /**
-     * @return iterable<array{0: array<string, mixed>|}>
-     */
     public static function withersDataProvider(): iterable
     {
         yield 'With values' => [[
@@ -70,6 +66,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::STANDALONE => false,
             XmlEncoder::TYPE_CAST_ATTRIBUTES => true,
             XmlEncoder::VERSION => '1.0',
+            XmlEncoder::CDATA_WRAPPING => false,
         ]];
 
         yield 'With null values' => [[
@@ -85,6 +82,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::STANDALONE => null,
             XmlEncoder::TYPE_CAST_ATTRIBUTES => null,
             XmlEncoder::VERSION => null,
+            XmlEncoder::CDATA_WRAPPING => null,
         ]];
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -234,13 +234,37 @@ XML;
     public function testEncodeCdataWrapping()
     {
         $array = [
-            'firstname' => 'Paul <or Me>',
+            'firstname' => 'Paul & Martha <or Me>',
         ];
 
         $expected = '<?xml version="1.0"?>'."\n".
-            '<response><firstname><![CDATA[Paul <or Me>]]></firstname></response>'."\n";
+            '<response><firstname><![CDATA[Paul & Martha <or Me>]]></firstname></response>'."\n";
 
         $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
+    }
+
+    public function testEnableCdataWrapping()
+    {
+        $array = [
+            'firstname' => 'Paul & Martha <or Me>',
+        ];
+
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response><firstname><![CDATA[Paul & Martha <or Me>]]></firstname></response>'."\n";
+
+        $this->assertEquals($expected, $this->encoder->encode($array, 'xml', ['cdata_wrapping' => true]));
+    }
+
+    public function testDisableCdataWrapping()
+    {
+        $array = [
+            'firstname' => 'Paul & Martha <or Me>',
+        ];
+
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response><firstname>Paul &amp; Martha &lt;or Me&gt;</firstname></response>'."\n";
+
+        $this->assertEquals($expected, $this->encoder->encode($array, 'xml', ['cdata_wrapping' => false]));
     }
 
     public function testEncodeScalarWithAttribute()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/26168
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/18155

Usage example :
```php
$data = [
	'Hello' => 'Paul & Martha <or Me>',
];

return new Response(
    $this->serializer->serialize(
        $data,
        XmlEncoder::FORMAT,
        [
            XmlEncoder::CDATA_WRAPPING => false
        ]
    ),
    headers: [
        'Content-Type' => 'application/xml'
    ]
);
```

will output

```xml
<?xml version="1.0"?>
<response><Hello>Paul &amp; Martha &lt;or Me&gt;</Hello></response>
```

instead of

```xml
<?xml version="1.0"?>
<response><Hello><![CDATA[Paul & Martha <or Me>]]></Hello></response>
```

---

As stated in [the following comment from PHP.net](https://www.php.net/manual/fr/domdocument.createtextnode.php#116351) : PHP automatically handles the escape when calling `DOMDocument::createTextNode` which is done in [::appendText](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php#L193).
`::appendText` is always called if `XmlEncoder::CDATA_WRAPPING => false`.

---

Questions:
* Should we allow for custom XPath to be wrapped in CDATA while others are simply escaped ?
* Should we allow for a callback function to be used in place of a boolean (`callable(string $val): bool`)
* [W3Schools#Entity References](https://www.w3schools.com/xml/xml_syntax.asp#:~:text=/note%3E-,Entity%20References,-Some%20characters%20have) states that `'` and `"` might also be escaped. Based on this should we instead provide a list of characters to escape/wrap ? (currently it would be set to `['<', '>', '&']`)

---
- [X] Create the documentation PR
- [X] Check Fabbot feedback to make sure code is well written