### PR TITLE
[Scheduler] Allow messages from the SchedulerTransport to be rejected

### DIFF
--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -40,7 +40,7 @@ class SchedulerTransport implements TransportInterface
 
     public function reject(Envelope $envelope): void
     {
-        throw new LogicException(sprintf('Messages from "%s" must not be rejected.', __CLASS__));
+        // ignore
     }
 
     public function send(Envelope $envelope): Envelope

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
@@ -52,7 +52,7 @@ class SchedulerTransportTest extends TestCase
     {
         $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class));
 
-        $this->expectException(LogicException::class);
+        $this->expectNotToPerformAssertions();
         $transport->reject(new Envelope(new \stdClass()));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Related to #49804
| License       | MIT

Currently, when the processing of a scheduled message fails, Messenger will not be able to go on because the SchedulerTransport will throw an exception. More importantly, the original error will be swallowed by this one and not sent to the failure transport if one is configured. By allowing message rejection, Messenger will continue working as expected.

This is the first step to more changes regarding failure handling in ScheduledMessage processing.

/cc @fabpot @kbond
