### PR TITLE
[Serializer] Fix serializer normalize attribute context

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -196,14 +196,14 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $attributeValue = $maxDepthHandler($attributeValue, $object, $attribute, $format, $attributeContext);
             }
 
-            $attributeValue = $this->applyCallbacks($attributeValue, $object, $attribute, $format, $attributeContext);
-
-            $stack[$attribute] = $attributeValue;
+            $stack[$attribute] = $this->applyCallbacks($attributeValue, $object, $attribute, $format, $attributeContext);
         }
 
         foreach ($stack as $attribute => $attributeValue) {
+            $attributeContext = $this->getAttributeNormalizationContext($object, $attribute, $context);
+
             if (null === $attributeValue || \is_scalar($attributeValue)) {
-                $data = $this->updateData($data, $attribute, $attributeValue, $class, $format, $context, $attributesMetadata, $classMetadata);
+                $data = $this->updateData($data, $attribute, $attributeValue, $class, $format, $attributeContext, $attributesMetadata, $classMetadata);
                 continue;
             }
 
@@ -211,7 +211,6 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 throw new LogicException(sprintf('Cannot normalize attribute "%s" because the injected serializer is not a normalizer.', $attribute));
             }
 
-            $attributeContext = $this->getAttributeNormalizationContext($object, $attribute, $context);
             $childContext = $this->createChildContext($attributeContext, $attribute, $format);
 
             $data = $this->updateData($data, $attribute, $this->serializer->normalize($attributeValue, $format, $childContext), $class, $format, $attributeContext, $attributesMetadata, $classMetadata);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Before 6.2.8 property attribute`#[Context(normalizationContext: [AbstractObjectNormalizer::SKIP_NULL_VALUES => true])]` was working correctly

Before this PR https://github.com/symfony/symfony/pull/49525 `updateData` was using the `$attributeContext` but it got changed to using `$context` (which ignored the attribute context)

Fixed the `testNormalizeUsesContextAttributeForPropertiesInConstructorWithSerializedPath` test also since `Context` attribute class was never used in the file (the date was still in `d-m-Y` format when the format key was `m-d-Y`)

Would have ported it to 5.4, but it was not added in that branch.
Latest commit for this file in 5.4 https://github.com/symfony/symfony/blob/6ae4ac9b9f46203b3ebae3c4c52edd546709bdb1/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php#L205