### PR TITLE
[Mailer] [Mailjet] Use body MessageID instead of X-MJ-Request-GUID

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -130,7 +130,7 @@ class MailjetApiTransportTest extends TestCase
 
         $sentMessage = $transport->send($email);
         $this->assertInstanceOf(SentMessage::class, $sentMessage);
-        $this->assertSame('576460756513665524', $sentMessage->getMessageId());
+        $this->assertSame('576460756513665525', $sentMessage->getMessageId());
     }
 
     public function testSendWithDecodingException()

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -108,7 +108,7 @@ class MailjetApiTransportTest extends TestCase
                         [
                             'Email' => 'passenger1@mailjet.com',
                             'MessageUUID' => '7c5f9f29-42ba-4959-b19c-dcd8b2f327ca',
-                            'MessageID' => 576460756513665525,
+                            'MessageID' => '576460756513665525',
                             'MessageHref' => 'https://api.mailjet.com/v3/message/576460756513665525',
                         ],
                     ],

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -109,10 +109,10 @@ class MailjetApiTransportTest extends TestCase
                             'Email' => 'passenger1@mailjet.com',
                             'MessageUUID' => '7c5f9f29-42ba-4959-b19c-dcd8b2f327ca',
                             'MessageID' => 576460756513665525,
-                            'MessageHref' => 'https://api.mailjet.com/v3/message/576460756513665525'
-                        ]
-                    ]
-                ]
+                            'MessageHref' => 'https://api.mailjet.com/v3/message/576460756513665525',
+                        ],
+                    ],
+                ],
             ],
         ]);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -102,15 +102,21 @@ class MailjetApiTransportTest extends TestCase
     {
         $json = json_encode([
             'Messages' => [
-                'foo' => 'bar',
+                [
+                    'Status' => 'success',
+                    'To' => [
+                        [
+                            'Email' => 'passenger1@mailjet.com',
+                            'MessageUUID' => '7c5f9f29-42ba-4959-b19c-dcd8b2f327ca',
+                            'MessageID' => 576460756513665525,
+                            'MessageHref' => 'https://api.mailjet.com/v3/message/576460756513665525'
+                        ]
+                    ]
+                ]
             ],
         ]);
 
-        $responseHeaders = [
-            'x-mj-request-guid' => ['baz'],
-        ];
-
-        $response = new MockResponse($json, ['response_headers' => $responseHeaders]);
+        $response = new MockResponse($json);
 
         $client = new MockHttpClient($response);
 
@@ -124,7 +130,7 @@ class MailjetApiTransportTest extends TestCase
 
         $sentMessage = $transport->send($email);
         $this->assertInstanceOf(SentMessage::class, $sentMessage);
-        $this->assertSame('baz', $sentMessage->getMessageId());
+        $this->assertSame('576460756513665524', $sentMessage->getMessageId());
     }
 
     public function testSendWithDecodingException()

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -85,7 +85,7 @@ class MailjetApiTransport extends AbstractApiTransport
             throw new HttpTransportException(sprintf('Unable to send an email: "%s" malformed api response.', $response->getContent(false)), $response);
         }
 
-        $sentMessage->setMessageId((string) $result['Messages'][0]['To'][0]['MessageID'] ?? '');
+        $sentMessage->setMessageId($result['Messages'][0]['To'][0]['MessageID'] ?? '');
 
         return $response;
     }

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -85,7 +85,7 @@ class MailjetApiTransport extends AbstractApiTransport
             throw new HttpTransportException(sprintf('Unable to send an email: "%s" malformed api response.', $response->getContent(false)), $response);
         }
 
-        $sentMessage->setMessageId($response->getHeaders(false)['x-mj-request-guid'][0]);
+        $sentMessage->setMessageId((string) $result['Messages'][0]['To'][0]['MessageID'] ?? '');
 
         return $response;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48550
| License       | MIT
| Doc PR        | N/A

As per #48550, the message ID of the `SentMessage` returned by the `MailjetApiTransport` is the `X-MJ-Request-GUID`. The issue is that this ID is only there for debug purposes by the MailJet engineers and cannot be consumed by the MailJet API to query the message metadata.

This change instead uses the `MessageID` attribute returned in the JSON body of the response which can be used in further API requests.

As the existing message ID was not usable for anything besides opening support tickets (which the new ID can still be used for), I've decided to submit this PR as a bug fix.

A slight limitation however is that MailJet will return multiple messages when sending to multiple recipients, each having their own `MessageID`. This implementation therefore only returns the first `MessageID`, there is an ongoing discussion on #48550 about that behavior but I am submitting this PR as is since it's still a net improvement over the previous ID.