### PR TITLE
[HttpClient] Fix canceling MockResponse

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -112,7 +112,7 @@ class MockResponse implements ResponseInterface, StreamableInterface
         }
 
         $onProgress = $this->requestOptions['on_progress'] ?? static function () {};
-        $dlSize = isset($this->headers['content-encoding']) || 'HEAD' === $this->info['http_method'] || \in_array($this->info['http_code'], [204, 304], true) ? 0 : (int) ($this->headers['content-length'][0] ?? 0);
+        $dlSize = isset($this->headers['content-encoding']) || 'HEAD' === ($this->info['http_method'] ?? null) || \in_array($this->info['http_code'], [204, 304], true) ? 0 : (int) ($this->headers['content-length'][0] ?? 0);
         $onProgress($this->offset, $dlSize, $this->info);
     }
 

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -507,7 +507,7 @@ class MockHttpClientTest extends HttpClientTestCase
         $this->assertSame(0, $client->getRequestsCount());
     }
 
-    public function testCancellingMockResponseExecutesOnProgressWithUpdatedInfo()
+    public function testCancelingMockResponseExecutesOnProgressWithUpdatedInfo()
     {
         $client = new MockHttpClient(new MockResponse(['foo', 'bar', 'ccc']));
         $canceled = false;

--- a/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
@@ -116,4 +116,12 @@ class MockResponseTest extends TestCase
             'error' => 'ccc error',
         ]))->getStatusCode();
     }
+
+    public function testCancelingAMockResponseNotIssuedByMockHttpClient()
+    {
+        $mockResponse = new MockResponse();
+        $mockResponse->cancel();
+
+        $this->assertTrue($mockResponse->getInfo('canceled'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | -
| Tickets       | https://github.com/symfony/symfony/issues/49925
| License       | MIT
| Doc PR        | -

MockResponse not issued by MockHttpClient might not have the http_method info set.

http_code looks safe since it's defined in the constructor.