### PR TITLE
[Console] Restoring the ability to output unicode text to the Win10 console

### DIFF
--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -157,6 +157,8 @@ class Terminal
             2 => ['pipe', 'w'],
         ];
 
+        $cp = \function_exists('sapi_windows_cp_set') ? sapi_windows_cp_get() : 0;
+
         $process = proc_open($command, $descriptorspec, $pipes, null, null, ['suppress_errors' => true]);
         if (!\is_resource($process)) {
             return null;
@@ -166,6 +168,10 @@ class Terminal
         fclose($pipes[1]);
         fclose($pipes[2]);
         proc_close($process);
+
+        if ($cp) {
+            sapi_windows_cp_set($cp);
+        }
 
         return $info;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Restoring the ability to output unicode text to the Win10 console after corrupting the console on line 224 in symfony/console/Terminal.php

```

require_once __DIR__ . '/../vendor/autoload.php';

use App\Commands\ClearcacheCommand;
use Symfony\Component\Console\Application;

echo "abc йфяЙФЯёЁ üÜiİöÖğĞıIəƏçÇşŞ" . PHP_EOL;

$app = new Application();
$app->setName("abc йфяЙФЯёЁ üÜiİöÖğĞıIəƏçÇşŞ");
$app->setVersion("0.0.001");

$app->run();

```

before
<img width="691" alt="ss_2023_04_10__13_58_30" src="https://user-images.githubusercontent.com/25248634/230881661-6506c435-f57f-4cd6-924f-5e6bb437f2b4.png">
after
<img width="440" alt="ss_2023_04_10__14_00_31" src="https://user-images.githubusercontent.com/25248634/230881671-9be5dc82-87f2-4eae-b24a-54e83b77f3b7.png">
