### PR TITLE
Fix intl data tests

### DIFF
--- a/.github/workflows/intl-data-tests.yml
+++ b/.github/workflows/intl-data-tests.yml
@@ -3,10 +3,18 @@ name: Intl data
 on:
   push:
     paths:
+      - 'src/Symfony/Component/Intl/*.php'
+      - 'src/Symfony/Component/Intl/Util/GitRepository.php'
       - 'src/Symfony/Component/Intl/Resources/data/**'
+      - 'src/Symfony/Component/Intl/Tests/*Test.php'
+      - 'src/Symfony/Component/Intl/Tests/Util/GitRepositoryTest.php'
   pull_request:
     paths:
+      - 'src/Symfony/Component/Intl/*.php'
+      - 'src/Symfony/Component/Intl/Util/GitRepository.php'
       - 'src/Symfony/Component/Intl/Resources/data/**'
+      - 'src/Symfony/Component/Intl/Tests/*Test.php'
+      - 'src/Symfony/Component/Intl/Tests/Util/GitRepositoryTest.php'
 
 defaults:
   run:

--- a/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
+++ b/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
@@ -736,7 +736,7 @@ class CurrenciesTest extends ResourceBundleTestCase
 
     public static function provideValidNumericCodes()
     {
-        $numericToAlpha3 = $this->getNumericToAlpha3Mapping();
+        $numericToAlpha3 = self::getNumericToAlpha3Mapping();
 
         return array_map(
             function ($numeric, $alpha3) { return [$numeric, $alpha3]; },
@@ -761,7 +761,7 @@ class CurrenciesTest extends ResourceBundleTestCase
 
     public static function provideInvalidNumericCodes()
     {
-        $validNumericCodes = array_keys($this->getNumericToAlpha3Mapping());
+        $validNumericCodes = array_keys(self::getNumericToAlpha3Mapping());
         $invalidNumericCodes = array_diff(range(0, 1000), $validNumericCodes);
 
         return array_map(
@@ -791,7 +791,7 @@ class CurrenciesTest extends ResourceBundleTestCase
         $this->assertFalse(Currencies::exists('XXX'));
     }
 
-    private function getNumericToAlpha3Mapping()
+    private static function getNumericToAlpha3Mapping()
     {
         $numericToAlpha3 = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The migration to static data providers in tests missed a broken method call because the CI did not run the intl-data tests when modifying those tests outside of a PR updating the data (I caught this when my PR moving the emoji data to a different location triggered this workflow).