### PR TITLE
[Serializer] Cleanup `static` uses when classes are final

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
@@ -90,6 +90,6 @@ final class FormErrorNormalizer implements NormalizerInterface, CacheableSupport
     {
         trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
 
-        return __CLASS__ === static::class;
+        return true;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -121,6 +121,6 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
     {
         trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
 
-        return __CLASS__ === static::class;
+        return true;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
@@ -106,6 +106,6 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface,
     {
         trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, use "getSupportedTypes()" instead.', __METHOD__);
 
-        return __CLASS__ === static::class;
+        return true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT
| Doc PR        | none
