### PR TITLE
[Serializer] Marking some Normalizer classes as final

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -117,4 +117,14 @@ Serializer
 
  * Deprecate `MissingConstructorArgumentsException` in favor of `MissingConstructorArgumentException`
  * Deprecate `CacheableSupportsMethodInterface` in favor of the new `getSupportedTypes(?string $format)` methods
- * The following Normalizer classes will become final in 7.0: `ObjectNormalizer`
+ * The following Normalizer classes will become final in 7.0:
+   * `ConstraintViolationListNormalizer`
+   * `CustomNormalizer`
+   * `DataUriNormalizer`
+   * `DateIntervalNormalizer`
+   * `DateTimeNormalizer`
+   * `DateTimeZoneNormalizer`
+   * `GetSetMethodNormalizer`
+   * `JsonSerializableNormalizer`
+   * `ObjectNormalizer`
+   * `PropertyNormalizer`

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -10,7 +10,17 @@ CHANGELOG
  * Make `ProblemNormalizer` give details about `ValidationFailedException` and `PartialDenormalizationException`
  * Deprecate `MissingConstructorArgumentsException` in favor of `MissingConstructorArgumentException`
  * Deprecate `CacheableSupportsMethodInterface` in favor of the new `getSupportedTypes(?string $format)` methods
- * The following Normalizer classes will become final in 7.0: `ObjectNormalizer`
+ * The following Normalizer classes will become final in 7.0:
+   * `ConstraintViolationListNormalizer`
+   * `CustomNormalizer`
+   * `DataUriNormalizer`
+   * `DateIntervalNormalizer`
+   * `DateTimeNormalizer`
+   * `DateTimeZoneNormalizer`
+   * `GetSetMethodNormalizer`
+   * `JsonSerializableNormalizer`
+   * `ObjectNormalizer`
+   * `PropertyNormalizer`
 
 6.2
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -21,6 +21,8 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 6.3
  */
 class ConstraintViolationListNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -16,6 +16,8 @@ use Symfony\Component\Serializer\SerializerAwareTrait;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @final since Symfony 6.3
  */
 class CustomNormalizer implements NormalizerInterface, DenormalizerInterface, SerializerAwareInterface, CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -22,6 +22,8 @@ use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
  * Denormalizes a data URI to a {@see \SplFileObject} object.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 6.3
  */
 class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
  * Denormalizes an interval string to an instance of {@see \DateInterval}.
  *
  * @author Jérôme Parmentier <jerome@prmntr.me>
+ *
+ * @final since Symfony 6.3
  */
 class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -20,6 +20,8 @@ use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
  * Denormalizes a date string to an instance of {@see \DateTime} or {@see \DateTimeImmutable}.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 6.3
  */
 class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
  * Normalizes a {@see \DateTimeZone} object to a timezone string.
  *
  * @author Jérôme Desjardins <jewome62@gmail.com>
+ *
+ * @final since Symfony 6.3
  */
 class DateTimeZoneNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -33,6 +33,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
  *
  * @author Nils Adermann <naderman@naderman.de>
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 6.3
  */
 class GetSetMethodNormalizer extends AbstractObjectNormalizer
 {

--- a/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
@@ -18,6 +18,8 @@ use Symfony\Component\Serializer\Exception\LogicException;
  * A normalizer that uses an objects own JsonSerializable implementation.
  *
  * @author Fred Cox <mcfedr@gmail.com>
+ *
+ * @final since Symfony 6.3
  */
 class JsonSerializableNormalizer extends AbstractNormalizer
 {

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -33,6 +33,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 6.3
  */
 class PropertyNormalizer extends AbstractObjectNormalizer
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/pull/49291#pullrequestreview-1306165711
| License       | MIT
| Doc PR        | n/a

As mentioned in https://github.com/symfony/symfony/pull/49291#pullrequestreview-1306165711.

Making those classes final will allow to get rid of all the `__CLASS__ === static::class` for cacheability checks in 7.0