### PR TITLE
[Serializer] Fix denormalization of object with typed constructor arg (not castable) and with COLLECT_DENORMALIZATION_ERRORS

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -417,7 +417,15 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             }
 
             if ($constructor->isConstructor()) {
-                return $reflectionClass->newInstanceArgs($params);
+                try {
+                    return $reflectionClass->newInstanceArgs($params);
+                } catch (\TypeError $th) {
+                    if (!isset($context['not_normalizable_value_exceptions'])) {
+                        throw $th;
+                    }
+
+                    return $reflectionClass->newInstanceWithoutConstructor();
+                }
             } else {
                 return $constructor->invokeArgs(null, $params);
             }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
@@ -28,6 +28,7 @@ final class Php74Full
     /** @var Php74Full[] */
     public array $collection;
     public Php74FullWithConstructor $php74FullWithConstructor;
+    public Php74FullWithTypedConstructor $php74FullWithTypedConstructor;
     public DummyMessageInterface $dummyMessage;
     /** @var TestFoo[] $nestedArray */
     public TestFoo $nestedObject;
@@ -39,6 +40,13 @@ final class Php74Full
 final class Php74FullWithConstructor
 {
     public function __construct($constructorArgument)
+    {
+    }
+}
+
+final class Php74FullWithTypedConstructor
+{
+    public function __construct(float $something)
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -852,6 +852,9 @@ class SerializerTest extends TestCase
                 }
             ],
             "php74FullWithConstructor": {},
+            "php74FullWithTypedConstructor": {
+                "something": "not a float"
+            },
             "dummyMessage": {
             },
             "nestedObject": {
@@ -1004,6 +1007,15 @@ class SerializerTest extends TestCase
                 'path' => 'php74FullWithConstructor',
                 'useMessageForUser' => true,
                 'message' => 'Failed to create object because the class misses the "constructorArgument" property.',
+            ],
+            [
+                'currentType' => 'string',
+                'expectedTypes' => [
+                    'float',
+                ],
+                'path' => 'php74FullWithTypedConstructor',
+                'useMessageForUser' => false,
+                'message' => 'The type of the "something" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74FullWithTypedConstructor" must be one of "float" ("string" given).',
             ],
             $classMetadataFactory ?
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

There is already a test for constructor instantiation but it worked "by chance".
The test is `testCollectDenormalizationErrorsWithConstructor`.
It worked because `$reflectionClass->newInstanceArgs($params)` works if
one give a `string` value that should fit in a `bool` type. PHP casts
automatically the value for us. (see: https://3v4l.org/GYr0T)

Now we ensure to not throw an exception if the instantiation cannot be
done. The mismatch is already collected few lines above, so there
nothing to do more
