### PR TITLE
[FrameworkBundle] Make private helper methods protected in test traits

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -156,7 +156,7 @@ trait BrowserKitAssertionsTrait
         self::assertThat(self::getClient(), $constraint, $message);
     }
 
-    private static function getClient(AbstractBrowser $newClient = null): ?AbstractBrowser
+    protected static function getClient(AbstractBrowser $newClient = null): ?AbstractBrowser
     {
         static $client;
 
@@ -171,7 +171,7 @@ trait BrowserKitAssertionsTrait
         return $client;
     }
 
-    private static function getResponse(): Response
+    protected static function getResponse(): Response
     {
         if (!$response = self::getClient()->getResponse()) {
             static::fail('A client must have an HTTP Response to make assertions. Did you forget to make an HTTP request?');
@@ -180,7 +180,7 @@ trait BrowserKitAssertionsTrait
         return $response;
     }
 
-    private static function getRequest(): Request
+    protected static function getRequest(): Request
     {
         if (!$request = self::getClient()->getRequest()) {
             static::fail('A client must have an HTTP Request to make assertions. Did you forget to make an HTTP request?');

--- a/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
@@ -116,7 +116,7 @@ trait DomCrawlerAssertionsTrait
         self::assertArrayNotHasKey($fieldName, $values, $message ?: sprintf('Field "%s" has a value in form "%s".', $fieldName, $formSelector));
     }
 
-    private static function getCrawler(): Crawler
+    protected static function getCrawler(): Crawler
     {
         if (!$crawler = self::getClient()->getCrawler()) {
             static::fail('A client must have a crawler to make assertions. Did you forget to make an HTTP request?');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Making these methods protected instead of private will allow users to use these methods in their own test files (e.g. traits and extended test classes). 

An example of my own application. I wanted to make an assertion that tested if a flash message was shown. It would have been very easy to just copy the existing assertions and just change one line, but because I can't use the `self::getCrawler()` and `self::getClient()` it was much more tedious.
