### PR TITLE
[Serializer] Mark `ObjectNormalizer` as final for 7.0

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -112,3 +112,4 @@ Serializer
 
  * Deprecate `MissingConstructorArgumentsException` in favor of `MissingConstructorArgumentException`
  * Deprecate `CacheableSupportsMethodInterface` in favor of the new `getSupportedTypes(?string $format)` methods
+ * The following Normalizer classes will become final in 7.0: `ObjectNormalizer`

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Make `ProblemNormalizer` give details about `ValidationFailedException` and `PartialDenormalizationException`
  * Deprecate `MissingConstructorArgumentsException` in favor of `MissingConstructorArgumentException`
  * Deprecate `CacheableSupportsMethodInterface` in favor of the new `getSupportedTypes(?string $format)` methods
+ * The following Normalizer classes will become final in 7.0: `ObjectNormalizer`
 
 6.2
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -25,6 +25,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * Converts between objects and arrays using the PropertyAccess component.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 6.3
  */
 class ObjectNormalizer extends AbstractObjectNormalizer
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/pull/49291#pullrequestreview-1306165711
| License       | MIT
| Doc PR        | none

Extracted from #49950 and related to https://github.com/symfony/symfony/pull/49291#pullrequestreview-1306165711