### PR TITLE
Fix the test for casting FlattenException on Windows

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -375,7 +375,7 @@ array:1 [
     -statusCode: 500
     -statusText: "Internal Server Error"
     -headers: []
-    -file: "%s/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php"
+    -file: "%sExceptionCasterTest.php"
     -line: %d
     -asString: null
   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The assertion should avoid forcing to show path separators, as done in other tests of the caster, as path separators are different on Windows.
This fixes the test introduced in https://github.com/symfony/symfony/pull/49853
