### PR TITLE
[DependencyInjection] Fallback to default value when autowiring undefined parameters for optional arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1217,6 +1217,38 @@ class AutowirePassTest extends TestCase
         $this->assertNull($service->invalid);
     }
 
+    public function testAutowireAttributeNullFallbackTestRequired()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', AutowireAttributeNullFallback::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $this->expectException(AutowiringFailedException::class);
+        $this->expectExceptionMessage('You have requested a non-existent parameter "required.parameter".');
+        (new AutowirePass())->process($container);
+    }
+
+    public function testAutowireAttributeNullFallbackTestOptional()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', AutowireAttributeNullFallback::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->setParameter('required.parameter', 'foo');
+
+        (new AutowirePass())->process($container);
+
+        $definition = $container->getDefinition('foo');
+
+        $this->assertSame(['foo'], $definition->getArguments());
+    }
+
     public function testAsDecoratorAttribute()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -56,6 +56,17 @@ class AutowireAttribute
     }
 }
 
+class AutowireAttributeNullFallback
+{
+    public function __construct(
+        #[Autowire('%required.parameter%')]
+        public string $required,
+        #[Autowire('%optional.parameter%')]
+        public ?string $optional = null,
+    ) {
+    }
+}
+
 interface AsDecoratorInterface
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2 / 6.3
| Bug fix?      | yes
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #50020 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT
| Related       | PR #50023

Allows autowiring of undefined nullable parameters, similar to existing behavior for non-parameter values. See related issue for more detail.