### PR TITLE
Scheduler/retries and failures

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/scheduler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/scheduler.php
@@ -18,6 +18,7 @@ return static function (ContainerConfigurator $container) {
         ->set('scheduler.messenger_transport_factory', SchedulerTransportFactory::class)
             ->args([
                 tagged_locator('scheduler.schedule_provider', 'name'),
+                tagged_locator('messenger.receiver', 'alias'),
                 service('clock'),
             ])
             ->tag('messenger.transport_factory')

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -40,7 +40,7 @@ class SchedulerTransport implements TransportInterface
 
     public function reject(Envelope $envelope): void
     {
-        throw new LogicException(sprintf('Messages from "%s" must not be rejected.', __CLASS__));
+        // ignore
     }
 
     public function send(Envelope $envelope): Envelope

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Scheduler\Messenger;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\Generator\MessageGeneratorInterface;
@@ -23,11 +25,18 @@ class SchedulerTransport implements TransportInterface
 {
     public function __construct(
         private readonly MessageGeneratorInterface $messageGenerator,
+        private readonly ?TransportInterface $retryTransport = null,
     ) {
     }
 
     public function get(): iterable
     {
+        // Every other type of transports should NOT be consumed here but by a
+        // dedicated consumer
+        if ($this->retryTransport instanceof InMemoryTransport) {
+            yield from $this->retryTransport->get();
+        }
+
         foreach ($this->messageGenerator->getMessages() as $message) {
             yield Envelope::wrap($message, [new ScheduledStamp()]);
         }
@@ -35,16 +44,32 @@ class SchedulerTransport implements TransportInterface
 
     public function ack(Envelope $envelope): void
     {
+        if ($this->retryTransport && $envelope->last(ScheduledStamp::class) && $envelope->last(RedeliveryStamp::class)) {
+            $this->retryTransport->ack($envelope);
+        }
+
         // ignore
     }
 
     public function reject(Envelope $envelope): void
     {
+        if ($this->retryTransport && $envelope->last(ScheduledStamp::class) && $envelope->last(RedeliveryStamp::class)) {
+            $this->retryTransport->reject($envelope);
+        }
+
         // ignore
     }
 
     public function send(Envelope $envelope): Envelope
     {
+        if ($envelope->last(ScheduledStamp::class) && $envelope->last(RedeliveryStamp::class)) {
+            if (!$this->retryTransport) {
+                throw new LogicException(sprintf('"%s" is not configured for retry. Please enable it by specifying ?retry=anotherTransport to its DSN', __CLASS__));
+            }
+
+            return $this->retryTransport->send($envelope);
+        }
+
         throw new LogicException(sprintf('"%s" cannot send messages.', __CLASS__));
     }
 }

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
@@ -52,7 +52,7 @@ class SchedulerTransportTest extends TestCase
     {
         $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class));
 
-        $this->expectException(LogicException::class);
+        $this->expectNotToPerformAssertions();
         $transport->reject(new Envelope(new \stdClass()));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | subjective
| New feature?  | yes
| Deprecations? | no
| Tickets       | Related to #49804
| License       | MIT
| Doc PR        | Can be directly integrated into https://github.com/symfony/symfony-docs/issues/18067

Right now the handling of failures happening during Scheduled Messages handling is not great (see #49804).
#49964 allows one to be notified of errors and save failed messages if a failure transport is configured.

But one might want to have messages retried automatically which is not possible at the moment.
There are two approaches to this:
- either we do nothing and one is encouraged to use `RedispatchMessage` to ensure retry happens when necessary on a transport supporting retries
- or we allow a user to specify which transport should be used for retries, leveraging in memory for simple use cases.

This PR is an attempt at the second approach.
It allows one to define the scheduler transport with a retry option to the DSN:
```yaml
framework:
    messenger:
        transports:
             scheduler_default: 'schedule://default?retry=async'
```
In case of failure when Messenger tries to send the message to ScheduleTransport it will then actually forward the envelope to the specified transport which will then be picked up by regular consumers.
For simple use cases, one can use the `'schedule://default?retry` that will use the in-memory transport and the SchedulerTransport will then pick them up once available after the retry delay.

/cc @kbond @fabpot 