### PR TITLE
[Mailer] Allow overriding default eSMTP authenticators

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add `MessageEvent::reject()` to allow rejecting an email before sending it
  * Change the default port for the `mailgun+smtp` transport from 465 to 587
+ * Add `$authenticators` parameter in `EsmtpTransport` constructor and `EsmtpTransport::setAuthenticators()`
+  to allow overriding of default eSMTP authenticators
 
 6.2.7
 -----

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/DummyStream.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/DummyStream.php
@@ -55,7 +55,21 @@ class DummyStream extends AbstractStream
         $this->commands[] = $bytes;
 
         if (str_starts_with($bytes, 'EHLO')) {
-            $this->nextResponse = '250 localhost';
+            $this->nextResponse = '250 localhost'."\r\n".'250-AUTH PLAIN LOGIN CRAM-MD5 XOAUTH2';
+        } elseif (str_starts_with($bytes, 'AUTH LOGIN')) {
+            $this->nextResponse = '334 VXNlcm5hbWU6';
+        } elseif (str_starts_with($bytes, 'dGVzdHVzZXI=')) {
+            $this->nextResponse = '334 UGFzc3dvcmQ6';
+        } elseif (str_starts_with($bytes, 'cDRzc3cwcmQ=')) {
+            $this->nextResponse = '535 5.7.139 Authentication unsuccessful';
+        } elseif (str_starts_with($bytes, 'AUTH CRAM-MD5')) {
+            $this->nextResponse = '334 PDAxMjM0NTY3ODkuMDEyMzQ1NjdAc3ltZm9ueT4=';
+        } elseif (str_starts_with($bytes, 'dGVzdHVzZXIgNTdlYzg2ODM5OWZhZThjY2M5OWFhZGVjZjhiZTAwNmY=')) {
+            $this->nextResponse = '535 5.7.139 Authentication unsuccessful';
+        } elseif (str_starts_with($bytes, 'AUTH PLAIN') || str_starts_with($bytes, 'AUTH XOAUTH2')) {
+            $this->nextResponse = '535 5.7.139 Authentication unsuccessful';
+        } elseif (str_starts_with($bytes, 'RSET')) {
+            $this->nextResponse = '250 2.0.0 Resetting';
         } elseif (str_starts_with($bytes, 'DATA')) {
             $this->nextResponse = '354 Enter message, ending with "." on a line by itself';
         } elseif (str_starts_with($bytes, 'QUIT')) {

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
@@ -12,6 +12,10 @@
 namespace Symfony\Component\Mailer\Tests\Transport\Smtp;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Transport\Smtp\Auth\CramMd5Authenticator;
+use Symfony\Component\Mailer\Transport\Smtp\Auth\LoginAuthenticator;
+use Symfony\Component\Mailer\Transport\Smtp\Auth\XOAuth2Authenticator;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mime\Email;
 
@@ -56,6 +60,137 @@ class EsmtpTransportTest extends TestCase
 
         $this->assertContains("MAIL FROM:<sender@example.org> RET=HDRS\r\n", $stream->getCommands());
         $this->assertContains("RCPT TO:<recipient@example.org> NOTIFY=FAILURE\r\n", $stream->getCommands());
+    }
+
+    public function testConstructorWithDefaultAuthenticators()
+    {
+        $stream = new DummyStream();
+        $transport = new EsmtpTransport(stream: $stream);
+        $transport->setUsername('testuser');
+        $transport->setPassword('p4ssw0rd');
+
+        $message = new Email();
+        $message->from('sender@example.org');
+        $message->addTo('recipient@example.org');
+        $message->text('.');
+
+        try {
+            $transport->send($message);
+            $this->fail('Symfony\Component\Mailer\Exception\TransportException to be thrown');
+        } catch (TransportException $e) {
+            $this->assertStringStartsWith('Failed to authenticate on SMTP server with username "testuser" using the following authenticators: "CRAM-MD5", "LOGIN", "PLAIN", "XOAUTH2".', $e->getMessage());
+        }
+
+        $this->assertEquals(
+            [
+                "EHLO [127.0.0.1]\r\n",
+                // S: 250 localhost
+                // S: 250-AUTH PLAIN LOGIN CRAM-MD5 XOAUTH2
+                "AUTH CRAM-MD5\r\n",
+                // S: 334 PDAxMjM0NTY3ODkuMDEyMzQ1NjdAc3ltZm9ueT4=
+                "dGVzdHVzZXIgNTdlYzg2ODM5OWZhZThjY2M5OWFhZGVjZjhiZTAwNmY=\r\n",
+                // S: 535 5.7.139 Authentication unsuccessful
+                "RSET\r\n",
+                // S: 250 2.0.0 Resetting
+                "AUTH LOGIN\r\n",
+                // S: 334 VXNlcm5hbWU6
+                "dGVzdHVzZXI=\r\n",
+                // S: 334 UGFzc3dvcmQ6
+                "cDRzc3cwcmQ=\r\n",
+                // S: 535 5.7.139 Authentication unsuccessful
+                "RSET\r\n",
+                // S: 250 2.0.0 Resetting
+                "AUTH PLAIN dGVzdHVzZXIAdGVzdHVzZXIAcDRzc3cwcmQ=\r\n",
+                // S: 535 5.7.139 Authentication unsuccessful
+                "RSET\r\n",
+                // S: 250 2.0.0 Resetting
+                "AUTH XOAUTH2 dXNlcj10ZXN0dXNlcgFhdXRoPUJlYXJlciBwNHNzdzByZAEB\r\n",
+                // S: 535 5.7.139 Authentication unsuccessful
+                "RSET\r\n",
+                // S: 250 2.0.0 Resetting
+            ],
+            $stream->getCommands()
+        );
+    }
+
+    public function testConstructorWithRedefinedAuthenticators()
+    {
+        $stream = new DummyStream();
+        $transport = new EsmtpTransport(
+            stream: $stream,
+            authenticators: [new CramMd5Authenticator(), new LoginAuthenticator()]
+        );
+        $transport->setUsername('testuser');
+        $transport->setPassword('p4ssw0rd');
+
+        $message = new Email();
+        $message->from('sender@example.org');
+        $message->addTo('recipient@example.org');
+        $message->text('.');
+
+        try {
+            $transport->send($message);
+            $this->fail('Symfony\Component\Mailer\Exception\TransportException to be thrown');
+        } catch (TransportException $e) {
+            $this->assertStringStartsWith('Failed to authenticate on SMTP server with username "testuser" using the following authenticators: "CRAM-MD5", "LOGIN".', $e->getMessage());
+        }
+
+        $this->assertEquals(
+            [
+                "EHLO [127.0.0.1]\r\n",
+                // S: 250 localhost
+                // S: 250-AUTH PLAIN LOGIN CRAM-MD5 XOAUTH2
+                "AUTH CRAM-MD5\r\n",
+                // S: 334 PDAxMjM0NTY3ODkuMDEyMzQ1NjdAc3ltZm9ueT4=
+                "dGVzdHVzZXIgNTdlYzg2ODM5OWZhZThjY2M5OWFhZGVjZjhiZTAwNmY=\r\n",
+                // S: 535 5.7.139 Authentication unsuccessful
+                "RSET\r\n",
+                // S: 250 2.0.0 Resetting
+                "AUTH LOGIN\r\n",
+                // S: 334 VXNlcm5hbWU6
+                "dGVzdHVzZXI=\r\n",
+                // S: 334 UGFzc3dvcmQ6
+                "cDRzc3cwcmQ=\r\n",
+                // S: 535 5.7.139 Authentication unsuccessful
+                "RSET\r\n",
+                // S: 250 2.0.0 Resetting
+            ],
+            $stream->getCommands()
+        );
+    }
+
+    public function testSetAuthenticators()
+    {
+        $stream = new DummyStream();
+        $transport = new EsmtpTransport(stream: $stream);
+        $transport->setUsername('testuser');
+        $transport->setPassword('p4ssw0rd');
+        $transport->setAuthenticators([new XOAuth2Authenticator()]);
+
+        $message = new Email();
+        $message->from('sender@example.org');
+        $message->addTo('recipient@example.org');
+        $message->text('.');
+
+        try {
+            $transport->send($message);
+            $this->fail('Symfony\Component\Mailer\Exception\TransportException to be thrown');
+        } catch (TransportException $e) {
+            $this->assertStringStartsWith('Failed to authenticate on SMTP server with username "testuser" using the following authenticators: "XOAUTH2".', $e->getMessage());
+        }
+
+        $this->assertEquals(
+            [
+                "EHLO [127.0.0.1]\r\n",
+                // S: 250 localhost
+                // S: 250-AUTH PLAIN LOGIN CRAM-MD5 XOAUTH2
+                "AUTH XOAUTH2 dXNlcj10ZXN0dXNlcgFhdXRoPUJlYXJlciBwNHNzdzByZAEB\r\n",
+                // S: 535 5.7.139 Authentication unsuccessful
+                "RSET\r\n",
+                // S: 250 2.0.0 Resetting
+            ],
+            $stream->getCommands()
+        );
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #49701
| License       | MIT
| Doc PR        | symfony/symfony-docs#... TODO

SMTP authentication using OAuth token on Azure servers is really long, due to high latency responses from the SMTP server (probably to prevent brute-force attacks).
Indeed, a `AUTH LOGIN` command is sent first, and have to wait for about 5 seconds get the error response back. Then a `RSET` command is sent and also have to wait for about 5 seconds get a response back. The `AUTH XOAUTH2` command is then sent and all is fast after that.

Adding the ability to override default eSMTP authenticators will permit developers to explicitely define that only `XOAUTH2` authenticator has to be used, to prevent high latency in SMTP authentication.

I will update the documentation once new methods signatures will be validated.