### PR TITLE
[Intl] Allow compressing emoji and data maps

### DIFF
--- a/src/Symfony/Component/Intl/CHANGELOG.md
+++ b/src/Symfony/Component/Intl/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the special `strip` locale to `EmojiTransliterator` to strip all emojis from a string
+ * Add `compress` script to compress the `Resources/data` directory when disk space matters
 
 6.2
 ---

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/PhpBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/PhpBundleReader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Data\Bundle\Reader;
 
 use Symfony\Component\Intl\Exception\ResourceBundleNotFoundException;
+use Symfony\Component\Intl\Util\GzipStreamWrapper;
 
 /**
  * Reads .php resource bundles.
@@ -29,6 +30,10 @@ class PhpBundleReader implements BundleReaderInterface
         // prevent directory traversal attacks
         if (\dirname($fileName) !== $path) {
             throw new ResourceBundleNotFoundException(sprintf('The resource bundle "%s" does not exist.', $fileName));
+        }
+
+        if (is_file($fileName.'.gz')) {
+            return GzipStreamWrapper::require($fileName.'.gz');
         }
 
         if (!is_file($fileName)) {

--- a/src/Symfony/Component/Intl/Resources/bin/compress
+++ b/src/Symfony/Component/Intl/Resources/bin/compress
@@ -1,0 +1,19 @@
+#!/usr/bin/env php
+<?php
+
+if ('cli' !== PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+if (!extension_loaded('zlib')) {
+    throw new Exception('This script requires the zlib extension.');
+}
+
+foreach (glob(dirname(__DIR__).'/data/*/*.php') as $file) {
+    if (in_array(basename($file), ['en.php', 'meta.php'], true)) {
+        continue;
+    }
+
+    file_put_contents('compress.zlib://'.$file.'.gz', $data);
+
+    unlink($file.(filesize($file.'.gz') >= filesize($file) ? '.gz' : ''));
+}

--- a/src/Symfony/Component/Intl/Resources/emoji/build.php
+++ b/src/Symfony/Component/Intl/Resources/emoji/build.php
@@ -19,9 +19,9 @@ use Symfony\Component\VarExporter\VarExporter;
 Builder::cleanTarget();
 $emojisCodePoints = Builder::getEmojisCodePoints();
 Builder::saveRules(Builder::buildRules($emojisCodePoints));
+Builder::saveRules(Builder::buildStripRules($emojisCodePoints));
 Builder::saveRules(Builder::buildGitHubRules($emojisCodePoints));
 Builder::saveRules(Builder::buildSlackRules($emojisCodePoints));
-Builder::saveRules(Builder::buildStripRules($emojisCodePoints));
 
 final class Builder
 {
@@ -178,7 +178,7 @@ final class Builder
             $maps[$codePointsCount][$emoji] = '';
         }
 
-        return ['strip' => self::createRules($maps)];
+        return ['emoji-strip' => self::createRules($maps)];
     }
 
     public static function cleanTarget(): void
@@ -192,7 +192,7 @@ final class Builder
     {
         $firstChars = [];
         foreach ($rulesByLocale as $filename => $rules) {
-            file_put_contents(self::TARGET_DIR."/$filename.php", "<?php\n\nreturn ".VarExporter::export($rules).";\n");
+            file_put_contents('compress.zlib://'.self::TARGET_DIR."/$filename.php.gz", "<?php\n\nreturn ".VarExporter::export($rules).";\n");
 
             foreach ($rules as $k => $v) {
                 if (!str_starts_with($filename, 'emoji-')) {

--- a/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
+++ b/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Intl\Transliterator;
 
+use Symfony\Component\Intl\Util\GzipStreamWrapper;
+
 if (!class_exists(\Transliterator::class)) {
     throw new \LogicException(sprintf('You cannot use the "%s\EmojiTransliterator" class as the "intl" extension is not installed. See https://php.net/intl.', __NAMESPACE__));
 } else {
@@ -40,7 +42,8 @@ if (!class_exists(\Transliterator::class)) {
                 $id = self::REVERSEABLE_IDS[$id];
             }
 
-            if (!preg_match('/^[a-z0-9@_\\.\\-]*$/', $id) || !is_file(\dirname(__DIR__)."/Resources/data/transliterator/emoji/{$id}.php")) {
+            $file = \dirname(__DIR__)."/Resources/data/transliterator/emoji/{$id}.php";
+            if (!preg_match('/^[a-z0-9@_\\.\\-]*$/', $id) || !is_file($file) && !is_file($file .= '.gz')) {
                 \Transliterator::create($id); // Populate intl_get_error_*()
 
                 throw new \IntlException(intl_get_error_message(), intl_get_error_code());
@@ -57,7 +60,7 @@ if (!class_exists(\Transliterator::class)) {
                 $instance = unserialize(sprintf('O:%d:"%s":1:{s:2:"id";s:%d:"%s";}', \strlen(self::class), self::class, \strlen($id), $id));
             }
 
-            $instance->map = $maps[$id] ??= require \dirname(__DIR__)."/Resources/data/transliterator/emoji/{$id}.php";
+            $instance->map = $maps[$id] ??= str_ends_with($file, '.gz') ? GzipStreamWrapper::require($file) : $require;
 
             return $instance;
         }
@@ -86,7 +89,9 @@ if (!class_exists(\Transliterator::class)) {
             }
 
             foreach (scandir(\dirname(__DIR__).'/Resources/data/transliterator/emoji/') as $file) {
-                if (str_ends_with($file, '.php')) {
+                if (str_ends_with($file, '.php.gz')) {
+                    $ids[] = substr($file, 0, -7);
+                } elseif (str_ends_with($file, '.php')) {
                     $ids[] = substr($file, 0, -4);
                 }
             }

--- a/src/Symfony/Component/Intl/Util/GzipStreamWrapper.php
+++ b/src/Symfony/Component/Intl/Util/GzipStreamWrapper.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Intl\Util;
+
+/**
+ * @internal
+ */
+class GzipStreamWrapper
+{
+    /** @var resource|null */
+    public $context;
+
+    /** @var resource */
+    private $handle;
+    private string $path;
+
+    public static function require(string $path): array
+    {
+        if (!\extension_loaded('zlib')) {
+            throw new \LogicException(sprintf('The "zlib" extension is required to load the "%s/%s" map, please enable it in your php.ini file.', basename(\dirname($path)), \basename($path)));
+        }
+
+        if (!\function_exists('opcache_is_script_cached') || !@opcache_is_script_cached($path)) {
+            stream_wrapper_unregister('file');
+            stream_wrapper_register('file', self::class);
+        }
+
+        return require $path;
+    }
+
+    public function stream_open(string $path, string $mode): bool
+    {
+        stream_wrapper_restore('file');
+        $this->path = $path;
+
+        return false !== $this->handle = fopen('compress.zlib://'. $path, $mode);
+    }
+
+    public function stream_read(int $count): string|false
+    {
+        return fread($this->handle, $count);
+    }
+
+    public function stream_eof(): bool
+    {
+        return feof($this->handle);
+    }
+
+    public function stream_set_option(int $option, int $arg1, int $arg2): bool
+    {
+        return match ($option) {
+            \STREAM_OPTION_BLOCKING => stream_set_blocking($this->handle, $arg1),
+            \STREAM_OPTION_READ_TIMEOUT => stream_set_timeout($this->handle, $arg1, $arg2),
+            \STREAM_OPTION_WRITE_BUFFER => 0 === stream_set_write_buffer($this->handle, $arg2),
+            default => false,
+        };
+    }
+
+    public function stream_stat(): array|false
+    {
+        if (!$stat = stat($this->path)) {
+            return false;
+        }
+
+        $h = fopen($this->path, 'rb');
+        fseek($h, -4, \SEEK_END);
+        $size = unpack('V', fread($h, 4));
+        fclose($h);
+
+        $stat[7] = $stat['size'] = end($size);
+
+        return $stat;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | #49943
| License       | MIT
| Doc PR        | -

This PR proposes to compress data and emoji maps into `.php.gz` files that are uncompressed on the fly.
Compatibility with opcache is preserved so that this will have no impact on performance.

I see this PR as an alternative to #49947.

`du -sh src/Symfony/Component/Intl/`:
- before: 45M
- after: 11M

`du -sh src/Symfony/Component/Intl/Resources/data/transliterator/`:
- before: 27MB
- after: 3,9M

The dependency to `ext-zlib` is made optional by not-compressing data for the "en" and the "meta" locales. The "en" locale is the default one in our recipes so this should help first timers. A LogicException is throw when using any other locales or when dealing with emojis and `ext-zlib` is missing.

For the record, this is how I compressed all files:
```sh
FILES=$(find Resources/data/ -name '*.php' | grep -v -F '/en.php' | grep -v -F '/meta.php')
echo $FILES | xargs -P0 -n1 php -r 'file_put_contents("compress.zlib://".$argv[1].".gz", file_get_contents($argv[1]));'
echo $FILES | xargs -P0 -n1 php -r 'unlink($argv[1].(filesize($argv[1].".gz") >= filesize($argv[1]) ? ".gz" : ""));'
```