### PR TITLE
[Serializer] Update return type for `NormalizableInterface::normalize` to match `NormalizerInterface::normalize`

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
@@ -33,5 +33,5 @@ interface NormalizableInterface
      *                                        based on different output formats
      * @param array               $context    Options for normalizing this object
      */
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = []): array|string|int|float|bool;
+    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 for features
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When implementing `NormalizableInterface::normalize` in a class like so ...

```php
use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

class MyClass implements NormalizableInterface {
...
    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = []): array|string|int|float|bool
    {
        return $normalizer->normalize(['some_key' => $this->someProperty], $format, $context);
    }
}
```

... then Psalm complains because the return types indicated by both interfaces (`NormalizerInterface` vs. `NormalizableInterface`) don't match. 

IMHO, my code is a valid use case and the allowed return types should be identical.

Caution: This is probably not OK to merge according to the BC promise. Please advise how to change the return type in a compliant manner.
