### PR TITLE
Constraint validator "validator.expression" does not exist or is not …

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -82,9 +82,4 @@ class Expression extends Constraint
     {
         return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
     }
-
-    public function validatedBy(): string
-    {
-        return 'validator.expression';
-    }
 }


### PR DESCRIPTION
…enabled. Check the "validatedBy" method in your constraint class "Symfony\Component\Validator\Constraints\Expression".

symfony:  6.2.8

fix bug  Constraint validator "validator.expression" does not exist or is not enabled. Check the "validatedBy" method in your constraint class "Symfony\Component\Validator\Constraints\Expression".

| Q             | A
| ------------- | ---
| Branch?       | 6.2 for bug fixes
| Bug fix?      | yes
| Deprecations? | no
| Tickets       | Fix #49998
| License       | MIT

