### PR TITLE
[Intl] Improve the description of the Intl component

### DIFF
--- a/src/Symfony/Component/Intl/README.md
+++ b/src/Symfony/Component/Intl/README.md
@@ -1,11 +1,7 @@
 Intl Component
 =============
 
-The Intl component provides a PHP replacement layer for the C intl extension
-that also provides access to the localization data of the ICU library.
-
-The replacement layer is limited to the locale "en". If you want to use other
-locales, you should [install the intl PHP extension][0] instead.
+The Intl component provides access to the localization data of the ICU library.
 
 Resources
 ---------
@@ -15,7 +11,3 @@ Resources
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
- * [Docker images with intl support](https://hub.docker.com/r/jakzal/php-intl)
-   (for the Intl component development)
-
-[0]: https://php.net/intl.setup

--- a/src/Symfony/Component/Intl/composer.json
+++ b/src/Symfony/Component/Intl/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "symfony/intl",
     "type": "library",
-    "description": "Provides a PHP replacement layer for the C intl extension that includes additional data from the ICU library",
+    "description": "Provides access to the localization data of the ICU library",
     "keywords": ["intl", "icu", "internationalization", "localization", "i18n", "l10n"],
     "homepage": "https://symfony.com",
     "license": "MIT",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

As of Symfony 6.0, the symfony/intl component does provide a replacement for ext-intl (that code was moved to symfony/polyfill instead). Now, this component is _only_ about exposing the ICU data (note that I intentionally avoid mentioning the EmojiTransliterator that expands a bit that scope in 6.2 because of #49947)