### PR TITLE
[TwigBridge][TwigBundle] Add current locale to `AppVariable`

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Translation\LocaleSwitcher;
 
 /**
  * Exposes some Symfony parameters and services as an "app" global variable.
@@ -29,6 +30,7 @@ class AppVariable
     private RequestStack $requestStack;
     private string $environment;
     private bool $debug;
+    private LocaleSwitcher $localeSwitcher;
 
     /**
      * @return void
@@ -60,6 +62,11 @@ class AppVariable
     public function setDebug(bool $debug)
     {
         $this->debug = $debug;
+    }
+
+    public function setLocaleSwitcher(LocaleSwitcher $localeSwitcher): void
+    {
+        $this->localeSwitcher = $localeSwitcher;
     }
 
     /**
@@ -137,6 +144,15 @@ class AppVariable
         }
 
         return $this->debug;
+    }
+
+    public function getLocale(): string
+    {
+        if (!isset($this->localeSwitcher)) {
+            throw new \RuntimeException('The "app.locale" variable is not available.');
+        }
+
+        return $this->localeSwitcher->getLocale();
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.3
+---
+
+ * Add `AppVariable::getLocale()` to retrieve the current locale when using the `LocaleSwitcher`
+
 6.2
 ---
 

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Translation\LocaleSwitcher;
 
 class AppVariableTest extends TestCase
 {
@@ -104,6 +105,16 @@ class AppVariableTest extends TestCase
         $this->assertEquals($user, $this->appVariable->getUser());
     }
 
+    public function testGetLocale()
+    {
+        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
+        $this->appVariable->setLocaleSwitcher($localeSwitcher);
+
+        $localeSwitcher->method('getLocale')->willReturn('fr');
+
+        self::assertEquals('fr', $this->appVariable->getLocale());
+    }
+
     public function testGetTokenWithNoToken()
     {
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
@@ -154,6 +165,13 @@ class AppVariableTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->appVariable->getSession();
+    }
+
+    public function testGetLocaleWithLocaleSwitcherNotSet()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The "app.locale" variable is not available.');
+        $this->appVariable->getLocale();
     }
 
     public function testGetFlashesWithNoRequest()

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -37,7 +37,7 @@
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/property-info": "^5.4|^6.0",
         "symfony/routing": "^5.4|^6.0",
-        "symfony/translation": "^5.4|^6.0",
+        "symfony/translation": "^6.1",
         "symfony/yaml": "^5.4|^6.0",
         "symfony/security-acl": "^2.8|^3.0",
         "symfony/security-core": "^5.4|^6.0",

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -76,6 +76,7 @@ return static function (ContainerConfigurator $container) {
             ->call('setDebug', [param('kernel.debug')])
             ->call('setTokenStorage', [service('security.token_storage')->ignoreOnInvalid()])
             ->call('setRequestStack', [service('request_stack')->ignoreOnInvalid()])
+            ->call('setLocaleSwitcher', [service('translation.locale_switcher')->ignoreOnInvalid()])
 
         ->set('twig.template_iterator', TemplateIterator::class)
             ->args([service('kernel'), abstract_arg('Twig paths'), param('twig.default_path'), abstract_arg('File name pattern')])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #49870
| License       | MIT
| Doc PR        | symfony/symfony-docs#18190

As stated in #49870, they were no way to get the current locale without passing it through a variable when rendering a template within `LocaleSwitcher::runWithLocale()`.


```php
#[AsController]
final class HomeController
{
    #[Route('/', name: 'app_home')]
    public function __invoke(LocaleSwitcher $localeSwitcher, Environment $twig): Response
    {
        $localeSwitcher->setLocale('en');

        return $localeSwitcher->runWithLocale('fr', function () use ($twig) {
            return new Response($twig->render('index.html.twig'));
        });
    }
}
```

```twig
{{ app.locale }} // fr
```

A doc PR will be submitted if this change is accepted.