### PR TITLE
[DependencyInjection] Add more precise types in `EnvVarProcessorInterface`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessorInterface.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessorInterface.php
@@ -23,16 +23,16 @@ interface EnvVarProcessorInterface
     /**
      * Returns the value of the given variable as managed by the current instance.
      *
-     * @param string   $prefix The namespace of the variable
-     * @param string   $name   The name of the variable within the namespace
-     * @param \Closure $getEnv A closure that allows fetching more env vars
+     * @param string                  $prefix The namespace of the variable
+     * @param string                  $name   The name of the variable within the namespace
+     * @param \Closure(string): mixed $getEnv A closure that allows fetching more env vars
      *
      * @throws RuntimeException on error
      */
     public function getEnv(string $prefix, string $name, \Closure $getEnv): mixed;
 
     /**
-     * @return string[] The PHP-types managed by getEnv(), keyed by prefixes
+     * @return array<string, string> The PHP-types managed by getEnv(), keyed by prefixes
      */
     public static function getProvidedTypes(): array;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This more precise type will help static analyzers and IDEs to spot mistakes in implementations of this interface
