### PR TITLE
[Serializer] Add missing return types

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -11211,70 +11211,6 @@ index b684fddb2f..ade2242791 100644
 +    public function getData(): mixed
      {
          return $this->data;
-diff --git a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
-index aeee5ac680..4ac78f5458 100644
---- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
-+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
-@@ -98,5 +98,5 @@ class AttributeMetadata implements AttributeMetadataInterface
-      * @return void
-      */
--    public function addGroup(string $group)
-+    public function addGroup(string $group): void
-     {
-         if (!\in_array($group, $this->groups)) {
-@@ -113,5 +113,5 @@ class AttributeMetadata implements AttributeMetadataInterface
-      * @return void
-      */
--    public function setMaxDepth(?int $maxDepth)
-+    public function setMaxDepth(?int $maxDepth): void
-     {
-         $this->maxDepth = $maxDepth;
-@@ -126,5 +126,5 @@ class AttributeMetadata implements AttributeMetadataInterface
-      * @return void
-      */
--    public function setSerializedName(string $serializedName = null)
-+    public function setSerializedName(string $serializedName = null): void
-     {
-         if (1 > \func_num_args()) {
-@@ -153,5 +153,5 @@ class AttributeMetadata implements AttributeMetadataInterface
-      * @return void
-      */
--    public function setIgnore(bool $ignore)
-+    public function setIgnore(bool $ignore): void
-     {
-         $this->ignore = $ignore;
-@@ -218,5 +218,5 @@ class AttributeMetadata implements AttributeMetadataInterface
-      * @return void
-      */
--    public function merge(AttributeMetadataInterface $attributeMetadata)
-+    public function merge(AttributeMetadataInterface $attributeMetadata): void
-     {
-         foreach ($attributeMetadata->getGroups() as $group) {
-diff --git a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
-index fc6336ebdb..e13a834930 100644
---- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
-+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
-@@ -64,5 +64,5 @@ class ClassMetadata implements ClassMetadataInterface
-      * @return void
-      */
--    public function addAttributeMetadata(AttributeMetadataInterface $attributeMetadata)
-+    public function addAttributeMetadata(AttributeMetadataInterface $attributeMetadata): void
-     {
-         $this->attributesMetadata[$attributeMetadata->getName()] = $attributeMetadata;
-@@ -77,5 +77,5 @@ class ClassMetadata implements ClassMetadataInterface
-      * @return void
-      */
--    public function merge(ClassMetadataInterface $classMetadata)
-+    public function merge(ClassMetadataInterface $classMetadata): void
-     {
-         foreach ($classMetadata->getAttributesMetadata() as $attributeMetadata) {
-@@ -105,5 +105,5 @@ class ClassMetadata implements ClassMetadataInterface
-      * @return void
-      */
--    public function setClassDiscriminatorMapping(ClassDiscriminatorMapping $mapping = null)
-+    public function setClassDiscriminatorMapping(ClassDiscriminatorMapping $mapping = null): void
-     {
-         if (1 > \func_num_args()) {
 diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
 index 58deea9f01..8fe0385cdc 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -11350,6 +11286,16 @@ index 20f15becb2..b378cd8c38 100644
 +    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
      {
          if (!isset($context['cache_key'])) {
+diff --git a/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareInterface.php b/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareInterface.php
+index 48e8c3fb54..a71c3ea476 100644
+--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareInterface.php
++++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareInterface.php
+@@ -22,4 +22,4 @@ interface DenormalizerAwareInterface
+      * @return void
+      */
+-    public function setDenormalizer(DenormalizerInterface $denormalizer);
++    public function setDenormalizer(DenormalizerInterface $denormalizer): void;
+ }
 diff --git a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
 index 4edb70096d..8c844785db 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -11379,6 +11325,16 @@ index 063d34ea59..fb10337d35 100644
 +    protected function setAttributeValue(object $object, string $attribute, mixed $value, string $format = null, array $context = []): void
      {
          $setter = 'set'.ucfirst($attribute);
+diff --git a/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareInterface.php b/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareInterface.php
+index 5f3deaa018..99de716dfb 100644
+--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareInterface.php
++++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareInterface.php
+@@ -22,4 +22,4 @@ interface NormalizerAwareInterface
+      * @return void
+      */
+-    public function setNormalizer(NormalizerInterface $normalizer);
++    public function setNormalizer(NormalizerInterface $normalizer): void;
+ }
 diff --git a/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareTrait.php b/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareTrait.php
 index 40a4fa0e8c..a1e2749aae 100644
 --- a/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareTrait.php
@@ -11430,6 +11386,16 @@ index ec12db9bb2..d3b7f036a8 100644
 +    protected function setAttributeValue(object $object, string $attribute, mixed $value, string $format = null, array $context = []): void
      {
          try {
+diff --git a/src/Symfony/Component/Serializer/SerializerAwareInterface.php b/src/Symfony/Component/Serializer/SerializerAwareInterface.php
+index 4919436d94..24ff404aa4 100644
+--- a/src/Symfony/Component/Serializer/SerializerAwareInterface.php
++++ b/src/Symfony/Component/Serializer/SerializerAwareInterface.php
+@@ -22,4 +22,4 @@ interface SerializerAwareInterface
+      * @return void
+      */
+-    public function setSerializer(SerializerInterface $serializer);
++    public function setSerializer(SerializerInterface $serializer): void;
+ }
 diff --git a/src/Symfony/Component/Serializer/SerializerAwareTrait.php b/src/Symfony/Component/Serializer/SerializerAwareTrait.php
 index 1835568745..2b98fc11d6 100644
 --- a/src/Symfony/Component/Serializer/SerializerAwareTrait.php
@@ -11437,6 +11403,17 @@ index 1835568745..2b98fc11d6 100644
 @@ -25,5 +25,5 @@ trait SerializerAwareTrait
       * @return void
       */
+-    public function setSerializer(SerializerInterface $serializer)
++    public function setSerializer(SerializerInterface $serializer): void
+     {
+         $this->serializer = $serializer;
+diff --git a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+index c32425b99e..ea8c3ba06e 100644
+--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
++++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+@@ -871,5 +871,5 @@ class ArrayDenormalizerDummy implements DenormalizerInterface, SerializerAwareIn
+     }
+ 
 -    public function setSerializer(SerializerInterface $serializer)
 +    public function setSerializer(SerializerInterface $serializer): void
      {

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -94,10 +94,7 @@ class AttributeMetadata implements AttributeMetadataInterface
         return $this->name;
     }
 
-    /**
-     * @return void
-     */
-    public function addGroup(string $group)
+    public function addGroup(string $group): void
     {
         if (!\in_array($group, $this->groups)) {
             $this->groups[] = $group;
@@ -109,10 +106,7 @@ class AttributeMetadata implements AttributeMetadataInterface
         return $this->groups;
     }
 
-    /**
-     * @return void
-     */
-    public function setMaxDepth(?int $maxDepth)
+    public function setMaxDepth(?int $maxDepth): void
     {
         $this->maxDepth = $maxDepth;
     }
@@ -122,10 +116,7 @@ class AttributeMetadata implements AttributeMetadataInterface
         return $this->maxDepth;
     }
 
-    /**
-     * @return void
-     */
-    public function setSerializedName(string $serializedName = null)
+    public function setSerializedName(string $serializedName = null): void
     {
         if (1 > \func_num_args()) {
             trigger_deprecation('symfony/serializer', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
@@ -149,10 +140,7 @@ class AttributeMetadata implements AttributeMetadataInterface
         return $this->serializedPath;
     }
 
-    /**
-     * @return void
-     */
-    public function setIgnore(bool $ignore)
+    public function setIgnore(bool $ignore): void
     {
         $this->ignore = $ignore;
     }
@@ -214,10 +202,7 @@ class AttributeMetadata implements AttributeMetadataInterface
         }
     }
 
-    /**
-     * @return void
-     */
-    public function merge(AttributeMetadataInterface $attributeMetadata)
+    public function merge(AttributeMetadataInterface $attributeMetadata): void
     {
         foreach ($attributeMetadata->getGroups() as $group) {
             $this->addGroup($group);

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -32,7 +32,7 @@ interface AttributeMetadataInterface
     /**
      * Adds this attribute to the given group.
      */
-    public function addGroup(string $group);
+    public function addGroup(string $group): void;
 
     /**
      * Gets groups of this attribute.
@@ -44,7 +44,7 @@ interface AttributeMetadataInterface
     /**
      * Sets the serialization max depth for this attribute.
      */
-    public function setMaxDepth(?int $maxDepth);
+    public function setMaxDepth(?int $maxDepth): void;
 
     /**
      * Gets the serialization max depth for this attribute.
@@ -54,7 +54,7 @@ interface AttributeMetadataInterface
     /**
      * Sets the serialization name for this attribute.
      */
-    public function setSerializedName(?string $serializedName);
+    public function setSerializedName(?string $serializedName): void;
 
     /**
      * Gets the serialization name for this attribute.
@@ -68,7 +68,7 @@ interface AttributeMetadataInterface
     /**
      * Sets if this attribute must be ignored or not.
      */
-    public function setIgnore(bool $ignore);
+    public function setIgnore(bool $ignore): void;
 
     /**
      * Gets if this attribute is ignored or not.
@@ -78,7 +78,7 @@ interface AttributeMetadataInterface
     /**
      * Merges an {@see AttributeMetadataInterface} with in the current one.
      */
-    public function merge(self $attributeMetadata);
+    public function merge(self $attributeMetadata): void;
 
     /**
      * Gets all the normalization contexts per group ("*" being the base context applied to all groups).

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -60,10 +60,7 @@ class ClassMetadata implements ClassMetadataInterface
         return $this->name;
     }
 
-    /**
-     * @return void
-     */
-    public function addAttributeMetadata(AttributeMetadataInterface $attributeMetadata)
+    public function addAttributeMetadata(AttributeMetadataInterface $attributeMetadata): void
     {
         $this->attributesMetadata[$attributeMetadata->getName()] = $attributeMetadata;
     }
@@ -73,10 +70,7 @@ class ClassMetadata implements ClassMetadataInterface
         return $this->attributesMetadata;
     }
 
-    /**
-     * @return void
-     */
-    public function merge(ClassMetadataInterface $classMetadata)
+    public function merge(ClassMetadataInterface $classMetadata): void
     {
         foreach ($classMetadata->getAttributesMetadata() as $attributeMetadata) {
             if (isset($this->attributesMetadata[$attributeMetadata->getName()])) {
@@ -101,10 +95,7 @@ class ClassMetadata implements ClassMetadataInterface
         return $this->classDiscriminatorMapping;
     }
 
-    /**
-     * @return void
-     */
-    public function setClassDiscriminatorMapping(ClassDiscriminatorMapping $mapping = null)
+    public function setClassDiscriminatorMapping(ClassDiscriminatorMapping $mapping = null): void
     {
         if (1 > \func_num_args()) {
             trigger_deprecation('symfony/serializer', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
@@ -32,7 +32,7 @@ interface ClassMetadataInterface
     /**
      * Adds an {@link AttributeMetadataInterface}.
      */
-    public function addAttributeMetadata(AttributeMetadataInterface $attributeMetadata);
+    public function addAttributeMetadata(AttributeMetadataInterface $attributeMetadata): void;
 
     /**
      * Gets the list of {@link AttributeMetadataInterface}.
@@ -44,7 +44,7 @@ interface ClassMetadataInterface
     /**
      * Merges a {@link ClassMetadataInterface} in the current one.
      */
-    public function merge(self $classMetadata);
+    public function merge(self $classMetadata): void;
 
     /**
      * Returns a {@link \ReflectionClass} instance for this class.
@@ -53,5 +53,5 @@ interface ClassMetadataInterface
 
     public function getClassDiscriminatorMapping(): ?ClassDiscriminatorMapping;
 
-    public function setClassDiscriminatorMapping(?ClassDiscriminatorMapping $mapping);
+    public function setClassDiscriminatorMapping(?ClassDiscriminatorMapping $mapping): void;
 }

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareInterface.php
@@ -18,6 +18,8 @@ interface DenormalizerAwareInterface
 {
     /**
      * Sets the owning Denormalizer object.
+     *
+     * @return void
      */
     public function setDenormalizer(DenormalizerInterface $denormalizer);
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareInterface.php
@@ -18,6 +18,8 @@ interface NormalizerAwareInterface
 {
     /**
      * Sets the owning Normalizer object.
+     *
+     * @return void
      */
     public function setNormalizer(NormalizerInterface $normalizer);
 }

--- a/src/Symfony/Component/Serializer/SerializerAwareInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerAwareInterface.php
@@ -18,6 +18,8 @@ interface SerializerAwareInterface
 {
     /**
      * Sets the owning Serializer object.
+     *
+     * @return void
      */
     public function setSerializer(SerializerInterface $serializer);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Tickets       | Contribution for #47551 
| License       | MIT
| Doc PR        |


Contribution on the issue #47551 concerning the **Serializer** component.
The type is added on PHPDoc when BC risk is present, else native type is used (private methods / tests).
