### PR TITLE
[SecurityBundle] Set request stateless only if the attribute is not defined

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate enabling bundle and not configuring it
- * Add `_stateless` attribute to the request when firewall is stateless
+ * Add `_stateless` attribute to the request when firewall is stateless and the attribute is not already set
  * Add `StatelessAuthenticatorFactoryInterface` for authenticators targeting `stateless` firewalls only and that don't require a user provider
  * Modify "icon.svg" to improve accessibility for blind/low vision users
  * Make `Security::login()` return the authenticator response

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -75,7 +75,7 @@ class FirewallMap implements FirewallMapInterface
                 /** @var FirewallContext $context */
                 $context = $this->container->get($contextId);
 
-                if ($context->getConfig()?->isStateless()) {
+                if ($context->getConfig()?->isStateless() && !$request->attributes->has('_stateless')) {
                     $request->attributes->set('_stateless', true);
                 }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -57,10 +57,9 @@ class FirewallMapTest extends TestCase
         $this->assertFalse($request->attributes->has('_stateless'));
     }
 
-    public function testGetListeners()
+    /** @dataProvider providesStatefulStatelessRequests */
+    public function testGetListeners(Request $request, bool $expectedState)
     {
-        $request = new Request();
-
         $firewallContext = $this->createMock(FirewallContext::class);
 
         $firewallConfig = new FirewallConfig('main', 'user_checker', null, true, true);
@@ -89,6 +88,13 @@ class FirewallMapTest extends TestCase
         $this->assertEquals([[$listener], $exceptionListener, $logoutListener], $firewallMap->getListeners($request));
         $this->assertEquals($firewallConfig, $firewallMap->getFirewallConfig($request));
         $this->assertEquals('security.firewall.map.context.foo', $request->attributes->get(self::ATTRIBUTE_FIREWALL_CONTEXT));
-        $this->assertTrue($request->attributes->get('_stateless'));
+        $this->assertEquals($expectedState, $request->attributes->get('_stateless'));
+    }
+
+    public static function providesStatefulStatelessRequests(): \Generator
+    {
+        yield [new Request(), true];
+        yield [new Request(attributes: ['_stateless' => false]), false];
+        yield [new Request(attributes: ['_stateless' => true]), true];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | yes-ish
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/48044#issuecomment-1504267293
| License       | MIT
| Doc PR        | n/a

The current implementation makes sense for most cases but not for every case as one can have a stateless authentication but still requires sessions.
This PR allows setting the request as non-stateless while having a stateless firewall but keeping the new behavior by default.
