### PR TITLE
Apply no_null_property_initialization PHP-CS-Fixer rule

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -32,11 +32,11 @@ class UniqueEntity extends Constraint
 
     public $message = 'This value is already used.';
     public $service = 'doctrine.orm.validator.unique';
-    public $em = null;
-    public $entityClass = null;
+    public $em;
+    public $entityClass;
     public $repositoryMethod = 'findBy';
     public $fields = [];
-    public $errorPath = null;
+    public $errorPath;
     public $ignoreNull = true;
 
     /**

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Mime\Email;
 class MailerHandlerTest extends TestCase
 {
     /** @var MockObject|MailerInterface */
-    private $mailer = null;
+    private $mailer;
 
     protected function setUp(): void
     {

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -59,7 +59,7 @@ class Configuration
     /**
      * @var string|null
      */
-    private $logFile = null;
+    private $logFile;
 
     /**
      * @param int[]       $thresholds       A hash associating groups to thresholds

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Routing\Route;
 
 class TextDescriptorTest extends AbstractDescriptorTestCase
 {
-    private static $fileLinkFormatter = null;
+    private static $fileLinkFormatter;
 
     protected static function getDescriptor()
     {

--- a/src/Symfony/Component/BrowserKit/Tests/TestClient.php
+++ b/src/Symfony/Component/BrowserKit/Tests/TestClient.php
@@ -16,8 +16,8 @@ use Symfony\Component\BrowserKit\Response;
 
 class TestClient extends AbstractBrowser
 {
-    protected $nextResponse = null;
-    protected $nextScript = null;
+    protected $nextResponse;
+    protected $nextScript;
 
     public function setNextResponse(Response $response)
     {

--- a/src/Symfony/Component/BrowserKit/Tests/TestHttpClient.php
+++ b/src/Symfony/Component/BrowserKit/Tests/TestHttpClient.php
@@ -20,8 +20,8 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 class TestHttpClient extends HttpBrowser
 {
-    protected $nextResponse = null;
-    protected $nextScript = null;
+    protected $nextResponse;
+    protected $nextScript;
 
     public function __construct(array $server = [], History $history = null, CookieJar $cookieJar = null)
     {

--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\Tests\Resource\ResourceStub;
 
 class ConfigCacheTest extends TestCase
 {
-    private $cacheFile = null;
+    private $cacheFile;
 
     protected function setUp(): void
     {

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Tests\Resource\ResourceStub;
 
 class ResourceCheckerConfigCacheTest extends TestCase
 {
-    private $cacheFile = null;
+    private $cacheFile;
 
     protected function setUp(): void
     {

--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -34,7 +34,7 @@ final class CompletionInput extends ArgvInput
     private $tokens;
     private $currentIndex;
     private $completionType;
-    private $completionName = null;
+    private $completionName;
     private $completionValue = '';
 
     /**

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -21,7 +21,7 @@ use Symfony\Component\String\UnicodeString;
  */
 abstract class Helper implements HelperInterface
 {
-    protected $helperSet = null;
+    protected $helperSet;
 
     /**
      * @return void

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -23,22 +23,22 @@ class FilesystemTestCase extends TestCase
     /**
      * @var Filesystem
      */
-    protected $filesystem = null;
+    protected $filesystem;
 
     /**
      * @var string
      */
-    protected $workspace = null;
+    protected $workspace;
 
     /**
      * @var bool|null Flag for hard links on Windows
      */
-    private static $linkOnWindows = null;
+    private static $linkOnWindows;
 
     /**
      * @var bool|null Flag for symbolic links on Windows
      */
-    private static $symlinkOnWindows = null;
+    private static $symlinkOnWindows;
 
     public static function setUpBeforeClass(): void
     {

--- a/src/Symfony/Component/Finder/Tests/Iterator/MockSplFileInfo.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/MockSplFileInfo.php
@@ -17,11 +17,11 @@ class MockSplFileInfo extends \SplFileInfo
     public const TYPE_FILE = 2;
     public const TYPE_UNKNOWN = 3;
 
-    private $contents = null;
-    private $mode = null;
-    private $type = null;
-    private $relativePath = null;
-    private $relativePathname = null;
+    private $contents;
+    private $mode;
+    private $type;
+    private $relativePath;
+    private $relativePathname;
 
     public function __construct($param)
     {

--- a/src/Symfony/Component/Notifier/Tests/Mailer/DummyMailer.php
+++ b/src/Symfony/Component/Notifier/Tests/Mailer/DummyMailer.php
@@ -20,7 +20,7 @@ use Symfony\Component\Mime\RawMessage;
  */
 class DummyMailer implements MailerInterface
 {
-    private $sentMessage = null;
+    private $sentMessage;
 
     public function send(RawMessage $message, Envelope $envelope = null): void
     {

--- a/src/Symfony/Component/Process/InputStream.php
+++ b/src/Symfony/Component/Process/InputStream.php
@@ -23,7 +23,7 @@ use Symfony\Component\Process\Exception\RuntimeException;
 class InputStream implements \IteratorAggregate
 {
     /** @var callable|null */
-    private $onEmpty = null;
+    private $onEmpty;
     private $input = [];
     private $open = true;
 

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -25,9 +25,9 @@ use Symfony\Component\Routing\Router;
 
 class RouterTest extends TestCase
 {
-    private $router = null;
+    private $router;
 
-    private $loader = null;
+    private $loader;
 
     private $cacheDir;
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -29,7 +29,7 @@ class YamlFileLoader extends FileLoader
      *
      * @var array
      */
-    protected $classes = null;
+    protected $classes;
 
     public function __construct(string $file)
     {

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -119,7 +119,7 @@ abstract class AbstractStaticLoader
 
 class StaticLoaderEntity
 {
-    public static $invokedWith = null;
+    public static $invokedWith;
 
     public static function loadMetadata(ClassMetadata $metadata)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

After a discussion with @stof, this rule should be part of the `@Symfony` PHP-CS-Fixer ruleset.
This PR apply the rule on the Symfony code base.
see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6876 for the PR on PHP-CS-Fixer
