### PR TITLE
[HttpKernel] Create `#[UploadedFile]` Attribute to map `UploadedFile` objects to Controller Arguments

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolve
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ServiceValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\SessionValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\UidValueResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\UploadedFileValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\VariadicValueResolver;
 use Symfony\Component\HttpKernel\Controller\ErrorController;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
@@ -63,6 +64,9 @@ return static function (ContainerConfigurator $container) {
 
         ->set('argument_resolver.request_attribute', RequestAttributeValueResolver::class)
             ->tag('controller.argument_value_resolver', ['priority' => 100, 'name' => RequestAttributeValueResolver::class])
+
+        ->set('argument_resolver.uploaded_file', UploadedFileValueResolver::class)
+            ->tag('controller.targeted_value_resolver', ['name' => UploadedFileValueResolver::class])
 
         ->set('argument_resolver.request', RequestValueResolver::class)
             ->tag('controller.argument_value_resolver', ['priority' => 50, 'name' => RequestValueResolver::class])

--- a/src/Symfony/Component/HttpKernel/Attribute/MapUploadedFile.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapUploadedFile.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\UploadedFileValueResolver;
+
+/**
+ * Controller parameter tag to map uploaded files.
+ *
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+final class MapUploadedFile extends ValueResolver
+{
+    public function __construct(
+        public readonly ?string $name = null,
+        string $resolver = UploadedFileValueResolver::class,
+    ) {
+        parent::__construct($resolver);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `#[WithLogLevel]` for defining log levels for exceptions
  * Add `skip_response_headers` to the `HttpCache` options
  * Introduce targeted value resolvers with `#[ValueResolver]` and `#[AsTargetedValueResolver]`
+ * Add `#[MapUploadedFiles]` to map uploaded files to controller arguments
 
 6.2
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/UploadedFileValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/UploadedFileValueResolver.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\MapUploadedFile;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ */
+final class UploadedFileValueResolver implements ValueResolverInterface
+{
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        if (!$attribute = $argument->getAttributesOfType(MapUploadedFile::class)[0] ?? null) {
+            return [];
+        }
+
+        $name = $attribute->name ?? $argument->getName();
+
+        if (!$request->files->has($name)) {
+            if ($argument->isNullable() || $argument->hasDefaultValue()) {
+                return [];
+            }
+
+            if ('array' === $argument->getType()) {
+                return [[]];
+            }
+
+            throw new NotFoundHttpException(sprintf('Missing uploaded file "%s".', $name));
+        }
+
+        $value = $request->files->all()[$name];
+        if ('array' === $argument->getType()) {
+            $value = (array) $value;
+        }
+
+        return $argument->isVariadic() ? $value : [$value];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | TBD

`#[MapUploadedFile(name: 'photo')]` provides `UploadedFile` as Controller Argument.

## Usage example :hammer: 
```php
class UploadFilesController
{
    public function uploadSingleFile(#[MapUploadedFile] UploadedFile $photo): Response
    {
        // $_FILES['photo'] or 404 response
    }

    public function uploadSingleNullableFile(#[MapUploadedFile] ?UploadedFile $photo): Response
    {
        // $_FILES['photo'] or null
    }

    public function uploadVariadic(#[MapUploadedFile] UploadedFile ...$photos): Response
    {
        // $_FILES['photos'] or 404 response
    }

    /**
     * @param UploadedFile[] $photos
     */
    public function uploadArrayWithCustomName(#[MapUploadedFile('images')] array $photos): Response
    {
        // $_FILES['images'] or empty array
    }
}
```

## :spiral_notepad: TODO
- [ ] Cover with tests