### PR TITLE
[BrowserKit] Add proper exception hierarchy

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -12,6 +12,9 @@
 namespace Symfony\Component\BrowserKit;
 
 use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
+use Symfony\Component\BrowserKit\Exception\InvalidArgumentException;
+use Symfony\Component\BrowserKit\Exception\LogicException;
+use Symfony\Component\BrowserKit\Exception\RuntimeException;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\Link;
@@ -110,12 +113,12 @@ abstract class AbstractBrowser
      *
      * @return void
      *
-     * @throws \RuntimeException When Symfony Process Component is not installed
+     * @throws LogicException When Symfony Process Component is not installed
      */
     public function insulate(bool $insulated = true)
     {
         if ($insulated && !class_exists(\Symfony\Component\Process\Process::class)) {
-            throw new \LogicException('Unable to isolate requests as the Symfony Process Component is not installed.');
+            throw new LogicException('Unable to isolate requests as the Symfony Process Component is not installed.');
         }
 
         $this->insulated = $insulated;
@@ -335,7 +338,7 @@ abstract class AbstractBrowser
         $buttonNode = $this->crawler->selectButton($button);
 
         if (0 === $buttonNode->count()) {
-            throw new \InvalidArgumentException(sprintf('There is no button with "%s" as its content, id, value or name.', $button));
+            throw new InvalidArgumentException(sprintf('There is no button with "%s" as its content, id, value or name.', $button));
         }
 
         $form = $buttonNode->form($fieldValues, $method);
@@ -459,7 +462,7 @@ abstract class AbstractBrowser
         }
 
         if (!$process->isSuccessful() || !preg_match('/^O\:\d+\:/', $process->getOutput())) {
-            throw new \RuntimeException(sprintf('OUTPUT: %s ERROR OUTPUT: %s.', $process->getOutput(), $process->getErrorOutput()));
+            throw new RuntimeException(sprintf('OUTPUT: %s ERROR OUTPUT: %s.', $process->getOutput(), $process->getErrorOutput()));
         }
 
         return unserialize($process->getOutput());
@@ -477,11 +480,11 @@ abstract class AbstractBrowser
      *
      * @param object $request An origin request instance
      *
-     * @throws \LogicException When this abstract class is not implemented
+     * @throws LogicException When this abstract class is not implemented
      */
     protected function getScript(object $request)
     {
-        throw new \LogicException('To insulate requests, you need to override the getScript() method.');
+        throw new LogicException('To insulate requests, you need to override the getScript() method.');
     }
 
     /**
@@ -556,18 +559,18 @@ abstract class AbstractBrowser
     /**
      * Follow redirects?
      *
-     * @throws \LogicException If request was not a redirect
+     * @throws LogicException If request was not a redirect
      */
     public function followRedirect(): Crawler
     {
         if (empty($this->redirect)) {
-            throw new \LogicException('The request was not redirected.');
+            throw new LogicException('The request was not redirected.');
         }
 
         if (-1 !== $this->maxRedirects) {
             if ($this->redirectCount > $this->maxRedirects) {
                 $this->redirectCount = 0;
-                throw new \LogicException(sprintf('The maximum number (%d) of redirections was reached.', $this->maxRedirects));
+                throw new LogicException(sprintf('The maximum number (%d) of redirections was reached.', $this->maxRedirects));
             }
         }
 

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\BrowserKit;
 
+use Symfony\Component\BrowserKit\Exception\InvalidArgumentException;
+use Symfony\Component\BrowserKit\Exception\UnexpectedValueException;
+
 /**
  * Cookie represents an HTTP cookie.
  *
@@ -74,7 +77,7 @@ class Cookie
         if (null !== $expires) {
             $timestampAsDateTime = \DateTimeImmutable::createFromFormat('U', $expires);
             if (false === $timestampAsDateTime) {
-                throw new \UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.', $expires));
+                throw new UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.', $expires));
             }
 
             $this->expires = $timestampAsDateTime->format('U');
@@ -119,14 +122,14 @@ class Cookie
     /**
      * Creates a Cookie instance from a Set-Cookie header value.
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public static function fromString(string $cookie, string $url = null): static
     {
         $parts = explode(';', $cookie);
 
         if (!str_contains($parts[0], '=')) {
-            throw new \InvalidArgumentException(sprintf('The cookie string "%s" is not valid.', $parts[0]));
+            throw new InvalidArgumentException(sprintf('The cookie string "%s" is not valid.', $parts[0]));
         }
 
         [$name, $value] = explode('=', array_shift($parts), 2);
@@ -145,7 +148,7 @@ class Cookie
 
         if (null !== $url) {
             if ((false === $urlParts = parse_url($url)) || !isset($urlParts['host'])) {
-                throw new \InvalidArgumentException(sprintf('The URL "%s" is not valid.', $url));
+                throw new InvalidArgumentException(sprintf('The URL "%s" is not valid.', $url));
             }
 
             $values['domain'] = $urlParts['host'];

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\BrowserKit;
 
+use Symfony\Component\BrowserKit\Exception\InvalidArgumentException;
+
 /**
  * CookieJar.
  *
@@ -129,7 +131,7 @@ class CookieJar
         foreach ($cookies as $cookie) {
             try {
                 $this->set(Cookie::fromString($cookie, $uri));
-            } catch (\InvalidArgumentException) {
+            } catch (InvalidArgumentException) {
                 // invalid cookies are just ignored
             }
         }

--- a/src/Symfony/Component/BrowserKit/Exception/BadMethodCallException.php
+++ b/src/Symfony/Component/BrowserKit/Exception/BadMethodCallException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\BrowserKit\Exception;
 
-class BadMethodCallException extends \BadMethodCallException
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/BrowserKit/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/BrowserKit/Exception/ExceptionInterface.php
@@ -11,6 +11,11 @@
 
 namespace Symfony\Component\BrowserKit\Exception;
 
-class JsonException extends \JsonException implements ExceptionInterface
+/**
+ * Base ExceptionInterface for the BrowserKit component.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface ExceptionInterface extends \Throwable
 {
 }

--- a/src/Symfony/Component/BrowserKit/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/BrowserKit/Exception/InvalidArgumentException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\BrowserKit\Exception;
 
-class JsonException extends \JsonException implements ExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/BrowserKit/Exception/LogicException.php
+++ b/src/Symfony/Component/BrowserKit/Exception/LogicException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\BrowserKit\Exception;
 
-class JsonException extends \JsonException implements ExceptionInterface
+class LogicException extends \LogicException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/BrowserKit/Exception/RuntimeException.php
+++ b/src/Symfony/Component/BrowserKit/Exception/RuntimeException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\BrowserKit\Exception;
 
-class JsonException extends \JsonException implements ExceptionInterface
+class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/BrowserKit/Exception/UnexpectedValueException.php
+++ b/src/Symfony/Component/BrowserKit/Exception/UnexpectedValueException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\BrowserKit\Exception;
 
-class JsonException extends \JsonException implements ExceptionInterface
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/BrowserKit/History.php
+++ b/src/Symfony/Component/BrowserKit/History.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\BrowserKit;
 
+use Symfony\Component\BrowserKit\Exception\LogicException;
+
 /**
  * History.
  *
@@ -55,12 +57,12 @@ class History
     /**
      * Goes back in the history.
      *
-     * @throws \LogicException if the stack is already on the first page
+     * @throws LogicException if the stack is already on the first page
      */
     public function back(): Request
     {
         if ($this->position < 1) {
-            throw new \LogicException('You are already on the first page.');
+            throw new LogicException('You are already on the first page.');
         }
 
         return clone $this->stack[--$this->position];
@@ -69,12 +71,12 @@ class History
     /**
      * Goes forward in the history.
      *
-     * @throws \LogicException if the stack is already on the last page
+     * @throws LogicException if the stack is already on the last page
      */
     public function forward(): Request
     {
         if ($this->position > \count($this->stack) - 2) {
-            throw new \LogicException('You are already on the last page.');
+            throw new LogicException('You are already on the last page.');
         }
 
         return clone $this->stack[++$this->position];
@@ -83,12 +85,12 @@ class History
     /**
      * Returns the current element in the history.
      *
-     * @throws \LogicException if the stack is empty
+     * @throws LogicException if the stack is empty
      */
     public function current(): Request
     {
         if (-1 === $this->position) {
-            throw new \LogicException('The page history is empty.');
+            throw new LogicException('The page history is empty.');
         }
 
         return clone $this->stack[$this->position];

--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\BrowserKit;
 
+use Symfony\Component\BrowserKit\Exception\LogicException;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\Part\DataPart;
@@ -31,7 +32,7 @@ class HttpBrowser extends AbstractBrowser
     public function __construct(HttpClientInterface $client = null, History $history = null, CookieJar $cookieJar = null)
     {
         if (!$client && !class_exists(HttpClient::class)) {
-            throw new \LogicException(sprintf('You cannot use "%s" as the HttpClient component is not installed. Try running "composer require symfony/http-client".', __CLASS__));
+            throw new LogicException(sprintf('You cannot use "%s" as the HttpClient component is not installed. Try running "composer require symfony/http-client".', __CLASS__));
         }
 
         $this->client = $client ?? HttpClient::create();
@@ -66,7 +67,7 @@ class HttpBrowser extends AbstractBrowser
         }
 
         if (!class_exists(AbstractPart::class)) {
-            throw new \LogicException('You cannot pass non-empty bodies as the Mime component is not installed. Try running "composer require symfony/mime".');
+            throw new LogicException('You cannot pass non-empty bodies as the Mime component is not installed. Try running "composer require symfony/mime".');
         }
 
         if (null !== $content = $request->getContent()) {

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\BrowserKit\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
+use Symfony\Component\BrowserKit\Exception\InvalidArgumentException;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\BrowserKit\Request;
 use Symfony\Component\BrowserKit\Response;
@@ -294,12 +295,8 @@ class AbstractBrowserTest extends TestCase
         $client->setNextResponse(new Response('<html><a href="/foo">foobar</a></html>'));
         $client->request('GET', 'http://www.example.com/foo/foobar');
 
-        try {
-            $client->clickLink('foo');
-            $this->fail('->clickLink() throws a \InvalidArgumentException if the link could not be found');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf(\InvalidArgumentException::class, $e, '->clickLink() throws a \InvalidArgumentException if the link could not be found');
-        }
+        $this->expectException(\InvalidArgumentException::class);
+        $client->clickLink('foo');
     }
 
     public function testClickForm()
@@ -351,7 +348,7 @@ class AbstractBrowserTest extends TestCase
         $client->request('GET', 'http://www.example.com/foo/foobar');
 
         $this->expectExceptionObject(
-            new \InvalidArgumentException('There is no button with "Register" as its content, id, value or name.')
+            new InvalidArgumentException('There is no button with "Register" as its content, id, value or name.')
         );
 
         $client->submitForm('Register', [

--- a/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\BrowserKit\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\BrowserKit\Exception\InvalidArgumentException;
+use Symfony\Component\BrowserKit\Exception\UnexpectedValueException;
 
 class CookieTest extends TestCase
 {
@@ -104,7 +106,7 @@ class CookieTest extends TestCase
 
     public function testFromStringThrowsAnExceptionIfCookieIsNotValid()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Cookie::fromString('foo');
     }
 
@@ -117,7 +119,7 @@ class CookieTest extends TestCase
 
     public function testFromStringThrowsAnExceptionIfUrlIsNotValid()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Cookie::fromString('foo=bar', 'foobar');
     }
 
@@ -200,7 +202,7 @@ class CookieTest extends TestCase
 
     public function testConstructException()
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('The cookie expiration time "string" is not valid.');
         new Cookie('foo', 'bar', 'string');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

Back in the day, we didn't always create exception class hierarchies for "small" component. But with time, the BrowserKit defined two of them, without the same convention as the other components. Let's fix that.
