### PR TITLE
[HttpClient] Support file uploads by nesting resource streams in `body` option

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `ServerSentEvent::getArrayData()` to get the Server-Sent Event's data decoded as an array when it's a JSON payload
  * Allow array of urls as `base_uri` option value in `RetryableHttpClient` to retry on a new url each time
  * Add `JsonMockResponse`, a `MockResponse` shortcut that automatically encodes the passed body to JSON and sets the content type to `application/json` by default
+ * Support file uploads by nesting resource streams in option "body"
 
 6.2
 ---

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpClient\HttpClientTrait;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -66,6 +67,94 @@ class HttpClientTraitTest extends TestCase
         ], $defaults);
 
         $this->assertContains('Content-Type: application/x-www-form-urlencoded; charset=utf-8', $options['headers']);
+    }
+
+    public function testNormalizeBodyMultipart()
+    {
+        $file = fopen('php://memory', 'r+');
+        stream_context_set_option($file, ['http' => [
+            'filename' => 'test.txt',
+            'content_type' => 'text/plain',
+        ]]);
+        fwrite($file, 'foobarbaz');
+        rewind($file);
+
+        $headers = [
+            'content-type' => ['Content-Type: multipart/form-data; boundary=ABCDEF'],
+        ];
+        $body = [
+            'foo[]' => 'bar',
+            'bar' => [
+                $file,
+            ],
+        ];
+
+        $body = self::normalizeBody($body, $headers);
+
+        $result = '';
+        while ('' !== $data = $body(self::$CHUNK_SIZE)) {
+            $result .= $data;
+        }
+
+        $expected = <<<'EOF'
+            --ABCDEF
+            Content-Disposition: form-data; name="foo[]"
+
+            bar
+            --ABCDEF
+            Content-Disposition: form-data; name="bar[0]"; filename="test.txt"
+            Content-Type: text/plain
+
+            foobarbaz
+            --ABCDEF--
+
+            EOF;
+        $expected = str_replace("\n", "\r\n", $expected);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @group network
+     *
+     * @dataProvider provideNormalizeBodyMultipartForwardStream
+     */
+    public function testNormalizeBodyMultipartForwardStream($stream)
+    {
+        $body = [
+            'logo' => $stream,
+        ];
+
+        $headers = [];
+        $body = self::normalizeBody($body, $headers);
+
+        $result = '';
+        while ('' !== $data = $body(self::$CHUNK_SIZE)) {
+            $result .= $data;
+        }
+
+        $this->assertSame(1, preg_match('/^Content-Type: multipart\/form-data; boundary=(?<boundary>.+)$/', $headers['content-type'][0], $matches));
+        $this->assertSame('Content-Length: 3086', $headers['content-length'][0]);
+        $this->assertSame(3086, \strlen($result));
+
+        $expected = <<<EOF
+            --{$matches['boundary']}
+            Content-Disposition: form-data; name="logo"; filename="1f44d.png"
+            Content-Type: image/png
+
+            %A
+            --{$matches['boundary']}--
+
+            EOF;
+        $expected = str_replace("\n", "\r\n", $expected);
+
+        $this->assertStringMatchesFormat($expected, $result);
+    }
+
+    public static function provideNormalizeBodyMultipartForwardStream()
+    {
+        yield 'native' => [fopen('https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png', 'r')];
+        yield 'symfony' => [HttpClient::create()->request('GET', 'https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png')->toStream()];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR makes it easy to upload files using `multipart/form-data`.

Nesting streams in option "body" is all one needs to do:
```php
$h = fopen('/path/to/the/file' 'r');
$client->request('POST', 'https://...', ['body' => ['the_file' => $h]]);
```

By default, the code will populate the `filename` using the base-name of the opened file.
It's possible to override this by calling `stream_context_set_option($h, 'http', 'filename', 'the-name.txt')`.

When forwarding an HTTP request coming either from the native `http` stream wrapper or from Symfony's `StreamableInterface`, the code will forward the content-type. It's also possible to set the content-type using `stream_context_set_option($h, 'http', 'content_type', 'my/content-type')`.

When possible, the code will generate a `Content-Length` header. This enables the destination server to reject the request early if it's too big and it allows tracking the progress of uploads on the client-side.