### PR TITLE
[HttpKernel] Don't use eval() to render ESI/SSI

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -24,6 +24,10 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 abstract class AbstractSurrogate implements SurrogateInterface
 {
     protected $contentTypes;
+
+    /**
+     * @deprecated since Symfony 6.3
+     */
     protected $phpEscapeMap = [
         ['<?', '<%', '<s', '<S'],
         ['<?php echo "<?"; ?>', '<?php echo "<%"; ?>', '<?php echo "<s"; ?>', '<?php echo "<S"; ?>'],

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -74,8 +74,10 @@ class Esi extends AbstractSurrogate
         $content = preg_replace('#<esi\:remove>.*?</esi\:remove>#s', '', $content);
         $content = preg_replace('#<esi\:comment[^>]+>#s', '', $content);
 
+        static $cookie;
+        $cookie = hash('xxh128', $cookie ??= random_bytes(16), true);
+        $boundary = base64_encode($cookie);
         $chunks = preg_split('#<esi\:include\s+(.*?)\s*(?:/|</esi\:include)>#', $content, -1, \PREG_SPLIT_DELIM_CAPTURE);
-        $chunks[0] = str_replace($this->phpEscapeMap[0], $this->phpEscapeMap[1], $chunks[0]);
 
         $i = 1;
         while (isset($chunks[$i])) {
@@ -89,16 +91,10 @@ class Esi extends AbstractSurrogate
                 throw new \RuntimeException('Unable to process an ESI tag without a "src" attribute.');
             }
 
-            $chunks[$i] = sprintf('<?php echo $this->surrogate->handle($this, %s, %s, %s) ?>'."\n",
-                var_export($options['src'], true),
-                var_export($options['alt'] ?? '', true),
-                isset($options['onerror']) && 'continue' === $options['onerror'] ? 'true' : 'false'
-            );
-            ++$i;
-            $chunks[$i] = str_replace($this->phpEscapeMap[0], $this->phpEscapeMap[1], $chunks[$i]);
-            ++$i;
+            $chunks[$i] = $boundary.$options['src']."\n".($options['alt'] ?? '')."\n".('continue' === ($options['onerror'] ?? ''))."\n";
+            $i += 2;
         }
-        $content = implode('', $chunks);
+        $content = $boundary.implode('', $chunks).$boundary;
 
         $response->setContent($content);
         $response->headers->set('X-Body-Eval', 'ESI');

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -641,7 +641,21 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             if ($response->headers->has('X-Body-File')) {
                 include $response->headers->get('X-Body-File');
             } else {
-                eval('; ?>'.$response->getContent().'<?php ;');
+                $content = $response->getContent();
+
+                if (substr($content, -24) === $boundary = substr($content, 0, 24)) {
+                    $j = strpos($content, $boundary, 24);
+                    echo substr($content, 24, $j - 24);
+                    $i = $j + 24;
+
+                    while (false !== $j = strpos($content, $boundary, $i)) {
+                        [$uri, $alt, $ignoreErrors, $part] = explode("\n", substr($content, $i, $j - $i), 4);
+                        $i = $j + 24;
+
+                        echo $this->surrogate->handle($this, $uri, $alt, $ignoreErrors);
+                        echo $part;
+                    }
+                }
             }
 
             $response->setContent(ob_get_clean());

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -101,13 +101,15 @@ class SsiTest extends TestCase
         $response = new Response('foo <!--#include virtual="..." -->');
         $ssi->process($request, $response);
 
-        $this->assertEquals('foo <?php echo $this->surrogate->handle($this, \'...\', \'\', false) ?>'."\n", $response->getContent());
+        $content = explode(substr($response->getContent(), 0, 24), $response->getContent());
+        $this->assertSame(['', 'foo ', "...\n\n\n", ''], $content);
         $this->assertEquals('SSI', $response->headers->get('x-body-eval'));
 
         $response = new Response('foo <!--#include virtual="foo\'" -->');
         $ssi->process($request, $response);
 
-        $this->assertEquals("foo <?php echo \$this->surrogate->handle(\$this, 'foo\\'', '', false) ?>\n", $response->getContent());
+        $content = explode(substr($response->getContent(), 0, 24), $response->getContent());
+        $this->assertSame(['', 'foo ', "foo'\n\n\n", ''], $content);
     }
 
     public function testProcessEscapesPhpTags()
@@ -118,7 +120,8 @@ class SsiTest extends TestCase
         $response = new Response('<?php <? <% <script language=php>');
         $ssi->process($request, $response);
 
-        $this->assertEquals('<?php echo "<?"; ?>php <?php echo "<?"; ?> <?php echo "<%"; ?> <?php echo "<s"; ?>cript language=php>', $response->getContent());
+        $content = explode(substr($response->getContent(), 0, 24), $response->getContent());
+        $this->assertSame(['', '<?php <? <% <script language=php>', ''], $content);
     }
 
     public function testProcessWhenNoSrcInAnSsi()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Yes, this would not be needed if people were able to use a real `kernel.secret`. But apparently, many fail.
And it looks like we can do something about it, so let's makes this impossible to exploit :)