### PR TITLE
[DomCrawler] Avoid passing null to substr/strrpos methods

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/UriResolverTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/UriResolverTest.php
@@ -81,6 +81,9 @@ class UriResolverTest extends TestCase
             ['/foo', 'file:///bar/baz', 'file:///foo'],
             ['foo', 'file:///', 'file:///foo'],
             ['foo', 'file:///bar/baz', 'file:///bar/foo'],
+
+            ['foo', 'http://localhost?bar=1', 'http://localhost/foo'],
+            ['foo', 'http://localhost#bar', 'http://localhost/foo'],
         ];
     }
 }

--- a/src/Symfony/Component/DomCrawler/UriResolver.php
+++ b/src/Symfony/Component/DomCrawler/UriResolver.php
@@ -70,7 +70,7 @@ class UriResolver
         }
 
         // relative path
-        $path = parse_url(substr($baseUri, \strlen($baseUriCleaned)), \PHP_URL_PATH);
+        $path = parse_url(substr($baseUri, \strlen($baseUriCleaned)), \PHP_URL_PATH) ?? '';
         $path = self::canonicalizePath(substr($path, 0, strrpos($path, '/')).'/'.$uri);
 
         return $baseUriCleaned.('' === $path || '/' !== $path[0] ? '/' : '').$path;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #49960
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When calling `resolve('foo', 'http://localhost?bar=1')` two php deprecations were triggered.
This is because `parse_url` returns null and then we use the result as a string.

I made the code working the same for `resolve('foo', 'http://localhost?bar=1')` than for `resolve('/foo', 'http://localhost?bar=1')` (which was already tested and was not triggering the deprecation).