### PR TITLE
[Validator] Fix support of Enum to `ConstraintValidator::formatValue`

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -99,6 +99,10 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
             return $value->format('Y-m-d H:i:s');
         }
 
+        if ($value instanceof \UnitEnum) {
+            return $value->name;
+        }
+
         if (\is_object($value)) {
             if (($format & self::OBJECT_TO_STRING) && method_exists($value, '__toString')) {
                 return $value->__toString();

--- a/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
@@ -41,6 +41,7 @@ class ConstraintValidatorTest extends TestCase
             ['array', []],
             ['object', $toString = new TestToStringObject()],
             ['ccc', $toString, ConstraintValidator::OBJECT_TO_STRING],
+            ['FirstCase', $toString = TestEnum::FirstCase],
             ['object', $dateTime = new \DateTimeImmutable('1971-02-02T08:00:00UTC')],
             [class_exists(\IntlDateFormatter::class) ? 'Oct 4, 2019, 11:02 AM' : '2019-10-04 11:02:03', new \DateTimeImmutable('2019-10-04T11:02:03+09:00'), ConstraintValidator::PRETTY_DATE],
             [class_exists(\IntlDateFormatter::class) ? 'Feb 2, 1971, 8:00 AM' : '1971-02-02 08:00:00', $dateTime, ConstraintValidator::PRETTY_DATE],
@@ -72,4 +73,10 @@ final class TestToStringObject
     {
         return 'ccc';
     }
+}
+
+enum TestEnum
+{
+    case FirstCase;
+    case SecondCase;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #50000
| License       | MIT

I have added a simple check in the `formatValue` to see if the object is an enum and in that case, return the name of the enum instead of the "object" string.

