### PR TITLE
[Security] Improve DX when invalid custom authenticators

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -104,6 +104,10 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         foreach ($this->authenticators as $authenticator) {
             $this->logger?->debug('Checking support on authenticator.', ['firewall_name' => $this->firewallName, 'authenticator' => $authenticator::class]);
 
+            if (!$authenticator instanceof AuthenticatorInterface) {
+                throw new \InvalidArgumentException(sprintf('Authenticator "%s" must implement "%s".', get_debug_type($authenticator), AuthenticatorInterface::class));
+            }
+
             if (false !== $supports = $authenticator->supports($request)) {
                 $authenticators[] = $authenticator;
                 $lazy = $lazy && null === $supports;

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -77,6 +77,17 @@ class AuthenticatorManagerTest extends TestCase
         yield [[], false];
     }
 
+    public function testSupportsInvalidAuthenticator()
+    {
+        $manager = $this->createManager([new \stdClass()]);
+
+        $this->expectExceptionObject(
+            new \InvalidArgumentException('Authenticator "stdClass" must implement "Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface".')
+        );
+
+        $manager->supports($this->request);
+    }
+
     public function testSupportCheckedUponRequestAuthentication()
     {
         // the attribute stores the supported authenticators, returning false now


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


Before this PR error was

```yaml
security:
    firewalls:
        main:
            lazy: true
            provider: users_in_memory
            custom_authenticators:
                - App\Security\FooProvider # Mistake is here, must be an AuthenticatorInterface
```

![image](https://user-images.githubusercontent.com/9253091/230036405-e6be6a7e-b05d-40ad-8155-113634f7e341.png)