### PR TITLE
[Mailer] Allow `TemplateWrapper` as html and text template

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+* Add support for `TemplateWrapper` as parameter in `TemplatedEmail`
+
 6.2
 ---
 

--- a/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mime\Part\DataPart;
 use Twig\Extra\CssInliner\CssInlinerExtension;
 use Twig\Extra\Inky\InkyExtension;
 use Twig\Extra\Markdown\MarkdownExtension;
+use Twig\TemplateWrapper;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -156,7 +157,7 @@ class NotificationEmail extends TemplatedEmail
         return $this;
     }
 
-    public function getTextTemplate(): ?string
+    public function getTextTemplate(): null|string|TemplateWrapper
     {
         if ($template = parent::getTextTemplate()) {
             return $template;
@@ -165,7 +166,7 @@ class NotificationEmail extends TemplatedEmail
         return '@email/'.$this->theme.'/notification/body.txt.twig';
     }
 
-    public function getHtmlTemplate(): ?string
+    public function getHtmlTemplate(): null|string|TemplateWrapper
     {
         if ($template = parent::getHtmlTemplate()) {
             return $template;

--- a/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
@@ -11,22 +11,29 @@
 
 namespace Symfony\Bridge\Twig\Mime;
 
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Email;
+use Twig\TemplateWrapper;
+use function is_array;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class TemplatedEmail extends Email
 {
-    private ?string $htmlTemplate = null;
-    private ?string $textTemplate = null;
+    private null|string|TemplateWrapper|array $htmlTemplate = null;
+    private null|string|TemplateWrapper|array $textTemplate = null;
     private array $context = [];
 
     /**
      * @return $this
      */
-    public function textTemplate(?string $template): static
+    public function textTemplate(null|string|TemplateWrapper|array $template): static
     {
+        if (is_array($template) && !isset($template['templateName'])) {
+            throw new InvalidArgumentException('Array parameter is only allowed as json serialized version of a TemplateWrapper');
+        }
+
         $this->textTemplate = $template;
 
         return $this;
@@ -35,20 +42,32 @@ class TemplatedEmail extends Email
     /**
      * @return $this
      */
-    public function htmlTemplate(?string $template): static
+    public function htmlTemplate(null|string|TemplateWrapper|array $template): static
     {
+        if (is_array($template) && !isset($template['templateName'])) {
+            throw new InvalidArgumentException('Array parameter is only allowed as json serialized version of a TemplateWrapper');
+        }
+
         $this->htmlTemplate = $template;
 
         return $this;
     }
 
-    public function getTextTemplate(): ?string
+    public function getTextTemplate(): null|string|TemplateWrapper|array
     {
+        if (is_array($this->textTemplate)) {
+            return $this->textTemplate['templateName'];
+        }
+
         return $this->textTemplate;
     }
 
-    public function getHtmlTemplate(): ?string
+    public function getHtmlTemplate(): null|string|TemplateWrapper|array
     {
+        if (is_array($this->htmlTemplate)) {
+            return $this->htmlTemplate['templateName'];
+        }
+
         return $this->htmlTemplate;
     }
 

--- a/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
@@ -52,7 +52,7 @@ class TemplatedEmail extends Email
         return $this;
     }
 
-    public function getTextTemplate(): null|string|TemplateWrapper|array
+    public function getTextTemplate(): null|string|TemplateWrapper
     {
         if (\is_array($this->textTemplate)) {
             return $this->textTemplate['templateName'];
@@ -61,7 +61,7 @@ class TemplatedEmail extends Email
         return $this->textTemplate;
     }
 
-    public function getHtmlTemplate(): null|string|TemplateWrapper|array
+    public function getHtmlTemplate(): null|string|TemplateWrapper
     {
         if (\is_array($this->htmlTemplate)) {
             return $this->htmlTemplate['templateName'];

--- a/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
@@ -14,7 +14,6 @@ namespace Symfony\Bridge\Twig\Mime;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Email;
 use Twig\TemplateWrapper;
-use function is_array;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -30,8 +29,8 @@ class TemplatedEmail extends Email
      */
     public function textTemplate(null|string|TemplateWrapper|array $template): static
     {
-        if (is_array($template) && !isset($template['templateName'])) {
-            throw new InvalidArgumentException('Array parameter is only allowed as json serialized version of a TemplateWrapper');
+        if (\is_array($template) && !isset($template['templateName'])) {
+            throw new InvalidArgumentException('Array parameter is only allowed as json serialized version of a TemplateWrapper.');
         }
 
         $this->textTemplate = $template;
@@ -44,8 +43,8 @@ class TemplatedEmail extends Email
      */
     public function htmlTemplate(null|string|TemplateWrapper|array $template): static
     {
-        if (is_array($template) && !isset($template['templateName'])) {
-            throw new InvalidArgumentException('Array parameter is only allowed as json serialized version of a TemplateWrapper');
+        if (\is_array($template) && !isset($template['templateName'])) {
+            throw new InvalidArgumentException('Array parameter is only allowed as json serialized version of a TemplateWrapper.');
         }
 
         $this->htmlTemplate = $template;
@@ -55,7 +54,7 @@ class TemplatedEmail extends Email
 
     public function getTextTemplate(): null|string|TemplateWrapper|array
     {
-        if (is_array($this->textTemplate)) {
+        if (\is_array($this->textTemplate)) {
             return $this->textTemplate['templateName'];
         }
 
@@ -64,7 +63,7 @@ class TemplatedEmail extends Email
 
     public function getHtmlTemplate(): null|string|TemplateWrapper|array
     {
-        if (is_array($this->htmlTemplate)) {
+        if (\is_array($this->htmlTemplate)) {
             return $this->htmlTemplate['templateName'];
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -62,7 +62,7 @@ class TemplatedEmailTest extends TestCase
             ->context($context = ['a' => 'b'])
         ;
 
-        $email = \unserialize(\serialize($email));
+        $email = unserialize(serialize($email));
         $this->assertEquals('text.txt.twig', $email->getTextTemplate());
         $this->assertEquals('text.html.twig', $email->getHtmlTemplate());
         $this->assertEquals($context, $email->getContext());
@@ -79,7 +79,7 @@ class TemplatedEmailTest extends TestCase
             ->context($context = ['a' => 'b'])
         ;
 
-        $email = \unserialize(\serialize($email));
+        $email = unserialize(serialize($email));
         $this->assertEquals($twigTemplate, $email->getTextTemplate());
         $this->assertEquals($twigTemplate, $email->getHtmlTemplate());
         $this->assertEquals($context, $email->getContext());
@@ -146,11 +146,11 @@ EOF;
         ], [new JsonEncoder()]);
 
         $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
-        $this->assertStringMatchesFormat($expectedJson, \json_encode(\json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $n = $serializer->deserialize($serialized, TemplatedEmail::class, 'json');
         $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
-        $this->assertStringMatchesFormat($expectedJson, \json_encode(\json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $n->from('fabien@symfony.com');
         $expected->from('fabien@symfony.com');
@@ -236,11 +236,11 @@ EOF;
         ], [new JsonEncoder()]);
 
         $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
-        $this->assertStringMatchesFormat($expectedJson, \json_encode(\json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $n = $serializer->deserialize($serialized, TemplatedEmail::class, 'json');
         $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
-        $this->assertStringMatchesFormat($expectedJson, \json_encode(\json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $n->from('fabien@symfony.com');
         $expected->from('fabien@symfony.com');

--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Tests\Mime;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -21,6 +22,13 @@ use Symfony\Component\Serializer\Normalizer\MimeMessageNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\TemplateWrapper;
+use function json_decode;
+use function json_encode;
+use function serialize;
+use function unserialize;
 
 class TemplatedEmailTest extends TestCase
 {
@@ -35,6 +43,20 @@ class TemplatedEmailTest extends TestCase
 
         $email->htmlTemplate($template = 'html');
         $this->assertEquals($template, $email->getHtmlTemplate());
+
+        $twig = new Environment(new ArrayLoader(['testTemplate' => 'Twig content']));
+        $twigTemplate = $twig->load('testTemplate');
+        $email->textTemplate($twigTemplate);
+        $this->assertEquals($twigTemplate, $email->getTextTemplate());
+
+        $email->htmlTemplate($twigTemplate);
+        $this->assertEquals($twigTemplate, $email->getHtmlTemplate());
+
+        $this->expectException(InvalidArgumentException::class);
+        $email->textTemplate(['some array']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $email->htmlTemplate(['some array']);
     }
 
     public function testSerialize()
@@ -49,6 +71,25 @@ class TemplatedEmailTest extends TestCase
         $this->assertEquals('text.txt.twig', $email->getTextTemplate());
         $this->assertEquals('text.html.twig', $email->getHtmlTemplate());
         $this->assertEquals($context, $email->getContext());
+    }
+
+    public function testSerializeTemplateWrapper()
+    {
+        $twig = new Environment(new ArrayLoader(['testTemplate' => 'Twig content']));
+        $twigTemplate = $twig->load('testTemplate');
+
+        $email = (new TemplatedEmail())
+            ->textTemplate($twigTemplate)
+            ->htmlTemplate($twigTemplate)
+            ->context($context = ['a' => 'b'])
+        ;
+
+        $email = unserialize(serialize($email));
+        $this->assertEquals($twigTemplate, $email->getTextTemplate());
+        $this->assertEquals($twigTemplate, $email->getHtmlTemplate());
+        $this->assertEquals($context, $email->getContext());
+        $this->assertEquals('Twig content', $twig->render($email->getTextTemplate()));
+        $this->assertEquals('Twig content', $twig->render($email->getHtmlTemplate()));
     }
 
     public function testSymfonySerialize()
@@ -120,5 +161,97 @@ EOF;
         $expected->from('fabien@symfony.com');
         $this->assertEquals($expected->getHeaders(), $n->getHeaders());
         $this->assertEquals($expected->getBody(), $n->getBody());
+    }
+
+    public function testSymfonySerializeTemplateWrapper()
+    {
+        $twig = new Environment(new ArrayLoader(['testTemplate' => 'Twig content']));
+        $twigTemplate = $twig->load('testTemplate');
+
+        // we don't add from/sender to check that validation is not triggered to serialize an email
+        $e = new TemplatedEmail();
+        $e->to('you@example.com');
+        $e->textTemplate($twigTemplate);
+        $e->htmlTemplate($twigTemplate);
+        $e->context(['foo' => 'bar']);
+        $e->addPart(new DataPart('Some Text file', 'test.txt'));
+        $expected = clone $e;
+
+        $expectedJson = <<<EOF
+{
+    "htmlTemplate": {
+        "blockNames": [],
+        "sourceContext": {
+            "code": "",
+            "name": "testTemplate",
+            "path": ""
+        },
+        "templateName": "testTemplate"
+    },
+    "textTemplate": {
+        "blockNames": [],
+        "sourceContext": {
+            "code": "",
+            "name": "testTemplate",
+            "path": ""
+        },
+        "templateName": "testTemplate"
+    },
+    "context": {
+        "foo": "bar"
+    },
+    "text": null,
+    "textCharset": null,
+    "html": null,
+    "htmlCharset": null,
+    "attachments": [
+        {%A
+            "body": "Some Text file",%A
+            "name": "test.txt",%A
+        }
+    ],
+    "headers": {
+        "to": [
+            {
+                "addresses": [
+                    {
+                        "address": "you@example.com",
+                        "name": ""
+                    }
+                ],
+                "name": "To",
+                "lineLength": 76,
+                "lang": null,
+                "charset": "utf-8"
+            }
+        ]
+    },
+    "body": null,
+    "message": null
+}
+EOF;
+
+        $extractor = new PhpDocExtractor();
+        $propertyNormalizer = new PropertyNormalizer(null, null, $extractor);
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new MimeMessageNormalizer($propertyNormalizer),
+            new ObjectNormalizer(null, null, null, $extractor),
+            $propertyNormalizer,
+        ], [new JsonEncoder()]);
+
+        $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
+        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $n = $serializer->deserialize($serialized, TemplatedEmail::class, 'json');
+        $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
+        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $n->from('fabien@symfony.com');
+        $expected->from('fabien@symfony.com');
+        $this->assertEquals($expected->getHeaders(), $n->getHeaders());
+        $this->assertEquals($expected->getBody(), $n->getBody());
+        $this->assertEquals($twig->render($expected->getTextTemplate()), $twig->render($n->getTextTemplate()));
+        $this->assertEquals($twig->render($expected->getTextTemplate()), $twig->render($n->getHtmlTemplate()));
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -24,11 +24,6 @@ use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
-use Twig\TemplateWrapper;
-use function json_decode;
-use function json_encode;
-use function serialize;
-use function unserialize;
 
 class TemplatedEmailTest extends TestCase
 {
@@ -67,7 +62,7 @@ class TemplatedEmailTest extends TestCase
             ->context($context = ['a' => 'b'])
         ;
 
-        $email = unserialize(serialize($email));
+        $email = \unserialize(\serialize($email));
         $this->assertEquals('text.txt.twig', $email->getTextTemplate());
         $this->assertEquals('text.html.twig', $email->getHtmlTemplate());
         $this->assertEquals($context, $email->getContext());
@@ -84,7 +79,7 @@ class TemplatedEmailTest extends TestCase
             ->context($context = ['a' => 'b'])
         ;
 
-        $email = unserialize(serialize($email));
+        $email = \unserialize(\serialize($email));
         $this->assertEquals($twigTemplate, $email->getTextTemplate());
         $this->assertEquals($twigTemplate, $email->getHtmlTemplate());
         $this->assertEquals($context, $email->getContext());
@@ -151,11 +146,11 @@ EOF;
         ], [new JsonEncoder()]);
 
         $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
-        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        $this->assertStringMatchesFormat($expectedJson, \json_encode(\json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $n = $serializer->deserialize($serialized, TemplatedEmail::class, 'json');
         $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
-        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        $this->assertStringMatchesFormat($expectedJson, \json_encode(\json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $n->from('fabien@symfony.com');
         $expected->from('fabien@symfony.com');
@@ -241,11 +236,11 @@ EOF;
         ], [new JsonEncoder()]);
 
         $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
-        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        $this->assertStringMatchesFormat($expectedJson, \json_encode(\json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $n = $serializer->deserialize($serialized, TemplatedEmail::class, 'json');
         $serialized = $serializer->serialize($e, 'json', [ObjectNormalizer::IGNORED_ATTRIBUTES => ['cachedBody']]);
-        $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        $this->assertStringMatchesFormat($expectedJson, \json_encode(\json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $n->from('fabien@symfony.com');
         $expected->from('fabien@symfony.com');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #41126
| License       | MIT
| Doc PR        | 

The `Symfony\Bridge\Twig\Mime\TemplatedEmail` currently only allows a string a param which contains the path to the twig template.

The `Symfony\Bridge\Twig\Mime\TemplatedEmail`  should additional allow `Twig\TemplateWrapper` for the methods:

```php
htmlTemplate()
textTemplate()
```

The BodyRenderer uses internally `$this->twig->render()`. This method allows the usage of string and TemplateWrapper as param.

As result also inline twig templates could be used. This is helpful if the template content should be modified before applying a twig rendering.

### Example

```php
$twig = new Environment(new ArrayLoader(['testTemplate' => 'Twig content']));
$twigTemplate = $twig->load('testTemplate');

$email = (new TemplatedEmail())
           ->from(new Address('me@example.com'))
           ->to(new Address('someone@example.com'))
           ->subject('E-Mail Subject')
           ->htmlTemplate($twigTemplate);
```

