### PR TITLE
[Notifier] Document Firebase options object in readme

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Firebase/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/README.md
@@ -14,6 +14,34 @@ where:
  - `USERNAME` is your Firebase username
  - `PASSWORD` is your Firebase password
 
+Adding Interactions to a Message
+--------------------------------
+
+With a Firebase message, you can use the `AndroidNotification`, `IOSNotification` or `WebNotification` classes to add
+[message options](https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref.html).
+
+```php
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Bridge\Firebase\Notification\AndroidNotification;
+
+$chatMessage = new ChatMessage('');
+
+// Create AndroidNotification options
+$androidOptions = (new AndroidNotification('/topics/news', []))
+    ->icon('myicon')
+    ->sound('default')
+    ->tag('myNotificationId')
+    ->color('#cccccc')
+    ->clickAction('OPEN_ACTIVITY_1')
+    // ...
+    ;
+
+// Add the custom options to the chat message and send the message
+$chatMessage->options($androidOptions);
+
+$chatter->send($chatMessage);
+```
+
 Resources
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Notifier bridges documentation is now in readme. This PR add missing documentation for Firebase Options. 

(Initially working on https://github.com/symfony/symfony-docs/issues/14950)
