### PR TITLE
[Security] Create Controller Argument Resolver for Security Token

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -42,6 +42,7 @@ use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\MissingUserProvider;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+use Symfony\Component\Security\Http\Controller\SecurityTokenValueResolver;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
 use Symfony\Component\Security\Http\EventListener\IsGrantedAttributeListener;
 use Symfony\Component\Security\Http\Firewall;
@@ -101,6 +102,12 @@ return static function (ContainerConfigurator $container) {
                 service('security.token_storage'),
             ])
             ->tag('controller.argument_value_resolver', ['priority' => 120, 'name' => UserValueResolver::class])
+
+        ->set('security.security_token_value_resolver', SecurityTokenValueResolver::class)
+            ->args([
+                service('security.token_storage'),
+            ])
+            ->tag('controller.argument_value_resolver', ['priority' => 120, 'name' => SecurityTokenValueResolver::class])
 
         // Authentication related services
         ->set('security.authentication.trust_resolver', AuthenticationTrustResolver::class)

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `attributes` optional array argument in `UserBadge`
  * Call `UserBadge::userLoader` with attributes if the argument is set
  * Allow to override badge fqcn on `Passport::addBadge`
+ * Add `SecurityTokenValueResolver` to inject token as controller argument
 
 6.2
 ---

--- a/src/Symfony/Component/Security/Http/Controller/SecurityTokenValueResolver.php
+++ b/src/Symfony/Component/Security/Http/Controller/SecurityTokenValueResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ */
+final class SecurityTokenValueResolver implements ValueResolverInterface
+{
+    public function __construct(private readonly TokenStorageInterface $tokenStorage)
+    {
+    }
+
+    /**
+     * @return TokenInterface[]
+     */
+    public function resolve(Request $request, ArgumentMetadata $argument): array
+    {
+        if (!($type = $argument->getType()) || (TokenInterface::class !== $type && !is_subclass_of($type, TokenInterface::class))) {
+            return [];
+        }
+
+        if (null !== $token = $this->tokenStorage->getToken()) {
+            return [$token];
+        }
+
+        if ($argument->isNullable()) {
+            return [];
+        }
+
+        throw new HttpException(Response::HTTP_UNAUTHORIZED, 'A security token is required but the token storage is empty.');
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Controller/SecurityTokenValueResolverTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Controller/SecurityTokenValueResolverTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Controller\SecurityTokenValueResolver;
+
+class SecurityTokenValueResolverTest extends TestCase
+{
+    public function testResolveSucceedsWithTokenInterface()
+    {
+        $user = new InMemoryUser('username', 'password');
+        $token = new UsernamePasswordToken($user, 'provider');
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken($token);
+
+        $resolver = new SecurityTokenValueResolver($tokenStorage);
+        $metadata = new ArgumentMetadata('foo', TokenInterface::class, false, false, null);
+
+        $this->assertSame([$token], $resolver->resolve(Request::create('/'), $metadata));
+    }
+
+    public function testResolveSucceedsWithSubclassType()
+    {
+        $user = new InMemoryUser('username', 'password');
+        $token = new UsernamePasswordToken($user, 'provider');
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken($token);
+
+        $resolver = new SecurityTokenValueResolver($tokenStorage);
+        $metadata = new ArgumentMetadata('foo', UsernamePasswordToken::class, false, false, null, false);
+
+        $this->assertSame([$token], $resolver->resolve(Request::create('/'), $metadata));
+    }
+
+    public function testResolveSucceedsWithNullableParamAndNoToken()
+    {
+        $tokenStorage = new TokenStorage();
+        $resolver = new SecurityTokenValueResolver($tokenStorage);
+        $metadata = new ArgumentMetadata('foo', TokenInterface::class, false, false, null, true);
+
+        $this->assertSame([], $resolver->resolve(Request::create('/'), $metadata));
+    }
+
+    public function testResolveThrowsUnauthenticatedWithNoToken()
+    {
+        $tokenStorage = new TokenStorage();
+        $resolver = new SecurityTokenValueResolver($tokenStorage);
+        $metadata = new ArgumentMetadata('foo', UsernamePasswordToken::class, false, false, null, false);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('A security token is required but the token storage is empty.');
+
+        $resolver->resolve(Request::create('/'), $metadata);
+    }
+
+    public function testIntegration()
+    {
+        $user = new InMemoryUser('username', 'password');
+        $token = new UsernamePasswordToken($user, 'provider');
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken($token);
+
+        $argumentResolver = new ArgumentResolver(null, [new SecurityTokenValueResolver($tokenStorage)]);
+        $this->assertSame([$token], $argumentResolver->getArguments(Request::create('/'), static function (TokenInterface $token) {}));
+    }
+
+    public function testIntegrationNoToken()
+    {
+        $tokenStorage = new TokenStorage();
+
+        $argumentResolver = new ArgumentResolver(null, [new SecurityTokenValueResolver($tokenStorage), new DefaultValueResolver()]);
+        $this->assertSame([null], $argumentResolver->getArguments(Request::create('/'), static function (?TokenInterface $token) {}));
+    }
+
+    public function testIntegrationNonNullablwWithNoToken()
+    {
+        $tokenStorage = new TokenStorage();
+
+        $argumentResolver = new ArgumentResolver(null, [new SecurityTokenValueResolver($tokenStorage), new DefaultValueResolver()]);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('A security token is required but the token storage is empty.');
+
+        $argumentResolver->getArguments(Request::create('/'), static function (TokenInterface $token) {});
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | TBD

Sometimes Authentication Token contains more data than we have persisted in the User. For this cases we can resolve Controller Arguments typed with `TokenInterface` or any sub-class/interface.

## Usage
```php
final class GetCurrentAuthenticatedUserController
{
    public function __invoke(TokenInterface $token)
    {
        // deal with $token
    }
}
```

## TODO:
- [x] Add changelog entry
- [x] Cover with tests
