### PR TITLE
[Notifier] Add options to Telegram Bridge

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
 * Add support to answer callback queries
+* Add support for `sendPhoto` API method
 
 5.3
 ---

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
@@ -47,6 +47,35 @@ $chatMessage->options($telegramOptions);
 $chatter->send($chatMessage);
 ```
 
+Adding Photo to a Message
+-------------------------
+
+With a Telegram message, you can use the `TelegramOptions` class to add
+[message options](https://core.telegram.org/bots/api).
+
+```php
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button\InlineKeyboardButton;
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\InlineKeyboardMarkup;
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('Photo Caption');
+
+// Create Telegram options
+$telegramOptions = (new TelegramOptions())
+    ->chatId('@symfonynotifierdev')
+    ->parseMode('MarkdownV2')
+    ->disableWebPagePreview(true)
+    ->hasSpoiler(true)
+    ->protectContent(true)
+    ->photo('https://symfony.com/favicons/android-chrome-192x192.png');
+
+// Add the custom options to the chat message and send the message
+$chatMessage->options($telegramOptions);
+
+$chatter->send($chatMessage);
+```
+
 Updating Messages
 -----------------
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
@@ -83,6 +83,38 @@ final class TelegramOptions implements MessageOptionsInterface
     /**
      * @return $this
      */
+    public function protectContent(bool $bool): static
+    {
+        $this->options['protect_content'] = $bool;
+
+        return $this;
+    }
+
+    /**
+     * Work only when photo option is defined.
+     *
+     * @return $this
+     */
+    public function hasSpoiler(bool $bool): static
+    {
+        $this->options['has_spoiler'] = $bool;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function photo(string $url): static
+    {
+        $this->options['photo'] = $url;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function replyTo(int $messageId): static
     {
         $this->options['reply_to_message_id'] = $messageId;

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -84,6 +84,11 @@ final class TelegramTransport extends AbstractTransport
             $options['text'] = preg_replace('/([_*\[\]()~`>#+\-=|{}.!])/', '\\\\$1', $message->getSubject());
         }
 
+        if (isset($options['photo'])) {
+            $options['caption'] = $options['text'];
+            unset($options['text']);
+        }
+
         $endpoint = sprintf('https://%s/bot%s/%s', $this->getEndpoint(), $this->token, $this->getPath($options));
 
         $response = $this->client->request('POST', $endpoint, [
@@ -117,6 +122,7 @@ final class TelegramTransport extends AbstractTransport
         return match (true) {
             isset($options['message_id']) => 'editMessageText',
             isset($options['callback_query_id']) => 'answerCallbackQuery',
+            isset($options['photo']) => 'sendPhoto',
             default => 'sendMessage',
         };
     }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -330,4 +330,85 @@ JSON;
 
         $transport->send(new ChatMessage('I contain special characters _ * [ ] ( ) ~ ` > # + - = | { } . ! to send.'));
     }
+
+    public function testSendPhotoWithOptions()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $content = <<<JSON
+            {
+                "ok": true,
+                "result": {
+                    "message_id": 1,
+                    "from": {
+                        "id": 12345678,
+                        "is_bot": true,
+                        "first_name": "YourBot",
+                        "username": "YourBot"
+                    },
+                    "chat": {
+                        "id": 1234567890,
+                        "first_name": "John",
+                        "last_name": "Doe",
+                        "username": "JohnDoe",
+                        "type": "private"
+                    },
+                    "date": 1459958199,
+                    "photo": [
+                        {
+                            "file_id": "ABCDEF",
+                            "file_unique_id" : "ABCDEF1",
+                            "file_size": 1378,
+                            "width": 90,
+                            "height": 51
+                        },
+                        {
+                            "file_id": "ABCDEF",
+                            "file_unique_id" : "ABCDEF2",
+                            "file_size": 19987,
+                            "width": 320,
+                            "height": 180
+                        }
+                    ],
+                    "caption": "Hello from Bot!"
+                }
+            }
+JSON;
+
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn($content)
+        ;
+
+        $expectedBody = [
+            'photo' => 'https://image.ur.l/',
+            'has_spoiler' => true,
+            'chat_id' => 'testChannel',
+            'parse_mode' => 'MarkdownV2',
+            'caption' => 'testMessage',
+        ];
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
+            $this->assertStringEndsWith('/sendPhoto', $url);
+            $this->assertSame($expectedBody, json_decode($options['body'], true));
+
+            return $response;
+        });
+
+        $transport = self::createTransport($client, 'testChannel');
+
+        $messageOptions = new TelegramOptions();
+        $messageOptions
+            ->photo('https://image.ur.l/')
+            ->hasSpoiler(true)
+        ;
+
+        $sentMessage = $transport->send(new ChatMessage('testMessage', $messageOptions));
+
+        $this->assertEquals(1, $sentMessage->getMessageId());
+        $this->assertEquals('telegram://api.telegram.org?channel=testChannel', $sentMessage->getTransport());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Discord, Mastodon and other notifier have possibility to send photo.

Telegram can send photo too but not the bridge.

With this small change, this is now possible.
