### PR TITLE
[DoctrineBridge] Deprecate passing doctrine subscribers to ContainerAwareEventManager

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -17,6 +17,7 @@ DependencyInjection
 DoctrineBridge
 --------------
 
+ * Deprecate passing Doctrine subscribers to `ContainerAwareEventManager` class, use listeners instead
  * Deprecate `DoctrineDbalCacheAdapterSchemaSubscriber` in favor of `DoctrineDbalCacheAdapterSchemaListener`
  * Deprecate `MessengerTransportDoctrineSchemaSubscriber` in favor of `MessengerTransportDoctrineSchemaListener`
  * Deprecate `RememberMeTokenProviderDoctrineSchemaSubscriber` in favor of `RememberMeTokenProviderDoctrineSchemaListener`

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.3
 ---
 
+ * Deprecate passing Doctrine subscribers to `ContainerAwareEventManager` class, use listeners instead
  * Add `AbstractSchemaListener`, `LockStoreSchemaListener` and `PdoSessionHandlerSchemaListener`
  * Deprecate `DoctrineDbalCacheAdapterSchemaSubscriber` in favor of `DoctrineDbalCacheAdapterSchemaListener`
  * Deprecate `MessengerTransportDoctrineSchemaSubscriber` in favor of `MessengerTransportDoctrineSchemaListener`

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -106,6 +106,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                     $refs = $managerDef->getArguments()[1] ?? [];
                     $listenerRefs[$con][$id] = new Reference($id);
                     if ($subscriberTag === $tagName) {
+                        trigger_deprecation('symfony/doctrine-bridge', '6.3', 'Using Doctrine subscribers as services is deprecated, declare listeners instead');
                         $refs[] = $id;
                     } else {
                         $refs[] = [[$tag['event']], $id];

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -32,22 +32,30 @@ class ContainerAwareEventManagerTest extends TestCase
 
     public function testDispatchEventRespectOrder()
     {
-        $this->evm = new ContainerAwareEventManager($this->container, ['sub1', [['foo'], 'list1'], 'sub2']);
+        $this->evm = new ContainerAwareEventManager($this->container, [[['foo'], 'list1'], [['foo'], 'list2']]);
 
         $this->container->set('list1', $listener1 = new MyListener());
+        $this->container->set('list2', $listener2 = new MyListener());
+
+        $this->assertSame([$listener1, $listener2], array_values($this->evm->getListeners('foo')));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDispatchEventRespectOrderWithSubscribers()
+    {
+        $this->evm = new ContainerAwareEventManager($this->container, ['sub1', 'sub2']);
+
         $this->container->set('sub1', $subscriber1 = new MySubscriber(['foo']));
         $this->container->set('sub2', $subscriber2 = new MySubscriber(['foo']));
 
-        $this->assertSame([$subscriber1, $listener1, $subscriber2], array_values($this->evm->getListeners('foo')));
+        $this->expectDeprecation('Since symfony/doctrine-bridge 6.3: Using Doctrine subscribers as services is deprecated, declare listeners instead');
+        $this->assertSame([$subscriber1,  $subscriber2], array_values($this->evm->getListeners('foo')));
     }
 
     public function testDispatchEvent()
     {
-        $this->evm = new ContainerAwareEventManager($this->container, ['lazy4']);
-
-        $this->container->set('lazy4', $subscriber1 = new MySubscriber(['foo']));
-        $this->assertSame(0, $subscriber1->calledSubscribedEventsCount);
-
         $this->container->set('lazy1', $listener1 = new MyListener());
         $this->evm->addEventListener('foo', 'lazy1');
         $this->evm->addEventListener('foo', $listener2 = new MyListener());
@@ -57,6 +65,36 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->container->set('lazy3', $listener5 = new MyListener());
         $this->evm->addEventListener('foo', $listener5 = new MyListener());
         $this->evm->addEventListener('bar', $listener5);
+
+        $this->evm->dispatchEvent('foo');
+        $this->evm->dispatchEvent('bar');
+
+        $this->assertSame(0, $listener1->calledByInvokeCount);
+        $this->assertSame(1, $listener1->calledByEventNameCount);
+        $this->assertSame(0, $listener2->calledByInvokeCount);
+        $this->assertSame(1, $listener2->calledByEventNameCount);
+        $this->assertSame(1, $listener3->calledByInvokeCount);
+        $this->assertSame(0, $listener3->calledByEventNameCount);
+        $this->assertSame(1, $listener4->calledByInvokeCount);
+        $this->assertSame(0, $listener4->calledByEventNameCount);
+        $this->assertSame(1, $listener5->calledByInvokeCount);
+        $this->assertSame(1, $listener5->calledByEventNameCount);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDispatchEventWithSubscribers()
+    {
+        $this->evm = new ContainerAwareEventManager($this->container, ['lazy4']);
+
+        $this->container->set('lazy4', $subscriber1 = new MySubscriber(['foo']));
+        $this->assertSame(0, $subscriber1->calledSubscribedEventsCount);
+
+        $this->container->set('lazy1', $listener1 = new MyListener());
+        $this->expectDeprecation('Since symfony/doctrine-bridge 6.3: Using Doctrine subscribers as services is deprecated, declare listeners instead');
+        $this->evm->addEventListener('foo', 'lazy1');
+        $this->evm->addEventListener('foo', $listener2 = new MyListener());
         $this->evm->addEventSubscriber($subscriber2 = new MySubscriber(['bar']));
 
         $this->assertSame(1, $subscriber2->calledSubscribedEventsCount);
@@ -71,29 +109,16 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->assertSame(1, $listener1->calledByEventNameCount);
         $this->assertSame(0, $listener2->calledByInvokeCount);
         $this->assertSame(1, $listener2->calledByEventNameCount);
-        $this->assertSame(1, $listener3->calledByInvokeCount);
-        $this->assertSame(0, $listener3->calledByEventNameCount);
-        $this->assertSame(1, $listener4->calledByInvokeCount);
-        $this->assertSame(0, $listener4->calledByEventNameCount);
-        $this->assertSame(1, $listener5->calledByInvokeCount);
-        $this->assertSame(1, $listener5->calledByEventNameCount);
         $this->assertSame(0, $subscriber1->calledByInvokeCount);
         $this->assertSame(1, $subscriber1->calledByEventNameCount);
         $this->assertSame(1, $subscriber2->calledByInvokeCount);
         $this->assertSame(0, $subscriber2->calledByEventNameCount);
     }
 
-    public function testAddEventListenerAndSubscriberAfterDispatchEvent()
+    public function testAddEventListenerAfterDispatchEvent()
     {
-        $this->evm = new ContainerAwareEventManager($this->container, ['lazy7']);
-
-        $this->container->set('lazy7', $subscriber1 = new MySubscriber(['foo']));
-        $this->assertSame(0, $subscriber1->calledSubscribedEventsCount);
-
         $this->container->set('lazy1', $listener1 = new MyListener());
         $this->evm->addEventListener('foo', 'lazy1');
-        $this->assertSame(1, $subscriber1->calledSubscribedEventsCount);
-
         $this->evm->addEventListener('foo', $listener2 = new MyListener());
         $this->container->set('lazy2', $listener3 = new MyListener());
         $this->evm->addEventListener('bar', 'lazy2');
@@ -101,15 +126,9 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->container->set('lazy3', $listener5 = new MyListener());
         $this->evm->addEventListener('foo', $listener5 = new MyListener());
         $this->evm->addEventListener('bar', $listener5);
-        $this->evm->addEventSubscriber($subscriber2 = new MySubscriber(['bar']));
-
-        $this->assertSame(1, $subscriber2->calledSubscribedEventsCount);
 
         $this->evm->dispatchEvent('foo');
         $this->evm->dispatchEvent('bar');
-
-        $this->assertSame(1, $subscriber1->calledSubscribedEventsCount);
-        $this->assertSame(1, $subscriber2->calledSubscribedEventsCount);
 
         $this->container->set('lazy4', $listener6 = new MyListener());
         $this->evm->addEventListener('foo', 'lazy4');
@@ -120,6 +139,61 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->container->set('lazy6', $listener10 = new MyListener());
         $this->evm->addEventListener('foo', $listener10 = new MyListener());
         $this->evm->addEventListener('bar', $listener10);
+
+        $this->evm->dispatchEvent('foo');
+        $this->evm->dispatchEvent('bar');
+
+        $this->assertSame(0, $listener1->calledByInvokeCount);
+        $this->assertSame(2, $listener1->calledByEventNameCount);
+        $this->assertSame(0, $listener2->calledByInvokeCount);
+        $this->assertSame(2, $listener2->calledByEventNameCount);
+        $this->assertSame(2, $listener3->calledByInvokeCount);
+        $this->assertSame(0, $listener3->calledByEventNameCount);
+        $this->assertSame(2, $listener4->calledByInvokeCount);
+        $this->assertSame(0, $listener4->calledByEventNameCount);
+        $this->assertSame(2, $listener5->calledByInvokeCount);
+        $this->assertSame(2, $listener5->calledByEventNameCount);
+
+        $this->assertSame(0, $listener6->calledByInvokeCount);
+        $this->assertSame(1, $listener6->calledByEventNameCount);
+        $this->assertSame(0, $listener7->calledByInvokeCount);
+        $this->assertSame(1, $listener7->calledByEventNameCount);
+        $this->assertSame(1, $listener8->calledByInvokeCount);
+        $this->assertSame(0, $listener8->calledByEventNameCount);
+        $this->assertSame(1, $listener9->calledByInvokeCount);
+        $this->assertSame(0, $listener9->calledByEventNameCount);
+        $this->assertSame(1, $listener10->calledByInvokeCount);
+        $this->assertSame(1, $listener10->calledByEventNameCount);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testAddEventListenerAndSubscriberAfterDispatchEvent()
+    {
+        $this->evm = new ContainerAwareEventManager($this->container, ['lazy7']);
+
+        $this->container->set('lazy7', $subscriber1 = new MySubscriber(['foo']));
+        $this->assertSame(0, $subscriber1->calledSubscribedEventsCount);
+
+        $this->container->set('lazy1', $listener1 = new MyListener());
+        $this->expectDeprecation('Since symfony/doctrine-bridge 6.3: Using Doctrine subscribers as services is deprecated, declare listeners instead');
+        $this->evm->addEventListener('foo', 'lazy1');
+        $this->assertSame(1, $subscriber1->calledSubscribedEventsCount);
+
+        $this->evm->addEventSubscriber($subscriber2 = new MySubscriber(['bar']));
+
+        $this->assertSame(1, $subscriber2->calledSubscribedEventsCount);
+
+        $this->evm->dispatchEvent('foo');
+        $this->evm->dispatchEvent('bar');
+
+        $this->assertSame(1, $subscriber1->calledSubscribedEventsCount);
+        $this->assertSame(1, $subscriber2->calledSubscribedEventsCount);
+
+        $this->container->set('lazy6', $listener2 = new MyListener());
+        $this->evm->addEventListener('foo', $listener2 = new MyListener());
+        $this->evm->addEventListener('bar', $listener2);
         $this->evm->addEventSubscriber($subscriber3 = new MySubscriber(['bar']));
 
         $this->assertSame(1, $subscriber1->calledSubscribedEventsCount);
@@ -135,39 +209,36 @@ class ContainerAwareEventManagerTest extends TestCase
 
         $this->assertSame(0, $listener1->calledByInvokeCount);
         $this->assertSame(2, $listener1->calledByEventNameCount);
-        $this->assertSame(0, $listener2->calledByInvokeCount);
-        $this->assertSame(2, $listener2->calledByEventNameCount);
-        $this->assertSame(2, $listener3->calledByInvokeCount);
-        $this->assertSame(0, $listener3->calledByEventNameCount);
-        $this->assertSame(2, $listener4->calledByInvokeCount);
-        $this->assertSame(0, $listener4->calledByEventNameCount);
-        $this->assertSame(2, $listener5->calledByInvokeCount);
-        $this->assertSame(2, $listener5->calledByEventNameCount);
         $this->assertSame(0, $subscriber1->calledByInvokeCount);
         $this->assertSame(2, $subscriber1->calledByEventNameCount);
         $this->assertSame(2, $subscriber2->calledByInvokeCount);
         $this->assertSame(0, $subscriber2->calledByEventNameCount);
 
-        $this->assertSame(0, $listener6->calledByInvokeCount);
-        $this->assertSame(1, $listener6->calledByEventNameCount);
-        $this->assertSame(0, $listener7->calledByInvokeCount);
-        $this->assertSame(1, $listener7->calledByEventNameCount);
-        $this->assertSame(1, $listener8->calledByInvokeCount);
-        $this->assertSame(0, $listener8->calledByEventNameCount);
-        $this->assertSame(1, $listener9->calledByInvokeCount);
-        $this->assertSame(0, $listener9->calledByEventNameCount);
-        $this->assertSame(1, $listener10->calledByInvokeCount);
-        $this->assertSame(1, $listener10->calledByEventNameCount);
+        $this->assertSame(1, $listener2->calledByInvokeCount);
+        $this->assertSame(1, $listener2->calledByEventNameCount);
         $this->assertSame(1, $subscriber3->calledByInvokeCount);
         $this->assertSame(0, $subscriber3->calledByEventNameCount);
     }
 
     public function testGetListenersForEvent()
     {
+        $this->container->set('lazy', $listener1 = new MyListener());
+        $this->evm->addEventListener('foo', 'lazy');
+        $this->evm->addEventListener('foo', $listener2 = new MyListener());
+
+        $this->assertSame([$listener1, $listener2], array_values($this->evm->getListeners('foo')));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetListenersForEventWhenSubscribersArePresent()
+    {
         $this->evm = new ContainerAwareEventManager($this->container, ['lazy2']);
 
         $this->container->set('lazy', $listener1 = new MyListener());
         $this->container->set('lazy2', $subscriber1 = new MySubscriber(['foo']));
+        $this->expectDeprecation('Since symfony/doctrine-bridge 6.3: Using Doctrine subscribers as services is deprecated, declare listeners instead');
         $this->evm->addEventListener('foo', 'lazy');
         $this->evm->addEventListener('foo', $listener2 = new MyListener());
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ContainerAwareEventManager;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -22,6 +23,8 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class RegisterEventListenersAndSubscribersPassTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testExceptionOnAbstractTaggedSubscriber()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -195,6 +198,9 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testProcessEventSubscribersWithMultipleConnections()
     {
         $container = $this->createBuilder(true);
@@ -232,6 +238,7 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
             ])
         ;
 
+        $this->expectDeprecation('Since symfony/doctrine-bridge 6.3: Using Doctrine subscribers as services is deprecated, declare listeners instead');
         $this->process($container);
 
         $eventManagerDef = $container->getDefinition('doctrine.dbal.default_connection.event_manager');
@@ -279,6 +286,9 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testProcessEventSubscribersWithPriorities()
     {
         $container = $this->createBuilder();
@@ -312,6 +322,7 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
             ])
         ;
 
+        $this->expectDeprecation('Since symfony/doctrine-bridge 6.3: Using Doctrine subscribers as services is deprecated, declare listeners instead');
         $this->process($container);
 
         $eventManagerDef = $container->getDefinition('doctrine.dbal.default_connection.event_manager');
@@ -341,6 +352,9 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testProcessEventSubscribersAndListenersWithPriorities()
     {
         $container = $this->createBuilder();
@@ -402,6 +416,7 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
             ])
         ;
 
+        $this->expectDeprecation('Since symfony/doctrine-bridge 6.3: Using Doctrine subscribers as services is deprecated, declare listeners instead');
         $this->process($container);
 
         $eventManagerDef = $container->getDefinition('doctrine.dbal.default_connection.event_manager');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes 
| Tickets       | Fix https://github.com/symfony/symfony/issues/49586
| License       | MIT
| Doc PR        | 

Following issue https://github.com/symfony/symfony/issues/49586, this PR aims to deprecate passing doctrine subscribers to ContainerAwareEventManager. As mentioned, "[#[AsDoctrineListener]]... is a way better alternative anyway."

Following https://github.com/symfony/symfony/issues/49387#issuecomment-1442179095,  in PR https://github.com/symfony/symfony/pull/49610 DoctrineSchemaSubscribers have already been deprecated in favor of listeners.

